### PR TITLE
Optimistic mark-all-as-read with animated inbox exit

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1477,7 +1477,7 @@ function NavigationListWithInbox({
             style={GRID_STYLE}
             animate={{ gridTemplateRows: "1fr" }}
             exit={{ gridTemplateRows: "0fr" }}
-            transition={{ duration: 0.3, ease: "easeOut" }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
           >
             <div className="overflow-hidden">
               <UnreadConversationsSection

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1400,10 +1400,9 @@ function NavigationListWithInbox({
     );
   }, [conversations, titleFilter]);
 
-  const { markAllAsRead, isMarkingAllAsRead } =
-    useMarkAllConversationsAsRead({
-      owner,
-    });
+  const { markAllAsRead, isMarkingAllAsRead } = useMarkAllConversationsAsRead({
+    owner,
+  });
 
   const conversationsByDate = readConversations?.length
     ? getGroupConversationsByDate({

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1476,8 +1476,8 @@ function NavigationListWithInbox({
               selectedConversations={selectedConversations}
               toggleConversationSelection={toggleConversationSelection}
               activeConversationId={activeConversationId}
-          owner={owner}
-          />
+              owner={owner}
+            />
           </motion.div>
         )}
       </AnimatePresence>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1137,7 +1137,7 @@ function UnreadConversationsSection({
           <motion.div
             key={conversation.sId}
             exit={{ opacity: 0, height: 0, overflow: "hidden" }}
-            transition={{ duration: 0.2 }}
+            transition={{ ease: "easeIn", duration: 0.3 }}
           >
             <ConversationListItem
               conversation={conversation}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -96,6 +96,7 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
+import { AnimatePresence, motion } from "framer-motion";
 import {
   memo,
   useCallback,
@@ -1131,18 +1132,25 @@ function UnreadConversationsSection({
         ) : null
       }
     >
-      {conversations.map((conversation) => (
-        <ConversationListItem
-          key={conversation.sId}
-          conversation={conversation}
-          isMultiSelect={isMultiSelect}
-          onConversationBranched={onConversationBranched}
-          selectedConversations={selectedConversations}
-          toggleConversationSelection={toggleConversationSelection}
-          activeConversationId={activeConversationId}
-          owner={owner}
-        />
-      ))}
+      <AnimatePresence initial={false}>
+        {conversations.map((conversation) => (
+          <motion.div
+            key={conversation.sId}
+            exit={{ opacity: 0, height: 0, overflow: "hidden" }}
+            transition={{ duration: 0.2 }}
+          >
+            <ConversationListItem
+              conversation={conversation}
+              isMultiSelect={isMultiSelect}
+              onConversationBranched={onConversationBranched}
+              selectedConversations={selectedConversations}
+              toggleConversationSelection={toggleConversationSelection}
+              activeConversationId={activeConversationId}
+              owner={owner}
+            />
+          </motion.div>
+        ))}
+      </AnimatePresence>
     </NavigationListCollapsibleSection>
   );
 }
@@ -1429,36 +1437,50 @@ function NavigationListWithInbox({
       ref={scrollContainerRef}
       className="dd-privacy-mask h-full w-full overflow-y-auto"
     >
-      {skillSuggestionConversations.length > 0 && (
-        <UnreadConversationsSection
-          label="Skill suggestions"
-          conversations={skillSuggestionConversations}
-          isMultiSelect={isMultiSelect}
-          isMarkingAllAsRead={isMarkingAllAsRead}
-          titleFilter={titleFilter}
-          onMarkAllAsRead={markAllAsRead}
-          onConversationBranched={onConversationBranched}
-          selectedConversations={selectedConversations}
-          toggleConversationSelection={toggleConversationSelection}
-          activeConversationId={activeConversationId}
+      <AnimatePresence initial={false}>
+        {skillSuggestionConversations.length > 0 && (
+          <motion.div
+            key="skill-suggestions"
+            exit={{ opacity: 0, height: 0, overflow: "hidden" }}
+            transition={{ duration: 0.2 }}
+          >
+            <UnreadConversationsSection
+              label="Skill suggestions"
+              conversations={skillSuggestionConversations}
+              isMultiSelect={isMultiSelect}
+              isMarkingAllAsRead={isMarkingAllAsRead}
+              titleFilter={titleFilter}
+              onMarkAllAsRead={markAllAsRead}
+              onConversationBranched={onConversationBranched}
+              selectedConversations={selectedConversations}
+              toggleConversationSelection={toggleConversationSelection}
+              activeConversationId={activeConversationId}
+              owner={owner}
+            />
+          </motion.div>
+        )}
+        {inboxConversations.length > 0 && (
+          <motion.div
+            key="inbox"
+            exit={{ opacity: 0, height: 0, overflow: "hidden" }}
+            transition={{ duration: 0.2 }}
+          >
+            <UnreadConversationsSection
+              label="Inbox"
+              conversations={inboxConversations}
+              isMultiSelect={isMultiSelect}
+              isMarkingAllAsRead={isMarkingAllAsRead}
+              titleFilter={titleFilter}
+              onMarkAllAsRead={markAllAsRead}
+              onConversationBranched={onConversationBranched}
+              selectedConversations={selectedConversations}
+              toggleConversationSelection={toggleConversationSelection}
+              activeConversationId={activeConversationId}
           owner={owner}
-        />
-      )}
-      {inboxConversations.length > 0 && (
-        <UnreadConversationsSection
-          label="Inbox"
-          conversations={inboxConversations}
-          isMultiSelect={isMultiSelect}
-          isMarkingAllAsRead={isMarkingAllAsRead}
-          titleFilter={titleFilter}
-          onMarkAllAsRead={markAllAsRead}
-          onConversationBranched={onConversationBranched}
-          selectedConversations={selectedConversations}
-          toggleConversationSelection={toggleConversationSelection}
-          activeConversationId={activeConversationId}
-          owner={owner}
-        />
-      )}
+          />
+          </motion.div>
+        )}
+      </AnimatePresence>
       {projectsSection}
       <NavigationList className="px-2">
         <NavigationListCollapsibleSection

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1095,6 +1095,10 @@ const ConversationListContainer = ({
   return <div className="sm:flex sm:flex-col sm:gap-0.5">{children}</div>;
 };
 
+const GRID_ANIMATE = { gridTemplateRows: "1fr", opacity: 1 };
+const GRID_EXIT = { gridTemplateRows: "0fr", opacity: 0 };
+const GRID_STYLE = { display: "grid" } as const;
+
 function UnreadConversationsSection({
   label,
   conversations,
@@ -1136,18 +1140,22 @@ function UnreadConversationsSection({
         {conversations.map((conversation) => (
           <motion.div
             key={conversation.sId}
-            exit={{ opacity: 0, height: 0, overflow: "hidden" }}
-            transition={{ ease: "easeIn", duration: 0.3 }}
+            style={GRID_STYLE}
+            animate={GRID_ANIMATE}
+            exit={GRID_EXIT}
+            transition={{ ease: "easeOut", duration: 0.1 }}
           >
-            <ConversationListItem
-              conversation={conversation}
-              isMultiSelect={isMultiSelect}
-              onConversationBranched={onConversationBranched}
-              selectedConversations={selectedConversations}
-              toggleConversationSelection={toggleConversationSelection}
-              activeConversationId={activeConversationId}
-              owner={owner}
-            />
+            <div className="overflow-hidden">
+              <ConversationListItem
+                conversation={conversation}
+                isMultiSelect={isMultiSelect}
+                onConversationBranched={onConversationBranched}
+                selectedConversations={selectedConversations}
+                toggleConversationSelection={toggleConversationSelection}
+                activeConversationId={activeConversationId}
+                owner={owner}
+              />
+            </div>
           </motion.div>
         ))}
       </AnimatePresence>
@@ -1392,9 +1400,10 @@ function NavigationListWithInbox({
     );
   }, [conversations, titleFilter]);
 
-  const { markAllAsRead, isMarkingAllAsRead } = useMarkAllConversationsAsRead({
-    owner,
-  });
+  const { markAllAsRead, isMarkingAllAsRead } =
+    useMarkAllConversationsAsRead({
+      owner,
+    });
 
   const conversationsByDate = readConversations?.length
     ? getGroupConversationsByDate({
@@ -1441,43 +1450,51 @@ function NavigationListWithInbox({
         {skillSuggestionConversations.length > 0 && (
           <motion.div
             key="skill-suggestions"
-            exit={{ opacity: 0, height: 0, overflow: "hidden" }}
-            transition={{ duration: 0.2 }}
+            style={GRID_STYLE}
+            animate={GRID_ANIMATE}
+            exit={GRID_EXIT}
+            transition={{ duration: 0.2, ease: "easeOut" }}
           >
-            <UnreadConversationsSection
-              label="Skill suggestions"
-              conversations={skillSuggestionConversations}
-              isMultiSelect={isMultiSelect}
-              isMarkingAllAsRead={isMarkingAllAsRead}
-              titleFilter={titleFilter}
-              onMarkAllAsRead={markAllAsRead}
-              onConversationBranched={onConversationBranched}
-              selectedConversations={selectedConversations}
-              toggleConversationSelection={toggleConversationSelection}
-              activeConversationId={activeConversationId}
-              owner={owner}
-            />
+            <div className="overflow-hidden">
+              <UnreadConversationsSection
+                label="Skill suggestions"
+                conversations={skillSuggestionConversations}
+                isMultiSelect={isMultiSelect}
+                isMarkingAllAsRead={isMarkingAllAsRead}
+                titleFilter={titleFilter}
+                onMarkAllAsRead={markAllAsRead}
+                onConversationBranched={onConversationBranched}
+                selectedConversations={selectedConversations}
+                toggleConversationSelection={toggleConversationSelection}
+                activeConversationId={activeConversationId}
+                owner={owner}
+              />
+            </div>
           </motion.div>
         )}
         {inboxConversations.length > 0 && (
           <motion.div
             key="inbox"
-            exit={{ opacity: 0, height: 0, overflow: "hidden" }}
-            transition={{ duration: 0.2 }}
+            style={GRID_STYLE}
+            animate={{ gridTemplateRows: "1fr" }}
+            exit={{ gridTemplateRows: "0fr" }}
+            transition={{ duration: 0.3, ease: "easeOut" }}
           >
-            <UnreadConversationsSection
-              label="Inbox"
-              conversations={inboxConversations}
-              isMultiSelect={isMultiSelect}
-              isMarkingAllAsRead={isMarkingAllAsRead}
-              titleFilter={titleFilter}
-              onMarkAllAsRead={markAllAsRead}
-              onConversationBranched={onConversationBranched}
-              selectedConversations={selectedConversations}
-              toggleConversationSelection={toggleConversationSelection}
-              activeConversationId={activeConversationId}
-              owner={owner}
-            />
+            <div className="overflow-hidden">
+              <UnreadConversationsSection
+                label="Inbox"
+                conversations={inboxConversations}
+                isMultiSelect={isMultiSelect}
+                isMarkingAllAsRead={isMarkingAllAsRead}
+                titleFilter={titleFilter}
+                onMarkAllAsRead={markAllAsRead}
+                onConversationBranched={onConversationBranched}
+                selectedConversations={selectedConversations}
+                toggleConversationSelection={toggleConversationSelection}
+                activeConversationId={activeConversationId}
+                owner={owner}
+              />
+            </div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/front/hooks/useMarkAllConversationsAsRead.ts
+++ b/front/hooks/useMarkAllConversationsAsRead.ts
@@ -50,6 +50,18 @@ export function useMarkAllConversationsAsRead({
       setIsMarkingAllAsRead(true);
 
       const total = conversationIds.length;
+      const markedIds = new Set(conversationIds);
+      const nowMs = Date.now();
+
+      void mutateConversations(
+        (prev) =>
+          prev?.map((c) =>
+            markedIds.has(c.sId)
+              ? { ...c, actionRequired: false, unread: false, lastReadMs: nowMs }
+              : c
+          ),
+        { revalidate: false }
+      );
 
       try {
         const response = await clientFetch(
@@ -76,7 +88,6 @@ export function useMarkAllConversationsAsRead({
           throw new Error("Failed to mark conversations as read");
         }
 
-        void mutateConversations();
         void mutateSpaceSummary();
         void mutateSpaceConversations();
         void mutateUnreadConversationIds();
@@ -87,6 +98,8 @@ export function useMarkAllConversationsAsRead({
           description: `${total} conversation${total > 1 ? "s" : ""} marked as read.`,
         });
       } catch {
+        void mutateConversations();
+
         sendNotification({
           type: "error",
           title: "Failed to mark conversations as read",

--- a/front/hooks/useMarkAllConversationsAsRead.ts
+++ b/front/hooks/useMarkAllConversationsAsRead.ts
@@ -57,7 +57,12 @@ export function useMarkAllConversationsAsRead({
         (prev) =>
           prev?.map((c) =>
             markedIds.has(c.sId)
-              ? { ...c, actionRequired: false, unread: false, lastReadMs: nowMs }
+              ? {
+                  ...c,
+                  actionRequired: false,
+                  unread: false,
+                  lastReadMs: nowMs,
+                }
               : c
           ),
         { revalidate: false }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -6819,6 +6819,45 @@ describe("ConversationResource cleanup on delete", () => {
         workspaceId: workspace.sId,
       });
     });
+
+    it("triggers workflow for each conversation on batchMarkAsReadAndClearActionRequired when FF is enabled", async () => {
+      const { workspace, authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent",
+        description: "Agent",
+      });
+      const [conv1, conv2] = await Promise.all([
+        ConversationFactory.create(auth, {
+          agentConfigurationId: agent.sId,
+          messagesCreatedAt: [],
+        }),
+        ConversationFactory.create(auth, {
+          agentConfigurationId: agent.sId,
+          messagesCreatedAt: [],
+        }),
+      ]);
+
+      await FeatureFlagFactory.basic(auth, "conversation_search_indexing");
+      mockWorkflow().mockClear();
+
+      await ConversationResource.batchMarkAsReadAndClearActionRequired(auth, [
+        conv1.sId,
+        conv2.sId,
+      ]);
+
+      expect(mockWorkflow()).toHaveBeenCalledTimes(2);
+      expect(mockWorkflow()).toHaveBeenCalledWith({
+        conversationId: conv1.sId,
+        workspaceId: workspace.sId,
+      });
+      expect(mockWorkflow()).toHaveBeenCalledWith({
+        conversationId: conv2.sId,
+        workspaceId: workspace.sId,
+      });
+    });
   });
 });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -32,6 +32,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
@@ -3564,6 +3565,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         workspaceId: workspaceModelId,
         lastReadAt: new Date(),
       }))
+    );
+
+    await concurrentExecutor(
+      conversations,
+      (c) => ConversationResource.triggerEsIndexing(auth, c.sId),
+      { concurrency: 8 }
     );
 
     return new Ok(undefined);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Marking all conversations as read used to wait for the API round-trip before trigger a new query to update the UI, and since read state now lives in Elasticsearch, the list would often not update at all. ES hadn't caught up yet.

This PR applies the read state change optimistically in the SWR cache the moment the user clicks "mark all as read", without waiting for the server. If the API call fails, the cache is revalidated and the UI reverts. If it succeeds, the optimistic state is kept and only the secondary caches (space summary, unread IDs) are refreshed.

Took the opportunity to add some animation, the inbox section was just disappearing abruptly when it became empty. Wrapping the section in `AnimatePresence` (like what @ykmsd did for the `InAppBanner`) at the right level makes it fade out and collapse smoothly instead.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
