### PR TITLE
Cancel wake-up on terminal agent errors at fire time

### DIFF
--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -367,6 +367,17 @@ export async function runWakeUpActivity({
       api_error: { message, type },
     } = postMessageResult.error;
 
+    if (
+      type === "agent_configuration_not_found" ||
+      type === "agent_inaccessible" ||
+      type === "model_disabled"
+    ) {
+      await wakeUp.markCancelled(auth);
+      throw new WakeUpNonRetryableError(
+        `Cancelling wake-up: ${type} (${message}).`
+      );
+    }
+
     throw new Error(`Error posting wake-up message: [${type}] ${message}`);
   }
 


### PR DESCRIPTION
## Description

Completes the "agent-side terminal errors" part of PR 10 from `x/spolu/wakeup/plan.md`.

When `postUserMessage` returns `agent_configuration_not_found`, `agent_inaccessible`, or `model_disabled`, the wake-up cannot possibly succeed: the agent no longer exists, the caller lost access, or the model was disabled by an admin. Retrying across the full Temporal backoff window and only marking the wake-up `expired` after retry exhaustion is wasteful.

`runWakeUpActivity` now:
- calls `markCancelled(auth)` on the wake-up, and
- throws `WakeUpNonRetryableError`

…for those three error types. Other `postUserMessage` errors (rate limits, transient workspace / subscription issues) remain on the existing retryable path.

## Tests

N/A.

## Risk

Low.

## Deploy Plan

- deploy `front`