### PR TITLE
[front] Add audit log events for wake-up lifecycle

### DIFF
--- a/front/admin/audit_log_schemas/wake_up.cancelled.json
+++ b/front/admin/audit_log_schemas/wake_up.cancelled.json
@@ -1,12 +1,17 @@
 {
   "action": "wake_up.cancelled",
   "targets": [
-    { "type": "workspace" },
-    { "type": "wake_up" }
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "wake_up"
+    }
   ],
   "metadata": {
     "scheduleType": "string",
-    "agentConfigurationId": "string",
-    "userId": "string"
+    "agentId": "string",
+    "initiating_user_id": "string",
+    "initiating_user_name": "string"
   }
 }

--- a/front/admin/audit_log_schemas/wake_up.cancelled.json
+++ b/front/admin/audit_log_schemas/wake_up.cancelled.json
@@ -5,6 +5,8 @@
     { "type": "wake_up" }
   ],
   "metadata": {
-    "agentConfigurationId": "string"
+    "scheduleType": "string",
+    "agentConfigurationId": "string",
+    "userId": "string"
   }
 }

--- a/front/admin/audit_log_schemas/wake_up.cancelled.json
+++ b/front/admin/audit_log_schemas/wake_up.cancelled.json
@@ -1,0 +1,10 @@
+{
+  "action": "wake_up.cancelled",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "wake_up" }
+  ],
+  "metadata": {
+    "agentConfigurationId": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/wake_up.created.json
+++ b/front/admin/audit_log_schemas/wake_up.created.json
@@ -1,13 +1,18 @@
 {
   "action": "wake_up.created",
   "targets": [
-    { "type": "workspace" },
-    { "type": "wake_up" }
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "wake_up"
+    }
   ],
   "metadata": {
     "scheduleType": "string",
-    "agentConfigurationId": "string",
+    "agentId": "string",
     "conversationId": "string",
-    "userId": "string"
+    "initiating_user_id": "string",
+    "initiating_user_name": "string"
   }
 }

--- a/front/admin/audit_log_schemas/wake_up.created.json
+++ b/front/admin/audit_log_schemas/wake_up.created.json
@@ -7,6 +7,7 @@
   "metadata": {
     "scheduleType": "string",
     "agentConfigurationId": "string",
-    "conversationId": "string"
+    "conversationId": "string",
+    "userId": "string"
   }
 }

--- a/front/admin/audit_log_schemas/wake_up.created.json
+++ b/front/admin/audit_log_schemas/wake_up.created.json
@@ -1,0 +1,12 @@
+{
+  "action": "wake_up.created",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "wake_up" }
+  ],
+  "metadata": {
+    "scheduleType": "string",
+    "agentConfigurationId": "string",
+    "conversationId": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/wake_up.expired.json
+++ b/front/admin/audit_log_schemas/wake_up.expired.json
@@ -7,7 +7,6 @@
   "metadata": {
     "scheduleType": "string",
     "agentConfigurationId": "string",
-    "userId": "string",
-    "userEmail": "string"
+    "userId": "string"
   }
 }

--- a/front/admin/audit_log_schemas/wake_up.expired.json
+++ b/front/admin/audit_log_schemas/wake_up.expired.json
@@ -1,0 +1,14 @@
+{
+  "action": "wake_up.expired",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "wake_up" }
+  ],
+  "metadata": {
+    "actor_type": "string",
+    "scheduleType": "string",
+    "agentConfigurationId": "string",
+    "userId": "string",
+    "userEmail": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/wake_up.expired.json
+++ b/front/admin/audit_log_schemas/wake_up.expired.json
@@ -1,12 +1,17 @@
 {
   "action": "wake_up.expired",
   "targets": [
-    { "type": "workspace" },
-    { "type": "wake_up" }
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "wake_up"
+    }
   ],
   "metadata": {
     "scheduleType": "string",
-    "agentConfigurationId": "string",
-    "userId": "string"
+    "agentId": "string",
+    "initiating_user_id": "string",
+    "initiating_user_name": "string"
   }
 }

