### PR TITLE
Fix new conversation not showing in sidebar

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -138,9 +138,9 @@ export function ConversationContainerVirtuoso({
 
         await mutateConversations(
           (currentData: ConversationListItemType[] | undefined) => [
-            // Immediately update the list of conversations in the sidebar by adding the new conversation.
-            ...(currentData ?? []),
+            // Prepend so the new conversation appears at the top of the DESC-sorted list.
             conversationRes.value,
+            ...(currentData ?? []),
           ],
           { revalidate: false }
         );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes an issue where new conversations were appended to the end of the DESC-sorted list and could be hidden below the scroll position. Changed to prepend so they appear at the top immediately after creation. It was mainly visible when creating the first conversation of the day.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
