### PR TITLE
[front] Split system skills out of agent loop state

### DIFF
--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -134,6 +134,7 @@ export async function getPromptForProcessDustApp({
         "Process the retrieved data to extract structured information based on the provided schema.",
       model,
       hasAvailableActions: false,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
       agentsList: null,

--- a/front/lib/api/actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/api/actions/servers/interactive_content/template_utils.ts
@@ -46,15 +46,18 @@ export async function fetchTemplateContent(
   const { agentConfiguration, conversation } = runContext;
 
   // Fetch skills for this agent and conversation (same pattern as agent loop).
-  const { enabledSkills } = await SkillResource.listForAgentLoop(auth, {
-    agentConfiguration,
-    conversation,
-  });
+  const { enabledSkills, systemSkills } = await SkillResource.listForAgentLoop(
+    auth,
+    {
+      agentConfiguration,
+      conversation,
+    }
+  );
 
   // Get merged data source configurations from skills.
   const { documentDataSourceConfigurations: skillDataSourceConfigurations } =
     await getSkillDataSourceConfigurations(auth, {
-      skills: enabledSkills,
+      skills: [...systemSkills, ...enabledSkills],
     });
 
   // Also collect data source configurations from the agent's actions.

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -12,9 +12,11 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type {
@@ -421,6 +423,46 @@ describe("constructPromptMultiActions - system prompt stability", () => {
 
     expect(text).toContain("<existing_memories>");
     expect(text).toContain("User prefers TypeScript");
+  });
+
+  it("should include system skills in the enabled skills section when passed separately", async () => {
+    await SkillFactory.linkGlobalSkillToAgent(authenticator1, {
+      globalSkillId: "discover_skills",
+      agentConfigurationId: agentConfig1.id,
+    });
+
+    const { systemSkills } = await SkillResource.listForAgentLoop(
+      authenticator1,
+      {
+        agentConfiguration: agentConfig1,
+        conversation: conversation1,
+      }
+    );
+    const discoverSkills = systemSkills.find(
+      (skill) => skill.sId === "discover_skills"
+    );
+    if (!discoverSkills) {
+      throw new Error("Expected discover_skills system skill to exist.");
+    }
+
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      systemSkills: [discoverSkills],
+      enabledSkills: [],
+      equippedSkills: [],
+    };
+
+    const sections = constructPromptMultiActions(authenticator1, params);
+    const text = systemPromptToText(sections);
+
+    expect(text).toContain("### ENABLED SKILLS");
+    expect(text).toContain(
+      "Some of the available skills come from the workspace"
+    );
   });
 
   it("should produce a valid prompt when memoriesContext is omitted", () => {

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -134,6 +134,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
     };
@@ -152,6 +153,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
     };
@@ -195,6 +197,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
       conversation: conversation1,
@@ -206,6 +209,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
       conversation: conversation2,
@@ -232,6 +236,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
     };
@@ -259,6 +264,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
     };
@@ -295,6 +301,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
       userContext: userCtx,
@@ -334,6 +341,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
       conversation: {
@@ -375,6 +383,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
       conversation: {
@@ -413,6 +422,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
       memoriesContext,
@@ -472,6 +482,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
     };
@@ -501,6 +512,7 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       model: modelConfig,
       hasAvailableActions: true,
       agentsList: null,
+      systemSkills: [],
       enabledSkills: [],
       equippedSkills: [],
       memoriesContext,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -216,11 +216,11 @@ function getEnabledSkillInstructions(
 }
 
 function constructSkillsSection({
-  systemSkills = [],
+  systemSkills,
   enabledSkills,
   equippedSkills,
 }: {
-  systemSkills?: SkillResource[];
+  systemSkills: SkillResource[];
   enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
   equippedSkills: SkillResource[];
 }): string {
@@ -406,7 +406,7 @@ export function constructPromptMultiActions(
     agentsList,
     conversation,
     serverToolsAndInstructions,
-    systemSkills = [],
+    systemSkills,
     enabledSkills,
     equippedSkills,
     memoriesContext,
@@ -423,7 +423,7 @@ export function constructPromptMultiActions(
     agentsList: LightAgentConfigurationType[] | null;
     conversation?: ConversationWithoutContentType;
     serverToolsAndInstructions?: ServerToolsAndInstructions[];
-    systemSkills?: SkillResource[];
+    systemSkills: SkillResource[];
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     equippedSkills: SkillResource[];
     memoriesContext?: string;

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -216,9 +216,11 @@ function getEnabledSkillInstructions(
 }
 
 function constructSkillsSection({
+  systemSkills = [],
   enabledSkills,
   equippedSkills,
 }: {
+  systemSkills?: SkillResource[];
   enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
   equippedSkills: SkillResource[];
 }): string {
@@ -241,20 +243,23 @@ function constructSkillsSection({
     "perspective on the currently available context.\n" +
     "Decisions taken prior to enabling a skill may need to be revisited after enabling it.\n";
 
-  if (!enabledSkills.length && !equippedSkills.length) {
+  if (!systemSkills.length && !enabledSkills.length && !equippedSkills.length) {
     skillsSection +=
       "\nNo skills are currently available or enabled for this agent.\n";
     return skillsSection;
   }
 
-  // Enabled skills - inject their full instructions
-  if (enabledSkills && enabledSkills.length > 0) {
+  // Enabled skills - inject their full instructions.
+  if (systemSkills.length > 0 || enabledSkills.length > 0) {
     skillsSection += "\n### ENABLED SKILLS\n";
     skillsSection += "The following skills are currently enabled:\n";
 
-    const skillInstructions = enabledSkills.map((skill) =>
-      getEnabledSkillInstructions(skill)
-    );
+    const skillInstructions = [
+      ...systemSkills.map(
+        (skill) => `<${skill.name}>\n${skill.instructions}\n</${skill.name}>`
+      ),
+      ...enabledSkills.map((skill) => getEnabledSkillInstructions(skill)),
+    ];
 
     skillsSection += skillInstructions.join("\n");
   }
@@ -401,6 +406,7 @@ export function constructPromptMultiActions(
     agentsList,
     conversation,
     serverToolsAndInstructions,
+    systemSkills = [],
     enabledSkills,
     equippedSkills,
     memoriesContext,
@@ -417,6 +423,7 @@ export function constructPromptMultiActions(
     agentsList: LightAgentConfigurationType[] | null;
     conversation?: ConversationWithoutContentType;
     serverToolsAndInstructions?: ServerToolsAndInstructions[];
+    systemSkills?: SkillResource[];
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     equippedSkills: SkillResource[];
     memoriesContext?: string;
@@ -458,6 +465,7 @@ export function constructPromptMultiActions(
     serverToolsAndInstructions,
   });
   const skillsSection = constructSkillsSection({
+    systemSkills,
     enabledSkills,
     equippedSkills,
   });

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -156,6 +156,32 @@ describe("getJITServers", () => {
 
       expect(skillManagementServer).toBeUndefined();
     });
+
+    it("should return system skills separately from equipped skills", async () => {
+      await SkillFactory.linkGlobalSkillToAgent(auth, {
+        globalSkillId: "discover_tools",
+        agentConfigurationId: agentConfig.id,
+      });
+
+      const customSkill = await SkillFactory.create(auth, {
+        name: "Test Skill",
+      });
+      await SkillFactory.linkToAgent(auth, {
+        skillId: customSkill.id,
+        agentConfigurationId: agentConfig.id,
+      });
+
+      const { enabledSkills, systemSkills, equippedSkills } =
+        await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+        });
+
+      expect(systemSkills.map((s) => s.sId)).toContain("discover_tools");
+      expect(enabledSkills.map((s) => s.sId)).toContain("discover_tools");
+      expect(equippedSkills.map((s) => s.sId)).toContain(customSkill.sId);
+      expect(equippedSkills.map((s) => s.sId)).not.toContain("discover_tools");
+    });
   });
 
   describe("projects feature", () => {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -178,7 +178,7 @@ describe("getJITServers", () => {
         });
 
       expect(systemSkills.map((s) => s.sId)).toContain("discover_tools");
-      expect(enabledSkills.map((s) => s.sId)).toContain("discover_tools");
+      expect(enabledSkills.map((s) => s.sId)).not.toContain("discover_tools");
       expect(equippedSkills.map((s) => s.sId)).toContain(customSkill.sId);
       expect(equippedSkills.map((s) => s.sId)).not.toContain("discover_tools");
     });

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -27,7 +27,7 @@ export async function getSkillServers(
     skills,
   }: {
     agentConfiguration: LightAgentConfigurationType;
-    skills: (SkillResource & { extendedSkill: SkillResource | null })[];
+    skills: (SkillResource & { extendedSkill?: SkillResource | null })[];
   }
 ): Promise<MCPServerConfigurationType[]> {
   const rawInheritedDataSourceViews = await concurrentExecutor(
@@ -277,17 +277,22 @@ export async function resolveSkillMCPServers(
     conversation: ConversationType;
   }
 ): Promise<MCPServerConfigurationType[]> {
-  const { enabledSkills } = await SkillResource.listForAgentLoop(auth, {
-    agentConfiguration,
-    conversation,
-  });
+  const { enabledSkills, systemSkills } = await SkillResource.listForAgentLoop(
+    auth,
+    {
+      agentConfiguration,
+      conversation,
+    }
+  );
 
-  if (enabledSkills.length === 0) {
+  const activeSkills = [...systemSkills, ...enabledSkills];
+
+  if (activeSkills.length === 0) {
     return [];
   }
 
   return getSkillServers(auth, {
     agentConfiguration,
-    skills: enabledSkills,
+    skills: activeSkills,
   });
 }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1259,6 +1259,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       | Pick<AgentLoopExecutionData, "agentConfiguration" | "conversation">
   ): Promise<{
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
+    systemSkills: SkillResource[];
     equippedSkills: SkillResource[];
   }> {
     const { agentConfiguration, conversation } = params;
@@ -1335,6 +1336,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return {
       enabledSkills: augmentedEnabledSkills,
+      systemSkills,
       equippedSkills,
     };
   }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1250,7 +1250,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * List skills for the agent loop, returning both (extended) enabled skills and equipped skills.
+   * List skills for the agent loop, returning system skills, (extended) enabled skills,
+   * and equipped skills.
    */
   static async listForAgentLoop(
     auth: Authenticator,
@@ -1303,9 +1304,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           )
         : [];
 
-    // Compute the enabled skills: system skills + conversation-enabled skills.
+    // Compute the enabled skills: conversation-enabled skills + project skill.
     const enabledSkills = [
-      ...systemSkills.sort(sortByName),
       ...conversationEnabledSkills.sort(sortByName),
       ...projectSkill,
     ];
@@ -1319,7 +1319,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // discoverable skills not already enabled or equipped.
     const enabledSkillIds = new Set(enabledSkills.map((s) => s.sId));
     const agentEquippedSkills = allAgentSkills.filter(
-      (s) => !enabledSkillIds.has(s.sId)
+      (s) => !s.isSystemSkill && !enabledSkillIds.has(s.sId)
     );
 
     const agentEquippedSkillIds = new Set(
@@ -1336,7 +1336,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return {
       enabledSkills: augmentedEnabledSkills,
-      systemSkills,
+      systemSkills: systemSkills.sort(sortByName),
       equippedSkills,
     };
   }

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -169,7 +169,7 @@ async function handler(
         attachments,
       });
 
-      const { enabledSkills, equippedSkills } =
+      const { enabledSkills, systemSkills, equippedSkills } =
         await SkillResource.listForAgentLoop(auth, {
           agentConfiguration,
           conversation,
@@ -177,7 +177,7 @@ async function handler(
 
       const skillServers = await getSkillServers(auth, {
         agentConfiguration,
-        skills: enabledSkills,
+        skills: [...systemSkills, ...enabledSkills],
       });
 
       const clientSideMCPActionConfigurations =
@@ -262,6 +262,7 @@ async function handler(
         agentsList,
         conversation,
         serverToolsAndInstructions,
+        systemSkills,
         enabledSkills,
         equippedSkills,
       });

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -168,14 +168,14 @@ async function listAvailableTools(
       userMessage.context.clientSideMCPServerIds
     );
 
-  const { enabledSkills } = await SkillResource.listForAgentLoop(
+  const { enabledSkills, systemSkills } = await SkillResource.listForAgentLoop(
     auth,
     runAgentData
   );
 
   const skillServers = await getSkillServers(auth, {
     agentConfiguration,
-    skills: enabledSkills,
+    skills: [...systemSkills, ...enabledSkills],
   });
 
   const { serverToolsAndInstructions: mcpActions } = await tryListMCPTools(

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -231,6 +231,7 @@ export async function runModel(
 
   const {
     enabledSkills,
+    systemSkills,
     equippedSkills,
     hasConditionalJITTools,
     mcpActions,
@@ -252,12 +253,12 @@ export async function runModel(
         userMessage.context.clientSideMCPServerIds
       );
 
-    const { enabledSkills, equippedSkills } =
+    const { enabledSkills, systemSkills, equippedSkills } =
       await SkillResource.listForAgentLoop(auth, runAgentData);
 
     const skillServers = await getSkillServers(auth, {
       agentConfiguration,
-      skills: enabledSkills,
+      skills: [...systemSkills, ...enabledSkills],
     });
 
     const {
@@ -279,6 +280,7 @@ export async function runModel(
     return {
       hasConditionalJITTools,
       enabledSkills,
+      systemSkills,
       equippedSkills,
       mcpActions,
       mcpToolsListingError,
@@ -382,6 +384,7 @@ export async function runModel(
     agentsList,
     conversation,
     serverToolsAndInstructions: filteredMcpActions,
+    systemSkills,
     enabledSkills,
     equippedSkills,
     memoriesContext,


### PR DESCRIPTION
## Description

This PR splits system skills out of `SkillResource.listForAgentLoop()` so the agent loop state now distinguishes between system, enabled and equipped skills.

This was carved out into its own PR first so the return-shape split can be reviewed independently from the later behavior changes in how skills are rendered in prompts and conversation messages.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
