### PR TITLE
feat(sbx): workspace egress policy management

### DIFF
--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -34,6 +34,13 @@ const SecretsPage = withSuspense(
     import("@dust-tt/front/components/pages/workspace/developers/SecretsPage"),
   "SecretsPage"
 );
+const EgressPolicyPage = withSuspense(
+  () =>
+    import(
+      "@dust-tt/front/components/pages/workspace/developers/EgressPolicyPage"
+    ),
+  "EgressPolicyPage"
+);
 const MembersPage = withSuspense(
   () => import("@dust-tt/front/components/pages/workspace/MembersPage"),
   "MembersPage"
@@ -102,6 +109,10 @@ export const adminRoutes: RouteObject[] = [
       {
         path: "developers/dev-secrets",
         element: <SecretsPage />,
+      },
+      {
+        path: "developers/egress-policy",
+        element: <EgressPolicyPage />,
       },
     ],
   },

--- a/front/admin/audit_log_schemas/sandbox_egress_policy.updated.json
+++ b/front/admin/audit_log_schemas/sandbox_egress_policy.updated.json
@@ -1,0 +1,16 @@
+{
+  "action": "sandbox_egress_policy.updated",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "sandbox_egress_policy"
+    }
+  ],
+  "metadata": {
+    "allowedDomainCount": "string",
+    "allowedDomains": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -15,6 +15,7 @@ import {
   CompanyIcon,
   DocumentTextIcon,
   FolderOpenIcon,
+  GlobeAltIcon,
   LockIcon,
   PlanetIcon,
   ShapesIcon,
@@ -80,6 +81,7 @@ export type SubNavigationAdminId =
   | "providers"
   | "api_keys"
   | "dev_secrets"
+  | "egress_policy"
   | "analytics"
   | "credits_usage";
 
@@ -93,6 +95,7 @@ export const ADMIN_ROUTE_PATTERNS: Record<SubNavigationAdminId, string[]> = {
   credits_usage: ["/w/[wId]/developers/credits-usage"],
   providers: ["/w/[wId]/developers/providers"],
   dev_secrets: ["/w/[wId]/developers/dev-secrets"],
+  egress_policy: ["/w/[wId]/developers/egress-policy"],
 };
 
 export type SubNavigationAppId =
@@ -201,6 +204,7 @@ export const getTopNavigationTabs = (
           "/w/[wId]/developers/providers",
           "/w/[wId]/developers/api-keys",
           "/w/[wId]/developers/dev-secrets",
+          "/w/[wId]/developers/egress-policy",
         ]),
       sizing: "hug",
     });
@@ -312,6 +316,14 @@ export const subNavigationAdmin = ({
           icon: BracesIcon,
           href: `/w/${owner.sId}/developers/dev-secrets`,
           current: isCurrent("dev_secrets"),
+        },
+        {
+          id: "egress_policy",
+          label: "Network",
+          icon: GlobeAltIcon,
+          href: `/w/${owner.sId}/developers/egress-policy`,
+          current: isCurrent("egress_policy"),
+          featureFlag: "sandbox_tools",
         },
       ],
     });

