### PR TITLE
[front] enh: Cache groups in system key codepath

### DIFF
--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -77,6 +77,7 @@ import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_me
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -86,11 +87,18 @@ function getCacheKeyForUser(userId: number, workspaceId: number): string {
   return `cacheWithRedis--groups:user:${userId}:workspace:${workspaceId}`;
 }
 
+function getCacheKeyForWorkspaceGroupsFromSystemKey(
+  workspaceId: number
+): string {
+  return `cacheWithRedis-_listWorkspaceGroupsFromSystemKeyUncached-workspace-groups-from-system-key:${workspaceId}`;
+}
+
 describe("GroupResource", () => {
   let workspace: LightWorkspaceType;
   let user: UserResource;
   let authenticator: Authenticator;
   let globalGroup: GroupResource;
+  let systemGroup: GroupResource;
 
   beforeEach(async () => {
     const testSetup = await createResourceTest({ role: "admin" });
@@ -98,6 +106,7 @@ describe("GroupResource", () => {
     user = testSetup.user;
     authenticator = testSetup.authenticator;
     globalGroup = testSetup.globalGroup;
+    systemGroup = testSetup.systemGroup;
     // Clear cache after setup since Authenticator creation may populate it
     inMemoryCache.clear();
   });
@@ -554,6 +563,149 @@ describe("GroupResource", () => {
         await transaction.commit();
 
         // NOW cache should be invalidated
+        expect(inMemoryCache.has(cacheKey)).toBe(false);
+      } catch (err) {
+        await transaction.rollback();
+        throw err;
+      }
+    });
+  });
+
+  describe("listWorkspaceGroupsFromKey", () => {
+    it("system key: populates cache on first call and serves from cache on second", async () => {
+      const key = await KeyFactory.system(systemGroup);
+      const cacheKey = getCacheKeyForWorkspaceGroupsFromSystemKey(workspace.id);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+
+      const first = await GroupResource.listWorkspaceGroupsFromKey(key);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const second = await GroupResource.listWorkspaceGroupsFromKey(key);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      expect(first.map((g) => g.id).sort()).toEqual(
+        second.map((g) => g.id).sort()
+      );
+    });
+
+    it("system key: returns groups matching the cached kinds", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Listed Regular Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      const key = await KeyFactory.system(systemGroup);
+
+      const groups = await GroupResource.listWorkspaceGroupsFromKey(key);
+      const ids = groups.map((g) => g.id);
+
+      expect(ids).toContain(globalGroup.id);
+      expect(ids).toContain(systemGroup.id);
+      expect(ids).toContain(regularGroup.id);
+    });
+
+    it("non-system key: does not touch the system-key cache", async () => {
+      const key = await KeyFactory.regular(globalGroup);
+      const cacheKey = getCacheKeyForWorkspaceGroupsFromSystemKey(workspace.id);
+
+      const groups = await GroupResource.listWorkspaceGroupsFromKey(key);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+      expect(groups.map((g) => g.id)).toEqual([globalGroup.id]);
+    });
+
+    it("makeNew invalidates the cache", async () => {
+      const key = await KeyFactory.system(systemGroup);
+      const cacheKey = getCacheKeyForWorkspaceGroupsFromSystemKey(workspace.id);
+
+      await GroupResource.listWorkspaceGroupsFromKey(key);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const newGroup = await GroupResource.makeNew({
+        name: "Cache Invalidation Regular",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+
+      const groups = await GroupResource.listWorkspaceGroupsFromKey(key);
+      expect(groups.map((g) => g.id)).toContain(newGroup.id);
+    });
+
+    it("delete of a group invalidates the cache", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Delete Invalidates System Key Cache",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      const key = await KeyFactory.system(systemGroup);
+      const cacheKey = getCacheKeyForWorkspaceGroupsFromSystemKey(workspace.id);
+
+      const before = await GroupResource.listWorkspaceGroupsFromKey(key);
+      expect(before.map((g) => g.id)).toContain(regularGroup.id);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const deleteResult = await regularGroup.delete(authenticator);
+      expect(deleteResult.isOk()).toBe(true);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+
+      const after = await GroupResource.listWorkspaceGroupsFromKey(key);
+      expect(after.map((g) => g.id)).not.toContain(regularGroup.id);
+    });
+
+    it("updateName does not invalidate the cache", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Name Before",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      const key = await KeyFactory.system(systemGroup);
+      const cacheKey = getCacheKeyForWorkspaceGroupsFromSystemKey(workspace.id);
+
+      await GroupResource.listWorkspaceGroupsFromKey(key);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const updateResult = await regularGroup.updateName(
+        authenticator,
+        "Name After"
+      );
+      expect(updateResult.isOk()).toBe(true);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+    });
+
+    it("defers cache invalidation from makeNew until after transaction commits", async () => {
+      const key = await KeyFactory.system(systemGroup);
+      const cacheKey = getCacheKeyForWorkspaceGroupsFromSystemKey(workspace.id);
+
+      await GroupResource.listWorkspaceGroupsFromKey(key);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const namespace = getNamespace("test-namespace");
+      const parentTransaction = namespace?.get("transaction");
+      expect(parentTransaction).toBeDefined();
+
+      const transaction = await frontSequelize.transaction({
+        transaction: parentTransaction,
+      });
+
+      try {
+        await GroupResource.makeNew(
+          {
+            name: "Deferred Invalidation Group",
+            workspaceId: workspace.id,
+            kind: "regular",
+          },
+          { transaction }
+        );
+
+        expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+        await transaction.commit();
+
         expect(inMemoryCache.has(cacheKey)).toBe(false);
       } catch (err) {
         await transaction.rollback();

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -26,7 +26,12 @@ import type {
   LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
 import type { GroupKind, GroupType } from "@app/types/groups";
-import { AGENT_GROUP_PREFIX, GROUP_KINDS } from "@app/types/groups";
+import {
+  AGENT_GROUP_PREFIX,
+  GROUP_KINDS,
+  isAgentEditorGroupKind,
+  isSkillEditorGroupKind,
+} from "@app/types/groups";
 import type { ResourcePermission } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -64,6 +69,16 @@ export const BUILDER_GROUP_NAME = "dust-builders";
  * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
  */
 
+type CachedGroup = {
+  id: ModelId;
+  name: string;
+  kind: GroupKind;
+  workspaceId: ModelId;
+  workOSGroupId: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -86,6 +101,77 @@ export class GroupResource extends BaseResource<GroupModel> {
   >[] = GROUP_KINDS.filter(
     (k): k is Exclude<GroupKind, "system"> => k !== "system"
   );
+
+  // Group kinds returned to system API keys by listWorkspaceGroupsFromKey.
+  // Excludes agent_editors and skill_editors which are per-agent/per-skill
+  // and not relevant to system auth.
+  private static readonly groupKindsFromSystemKey: GroupKind[] =
+    GROUP_KINDS.filter(
+      (k) => !isAgentEditorGroupKind(k) && !isSkillEditorGroupKind(k)
+    );
+
+  private static readonly workspaceGroupsFromSystemKeyCacheKeyResolver = (
+    workspaceModelId: ModelId
+  ) => `workspace-groups-from-system-key:${workspaceModelId}`;
+
+  private static async _listWorkspaceGroupsFromSystemKeyUncached(
+    workspaceModelId: ModelId
+  ): Promise<CachedGroup[]> {
+    const groups = await GroupModel.findAll({
+      where: {
+        workspaceId: workspaceModelId,
+        kind: { [Op.in]: GroupResource.groupKindsFromSystemKey },
+      },
+    });
+    return groups.map((g) => ({
+      id: g.id,
+      name: g.name,
+      kind: g.kind,
+      workspaceId: g.workspaceId,
+      workOSGroupId: g.workOSGroupId,
+      createdAt: g.createdAt.getTime(),
+      updatedAt: g.updatedAt.getTime(),
+    }));
+  }
+
+  private static listWorkspaceGroupsFromSystemKeyCached = cacheWithRedis(
+    GroupResource._listWorkspaceGroupsFromSystemKeyUncached,
+    GroupResource.workspaceGroupsFromSystemKeyCacheKeyResolver,
+    { cacheNullValues: false }
+  );
+
+  private static _invalidateWorkspaceGroupsFromSystemKeyCache =
+    invalidateCacheWithRedis(
+      GroupResource._listWorkspaceGroupsFromSystemKeyUncached,
+      GroupResource.workspaceGroupsFromSystemKeyCacheKeyResolver
+    );
+
+  static invalidateWorkspaceGroupsFromSystemKeyCache = async (
+    workspaceModelId: ModelId
+  ) => {
+    logger.info(
+      {
+        workspaceModelId,
+        method: "GroupResource.invalidateWorkspaceGroupsFromSystemKeyCache",
+      },
+      "Invalidating workspace groups from system key cache"
+    );
+    return GroupResource._invalidateWorkspaceGroupsFromSystemKeyCache(
+      workspaceModelId
+    );
+  };
+
+  private static fromCachedGroup(data: CachedGroup): GroupResource {
+    return new GroupResource(GroupModel, {
+      id: data.id,
+      name: data.name,
+      kind: data.kind,
+      workspaceId: data.workspaceId,
+      workOSGroupId: data.workOSGroupId,
+      createdAt: new Date(data.createdAt),
+      updatedAt: new Date(data.updatedAt),
+    });
+  }
 
   private static readonly groupIdsCacheKeyResolver = ({
     user,
@@ -256,6 +342,12 @@ export class GroupResource extends BaseResource<GroupModel> {
   ) {
     const group = await GroupModel.create(blob, { transaction });
     const workspaceModelId = group.workspaceId;
+
+    invalidateCacheAfterCommit(transaction, () =>
+      GroupResource.invalidateWorkspaceGroupsFromSystemKeyCache(
+        workspaceModelId
+      )
+    );
 
     // If memberIds are provided, create memberships
     if (memberIds && memberIds.length > 0) {
@@ -565,34 +657,26 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   static async listWorkspaceGroupsFromKey(
-    key: KeyResource,
-    groupKinds: GroupKind[] = [
-      "global",
-      "regular",
-      "space_editors",
-      "system",
-      "provisioned",
-    ]
+    key: KeyResource
   ): Promise<GroupResource[]> {
-    let groups: GroupModel[] = [];
-
     if (key.isSystem) {
-      groups = await this.model.findAll({
-        where: {
-          workspaceId: key.workspaceId,
-          kind: {
-            [Op.in]: groupKinds,
-          },
-        },
-      });
-    } else {
-      groups = await this.model.findAll({
-        where: {
-          workspaceId: key.workspaceId,
-          id: { [Op.in]: key.groupIds },
-        },
-      });
+      const cached = await GroupResource.listWorkspaceGroupsFromSystemKeyCached(
+        key.workspaceId
+      );
+
+      if (cached.length === 0) {
+        throw new Error("Group for key not found.");
+      }
+
+      return cached.map((g) => GroupResource.fromCachedGroup(g));
     }
+
+    const groups = await this.model.findAll({
+      where: {
+        workspaceId: key.workspaceId,
+        id: { [Op.in]: key.groupIds },
+      },
+    });
 
     if (groups.length === 0) {
       throw new Error("Group for key not found.");
@@ -1927,6 +2011,11 @@ export class GroupResource extends BaseResource<GroupModel> {
           );
         });
       }
+
+      const workspaceId = owner.id;
+      invalidateCacheAfterCommit(transaction, () =>
+        GroupResource.invalidateWorkspaceGroupsFromSystemKeyCache(workspaceId)
+      );
 
       return new Ok(undefined);
     } catch (err) {


### PR DESCRIPTION
## Description

Full context [here](https://app.datadoghq.eu/notebook/304607/investigation-10k-qpm-groups-table-select-on-cell-0000) with numbers and why we are doing it

Tl;Dr we are caching this query 

```
SELECT "createdAt", "updatedAt", "contentType", "fileName", "fileSize", "status", "useCase", "version", "useCaseMetadata", "snippet", "mountFilePath", "workspaceId", "id", "userId" 
  FROM "files" AS "files" 
 WHERE "files"."workspaceId" = $1 AND "files"."id" IN ($0)
```

At the resource level
This codepath is only used by connectors, so no visible user impact except from the fact that we're freeing some runtime, and by extension connection time.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low
Blast radius: All requests from connectors

## Deploy Plan

- [ ] Deploy front