### PR TITLE
[front] jira mcp: allow to add instance url in authentication step

### DIFF
--- a/front/lib/api/actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/api/actions/servers/jira/jira_api_helper.ts
@@ -47,6 +47,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isTextExtractionSupportedContentType } from "@app/types/shared/text_extraction";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { markdownToAdf } from "marklassian";
@@ -214,11 +215,13 @@ export async function listUsers(
 
 export async function getIssue({
   baseUrl,
+  resourceInfo,
   accessToken,
   issueKey,
   fields,
 }: {
   baseUrl: string;
+  resourceInfo: ResourceInfo;
   accessToken: string;
   issueKey: string;
   fields?: string[];
@@ -246,13 +249,10 @@ export async function getIssue({
     return new Ok(null);
   }
 
-  const resourceInfo = await getJiraResourceInfo(accessToken);
-  if (resourceInfo) {
-    handledResult.value = {
-      ...handledResult.value,
-      browseUrl: `${resourceInfo.url}/browse/${handledResult.value.key}`,
-    };
-  }
+  handledResult.value = {
+    ...handledResult.value,
+    browseUrl: `${resourceInfo.url}/browse/${handledResult.value.key}`,
+  };
   return new Ok(handledResult.value);
 }
 
@@ -332,11 +332,10 @@ export async function getTransitions(
 }
 
 // Jira resource and URL utilities
-async function getJiraResourceInfo(accessToken: string): Promise<{
-  id: string;
-  url: string;
-  name: string;
-} | null> {
+export async function getJiraBaseUrlAndResourceInfo(
+  accessToken: string,
+  cloudUrl: string | null
+): Promise<{ baseUrl: string; resourceInfo: ResourceInfo } | null> {
   const result = await jiraApiCall(
     {
       endpoint: "/oauth/token/accessible-resources",
@@ -353,28 +352,28 @@ async function getJiraResourceInfo(accessToken: string): Promise<{
   }
 
   const resources = result.value;
-  if (resources && resources.length > 0) {
-    const resource = resources[0];
-    return {
-      id: resource.id,
-      url: resource.url,
-      name: resource.name,
-    };
+  if (!resources || resources.length === 0) {
+    return null;
   }
 
-  return null;
-}
+  const resource = !cloudUrl
+    ? resources[0]
+    : (resources.find((r) => r.url === cloudUrl) ?? null);
 
-export async function getJiraBaseUrl(
-  accessToken: string
-): Promise<string | null> {
-  const resourceInfo = await getJiraResourceInfo(accessToken);
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const cloudId = resourceInfo?.id || null;
-  if (cloudId) {
-    return `https://api.atlassian.com/ex/jira/${cloudId}`;
+  if (!resource) {
+    return null;
   }
-  return null;
+
+  const resourceInfo: ResourceInfo = {
+    id: resource.id,
+    url: resource.url,
+    name: resource.name,
+  };
+
+  return {
+    baseUrl: `https://api.atlassian.com/ex/jira/${resource.id}`,
+    resourceInfo,
+  };
 }
 
 export async function createComment(
@@ -457,6 +456,7 @@ export async function getIssueComments({
 
 export async function searchIssues(
   baseUrl: string,
+  resourceInfo: ResourceInfo,
   accessToken: string,
   filters: SearchFilter[],
   options?: {
@@ -520,8 +520,7 @@ export async function searchIssues(
     return result;
   }
 
-  const resourceInfo = await getJiraResourceInfo(accessToken);
-  if (resourceInfo && result.value.issues) {
+  if (result.value.issues) {
     result.value.issues = result.value.issues.map((issue) => ({
       ...issue,
       browseUrl: `${resourceInfo.url}/browse/${issue.key}`,
@@ -539,6 +538,7 @@ export async function searchIssues(
 
 export async function searchJiraIssuesUsingJql(
   baseUrl: string,
+  resourceInfo: ResourceInfo,
   accessToken: string,
   jql: string,
   options?: {
@@ -581,8 +581,7 @@ export async function searchJiraIssuesUsingJql(
     return result;
   }
 
-  const resourceInfo = await getJiraResourceInfo(accessToken);
-  if (resourceInfo && result.value.issues) {
+  if (result.value.issues) {
     result.value.issues = result.value.issues.map((issue) => ({
       ...issue,
       browseUrl: `${resourceInfo.url}/browse/${issue.key}`,
@@ -657,14 +656,10 @@ async function getUserInfo(
 }
 
 export async function getConnectionInfo(
+  baseUrl: string,
+  resourceInfo: ResourceInfo,
   accessToken: string
 ): Promise<Result<z.infer<typeof JiraConnectionInfoSchema>, JiraErrorResult>> {
-  const resourceInfo = await getJiraResourceInfo(accessToken);
-  if (!resourceInfo) {
-    return new Err("Failed to retrieve JIRA resource information");
-  }
-
-  const baseUrl = `https://api.atlassian.com/ex/jira/${resourceInfo.id}`;
   const userResult = await getUserInfo(baseUrl, accessToken);
   if (userResult.isErr()) {
     return userResult;
@@ -825,6 +820,7 @@ async function processFieldsWithMetadata(
 
 export async function createIssue(
   baseUrl: string,
+  resourceInfo: ResourceInfo,
   accessToken: string,
   issueData: z.infer<typeof JiraCreateIssueRequestSchema>
 ): Promise<Result<z.infer<typeof JiraIssueSchema>, JiraErrorResult>> {
@@ -851,8 +847,7 @@ export async function createIssue(
     return result;
   }
 
-  const resourceInfo = await getJiraResourceInfo(accessToken);
-  if (resourceInfo && result.value) {
+  if (result.value) {
     result.value.browseUrl = `${resourceInfo.url}/browse/${result.value.key}`;
   }
 
@@ -861,6 +856,7 @@ export async function createIssue(
 
 export async function updateIssue(
   baseUrl: string,
+  resourceInfo: ResourceInfo,
   accessToken: string,
   issueKey: string,
   updateData: Partial<z.infer<typeof JiraCreateIssueRequestSchema>>
@@ -893,21 +889,23 @@ export async function updateIssue(
 
   const responseData = { issueKey };
 
-  const resourceInfo = await getJiraResourceInfo(accessToken);
-  if (resourceInfo) {
-    return new Ok({
-      ...responseData,
-      browseUrl: `${resourceInfo.url}/browse/${issueKey}`,
-    });
-  }
-
-  return new Ok(responseData);
+  return new Ok({
+    ...responseData,
+    browseUrl: `${resourceInfo.url}/browse/${issueKey}`,
+  });
 }
+
+type ResourceInfo = {
+  id: string;
+  url: string;
+  name: string;
+};
 
 type WithAuthParams = {
   authInfo?: AuthInfo;
   action: (
     baseUrl: string,
+    resourceInfo: ResourceInfo,
     accessToken: string
   ) => Promise<Result<CallToolResult["content"], MCPError>>;
 };
@@ -1059,13 +1057,20 @@ export const withAuth = async ({
   }
 
   try {
-    // Get the base URL from accessible resources
-    const baseUrl = await getJiraBaseUrl(accessToken);
-    if (!baseUrl) {
-      return new Err(new MCPError("No base url found"));
+    const cloudUrl = getCloudUrl(authInfo);
+    const result = await getJiraBaseUrlAndResourceInfo(accessToken, cloudUrl);
+    if (!result) {
+      return new Err(
+        new MCPError(
+          cloudUrl
+            ? `Jira resource could not be found for url: ${cloudUrl}`
+            : "Jira resource could not be found (no instance url provided)"
+        )
+      );
     }
+    const { baseUrl, resourceInfo } = result;
 
-    return await action(baseUrl, accessToken);
+    return await action(baseUrl, resourceInfo, accessToken);
   } catch (error: unknown) {
     return logAndReturnError({
       error,
@@ -1073,6 +1078,17 @@ export const withAuth = async ({
     });
   }
 };
+
+function getCloudUrl(authInfo?: AuthInfo): string | null {
+  if (!authInfo?.extra) {
+    return null;
+  }
+  const cloudUrl = authInfo.extra.jira_cloud_url;
+  if (!isString(cloudUrl)) {
+    return null;
+  }
+  return cloudUrl;
+}
 
 function logAndReturnError({
   error,

--- a/front/lib/api/actions/servers/jira/tools/index.ts
+++ b/front/lib/api/actions/servers/jira/tools/index.ts
@@ -40,7 +40,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
   get_issue_read_fields: async (_params, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const result = await listFieldSummaries(baseUrl, accessToken);
         if (result.isErr()) {
           return new Err(
@@ -61,9 +61,10 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   get_issue: async ({ issueKey, fields }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, resourceInfo, accessToken) => {
         const issue = await getIssue({
           baseUrl,
+          resourceInfo,
           accessToken,
           issueKey,
           fields,
@@ -104,7 +105,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   get_projects: async (_params, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const result = await getProjects(baseUrl, accessToken);
         if (result.isErr()) {
           return new Err(
@@ -125,7 +126,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   get_project: async ({ projectKey }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const result = await getProject(baseUrl, accessToken, projectKey);
         if (result.isErr()) {
           return new Err(
@@ -153,7 +154,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   get_project_versions: async ({ projectKey }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const result = await getProjectVersions(
           baseUrl,
           accessToken,
@@ -181,7 +182,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   get_transitions: async ({ issueKey }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const result = await getTransitions(baseUrl, accessToken, issueKey);
         if (result.isErr()) {
           return new Err(
@@ -202,11 +203,17 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   get_issues: async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
-        const result = await searchIssues(baseUrl, accessToken, filters, {
-          nextPageToken,
-          sortBy,
-        });
+      action: async (baseUrl, resourceInfo, accessToken) => {
+        const result = await searchIssues(
+          baseUrl,
+          resourceInfo,
+          accessToken,
+          filters,
+          {
+            nextPageToken,
+            sortBy,
+          }
+        );
         if (result.isErr()) {
           return new Err(
             new MCPError(`Error searching issues: ${result.error}`)
@@ -246,9 +253,10 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
     { authInfo }
   ) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, resourceInfo, accessToken) => {
         const result = await searchJiraIssuesUsingJql(
           baseUrl,
+          resourceInfo,
           accessToken,
           jql,
           {
@@ -293,7 +301,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   get_issue_types: async ({ projectKey }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, resourceInfo, accessToken) => {
         try {
           const result = await getIssueTypes(baseUrl, accessToken, projectKey);
           if (result.isErr()) {
@@ -328,7 +336,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
     { authInfo }
   ) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, resourceInfo, accessToken) => {
         try {
           const result = await getIssueFields(
             baseUrl,
@@ -364,35 +372,39 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
   },
 
   get_connection_info: async (_params, { authInfo }) => {
-    const accessToken = authInfo?.token;
-    if (!accessToken) {
-      return new Err(new MCPError("No access token found"));
-    }
+    return withAuth({
+      action: async (baseUrl, resourceInfo, accessToken) => {
+        const connectionInfo = await getConnectionInfo(
+          baseUrl,
+          resourceInfo,
+          accessToken
+        );
+        if (connectionInfo.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to retrieve connection information: ${connectionInfo.error}`
+            )
+          );
+        }
 
-    const connectionInfo = await getConnectionInfo(accessToken);
-    if (connectionInfo.isErr()) {
-      return new Err(
-        new MCPError(
-          `Failed to retrieve connection information: ${connectionInfo.error}`
-        )
-      );
-    }
-
-    return new Ok([
-      {
-        type: "text" as const,
-        text: "Connection information retrieved successfully",
+        return new Ok([
+          {
+            type: "text" as const,
+            text: "Connection information retrieved successfully",
+          },
+          {
+            type: "text" as const,
+            text: JSON.stringify(connectionInfo, null, 2),
+          },
+        ]);
       },
-      {
-        type: "text" as const,
-        text: JSON.stringify(connectionInfo, null, 2),
-      },
-    ]);
+      authInfo,
+    });
   },
 
   get_issue_link_types: async (_params, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const result = await getIssueLinkTypes(baseUrl, accessToken);
         if (result.isErr()) {
           return new Err(
@@ -419,7 +431,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
     { authInfo }
   ) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         if (emailAddress) {
           const result = await searchUsersByEmailExact(
             baseUrl,
@@ -493,7 +505,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   get_attachments: async ({ issueKey }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const attachmentsResult = await getIssueAttachments({
           baseUrl,
           accessToken,
@@ -545,7 +557,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   read_attachment: async ({ issueKey, attachmentId }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         try {
           const attachmentsResult = await getIssueAttachments({
             baseUrl,
@@ -614,7 +626,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
     { authInfo }
   ) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const visibility =
           visibilityType && visibilityValue
             ? { type: visibilityType, value: visibilityValue }
@@ -665,7 +677,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   transition_issue: async ({ issueKey, transitionId }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const result = await transitionIssue(
           baseUrl,
           accessToken,
@@ -721,8 +733,13 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   create_issue: async ({ issueData }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
-        const result = await createIssue(baseUrl, accessToken, issueData);
+      action: async (baseUrl, resourceInfo, accessToken) => {
+        const result = await createIssue(
+          baseUrl,
+          resourceInfo,
+          accessToken,
+          issueData
+        );
         if (result.isErr()) {
           let errorMessage = `Error creating issue: ${result.error}`;
           if (
@@ -747,9 +764,10 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   update_issue: async ({ issueKey, updateData }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, resourceInfo, accessToken) => {
         const result = await updateIssue(
           baseUrl,
+          resourceInfo,
           accessToken,
           issueKey,
           updateData
@@ -790,7 +808,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   create_issue_link: async ({ linkData }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const result = await createIssueLink(baseUrl, accessToken, linkData);
         if (result.isErr()) {
           return new Err(
@@ -820,7 +838,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
 
   delete_issue_link: async ({ linkId }, { authInfo }) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         const result = await deleteIssueLink(baseUrl, accessToken, linkId);
         if (result.isErr()) {
           return new Err(
@@ -847,7 +865,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
     { auth, authInfo, agentLoopContext }
   ) => {
     return withAuth({
-      action: async (baseUrl, accessToken) => {
+      action: async (baseUrl, _resourceInfo, accessToken) => {
         let fileToUpload: {
           buffer: Buffer;
           filename: string;

--- a/front/lib/api/oauth/providers/jira.ts
+++ b/front/lib/api/oauth/providers/jira.ts
@@ -9,6 +9,7 @@ import type {
   OAuthConnectionType,
   OAuthUseCase,
 } from "@app/types/oauth/lib";
+import { isValidJiraCloudUrlOrEmpty } from "@app/types/oauth/lib";
 import type { ParsedUrlQuery } from "querystring";
 
 export class JiraOAuthProvider implements BaseOAuthStrategyProvider {
@@ -65,6 +66,7 @@ export class JiraOAuthProvider implements BaseOAuthStrategyProvider {
         return true;
       }
     }
-    return Object.keys(extraConfig).length === 0;
+    // cloud_url is optional — absent or empty means fall back to dynamic resolution.
+    return isValidJiraCloudUrlOrEmpty(extraConfig.jira_cloud_url);
   }
 }

--- a/front/lib/providers/jira/search.ts
+++ b/front/lib/providers/jira/search.ts
@@ -1,7 +1,7 @@
 import {
   getIssue,
   getIssueComments,
-  getJiraBaseUrl,
+  getJiraBaseUrlAndResourceInfo,
   searchJiraIssuesUsingJql,
 } from "@app/lib/api/actions/servers/jira/jira_api_helper";
 import { renderIssue } from "@app/lib/api/actions/servers/jira/rendering";
@@ -21,11 +21,14 @@ export async function search({
   accessToken,
   query,
   pageSize,
+  metadata,
 }: ToolSearchParams): Promise<ToolSearchRawResult[]> {
-  const baseUrl = await getJiraBaseUrl(accessToken);
-  if (!baseUrl) {
+  const cloudUrl = metadata?.jira_cloud_url ?? null;
+  const jiraResult = await getJiraBaseUrlAndResourceInfo(accessToken, cloudUrl);
+  if (!jiraResult) {
     return [];
   }
+  const { baseUrl, resourceInfo } = jiraResult;
 
   const issueKeyMatch = query.match(/^#?([A-Z][A-Z0-9]*-\d+)$/i);
 
@@ -33,6 +36,7 @@ export async function search({
     const issueKey = issueKeyMatch[1].toUpperCase();
     const issueResult = await getIssue({
       baseUrl,
+      resourceInfo,
       accessToken,
       issueKey,
     });
@@ -54,10 +58,16 @@ export async function search({
   }
 
   const jql = `summary ~ "${query.replace(/"/g, '\\"')}" ORDER BY updated DESC`;
-  const result = await searchJiraIssuesUsingJql(baseUrl, accessToken, jql, {
-    maxResults: pageSize,
-    fields: ["summary"],
-  });
+  const result = await searchJiraIssuesUsingJql(
+    baseUrl,
+    resourceInfo,
+    accessToken,
+    jql,
+    {
+      maxResults: pageSize,
+      fields: ["summary"],
+    }
+  );
 
   if (result.isErr()) {
     return [];
@@ -75,14 +85,18 @@ export async function search({
 export async function download({
   accessToken,
   externalId,
+  metadata,
 }: ToolDownloadParams): Promise<ToolDownloadResult> {
-  const baseUrl = await getJiraBaseUrl(accessToken);
-  if (!baseUrl) {
-    throw new Error("Failed to get Jira base URL");
+  const cloudUrl = metadata?.jira_cloud_url ?? null;
+  const jiraResult = await getJiraBaseUrlAndResourceInfo(accessToken, cloudUrl);
+  if (!jiraResult) {
+    throw new Error("Failed to get Jira base URL or resource info");
   }
+  const { baseUrl, resourceInfo } = jiraResult;
 
   const issueResult = await getIssue({
     baseUrl,
+    resourceInfo,
     accessToken,
     issueKey: externalId,
     fields: [

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -110,6 +110,7 @@ const SUPPORTED_OAUTH_CREDENTIALS = [
   "snowflake_role",
   "snowflake_warehouse",
   "ukg_ready_company_id",
+  "jira_cloud_url",
 ] as const;
 
 export type SupportedOAuthCredentials =
@@ -306,6 +307,22 @@ export function getProviderRequiredOAuthCredentialInputs({
         return result;
       }
       return null;
+    case "jira":
+      if (useCase === "platform_actions" || useCase === "personal_actions") {
+        const result: OAuthCredentialInputs = {
+          jira_cloud_url: {
+            label: "Jira Cloud URL",
+            value: undefined,
+            helpMessage:
+              "Your Atlassian Cloud URL (e.g. https://company.atlassian.net). " +
+              "Optional — leave blank to use the first accessible instance.",
+            validator: isValidJiraCloudUrlOrEmpty,
+            overridableAtPersonalAuth: false,
+          },
+        };
+        return result;
+      }
+      return null;
     case "hubspot":
     case "slack":
     case "slack_tools":
@@ -319,7 +336,6 @@ export function getProviderRequiredOAuthCredentialInputs({
     case "github":
     case "google_drive":
     case "intercom":
-    case "jira":
     case "linear":
     case "mcp":
     case "discord":
@@ -477,6 +493,33 @@ export function isValidZendeskSubdomain(s: unknown): s is string {
   return (
     typeof s === "string" && /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(s)
   );
+}
+
+const ATLASSIAN_CLOUD_URL_REGEX =
+  /^https:\/\/[a-z0-9][a-z0-9-]*\.atlassian\.net$/i;
+
+export function normalizeJiraCloudUrl(raw: string): string {
+  let url = raw.trim();
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    url = "https://" + url;
+  }
+  return url.replace(/\/+$/, "");
+}
+
+export function isValidJiraCloudUrl(cloudUrl: string | undefined): boolean {
+  if (!cloudUrl) {
+    return false;
+  }
+  return ATLASSIAN_CLOUD_URL_REGEX.test(normalizeJiraCloudUrl(cloudUrl));
+}
+
+export function isValidJiraCloudUrlOrEmpty(
+  cloudUrl: string | undefined
+): boolean {
+  if (!cloudUrl || cloudUrl.trim() === "") {
+    return true;
+  }
+  return ATLASSIAN_CLOUD_URL_REGEX.test(normalizeJiraCloudUrl(cloudUrl));
 }
 
 export function isValidSalesforceDomain(s: unknown): s is string {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/4500
Add possibility to choose a specific Jira instance (cloud url) in the component when adding the Jira MCP
=> stores the cloud url in the metadata of the connection to reuse it directly when calling the tools

If no jira instance is provided, we keep the same behavior as before for backward compatibility => the tool will use the first instance returned by Jira

Limitation from Jira: the OAuth page lists all the instances and we cannot limit to the provided instance
=> the admin (and afterwards the user) have to choose the instance that was provided previously to be have the access to the instance via the OAuth token.

Possible improvements (not handled in this PR);
- display the cloud url in the tool description
- update Jira MCP public doc to explain this behavior
- find a way to display a message to the user so that they knows that they should select a specific instance in the OAuth view provided by Jira

## Tests

Tested locally by the different cases:
- add a Jira tool without cloudUrl => the tools point to the first Jira instance in the resource list (as before)
- add a Jira tool with a cloudUrl that corresponds to not the first one in the resource list => the tools point to this specific Jira instance and not the first one in the list
- have a Jira tool setup with previous code state + upgrade to new version => same behavior as before and uses first Jira instance in the resource list

+ tests that search feature still worked with cloud url set

## Risk

Low, only Jira MCP + backward compatibility with no instance url provided

## Deploy Plan

Deploy front