--- a/front/admin/audit_log_schemas/wake_up.expired.json
+++ b/front/admin/audit_log_schemas/wake_up.expired.json
@@ -5,7 +5,6 @@
     { "type": "wake_up" }
   ],
   "metadata": {
-    "actor_type": "string",
     "scheduleType": "string",
     "agentConfigurationId": "string",
     "userId": "string",

--- a/front/admin/audit_log_schemas/wake_up.fired.json
+++ b/front/admin/audit_log_schemas/wake_up.fired.json
@@ -7,7 +7,6 @@
   "metadata": {
     "scheduleType": "string",
     "agentConfigurationId": "string",
-    "userId": "string",
-    "userEmail": "string"
+    "userId": "string"
   }
 }

--- a/front/admin/audit_log_schemas/wake_up.fired.json
+++ b/front/admin/audit_log_schemas/wake_up.fired.json
@@ -1,0 +1,14 @@
+{
+  "action": "wake_up.fired",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "wake_up" }
+  ],
+  "metadata": {
+    "actor_type": "string",
+    "scheduleType": "string",
+    "agentConfigurationId": "string",
+    "userId": "string",
+    "userEmail": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/wake_up.fired.json
+++ b/front/admin/audit_log_schemas/wake_up.fired.json
@@ -1,12 +1,17 @@
 {
   "action": "wake_up.fired",
   "targets": [
-    { "type": "workspace" },
-    { "type": "wake_up" }
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "wake_up"
+    }
   ],
   "metadata": {
     "scheduleType": "string",
-    "agentConfigurationId": "string",
-    "userId": "string"
+    "agentId": "string",
+    "initiating_user_id": "string",
+    "initiating_user_name": "string"
   }
 }

--- a/front/admin/audit_log_schemas/wake_up.fired.json
+++ b/front/admin/audit_log_schemas/wake_up.fired.json
@@ -5,7 +5,6 @@
     { "type": "wake_up" }
   ],
   "metadata": {
-    "actor_type": "string",
     "scheduleType": "string",
     "agentConfigurationId": "string",
     "userId": "string",

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -78,6 +78,11 @@ type AuditAction =
   | "trigger.disabled"
   | "trigger.fired"
   | "trigger.email_received"
+  // Wake-ups.
+  | "wake_up.cancelled"
+  | "wake_up.created"
+  | "wake_up.expired"
+  | "wake_up.fired"
   // Agent lifecycle.
   | "agent.created"
   | "agent.updated"
@@ -298,6 +303,7 @@ type AuditTargetType =
   | "data_source"
   | "tool"
   | "trigger"
+  | "wake_up"
   | "api_key"
   | "invitation"
   | "group"

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -252,9 +252,10 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       context: getAuditLogContext(auth),
       metadata: {
         scheduleType: wakeUp.scheduleType,
-        agentConfigurationId: wakeUp.agentConfigurationId,
+        agentId: wakeUp.agentConfigurationId,
         conversationId: conversation.sId,
-        userId: auth.user()?.sId ?? "",
+        initiating_user_id: auth.user()?.sId ?? "",
+        initiating_user_name: auth.user()?.name ?? "",
       },
     });
 
@@ -521,8 +522,9 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       context: getAuditLogContext(auth),
       metadata: {
         scheduleType: this.scheduleType,
-        agentConfigurationId: this.agentConfigurationId,
-        userId: auth.user()?.sId ?? "",
+        agentId: this.agentConfigurationId,
+        initiating_user_id: auth.user()?.sId ?? "",
+        initiating_user_name: auth.user()?.name ?? "",
       },
     });
   }
@@ -557,8 +559,9 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       context: getAuditLogContext(auth),
       metadata: {
         scheduleType: this.scheduleType,
-        agentConfigurationId: this.agentConfigurationId,
-        userId: auth.user()?.sId ?? "",
+        agentId: this.agentConfigurationId,
+        initiating_user_id: auth.user()?.sId ?? "",
+        initiating_user_name: auth.user()?.name ?? "",
       },
     });
   }
