### PR TITLE
[front] - fix(AgentPicker): flickering

### DIFF
--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -14,7 +14,7 @@ import {
   MoreIcon,
   RobotIcon,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 interface AgentPickerProps {
   owner: WorkspaceType;
@@ -46,6 +46,7 @@ export function AgentPicker({
 }: AgentPickerProps) {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
+  const pendingAgentDetailsIdRef = useRef<string | null>(null);
 
   const searchedAgents = filterAndSortAgents(agents, searchText);
 
@@ -78,6 +79,13 @@ export function AgentPicker({
         className="h-96 w-80"
         side={side}
         align="start"
+        onCloseAutoFocus={() => {
+          const pendingId = pendingAgentDetailsIdRef.current;
+          if (pendingId !== null) {
+            pendingAgentDetailsIdRef.current = null;
+            onAgentDetailsClick?.(pendingId);
+          }
+        }}
         dropdownHeaders={
           <>
             <DropdownMenuSearchbar
@@ -118,10 +126,14 @@ export function AgentPicker({
                     variant="outline"
                     size="mini"
                     className="opacity-0 group-hover:opacity-100"
+                    onPointerDown={(e) => e.stopPropagation()}
                     onClick={(e) => {
                       e.stopPropagation();
-                      e.preventDefault();
-                      onAgentDetailsClick(c.sId);
+                      // Defer opening the details sheet until the dropdown has
+                      // fully closed, so Radix's dropdown modal layer tears
+                      // down before the sheet's modal layer mounts. Opening
+                      // them concurrently produces a visible flicker.
+                      pendingAgentDetailsIdRef.current = c.sId;
                       setIsOpen(false);
                     }}
                   />


### PR DESCRIPTION
## Description

This PR fixes a weird flickering when opening an agent details sheet from the agent picker.

<details>

<summary>Open for full bug description and solution</summary>

### What was the bug

  Clicking the "more" icon inside the AgentPicker dropdown produced a visible flicker — the dropdown would close, reopen, close, and only then the agent details sheet would appear.

###  Why it happened

Two Radix modal primitives were trying to own the modal state at the same time:

1. Sparkle's `DropdownMenu` defaults to `modal={true}`. That installs a `FocusScope` (focus trap), a `RemoveScroll` body-lock, and a `DismissableLayer`.
2. The agent details sheet is a Radix Dialog which installs its own `FocusScope`, body-lock, and `DismissableLayer`.

  The original handler called two things synchronously:
```
onAgentDetailsClick(c.sId);  // router.push → sheet mounts
setIsOpen(false);            // dropdown starts closing
```

So the sheet's modal layer was mounting while the dropdown's modal layer was still tearing down. The two `FocusScopes` fought over focus, the two `DismissableLayers` passed pointer-events back and forth on `<body>`, and each ping-pong flipped Radix's data-state between open and closed. That's the `close → reopen → close` sequence.

This is a known class of Radix bug whenever a dropdown item opens a dialog (radix-ui/primitives#1830, radix-ui/primitives#2355, shadcn-ui/ui#7124). The usual "one-liner" fix is modal={false} on the dropdown, but that didn't work here: without the FocusScope, the input bar auto-focuses itself and Radix immediately
  fires onFocusOutside → the dropdown closes the instant it opens.

### The fix

Sequence the two modal layers so they never coexist:
```
  const pendingAgentDetailsIdRef = useRef<string | null>(null);

  <DropdownMenuContent
    onCloseAutoFocus={() => {
      const pendingId = pendingAgentDetailsIdRef.current;
      if (pendingId !== null) {
        pendingAgentDetailsIdRef.current = null;
        onAgentDetailsClick?.(pendingId);
      }
    }}
    ...
  >
    ...
    <Button
      onPointerDown={(e) => e.stopPropagation()}
      onClick={(e) => {
        e.stopPropagation();
        pendingAgentDetailsIdRef.current = c.sId;
        setIsOpen(false);
      }}
    />
```
**Three pieces:**

  - onPointerDown stopPropagation on the more button — prevents Radix's DropdownMenu.Item from treating the press as an item-select, which would emit its own competing close signal. Radix items react at the pointer level, not at click, so stopping click isn't enough.
  - Ref + setIsOpen(false) only on click — the click no longer triggers router.push directly. It records the intent and closes the dropdown.
  - onCloseAutoFocus on DropdownMenuContent — this Radix event fires at the very end of the close lifecycle, once the FocusScope, RemoveScroll and DismissableLayer have all torn down. Only then do we call onAgentDetailsClick(pendingId) → router.push → sheet opens.

  The sheet's modal layer mounts into an empty modal stack. No concurrent FocusScopes, no pointer-events fight, no flicker — a single clean close, then the sheet.

  Sources
  - radix-ui/primitives discussion #1830 — How to handle dropdown that opens dialog
  - radix-ui/primitives issue #2355 — Dialog + Dropdown menu components conflict
  - radix-ui/primitives issue #3141 — Dialog and Dropdown Menu components conflict
  - shadcn-ui/ui issue #7124 — AlertDialog and DropdownMenu integration
  - Radix Dropdown Menu docs — onCloseAutoFocus

</details>

## Tests

Locally

## Risks

Low

## Deploy plan

Front