### PR TITLE
[Branching] Add FK for compaction source conversations

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -314,6 +314,18 @@ export async function destroyConversation(
   //     conversationId: conversation.sId,
   //   })
   // );
+
+  // Preserve child compaction messages if their source conversation is hard-deleted.
+  await CompactionMessageModel.update(
+    { sourceConversationId: null },
+    {
+      where: {
+        workspaceId: owner.id,
+        sourceConversationId: conversation.sId,
+      },
+    }
+  );
+
   const result = await conversation.delete(auth);
   if (result.isErr()) {
     return result;

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -710,6 +710,11 @@ CompactionMessageModel.init(
         fields: ["workspaceId"],
         concurrently: true,
       },
+      {
+        fields: ["workspaceId", "sourceConversationId"],
+        name: "compaction_messages_workspace_id_source_conversation_id_idx",
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/migrations/db/migration_602.sql
+++ b/front/migrations/db/migration_602.sql
@@ -1,0 +1,23 @@
+UPDATE "compaction_messages" AS "cm"
+SET "sourceConversationId" = NULL
+WHERE "sourceConversationId" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "conversations" AS "c"
+    WHERE "c"."workspaceId" = "cm"."workspaceId"
+      AND "c"."sId" = "cm"."sourceConversationId"
+  );
+
+CREATE INDEX CONCURRENTLY "compaction_messages_workspace_id_source_conversation_id_idx"
+  ON "compaction_messages" ("workspaceId", "sourceConversationId");
+
+ALTER TABLE "compaction_messages"
+ADD CONSTRAINT "compaction_messages_workspace_id_source_conversation_id_fkey"
+FOREIGN KEY ("workspaceId", "sourceConversationId")
+REFERENCES "conversations" ("workspaceId", "sId")
+ON DELETE RESTRICT
+ON UPDATE CASCADE
+NOT VALID;
+
+ALTER TABLE "compaction_messages"
+VALIDATE CONSTRAINT "compaction_messages_workspace_id_source_conversation_id_fkey";


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/24789.
Context: https://github.com/dust-tt/dust/pull/24789#discussion_r3136334875
Adds a composite FK from `compaction_messages (workspaceId, sourceConversationId)` to `conversations (workspaceId, sId)`. The migration clears any already-dangling source ids before validating the constraint, and hard-deleting a source conversation now nulls child compaction references first so the FK does not block deletes.

## Risks
Blast radius: compaction message persistence and hard deletion of conversations.
Risk: low

## Deploy Plan
- run `front/migrations/db/migration_602.sql`
- deploy front