@@ -637,8 +640,9 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       context: getAuditLogContext(auth),
       metadata: {
         scheduleType: this.scheduleType,
-        agentConfigurationId: this.agentConfigurationId,
-        userId: auth.user()?.sId ?? "",
+        agentId: this.agentConfigurationId,
+        initiating_user_id: auth.user()?.sId ?? "",
+        initiating_user_name: auth.user()?.name ?? "",
       },
     });
   }

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -1,3 +1,8 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -234,6 +239,21 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       return temporalResult;
     }
 
+    void emitAuditLogEvent({
+      auth,
+      action: "wake_up.created",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("wake_up", { sId: wakeUp.sId, name: wakeUp.reason }),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        scheduleType: wakeUp.scheduleType,
+        agentConfigurationId: wakeUp.agentConfigurationId,
+        conversationId: conversation.sId,
+      },
+    });
+
     return new Ok(wakeUp);
   }
 
@@ -466,6 +486,19 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     }
 
     await this.markCancelled(auth, { transaction });
+
+    void emitAuditLogEvent({
+      auth,
+      action: "wake_up.cancelled",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("wake_up", { sId: this.sId, name: this.reason }),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        agentConfigurationId: this.agentConfigurationId,
+      },
+    });
 
     return new Ok(undefined);
   }

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -244,13 +244,17 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       action: "wake_up.created",
       targets: [
         buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-        buildAuditLogTarget("wake_up", { sId: wakeUp.sId, name: wakeUp.reason }),
+        buildAuditLogTarget("wake_up", {
+          sId: wakeUp.sId,
+          name: wakeUp.reason,
+        }),
       ],
       context: getAuditLogContext(auth),
       metadata: {
         scheduleType: wakeUp.scheduleType,
         agentConfigurationId: wakeUp.agentConfigurationId,
         conversationId: conversation.sId,
+        userId: auth.user()?.sId ?? "",
       },
     });
 
@@ -487,19 +491,6 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
 
     await this.markCancelled(auth, { transaction });
 
-    void emitAuditLogEvent({
-      auth,
-      action: "wake_up.cancelled",
-      targets: [
-        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-        buildAuditLogTarget("wake_up", { sId: this.sId, name: this.reason }),
-      ],
-      context: getAuditLogContext(auth),
-      metadata: {
-        agentConfigurationId: this.agentConfigurationId,
-      },
-    });
-
     return new Ok(undefined);
   }
 
@@ -519,6 +510,21 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     );
 
     await this.triggerConversationESIndexing(auth);
+
+    void emitAuditLogEvent({
+      auth,
+      action: "wake_up.cancelled",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("wake_up", { sId: this.sId, name: this.reason }),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        scheduleType: this.scheduleType,
+        agentConfigurationId: this.agentConfigurationId,
+        userId: auth.user()?.sId ?? "",
+      },
+    });
   }
 
   async markExpired(
@@ -537,6 +543,24 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     );
 
     await this.triggerConversationESIndexing(auth);
+
+    void emitAuditLogEvent({
+      auth,
+      action: "wake_up.expired",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("wake_up", {
+          sId: this.sId,
+          name: this.reason,
+        }),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        scheduleType: this.scheduleType,
+        agentConfigurationId: this.agentConfigurationId,
+        userId: auth.user()?.sId ?? "",
+      },
+    });
   }
 
   maxFires(): number {
@@ -599,6 +623,24 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     );
 
     await this.triggerConversationESIndexing(auth);
+
+    void emitAuditLogEvent({
+      auth,
+      action: "wake_up.fired",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("wake_up", {
+          sId: this.sId,
+          name: this.reason,
+        }),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        scheduleType: this.scheduleType,
+        agentConfigurationId: this.agentConfigurationId,
+        userId: auth.user()?.sId ?? "",
+      },
+    });
   }
 
   async cleanupTemporalIfCronExpired(

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -8,7 +8,6 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
-  emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
 import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -8,6 +8,7 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
+  emitAuditLogEventDirect,
 } from "@app/lib/api/audit/workos_audit";
 import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