--- a/front/components/pages/workspace/developers/EgressPolicyPage.tsx
+++ b/front/components/pages/workspace/developers/EgressPolicyPage.tsx
@@ -160,10 +160,12 @@ export function EgressPolicyPage() {
           <div className="flex w-full flex-col divide-y divide-separator dark:divide-separator-night">
             {policy.allowedDomains.map((domain) => (
               <div key={domain} className="flex items-center gap-3 py-3">
-                <pre className="rounded bg-muted-background p-2 text-sm text-foreground dark:bg-muted-background-night dark:text-foreground-night">
+                <pre
+                  title={domain}
+                  className="min-w-0 grow overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2 text-sm text-foreground dark:bg-muted-background-night dark:text-foreground-night"
+                >
                   {domain}
                 </pre>
-                <div className="grow" />
                 <Button
                   variant="warning"
                   size="mini"
@@ -173,6 +175,7 @@ export function EgressPolicyPage() {
                   onClick={() => {
                     void handleRemoveDomain(domain);
                   }}
+                  className="shrink-0"
                 />
               </div>
             ))}

--- a/front/components/pages/workspace/developers/EgressPolicyPage.tsx
+++ b/front/components/pages/workspace/developers/EgressPolicyPage.tsx
@@ -1,0 +1,180 @@
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
+import {
+  useUpdateWorkspaceEgressPolicy,
+  useWorkspaceEgressPolicy,
+} from "@app/lib/swr/sandbox";
+import { normalizeEgressPolicyDomain } from "@app/types/sandbox/egress_policy";
+import {
+  Button,
+  GlobeAltIcon,
+  Input,
+  Page,
+  PlusIcon,
+  Spinner,
+  TrashIcon,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+export function EgressPolicyPage() {
+  const owner = useWorkspace();
+  const { isAdmin } = useAuth();
+  const { featureFlags } = useFeatureFlags();
+  const hasSandboxTools = featureFlags.includes("sandbox_tools");
+  const [domainInput, setDomainInput] = useState("");
+
+  const {
+    policy,
+    isWorkspaceEgressPolicyLoading,
+    isWorkspaceEgressPolicyError,
+  } = useWorkspaceEgressPolicy({
+    owner,
+    disabled: !hasSandboxTools || !isAdmin,
+  });
+  const { updateWorkspaceEgressPolicy, isUpdatingWorkspaceEgressPolicy } =
+    useUpdateWorkspaceEgressPolicy({ owner });
+
+  const hasDomainInput = domainInput.trim().length > 0;
+  const domainInputResult = hasDomainInput
+    ? normalizeEgressPolicyDomain(domainInput)
+    : null;
+  const normalizedDomain =
+    domainInputResult?.isOk() === true ? domainInputResult.value : null;
+  const isDuplicate =
+    normalizedDomain !== null &&
+    policy.allowedDomains.includes(normalizedDomain);
+  const domainInputMessage =
+    domainInputResult?.isErr() === true
+      ? domainInputResult.error.message
+      : isDuplicate
+        ? "This domain is already allowed."
+        : normalizedDomain
+          ? `Will be saved as ${normalizedDomain}.`
+          : "Use an exact domain such as api.github.com or a wildcard such as *.github.com.";
+  const isDomainInputInvalid =
+    domainInputResult?.isErr() === true || isDuplicate;
+  const canAddDomain =
+    normalizedDomain !== null &&
+    !isDuplicate &&
+    !isUpdatingWorkspaceEgressPolicy;
+
+  const saveDomains = async (allowedDomains: string[]) => {
+    return updateWorkspaceEgressPolicy({ allowedDomains });
+  };
+
+  const handleAddDomain = async () => {
+    if (!canAddDomain || normalizedDomain === null) {
+      return;
+    }
+
+    const success = await saveDomains([
+      ...policy.allowedDomains,
+      normalizedDomain,
+    ]);
+    if (success) {
+      setDomainInput("");
+    }
+  };
+
+  const handleRemoveDomain = async (domain: string) => {
+    await saveDomains(policy.allowedDomains.filter((d) => d !== domain));
+  };
+
+  return (
+    <Page.Vertical gap="xl" align="stretch">
+      <Page.Header
+        title="Network"
+        icon={GlobeAltIcon}
+        description="Configure workspace-level domains that sandboxes are allowed to access through the egress proxy."
+      />
+
+      {!isAdmin ? (
+        <div className="rounded-xl border border-border bg-muted-background p-4 text-sm text-muted-foreground dark:border-border-night dark:bg-muted-background-night dark:text-muted-foreground-night">
+          Only workspace admins can manage sandbox network settings.
+        </div>
+      ) : !hasSandboxTools ? (
+        <div className="rounded-xl border border-border bg-muted-background p-4 text-sm text-muted-foreground dark:border-border-night dark:bg-muted-background-night dark:text-muted-foreground-night">
+          Sandbox tools are not enabled for this workspace.
+        </div>
+      ) : isWorkspaceEgressPolicyLoading ? (
+        <Spinner />
+      ) : isWorkspaceEgressPolicyError ? (
+        <div className="rounded-xl border border-warning-200 bg-muted-background p-4 text-sm text-warning-800 dark:border-warning-200-night dark:bg-muted-background-night dark:text-warning-800-night">
+          Failed to load the sandbox network policy.
+        </div>
+      ) : (
+        <Page.Vertical align="stretch" gap="lg">
+          <div className="rounded-xl border border-border bg-muted-background p-4 dark:border-border-night dark:bg-muted-background-night">
+            <div className="text-sm font-medium text-foreground dark:text-foreground-night">
+              Allowed domains
+            </div>
+            <div className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+              These domains apply to all sandboxes in this workspace. Changes
+              are picked up by egress proxy cache refreshes, typically within 60
+              seconds.
+            </div>
+
+            <form
+              className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleAddDomain();
+              }}
+            >
+              <div className="grow">
+                <Input
+                  label="Domain"
+                  name="domain"
+                  placeholder="api.github.com or *.github.com"
+                  value={domainInput}
+                  message={domainInputMessage}
+                  messageStatus={isDomainInputInvalid ? "error" : "info"}
+                  onChange={(event) => setDomainInput(event.target.value)}
+                  disabled={isUpdatingWorkspaceEgressPolicy}
+                />
+              </div>
+              <Button
+                type="submit"
+                label="Add domain"
+                icon={PlusIcon}
+                disabled={!canAddDomain}
+                isLoading={isUpdatingWorkspaceEgressPolicy}
+                className="mt-0 sm:mt-7"
+              />
+            </form>
+          </div>
+
+          {policy.allowedDomains.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground dark:border-border-night dark:text-muted-foreground-night">
+              No workspace-specific domains are currently allowed.
+            </div>
+          ) : (
+            <div className="divide-y divide-separator rounded-xl border border-border dark:divide-separator-night dark:border-border-night">
+              {policy.allowedDomains.map((domain) => (
+                <div key={domain} className="flex items-center gap-3 px-4 py-3">
+                  <code className="rounded-lg bg-muted-background px-2 py-1 text-sm text-foreground dark:bg-muted-background-night dark:text-foreground-night">
+                    {domain}
+                  </code>
+                  <div className="grow" />
+                  <Button
+                    variant="warning"
+                    size="mini"
+                    icon={TrashIcon}
+                    tooltip={`Remove ${domain}`}
+                    disabled={isUpdatingWorkspaceEgressPolicy}
+                    onClick={() => {
+                      void handleRemoveDomain(domain);
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </Page.Vertical>
+      )}
+    </Page.Vertical>
+  );
+}

--- a/front/components/pages/workspace/developers/EgressPolicyPage.tsx
+++ b/front/components/pages/workspace/developers/EgressPolicyPage.tsx
@@ -10,7 +10,9 @@ import {
 import { normalizeEgressPolicyDomain } from "@app/types/sandbox/egress_policy";
 import {
   Button,
+  ContentMessage,
   GlobeAltIcon,
+  InformationCircleIcon,
   Input,
   Page,
   PlusIcon,
@@ -83,6 +85,103 @@ export function EgressPolicyPage() {
     await saveDomains(policy.allowedDomains.filter((d) => d !== domain));
   };
 
+  const renderBody = () => {
+    if (!isAdmin) {
+      return (
+        <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
+          Only workspace admins can manage sandbox network settings.
+        </ContentMessage>
+      );
+    }
+    if (!hasSandboxTools) {
+      return (
+        <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
+          Sandbox tools are not enabled for this workspace.
+        </ContentMessage>
+      );
+    }
+    if (isWorkspaceEgressPolicyLoading) {
+      return <Spinner />;
+    }
+    if (isWorkspaceEgressPolicyError) {
+      return (
+        <ContentMessage
+          variant="warning"
+          icon={InformationCircleIcon}
+          size="lg"
+          title="Failed to load"
+        >
+          The sandbox network policy could not be loaded.
+        </ContentMessage>
+      );
+    }
+
+    return (
+      <Page.Vertical align="stretch" gap="lg">
+        <Page.SectionHeader
+          title="Allowed domains"
+          description="These domains apply to all sandboxes in this workspace. Changes are picked up by egress proxy cache refreshes, typically within 60 seconds."
+        />
+
+        <form
+          className="flex flex-col gap-3 sm:flex-row sm:items-start"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleAddDomain();
+          }}
+        >
+          <div className="grow">
+            <Input
+              label="Domain"
+              name="domain"
+              placeholder="api.github.com or *.github.com"
+              value={domainInput}
+              message={domainInputMessage}
+              messageStatus={isDomainInputInvalid ? "error" : "info"}
+              onChange={(event) => setDomainInput(event.target.value)}
+              disabled={isUpdatingWorkspaceEgressPolicy}
+            />
+          </div>
+          <Button
+            type="submit"
+            label="Add domain"
+            icon={PlusIcon}
+            disabled={!canAddDomain}
+            isLoading={isUpdatingWorkspaceEgressPolicy}
+            className="mt-0 sm:mt-7"
+          />
+        </form>
+
+        {policy.allowedDomains.length === 0 ? (
+          <ContentMessage variant="outline" size="lg">
+            No workspace-specific domains are currently allowed.
+          </ContentMessage>
+        ) : (
+          <div className="flex w-full flex-col divide-y divide-separator dark:divide-separator-night">
+            {policy.allowedDomains.map((domain) => (
+              <div key={domain} className="flex items-center gap-3 py-3">
+                <pre className="rounded bg-muted-background p-2 text-sm text-foreground dark:bg-muted-background-night dark:text-foreground-night">
+                  {domain}
+                </pre>
+                <div className="grow" />
+                <Button
+                  variant="warning"
+                  size="mini"
+                  icon={TrashIcon}
+                  tooltip={`Remove ${domain}`}
+                  disabled={isUpdatingWorkspaceEgressPolicy}
+                  onClick={() => {
+                    void handleRemoveDomain(domain);
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </Page.Vertical>
+    );
+  };
+
   return (
     <Page.Vertical gap="xl" align="stretch">
       <Page.Header
@@ -90,91 +189,7 @@ export function EgressPolicyPage() {
         icon={GlobeAltIcon}
         description="Configure workspace-level domains that sandboxes are allowed to access through the egress proxy."
       />
-
-      {!isAdmin ? (
-        <div className="rounded-xl border border-border bg-muted-background p-4 text-sm text-muted-foreground dark:border-border-night dark:bg-muted-background-night dark:text-muted-foreground-night">
-          Only workspace admins can manage sandbox network settings.
-        </div>
-      ) : !hasSandboxTools ? (
-        <div className="rounded-xl border border-border bg-muted-background p-4 text-sm text-muted-foreground dark:border-border-night dark:bg-muted-background-night dark:text-muted-foreground-night">
-          Sandbox tools are not enabled for this workspace.
-        </div>
-      ) : isWorkspaceEgressPolicyLoading ? (
-        <Spinner />
-      ) : isWorkspaceEgressPolicyError ? (
-        <div className="rounded-xl border border-warning-200 bg-muted-background p-4 text-sm text-warning-800 dark:border-warning-200-night dark:bg-muted-background-night dark:text-warning-800-night">
-          Failed to load the sandbox network policy.
-        </div>
-      ) : (
-        <Page.Vertical align="stretch" gap="lg">
-          <div className="rounded-xl border border-border bg-muted-background p-4 dark:border-border-night dark:bg-muted-background-night">
-            <div className="text-sm font-medium text-foreground dark:text-foreground-night">
-              Allowed domains
-            </div>
-            <div className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
-              These domains apply to all sandboxes in this workspace. Changes
-              are picked up by egress proxy cache refreshes, typically within 60
-              seconds.
-            </div>
-
-            <form
-              className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void handleAddDomain();
-              }}
-            >
-              <div className="grow">
-                <Input
-                  label="Domain"
-                  name="domain"
-                  placeholder="api.github.com or *.github.com"
-                  value={domainInput}
-                  message={domainInputMessage}
-                  messageStatus={isDomainInputInvalid ? "error" : "info"}
-                  onChange={(event) => setDomainInput(event.target.value)}
-                  disabled={isUpdatingWorkspaceEgressPolicy}
-                />
-              </div>
-              <Button
-                type="submit"
-                label="Add domain"
-                icon={PlusIcon}
-                disabled={!canAddDomain}
-                isLoading={isUpdatingWorkspaceEgressPolicy}
-                className="mt-0 sm:mt-7"
-              />
-            </form>
-          </div>
-
-          {policy.allowedDomains.length === 0 ? (
-            <div className="rounded-xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground dark:border-border-night dark:text-muted-foreground-night">
-              No workspace-specific domains are currently allowed.
-            </div>
-          ) : (
-            <div className="divide-y divide-separator rounded-xl border border-border dark:divide-separator-night dark:border-border-night">
-              {policy.allowedDomains.map((domain) => (
-                <div key={domain} className="flex items-center gap-3 px-4 py-3">
-                  <code className="rounded-lg bg-muted-background px-2 py-1 text-sm text-foreground dark:bg-muted-background-night dark:text-foreground-night">
-                    {domain}
-                  </code>
-                  <div className="grow" />
-                  <Button
-                    variant="warning"
-                    size="mini"
-                    icon={TrashIcon}
-                    tooltip={`Remove ${domain}`}
-                    disabled={isUpdatingWorkspaceEgressPolicy}
-                    onClick={() => {
-                      void handleRemoveDomain(domain);
-                    }}
-                  />
-                </div>
-              ))}
-            </div>
-          )}
-        </Page.Vertical>
-      )}
+      {renderBody()}
     </Page.Vertical>
   );
 }

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -56,6 +56,8 @@ type AuditAction =
   // Projects.
   | "project.joined"
   | "project.left"
+  // Sandbox.
+  | "sandbox_egress_policy.updated"
   // SCIM / Directory Sync.
   | "scim.user_provisioned"
   | "scim.user_updated"

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -211,6 +211,9 @@ const config = {
   getEgressProxyTlsName: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("EGRESS_PROXY_TLS_NAME");
   },
+  getEgressPolicyBucket: (): string => {
+    return EnvironmentConfig.getEnvVariable("EGRESS_PROXY_POLICY_BUCKET");
+  },
   getOAuthAPIConfig: (): { url: string; apiKey: string | null } => {
     return {
       url: EnvironmentConfig.getEnvVariable("OAUTH_API"),

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -1,0 +1,115 @@
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockDelete,
+  mockFetchFileContent,
+  mockGetBucketInstance,
+  mockGetEgressPolicyBucket,
+  mockUploadRawContentToBucket,
+} = vi.hoisted(() => ({
+  mockDelete: vi.fn(),
+  mockFetchFileContent: vi.fn(),
+  mockGetBucketInstance: vi.fn(),
+  mockGetEgressPolicyBucket: vi.fn(),
+  mockUploadRawContentToBucket: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getEgressPolicyBucket: mockGetEgressPolicyBucket,
+  },
+}));
+
+vi.mock("@app/lib/file_storage", () => ({
+  getBucketInstance: mockGetBucketInstance,
+}));
+
+import {
+  deleteWorkspacePolicy,
+  readWorkspacePolicy,
+  writeWorkspacePolicy,
+} from "./egress_policy";
+
+describe("workspace egress policy storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetEgressPolicyBucket.mockReturnValue("egress-policy-bucket");
+    mockFetchFileContent.mockResolvedValue(
+      JSON.stringify({ allowedDomains: ["API.GitHub.COM"] })
+    );
+    mockUploadRawContentToBucket.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
+    mockGetBucketInstance.mockReturnValue({
+      delete: mockDelete,
+      fetchFileContent: mockFetchFileContent,
+      uploadRawContentToBucket: mockUploadRawContentToBucket,
+    });
+  });
+
+  it("reads workspace policy files from the workspace prefix", async () => {
+    const result = await readWorkspacePolicy("workspace-sid");
+
+    expect(result).toEqual(
+      new Ok({
+        allowedDomains: ["api.github.com"],
+      })
+    );
+    expect(mockGetBucketInstance).toHaveBeenCalledWith("egress-policy-bucket");
+    expect(mockFetchFileContent).toHaveBeenCalledWith(
+      "workspaces/workspace-sid.json"
+    );
+  });
+
+  it("returns an empty policy when the workspace policy file is missing", async () => {
+    mockFetchFileContent.mockRejectedValue({ code: 404 });
+
+    const result = await readWorkspacePolicy("workspace-sid");
+
+    expect(result).toEqual(new Ok({ allowedDomains: [] }));
+  });
+
+  it("writes normalized workspace policy files", async () => {
+    const result = await writeWorkspacePolicy({
+      workspaceId: "workspace-sid",
+      policy: {
+        allowedDomains: ["API.GitHub.COM", "*.GitHub.COM"],
+      },
+    });
+
+    expect(result).toEqual(
+      new Ok({
+        allowedDomains: ["api.github.com", "*.github.com"],
+      })
+    );
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content: JSON.stringify({
+        allowedDomains: ["api.github.com", "*.github.com"],
+      }),
+      contentType: "application/json",
+      filePath: "workspaces/workspace-sid.json",
+    });
+  });
+
+  it("does not write invalid domain entries", async () => {
+    const result = await writeWorkspacePolicy({
+      workspaceId: "workspace-sid",
+      policy: {
+        allowedDomains: ["127.0.0.1"],
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("deletes workspace policy files and ignores missing objects", async () => {
+    const result = await deleteWorkspacePolicy("workspace-sid");
+
+    expect(result).toEqual(new Ok(undefined));
+    expect(mockDelete).toHaveBeenCalledWith("workspaces/workspace-sid.json", {
+      ignoreNotFound: true,
+    });
+  });
+});

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -1,3 +1,4 @@
+import type { Authenticator } from "@app/lib/auth";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -31,6 +32,10 @@ import {
   writeWorkspacePolicy,
 } from "./egress_policy";
 
+const mockAuth = {
+  getNonNullableWorkspace: () => ({ sId: "workspace-sid" }),
+} as unknown as Authenticator;
+
 describe("workspace egress policy storage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -49,7 +54,7 @@ describe("workspace egress policy storage", () => {
   });
 
   it("reads workspace policy files from the workspace prefix", async () => {
-    const result = await readWorkspacePolicy("workspace-sid");
+    const result = await readWorkspacePolicy(mockAuth);
 
     expect(result).toEqual(
       new Ok({
@@ -65,14 +70,13 @@ describe("workspace egress policy storage", () => {
   it("returns an empty policy when the workspace policy file is missing", async () => {
     mockFetchFileContent.mockRejectedValue({ code: 404 });
 
-    const result = await readWorkspacePolicy("workspace-sid");
+    const result = await readWorkspacePolicy(mockAuth);
 
     expect(result).toEqual(new Ok({ allowedDomains: [] }));
   });
 
   it("writes normalized workspace policy files", async () => {
-    const result = await writeWorkspacePolicy({
-      workspaceId: "workspace-sid",
+    const result = await writeWorkspacePolicy(mockAuth, {
       policy: {
         allowedDomains: ["API.GitHub.COM", "*.GitHub.COM"],
       },
@@ -93,8 +97,7 @@ describe("workspace egress policy storage", () => {
   });
 
   it("does not write invalid domain entries", async () => {
-    const result = await writeWorkspacePolicy({
-      workspaceId: "workspace-sid",
+    const result = await writeWorkspacePolicy(mockAuth, {
       policy: {
         allowedDomains: ["127.0.0.1"],
       },
@@ -105,7 +108,7 @@ describe("workspace egress policy storage", () => {
   });
 
   it("deletes workspace policy files and ignores missing objects", async () => {
-    const result = await deleteWorkspacePolicy("workspace-sid");
+    const result = await deleteWorkspacePolicy(mockAuth);
 
     expect(result).toEqual(new Ok(undefined));
     expect(mockDelete).toHaveBeenCalledWith("workspaces/workspace-sid.json", {

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
 import { getBucketInstance } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
@@ -10,8 +11,8 @@ import {
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-function getWorkspacePolicyPath(workspaceId: string): string {
-  return `workspaces/${workspaceId}.json`;
+function getWorkspacePolicyPath(auth: Authenticator): string {
+  return `workspaces/${auth.getNonNullableWorkspace().sId}.json`;
 }
 
 function getPolicyBucket() {
@@ -19,11 +20,11 @@ function getPolicyBucket() {
 }
 
 export async function readWorkspacePolicy(
-  workspaceId: string
+  auth: Authenticator
 ): Promise<Result<EgressPolicy, Error>> {
   try {
     const content = await getPolicyBucket().fetchFileContent(
-      getWorkspacePolicyPath(workspaceId)
+      getWorkspacePolicyPath(auth)
     );
     const parsed = parseEgressPolicy(JSON.parse(content));
 
@@ -41,13 +42,10 @@ export async function readWorkspacePolicy(
   }
 }
 
-export async function writeWorkspacePolicy({
-  workspaceId,
-  policy,
-}: {
-  workspaceId: string;
-  policy: EgressPolicy;
-}): Promise<Result<EgressPolicy, Error>> {
+export async function writeWorkspacePolicy(
+  auth: Authenticator,
+  { policy }: { policy: EgressPolicy }
+): Promise<Result<EgressPolicy, Error>> {
   const normalizedPolicy = normalizeEgressPolicy(policy);
 
   if (normalizedPolicy.isErr()) {
@@ -58,7 +56,7 @@ export async function writeWorkspacePolicy({
     await getPolicyBucket().uploadRawContentToBucket({
       content: JSON.stringify(normalizedPolicy.value),
       contentType: "application/json",
-      filePath: getWorkspacePolicyPath(workspaceId),
+      filePath: getWorkspacePolicyPath(auth),
     });
 
     return new Ok(normalizedPolicy.value);
@@ -68,10 +66,10 @@ export async function writeWorkspacePolicy({
 }
 
 export async function deleteWorkspacePolicy(
-  workspaceId: string
+  auth: Authenticator
 ): Promise<Result<void, Error>> {
   try {
-    await getPolicyBucket().delete(getWorkspacePolicyPath(workspaceId), {
+    await getPolicyBucket().delete(getWorkspacePolicyPath(auth), {
       ignoreNotFound: true,
     });
 

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -1,0 +1,82 @@
+import config from "@app/lib/api/config";
+import { getBucketInstance } from "@app/lib/file_storage";
+import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import {
+  EMPTY_EGRESS_POLICY,
+  normalizeEgressPolicy,
+  parseEgressPolicy,
+} from "@app/types/sandbox/egress_policy";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+function getWorkspacePolicyPath(workspaceId: string): string {
+  return `workspaces/${workspaceId}.json`;
+}
+
+function getPolicyBucket() {
+  return getBucketInstance(config.getEgressPolicyBucket());
+}
+
+export async function readWorkspacePolicy(
+  workspaceId: string
+): Promise<Result<EgressPolicy, Error>> {
+  try {
+    const content = await getPolicyBucket().fetchFileContent(
+      getWorkspacePolicyPath(workspaceId)
+    );
+    const parsed = parseEgressPolicy(JSON.parse(content));
+
+    if (parsed.isErr()) {
+      return parsed;
+    }
+
+    return new Ok(parsed.value);
+  } catch (error) {
+    if (isGCSNotFoundError(error)) {
+      return new Ok(EMPTY_EGRESS_POLICY);
+    }
+
+    return new Err(normalizeError(error));
+  }
+}
+
+export async function writeWorkspacePolicy({
+  workspaceId,
+  policy,
+}: {
+  workspaceId: string;
+  policy: EgressPolicy;
+}): Promise<Result<EgressPolicy, Error>> {
+  const normalizedPolicy = normalizeEgressPolicy(policy);
+
+  if (normalizedPolicy.isErr()) {
+    return normalizedPolicy;
+  }
+
+  try {
+    await getPolicyBucket().uploadRawContentToBucket({
+      content: JSON.stringify(normalizedPolicy.value),
+      contentType: "application/json",
+      filePath: getWorkspacePolicyPath(workspaceId),
+    });
+
+    return new Ok(normalizedPolicy.value);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+export async function deleteWorkspacePolicy(
+  workspaceId: string
+): Promise<Result<void, Error>> {
+  try {
+    await getPolicyBucket().delete(getWorkspacePolicyPath(workspaceId), {
+      ignoreNotFound: true,
+    });
+
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -1,0 +1,105 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import type {
+  GetWorkspaceEgressPolicyResponseBody,
+  PutWorkspaceEgressPolicyResponseBody,
+} from "@app/pages/api/w/[wId]/sandbox/egress-policy";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import { EMPTY_EGRESS_POLICY } from "@app/types/sandbox/egress_policy";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useState } from "react";
+import type { Fetcher } from "swr";
+
+function workspaceEgressPolicyUrl(workspaceId: string) {
+  return `/api/w/${workspaceId}/sandbox/egress-policy`;
+}
+
+export function useWorkspaceEgressPolicy({
+  owner,
+  disabled = false,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const policyFetcher: Fetcher<GetWorkspaceEgressPolicyResponseBody> = fetcher;
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    workspaceEgressPolicyUrl(owner.sId),
+    policyFetcher,
+    { disabled }
+  );
+
+  return {
+    policy: data?.policy ?? EMPTY_EGRESS_POLICY,
+    isWorkspaceEgressPolicyLoading: isLoading,
+    isWorkspaceEgressPolicyError: !!error,
+    mutateWorkspaceEgressPolicy: mutate,
+  };
+}
+
+export function useUpdateWorkspaceEgressPolicy({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isUpdating, setIsUpdating] = useState(false);
+  const { mutateWorkspaceEgressPolicy } = useWorkspaceEgressPolicy({
+    owner,
+    disabled: true,
+  });
+
+  const updateWorkspaceEgressPolicy = async (
+    policy: EgressPolicy
+  ): Promise<boolean> => {
+    setIsUpdating(true);
+    try {
+      const response = await clientFetch(workspaceEgressPolicyUrl(owner.sId), {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(policy),
+      });
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to update network policy",
+          description: error.message,
+        });
+        return false;
+      }
+
+      const data: PutWorkspaceEgressPolicyResponseBody = await response.json();
+      await mutateWorkspaceEgressPolicy({ policy: data.policy }, false);
+      sendNotification({
+        type: "success",
+        title: "Network policy updated",
+        description:
+          "Sandbox egress policy changes will be applied by the proxy cache shortly.",
+      });
+      return true;
+    } catch {
+      sendNotification({
+        type: "error",
+        title: "Failed to update network policy",
+        description: "An unexpected error occurred. Please try again.",
+      });
+      return false;
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return {
+    updateWorkspaceEgressPolicy,
+    isUpdatingWorkspaceEgressPolicy: isUpdating,
+  };
+}

--- a/front/pages/api/w/[wId]/sandbox/egress-policy.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/egress-policy.test.ts
@@ -38,14 +38,17 @@ describe("GET/PUT /api/w/[wId]/sandbox/egress-policy", () => {
       new Ok({ allowedDomains: ["api.github.com"] })
     );
     mockWriteWorkspacePolicy.mockImplementation(
-      async ({ policy }: { policy: { allowedDomains: string[] } }) => {
+      async (
+        _auth: unknown,
+        { policy }: { policy: { allowedDomains: string[] } }
+      ) => {
         return new Ok(policy);
       }
     );
   });
 
   it("returns the workspace egress policy to workspace admins with sandbox tools enabled", async () => {
-    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+    const { req, res, auth } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
     });
@@ -57,7 +60,7 @@ describe("GET/PUT /api/w/[wId]/sandbox/egress-policy", () => {
     expect(JSON.parse(res._getData())).toEqual({
       policy: { allowedDomains: ["api.github.com"] },
     });
-    expect(mockReadWorkspacePolicy).toHaveBeenCalledWith(workspace.sId);
+    expect(mockReadWorkspacePolicy).toHaveBeenCalledWith(expect.any(Object));
   });
 
   it("updates the workspace egress policy with normalized domains", async () => {
@@ -73,8 +76,7 @@ describe("GET/PUT /api/w/[wId]/sandbox/egress-policy", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(mockWriteWorkspacePolicy).toHaveBeenCalledWith({
-      workspaceId: workspace.sId,
+    expect(mockWriteWorkspacePolicy).toHaveBeenCalledWith(expect.any(Object), {
       policy: {
         allowedDomains: ["api.github.com", "*.github.com"],
       },

--- a/front/pages/api/w/[wId]/sandbox/egress-policy.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/egress-policy.test.ts
@@ -1,0 +1,175 @@
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockEmitAuditLogEvent,
+  mockReadWorkspacePolicy,
+  mockWriteWorkspacePolicy,
+} = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
+  mockReadWorkspacePolicy: vi.fn(),
+  mockWriteWorkspacePolicy: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return {
+    ...actual,
+    emitAuditLogEvent: mockEmitAuditLogEvent,
+  };
+});
+
+vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
+  readWorkspacePolicy: mockReadWorkspacePolicy,
+  writeWorkspacePolicy: mockWriteWorkspacePolicy,
+}));
+
+import handler from "./egress-policy";
+
+describe("GET/PUT /api/w/[wId]/sandbox/egress-policy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockReadWorkspacePolicy.mockResolvedValue(
+      new Ok({ allowedDomains: ["api.github.com"] })
+    );
+    mockWriteWorkspacePolicy.mockImplementation(
+      async ({ policy }: { policy: { allowedDomains: string[] } }) => {
+        return new Ok(policy);
+      }
+    );
+  });
+
+  it("returns the workspace egress policy to workspace admins with sandbox tools enabled", async () => {
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData())).toEqual({
+      policy: { allowedDomains: ["api.github.com"] },
+    });
+    expect(mockReadWorkspacePolicy).toHaveBeenCalledWith(workspace.sId);
+  });
+
+  it("updates the workspace egress policy with normalized domains", async () => {
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "PUT",
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    req.body = {
+      allowedDomains: ["API.GitHub.COM", "*.GitHub.COM"],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockWriteWorkspacePolicy).toHaveBeenCalledWith({
+      workspaceId: workspace.sId,
+      policy: {
+        allowedDomains: ["api.github.com", "*.github.com"],
+      },
+    });
+    expect(JSON.parse(res._getData())).toEqual({
+      policy: {
+        allowedDomains: ["api.github.com", "*.github.com"],
+      },
+    });
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sandbox_egress_policy.updated",
+        auth: expect.any(Object),
+        context: expect.objectContaining({
+          location: expect.any(String),
+        }),
+        metadata: {
+          allowedDomainCount: "2",
+          allowedDomains: "api.github.com,*.github.com",
+        },
+        targets: [
+          expect.objectContaining({
+            type: "workspace",
+            id: workspace.sId,
+          }),
+          {
+            type: "sandbox_egress_policy",
+            id: workspace.sId,
+            name: "Sandbox egress policy",
+          },
+        ],
+      })
+    );
+  });
+
+  it("rejects invalid domain entries", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "PUT",
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    req.body = {
+      allowedDomains: ["127.0.0.1"],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockWriteWorkspacePolicy).not.toHaveBeenCalled();
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects workspaces without sandbox tools enabled", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(JSON.parse(res._getData())).toMatchObject({
+      error: {
+        type: "feature_flag_not_found",
+      },
+    });
+  });
+
+  it("rejects non-admin users", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(JSON.parse(res._getData())).toMatchObject({
+      error: {
+        type: "workspace_auth_error",
+      },
+    });
+  });
+
+  it("returns 500 when storage read fails", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    mockReadWorkspacePolicy.mockResolvedValue(new Err(new Error("GCS failed")));
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+  });
+});

--- a/front/pages/api/w/[wId]/sandbox/egress-policy.ts
+++ b/front/pages/api/w/[wId]/sandbox/egress-policy.ts
@@ -1,0 +1,135 @@
+/** @ignoreswagger */
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  readWorkspacePolicy,
+  writeWorkspacePolicy,
+} from "@app/lib/api/sandbox/egress_policy";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import { parseEgressPolicy } from "@app/types/sandbox/egress_policy";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetWorkspaceEgressPolicyResponseBody = {
+  policy: EgressPolicy;
+};
+
+export type PutWorkspaceEgressPolicyResponseBody = {
+  policy: EgressPolicy;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      | GetWorkspaceEgressPolicyResponseBody
+      | PutWorkspaceEgressPolicyResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can manage sandbox network settings.",
+      },
+    });
+  }
+
+  if (!(await hasFeatureFlag(auth, "sandbox_tools"))) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message: "Sandbox tools are not enabled for this workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const result = await readWorkspacePolicy(owner.sId);
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to read sandbox egress policy: ${result.error.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({ policy: result.value });
+    }
+
+    case "PUT": {
+      const parsedPolicy = parseEgressPolicy(req.body);
+      if (parsedPolicy.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid sandbox egress policy: ${parsedPolicy.error.message}`,
+          },
+        });
+      }
+
+      const result = await writeWorkspacePolicy({
+        workspaceId: owner.sId,
+        policy: parsedPolicy.value,
+      });
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to write sandbox egress policy: ${result.error.message}`,
+          },
+        });
+      }
+
+      void emitAuditLogEvent({
+        auth,
+        action: "sandbox_egress_policy.updated",
+        targets: [
+          buildAuditLogTarget("workspace", owner),
+          {
+            type: "sandbox_egress_policy",
+            id: owner.sId,
+            name: "Sandbox egress policy",
+          },
+        ],
+        context: getAuditLogContext(auth, req),
+        metadata: {
+          allowedDomainCount: String(result.value.allowedDomains.length),
+          allowedDomains: result.value.allowedDomains.join(","),
+        },
+      });
+
+      return res.status(200).json({ policy: result.value });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or PUT is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/sandbox/egress-policy.ts
+++ b/front/pages/api/w/[wId]/sandbox/egress-policy.ts
@@ -59,7 +59,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const result = await readWorkspacePolicy(owner.sId);
+      const result = await readWorkspacePolicy(auth);
       if (result.isErr()) {
         return apiError(req, res, {
           status_code: 500,
@@ -85,8 +85,7 @@ async function handler(
         });
       }
 
-      const result = await writeWorkspacePolicy({
-        workspaceId: owner.sId,
+      const result = await writeWorkspacePolicy(auth, {
         policy: parsedPolicy.value,
       });
       if (result.isErr()) {

--- a/front/types/sandbox/egress_policy.test.ts
+++ b/front/types/sandbox/egress_policy.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EMPTY_EGRESS_POLICY,
+  normalizeEgressPolicyDomain,
+  normalizeEgressPolicyDomains,
+  parseEgressPolicy,
+} from "./egress_policy";
+
+describe("egress policy domain validation", () => {
+  it("normalizes exact and wildcard domains", () => {
+    expect(normalizeEgressPolicyDomain("API.GitHub.COM.")).toMatchObject({
+      value: "api.github.com",
+    });
+    expect(normalizeEgressPolicyDomain(" *.GitHub.COM. ")).toMatchObject({
+      value: "*.github.com",
+    });
+  });
+
+  it("deduplicates domains while preserving order", () => {
+    const result = normalizeEgressPolicyDomains([
+      "api.github.com",
+      "API.GitHub.COM.",
+      "*.github.com",
+    ]);
+
+    expect(result).toMatchObject({
+      value: ["api.github.com", "*.github.com"],
+    });
+  });
+
+  it("rejects IP literals and malformed wildcard entries", () => {
+    for (const domain of [
+      "127.0.0.1",
+      "::1",
+      "[::1]",
+      "*.com",
+      "*.*.github.com",
+      "*github.com",
+      "bad domain",
+      "github..com",
+    ]) {
+      expect(normalizeEgressPolicyDomain(domain).isErr()).toBe(true);
+    }
+  });
+
+  it("returns a clear message for IP literals", () => {
+    for (const domain of ["127.0.0.1", "::1", "[::1]"]) {
+      const result = normalizeEgressPolicyDomain(domain);
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toBe("IP addresses are not supported.");
+      }
+    }
+  });
+
+  it("parses and normalizes policy objects", () => {
+    const result = parseEgressPolicy({
+      allowedDomains: ["API.GitHub.COM", "*.GitHub.COM"],
+    });
+
+    expect(result).toMatchObject({
+      value: {
+        allowedDomains: ["api.github.com", "*.github.com"],
+      },
+    });
+  });
+
+  it("keeps the empty policy singleton immutable", () => {
+    expect(Object.isFrozen(EMPTY_EGRESS_POLICY)).toBe(true);
+    expect(Object.isFrozen(EMPTY_EGRESS_POLICY.allowedDomains)).toBe(true);
+  });
+});

--- a/front/types/sandbox/egress_policy.test.ts
+++ b/front/types/sandbox/egress_policy.test.ts
@@ -39,6 +39,9 @@ describe("egress policy domain validation", () => {
       "*github.com",
       "bad domain",
       "github..com",
+      "127.0.0",
+      "192.168",
+      "10",
     ]) {
       expect(normalizeEgressPolicyDomain(domain).isErr()).toBe(true);
     }

--- a/front/types/sandbox/egress_policy.ts
+++ b/front/types/sandbox/egress_policy.ts
@@ -39,6 +39,13 @@ function normalizeDnsName(value: string): Result<string, Error> {
     }
   }
 
+  const tld = labels[labels.length - 1];
+  if (!/[a-z]/.test(tld)) {
+    return new Err(
+      new Error("Domain must have a top-level label containing a letter.")
+    );
+  }
+
   return new Ok(normalized);
 }
 

--- a/front/types/sandbox/egress_policy.ts
+++ b/front/types/sandbox/egress_policy.ts
@@ -1,0 +1,145 @@
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { z } from "zod";
+
+export type EgressPolicy = {
+  allowedDomains: string[];
+};
+
+export const EMPTY_EGRESS_POLICY = Object.freeze({
+  allowedDomains: Object.freeze([]),
+}) as unknown as EgressPolicy;
+
+const EgressPolicyShapeSchema = z.object({
+  allowedDomains: z.array(z.string()),
+});
+
+function normalizeDnsName(value: string): Result<string, Error> {
+  const normalized = value.toLowerCase().replace(/\.$/, "");
+
+  if (normalized.length === 0) {
+    return new Err(new Error("Domain cannot be empty."));
+  }
+
+  if (normalized.length > 253) {
+    return new Err(new Error("Domain must be 253 characters or less."));
+  }
+
+  if (isIpLiteral(normalized)) {
+    return new Err(new Error("IP addresses are not supported."));
+  }
+
+  const labels = normalized.split(".");
+  for (const label of labels) {
+    if (!isValidDnsLabel(label)) {
+      return new Err(
+        new Error(
+          "Use an exact domain such as api.github.com or a wildcard such as *.github.com."
+        )
+      );
+    }
+  }
+
+  return new Ok(normalized);
+}
+
+function isIpLiteral(value: string): boolean {
+  const unbracketed =
+    value.startsWith("[") && value.endsWith("]") ? value.slice(1, -1) : value;
+
+  return isIpv4Literal(unbracketed) || isIpv6Literal(unbracketed);
+}
+
+function isIpv4Literal(value: string): boolean {
+  const parts = value.split(".");
+  return (
+    parts.length === 4 &&
+    parts.every((part) => {
+      if (!/^\d+$/.test(part)) {
+        return false;
+      }
+
+      const octet = Number.parseInt(part, 10);
+      return octet >= 0 && octet <= 255;
+    })
+  );
+}
+
+function isIpv6Literal(value: string): boolean {
+  return value.includes(":") && /^[0-9a-f:.]+$/i.test(value);
+}
+
+function isValidDnsLabel(label: string): boolean {
+  if (label.length === 0 || label.length > 63) {
+    return false;
+  }
+
+  return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label);
+}
+
+export function normalizeEgressPolicyDomain(
+  value: string
+): Result<string, Error> {
+  const trimmed = value.trim();
+
+  if (trimmed.length === 0) {
+    return new Err(new Error("Domain cannot be empty."));
+  }
+
+  if (trimmed.startsWith("*.")) {
+    const suffixResult = normalizeDnsName(trimmed.slice(2));
+    if (suffixResult.isErr()) {
+      return suffixResult;
+    }
+
+    const suffix = suffixResult.value;
+    if (suffix.split(".").length < 2) {
+      return new Err(new Error("Wildcard domains must include a suffix."));
+    }
+
+    return new Ok(`*.${suffix}`);
+  }
+
+  if (trimmed.includes("*")) {
+    return new Err(new Error("Wildcards must use the form *.example.com."));
+  }
+
+  return normalizeDnsName(trimmed);
+}
+
+export function normalizeEgressPolicyDomains(
+  values: string[]
+): Result<string[], Error> {
+  const domains = new Set<string>();
+
+  for (const value of values) {
+    const normalized = normalizeEgressPolicyDomain(value);
+    if (normalized.isErr()) {
+      return new Err(new Error(`${value}: ${normalized.error.message}`));
+    }
+    domains.add(normalized.value);
+  }
+
+  return new Ok([...domains]);
+}
+
+export function normalizeEgressPolicy(
+  policy: EgressPolicy
+): Result<EgressPolicy, Error> {
+  const domains = normalizeEgressPolicyDomains(policy.allowedDomains);
+  if (domains.isErr()) {
+    return domains;
+  }
+
+  return new Ok({
+    allowedDomains: domains.value,
+  });
+}
+
+export function parseEgressPolicy(value: unknown): Result<EgressPolicy, Error> {
+  const parsed = EgressPolicyShapeSchema.safeParse(value);
+  if (!parsed.success) {
+    return new Err(new Error("Invalid egress policy shape."));
+  }
+
+  return normalizeEgressPolicy(parsed.data);
+}


### PR DESCRIPTION
## Description

Workspace admins can now manage their sandbox egress domain allowlist through a new **Network** page under developer settings (gated behind `sandbox_tools` feature flag).

The allowlist is stored in GCS at `workspaces/{wId}.json` and enforced by the egress proxy alongside the default allowlist (`EGRESS_PROXY_ALLOWED_DOMAINS`). A domain is allowed if it appears in **any** of three sources:
1. Default allowlist (env var, infrastructure domains like `dust.tt`)
2. Workspace policy (this PR — admin-managed via settings UI)
3. Sandbox policy (future PR — agent-requested domains)

### What's included

- **Type layer** (`front/types/sandbox/egress_policy.ts`): `EgressPolicy` type, domain validation that mirrors the proxy's `DomainPattern::parse_policy_entry` rules (DNS names only, no IPs, no bare TLDs, wildcard suffix support, normalized to lowercase, deduped).
- **GCS storage** (`front/lib/api/sandbox/egress_policy.ts`): `readWorkspacePolicy`, `writeWorkspacePolicy`, `deleteWorkspacePolicy` via `FileStorage`. GCS 404 returns empty policy.
- **API endpoint** (`front/pages/api/w/[wId]/sandbox/egress-policy.ts`): GET (read) and PUT (write), admin-only + feature flag gated. Server-side validation.
- **Audit logging**: `sandbox_egress_policy.updated` action emitted on PUT with domain list metadata.
- **SWR hooks** (`front/lib/swr/sandbox.ts`): `useWorkspaceEgressPolicy` + `useUpdateWorkspaceEgressPolicy` with optimistic mutation and notifications.
- **UI** (`EgressPolicyPage.tsx`): Settings page with live domain input validation, add/remove controls, feature flag + admin gating.
- **Navigation**: Sidebar entry under developers section, feature-flag gated.

⚠️ I know the copy is nerdy and not shippable. Temporary: a designer will tweak that.

<img width="1861" height="606" alt="Screenshot 2026-04-24 at 14 44 10" src="https://github.com/user-attachments/assets/c7adab73-6c9b-4ff2-81d0-cd5c8de2430f" />

<img width="1080" height="489" alt="Screenshot 2026-04-24 at 14 49 27" src="https://github.com/user-attachments/assets/e97fc9e4-5b7a-42c0-a412-8addaddfc45e" />



### How it works

Changes are written to GCS immediately. The proxy picks them up on next cache refresh (60s TTL). Immediate invalidation will be added in a follow-up PR (cache invalidation endpoint).

## Tests

- **4 type/validation tests**: exact + wildcard normalization, dedup, rejects IPs/malformed entries, policy parsing.
- **5 storage layer tests**: read from GCS, missing file → empty policy, write with normalization, reject invalid domains, delete with ignoreNotFound.
- **6 API endpoint tests**: admin GET, admin PUT with normalization, rejects invalid domains, rejects non-admin, rejects without feature flag, handles storage errors.

All tests pass locally.

## Risk

**Low.** Feature-flag gated (`sandbox_tools`) — no impact on workspaces without the flag. The GCS write path is new but uses the same `FileStorage` wrapper used by all other GCS operations in front. The egress proxy already reads workspace policy files (deployed in PR #24781) — this PR just adds the write side.

**Prerequisite**: The front service account needs write access to the egress policy bucket. If missing, PUT calls will return 500 (read-only GET still works).

## Deploy Plan

1. Ensure front service account has `roles/storage.objectAdmin` on the egress policy bucket.
2. Merge and deploy front — feature flag gates all access, no immediate user impact.