### PR TITLE
Wake-ups: server name, remove preview

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1106,7 +1106,7 @@ export const INTERNAL_MCP_SERVERS = {
     id: 1031,
     availability: "auto",
     allowMultipleInstances: false,
-    isPreview: true,
+    isPreview: false,
     isRestricted: ({ featureFlags }) =>
       !featureFlags.includes("enable_wakeups"),
     tools_arguments_requiring_approval: undefined,

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -203,6 +203,10 @@ export function asDisplayToolName(name?: string | null) {
     return "Query Tables";
   }
 
+  if (name === "wakeups") {
+    return "Wake-ups";
+  }
+
   return formatAsDisplayName(name);
 }
 


### PR DESCRIPTION
## Description

Naming nits for wake-ups MCP server.

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`