@@ -383,6 +384,23 @@ export async function runWakeUpActivity({
 
   await wakeUp.markFired(auth);
 
+  void emitAuditLogEventDirect({
+    workspace: auth.getNonNullableWorkspace(),
+    action: "wake_up.fired",
+    actor: { type: "system", id: "temporal", name: "Temporal" },
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("wake_up", { sId: wakeUp.sId, name: wakeUp.reason }),
+    ],
+    context: { location: "internal" },
+    metadata: {
+      scheduleType: wakeUp.scheduleType,
+      agentConfigurationId: wakeUp.agentConfigurationId,
+      userId: auth.user()?.sId ?? "",
+      userEmail: auth.user()?.email ?? "",
+    },
+  });
+
   const cleanupRes = await wakeUp.cleanupTemporalIfCronExpired(auth);
   if (cleanupRes.isErr()) {
     logger.error(
@@ -419,4 +437,21 @@ export async function expireWakeUpActivity({
   const { auth, wakeUp } = wakeUpAndAuthRes.value;
 
   await wakeUp.markExpired(auth);
+
+  void emitAuditLogEventDirect({
+    workspace: auth.getNonNullableWorkspace(),
+    action: "wake_up.expired",
+    actor: { type: "system", id: "temporal", name: "Temporal" },
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("wake_up", { sId: wakeUp.sId, name: wakeUp.reason }),
+    ],
+    context: { location: "internal" },
+    metadata: {
+      scheduleType: wakeUp.scheduleType,
+      agentConfigurationId: wakeUp.agentConfigurationId,
+      userId: auth.user()?.sId ?? "",
+      userEmail: auth.user()?.email ?? "",
+    },
+  });
 }

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -384,23 +384,6 @@ export async function runWakeUpActivity({
 
   await wakeUp.markFired(auth);
 
-  void emitAuditLogEventDirect({
-    workspace: auth.getNonNullableWorkspace(),
-    action: "wake_up.fired",
-    actor: { type: "system", id: "temporal", name: "Temporal" },
-    targets: [
-      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-      buildAuditLogTarget("wake_up", { sId: wakeUp.sId, name: wakeUp.reason }),
-    ],
-    context: { location: "internal" },
-    metadata: {
-      scheduleType: wakeUp.scheduleType,
-      agentConfigurationId: wakeUp.agentConfigurationId,
-      userId: auth.user()?.sId ?? "",
-      userEmail: auth.user()?.email ?? "",
-    },
-  });
-
   const cleanupRes = await wakeUp.cleanupTemporalIfCronExpired(auth);
   if (cleanupRes.isErr()) {
     logger.error(
@@ -437,21 +420,4 @@ export async function expireWakeUpActivity({
   const { auth, wakeUp } = wakeUpAndAuthRes.value;
 
   await wakeUp.markExpired(auth);
-
-  void emitAuditLogEventDirect({
-    workspace: auth.getNonNullableWorkspace(),
-    action: "wake_up.expired",
-    actor: { type: "system", id: "temporal", name: "Temporal" },
-    targets: [
-      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-      buildAuditLogTarget("wake_up", { sId: wakeUp.sId, name: wakeUp.reason }),
-    ],
-    context: { location: "internal" },
-    metadata: {
-      scheduleType: wakeUp.scheduleType,
-      agentConfigurationId: wakeUp.agentConfigurationId,
-      userId: auth.user()?.sId ?? "",
-      userEmail: auth.user()?.email ?? "",
-    },
-  });
 }


### PR DESCRIPTION
## Description

Emits four audit log events covering the full wake-up lifecycle, per [AUDIT1].

| Event | Where | 
|---|---|---|
| `wake_up.created` | `WakeUpResource.makeNew` after Temporal workflow starts | 
| `wake_up.cancelled` | `WakeUpResource.markCancelled` | 
| `wake_up.fired` | `WakeUpResource.markFired`  | 
| `wake_up.expired` | `WakeUpResource.markExpired` | 

Also adds `"wake_up"` to `AuditTargetType` and four strings to `AuditAction`.

Schema files created under `front/admin/audit_log_schemas/`

## Tests

N/A, tested locally.

## Risk

Low. Audit failures are swallowed internally and never block the main path.

## Deploy Plan

- deploy `front`
- run `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`