### PR TITLE
fix: static oauth mcp reconnection

### DIFF
--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -38,7 +38,6 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Dialog,
-  DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
@@ -387,7 +386,7 @@ export function ConnectMCPServerDialog({
               Connect {toolName}
             </DialogTitle>
           </DialogHeader>
-          <DialogContainer>
+          <div className="overflow-y-auto px-5 py-4">
             {authorization && (
               <MCPServerAuthConnection
                 toolName={toolName}
@@ -398,7 +397,7 @@ export function ConnectMCPServerDialog({
                 staticCredentialConfig={staticCredentialConfig}
               />
             )}
-          </DialogContainer>
+          </div>
           <DialogFooter
             leftButtonProps={{
               label: "Cancel",

--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -131,6 +131,14 @@ export function ConnectMCPServerDialog({
           mcpServerView.server.url &&
           !remoteMCPServerOAuthDiscoveryDone
         ) {
+          // For static OAuth servers, skip discovery entirely — their credentials
+          // are manually provided by the admin and there is no .well-known endpoint.
+          if (mcpServerView.server.authorization?.provider === "mcp_static") {
+            setAuthorization(mcpServerView.server.authorization);
+            setRemoteMCPServerOAuthDiscoveryDone(true);
+            setIsLoading(false);
+            return;
+          }
           setIsLoading(true);
           const discoverOAuthMetadataRes = await discoverOAuthMetadata(
             mcpServerView.server.url,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7758

This PR fixes the reconnection flow for MCP servers using static OAuth by skipping unnecessary OAuth discovery when clicking on the "Activate" button.

- Adds early return for `mcp_static` authorization provider to bypass the `.well-known` endpoint discovery
- Marks discovery as complete and stops loading state immediately for these servers

Before:

<img width="1042" height="580" alt="Capture d’écran 2026-04-24 à 10 47 57" src="https://github.com/user-attachments/assets/9ac71c62-b0af-4da0-bd77-281b8a511b0a" />

After:

<img width="746" height="823" alt="Capture d’écran 2026-04-24 à 10 48 17" src="https://github.com/user-attachments/assets/6d6a4359-8b4f-4b0e-a27b-f529d53a7429" />


## Tests

Manually

## Risks

Low - This only affects the static OAuth reconnection flow by skipping unnecessary steps

## Deploy Plan

Standard deployment
