### PR TITLE
Update skill suggestion notification convos on accept/reject

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -342,7 +342,7 @@ function _getDustLikeGlobalAgent(
   let isPreferredModel = false;
 
   const modelConfiguration = (() => {
-    if (!!staticReply) {
+    if (staticReply) {
       return NOOP_MODEL_CONFIG;
     }
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -335,18 +335,14 @@ function _getDustLikeGlobalAgent(
 - Create content like documents, presentations, images, and dashboards`;
   const pictureUrl = DUST_AVATAR_URL;
 
-  // A reinforced-skill notification turn is any turn triggered by a hidden user
-  // message posted by the skill-notification flow — the initial TODO list or a
-  // later accept/reject status update. `staticText` is set for those and carries
-  // the pre-formatted reply Dust should echo without invoking the LLM.
-  const reinforcedStaticText =
-    globalAgentContext?.reinforcedSkillNotification?.staticText;
-  const isReinforcedNotificationTurn = !!reinforcedStaticText;
-
+  // When the triggering user message carries pre-formatted text (today: the
+  // skill-suggestion notification flow), Dust echoes it as a NOOP static reply
+  // instead of running the LLM.
+  const staticReply = globalAgentContext?.staticReply;
   let isPreferredModel = false;
 
   const modelConfiguration = (() => {
-    if (isReinforcedNotificationTurn) {
+    if (!!staticReply) {
       return NOOP_MODEL_CONFIG;
     }
 
@@ -366,10 +362,6 @@ function _getDustLikeGlobalAgent(
     return getLargeWhitelistedModel(auth, excludeProviders);
   })();
 
-  const reinforcedStaticResponse = isReinforcedNotificationTurn
-    ? reinforcedStaticText
-    : undefined;
-
   const model: AgentModelConfigurationType = modelConfiguration
     ? {
         providerId: modelConfiguration.providerId,
@@ -379,9 +371,9 @@ function _getDustLikeGlobalAgent(
           isPreferredModel && preferredReasoningEffort
             ? preferredReasoningEffort
             : modelConfiguration.defaultReasoningEffort,
-        ...(reinforcedStaticResponse && {
+        ...(staticReply && {
           metaData: {
-            staticResponse: reinforcedStaticResponse,
+            staticResponse: staticReply,
           },
         }),
       }

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -38,7 +38,6 @@ import {
 import type { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -301,29 +300,6 @@ function buildInstructions({
   return parts.join("\n\n");
 }
 
-function buildReinforcedSkillStaticResponse(
-  workspaceId: string,
-  skillName: string,
-  skillId: string
-): string {
-  const builderUrl = getSkillBuilderRoute(workspaceId, skillId);
-  const messages = [
-    [
-      `Dust has analyzed conversations in your workspace that use the ${skillName} skill and found suggestions to improve it.`,
-      `You can view and apply these suggestions by going to the [skill builder](${builderUrl}).`,
-    ],
-    [
-      `Based on recent conversations, Dust has identified ways to enhance the ${skillName} skill.`,
-      `Head over to the [skill builder](${builderUrl}) to review and apply these improvements.`,
-    ],
-    [
-      `Dust has reviewed how the ${skillName} skill is being used and has new improvement suggestions.`,
-      `Check them out in the [skill builder](${builderUrl}) and apply the ones you like.`,
-    ],
-  ];
-  return messages[Math.floor(Math.random() * messages.length)].join("\n");
-}
-
 function _getDustLikeGlobalAgent(
   auth: Authenticator,
   {
@@ -352,7 +328,6 @@ function _getDustLikeGlobalAgent(
     agent_memory: agentMemoryMCPServerView,
     ask_user_question: askUserQuestionMCPServerView,
   } = mcpServerViews;
-  const owner = auth.getNonNullableWorkspace();
 
   const description = `Dust is your general purpose agent. It has access to all of your company data and tools available in the Company space. Dust can help you:
 - Find and analyze data across your company knowledge
@@ -360,21 +335,18 @@ function _getDustLikeGlobalAgent(
 - Create content like documents, presentations, images, and dashboards`;
   const pictureUrl = DUST_AVATAR_URL;
 
-  // Content fragments are posted before the user message and each gets its own
-  // rank, so the first user message may have rank > 0 (e.g. rank 1 when a file
-  // is attached). Use <= 1 to account for this.
-  const isFirstUserMessage =
-    globalAgentContext?.userMessageRank !== undefined &&
-    globalAgentContext.userMessageRank <= 1;
-  const isReinforcedSkillNotificationFirstTurn =
-    isFirstUserMessage && globalAgentContext?.reinforcedSkillNotification;
-  const isReinforcedNotificationFirstTurn =
-    isReinforcedSkillNotificationFirstTurn;
+  // A reinforced-skill notification turn is any turn triggered by a hidden user
+  // message posted by the skill-notification flow — the initial TODO list or a
+  // later accept/reject status update. `staticText` is set for those and carries
+  // the pre-formatted reply Dust should echo without invoking the LLM.
+  const reinforcedStaticText =
+    globalAgentContext?.reinforcedSkillNotification?.staticText;
+  const isReinforcedNotificationTurn = !!reinforcedStaticText;
 
   let isPreferredModel = false;
 
   const modelConfiguration = (() => {
-    if (isReinforcedNotificationFirstTurn) {
+    if (isReinforcedNotificationTurn) {
       return NOOP_MODEL_CONFIG;
     }
 
@@ -394,19 +366,9 @@ function _getDustLikeGlobalAgent(
     return getLargeWhitelistedModel(auth, excludeProviders);
   })();
 
-  const reinforcedStaticResponse = (() => {
-    if (
-      isReinforcedSkillNotificationFirstTurn &&
-      globalAgentContext?.reinforcedSkillNotification
-    ) {
-      return buildReinforcedSkillStaticResponse(
-        owner.sId,
-        globalAgentContext.reinforcedSkillNotification.skillName,
-        globalAgentContext.reinforcedSkillNotification.skillId
-      );
-    }
-    return undefined;
-  })();
+  const reinforcedStaticResponse = isReinforcedNotificationTurn
+    ? reinforcedStaticText
+    : undefined;
 
   const model: AgentModelConfigurationType = modelConfiguration
     ? {

--- a/front/lib/api/assistant/static_reply.ts
+++ b/front/lib/api/assistant/static_reply.ts
@@ -1,0 +1,34 @@
+import type {
+  ConversationType,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
+import { isReinforcedSkillNotificationMetadata } from "@app/types/assistant/conversation";
+
+/**
+ * Returns pre-formatted text that the Dust global agent should echo as its
+ * NOOP static reply for this turn, or `undefined` to fall back to the normal
+ * LLM-driven response.
+ *
+ * Today only the skill-suggestion notification flow uses this: it posts hidden
+ * user messages whose content is exactly the message we want Dust to display
+ * (initial TODO list, accept/reject status updates). Adding a new caller is a
+ * matter of recognizing it here — keep `dust.ts` and the agent-run plumbing
+ * generic.
+ */
+export function getStaticReplyForUserMessage({
+  conversation,
+  userMessage,
+}: {
+  conversation: ConversationType;
+  userMessage: UserMessageType;
+}): string | undefined {
+  if (
+    isReinforcedSkillNotificationMetadata(
+      conversation.metadata?.reinforcedSkillNotification
+    ) &&
+    userMessage.context.origin === "reinforced_skill_notification"
+  ) {
+    return userMessage.content;
+  }
+  return undefined;
+}

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -454,6 +454,15 @@ export async function postSkillSuggestionStatusUpdate(
 
   const verb = state === "approved" ? "accepted" : "rejected";
   const marker = state === "approved" ? "✅" : "❌";
+  const actorName = user.fullName();
+  const messageContext = {
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
+    username: user.username,
+    fullName: actorName,
+    email: user.email,
+    profilePictureUrl: user.imageUrl,
+    origin: "reinforced_skill_notification" as const,
+  };
 
   for (const [conversationId, items] of byConversation) {
     const conversationRes = await getConversation(auth, conversationId);
@@ -470,7 +479,6 @@ export async function postSkillSuggestionStatusUpdate(
     const conversation = conversationRes.value;
 
     const titles = items.map((s) => s.title ?? s.sId);
-    const actorName = user.fullName();
     const content =
       items.length === 1
         ? `${marker} ${actorName} ${verb} "${titles[0]}"`
@@ -480,14 +488,7 @@ export async function postSkillSuggestionStatusUpdate(
       conversation,
       content,
       mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
-      context: {
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
-        username: user.username,
-        fullName: actorName,
-        email: user.email,
-        profilePictureUrl: user.imageUrl,
-        origin: "reinforced_skill_notification",
-      },
+      context: messageContext,
       skipToolsValidation: true,
     });
 

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -4,6 +4,7 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context";
@@ -12,10 +13,11 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-import { escapeXml, pluralize } from "@app/types/shared/utils/string_utils";
+import { escapeXml } from "@app/types/shared/utils/string_utils";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import type { UserType } from "@app/types/user";
 
@@ -245,6 +247,33 @@ export async function buildSkillAggregationBatchMap(
 }
 
 /**
+ * Random canned intro that opens the notification conversation. Returns the
+ * two-sentence variant; the caller appends the TODO list of suggestion titles.
+ */
+function buildReinforcedSkillCannedIntro(
+  workspaceId: string,
+  skillName: string,
+  skillId: string
+): string {
+  const builderUrl = getSkillBuilderRoute(workspaceId, skillId);
+  const messages = [
+    [
+      `Dust has analyzed conversations in your workspace that use the ${skillName} skill and found suggestions to improve it.`,
+      `You can view and apply these suggestions by going to the [skill builder](${builderUrl}).`,
+    ],
+    [
+      `Based on recent conversations, Dust has identified ways to enhance the ${skillName} skill.`,
+      `Head over to the [skill builder](${builderUrl}) to review and apply these improvements.`,
+    ],
+    [
+      `Dust has reviewed how the ${skillName} skill is being used and has new improvement suggestions.`,
+      `Check them out in the [skill builder](${builderUrl}) and apply the ones you like.`,
+    ],
+  ];
+  return messages[Math.floor(Math.random() * messages.length)].join("\n");
+}
+
+/**
  * Create a conversation with the pending suggestions for the skill editors.
  * It's a single notification conversation that's sent to all editors of the skill.
  */
@@ -340,9 +369,19 @@ export async function createSkillSuggestionsConversation(
     return;
   }
 
+  const suggestionList = pendingSuggestions
+    .map((s) => `- [ ] ${s.title ?? s.sId}`)
+    .join("\n");
+  const canned = buildReinforcedSkillCannedIntro(
+    auth.getNonNullableWorkspace().sId,
+    skillType.name,
+    skillType.sId
+  );
+  const todoIntro = `I'll update this thread as each suggestion is accepted or rejected:`;
+
   const messageRes = await postUserMessage(auth, {
     conversation,
-    content: `Here are ${pendingSuggestions.length} pending improvement${pluralize(pendingSuggestions.length)} suggestions for the ${skillType.name} skill.`,
+    content: `${canned}\n\n${todoIntro}\n${suggestionList}`,
     mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
     context: {
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
@@ -376,5 +415,93 @@ export async function createSkillSuggestionsConversation(
         lastReadAt: null,
       }),
     { concurrency: 8 }
+  );
+}
+
+/**
+ * Posts a short status update to each notification conversation affected by an
+ * accept/reject action, so editors can see progress on the TODO list posted by
+ * `createSkillSuggestionsConversation`.
+ *
+ * Best-effort: errors are logged and never propagated, so the PATCH call does
+ * not fail if the conversation is gone or inaccessible.
+ */
+export async function postSkillSuggestionStatusUpdate(
+  auth: Authenticator,
+  suggestions: SkillSuggestionResource[],
+  state: "approved" | "rejected"
+): Promise<void> {
+  const user = auth.user();
+  if (!user) {
+    return;
+  }
+
+  // Group suggestions by their notification conversation sId.
+  const byConversation = new Map<string, SkillSuggestionResource[]>();
+  for (const s of suggestions) {
+    if (!s.notificationConversationId) {
+      continue;
+    }
+    const list = byConversation.get(s.notificationConversationId) ?? [];
+    list.push(s);
+    byConversation.set(s.notificationConversationId, list);
+  }
+
+  if (byConversation.size === 0) {
+    return;
+  }
+
+  const verb = state === "approved" ? "accepted" : "rejected";
+  const marker = state === "approved" ? "✅" : "❌";
+
+  await concurrentExecutor(
+    [...byConversation.entries()],
+    async ([conversationId, items]) => {
+      const conversationRes = await getConversation(auth, conversationId);
+      if (conversationRes.isErr()) {
+        logger.warn(
+          {
+            conversationId,
+            error: conversationRes.error.message,
+          },
+          "ReinforcedSkills: failed to fetch notification conversation for status update"
+        );
+        return;
+      }
+      const conversation = conversationRes.value;
+
+      const titles = items.map((s) => s.title ?? s.sId);
+      const actorName = user.fullName();
+      const content =
+        items.length === 1
+          ? `${marker} ${actorName} ${verb} "${titles[0]}"`
+          : `${actorName} ${verb}:\n${titles.map((t) => `${marker} ${t}`).join("\n")}`;
+
+      const postRes = await postUserMessage(auth, {
+        conversation,
+        content,
+        mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
+        context: {
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
+          username: user.username,
+          fullName: actorName,
+          email: user.email,
+          profilePictureUrl: user.imageUrl,
+          origin: "reinforced_skill_notification",
+        },
+        skipToolsValidation: true,
+      });
+
+      if (postRes.isErr()) {
+        logger.warn(
+          {
+            conversationId,
+            error: postRes.error.api_error.message,
+          },
+          "ReinforcedSkills: failed to post status update to notification conversation"
+        );
+      }
+    },
+    { concurrency: 4 }
   );
 }

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -247,30 +247,34 @@ export async function buildSkillAggregationBatchMap(
 }
 
 /**
- * Random canned intro that opens the notification conversation. Returns the
- * two-sentence variant; the caller appends the TODO list of suggestion titles.
+ * Random canned opener for the notification conversation, merged into a single
+ * message with the suggestion titles between the intro and outro lines.
  */
-function buildReinforcedSkillCannedIntro(
+function buildReinforcedSkillInitialMessage(
   workspaceId: string,
   skillName: string,
-  skillId: string
+  skillId: string,
+  titles: string[]
 ): string {
   const builderUrl = getSkillBuilderRoute(workspaceId, skillId);
-  const messages = [
-    [
-      `Dust has analyzed conversations in your workspace that use the ${skillName} skill and found suggestions to improve it.`,
-      `You can view and apply these suggestions by going to the [skill builder](${builderUrl}).`,
-    ],
-    [
-      `Based on recent conversations, Dust has identified ways to enhance the ${skillName} skill.`,
-      `Head over to the [skill builder](${builderUrl}) to review and apply these improvements.`,
-    ],
-    [
-      `Dust has reviewed how the ${skillName} skill is being used and has new improvement suggestions.`,
-      `Check them out in the [skill builder](${builderUrl}) and apply the ones you like.`,
-    ],
+  const variants: Array<{ intro: string; outro: string }> = [
+    {
+      intro: `Dust has analyzed conversations in your workspace that use the ${skillName} skill and found suggestions to improve it:`,
+      outro: `You can view and apply these suggestions by going to the [skill builder](${builderUrl}).`,
+    },
+    {
+      intro: `Based on recent conversations, Dust has identified ways to enhance the ${skillName} skill:`,
+      outro: `Head over to the [skill builder](${builderUrl}) to review and apply these improvements.`,
+    },
+    {
+      intro: `Dust has reviewed how the ${skillName} skill is being used and has new improvement suggestions:`,
+      outro: `Check them out in the [skill builder](${builderUrl}) and apply the ones you like.`,
+    },
   ];
-  return messages[Math.floor(Math.random() * messages.length)].join("\n");
+  const { intro, outro } =
+    variants[Math.floor(Math.random() * variants.length)];
+  const list = titles.map((t) => `- ${t}`).join("\n");
+  return `${intro}\n${list}\n\n${outro}`;
 }
 
 /**
@@ -369,19 +373,16 @@ export async function createSkillSuggestionsConversation(
     return;
   }
 
-  const suggestionList = pendingSuggestions
-    .map((s) => `- [ ] ${s.title ?? s.sId}`)
-    .join("\n");
-  const canned = buildReinforcedSkillCannedIntro(
+  const content = buildReinforcedSkillInitialMessage(
     auth.getNonNullableWorkspace().sId,
     skillType.name,
-    skillType.sId
+    skillType.sId,
+    pendingSuggestions.map((s) => s.title ?? s.sId)
   );
-  const todoIntro = `I'll update this thread as each suggestion is accepted or rejected:`;
 
   const messageRes = await postUserMessage(auth, {
     conversation,
-    content: `${canned}\n\n${todoIntro}\n${suggestionList}`,
+    content,
     mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
     context: {
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
@@ -500,7 +501,18 @@ export async function postSkillSuggestionStatusUpdate(
           },
           "ReinforcedSkills: failed to post status update to notification conversation"
         );
+        return;
       }
+
+      // postUserMessage marks the conversation read at T1, but the Dust static
+      // reply will bump `updatedAt` to T2 and make the conversation re-appear
+      // as unread for the acting editor. Push `lastReadAt` a minute into the
+      // future so the ack holds through the imminent agent completion — the
+      // NOOP reply lands within milliseconds.
+      await ConversationResource.markAsReadForAuthUser(auth, {
+        conversation,
+        lastReadAt: new Date(Date.now() + 60_000),
+      });
     },
     { concurrency: 4 }
   );

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -455,65 +455,61 @@ export async function postSkillSuggestionStatusUpdate(
   const verb = state === "approved" ? "accepted" : "rejected";
   const marker = state === "approved" ? "✅" : "❌";
 
-  await concurrentExecutor(
-    [...byConversation.entries()],
-    async ([conversationId, items]) => {
-      const conversationRes = await getConversation(auth, conversationId);
-      if (conversationRes.isErr()) {
-        logger.warn(
-          {
-            conversationId,
-            error: conversationRes.error.message,
-          },
-          "ReinforcedSkills: failed to fetch notification conversation for status update"
-        );
-        return;
-      }
-      const conversation = conversationRes.value;
-
-      const titles = items.map((s) => s.title ?? s.sId);
-      const actorName = user.fullName();
-      const content =
-        items.length === 1
-          ? `${marker} ${actorName} ${verb} "${titles[0]}"`
-          : `${actorName} ${verb}:\n${titles.map((t) => `${marker} ${t}`).join("\n")}`;
-
-      const postRes = await postUserMessage(auth, {
-        conversation,
-        content,
-        mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
-        context: {
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
-          username: user.username,
-          fullName: actorName,
-          email: user.email,
-          profilePictureUrl: user.imageUrl,
-          origin: "reinforced_skill_notification",
+  for (const [conversationId, items] of byConversation) {
+    const conversationRes = await getConversation(auth, conversationId);
+    if (conversationRes.isErr()) {
+      logger.warn(
+        {
+          conversationId,
+          error: conversationRes.error.message,
         },
-        skipToolsValidation: true,
-      });
+        "ReinforcedSkills: failed to fetch notification conversation for status update"
+      );
+      continue;
+    }
+    const conversation = conversationRes.value;
 
-      if (postRes.isErr()) {
-        logger.warn(
-          {
-            conversationId,
-            error: postRes.error.api_error.message,
-          },
-          "ReinforcedSkills: failed to post status update to notification conversation"
-        );
-        return;
-      }
+    const titles = items.map((s) => s.title ?? s.sId);
+    const actorName = user.fullName();
+    const content =
+      items.length === 1
+        ? `${marker} ${actorName} ${verb} "${titles[0]}"`
+        : `${actorName} ${verb}:\n${titles.map((t) => `${marker} ${t}`).join("\n")}`;
 
-      // postUserMessage marks the conversation read at T1, but the Dust static
-      // reply will bump `updatedAt` to T2 and make the conversation re-appear
-      // as unread for the acting editor. Push `lastReadAt` a minute into the
-      // future so the ack holds through the imminent agent completion — the
-      // NOOP reply lands within milliseconds.
-      await ConversationResource.markAsReadForAuthUser(auth, {
-        conversation,
-        lastReadAt: new Date(Date.now() + 60_000),
-      });
-    },
-    { concurrency: 4 }
-  );
+    const postRes = await postUserMessage(auth, {
+      conversation,
+      content,
+      mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
+      context: {
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
+        username: user.username,
+        fullName: actorName,
+        email: user.email,
+        profilePictureUrl: user.imageUrl,
+        origin: "reinforced_skill_notification",
+      },
+      skipToolsValidation: true,
+    });
+
+    if (postRes.isErr()) {
+      logger.warn(
+        {
+          conversationId,
+          error: postRes.error.api_error.message,
+        },
+        "ReinforcedSkills: failed to post status update to notification conversation"
+      );
+      continue;
+    }
+
+    // postUserMessage marks the conversation read at T1, but the Dust static
+    // reply will bump `updatedAt` to T2 and make the conversation re-appear
+    // as unread for the acting editor. Push `lastReadAt` a minute into the
+    // future so the ack holds through the imminent agent completion — the
+    // NOOP reply lands within milliseconds.
+    await ConversationResource.markAsReadForAuthUser(auth, {
+      conversation,
+      lastReadAt: new Date(Date.now() + 60_000),
+    });
+  }
 }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -5716,6 +5716,70 @@ describe("markAsActionRequired", () => {
   });
 });
 
+describe("markAsReadForAuthUser", () => {
+  let auth: Authenticator;
+  let conversation: ConversationWithoutContentType;
+
+  beforeEach(async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const [agent] = await setupTestAgents(workspace, user);
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+  });
+
+  it("defaults lastReadAt to now when no override is provided", async () => {
+    const before = new Date();
+    const result = await ConversationResource.markAsReadForAuthUser(auth, {
+      conversation,
+    });
+    expect(result.isOk()).toBe(true);
+    const after = new Date();
+
+    const { UserConversationReadsModel } = await import(
+      "@app/lib/models/agent/conversation"
+    );
+    const row = await UserConversationReadsModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        userId: auth.getNonNullableUser().id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    assert(row);
+    expect(row.lastReadAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(row.lastReadAt.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  it("persists the lastReadAt override when one is provided", async () => {
+    const explicit = new Date(Date.now() + 60_000);
+    const result = await ConversationResource.markAsReadForAuthUser(auth, {
+      conversation,
+      lastReadAt: explicit,
+    });
+    expect(result.isOk()).toBe(true);
+
+    const { UserConversationReadsModel } = await import(
+      "@app/lib/models/agent/conversation"
+    );
+    const row = await UserConversationReadsModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        userId: auth.getNonNullableUser().id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    assert(row);
+    expect(row.lastReadAt.getTime()).toBe(explicit.getTime());
+  });
+});
+
 describe("ConversationResource.isConversationCreator", () => {
   let auth: Authenticator;
   let conversationId: string;

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2226,9 +2226,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     {
       conversation,
       transaction,
+      lastReadAt,
     }: {
       conversation: ConversationWithoutContentType;
       transaction?: Transaction;
+      // Optional override; defaults to now. Callers can pass a timestamp in the
+      // future to keep the conversation marked as read through an imminent
+      // `markAsUpdated` bump (e.g. a static agent reply that the user just
+      // triggered and does not need to be re-notified about).
+      lastReadAt?: Date;
     }
   ) {
     if (!auth.user()) {
@@ -2239,7 +2245,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         conversationId: conversation.id,
         userId: auth.getNonNullableUser().id,
         workspaceId: auth.getNonNullableWorkspace().id,
-        lastReadAt: new Date(),
+        lastReadAt: lastReadAt ?? new Date(),
       },
       { transaction }
     );

--- a/front/lib/resources/skill_suggestion_resource.ts
+++ b/front/lib/resources/skill_suggestion_resource.ts
@@ -353,14 +353,14 @@ export class SkillSuggestionResource extends BaseResource<SkillSuggestionModel> 
   static async bulkSetNotificationConversation(
     auth: Authenticator,
     suggestions: SkillSuggestionResource[],
-    notificationConversationId: ModelId
+    notificationConversationModelId: ModelId
   ): Promise<void> {
     if (suggestions.length === 0) {
       return;
     }
 
     await this.model.update(
-      { notificationConversationModelId: notificationConversationId },
+      { notificationConversationModelId: notificationConversationModelId },
       {
         where: {
           workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.test.ts
@@ -14,6 +14,14 @@ vi.mock("@app/lib/reinforcement/workspace_check", () => ({
   hasReinforcementEnabled: vi.fn().mockResolvedValue(true),
 }));
 
+const postSkillSuggestionStatusUpdateMock = vi
+  .fn()
+  .mockResolvedValue(undefined);
+vi.mock("@app/lib/reinforcement/aggregate_suggestions", () => ({
+  postSkillSuggestionStatusUpdate: (...args: unknown[]) =>
+    postSkillSuggestionStatusUpdateMock(...args),
+}));
+
 import handler from "./suggestions";
 
 async function setupTest(
@@ -354,6 +362,57 @@ describe("PATCH /api/w/[wId]/assistant/skills/[sId]/suggestions", () => {
     );
     expect(fetched1?.state).toBe("approved");
     expect(fetched2?.state).toBe("approved");
+  });
+
+  it("triggers postSkillSuggestionStatusUpdate when approving", async () => {
+    postSkillSuggestionStatusUpdateMock.mockClear();
+    const { req, res, auth, skill } = await setupTest();
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    req.body = { suggestionIds: [suggestion.sId], state: "approved" };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(postSkillSuggestionStatusUpdateMock).toHaveBeenCalledTimes(1);
+    const [, suggestions, state] =
+      postSkillSuggestionStatusUpdateMock.mock.calls[0];
+    expect(state).toBe("approved");
+    expect(suggestions.map((s: { sId: string }) => s.sId)).toEqual([
+      suggestion.sId,
+    ]);
+  });
+
+  it("triggers postSkillSuggestionStatusUpdate when rejecting", async () => {
+    postSkillSuggestionStatusUpdateMock.mockClear();
+    const { req, res, auth, skill } = await setupTest();
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    req.body = { suggestionIds: [suggestion.sId], state: "rejected" };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(postSkillSuggestionStatusUpdateMock).toHaveBeenCalledTimes(1);
+    expect(postSkillSuggestionStatusUpdateMock.mock.calls[0][2]).toBe(
+      "rejected"
+    );
+  });
+
+  it("does not trigger postSkillSuggestionStatusUpdate when marking outdated", async () => {
+    postSkillSuggestionStatusUpdateMock.mockClear();
+    const { req, res, auth, skill } = await setupTest();
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    req.body = { suggestionIds: [suggestion.sId], state: "outdated" };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(postSkillSuggestionStatusUpdateMock).not.toHaveBeenCalled();
   });
 
   it("returns 400 when reinforcement is disabled", async () => {

--- a/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { postSkillSuggestionStatusUpdate } from "@app/lib/reinforcement/aggregate_suggestions";
 import { hasReinforcementEnabled } from "@app/lib/reinforcement/workspace_check";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
@@ -195,6 +196,10 @@ async function handler(
       }
 
       await SkillSuggestionResource.bulkUpdateState(auth, suggestions, state);
+
+      if (state === "approved" || state === "rejected") {
+        await postSkillSuggestionStatusUpdate(auth, suggestions, state);
+      }
 
       // Bulk update doesn't mutate the resources, so we need to refetch here.
       const updatedSuggestions = await SkillSuggestionResource.fetchByIds(

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -163,15 +163,11 @@ export type AgentFetchVariant = "light" | "full" | "extra_light";
 export type GlobalAgentContext = {
   userMessageRank: number;
   sidekickIsNewAgentFromScratch?: boolean;
-  reinforcedSkillNotification?: {
-    skillName: string;
-    skillId: string;
-    // Pre-formatted text that Dust should echo as its static (NOOP) response.
-    // Populated when the triggering user message carries the
-    // `reinforced_skill_notification` origin, which covers both the initial
-    // TODO-list bootstrap and every accept/reject status update.
-    staticText?: string;
-  };
+  // Pre-formatted text that the Dust global agent should echo as its NOOP
+  // static reply for this turn. Set by `getStaticReplyForUserMessage` when the
+  // triggering user message is a system-posted bootstrap/status update that
+  // carries its own rendered content.
+  staticReply?: string;
 };
 
 export const LightAgentConfigurationSchema = z.object({

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -166,6 +166,11 @@ export type GlobalAgentContext = {
   reinforcedSkillNotification?: {
     skillName: string;
     skillId: string;
+    // Pre-formatted text that Dust should echo as its static (NOOP) response.
+    // Populated when the triggering user message carries the
+    // `reinforced_skill_notification` origin, which covers both the initial
+    // TODO-list bootstrap and every accept/reject status update.
+    staticText?: string;
   };
 };
 

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -314,7 +314,15 @@ export async function getAgentLoopDataWithAuth(
   const reinforcedSkillNotification = isReinforcedSkillNotificationMetadata(
     reinforcedSkillMeta
   )
-    ? reinforcedSkillMeta
+    ? {
+        ...reinforcedSkillMeta,
+        // The skill-notification flow posts hidden user messages with this origin
+        // whose content is the pre-formatted text we want Dust to echo.
+        staticText:
+          userMessage.context.origin === "reinforced_skill_notification"
+            ? userMessage.content
+            : undefined,
+      }
     : undefined;
 
   const globalAgentContext: GlobalAgentContext = {

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -4,6 +4,7 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
+import { getStaticReplyForUserMessage } from "@app/lib/api/assistant/static_reply";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -21,7 +22,6 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   isAgentMessageType,
-  isReinforcedSkillNotificationMetadata,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import type { Result } from "../shared/result";
@@ -309,28 +309,12 @@ export async function getAgentLoopDataWithAuth(
 
   const agentId = agentMessage.configuration.sId;
 
-  const reinforcedSkillMeta =
-    conversation.metadata?.reinforcedSkillNotification;
-  const reinforcedSkillNotification = isReinforcedSkillNotificationMetadata(
-    reinforcedSkillMeta
-  )
-    ? {
-        ...reinforcedSkillMeta,
-        // The skill-notification flow posts hidden user messages with this origin
-        // whose content is the pre-formatted text we want Dust to echo.
-        staticText:
-          userMessage.context.origin === "reinforced_skill_notification"
-            ? userMessage.content
-            : undefined,
-      }
-    : undefined;
-
   const globalAgentContext: GlobalAgentContext = {
     userMessageRank: userMessage.rank,
     sidekickIsNewAgentFromScratch:
       conversation.metadata?.sidekickIsNewAgentFromScratch === true ||
       undefined,
-    reinforcedSkillNotification,
+    staticReply: getStaticReplyForUserMessage({ conversation, userMessage }),
   };
 
   // As the agent configuration is never supposed to change during a loop, we can cache it for a long time.


### PR DESCRIPTION
## Description

- Track the reinforcement notification conversation on each skill_suggestion (new optional FK notificationConversationId) and surface it on the Poke skill page and suggestion details page.
- Restructure the notification conversation so every message appears as a Dust static reply (no LLM call): a merged TODO-style intro on aggregation, plus a status update on each accept/reject ("✅/❌   ‘’").
- Keep the acting editor from re-seeing the conversation as unread when they accept/reject from the skill builder.

Fixes https://github.com/dust-tt/tasks/issues/7754

## Tests

Added

## Risk

Low

## Deploy Plan

Front