### PR TITLE
chore: restore intercom script

### DIFF
--- a/front/migrations/20260423_restore_intercom_data_source.ts
+++ b/front/migrations/20260423_restore_intercom_data_source.ts
@@ -61,14 +61,45 @@ function buildIntercomParentRewriter(
   };
 }
 
-function mapParents(
+type ParentsDiff = {
+  before: string[] | null;
+  after: string[] | null;
+  changedCount: number;
+};
+
+function diffParents(
   parents: string[] | null,
   rewrite: (s: string) => string
-): string[] | null {
+): ParentsDiff {
   if (parents === null) {
-    return null;
+    return { before: null, after: null, changedCount: 0 };
   }
-  return parents.map(rewrite);
+  const after = parents.map(rewrite);
+  let changedCount = 0;
+  for (let i = 0; i < parents.length; i++) {
+    if (parents[i] !== after[i]) {
+      changedCount++;
+    }
+  }
+  return { before: parents, after, changedCount };
+}
+
+type RestoreStats = {
+  snapshotRowCount: number;
+  inserted: number;
+  reused: number;
+  skippedOrphan: number;
+  parentsRewritten: number;
+};
+
+function emptyStats(): RestoreStats {
+  return {
+    snapshotRowCount: 0,
+    inserted: 0,
+    reused: 0,
+    skippedOrphan: 0,
+    parentsRewritten: 0,
+  };
 }
 
 async function resolveDataSource({
@@ -134,7 +165,7 @@ async function restoreDataSourceViews({
   newDs: DataSourceModel;
   rewrite: (s: string) => string;
   execute: boolean;
-}): Promise<Map<number, number>> {
+}): Promise<{ oldToNewDsvId: Map<number, number>; stats: RestoreStats }> {
   const snapshotDsvs = await snapshot.query<DataSourceViewModel>(
     `
     SELECT *
@@ -150,6 +181,9 @@ async function restoreDataSourceViews({
       },
     }
   );
+
+  const stats = emptyStats();
+  stats.snapshotRowCount = snapshotDsvs.length;
 
   logger.info(
     { count: snapshotDsvs.length },
@@ -173,28 +207,63 @@ async function restoreDataSourceViews({
     });
 
     if (existing && existing.kind === snap.kind) {
+      const snapParentsRewritten = snap.parentsIn?.map(rewrite) ?? null;
+      const existingParents = existing.parentsIn ?? null;
+      const parentsMatch =
+        (snapParentsRewritten === null && existingParents === null) ||
+        (snapParentsRewritten !== null &&
+          existingParents !== null &&
+          snapParentsRewritten.length === existingParents.length &&
+          snapParentsRewritten.every((p, i) => p === existingParents[i]));
+
       logger.info(
         {
           oldDsvId: snap.id,
           existingDsvId: existing.id,
           vaultId: snap.vaultId,
           kind: snap.kind,
+          snapParentsIn: snap.parentsIn,
+          existingParentsIn: existing.parentsIn,
+          parentsMatch,
         },
         "Reusing existing live DSV (auto-created on re-creation of the data source)"
       );
+
+      if (!parentsMatch) {
+        logger.warn(
+          {
+            oldDsvId: snap.id,
+            existingDsvId: existing.id,
+            snapParentsIn: snap.parentsIn,
+            snapParentsRewritten,
+            existingParentsIn: existing.parentsIn,
+          },
+          "Reused DSV has different parentsIn than snapshot — snapshot state NOT restored on this DSV"
+        );
+      }
+
       oldToNewDsvId.set(snap.id, existing.id);
+      stats.reused++;
       continue;
     }
 
-    const parentsIn = mapParents(snap.parentsIn, rewrite);
+    const parents = diffParents(snap.parentsIn, rewrite);
+    stats.parentsRewritten += parents.changedCount;
 
     logger.info(
       {
         oldDsvId: snap.id,
         vaultId: snap.vaultId,
         kind: snap.kind,
-        parentsInSample: parentsIn?.slice(0, 3),
-        parentsInCount: parentsIn?.length ?? 0,
+        parentsInBefore: parents.before,
+        parentsInAfter: parents.after,
+        parentsInCount: parents.after?.length ?? 0,
+        parentsRewrittenCount: parents.changedCount,
+        editedByUserId: snap.editedByUserId,
+        editedAt: snap.editedAt,
+        createdAt: snap.createdAt,
+        updatedAt: snap.updatedAt,
+        deletedAt: snap.deletedAt,
         dryRun: !execute,
       },
       execute ? "Restoring DSV" : "[dry-run] Would restore DSV"
@@ -205,6 +274,7 @@ async function restoreDataSourceViews({
       // every referenced DSV has a mapping entry. Negative ids make it
       // obvious in logs that these are not real live ids.
       oldToNewDsvId.set(snap.id, -snap.id);
+      stats.inserted++;
       continue;
     }
 
@@ -217,7 +287,7 @@ async function restoreDataSourceViews({
         dataSourceId: newDs.id,
         vaultId: snap.vaultId,
         kind: snap.kind,
-        parentsIn,
+        parentsIn: parents.after,
         editedByUserId: snap.editedByUserId,
         editedAt: snap.editedAt,
         createdAt: snap.createdAt,
@@ -227,10 +297,21 @@ async function restoreDataSourceViews({
       { transaction, silent: true }
     );
 
+    logger.info(
+      {
+        oldDsvId: snap.id,
+        newDsvId: created.id,
+        vaultId: created.vaultId,
+        kind: created.kind,
+      },
+      "Restored DSV (inserted)"
+    );
+
     oldToNewDsvId.set(snap.id, created.id);
+    stats.inserted++;
   }
 
-  return oldToNewDsvId;
+  return { oldToNewDsvId, stats };
 }
 
 async function restoreAgentDataSourceConfigurations({
@@ -251,7 +332,7 @@ async function restoreAgentDataSourceConfigurations({
   oldToNewDsvId: Map<number, number>;
   rewrite: (s: string) => string;
   execute: boolean;
-}): Promise<void> {
+}): Promise<RestoreStats> {
   const rows = await snapshot.query<AgentDataSourceConfigurationModel>(
     `
     SELECT *
@@ -268,6 +349,9 @@ async function restoreAgentDataSourceConfigurations({
     }
   );
 
+  const stats = emptyStats();
+  stats.snapshotRowCount = rows.length;
+
   logger.info(
     { count: rows.length },
     "Found agent_data_source_configurations in snapshot"
@@ -283,9 +367,6 @@ async function restoreAgentDataSourceConfigurations({
       })
     ).map((m) => m.id)
   );
-
-  let inserted = 0;
-  let skippedOrphan = 0;
 
   for (const row of rows) {
     const newDsvId = oldToNewDsvId.get(row.dataSourceViewId);
@@ -306,21 +387,33 @@ async function restoreAgentDataSourceConfigurations({
         },
         "Skipping agent_data_source_configuration: parent MCP server config no longer exists"
       );
-      skippedOrphan++;
+      stats.skippedOrphan++;
       continue;
     }
 
-    const parentsIn = mapParents(row.parentsIn, rewrite);
-    const parentsNotIn = mapParents(row.parentsNotIn, rewrite);
+    const parentsIn = diffParents(row.parentsIn, rewrite);
+    const parentsNotIn = diffParents(row.parentsNotIn, rewrite);
+    stats.parentsRewritten +=
+      parentsIn.changedCount + parentsNotIn.changedCount;
 
     logger.info(
       {
         snapshotRowId: row.id,
         newDataSourceId: newDs.id,
+        oldDataSourceViewId: row.dataSourceViewId,
         newDataSourceViewId: newDsvId,
         mcpServerConfigurationId: row.mcpServerConfigurationId,
-        parentsInCount: parentsIn?.length ?? 0,
-        parentsNotInCount: parentsNotIn?.length ?? 0,
+        parentsInBefore: parentsIn.before,
+        parentsInAfter: parentsIn.after,
+        parentsInRewrittenCount: parentsIn.changedCount,
+        parentsNotInBefore: parentsNotIn.before,
+        parentsNotInAfter: parentsNotIn.after,
+        parentsNotInRewrittenCount: parentsNotIn.changedCount,
+        tagsMode: row.tagsMode,
+        tagsIn: row.tagsIn,
+        tagsNotIn: row.tagsNotIn,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
         dryRun: !execute,
       },
       execute
@@ -329,18 +422,18 @@ async function restoreAgentDataSourceConfigurations({
     );
 
     if (!execute) {
-      inserted++;
+      stats.inserted++;
       continue;
     }
 
-    await AgentDataSourceConfigurationModel.create(
+    const created = await AgentDataSourceConfigurationModel.create(
       {
         workspaceId: newDs.workspaceId,
         dataSourceId: newDs.id,
         dataSourceViewId: newDsvId,
         mcpServerConfigurationId: row.mcpServerConfigurationId,
-        parentsIn,
-        parentsNotIn,
+        parentsIn: parentsIn.after,
+        parentsNotIn: parentsNotIn.after,
         tagsMode: row.tagsMode,
         tagsIn: row.tagsIn,
         tagsNotIn: row.tagsNotIn,
@@ -349,13 +442,20 @@ async function restoreAgentDataSourceConfigurations({
       },
       { transaction, silent: true }
     );
-    inserted++;
+
+    logger.info(
+      {
+        snapshotRowId: row.id,
+        newRowId: created.id,
+        newDataSourceViewId: created.dataSourceViewId,
+      },
+      "Restored agent_data_source_configuration (inserted)"
+    );
+    stats.inserted++;
   }
 
-  logger.info(
-    { inserted, skippedOrphan },
-    "Done agent_data_source_configurations"
-  );
+  logger.info(stats, "Done agent_data_source_configurations");
+  return stats;
 }
 
 async function restoreAgentTablesQueryConfigurationTables({
@@ -374,7 +474,7 @@ async function restoreAgentTablesQueryConfigurationTables({
   newDs: DataSourceModel;
   oldToNewDsvId: Map<number, number>;
   execute: boolean;
-}): Promise<void> {
+}): Promise<RestoreStats> {
   // Intercom never produces tables. Included defensively; expected count: 0.
   const rows = await snapshot.query<AgentTablesQueryConfigurationTableModel>(
     `
@@ -392,13 +492,16 @@ async function restoreAgentTablesQueryConfigurationTables({
     }
   );
 
+  const stats = emptyStats();
+  stats.snapshotRowCount = rows.length;
+
   logger.info(
     { count: rows.length },
     "Found agent_tables_query_configuration_tables in snapshot (expected 0 for Intercom)"
   );
 
   if (rows.length === 0) {
-    return;
+    return stats;
   }
 
   const liveMcpIds = new Set(
@@ -420,24 +523,38 @@ async function restoreAgentTablesQueryConfigurationTables({
     }
     if (!liveMcpIds.has(row.mcpServerConfigurationId)) {
       logger.warn(
-        { snapshotRowId: row.id },
+        {
+          snapshotRowId: row.id,
+          mcpServerConfigurationId: row.mcpServerConfigurationId,
+        },
         "Skipping agent_tables_query_configuration_table: parent MCP server config no longer exists"
       );
+      stats.skippedOrphan++;
       continue;
     }
 
     logger.info(
-      { snapshotRowId: row.id, tableId: row.tableId, dryRun: !execute },
+      {
+        snapshotRowId: row.id,
+        tableId: row.tableId,
+        oldDataSourceViewId: row.dataSourceViewId,
+        newDataSourceViewId: newDsvId,
+        mcpServerConfigurationId: row.mcpServerConfigurationId,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        dryRun: !execute,
+      },
       execute
         ? "Restoring agent_tables_query_configuration_table"
         : "[dry-run] Would restore agent_tables_query_configuration_table"
     );
 
     if (!execute) {
+      stats.inserted++;
       continue;
     }
 
-    await AgentTablesQueryConfigurationTableModel.create(
+    const created = await AgentTablesQueryConfigurationTableModel.create(
       {
         workspaceId: newDs.workspaceId,
         dataSourceId: newDs.id,
@@ -449,7 +566,20 @@ async function restoreAgentTablesQueryConfigurationTables({
       },
       { transaction, silent: true }
     );
+
+    logger.info(
+      {
+        snapshotRowId: row.id,
+        newRowId: created.id,
+        tableId: created.tableId,
+      },
+      "Restored agent_tables_query_configuration_table (inserted)"
+    );
+    stats.inserted++;
   }
+
+  logger.info(stats, "Done agent_tables_query_configuration_tables");
+  return stats;
 }
 
 async function restoreSkillDataSourceConfigurations({
@@ -470,7 +600,7 @@ async function restoreSkillDataSourceConfigurations({
   oldToNewDsvId: Map<number, number>;
   rewrite: (s: string) => string;
   execute: boolean;
-}): Promise<void> {
+}): Promise<RestoreStats> {
   const rows = await snapshot.query<SkillDataSourceConfigurationModel>(
     `
     SELECT *
@@ -487,6 +617,9 @@ async function restoreSkillDataSourceConfigurations({
     }
   );
 
+  const stats = emptyStats();
+  stats.snapshotRowCount = rows.length;
+
   logger.info(
     { count: rows.length },
     "Found skill_data_source_configurations in snapshot"
@@ -501,9 +634,6 @@ async function restoreSkillDataSourceConfigurations({
       })
     ).map((s) => s.id)
   );
-
-  let inserted = 0;
-  let skippedOrphan = 0;
 
   for (const row of rows) {
     const newDsvId = oldToNewDsvId.get(row.dataSourceViewId);
@@ -520,18 +650,26 @@ async function restoreSkillDataSourceConfigurations({
         },
         "Skipping skill_data_source_configuration: skill_configuration no longer exists"
       );
-      skippedOrphan++;
+      stats.skippedOrphan++;
       continue;
     }
 
-    const parentsIn = row.parentsIn.map(rewrite);
+    // parentsIn on this model is non-nullable (required).
+    const parentsIn = diffParents(row.parentsIn, rewrite);
+    stats.parentsRewritten += parentsIn.changedCount;
 
     logger.info(
       {
         snapshotRowId: row.id,
         skillConfigurationId: row.skillConfigurationId,
+        oldDataSourceViewId: row.dataSourceViewId,
         newDataSourceViewId: newDsvId,
-        parentsInCount: parentsIn.length,
+        parentsInBefore: parentsIn.before,
+        parentsInAfter: parentsIn.after,
+        parentsInCount: parentsIn.after?.length ?? 0,
+        parentsRewrittenCount: parentsIn.changedCount,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
         dryRun: !execute,
       },
       execute
@@ -540,29 +678,37 @@ async function restoreSkillDataSourceConfigurations({
     );
 
     if (!execute) {
-      inserted++;
+      stats.inserted++;
       continue;
     }
 
-    await SkillDataSourceConfigurationModel.create(
+    const created = await SkillDataSourceConfigurationModel.create(
       {
         workspaceId: newDs.workspaceId,
         skillConfigurationId: row.skillConfigurationId,
         dataSourceId: newDs.id,
         dataSourceViewId: newDsvId,
-        parentsIn,
+        parentsIn: parentsIn.after ?? [],
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
       },
       { transaction, silent: true }
     );
-    inserted++;
+
+    logger.info(
+      {
+        snapshotRowId: row.id,
+        newRowId: created.id,
+        skillConfigurationId: created.skillConfigurationId,
+        newDataSourceViewId: created.dataSourceViewId,
+      },
+      "Restored skill_data_source_configuration (inserted)"
+    );
+    stats.inserted++;
   }
 
-  logger.info(
-    { inserted, skippedOrphan },
-    "Done skill_data_source_configurations"
-  );
+  logger.info(stats, "Done skill_data_source_configurations");
+  return stats;
 }
 
 makeScript(
@@ -672,17 +818,28 @@ makeScript(
       // the --execute flag (no throw-to-rollback dance).
       const transaction = await frontSequelize.transaction();
       try {
-        const oldToNewDsvId = await restoreDataSourceViews({
-          snapshot,
-          transaction,
-          logger,
-          oldDs,
-          newDs,
-          rewrite,
-          execute,
-        });
+        const { oldToNewDsvId, stats: dsvStats } = await restoreDataSourceViews(
+          {
+            snapshot,
+            transaction,
+            logger,
+            oldDs,
+            newDs,
+            rewrite,
+            execute,
+          }
+        );
 
-        await restoreAgentDataSourceConfigurations({
+        logger.info(
+          {
+            dsvMapping: Array.from(oldToNewDsvId.entries()).map(
+              ([oldId, newId]) => ({ oldDsvId: oldId, newDsvId: newId })
+            ),
+          },
+          "DSV old→new id mapping"
+        );
+
+        const agentConfigStats = await restoreAgentDataSourceConfigurations({
           snapshot,
           transaction,
           logger,
@@ -693,7 +850,7 @@ makeScript(
           execute,
         });
 
-        await restoreAgentTablesQueryConfigurationTables({
+        const tablesStats = await restoreAgentTablesQueryConfigurationTables({
           snapshot,
           transaction,
           logger,
@@ -703,7 +860,7 @@ makeScript(
           execute,
         });
 
-        await restoreSkillDataSourceConfigurations({
+        const skillStats = await restoreSkillDataSourceConfigurations({
           snapshot,
           transaction,
           logger,
@@ -718,12 +875,25 @@ makeScript(
           "Skipping content_fragment restore (single stale row, not worth the risk)."
         );
 
+        logger.info(
+          {
+            execute,
+            dataSourceViews: dsvStats,
+            agentDataSourceConfigurations: agentConfigStats,
+            agentTablesQueryConfigurationTables: tablesStats,
+            skillDataSourceConfigurations: skillStats,
+          },
+          "=== Reconciliation summary ==="
+        );
+
         if (execute) {
           await transaction.commit();
-          logger.info("Reconciliation complete.");
+          logger.info("Reconciliation complete — transaction committed.");
         } else {
           await transaction.rollback();
-          logger.info("Dry-run complete. Re-run with --execute to commit.");
+          logger.info(
+            "Dry-run complete — transaction rolled back. Re-run with --execute to commit."
+          );
         }
       } catch (err) {
         await transaction.rollback();

--- a/front/migrations/20260423_restore_intercom_data_source.ts
+++ b/front/migrations/20260423_restore_intercom_data_source.ts
@@ -1,0 +1,796 @@
+// Reconcile a workspace's Intercom data source that was accidentally deleted
+// and re-created. The deletion cascaded (via app-level cleanup) through all
+// FK-attached configuration rows. The user re-created the connector, so we
+// now have a new DataSource (new id, new connectorId) and we restore the
+// FK-attached rows from a pre-incident snapshot, rewriting Intercom parent
+// strings that embed the old connectorId.
+//
+// Content fragments are intentionally NOT restored. Post-incident check found
+// only 1 content_fragment row referenced a DSV of the lost Intercom data
+// source; the fragment itself still exists, only the nodeDataSourceViewId
+// pointer was nulled by the cascade. Not worth the restore complexity.
+
+import type { Transaction } from "sequelize";
+import { QueryTypes, Sequelize } from "sequelize";
+
+import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
+import {
+  SkillConfigurationModel,
+  SkillDataSourceConfigurationModel,
+} from "@app/lib/models/skill";
+import type { Logger } from "@app/logger/logger";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { makeScript } from "@app/scripts/helpers";
+import type { DataSourceViewKind } from "@app/types/data_source_view";
+import { EnvironmentConfig } from "@app/types/shared/utils/config";
+
+class DryRunRollback extends Error {
+  constructor() {
+    super("dry-run rollback");
+    this.name = "DryRunRollback";
+  }
+}
+
+type DataSourceRow = {
+  id: number;
+  name: string;
+  workspaceId: number;
+  vaultId: number;
+  connectorId: string | null;
+  connectorProvider: string | null;
+  dustAPIDataSourceId: string;
+};
+
+type DataSourceViewRow = {
+  id: number;
+  workspaceId: number;
+  dataSourceId: number;
+  vaultId: number;
+  kind: DataSourceViewKind;
+  parentsIn: string[] | null;
+  editedByUserId: number | null;
+  editedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+};
+
+type AgentDataSourceConfigurationRow = {
+  id: number;
+  workspaceId: number;
+  dataSourceId: number;
+  dataSourceViewId: number;
+  mcpServerConfigurationId: number | null;
+  parentsIn: string[] | null;
+  parentsNotIn: string[] | null;
+  tagsMode: "custom" | "auto" | null;
+  tagsIn: string[] | null;
+  tagsNotIn: string[] | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type AgentTablesQueryTableRow = {
+  id: number;
+  workspaceId: number;
+  dataSourceViewId: number;
+  mcpServerConfigurationId: number;
+  tableId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type SkillDataSourceConfigurationRow = {
+  id: number;
+  workspaceId: number;
+  skillConfigurationId: number;
+  dataSourceId: number;
+  dataSourceViewId: number;
+  parentsIn: string[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function buildIntercomParentRewriter(
+  oldConnectorId: string,
+  newConnectorId: string
+): (s: string) => string {
+  // Longest alternatives first so `team` doesn't eat `teams`.
+  const kind = "(teams|team|help-center|collection|article|conversation)";
+  const re = new RegExp(
+    `^intercom-${kind}-${oldConnectorId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(-|$)`
+  );
+  return (s: string) =>
+    s.replace(
+      re,
+      (_match, k: string, tail: string) =>
+        `intercom-${k}-${newConnectorId}${tail}`
+    );
+}
+
+function mapParents(
+  parents: string[] | null,
+  rewrite: (s: string) => string
+): string[] | null {
+  if (parents === null) {
+    return null;
+  }
+  return parents.map(rewrite);
+}
+
+async function resolveDataSource({
+  sequelize,
+  workspaceModelId,
+  name,
+  label,
+}: {
+  sequelize: Sequelize;
+  workspaceModelId: number;
+  name: string;
+  label: string;
+}): Promise<DataSourceRow> {
+  const rows = await sequelize.query<DataSourceRow>(
+    `
+    SELECT
+      id,
+      name,
+      "workspaceId",
+      "vaultId",
+      "connectorId",
+      "connectorProvider",
+      "dustAPIDataSourceId"
+    FROM data_sources
+    WHERE "workspaceId" = :workspaceModelId
+      AND name = :name
+      AND "deletedAt" IS NULL
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { workspaceModelId, name },
+    }
+  );
+  if (rows.length !== 1) {
+    throw new Error(
+      `Expected 1 ${label} data source (workspaceModelId=${workspaceModelId}, name=${name}), got ${rows.length}.`
+    );
+  }
+  return rows[0];
+}
+
+async function resolveWorkspaceModelId(
+  sequelize: Sequelize,
+  workspaceId: string
+): Promise<number> {
+  const rows = await sequelize.query<{ id: number }>(
+    `SELECT id FROM workspaces WHERE "sId" = :sId`,
+    { type: QueryTypes.SELECT, replacements: { sId: workspaceId } }
+  );
+  if (rows.length !== 1) {
+    throw new Error(
+      `Workspace not found (sId=${workspaceId}) in one of the databases`
+    );
+  }
+  return rows[0].id;
+}
+
+async function restoreDataSourceViews({
+  snapshot,
+  transaction,
+  logger,
+  oldDs,
+  newDs,
+  rewrite,
+  execute,
+}: {
+  snapshot: Sequelize;
+  transaction: Transaction;
+  logger: Logger;
+  oldDs: DataSourceRow;
+  newDs: DataSourceRow;
+  rewrite: (s: string) => string;
+  execute: boolean;
+}): Promise<Map<number, number>> {
+  const snapshotDsvs = await snapshot.query<DataSourceViewRow>(
+    `
+    SELECT
+      id, "workspaceId", "dataSourceId", "vaultId", kind, "parentsIn",
+      "editedByUserId", "editedAt", "createdAt", "updatedAt", "deletedAt"
+    FROM data_source_views
+    WHERE "dataSourceId" = :oldDsId
+      AND "workspaceId" = :workspaceModelId
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { oldDsId: oldDs.id, workspaceModelId: oldDs.workspaceId },
+    }
+  );
+
+  logger.info(
+    { count: snapshotDsvs.length },
+    "Found data_source_views in snapshot"
+  );
+
+  const oldToNewDsvId = new Map<number, number>();
+
+  for (const snap of snapshotDsvs) {
+    // Preserve snap.vaultId so DSVs that lived in other spaces (the data
+    // source was shared into those spaces) get restored in place. Only the
+    // auto-created default DSV in the DS's home space collides with a
+    // snapshot row.
+    const existing = await DataSourceViewModel.findOne({
+      where: {
+        workspaceId: newDs.workspaceId,
+        dataSourceId: newDs.id,
+        vaultId: snap.vaultId,
+        deletedAt: null,
+      },
+      paranoid: false,
+      transaction,
+    });
+
+    if (existing && existing.kind === snap.kind) {
+      logger.info(
+        {
+          oldDsvId: snap.id,
+          existingDsvId: existing.id,
+          vaultId: snap.vaultId,
+          kind: snap.kind,
+        },
+        "Reusing existing live DSV (auto-created on re-creation of the data source)"
+      );
+      oldToNewDsvId.set(snap.id, existing.id);
+      continue;
+    }
+
+    const parentsIn = mapParents(snap.parentsIn, rewrite);
+
+    logger.info(
+      {
+        oldDsvId: snap.id,
+        vaultId: snap.vaultId,
+        kind: snap.kind,
+        parentsInSample: parentsIn?.slice(0, 3),
+        parentsInCount: parentsIn?.length ?? 0,
+        dryRun: !execute,
+      },
+      execute ? "Restoring DSV" : "[dry-run] Would restore DSV"
+    );
+
+    if (!execute) {
+      // Placeholder mapping so downstream dry-run steps can validate that
+      // every referenced DSV has a mapping entry. Negative ids make it
+      // obvious in logs that these are not real live ids.
+      oldToNewDsvId.set(snap.id, -snap.id);
+      continue;
+    }
+
+    const created = await DataSourceViewModel.create(
+      {
+        workspaceId: newDs.workspaceId,
+        dataSourceId: newDs.id,
+        vaultId: snap.vaultId,
+        kind: snap.kind,
+        parentsIn,
+        editedByUserId: snap.editedByUserId,
+        editedAt: snap.editedAt,
+        createdAt: snap.createdAt,
+        updatedAt: snap.updatedAt,
+        deletedAt: snap.deletedAt,
+      },
+      { transaction, silent: true }
+    );
+
+    oldToNewDsvId.set(snap.id, created.id);
+  }
+
+  return oldToNewDsvId;
+}
+
+async function restoreAgentDataSourceConfigurations({
+  snapshot,
+  transaction,
+  logger,
+  oldDs,
+  newDs,
+  oldToNewDsvId,
+  rewrite,
+  execute,
+}: {
+  snapshot: Sequelize;
+  transaction: Transaction;
+  logger: Logger;
+  oldDs: DataSourceRow;
+  newDs: DataSourceRow;
+  oldToNewDsvId: Map<number, number>;
+  rewrite: (s: string) => string;
+  execute: boolean;
+}): Promise<void> {
+  const rows = await snapshot.query<AgentDataSourceConfigurationRow>(
+    `
+    SELECT
+      id, "workspaceId", "dataSourceId", "dataSourceViewId",
+      "mcpServerConfigurationId", "parentsIn", "parentsNotIn",
+      "tagsMode", "tagsIn", "tagsNotIn", "createdAt", "updatedAt"
+    FROM agent_data_source_configurations
+    WHERE "dataSourceId" = :oldDsId
+      AND "workspaceId" = :workspaceModelId
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { oldDsId: oldDs.id, workspaceModelId: oldDs.workspaceId },
+    }
+  );
+
+  logger.info(
+    { count: rows.length },
+    "Found agent_data_source_configurations in snapshot"
+  );
+
+  // Pre-fetch all valid mcpServerConfigurationIds in the live DB (workspace-scoped).
+  const liveMcpIds = new Set(
+    (
+      await AgentMCPServerConfigurationModel.findAll({
+        where: { workspaceId: newDs.workspaceId },
+        attributes: ["id"],
+        transaction,
+      })
+    ).map((m) => m.id)
+  );
+
+  let inserted = 0;
+  let skippedOrphan = 0;
+
+  for (const row of rows) {
+    const newDsvId = oldToNewDsvId.get(row.dataSourceViewId);
+    if (newDsvId === undefined) {
+      throw new Error(
+        `agent_data_source_configuration ${row.id} references DSV ${row.dataSourceViewId} which has no mapping — DSV restore step missed it.`
+      );
+    }
+
+    if (
+      row.mcpServerConfigurationId !== null &&
+      !liveMcpIds.has(row.mcpServerConfigurationId)
+    ) {
+      logger.warn(
+        {
+          snapshotRowId: row.id,
+          mcpServerConfigurationId: row.mcpServerConfigurationId,
+        },
+        "Skipping agent_data_source_configuration: parent MCP server config no longer exists"
+      );
+      skippedOrphan++;
+      continue;
+    }
+
+    const parentsIn = mapParents(row.parentsIn, rewrite);
+    const parentsNotIn = mapParents(row.parentsNotIn, rewrite);
+
+    logger.info(
+      {
+        snapshotRowId: row.id,
+        newDataSourceId: newDs.id,
+        newDataSourceViewId: newDsvId,
+        mcpServerConfigurationId: row.mcpServerConfigurationId,
+        parentsInCount: parentsIn?.length ?? 0,
+        parentsNotInCount: parentsNotIn?.length ?? 0,
+        dryRun: !execute,
+      },
+      execute
+        ? "Restoring agent_data_source_configuration"
+        : "[dry-run] Would restore agent_data_source_configuration"
+    );
+
+    if (!execute) {
+      inserted++;
+      continue;
+    }
+
+    await AgentDataSourceConfigurationModel.create(
+      {
+        workspaceId: newDs.workspaceId,
+        dataSourceId: newDs.id,
+        dataSourceViewId: newDsvId,
+        mcpServerConfigurationId: row.mcpServerConfigurationId,
+        parentsIn,
+        parentsNotIn,
+        tagsMode: row.tagsMode,
+        tagsIn: row.tagsIn,
+        tagsNotIn: row.tagsNotIn,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      },
+      { transaction, silent: true }
+    );
+    inserted++;
+  }
+
+  logger.info(
+    { inserted, skippedOrphan },
+    "Done agent_data_source_configurations"
+  );
+}
+
+async function restoreAgentTablesQueryConfigurationTables({
+  snapshot,
+  transaction,
+  logger,
+  oldDs,
+  newDs,
+  oldToNewDsvId,
+  execute,
+}: {
+  snapshot: Sequelize;
+  transaction: Transaction;
+  logger: Logger;
+  oldDs: DataSourceRow;
+  newDs: DataSourceRow;
+  oldToNewDsvId: Map<number, number>;
+  execute: boolean;
+}): Promise<void> {
+  // Intercom never produces tables. Included defensively; expected count: 0.
+  const rows = await snapshot.query<AgentTablesQueryTableRow>(
+    `
+    SELECT
+      id, "workspaceId", "dataSourceViewId",
+      "mcpServerConfigurationId", "tableId", "createdAt", "updatedAt"
+    FROM agent_tables_query_configuration_tables
+    WHERE "dataSourceId" = :oldDsId
+      AND "workspaceId" = :workspaceModelId
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { oldDsId: oldDs.id, workspaceModelId: oldDs.workspaceId },
+    }
+  );
+
+  logger.info(
+    { count: rows.length },
+    "Found agent_tables_query_configuration_tables in snapshot (expected 0 for Intercom)"
+  );
+
+  if (rows.length === 0) {
+    return;
+  }
+
+  const liveMcpIds = new Set(
+    (
+      await AgentMCPServerConfigurationModel.findAll({
+        where: { workspaceId: newDs.workspaceId },
+        attributes: ["id"],
+        transaction,
+      })
+    ).map((m) => m.id)
+  );
+
+  for (const row of rows) {
+    const newDsvId = oldToNewDsvId.get(row.dataSourceViewId);
+    if (newDsvId === undefined) {
+      throw new Error(
+        `agent_tables_query_configuration_table ${row.id} references DSV ${row.dataSourceViewId} which has no mapping.`
+      );
+    }
+    if (!liveMcpIds.has(row.mcpServerConfigurationId)) {
+      logger.warn(
+        { snapshotRowId: row.id },
+        "Skipping agent_tables_query_configuration_table: parent MCP server config no longer exists"
+      );
+      continue;
+    }
+
+    logger.info(
+      { snapshotRowId: row.id, tableId: row.tableId, dryRun: !execute },
+      execute
+        ? "Restoring agent_tables_query_configuration_table"
+        : "[dry-run] Would restore agent_tables_query_configuration_table"
+    );
+
+    if (!execute) {
+      continue;
+    }
+
+    await AgentTablesQueryConfigurationTableModel.create(
+      {
+        workspaceId: newDs.workspaceId,
+        dataSourceId: newDs.id,
+        dataSourceViewId: newDsvId,
+        mcpServerConfigurationId: row.mcpServerConfigurationId,
+        tableId: row.tableId,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      },
+      { transaction, silent: true }
+    );
+  }
+}
+
+async function restoreSkillDataSourceConfigurations({
+  snapshot,
+  transaction,
+  logger,
+  oldDs,
+  newDs,
+  oldToNewDsvId,
+  rewrite,
+  execute,
+}: {
+  snapshot: Sequelize;
+  transaction: Transaction;
+  logger: Logger;
+  oldDs: DataSourceRow;
+  newDs: DataSourceRow;
+  oldToNewDsvId: Map<number, number>;
+  rewrite: (s: string) => string;
+  execute: boolean;
+}): Promise<void> {
+  const rows = await snapshot.query<SkillDataSourceConfigurationRow>(
+    `
+    SELECT
+      id, "workspaceId", "skillConfigurationId", "dataSourceId",
+      "dataSourceViewId", "parentsIn", "createdAt", "updatedAt"
+    FROM skill_data_source_configurations
+    WHERE "dataSourceId" = :oldDsId
+      AND "workspaceId" = :workspaceModelId
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { oldDsId: oldDs.id, workspaceModelId: oldDs.workspaceId },
+    }
+  );
+
+  logger.info(
+    { count: rows.length },
+    "Found skill_data_source_configurations in snapshot"
+  );
+
+  const liveSkillIds = new Set(
+    (
+      await SkillConfigurationModel.findAll({
+        where: { workspaceId: newDs.workspaceId },
+        attributes: ["id"],
+        transaction,
+      })
+    ).map((s) => s.id)
+  );
+
+  let inserted = 0;
+  let skippedOrphan = 0;
+
+  for (const row of rows) {
+    const newDsvId = oldToNewDsvId.get(row.dataSourceViewId);
+    if (newDsvId === undefined) {
+      throw new Error(
+        `skill_data_source_configuration ${row.id} references DSV ${row.dataSourceViewId} which has no mapping.`
+      );
+    }
+    if (!liveSkillIds.has(row.skillConfigurationId)) {
+      logger.warn(
+        {
+          snapshotRowId: row.id,
+          skillConfigurationId: row.skillConfigurationId,
+        },
+        "Skipping skill_data_source_configuration: skill_configuration no longer exists"
+      );
+      skippedOrphan++;
+      continue;
+    }
+
+    const parentsIn = row.parentsIn.map(rewrite);
+
+    logger.info(
+      {
+        snapshotRowId: row.id,
+        skillConfigurationId: row.skillConfigurationId,
+        newDataSourceViewId: newDsvId,
+        parentsInCount: parentsIn.length,
+        dryRun: !execute,
+      },
+      execute
+        ? "Restoring skill_data_source_configuration"
+        : "[dry-run] Would restore skill_data_source_configuration"
+    );
+
+    if (!execute) {
+      inserted++;
+      continue;
+    }
+
+    await SkillDataSourceConfigurationModel.create(
+      {
+        workspaceId: newDs.workspaceId,
+        skillConfigurationId: row.skillConfigurationId,
+        dataSourceId: newDs.id,
+        dataSourceViewId: newDsvId,
+        parentsIn,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+      },
+      { transaction, silent: true }
+    );
+    inserted++;
+  }
+
+  logger.info(
+    { inserted, skippedOrphan },
+    "Done skill_data_source_configurations"
+  );
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      demandOption: true,
+      describe: "Workspace sId",
+    },
+    oldDataSourceName: {
+      type: "string",
+      demandOption: true,
+      describe: "Name of the deleted Intercom data source (in snapshot)",
+    },
+    newDataSourceName: {
+      type: "string",
+      demandOption: true,
+      describe: "Name of the re-created Intercom data source (in current DB)",
+    },
+  },
+  async (
+    { workspaceId, oldDataSourceName, newDataSourceName, execute },
+    logger
+  ) => {
+    const snapshot = new Sequelize(
+      EnvironmentConfig.getEnvVariable("FRONT_SNAPSHOT_URI"),
+      { logging: false }
+    );
+
+    try {
+      const liveWorkspaceModelId = await resolveWorkspaceModelId(
+        frontSequelize,
+        workspaceId
+      );
+      const snapshotWorkspaceModelId = await resolveWorkspaceModelId(
+        snapshot,
+        workspaceId
+      );
+      if (liveWorkspaceModelId !== snapshotWorkspaceModelId) {
+        throw new Error(
+          `Workspace ModelId mismatch between live (${liveWorkspaceModelId}) and snapshot (${snapshotWorkspaceModelId}). Aborting — cross-DB lookups by workspaceId won't be safe.`
+        );
+      }
+      const workspaceModelId = liveWorkspaceModelId;
+
+      const oldDs = await resolveDataSource({
+        sequelize: snapshot,
+        workspaceModelId,
+        name: oldDataSourceName,
+        label: "old (snapshot)",
+      });
+      const newDs = await resolveDataSource({
+        sequelize: frontSequelize,
+        workspaceModelId,
+        name: newDataSourceName,
+        label: "new (live)",
+      });
+
+      if (oldDs.connectorProvider !== "intercom") {
+        throw new Error(
+          `Old DS connectorProvider is ${oldDs.connectorProvider}, expected intercom`
+        );
+      }
+      if (newDs.connectorProvider !== "intercom") {
+        throw new Error(
+          `New DS connectorProvider is ${newDs.connectorProvider}, expected intercom`
+        );
+      }
+      if (!oldDs.connectorId || !newDs.connectorId) {
+        throw new Error("Both data sources must have a connectorId");
+      }
+      if (oldDs.connectorId === newDs.connectorId) {
+        throw new Error(
+          `connectorIds must differ, got ${oldDs.connectorId} for both`
+        );
+      }
+
+      logger.info(
+        {
+          workspaceId,
+          workspaceModelId,
+          oldDsId: oldDs.id,
+          newDsId: newDs.id,
+          oldConnectorId: oldDs.connectorId,
+          newConnectorId: newDs.connectorId,
+          oldDustAPIDataSourceId: oldDs.dustAPIDataSourceId,
+          newDustAPIDataSourceId: newDs.dustAPIDataSourceId,
+        },
+        "Resolved data sources"
+      );
+
+      const rewrite = buildIntercomParentRewriter(
+        oldDs.connectorId,
+        newDs.connectorId
+      );
+
+      // Sanity check: rewrite a known sample.
+      const sample = `intercom-help-center-${oldDs.connectorId}-abc`;
+      const rewritten = rewrite(sample);
+      logger.info({ sample, rewritten }, "Parent rewrite sanity check");
+      if (rewritten === sample) {
+        throw new Error(
+          "Parent rewriter failed sanity check — connectorId regex escape broken?"
+        );
+      }
+
+      try {
+        await frontSequelize.transaction(async (transaction) => {
+          const oldToNewDsvId = await restoreDataSourceViews({
+            snapshot,
+            transaction,
+            logger,
+            oldDs,
+            newDs,
+            rewrite,
+            execute,
+          });
+
+          await restoreAgentDataSourceConfigurations({
+            snapshot,
+            transaction,
+            logger,
+            oldDs,
+            newDs,
+            oldToNewDsvId,
+            rewrite,
+            execute,
+          });
+
+          await restoreAgentTablesQueryConfigurationTables({
+            snapshot,
+            transaction,
+            logger,
+            oldDs,
+            newDs,
+            oldToNewDsvId,
+            execute,
+          });
+
+          await restoreSkillDataSourceConfigurations({
+            snapshot,
+            transaction,
+            logger,
+            oldDs,
+            newDs,
+            oldToNewDsvId,
+            rewrite,
+            execute,
+          });
+
+          logger.info(
+            "Skipping content_fragment restore (single stale row, not worth the risk)."
+          );
+
+          if (!execute) {
+            logger.info("Dry-run complete, rolling back transaction.");
+            // Force rollback by throwing a sentinel.
+            throw new DryRunRollback();
+          }
+        });
+      } catch (err) {
+        if (!(err instanceof DryRunRollback)) {
+          throw err;
+        }
+      }
+
+      logger.info(
+        { execute },
+        execute
+          ? "Reconciliation complete."
+          : "Dry-run complete. Re-run with --execute to commit."
+      );
+    } finally {
+      await snapshot.close();
+    }
+  }
+);

--- a/front/migrations/20260423_restore_intercom_data_source.ts
+++ b/front/migrations/20260423_restore_intercom_data_source.ts
@@ -22,93 +22,43 @@ import {
 } from "@app/lib/models/skill";
 import type { Logger } from "@app/logger/logger";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { makeScript } from "@app/scripts/helpers";
-import type { DataSourceViewKind } from "@app/types/data_source_view";
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
 
-class DryRunRollback extends Error {
-  constructor() {
-    super("dry-run rollback");
-    this.name = "DryRunRollback";
-  }
-}
-
-type DataSourceRow = {
-  id: number;
-  name: string;
-  workspaceId: number;
-  vaultId: number;
-  connectorId: string | null;
-  connectorProvider: string | null;
-  dustAPIDataSourceId: string;
-};
-
-type DataSourceViewRow = {
-  id: number;
-  workspaceId: number;
-  dataSourceId: number;
-  vaultId: number;
-  kind: DataSourceViewKind;
-  parentsIn: string[] | null;
-  editedByUserId: number | null;
-  editedAt: Date;
-  createdAt: Date;
-  updatedAt: Date;
-  deletedAt: Date | null;
-};
-
-type AgentDataSourceConfigurationRow = {
-  id: number;
-  workspaceId: number;
-  dataSourceId: number;
-  dataSourceViewId: number;
-  mcpServerConfigurationId: number | null;
-  parentsIn: string[] | null;
-  parentsNotIn: string[] | null;
-  tagsMode: "custom" | "auto" | null;
-  tagsIn: string[] | null;
-  tagsNotIn: string[] | null;
-  createdAt: Date;
-  updatedAt: Date;
-};
-
-type AgentTablesQueryTableRow = {
-  id: number;
-  workspaceId: number;
-  dataSourceViewId: number;
-  mcpServerConfigurationId: number;
-  tableId: string;
-  createdAt: Date;
-  updatedAt: Date;
-};
-
-type SkillDataSourceConfigurationRow = {
-  id: number;
-  workspaceId: number;
-  skillConfigurationId: number;
-  dataSourceId: number;
-  dataSourceViewId: number;
-  parentsIn: string[];
-  createdAt: Date;
-  updatedAt: Date;
-};
+// Every Intercom content node is identified by `intercom-<kind>-<connectorId>`
+// optionally followed by `-<resourceId>`. See
+// connectors/src/connectors/intercom/lib/utils.ts.
+const INTERCOM_KIND_PREFIXES = [
+  "intercom-help-center-",
+  "intercom-collection-",
+  "intercom-article-",
+  "intercom-teams-", // all-teams folder, no trailing resource id
+  "intercom-team-",
+  "intercom-conversation-",
+] as const;
 
 function buildIntercomParentRewriter(
   oldConnectorId: string,
   newConnectorId: string
 ): (s: string) => string {
-  // Longest alternatives first so `team` doesn't eat `teams`.
-  const kind = "(teams|team|help-center|collection|article|conversation)";
-  const re = new RegExp(
-    `^intercom-${kind}-${oldConnectorId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(-|$)`
-  );
-  return (s: string) =>
-    s.replace(
-      re,
-      (_match, k: string, tail: string) =>
-        `intercom-${k}-${newConnectorId}${tail}`
-    );
+  return (s) => {
+    const prefix = INTERCOM_KIND_PREFIXES.find((p) => s.startsWith(p));
+    if (!prefix) {
+      return s;
+    }
+    const afterPrefix = s.slice(prefix.length);
+    // Two shapes: `<connectorId>` alone (e.g. intercom-teams-123)
+    // or `<connectorId>-<resourceId...>`.
+    if (afterPrefix === oldConnectorId) {
+      return prefix + newConnectorId;
+    }
+    if (afterPrefix.startsWith(`${oldConnectorId}-`)) {
+      return prefix + newConnectorId + afterPrefix.slice(oldConnectorId.length);
+    }
+    return s;
+  };
 }
 
 function mapParents(
@@ -124,37 +74,29 @@ function mapParents(
 async function resolveDataSource({
   sequelize,
   workspaceModelId,
-  name,
+  dataSourceModelId,
   label,
 }: {
   sequelize: Sequelize;
   workspaceModelId: number;
-  name: string;
+  dataSourceModelId: number;
   label: string;
-}): Promise<DataSourceRow> {
-  const rows = await sequelize.query<DataSourceRow>(
+}): Promise<DataSourceModel> {
+  const rows = await sequelize.query<DataSourceModel>(
     `
-    SELECT
-      id,
-      name,
-      "workspaceId",
-      "vaultId",
-      "connectorId",
-      "connectorProvider",
-      "dustAPIDataSourceId"
+    SELECT *
     FROM data_sources
-    WHERE "workspaceId" = :workspaceModelId
-      AND name = :name
-      AND "deletedAt" IS NULL
+    WHERE id = :dataSourceModelId
+      AND "workspaceId" = :workspaceModelId
     `,
     {
       type: QueryTypes.SELECT,
-      replacements: { workspaceModelId, name },
+      replacements: { dataSourceModelId, workspaceModelId },
     }
   );
   if (rows.length !== 1) {
     throw new Error(
-      `Expected 1 ${label} data source (workspaceModelId=${workspaceModelId}, name=${name}), got ${rows.length}.`
+      `Expected 1 ${label} data source (id=${dataSourceModelId}, workspaceModelId=${workspaceModelId}), got ${rows.length}.`
     );
   }
   return rows[0];
@@ -188,23 +130,24 @@ async function restoreDataSourceViews({
   snapshot: Sequelize;
   transaction: Transaction;
   logger: Logger;
-  oldDs: DataSourceRow;
-  newDs: DataSourceRow;
+  oldDs: DataSourceModel;
+  newDs: DataSourceModel;
   rewrite: (s: string) => string;
   execute: boolean;
 }): Promise<Map<number, number>> {
-  const snapshotDsvs = await snapshot.query<DataSourceViewRow>(
+  const snapshotDsvs = await snapshot.query<DataSourceViewModel>(
     `
-    SELECT
-      id, "workspaceId", "dataSourceId", "vaultId", kind, "parentsIn",
-      "editedByUserId", "editedAt", "createdAt", "updatedAt", "deletedAt"
+    SELECT *
     FROM data_source_views
-    WHERE "dataSourceId" = :oldDsId
+    WHERE "dataSourceId" = :oldDataSourceModelId
       AND "workspaceId" = :workspaceModelId
     `,
     {
       type: QueryTypes.SELECT,
-      replacements: { oldDsId: oldDs.id, workspaceModelId: oldDs.workspaceId },
+      replacements: {
+        oldDataSourceModelId: oldDs.id,
+        workspaceModelId: oldDs.workspaceId,
+      },
     }
   );
 
@@ -225,9 +168,7 @@ async function restoreDataSourceViews({
         workspaceId: newDs.workspaceId,
         dataSourceId: newDs.id,
         vaultId: snap.vaultId,
-        deletedAt: null,
       },
-      paranoid: false,
       transaction,
     });
 
@@ -267,6 +208,9 @@ async function restoreDataSourceViews({
       continue;
     }
 
+    // `silent: true` prevents Sequelize from overwriting our explicit
+    // `updatedAt` with `new Date()` — we want to preserve the snapshot's
+    // timestamps on restored rows.
     const created = await DataSourceViewModel.create(
       {
         workspaceId: newDs.workspaceId,
@@ -302,25 +246,25 @@ async function restoreAgentDataSourceConfigurations({
   snapshot: Sequelize;
   transaction: Transaction;
   logger: Logger;
-  oldDs: DataSourceRow;
-  newDs: DataSourceRow;
+  oldDs: DataSourceModel;
+  newDs: DataSourceModel;
   oldToNewDsvId: Map<number, number>;
   rewrite: (s: string) => string;
   execute: boolean;
 }): Promise<void> {
-  const rows = await snapshot.query<AgentDataSourceConfigurationRow>(
+  const rows = await snapshot.query<AgentDataSourceConfigurationModel>(
     `
-    SELECT
-      id, "workspaceId", "dataSourceId", "dataSourceViewId",
-      "mcpServerConfigurationId", "parentsIn", "parentsNotIn",
-      "tagsMode", "tagsIn", "tagsNotIn", "createdAt", "updatedAt"
+    SELECT *
     FROM agent_data_source_configurations
-    WHERE "dataSourceId" = :oldDsId
+    WHERE "dataSourceId" = :oldDataSourceModelId
       AND "workspaceId" = :workspaceModelId
     `,
     {
       type: QueryTypes.SELECT,
-      replacements: { oldDsId: oldDs.id, workspaceModelId: oldDs.workspaceId },
+      replacements: {
+        oldDataSourceModelId: oldDs.id,
+        workspaceModelId: oldDs.workspaceId,
+      },
     }
   );
 
@@ -426,24 +370,25 @@ async function restoreAgentTablesQueryConfigurationTables({
   snapshot: Sequelize;
   transaction: Transaction;
   logger: Logger;
-  oldDs: DataSourceRow;
-  newDs: DataSourceRow;
+  oldDs: DataSourceModel;
+  newDs: DataSourceModel;
   oldToNewDsvId: Map<number, number>;
   execute: boolean;
 }): Promise<void> {
   // Intercom never produces tables. Included defensively; expected count: 0.
-  const rows = await snapshot.query<AgentTablesQueryTableRow>(
+  const rows = await snapshot.query<AgentTablesQueryConfigurationTableModel>(
     `
-    SELECT
-      id, "workspaceId", "dataSourceViewId",
-      "mcpServerConfigurationId", "tableId", "createdAt", "updatedAt"
+    SELECT *
     FROM agent_tables_query_configuration_tables
-    WHERE "dataSourceId" = :oldDsId
+    WHERE "dataSourceId" = :oldDataSourceModelId
       AND "workspaceId" = :workspaceModelId
     `,
     {
       type: QueryTypes.SELECT,
-      replacements: { oldDsId: oldDs.id, workspaceModelId: oldDs.workspaceId },
+      replacements: {
+        oldDataSourceModelId: oldDs.id,
+        workspaceModelId: oldDs.workspaceId,
+      },
     }
   );
 
@@ -520,24 +465,25 @@ async function restoreSkillDataSourceConfigurations({
   snapshot: Sequelize;
   transaction: Transaction;
   logger: Logger;
-  oldDs: DataSourceRow;
-  newDs: DataSourceRow;
+  oldDs: DataSourceModel;
+  newDs: DataSourceModel;
   oldToNewDsvId: Map<number, number>;
   rewrite: (s: string) => string;
   execute: boolean;
 }): Promise<void> {
-  const rows = await snapshot.query<SkillDataSourceConfigurationRow>(
+  const rows = await snapshot.query<SkillDataSourceConfigurationModel>(
     `
-    SELECT
-      id, "workspaceId", "skillConfigurationId", "dataSourceId",
-      "dataSourceViewId", "parentsIn", "createdAt", "updatedAt"
+    SELECT *
     FROM skill_data_source_configurations
-    WHERE "dataSourceId" = :oldDsId
+    WHERE "dataSourceId" = :oldDataSourceModelId
       AND "workspaceId" = :workspaceModelId
     `,
     {
       type: QueryTypes.SELECT,
-      replacements: { oldDsId: oldDs.id, workspaceModelId: oldDs.workspaceId },
+      replacements: {
+        oldDataSourceModelId: oldDs.id,
+        workspaceModelId: oldDs.workspaceId,
+      },
     }
   );
 
@@ -626,19 +572,20 @@ makeScript(
       demandOption: true,
       describe: "Workspace sId",
     },
-    oldDataSourceName: {
-      type: "string",
+    oldDataSourceModelId: {
+      type: "number",
       demandOption: true,
-      describe: "Name of the deleted Intercom data source (in snapshot)",
+      describe: "Numeric id of the deleted Intercom data source (in snapshot)",
     },
-    newDataSourceName: {
-      type: "string",
+    newDataSourceModelId: {
+      type: "number",
       demandOption: true,
-      describe: "Name of the re-created Intercom data source (in current DB)",
+      describe:
+        "Numeric id of the re-created Intercom data source (in current DB)",
     },
   },
   async (
-    { workspaceId, oldDataSourceName, newDataSourceName, execute },
+    { workspaceId, oldDataSourceModelId, newDataSourceModelId, execute },
     logger
   ) => {
     const snapshot = new Sequelize(
@@ -665,13 +612,13 @@ makeScript(
       const oldDs = await resolveDataSource({
         sequelize: snapshot,
         workspaceModelId,
-        name: oldDataSourceName,
+        dataSourceModelId: oldDataSourceModelId,
         label: "old (snapshot)",
       });
       const newDs = await resolveDataSource({
         sequelize: frontSequelize,
         workspaceModelId,
-        name: newDataSourceName,
+        dataSourceModelId: newDataSourceModelId,
         label: "new (live)",
       });
 
@@ -698,8 +645,8 @@ makeScript(
         {
           workspaceId,
           workspaceModelId,
-          oldDsId: oldDs.id,
-          newDsId: newDs.id,
+          oldDataSourceModelId: oldDs.id,
+          newDataSourceModelId: newDs.id,
           oldConnectorId: oldDs.connectorId,
           newConnectorId: newDs.connectorId,
           oldDustAPIDataSourceId: oldDs.dustAPIDataSourceId,
@@ -718,77 +665,70 @@ makeScript(
       const rewritten = rewrite(sample);
       logger.info({ sample, rewritten }, "Parent rewrite sanity check");
       if (rewritten === sample) {
-        throw new Error(
-          "Parent rewriter failed sanity check — connectorId regex escape broken?"
-        );
+        throw new Error("Parent rewriter failed sanity check");
       }
 
+      // Unmanaged transaction so we can commit/rollback explicitly based on
+      // the --execute flag (no throw-to-rollback dance).
+      const transaction = await frontSequelize.transaction();
       try {
-        await frontSequelize.transaction(async (transaction) => {
-          const oldToNewDsvId = await restoreDataSourceViews({
-            snapshot,
-            transaction,
-            logger,
-            oldDs,
-            newDs,
-            rewrite,
-            execute,
-          });
-
-          await restoreAgentDataSourceConfigurations({
-            snapshot,
-            transaction,
-            logger,
-            oldDs,
-            newDs,
-            oldToNewDsvId,
-            rewrite,
-            execute,
-          });
-
-          await restoreAgentTablesQueryConfigurationTables({
-            snapshot,
-            transaction,
-            logger,
-            oldDs,
-            newDs,
-            oldToNewDsvId,
-            execute,
-          });
-
-          await restoreSkillDataSourceConfigurations({
-            snapshot,
-            transaction,
-            logger,
-            oldDs,
-            newDs,
-            oldToNewDsvId,
-            rewrite,
-            execute,
-          });
-
-          logger.info(
-            "Skipping content_fragment restore (single stale row, not worth the risk)."
-          );
-
-          if (!execute) {
-            logger.info("Dry-run complete, rolling back transaction.");
-            // Force rollback by throwing a sentinel.
-            throw new DryRunRollback();
-          }
+        const oldToNewDsvId = await restoreDataSourceViews({
+          snapshot,
+          transaction,
+          logger,
+          oldDs,
+          newDs,
+          rewrite,
+          execute,
         });
-      } catch (err) {
-        if (!(err instanceof DryRunRollback)) {
-          throw err;
-        }
-      }
 
-      logger.info(
-        { execute },
-        execute
-          ? "Reconciliation complete."
-          : "Dry-run complete. Re-run with --execute to commit."
-      );
+        await restoreAgentDataSourceConfigurations({
+          snapshot,
+          transaction,
+          logger,
+          oldDs,
+          newDs,
+          oldToNewDsvId,
+          rewrite,
+          execute,
+        });
+
+        await restoreAgentTablesQueryConfigurationTables({
+          snapshot,
+          transaction,
+          logger,
+          oldDs,
+          newDs,
+          oldToNewDsvId,
+          execute,
+        });
+
+        await restoreSkillDataSourceConfigurations({
+          snapshot,
+          transaction,
+          logger,
+          oldDs,
+          newDs,
+          oldToNewDsvId,
+          rewrite,
+          execute,
+        });
+
+        logger.info(
+          "Skipping content_fragment restore (single stale row, not worth the risk)."
+        );
+
+        if (execute) {
+          await transaction.commit();
+          logger.info("Reconciliation complete.");
+        } else {
+          await transaction.rollback();
+          logger.info("Dry-run complete. Re-run with --execute to commit.");
+        }
+      } catch (err) {
+        await transaction.rollback();
+        throw err;
+      }
     } finally {
       await snapshot.close();
     }


### PR DESCRIPTION
## Context

A workspace's Intercom data source was accidentally deleted. The deletion cascaded through the `front` DB, removing all `DataSourceView`s for this DS and every FK-attached configuration row (agent data-source configs, tables-query configs, skill data-source configs). The user re-created the connector, producing a new `DataSource` with a new `id`, new `connectorId`, new `dustAPIDataSourceId`, and a single auto-created default `DataSourceView` in the home space.

We have a pre-incident snapshot of the `front` DB (`FRONT_SNAPSHOT_URI`). This PR adds a one-off migration that restores the cascade-deleted rows against the re-created DS, remapping FK IDs and rewriting Intercom parent strings that embed the old `connectorId`.

## What the script does

One transaction, dry-run by default. Scope: `front` DB only.

1. **Resolve old & new DataSource** by workspace sId + numeric DataSource model IDs. Sanity checks: both `connectorProvider === "intercom"`, distinct `connectorId`s, workspace model ID parity across both DBs.
2. **Restore DataSourceViews** — for each snapshot DSV:
   - If a live DSV of the same kind already exists in that vault (the auto-created default in the DS's home space), **reuse** its id. Warn if its `parentsIn` differs from the snapshot's rewritten `parentsIn`.
   - Otherwise insert a fresh DSV preserving `snap.vaultId` (so DSVs that lived in other spaces get restored in place), with `parentsIn` passed through the Intercom connector-id rewriter.
   - Build `oldDsvId → newDsvId` map for downstream steps.
3. **Restore `agent_data_source_configuration`** — insert each snapshot row against the new DS id and remapped DSV id, with `parentsIn` / `parentsNotIn` rewritten. Skip rows whose parent `mcpServerConfigurationId` no longer exists (warn).
4. **Restore `agent_tables_query_configuration_table`** — same pattern. Expected 0 rows for Intercom; included defensively.
5. **Restore `skill_data_source_configuration`** — same pattern. Skip rows whose `skillConfigurationId` no longer exists.
6. **Skip `content_fragment`** — only 1 affected row (stale past-conversation artifact); commented inline.

### Intercom parent rewrite

Intercom embeds the `connectorId` directly in content-node IDs: `intercom-<kind>-<connectorId>[-<resourceId>]` where `<kind>` is one of `help-center`, `collection`, `article`, `teams`, `team`, `conversation`. The rewriter scans a prefix list (no regex) and swaps the connector segment, preserving the trailing resource id.

Affected columns:
- `DataSourceView.parentsIn`
- `AgentDataSourceConfiguration.parentsIn` / `parentsNotIn`
- `SkillDataSourceConfiguration.parentsIn`

Core-side parents (`data_sources_documents.parents`) are out of scope — they'll be regenerated when the connector re-syncs.

## Logging

Every mutation is logged with before/after arrays, rewritten counts, old→new ID mapping, timestamps, and a `dryRun` flag. Each step ends with a per-table `RestoreStats` summary, and the script emits a `=== Reconciliation summary ===` block at the end. Pipe through `jq` for filtering.

## Run

Dry-run (default):
```
FRONT_SNAPSHOT_URI="..." \
npx tsx migrations/20260423_restore_intercom_data_source.ts \
  --workspaceId <sId> \
  --oldDataSourceModelId <int> \
  --newDataSourceModelId <int>
```

Commit:
```
… --execute
```

## Follow-up

After running with `--execute`, trigger an Intercom resync so the core-side `data_sources_documents.parents` get rebuilt with the new `connectorId`.

## Rollback

All writes are in a single transaction — failure mid-run auto-rolls back. Post-commit rollback is surgical: every restored row is FK-attached to the new DS, so `DELETE … WHERE dataSourceId = <newDataSourceModelId>` (plus DSV cleanup) reverses the change. The dry-run logs include the old→new DSV mapping and every new row's id to make this easier.
