### PR TITLE
Clean up user wake-ups during poke hard-delete

### DIFF
--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -27,6 +27,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { UserType } from "@app/types/user";
 import { CronExpressionParser } from "cron-parser";
 import type { Attributes, Transaction, WhereOptions } from "sequelize";
 
@@ -396,6 +397,41 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         conversationId: conversation.id,
+      } as WhereOptions<WakeUpModel>,
+      transaction,
+    });
+  }
+
+  /**
+   * Cancels Temporal workflows / schedules for any active wake-up owned by `user` in the current
+   * workspace, then deletes all wake-up rows (any status) for that user.
+   */
+  static async deleteAllForUser(
+    auth: Authenticator,
+    user: UserType,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    const wakeUps = await this.baseFetch(auth, {
+      where: { userId: user.id },
+    });
+
+    const activeWakeUps = wakeUps.filter((w) => isActiveWakeUp(w.toJSON()));
+
+    const cancelResults = await concurrentExecutor(
+      activeWakeUps,
+      async (wakeUp) => wakeUp.cancelTemporalWorkflow(auth),
+      { concurrency: 10 }
+    );
+
+    const cancellationError = cancelResults.find((result) => result.isErr());
+    if (cancellationError?.isErr()) {
+      throw cancellationError.error;
+    }
+
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: user.id,
       } as WhereOptions<WakeUpModel>,
       transaction,
     });

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -69,6 +69,7 @@ import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -559,6 +560,10 @@ export async function deleteMembersActivity({
           },
         });
         await OnboardingTaskResource.deleteAllForUser(auth, user.toJSON());
+
+        // Cancel any remaining Temporal workflows/schedules and delete wake-up rows owned by the
+        // user in this workspace.
+        await WakeUpResource.deleteAllForUser(auth, user.toJSON());
 
         await user.delete(auth, {});
       }


### PR DESCRIPTION
## Description

Adds `WakeUpResource.deleteAllForUser(auth, user)`:
- Fetches every wake-up owned by `user` in the workspace (any status).
- Cancels Temporal workflows / schedules for any that are still active.
- Bulk-deletes the rows.

Wires it into the existing user hard-delete path in `front/poke/temporal/activities.ts` (the block that runs when the membership being revoked is the user's last, alongside `FileResource.deleteAllForUser`, `AgentMemoryModel.destroy`, and `OnboardingTaskResource.deleteAllForUser`).

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `front`