### PR TITLE
Add tool call to reject invalid suggestions, keep the minor one opened

### DIFF
--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -34,12 +34,17 @@ const REINFORCED_SKILL_AGGREGATION_SECTIONS: Record<
   primary: `You improve a skill's configuration by consolidating many draft suggestions. Each draft was produced from a single conversation that used the skill.
 Your job is to produce a subset of the highest quality suggestions for the skill builder to review.
 
-You have access to the following tool:
+You have access to the following tools:
 - edit_skill: For suggesting instruction edits and tool add/remove for one skill. The skill block above includes <agentFacingDescription> when set (for context only); you MUST NOT use edit_skill to change it.
+- reject_suggestion: For discarding source suggestions that are invalid, not actionable, or too similar to already declined suggestions. Do NOT reject minor but valid suggestions, simply ignore them.
 
 Your goal is to keep the most impactful suggestions. NEVER create more than 5 suggestions.
 You MUST follow <aggregation_rules> to determine the final set of suggestions.
-You will call suggestion tools to create each of the final suggestions. You MUST follow <suggestion_tool_calls> for each suggestion.
+You will call edit_skill to create each of the final suggestions and reject_suggestion to discard bad ones. Minor ones will just be ignored and not included in any tool.
+You MUST follow <suggestion_tool_calls> for each suggestion.
+
+IMPORTANT: Both edit_skill and reject_suggestion are terminal calls — you will NOT be called again after using them. Not all suggestions must be included in edit_skill or reject_suggestion, low impact but valid ones must be simply ignored.
+It is ok to simply call no tool if all suggestions are minor.
 `,
 
   aggregation_rules: `
@@ -56,7 +61,12 @@ Rank the groups based on impact to the skill. Use these heuristics in priority o
 
 Use your discretion on what suggestions will most improve the skill's ability to handle the user's intent.
 
-You SHOULD drop suggestions that only have minor impact and are only supported by a single conversation.
+Classify the groups in these 3 categories:
+ - impactful -> create a new suggestion for the most impactful ones.
+ - minor -> just ignore them, call no tool for these suggestions
+ - invalid or too similar to existing declined/pending suggestions -> call reject_suggestion
+
+You SHOULD ignore suggestions that only have minor impact and are only supported by a single conversation (don't reject them, do NOT call reject_suggestion, just take no action for these suggestions).
 
 There may be situations where suggestions are co-dependent. For example, there may be an instruction suggestion that requires a tool suggestion to be effective. In this case, NEVER create one suggestion without the other.`,
 

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -36,6 +36,7 @@ import logger from "@app/logger/logger";
 import { GPT_5_4_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 import type { SkillSuggestionSource } from "@app/types/suggestions/skill_suggestion";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
@@ -130,6 +131,20 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
         ),
     },
   },
