### PR TITLE
fix: microsoft drive copy file tool with parent reference

### DIFF
--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -179,11 +179,16 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
         .describe(
           "ID of the SharePoint site containing the file (used if driveId not provided)"
         ),
-      parentItemId: z
-        .string()
+      parentReference: z
+        .object({
+          id: z.string().describe("ID of the destination folder for the copy."),
+          driveId: z
+            .string()
+            .describe("ID of the drive containing the destination folder"),
+        })
         .optional()
         .describe(
-          "ID of the destination folder for the copy (defaults to same folder if not specified)"
+          "Reference to the destination folder for the copy. If omitted, the item is copied into the same folder as the source."
         ),
       name: z.string().describe("Name for the copied item"),
     },

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -446,7 +446,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
   },
 
   copy_file: async (
-    { itemId, driveId, siteId, parentItemId, name },
+    { itemId, driveId, siteId, parentReference, name },
     { authInfo }
   ) => {
     if (!driveId && !siteId) {
@@ -467,12 +467,13 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         siteId
       );
 
-      const requestBody: { name: string; parentReference?: { id: string } } = {
-        name,
-      };
+      const requestBody: {
+        name: string;
+        parentReference?: { id: string; driveId: string };
+      } = { name };
 
-      if (parentItemId) {
-        requestBody.parentReference = { id: parentItemId };
+      if (parentReference) {
+        requestBody.parentReference = parentReference;
       }
 
       const response = (await client


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7726

This PR fixes the Microsoft Drive copy file tool to use the proper `parentReference` object structure instead of just a parent item ID.

- Changes the `parentItemId` parameter to `parentReference` object containing both `id` and `driveId` fields to match Microsoft Graph API requirements.

See the documentation at https://learn.microsoft.com/en-us/graph/api/driveitem-copy?view=graph-rest-1.0

<img width="806" height="262" alt="Capture d’écran 2026-04-24 à 11 39 50" src="https://github.com/user-attachments/assets/888f9657-3bb4-45c5-828a-33845fb9760e" />



## Tests

No

## Risk

Low

## Deploy Plan

Standard deployment
