### PR TITLE
Add conversation event streaming to JS SDK

### DIFF
--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -183,12 +183,49 @@ export type AgentEvent =
 
 export type ConversationEvent = ConversationEventType["data"];
 
+const AGENT_EVENT_TYPES: ReadonlySet<string> = new Set<AgentEvent["type"]>([
+  "agent_action_success",
+  "agent_context_pruned",
+  "agent_error",
+  "agent_generation_cancelled",
+  "agent_message_done",
+  "agent_message_gracefully_stopped",
+  "agent_message_success",
+  "generation_tokens",
+  "tool_approve_execution",
+  "tool_ask_user_question",
+  "tool_call_started",
+  "tool_error",
+  "tool_file_auth_required",
+  "tool_notification",
+  "tool_params",
+  "tool_personal_auth_required",
+  "user_message_error",
+]);
+
+const CONVERSATION_EVENT_TYPES: ReadonlySet<string> = new Set<
+  ConversationEvent["type"]
+>([
+  "agent_message_done",
+  "agent_message_new",
+  "conversation_title",
+  "user_message_new",
+]);
+
 function isAgentEvent(value: unknown): value is AgentEvent {
-  return isRecord(value) && typeof value.type === "string";
+  return (
+    isRecord(value) &&
+    typeof value.type === "string" &&
+    AGENT_EVENT_TYPES.has(value.type)
+  );
 }
 
 function isConversationEvent(value: unknown): value is ConversationEvent {
-  return isRecord(value) && typeof value.type === "string";
+  return (
+    isRecord(value) &&
+    typeof value.type === "string" &&
+    CONVERSATION_EVENT_TYPES.has(value.type)
+  );
 }
 
 const textFromResponse = async (response: DustResponse): Promise<string> => {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -7,17 +7,9 @@ import { ConversationsAPI } from "./high_level/conversations";
 import { FilesAPI } from "./high_level/files";
 import type { DustAPIOptions } from "./high_level/types";
 import type {
-  AgentActionSpecificEvent,
-  AgentActionSuccessEvent,
   AgentConfigurationViewType,
-  AgentContextPrunedEvent,
-  AgentErrorEvent,
-  AgentGenerationCancelledEvent,
-  AgentMessageDoneEvent,
-  AgentMessageGracefullyStoppedEvent,
+  AgentMessageEventData,
   AgentMessagePublicType,
-  AgentMessageSuccessEvent,
-  AgentToolCallStartedEvent,
   AnswerUserQuestionRequestBodyType,
   AnswerUserQuestionResponseType,
   APIError,
@@ -25,7 +17,7 @@ import type {
   BlockedActionsResponseType,
   CancelMessageGenerationRequestType,
   ContentNodeType,
-  ConversationEventType,
+  ConversationEventData,
   ConversationPublicType,
   CreateConversationResponseType,
   DataSourceContentNodeType,
@@ -43,7 +35,6 @@ import type {
   DustAppRunRunStatusEvent,
   DustAppRunTokensEvent,
   FileUploadUrlRequestType,
-  GenerationTokensEvent,
   HeartbeatMCPResponseType,
   LoggerInterface,
   PatchConversationRequestType,
@@ -60,17 +51,17 @@ import type {
   Result,
   SearchRequestBodyType,
   SearchWarningCode,
-  ToolErrorEvent,
-  UserMessageErrorEvent,
   ValidateActionRequestBodyType,
   ValidateActionResponseType,
 } from "./types";
 import {
+  AgentMessageEventDataSchema,
   AnswerUserQuestionResponseSchema,
   APIErrorSchema,
   AppsCheckResponseSchema,
   BlockedActionsResponseSchema,
   CancelMessageGenerationResponseSchema,
+  ConversationEventDataSchema,
   CreateConversationResponseSchema,
   CreateGenericAgentConfigurationResponseSchema,
   DataSourceViewResponseSchema,
@@ -167,65 +158,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
 const DEFAULT_RECONNECT_DELAY = 5000;
 
-export type AgentEvent =
-  | AgentActionSpecificEvent
-  | AgentActionSuccessEvent
-  | AgentContextPrunedEvent
-  | AgentErrorEvent
-  | AgentGenerationCancelledEvent
-  | AgentMessageGracefullyStoppedEvent
-  | AgentMessageSuccessEvent
-  | AgentMessageDoneEvent
-  | AgentToolCallStartedEvent
-  | GenerationTokensEvent
-  | UserMessageErrorEvent
-  | ToolErrorEvent;
+export type AgentEvent = AgentMessageEventData;
 
-export type ConversationEvent = ConversationEventType["data"];
-
-const AGENT_EVENT_TYPES: ReadonlySet<string> = new Set<AgentEvent["type"]>([
-  "agent_action_success",
-  "agent_context_pruned",
-  "agent_error",
-  "agent_generation_cancelled",
-  "agent_message_done",
-  "agent_message_gracefully_stopped",
-  "agent_message_success",
-  "generation_tokens",
-  "tool_approve_execution",
-  "tool_ask_user_question",
-  "tool_call_started",
-  "tool_error",
-  "tool_file_auth_required",
-  "tool_notification",
-  "tool_params",
-  "tool_personal_auth_required",
-  "user_message_error",
-]);
-
-const CONVERSATION_EVENT_TYPES: ReadonlySet<string> = new Set<
-  ConversationEvent["type"]
->([
-  "agent_message_done",
-  "agent_message_new",
-  "conversation_title",
-  "user_message_new",
-]);
+export type ConversationEvent = ConversationEventData;
 
 function isAgentEvent(value: unknown): value is AgentEvent {
-  return (
-    isRecord(value) &&
-    typeof value.type === "string" &&
-    AGENT_EVENT_TYPES.has(value.type)
-  );
+  return AgentMessageEventDataSchema.safeParse(value).success;
 }
 
 function isConversationEvent(value: unknown): value is ConversationEvent {
-  return (
-    isRecord(value) &&
-    typeof value.type === "string" &&
-    CONVERSATION_EVENT_TYPES.has(value.type)
-  );
+  return ConversationEventDataSchema.safeParse(value).success;
 }
 
 const textFromResponse = async (response: DustResponse): Promise<string> => {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -55,13 +55,13 @@ import type {
   ValidateActionResponseType,
 } from "./types";
 import {
-  AgentMessageEventDataSchema,
+  AgentMessageEventDataTypeSchema,
   AnswerUserQuestionResponseSchema,
   APIErrorSchema,
   AppsCheckResponseSchema,
   BlockedActionsResponseSchema,
   CancelMessageGenerationResponseSchema,
-  ConversationEventDataSchema,
+  ConversationEventDataTypeSchema,
   CreateConversationResponseSchema,
   CreateGenericAgentConfigurationResponseSchema,
   DataSourceViewResponseSchema,
@@ -163,11 +163,17 @@ export type AgentEvent = AgentMessageEventData;
 export type ConversationEvent = ConversationEventData;
 
 function isAgentEvent(value: unknown): value is AgentEvent {
-  return AgentMessageEventDataSchema.safeParse(value).success;
+  return (
+    isRecord(value) &&
+    AgentMessageEventDataTypeSchema.safeParse(value.type).success
+  );
 }
 
 function isConversationEvent(value: unknown): value is ConversationEvent {
-  return ConversationEventDataSchema.safeParse(value).success;
+  return (
+    isRecord(value) &&
+    ConversationEventDataTypeSchema.safeParse(value.type).success
+  );
 }
 
 const textFromResponse = async (response: DustResponse): Promise<string> => {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1251,6 +1251,7 @@ export class DustAPI {
       const res = await createRequest(lastEventId);
 
       if (res.isErr()) {
+        // Treat request errors as transient and apply reconnection policy when enabled.
         if (autoReconnect) {
           reconnectAttempts += 1;
           if (reconnectAttempts >= maxReconnectAttempts) {
@@ -1338,20 +1339,26 @@ export class DustAPI {
         logger.error({ error: e }, "Failed processing event stream");
         streamEndedWithError = true;
 
+        // Respect caller-initiated aborts.
         if (signal?.aborted) {
           return;
         }
+        // Apply reconnection policy on stream termination or abort; otherwise propagate.
         if (!isStreamTerminationError(e)) {
           throw new Error(`Error processing event stream: ${e}`);
         }
+        // Do not throw; flow continues to reconnection block below.
       } finally {
         reader.releaseLock();
       }
 
+      // Stream ended; check whether we need to reconnect.
       if (shouldReconnect() && autoReconnect) {
         if (streamEndedWithError || !receivedEventsInThisConnection) {
+          // Increment on errors and empty clean closures from stale or finished streams.
           reconnectAttempts += 1;
         } else {
+          // Successful connections with events reset the counter like EventSource onopen.
           reconnectAttempts = 0;
         }
 
@@ -1363,6 +1370,7 @@ export class DustAPI {
         continue;
       }
 
+      // Exit the generator after a terminal event or when auto-reconnect is disabled.
       return;
     }
   }

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1187,7 +1187,9 @@ export class DustAPI {
   }: {
     createRequest: (
       lastEventId?: string | null
-    ) => Promise<Result<{ response: DustResponse; duration: number }, APIError>>;
+    ) => Promise<
+      Result<{ response: DustResponse; duration: number }, APIError>
+    >;
     signal?: AbortSignal;
     options: {
       maxReconnectAttempts: number;

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -55,13 +55,11 @@ import type {
   ValidateActionResponseType,
 } from "./types";
 import {
-  AgentMessageEventDataTypeSchema,
   AnswerUserQuestionResponseSchema,
   APIErrorSchema,
   AppsCheckResponseSchema,
   BlockedActionsResponseSchema,
   CancelMessageGenerationResponseSchema,
-  ConversationEventDataTypeSchema,
   CreateConversationResponseSchema,
   CreateGenericAgentConfigurationResponseSchema,
   DataSourceViewResponseSchema,
@@ -161,20 +159,6 @@ const DEFAULT_RECONNECT_DELAY = 5000;
 export type AgentEvent = AgentMessageEventData;
 
 export type ConversationEvent = ConversationEventData;
-
-function isAgentEvent(value: unknown): value is AgentEvent {
-  return (
-    isRecord(value) &&
-    AgentMessageEventDataTypeSchema.safeParse(value.type).success
-  );
-}
-
-function isConversationEvent(value: unknown): value is ConversationEvent {
-  return (
-    isRecord(value) &&
-    ConversationEventDataTypeSchema.safeParse(value.type).success
-  );
-}
 
 const textFromResponse = async (response: DustResponse): Promise<string> => {
   if (typeof response.body === "string") {
@@ -1088,7 +1072,7 @@ export class DustAPI {
             return null;
           }
           const { data } = eventData;
-          return isConversationEvent(data) ? data : null;
+          return isRecord(data) ? (data as ConversationEvent) : null;
         },
       }),
     });
@@ -1150,7 +1134,7 @@ export class DustAPI {
             return null;
           }
           const { data } = eventData;
-          return isAgentEvent(data) ? data : null;
+          return isRecord(data) ? (data as AgentEvent) : null;
         },
         onEvent: (event) => {
           if (terminalEventTypes.includes(event.type)) {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -25,6 +25,7 @@ import type {
   BlockedActionsResponseType,
   CancelMessageGenerationRequestType,
   ContentNodeType,
+  ConversationEventType,
   ConversationPublicType,
   CreateConversationResponseType,
   DataSourceContentNodeType,
@@ -158,6 +159,10 @@ function isTransientHttpStatus(status: number): boolean {
   return status === 408 || status === 429;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 // Copied from front/hooks/useEventSource.ts
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
 const DEFAULT_RECONNECT_DELAY = 5000;
@@ -175,6 +180,16 @@ export type AgentEvent =
   | GenerationTokensEvent
   | UserMessageErrorEvent
   | ToolErrorEvent;
+
+export type ConversationEvent = ConversationEventType["data"];
+
+function isAgentEvent(value: unknown): value is AgentEvent {
+  return isRecord(value) && typeof value.type === "string";
+}
+
+function isConversationEvent(value: unknown): value is ConversationEvent {
+  return isRecord(value) && typeof value.type === "string";
+}
 
 const textFromResponse = async (response: DustResponse): Promise<string> => {
   if (typeof response.body === "string") {
@@ -1035,6 +1050,65 @@ export class DustAPI {
     });
   }
 
+  async streamConversationEvents({
+    conversationId,
+    signal,
+    options = {
+      maxReconnectAttempts: DEFAULT_MAX_RECONNECT_ATTEMPTS,
+      reconnectDelay: DEFAULT_RECONNECT_DELAY,
+      autoReconnect: true,
+    },
+  }: {
+    conversationId: string;
+    signal?: AbortSignal;
+    options?: {
+      maxReconnectAttempts?: number;
+      reconnectDelay?: number;
+      autoReconnect?: boolean;
+    };
+  }): Promise<
+    Result<
+      {
+        eventStream: AsyncGenerator<ConversationEvent, void, unknown>;
+      },
+      { type: string; message: string } | Error
+    >
+  > {
+    const createRequest = async (lastId?: string | null) => {
+      let path = `assistant/conversations/${conversationId}/events`;
+      if (lastId) {
+        path += `?lastEventId=${lastId}`;
+      }
+
+      return this.request({
+        method: "GET",
+        path,
+        signal,
+        stream: true,
+      });
+    };
+
+    return new Ok({
+      eventStream: this._streamEventsWithReconnection({
+        createRequest,
+        signal,
+        options: {
+          maxReconnectAttempts:
+            options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS,
+          reconnectDelay: options.reconnectDelay ?? DEFAULT_RECONNECT_DELAY,
+          autoReconnect: options.autoReconnect ?? true,
+        },
+        parseEvent: (eventData) => {
+          if (!isRecord(eventData)) {
+            return null;
+          }
+          const { data } = eventData;
+          return isConversationEvent(data) ? data : null;
+        },
+      }),
+    });
+  }
+
   async streamAgentMessageEvents({
     conversationId,
     agentMessageId,
@@ -1057,10 +1131,6 @@ export class DustAPI {
       { type: string; message: string }
     >
   > {
-    const { maxReconnectAttempts, reconnectDelay, autoReconnect } = options;
-
-    let lastEventId: string | null = null;
-
     const terminalEventTypes: AgentEvent["type"][] = [
       "agent_message_success",
       "agent_message_gracefully_stopped",
@@ -1083,151 +1153,179 @@ export class DustAPI {
       });
     };
 
-    const logger = this._logger;
-    let reconnectAttempts = 0;
     let receivedTerminalEvent = false;
 
-    const streamEventsWithReconnection = async function* () {
-      while (true) {
-        if (signal?.aborted) {
-          return;
-        }
-
-        const res = await createRequest(lastEventId);
-
-        if (res.isErr()) {
-          // Treat request errors as transient and apply reconnection policy when enabled.
-          if (autoReconnect) {
-            reconnectAttempts += 1;
-            if (reconnectAttempts >= maxReconnectAttempts) {
-              throw new Error(
-                `Exceeded maximum reconnection attempts (request error): ${res.error.message}`
-              );
-            }
-            await new Promise((resolve) => setTimeout(resolve, reconnectDelay));
-            continue;
+    return new Ok({
+      eventStream: this._streamEventsWithReconnection({
+        createRequest,
+        signal,
+        options,
+        parseEvent: (eventData) => {
+          if (!isRecord(eventData)) {
+            return null;
           }
-          const error = res.error;
-          throw new Error(`Error requesting event stream: ${error.message}`);
-        }
-
-        if (!res.value.response.ok || !res.value.response.body) {
-          if (
-            autoReconnect &&
-            isTransientHttpStatus(res.value.response.status)
-          ) {
-            reconnectAttempts += 1;
-            if (reconnectAttempts >= maxReconnectAttempts) {
-              throw new Error(
-                `Exceeded maximum reconnection attempts (http ${res.value.response.status})`
-              );
-            }
-            await new Promise((resolve) => setTimeout(resolve, reconnectDelay));
-            continue;
+          const { data } = eventData;
+          return isAgentEvent(data) ? data : null;
+        },
+        onEvent: (event) => {
+          if (terminalEventTypes.includes(event.type)) {
+            receivedTerminalEvent = true;
           }
-          throw new Error(
-            `Error requesting event stream: status_code=${res.value.response.status}`
-          );
-        }
+        },
+        shouldReconnect: () => !receivedTerminalEvent,
+      }),
+    });
+  }
 
-        let pendingEvents: AgentEvent[] = [];
-        let receivedEventsInThisConnection = false;
+  private async *_streamEventsWithReconnection<T>({
+    createRequest,
+    signal,
+    options,
+    parseEvent,
+    onEvent,
+    shouldReconnect = () => true,
+  }: {
+    createRequest: (
+      lastEventId?: string | null
+    ) => Promise<Result<{ response: DustResponse; duration: number }, APIError>>;
+    signal?: AbortSignal;
+    options: {
+      maxReconnectAttempts: number;
+      reconnectDelay: number;
+      autoReconnect: boolean;
+    };
+    parseEvent: (eventData: unknown) => T | null;
+    onEvent?: (event: T) => void;
+    shouldReconnect?: () => boolean;
+  }): AsyncGenerator<T, void, unknown> {
+    const { maxReconnectAttempts, reconnectDelay, autoReconnect } = options;
 
-        const parser = createParser((event) => {
-          if (event.type === "event") {
-            if (event.data) {
-              try {
-                const eventData = JSON.parse(event.data);
-                if (eventData.eventId) {
-                  lastEventId = eventData.eventId;
-                }
-                pendingEvents.push(eventData.data);
-              } catch (err) {
-                logger.error(
-                  { error: err },
-                  "Failed parsing chunk from Dust API"
-                );
-              }
-            }
-          }
-        });
+    const logger = this._logger;
+    let lastEventId: string | null = null;
+    let reconnectAttempts = 0;
 
-        if (
-          !res.value.response.body ||
-          typeof res.value.response.body === "string"
-        ) {
-          throw new Error(
-            "Expected a stream response, but got a string or null"
-          );
-        }
+    while (true) {
+      if (signal?.aborted) {
+        return;
+      }
 
-        const reader = res.value.response.body.getReader();
-        const decoder = new TextDecoder();
+      const res = await createRequest(lastEventId);
 
-        let streamEndedWithError = false;
-
-        try {
-          for (;;) {
-            const { value, done } = await reader.read();
-            if (value) {
-              parser.feed(decoder.decode(value, { stream: true }));
-
-              for (const event of pendingEvents) {
-                yield event;
-                receivedEventsInThisConnection = true;
-
-                if (terminalEventTypes.includes(event.type)) {
-                  receivedTerminalEvent = true;
-                }
-              }
-              pendingEvents = [];
-            }
-
-            if (done) {
-              break;
-            }
-          }
-        } catch (e) {
-          logger.error({ error: e }, "Failed processing event stream");
-          streamEndedWithError = true;
-
-          // Respect caller-initiated aborts.
-          if (signal?.aborted) {
-            return;
-          }
-          // Apply reconnection policy on stream termination/abort; otherwise propagate.
-          if (!isStreamTerminationError(e)) {
-            throw new Error(`Error processing event stream: ${e}`);
-          }
-          // Do not throw; flow continues to reconnection block below.
-        } finally {
-          reader.releaseLock();
-        }
-
-        // Stream ended - check if we need to reconnect
-        if (!receivedTerminalEvent && autoReconnect) {
-          if (streamEndedWithError || !receivedEventsInThisConnection) {
-            // Increment on errors AND empty clean closures (stale/finished stream).
-            reconnectAttempts += 1;
-          } else {
-            // Successful connection with events: reset counter (like EventSource onopen).
-            reconnectAttempts = 0;
-          }
-
+      if (res.isErr()) {
+        if (autoReconnect) {
+          reconnectAttempts += 1;
           if (reconnectAttempts >= maxReconnectAttempts) {
-            throw new Error("Exceeded maximum reconnection attempts");
+            throw new Error(
+              `Exceeded maximum reconnection attempts (request error): ${res.error.message}`
+            );
           }
-
           await new Promise((resolve) => setTimeout(resolve, reconnectDelay));
           continue;
         }
-
-        // terminal event or autoReconnect disabled, exit the generator
-        return;
+        const error = res.error;
+        throw new Error(`Error requesting event stream: ${error.message}`);
       }
-    };
 
-    return new Ok({ eventStream: streamEventsWithReconnection() });
+      if (!res.value.response.ok || !res.value.response.body) {
+        if (autoReconnect && isTransientHttpStatus(res.value.response.status)) {
+          reconnectAttempts += 1;
+          if (reconnectAttempts >= maxReconnectAttempts) {
+            throw new Error(
+              `Exceeded maximum reconnection attempts (http ${res.value.response.status})`
+            );
+          }
+          await new Promise((resolve) => setTimeout(resolve, reconnectDelay));
+          continue;
+        }
+        throw new Error(
+          `Error requesting event stream: status_code=${res.value.response.status}`
+        );
+      }
+
+      let pendingEvents: T[] = [];
+      let receivedEventsInThisConnection = false;
+
+      const parser = createParser((event) => {
+        if (event.type === "event" && event.data && event.data !== "done") {
+          try {
+            const eventData: unknown = JSON.parse(event.data);
+
+            if (isRecord(eventData) && typeof eventData.eventId === "string") {
+              lastEventId = eventData.eventId;
+            }
+
+            const parsedEvent = parseEvent(eventData);
+
+            if (parsedEvent) {
+              pendingEvents.push(parsedEvent);
+            }
+          } catch (err) {
+            logger.error({ error: err }, "Failed parsing chunk from Dust API");
+          }
+        }
+      });
+
+      if (
+        !res.value.response.body ||
+        typeof res.value.response.body === "string"
+      ) {
+        throw new Error("Expected a stream response, but got a string or null");
+      }
+
+      const reader = res.value.response.body.getReader();
+      const decoder = new TextDecoder();
+
+      let streamEndedWithError = false;
+
+      try {
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (value) {
+            parser.feed(decoder.decode(value, { stream: true }));
+
+            for (const event of pendingEvents) {
+              yield event;
+              receivedEventsInThisConnection = true;
+              onEvent?.(event);
+            }
+            pendingEvents = [];
+          }
+
+          if (done) {
+            break;
+          }
+        }
+      } catch (e) {
+        logger.error({ error: e }, "Failed processing event stream");
+        streamEndedWithError = true;
+
+        if (signal?.aborted) {
+          return;
+        }
+        if (!isStreamTerminationError(e)) {
+          throw new Error(`Error processing event stream: ${e}`);
+        }
+      } finally {
+        reader.releaseLock();
+      }
+
+      if (shouldReconnect() && autoReconnect) {
+        if (streamEndedWithError || !receivedEventsInThisConnection) {
+          reconnectAttempts += 1;
+        } else {
+          reconnectAttempts = 0;
+        }
+
+        if (reconnectAttempts >= maxReconnectAttempts) {
+          throw new Error("Exceeded maximum reconnection attempts");
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, reconnectDelay));
+        continue;
+      }
+
+      return;
+    }
   }
 
   async cancelMessageGeneration({

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1629,6 +1629,17 @@ export const ConversationEventDataSchema = z.union([
 ]);
 export type ConversationEventData = z.infer<typeof ConversationEventDataSchema>;
 
+export const CONVERSATION_EVENT_DATA_TYPES = [
+  "agent_message_done",
+  "agent_message_new",
+  "conversation_title",
+  "user_message_new",
+] as const satisfies readonly ConversationEventData["type"][];
+
+export const ConversationEventDataTypeSchema = z.enum(
+  CONVERSATION_EVENT_DATA_TYPES
+);
+
 const ConversationEventTypeSchema = z.object({
   eventId: z.string(),
   data: ConversationEventDataSchema,
@@ -1650,9 +1661,31 @@ export const AgentMessageEventDataSchema = z.union([
   ToolErrorEventSchema,
   UserMessageErrorEventSchema,
 ]);
-export type AgentMessageEventData = z.infer<
-  typeof AgentMessageEventDataSchema
->;
+export type AgentMessageEventData = z.infer<typeof AgentMessageEventDataSchema>;
+
+export const AGENT_MESSAGE_EVENT_DATA_TYPES = [
+  "agent_action_success",
+  "agent_context_pruned",
+  "agent_error",
+  "agent_generation_cancelled",
+  "agent_message_done",
+  "agent_message_gracefully_stopped",
+  "agent_message_success",
+  "generation_tokens",
+  "tool_approve_execution",
+  "tool_ask_user_question",
+  "tool_call_started",
+  "tool_error",
+  "tool_file_auth_required",
+  "tool_notification",
+  "tool_params",
+  "tool_personal_auth_required",
+  "user_message_error",
+] as const satisfies readonly AgentMessageEventData["type"][];
+
+export const AgentMessageEventDataTypeSchema = z.enum(
+  AGENT_MESSAGE_EVENT_DATA_TYPES
+);
 
 const AgentMessageEventTypeSchema = z.object({
   eventId: z.string(),

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1621,29 +1621,42 @@ export type ConversationTitleEvent = z.infer<
   typeof ConversationTitleEventSchema
 >;
 
+export const ConversationEventDataSchema = z.union([
+  UserMessageNewEventSchema,
+  AgentMessageNewEventSchema,
+  AgentMessageDoneEventSchema,
+  ConversationTitleEventSchema,
+]);
+export type ConversationEventData = z.infer<typeof ConversationEventDataSchema>;
+
 const ConversationEventTypeSchema = z.object({
   eventId: z.string(),
-  data: z.union([
-    UserMessageNewEventSchema,
-    AgentMessageNewEventSchema,
-    AgentMessageDoneEventSchema,
-    ConversationTitleEventSchema,
-  ]),
+  data: ConversationEventDataSchema,
 });
 
 export type ConversationEventType = z.infer<typeof ConversationEventTypeSchema>;
 
+export const AgentMessageEventDataSchema = z.union([
+  AgentActionSpecificEventSchema,
+  AgentActionSuccessEventSchema,
+  AgentContextPrunedEventSchema,
+  AgentErrorEventSchema,
+  AgentGenerationCancelledEventSchema,
+  AgentMessageDoneEventSchema,
+  AgentMessageGracefullyStoppedEventSchema,
+  AgentMessageSuccessEventSchema,
+  AgentToolCallStartedEventSchema,
+  GenerationTokensEventSchema,
+  ToolErrorEventSchema,
+  UserMessageErrorEventSchema,
+]);
+export type AgentMessageEventData = z.infer<
+  typeof AgentMessageEventDataSchema
+>;
+
 const AgentMessageEventTypeSchema = z.object({
   eventId: z.string(),
-  data: z.union([
-    AgentErrorEventSchema,
-    AgentActionSpecificEventSchema,
-    AgentToolCallStartedEventSchema,
-    AgentActionSuccessEventSchema,
-    AgentContextPrunedEventSchema,
-    AgentGenerationCancelledEventSchema,
-    GenerationTokensEventSchema,
-  ]),
+  data: AgentMessageEventDataSchema,
 });
 
 export type AgentMessageEventType = z.infer<typeof AgentMessageEventTypeSchema>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1629,17 +1629,6 @@ export const ConversationEventDataSchema = z.union([
 ]);
 export type ConversationEventData = z.infer<typeof ConversationEventDataSchema>;
 
-export const CONVERSATION_EVENT_DATA_TYPES = [
-  "agent_message_done",
-  "agent_message_new",
-  "conversation_title",
-  "user_message_new",
-] as const satisfies readonly ConversationEventData["type"][];
-
-export const ConversationEventDataTypeSchema = z.enum(
-  CONVERSATION_EVENT_DATA_TYPES
-);
-
 const ConversationEventTypeSchema = z.object({
   eventId: z.string(),
   data: ConversationEventDataSchema,
@@ -1662,30 +1651,6 @@ export const AgentMessageEventDataSchema = z.union([
   UserMessageErrorEventSchema,
 ]);
 export type AgentMessageEventData = z.infer<typeof AgentMessageEventDataSchema>;
-
-export const AGENT_MESSAGE_EVENT_DATA_TYPES = [
-  "agent_action_success",
-  "agent_context_pruned",
-  "agent_error",
-  "agent_generation_cancelled",
-  "agent_message_done",
-  "agent_message_gracefully_stopped",
-  "agent_message_success",
-  "generation_tokens",
-  "tool_approve_execution",
-  "tool_ask_user_question",
-  "tool_call_started",
-  "tool_error",
-  "tool_file_auth_required",
-  "tool_notification",
-  "tool_params",
-  "tool_personal_auth_required",
-  "user_message_error",
-] as const satisfies readonly AgentMessageEventData["type"][];
-
-export const AgentMessageEventDataTypeSchema = z.enum(
-  AGENT_MESSAGE_EVENT_DATA_TYPES
-);
 
 const AgentMessageEventTypeSchema = z.object({
   eventId: z.string(),


### PR DESCRIPTION
## Description

Adds public conversation event streaming support to the JS SDK and reuses the same SSE parsing/reconnect helper for both conversation-level and agent-message event streams. The existing `streamAgentAnswerEvents` behavior remains unchanged.

This is a preparation for better handling steering situations in `streamAgentAnswerEvents`.

No breaking change or change of behavior to existing methods in the SDK.

## Tests

- Tested locally
- `npm run tsgo` in `sdks/js`
- `npm run build` in `sdks/js`

## Risk

High, could break slack/discord/teams bots and other integrations relying on SDK for streaming agent messages.

## Deploy Plan

- release `@dust-tt/client` package as usual
- deploy `front`