+  reject_suggestion: {
+    description:
+      "Reject source suggestions that are very bad quality, not actionable, or too similar to already declined suggestions. " +
+      "Use this tool in parallel with edit_skill calls — both are terminal and no further calls will be made after." +
+      "Do not use to ingore minor suggestions.",
+    schema: {
+      sourceSuggestionIds: z
+        .array(z.string())
+        .min(1)
+        .describe(
+          "The sIds of the source suggestions to reject. Must include at least one suggestion sId."
+        ),
+    },
+  },
 };
 
 const AGGREGATION_EXTRA_FIELDS: z.ZodRawShape = {
@@ -145,16 +160,19 @@ const AGGREGATION_EXTRA_FIELDS: z.ZodRawShape = {
 export function buildReinforcedSkillsSpecifications(
   operationType: ReinforcedSkillsOperationType
 ): AgentActionSpecification[] {
-  const extraEditSkillFields =
-    operationType === "reinforcement_aggregate_suggestions"
-      ? AGGREGATION_EXTRA_FIELDS
-      : undefined;
+  const isAggregation = operationType === "reinforcement_aggregate_suggestions";
 
-  return ALL_TOOLS.map((toolName) => {
+  return ALL_TOOLS.filter((toolName) => {
+    // reject_suggestion is only available during aggregation.
+    if (toolName === "reject_suggestion") {
+      return isAggregation;
+    }
+    return true;
+  }).map((toolName) => {
     const meta = REINFORCED_SKILLS_TOOL_DEFINITIONS[toolName];
     const schema =
-      toolName === "edit_skill" && extraEditSkillFields
-        ? z.object({ ...meta.schema, ...extraEditSkillFields })
+      toolName === "edit_skill" && isAggregation
+        ? z.object({ ...meta.schema, ...AGGREGATION_EXTRA_FIELDS })
         : z.object(meta.schema);
     return {
       name: toolName,
@@ -351,6 +369,8 @@ export async function processSkillReinforcedEvents({
     );
     return {
       suggestionsCreated: 0,
+      suggestionsRejected: 0,
+      approvedSourceSuggestionIds: [],
       successfulToolCalls: [],
       failedToolCalls: [],
     };
@@ -367,12 +387,16 @@ export async function processSkillReinforcedEvents({
     );
     return {
       suggestionsCreated: 0,
+      suggestionsRejected: 0,
+      approvedSourceSuggestionIds: [],
       successfulToolCalls: [],
       failedToolCalls: [],
     };
   }
 
   let totalCreated = 0;
+  let totalRejected = 0;
+  const approvedSourceSuggestionIds: string[] = [];
   const successfulToolCalls: TerminalToolCallSuccess[] = [];
   const failedToolCalls: TerminalToolCallFailure[] = [];
 
@@ -388,28 +412,51 @@ export async function processSkillReinforcedEvents({
       contextId,
       conversation,
     });
-    totalCreated += result.suggestionsCreated;
-    if (result.error) {
-      failedToolCalls.push({ toolCall, errorMessage: result.error });
-    } else {
-      successfulToolCalls.push({
-        toolCall,
-        message: `Successfully created ${result.suggestionsCreated} suggestion(s).`,
-      });
+    switch (result.type) {
+      case "created": {
+        totalCreated += result.suggestionsCreated;
+        // Collect sourceSuggestionIds from successful edit_skill calls.
+        const sourceIds = args.sourceSuggestionIds;
+        if (Array.isArray(sourceIds)) {
+          approvedSourceSuggestionIds.push(...sourceIds.filter(isString));
+        }
+        successfulToolCalls.push({
+          toolCall,
+          message: `Successfully created ${result.suggestionsCreated} suggestion(s).`,
+        });
+        break;
+      }
+      case "rejected":
+        totalRejected += result.suggestionsRejected;
+        successfulToolCalls.push({
+          toolCall,
+          message: `Successfully rejected ${result.suggestionsRejected} suggestion(s).`,
+        });
+        break;
+      case "error":
+        failedToolCalls.push({
+          toolCall,
+          errorMessage: result.errorMessage,
+        });
+        break;
+      default:
+        assertNever(result);
     }
   }
 
   return {
     suggestionsCreated: totalCreated,
+    suggestionsRejected: totalRejected,
+    approvedSourceSuggestionIds,
     successfulToolCalls,
     failedToolCalls,
   };
 }
 
-interface ToolCallResult {
-  suggestionsCreated: number;
-  error?: string;
-}
+type ToolCallResult =
+  | { type: "created"; suggestionsCreated: number }
+  | { type: "rejected"; suggestionsRejected: number }
+  | { type: "error"; errorMessage: string };
 
 async function createSkillSuggestionsFromToolCall({
   auth,
@@ -432,12 +479,14 @@ async function createSkillSuggestionsFromToolCall({
     case "edit_skill": {
       const parsed = TOOL_SCHEMAS.edit_skill.safeParse(actionArguments);
       if (!parsed.success) {
-        const errorMessage = `Invalid arguments for ${toolName}: ${parsed.error.message}`;
         logger.warn(
           { contextId, toolName, error: parsed.error },
           `ReinforcedSkills: invalid LLM response shape for ${operationType}`
         );
-        return { suggestionsCreated: 0, error: errorMessage };
+        return {
+          type: "error",
+          errorMessage: `Invalid arguments for ${toolName}: ${parsed.error.message}`,
+        };
       }
 
       const skill = await SkillResource.fetchById(auth, parsed.data.skillId);
@@ -446,7 +495,7 @@ async function createSkillSuggestionsFromToolCall({
           { skillId: parsed.data.skillId, contextId },
           "ReinforcedSkills: skill not found for edit_skill"
         );
-        return { suggestionsCreated: 0, error: "Skill not found" };
+        return { type: "error", errorMessage: "Skill not found" };
       }
 
       const hasInstructionEdits =
@@ -454,16 +503,16 @@ async function createSkillSuggestionsFromToolCall({
       const hasToolEdits = (parsed.data.toolEdits?.length ?? 0) > 0;
       if (!hasInstructionEdits && !hasToolEdits) {
         return {
-          suggestionsCreated: 0,
-          error:
+          type: "error",
+          errorMessage:
             "edit_skill requires at least one instruction edit or tool edit.",
         };
       }
 
       if (hasInstructionEdits && !skill.instructionsHtml) {
         return {
-          suggestionsCreated: 0,
-          error:
+          type: "error",
+          errorMessage:
             "edit_skill with instructionEdits requires the skill to have instructionsHtml.",
         };
       }
@@ -478,8 +527,8 @@ async function createSkillSuggestionsFromToolCall({
         )
       ) {
         return {
-          suggestionsCreated: 0,
-          error:
+          type: "error",
+          errorMessage:
             "Suggestion has conflicting edits (overlapping block targets or duplicate tool IDs).",
         };
       }
@@ -522,7 +571,49 @@ async function createSkillSuggestionsFromToolCall({
 
       await pruneConflictingSkillEditSuggestions(auth, skill, newSuggestion);
 
-      return { suggestionsCreated: 1 };
+      return { type: "created", suggestionsCreated: 1 };
+    }
+
+    case "reject_suggestion": {
+      const parsed = TOOL_SCHEMAS.reject_suggestion.safeParse(actionArguments);
+      if (!parsed.success) {
+        logger.warn(
+          { contextId, toolName, error: parsed.error },
+          `ReinforcedSkills: invalid LLM response shape for ${operationType}`
+        );
+        return {
+          type: "error",
+          errorMessage: `Invalid arguments for ${toolName}: ${parsed.error.message}`,
+        };
+      }
+
+      const suggestions = await SkillSuggestionResource.fetchByIds(
+        auth,
+        parsed.data.sourceSuggestionIds
+      );
+
+      if (suggestions.length === 0) {
+        return {
+          type: "error",
+          errorMessage: `No suggestions found for sourceSuggestionIds: ${parsed.data.sourceSuggestionIds.join(", ")}`,
+        };
+      }
+
+      await SkillSuggestionResource.bulkUpdateState(
+        auth,
+        suggestions,
+        "rejected"
+      );
+
+      logger.info(
+        {
+          contextId,
+          rejectedCount: suggestions.length,
+        },
+        `ReinforcedSkills: rejected ${suggestions.length} suggestion(s) via reject_suggestion`
+      );
+
+      return { type: "rejected", suggestionsRejected: suggestions.length };
     }
 
     default:
@@ -530,6 +621,9 @@ async function createSkillSuggestionsFromToolCall({
         { contextId, toolName },
         `ReinforcedSkills: unexpected tool name for ${operationType}`
       );
-      return { suggestionsCreated: 0 };
+      return {
+        type: "error",
+        errorMessage: `Unexpected tool name: ${toolName}`,
+      };
   }
 }

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -8,9 +8,12 @@ export type ExploratoryToolName =
   | "search_knowledge"
   | typeof DESCRIBE_MCP_TOOL_NAME;
 
-export type TerminalToolName = "edit_skill";
+export type TerminalToolName = "edit_skill" | "reject_suggestion";
 
-export const TERMINAL_TOOLS: TerminalToolName[] = ["edit_skill"];
+export const TERMINAL_TOOLS: TerminalToolName[] = [
+  "edit_skill",
+  "reject_suggestion",
+];
 
 export const EXPLORATORY_TOOLS: ExploratoryToolName[] = [
   "get_available_tools",
@@ -92,6 +95,14 @@ export const TOOL_SCHEMAS: Record<
         "The sIds of the source suggestions consolidated into this suggestion."
       ),
   }),
+  reject_suggestion: z.object({
+    sourceSuggestionIds: z
+      .array(z.string())
+      .min(1)
+      .describe(
+        "The sIds of the source suggestions to reject. Must include at least one suggestion sId."
+      ),
+  }),
 };
 
 export interface TerminalToolCallEvent extends ToolCallEvent {
@@ -126,6 +137,8 @@ export interface TerminalToolCallFailure {
 
 export interface ProcessReinforcedSkillsEventsResult {
   suggestionsCreated: number;
+  suggestionsRejected: number;
+  approvedSourceSuggestionIds: string[];
   successfulToolCalls: TerminalToolCallSuccess[];
   failedToolCalls: TerminalToolCallFailure[];
 }

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -87,6 +87,7 @@ async function runReinforcedSkillsStep({
 }): Promise<{
   isTerminal: boolean;
   suggestionsCreated: number;
+  approvedSourceSuggestionIds: string[];
   reinforcementConversationId?: string;
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
@@ -96,7 +97,11 @@ async function runReinforcedSkillsStep({
       { contextId, workspaceId: auth.getNonNullableWorkspace().sId },
       "ReinforcedSkills: no LLM available for step activity"
     );
-    return { isTerminal: true, suggestionsCreated: 0 };
+    return {
+      isTerminal: true,
+      suggestionsCreated: 0,
+      approvedSourceSuggestionIds: [],
+    };
   }
 
   const conversationRes = await getConversation(
@@ -192,6 +197,7 @@ async function runReinforcedSkillsStep({
       return {
         isTerminal: false,
         suggestionsCreated: result.suggestionsCreated,
+        approvedSourceSuggestionIds: result.approvedSourceSuggestionIds,
         reinforcementConversationId,
       };
     }
@@ -199,6 +205,7 @@ async function runReinforcedSkillsStep({
     return {
       isTerminal: true,
       suggestionsCreated: result.suggestionsCreated,
+      approvedSourceSuggestionIds: result.approvedSourceSuggestionIds,
       reinforcementConversationId,
     };
   }
@@ -215,6 +222,7 @@ async function runReinforcedSkillsStep({
   return {
     isTerminal: false,
     suggestionsCreated: 0,
+    approvedSourceSuggestionIds: [],
     reinforcementConversationId,
     toolActionInfo,
   };
@@ -292,6 +300,7 @@ export async function analyzeConversationStepActivity({
 }): Promise<{
   isTerminal: boolean;
   suggestionsCreated: number;
+  approvedSourceSuggestionIds: string[];
   reinforcementConversationId?: string;
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
@@ -311,7 +320,11 @@ export async function analyzeConversationStepActivity({
         { conversationId },
         "ReinforcedSkills: conversation not found for step activity"
       );
-      return { isTerminal: true, suggestionsCreated: 0 };
+      return {
+        isTerminal: true,
+        suggestionsCreated: 0,
+        approvedSourceSuggestionIds: [],
+      };
     }
 
     if (skills.length === 0) {
@@ -319,7 +332,11 @@ export async function analyzeConversationStepActivity({
         { conversationId, skillIds },
         "ReinforcedSkills: no skills found for step activity"
       );
-      return { isTerminal: true, suggestionsCreated: 0 };
+      return {
+        isTerminal: true,
+        suggestionsCreated: 0,
+        approvedSourceSuggestionIds: [],
+      };
     }
 
     const skillTypes = skills.map((s) => s.toJSON(auth));
@@ -414,6 +431,7 @@ export async function aggregateSuggestionsForSkillStepActivity({
 }): Promise<{
   isTerminal: boolean;
   suggestionsCreated: number;
+  approvedSourceSuggestionIds: string[];
   reinforcementConversationId?: string;
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
@@ -423,7 +441,11 @@ export async function aggregateSuggestionsForSkillStepActivity({
   if (!reinforcementConversationId) {
     const ctx = await loadSkillAggregationContext(auth, skillId);
     if (!ctx) {
-      return { isTerminal: true, suggestionsCreated: 0 };
+      return {
+        isTerminal: true,
+        suggestionsCreated: 0,
+        approvedSourceSuggestionIds: [],
+      };
     }
 
     reinforcementConversationId = await createReinforcedSkillsConversation(
@@ -455,27 +477,30 @@ export async function finalizeSkillAggregationActivity({
   workspaceId,
   skillId,
   suggestionsCreated,
+  approvedSourceSuggestionIds,
   disableNotifications,
 }: {
   workspaceId: string;
   skillId: string;
   suggestionsCreated: number;
+  approvedSourceSuggestionIds: string[];
   disableNotifications: boolean;
 }): Promise<void> {
   const auth = await getAuthForWorkspace(workspaceId);
 
-  // Mark synthetic suggestions as approved (consumed by aggregation).
-  const syntheticSuggestions =
-    await SkillSuggestionResource.listBySkillConfigurationId(auth, skillId, {
-      sources: ["synthetic"],
-      states: ["pending"],
-    });
-
-  await SkillSuggestionResource.bulkUpdateState(
-    auth,
-    syntheticSuggestions,
-    "approved"
-  );
+  // Mark only the synthetic suggestions that were used by edit_skill as approved.
+  // Rejected ones were already marked during processing; the rest stay pending.
+  if (approvedSourceSuggestionIds.length > 0) {
+    const approvedSuggestions = await SkillSuggestionResource.fetchByIds(
+      auth,
+      approvedSourceSuggestionIds
+    );
+    await SkillSuggestionResource.bulkUpdateState(
+      auth,
+      approvedSuggestions,
+      "approved"
+    );
+  }
 
   // Record that reinforcement analysis has completed for this skill.
   const skill = await SkillResource.fetchById(auth, skillId);
@@ -503,7 +528,7 @@ export async function finalizeSkillAggregationActivity({
   logger.info(
     {
       skillId,
-      syntheticCount: syntheticSuggestions.length,
+      approvedCount: approvedSourceSuggestionIds.length,
       pendingCreated: suggestionsCreated,
       disableNotifications,
     },
@@ -904,6 +929,7 @@ export async function processSkillAggregationBatchResultActivity({
 }): Promise<{
   needsContinuation: boolean;
   suggestionsCreated: number;
+  approvedSourceSuggestionIds: string[];
   reinforcementConversationId?: string;
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
@@ -914,7 +940,11 @@ export async function processSkillAggregationBatchResultActivity({
     "reinforcement_aggregate_suggestions"
   );
   if (!llm) {
-    return { needsContinuation: false, suggestionsCreated: 0 };
+    return {
+      needsContinuation: false,
+      suggestionsCreated: 0,
+      approvedSourceSuggestionIds: [],
+    };
   }
 
   // Download results and store agent messages in reinforcement conversations.
@@ -932,7 +962,11 @@ export async function processSkillAggregationBatchResultActivity({
   const events = batchEvents.get(firstConvId);
 
   if (!events) {
-    return { needsContinuation: false, suggestionsCreated: 0 };
+    return {
+      needsContinuation: false,
+      suggestionsCreated: 0,
+      approvedSourceSuggestionIds: [],
+    };
   }
 
   const { exploratoryToolCalls, terminalToolCalls } =
@@ -962,6 +996,7 @@ export async function processSkillAggregationBatchResultActivity({
         return {
           needsContinuation: true,
           suggestionsCreated: result.suggestionsCreated,
+          approvedSourceSuggestionIds: result.approvedSourceSuggestionIds,
           reinforcementConversationId: firstConvId,
         };
       }
@@ -979,13 +1014,18 @@ export async function processSkillAggregationBatchResultActivity({
     return {
       needsContinuation: false,
       suggestionsCreated: result.suggestionsCreated,
+      approvedSourceSuggestionIds: result.approvedSourceSuggestionIds,
     };
   }
 
   // Only exploratory tools — prepare actions for the workflow to execute.
   const storedInfo = storedResultInfo.get(firstConvId);
   if (!storedInfo) {
-    return { needsContinuation: false, suggestionsCreated: 0 };
+    return {
+      needsContinuation: false,
+      suggestionsCreated: 0,
+      approvedSourceSuggestionIds: [],
+    };
   }
 
   const toolActionInfo = await prepareReinforcedToolActions(auth, {
@@ -999,6 +1039,7 @@ export async function processSkillAggregationBatchResultActivity({
   return {
     needsContinuation: true,
     suggestionsCreated: 0,
+    approvedSourceSuggestionIds: [],
     reinforcementConversationId: firstConvId,
     toolActionInfo,
   };

--- a/front/temporal/reinforcement/workflows.ts
+++ b/front/temporal/reinforcement/workflows.ts
@@ -143,6 +143,7 @@ interface ReinforcedToolActionInfo {
 interface ReinforcedStepResult {
   isTerminal: boolean;
   suggestionsCreated: number;
+  approvedSourceSuggestionIds: string[];
   reinforcementConversationId?: string;
   toolActionInfo?: ReinforcedToolActionInfo;
 }
@@ -183,15 +184,20 @@ async function runMultiStepStreamingLoop(
   stepFn: (
     reinforcementConversationId: string | undefined
   ) => Promise<ReinforcedStepResult>
-): Promise<{ suggestionsCreated: number }> {
+): Promise<{
+  suggestionsCreated: number;
+  approvedSourceSuggestionIds: string[];
+}> {
   let reinforcementConversationId: string | undefined;
   let totalSuggestionsCreated = 0;
+  const allApprovedSourceSuggestionIds: string[] = [];
 
   for (let step = 0; step < MAX_REINFORCED_ANALYSIS_STEPS; step++) {
     const result = await stepFn(reinforcementConversationId);
 
     reinforcementConversationId = result.reinforcementConversationId;
     totalSuggestionsCreated += result.suggestionsCreated;
+    allApprovedSourceSuggestionIds.push(...result.approvedSourceSuggestionIds);
 
     if (result.isTerminal) {
       break;
@@ -202,7 +208,10 @@ async function runMultiStepStreamingLoop(
     }
   }
 
-  return { suggestionsCreated: totalSuggestionsCreated };
+  return {
+    suggestionsCreated: totalSuggestionsCreated,
+    approvedSourceSuggestionIds: allApprovedSourceSuggestionIds,
+  };
 }
 
 /**
@@ -219,6 +228,7 @@ async function aggregateSkillWithMultiStepBatch({
 }): Promise<void> {
   let reinforcementConversationId: string | undefined;
   let totalSuggestionsCreated = 0;
+  const allApprovedSourceSuggestionIds: string[] = [];
 
   for (let step = 0; step < MAX_REINFORCED_ANALYSIS_STEPS; step++) {
     const batchResult = await startSkillAggregationBatchActivity({
@@ -241,6 +251,7 @@ async function aggregateSkillWithMultiStepBatch({
     });
 
     totalSuggestionsCreated += result.suggestionsCreated;
+    allApprovedSourceSuggestionIds.push(...result.approvedSourceSuggestionIds);
 
     if (!result.needsContinuation) {
       break;
@@ -257,6 +268,7 @@ async function aggregateSkillWithMultiStepBatch({
     workspaceId,
     skillId,
     suggestionsCreated: totalSuggestionsCreated,
+    approvedSourceSuggestionIds: allApprovedSourceSuggestionIds,
     disableNotifications,
   });
 }
@@ -421,15 +433,19 @@ export async function reinforcementWorkspaceWorkflow({
     const aggregationResults = await concurrentExecutor(
       skillIdsWithSuggestions,
       async (currentSkillId) => {
-        const { suggestionsCreated } = await runMultiStepStreamingLoop(
-          (reinforcementConversationId) =>
+        const { suggestionsCreated, approvedSourceSuggestionIds } =
+          await runMultiStepStreamingLoop((reinforcementConversationId) =>
             aggregateSuggestionsForSkillStepActivity({
               workspaceId,
               skillId: currentSkillId,
               reinforcementConversationId,
             })
-        );
-        return { skillId: currentSkillId, suggestionsCreated };
+          );
+        return {
+          skillId: currentSkillId,
+          suggestionsCreated,
+          approvedSourceSuggestionIds,
+        };
       },
       { concurrency: SKILL_AGGREGATION_CONCURRENCY }
     );
@@ -438,11 +454,13 @@ export async function reinforcementWorkspaceWorkflow({
     for (const {
       skillId: currentSkillId,
       suggestionsCreated,
+      approvedSourceSuggestionIds,
     } of aggregationResults) {
       await finalizeSkillAggregationActivity({
         workspaceId,
         skillId: currentSkillId,
         suggestionsCreated,
+        approvedSourceSuggestionIds,
         disableNotifications,
       });
     }

--- a/front/tests/reinforcement-evals/lib/assertions.ts
+++ b/front/tests/reinforcement-evals/lib/assertions.ts
@@ -247,6 +247,31 @@ export function validateToolCallAssertion(
       }
       return { success: true };
     }
+    case "rejectSuggestion": {
+      const rejectCalls = toolCalls.filter(
+        (tc) => tc.name === "reject_suggestion"
+      );
+      if (rejectCalls.length === 0) {
+        return {
+          success: false,
+          error: `Expected reject_suggestion to be called with sourceSuggestionIds ${JSON.stringify(assertion.sourceSuggestionIds.sort())}, but reject_suggestion was not called`,
+        };
+      }
+      const allRejectedIds = new Set(
+        rejectCalls.flatMap((tc) => getSourceSuggestionIds(tc.arguments))
+      );
+      const expectedSet = new Set(assertion.sourceSuggestionIds);
+      if (
+        expectedSet.size !== allRejectedIds.size ||
+        [...expectedSet].some((id) => !allRejectedIds.has(id))
+      ) {
+        return {
+          success: false,
+          error: `Expected reject_suggestion sourceSuggestionIds ${JSON.stringify([...expectedSet].sort())} but got ${JSON.stringify([...allRejectedIds].sort())}`,
+        };
+      }
+      return { success: true };
+    }
     case "calledDescribeMcp": {
       const called = toolCalls.some(
         (tc) =>

--- a/front/tests/reinforcement-evals/lib/types.ts
+++ b/front/tests/reinforcement-evals/lib/types.ts
@@ -208,6 +208,10 @@ export type ToolCallAssertion =
   | { type: "editSkillCallCount"; count: number }
   | { type: "editSkillCallsWithSources"; sourceSuggestionIdGroups: string[][] }
   | { type: "noSuggestion" }
+  | {
+      type: "rejectSuggestion";
+      sourceSuggestionIds: string[];
+    }
   | { type: "calledDescribeMcp"; mcpId: string };
 
 /** Expects an edit_skill call with instructionEdits for the given skill. */
@@ -237,6 +241,13 @@ export function editSkill(
 
 export function noSuggestion(): ToolCallAssertion {
   return { type: "noSuggestion" };
+}
+
+/** Expects reject_suggestion to be called with the given sourceSuggestionIds. */
+export function rejectSuggestion(
+  sourceSuggestionIds: string[]
+): ToolCallAssertion {
+  return { type: "rejectSuggestion", sourceSuggestionIds };
 }
 
 /** Expects exactly `count` edit_skill calls. */

--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -4,6 +4,7 @@ import {
   editSkillWithTool,
   mockTool,
   noSuggestion,
+  rejectSuggestion,
   type TestSuite,
   type WorkspaceContext,
 } from "@app/tests/reinforcement-evals/lib/types";
@@ -253,13 +254,14 @@ Score 3 if well-merged with clear analysis covering all use cases and conversati
         rejected: [],
       },
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: [noSuggestion()],
+      expectedToolCalls: [noSuggestion(), rejectSuggestion(["sug-1"])],
       judgeCriteria: `The synthetic suggestion about tone/warmth is essentially the same as the existing pending
-suggestion. The analyst must not duplicate it.
+suggestion. The analyst must not duplicate it and must reject the source suggestion using reject_suggestion.
 
 Score 0 if it creates a suggestion similar to the existing pending one (tone/warmth/friendliness).
-Score 1 if it creates an unrelated suggestion.
-Score 3 if no suggestion is created.`,
+Score 1 if no edit_skill suggestion is created but reject_suggestion is not called for sug-1.
+Score 1 if reject_suggestion is called but with wrong sourceSuggestionIds.
+Score 3 if no edit_skill suggestion is created AND reject_suggestion is called with sourceSuggestionIds including "sug-1".`,
     },
     {
       scenarioId: "dedup-vs-rejected",
@@ -303,13 +305,14 @@ Score 3 if no suggestion is created.`,
         ],
       },
       workspaceContext: WORKSPACE_CONTEXT,
-      expectedToolCalls: [noSuggestion()],
+      expectedToolCalls: [noSuggestion(), rejectSuggestion(["sug-1"])],
       judgeCriteria: `The synthetic suggestion about empathy/acknowledging frustration is essentially the same
-as a previously rejected suggestion. The analyst must not recreate it.
+as a previously rejected suggestion. The analyst must not recreate it and must reject the source suggestion using reject_suggestion.
 
 Score 0 if it creates a suggestion similar to the rejected one (empathy/acknowledging frustration).
-Score 1 if it creates an unrelated suggestion.
-Score 3 if no suggestion is created.`,
+Score 1 if no edit_skill suggestion is created but reject_suggestion is not called for sug-1.
+Score 1 if reject_suggestion is called but with wrong sourceSuggestionIds.
+Score 3 if no edit_skill suggestion is created AND reject_suggestion is called with sourceSuggestionIds including "sug-1".`,
     },
     {
       scenarioId: "split-unrelated-topics",
@@ -404,10 +407,10 @@ tool usage (account ID + refresh flag), each with well-written merged instructio
           sId: "sug-1",
           skillConfigurationId: "skill_writing",
           analysis:
-            "User found responses slightly long. The skill tends to include one or two unnecessary filler sentences at the end.",
+            "Response was slightly long. The skill tends to include one or two unnecessary filler sentences at the end.",
           instructionEdits: [
             {
-              targetBlockId: "block-clarity",
+              targetBlockId: "instructions-root",
               content:
                 "<p>Focus on clarity and correctness. Keep responses concise. Avoid unnecessary filler sentences.</p>",
             },
@@ -418,10 +421,12 @@ tool usage (account ID + refresh flag), each with well-written merged instructio
       expectedToolCalls: [noSuggestion()],
       judgeCriteria: `There is only one synthetic suggestion from a single conversation, and the issue is minor
 (slight verbosity / filler sentences — a style preference). According to prioritisation rules,
-low-severity issues from a single conversation should be dropped.
+low-severity issues from a single conversation should be ignored, but not rejected.
 
-Score 0 if it creates any suggestion based on this single minor synthetic input.
-Score 3 if no suggestion is created (correct: single low-severity conversation is insufficient evidence).`,
+Score 0 if it creates any edit_skill suggestion based on this single minor synthetic input.
+Score 1 if no edit_skill suggestion is created but reject_suggestion is not called for sug-1.
+Score 1 if reject_suggestion is called.
+Score 3 if no edit_skill suggestion is created AND reject_suggestion is not called.`,
     },
   ],
 };


### PR DESCRIPTION
## Description

 - Add tool to jreject suggestions
 - suggestions are now accepted when used in aggregated suggestion, or rejected when explicilty passed in reject tool. Other suggestions are kept as pending.

## Tests

 - eval tests are passing

## Risk

low

## Deploy Plan

deploy front
