### PR TITLE
[front] feat: Metronome-billed subscription page

### DIFF
--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -4,7 +4,12 @@ import config from "@app/lib/api/config";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
-import { isEntreprisePlanPrefix, isUpgraded } from "@app/lib/plans/plan_codes";
+import {
+  isEntreprisePlanPrefix,
+  isProPlan,
+  isUpgraded,
+  isWhitelistedBusinessPlan,
+} from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import {
   useMetronomeContract,
@@ -13,6 +18,7 @@ import {
 } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { PatchMetronomeContractRequestBody } from "@app/pages/api/w/[wId]/metronome/contract";
+import type { PatchSubscriptionRequestBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { BillingPeriod, SubscriptionType } from "@app/types/plan";
 import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -102,6 +108,62 @@ function CancelMetronomeSubscriptionDialog({
   );
 }
 
+interface UpgradeToBusinessDialogProps {
+  show: boolean;
+  onClose: () => void;
+  onValidate: () => Promise<void>;
+  isSaving: boolean;
+}
+
+function UpgradeToBusinessDialog({
+  show,
+  onClose,
+  onValidate,
+  isSaving,
+}: UpgradeToBusinessDialogProps) {
+  return (
+    <Dialog
+      open={show}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Upgrade to Enterprise seat-based plan</DialogTitle>
+          <DialogDescription>
+            Your current contract will end now and a new contract on the
+            Enterprise seat-based plan will start immediately. Future invoices
+            will reflect the new pricing.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          {isSaving ? (
+            <div className="flex justify-center py-8">
+              <Spinner variant="dark" size="md" />
+            </div>
+          ) : (
+            <div className="font-bold">Are you sure you want to proceed?</div>
+          )}
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: "Upgrade",
+            variant: "primary",
+            onClick: onValidate,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 interface MetronomeSubscriptionPanelProps {
   owner: LightWorkspaceType;
   subscription: SubscriptionType;
@@ -119,6 +181,7 @@ export function MetronomeSubscriptionPanel({
 
   const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("monthly");
   const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
 
   const { seatsCount, isSeatsCountLoading } = useWorkspaceSeatsCount({
     workspaceId: owner.sId,
@@ -215,6 +278,41 @@ export function MetronomeSubscriptionPanel({
       router.reload();
     });
 
+  const {
+    submit: handleUpgradeToBusiness,
+    isSubmitting: isUpgradingToBusiness,
+  } = useSubmitFunction(async () => {
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}/subscriptions`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "upgrade_to_business",
+        } satisfies t.TypeOf<typeof PatchSubscriptionRequestBody>),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        sendNotification({
+          type: "error",
+          title: "Upgrade failed",
+          description:
+            body?.error?.message ??
+            "Failed to upgrade to Enterprise seat-based plan.",
+        });
+        return;
+      }
+      sendNotification({
+        type: "success",
+        title: "Upgrade successful",
+        description:
+          "Your workspace has been upgraded to Enterprise seat-based plan.",
+      });
+      router.reload();
+    } finally {
+      setShowUpgradeDialog(false);
+    }
+  });
+
   if (!isMetronomeBilled) {
     return (
       <div className="pt-2">
@@ -252,6 +350,8 @@ export function MetronomeSubscriptionPanel({
   const chipColor = !isUpgraded(plan) ? "green" : "blue";
   const isCancellationScheduled =
     subscription.endDate !== null || subscription.requestCancelAt !== null;
+  const canUpsellToBusinessPlan =
+    isProPlan(plan) && isWhitelistedBusinessPlan(owner);
 
   const contractEndingLabel = contract?.contractEndingAtMs
     ? formatDate(contract.contractEndingAtMs)
@@ -271,6 +371,12 @@ export function MetronomeSubscriptionPanel({
         onValidate={cancelSubscription}
         isSaving={isCancelling}
         periodEndLabel={periodEndLabel}
+      />
+      <UpgradeToBusinessDialog
+        show={showUpgradeDialog}
+        onClose={() => setShowUpgradeDialog(false)}
+        onValidate={handleUpgradeToBusiness}
+        isSaving={isUpgradingToBusiness}
       />
 
       <Page.Vertical align="stretch" gap="md">
@@ -354,6 +460,30 @@ export function MetronomeSubscriptionPanel({
               ))}
           </div>
         </Page.Vertical>
+
+        {canUpsellToBusinessPlan && (
+          <Page.Vertical gap="sm">
+            <Page.H variant="h5">Upgrade your plan</Page.H>
+            <Page.P>
+              You are eligible to upgrade to the Enterprise seat-based plan with
+              additional features.
+            </Page.P>
+            <div>
+              <Button
+                label="Upgrade to Enterprise seat-based plan"
+                variant="primary"
+                disabled={isUpgradingToBusiness}
+                onClick={withTracking(
+                  TRACKING_AREAS.AUTH,
+                  "subscription_upgrade_to_business",
+                  () => {
+                    setShowUpgradeDialog(true);
+                  }
+                )}
+              />
+            </div>
+          </Page.Vertical>
+        )}
 
         {isEnterprise && (
           <Page.Vertical gap="sm">

--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -1,0 +1,448 @@
+import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
+import { useSendNotification } from "@app/hooks/useNotification";
+import config from "@app/lib/api/config";
+import { getPriceAsString } from "@app/lib/client/subscription";
+import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress/client";
+import { isEntreprisePlanPrefix, isUpgraded } from "@app/lib/plans/plan_codes";
+import { useAppRouter } from "@app/lib/platform";
+import {
+  useMetronomeContract,
+  useMetronomeInvoice,
+  useWorkspaceSeatsCount,
+} from "@app/lib/swr/workspaces";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import type { PatchMetronomeContractRequestBody } from "@app/pages/api/w/[wId]/metronome/contract";
+import type { BillingPeriod, SubscriptionType } from "@app/types/plan";
+import { isSubscriptionMetronomeBilled } from "@app/types/plan";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
+  Chip,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Page,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type * as t from "io-ts";
+import { useState } from "react";
+
+const CONTACT_SALES_URL = `${config.getStaticWebsiteUrl()}/home/contact`;
+
+function formatDate(ms: number): string {
+  return new Date(ms).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+interface CancelMetronomeSubscriptionDialogProps {
+  show: boolean;
+  onClose: () => void;
+  onValidate: () => Promise<void>;
+  isSaving: boolean;
+  periodEndLabel: string | null;
+}
+
+function CancelMetronomeSubscriptionDialog({
+  show,
+  onClose,
+  onValidate,
+  isSaving,
+  periodEndLabel,
+}: CancelMetronomeSubscriptionDialogProps) {
+  return (
+    <Dialog
+      open={show}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Cancel subscription</DialogTitle>
+          <DialogDescription>
+            {periodEndLabel
+              ? `Your subscription will end on ${periodEndLabel}. Until then you keep full access.`
+              : "Your subscription will end at the end of the current billing period. Until then you keep full access."}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          {isSaving ? (
+            <div className="flex justify-center py-8">
+              <Spinner variant="dark" size="md" />
+            </div>
+          ) : (
+            <div className="font-bold">Are you sure you want to proceed?</div>
+          )}
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Keep subscription",
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: "Cancel subscription",
+            variant: "warning",
+            onClick: onValidate,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface MetronomeSubscriptionPanelProps {
+  owner: LightWorkspaceType;
+  subscription: SubscriptionType;
+}
+
+export function MetronomeSubscriptionPanel({
+  owner,
+  subscription,
+}: MetronomeSubscriptionPanelProps) {
+  const router = useAppRouter();
+  const sendNotification = useSendNotification();
+
+  const isMetronomeBilled = isSubscriptionMetronomeBilled(subscription);
+  const isEnterprise = isEntreprisePlanPrefix(subscription.plan.code);
+
+  const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("monthly");
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+
+  const { seatsCount, isSeatsCountLoading } = useWorkspaceSeatsCount({
+    workspaceId: owner.sId,
+    disabled: !isMetronomeBilled,
+  });
+  const { contract, isMetronomeContractLoading } = useMetronomeContract({
+    workspaceId: owner.sId,
+    disabled: !isMetronomeBilled,
+  });
+  const { invoice, isMetronomeInvoiceLoading } = useMetronomeInvoice({
+    workspaceId: owner.sId,
+    disabled: !isMetronomeBilled,
+  });
+
+  const { submit: handleSubscribePlan, isSubmitting: isSubscribingPlan } =
+    useSubmitFunction(async () => {
+      const res = await clientFetch(`/api/w/${owner.sId}/subscriptions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ billingPeriod }),
+      });
+
+      if (!res.ok) {
+        sendNotification({
+          type: "error",
+          title: "Subscription failed",
+          description: "Failed to subscribe to a new plan.",
+        });
+        return;
+      }
+
+      const content = await res.json();
+      if (content.checkoutUrl) {
+        await router.push(content.checkoutUrl);
+      } else if (content.success) {
+        router.reload();
+      }
+    });
+
+  const { submit: cancelSubscription, isSubmitting: isCancelling } =
+    useSubmitFunction(async () => {
+      try {
+        const res = await clientFetch(
+          `/api/w/${owner.sId}/metronome/contract`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              action: "cancel",
+            } satisfies t.TypeOf<typeof PatchMetronomeContractRequestBody>),
+          }
+        );
+        if (!res.ok) {
+          sendNotification({
+            type: "error",
+            title: "Cancellation failed",
+            description: "Failed to cancel your subscription.",
+          });
+          return;
+        }
+        sendNotification({
+          type: "success",
+          title: "Subscription cancelled",
+          description: "Your subscription will end at the end of the period.",
+        });
+        router.reload();
+      } finally {
+        setShowCancelDialog(false);
+      }
+    });
+
+  const { submit: reactivateSubscription, isSubmitting: isReactivating } =
+    useSubmitFunction(async () => {
+      const res = await clientFetch(`/api/w/${owner.sId}/metronome/contract`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "reactivate",
+        } satisfies t.TypeOf<typeof PatchMetronomeContractRequestBody>),
+      });
+      if (!res.ok) {
+        sendNotification({
+          type: "error",
+          title: "Reactivation failed",
+          description: "Failed to reactivate your subscription.",
+        });
+        return;
+      }
+      sendNotification({
+        type: "success",
+        title: "Subscription reactivated",
+        description: "Your subscription will continue normally.",
+      });
+      router.reload();
+    });
+
+  if (!isMetronomeBilled) {
+    return (
+      <div className="pt-2">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <Page.H variant="h5">Choose a plan</Page.H>
+            <Page.P>Pick a plan that best suits your team.</Page.P>
+          </div>
+          <ButtonsSwitchList
+            defaultValue={billingPeriod}
+            size="xs"
+            onValueChange={(v) => {
+              if (v === "monthly" || v === "yearly") {
+                setBillingPeriod(v);
+              }
+            }}
+          >
+            <ButtonsSwitch value="monthly" label="Monthly billing" />
+            <ButtonsSwitch value="yearly" label="Yearly billing" />
+          </ButtonsSwitchList>
+        </div>
+        <div className="pt-4">
+          <SubscriptionPlanCards
+            billingPeriod={billingPeriod}
+            onSubscribe={handleSubscribePlan}
+            isProcessing={isSubscribingPlan}
+            owner={owner}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const plan = subscription.plan;
+  const chipColor = !isUpgraded(plan) ? "green" : "blue";
+  const isCancellationScheduled =
+    subscription.endDate !== null || subscription.requestCancelAt !== null;
+
+  const contractEndingLabel = contract?.contractEndingAt
+    ? formatDate(contract.contractEndingAt)
+    : null;
+  const periodEndLabel = invoice ? formatDate(invoice.currentPeriodEnd) : null;
+  const periodStartLabel = invoice
+    ? formatDate(invoice.currentPeriodStart)
+    : null;
+
+  return (
+    <>
+      <CancelMetronomeSubscriptionDialog
+        show={showCancelDialog}
+        onClose={() => setShowCancelDialog(false)}
+        onValidate={cancelSubscription}
+        isSaving={isCancelling}
+        periodEndLabel={periodEndLabel}
+      />
+
+      <Page.Vertical align="stretch" gap="md">
+        <div>
+          <Page.Horizontal gap="sm">
+            <Chip size="sm" color={chipColor} label={plan.name} />
+          </Page.Horizontal>
+        </div>
+
+        <Page.Vertical gap="sm">
+          <Page.H variant="h5">Contract</Page.H>
+          {isMetronomeContractLoading || isSeatsCountLoading ? (
+            <Spinner size="sm" />
+          ) : contract && invoice ? (
+            <ContractSection
+              contract={contract}
+              invoice={invoice}
+              seatsCount={seatsCount}
+            />
+          ) : (
+            <Page.P>No contract information available.</Page.P>
+          )}
+          {contractEndingLabel && (
+            <Page.P>Contract ends on {contractEndingLabel}.</Page.P>
+          )}
+        </Page.Vertical>
+
+        <Page.Vertical gap="sm">
+          <Page.H variant="h5">Current billing period</Page.H>
+          {isMetronomeInvoiceLoading ? (
+            <Spinner size="sm" />
+          ) : invoice && periodStartLabel && periodEndLabel ? (
+            <>
+              <Page.P>
+                {periodStartLabel} — {periodEndLabel}.
+              </Page.P>
+              <Page.P>
+                Estimated {invoice.billingPeriod} billing:{" "}
+                <span className="font-bold">
+                  {getPriceAsString({
+                    currency: invoice.currency,
+                    priceInCents: invoice.estimatedAmountCents,
+                  })}
+                </span>{" "}
+                (excluding taxes).
+              </Page.P>
+            </>
+          ) : (
+            <Page.P>
+              No billing information available for this period yet.
+            </Page.P>
+          )}
+          <div className="my-5 flex flex-row gap-2">
+            {!isEnterprise &&
+              (isCancellationScheduled ? (
+                <Button
+                  label="Resume subscription"
+                  variant="highlight"
+                  disabled={isReactivating}
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "subscription_reactivate",
+                    () => {
+                      void reactivateSubscription();
+                    }
+                  )}
+                />
+              ) : (
+                <Button
+                  label="Cancel subscription"
+                  variant="warning"
+                  disabled={isCancelling}
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "subscription_cancel",
+                    () => {
+                      setShowCancelDialog(true);
+                    }
+                  )}
+                />
+              ))}
+          </div>
+        </Page.Vertical>
+
+        {isEnterprise && (
+          <Page.Vertical gap="sm">
+            <Page.H variant="h5">Need changes?</Page.H>
+            <Page.P>
+              Reach out to sales to adjust your enterprise contract.
+            </Page.P>
+            <div>
+              <Button
+                label="Contact sales"
+                variant="outline"
+                href={CONTACT_SALES_URL}
+                target="_blank"
+              />
+            </div>
+          </Page.Vertical>
+        )}
+      </Page.Vertical>
+    </>
+  );
+}
+
+interface ContractSectionProps {
+  contract: NonNullable<ReturnType<typeof useMetronomeContract>["contract"]>;
+  invoice: NonNullable<ReturnType<typeof useMetronomeInvoice>["invoice"]>;
+  seatsCount: number;
+}
+
+function ContractSection({
+  contract,
+  invoice,
+  seatsCount,
+}: ContractSectionProps) {
+  const { currency } = invoice;
+
+  if (contract.planFamily === "pro") {
+    const seatPrice = invoice.seatUnitPriceCents;
+    return (
+      <>
+        <Page.P>
+          {seatsCount === 1 ? `${seatsCount} member` : `${seatsCount} members`}
+          {seatPrice !== null
+            ? ` — ${getPriceAsString({ currency, priceInCents: seatPrice })} per member.`
+            : "."}
+        </Page.P>
+      </>
+    );
+  }
+
+  // Enterprise
+  if (contract.mauTiers && invoice.mauTierUnitPricesCents) {
+    return (
+      <>
+        <Page.P>
+          {invoice.mau !== null
+            ? `${invoice.mau} active ${invoice.mau === 1 ? "user" : "users"} this period`
+            : "MAU billing"}
+          {" (tiered):"}
+        </Page.P>
+        <div className="pl-4">
+          {contract.mauTiers.map((tier, idx) => {
+            const price = invoice.mauTierUnitPricesCents?.[idx] ?? null;
+            const label =
+              tier.end !== null
+                ? `${tier.start}–${tier.end - 1} users`
+                : `${tier.start}+ users`;
+            const priceLabel =
+              price !== null
+                ? getPriceAsString({ currency, priceInCents: price })
+                : "—";
+            return (
+              <Page.P key={`${tier.start}-${tier.end ?? "inf"}`}>
+                {label}: {priceLabel} per user.
+              </Page.P>
+            );
+          })}
+        </div>
+      </>
+    );
+  }
+
+  // Simple MAU
+  const mauPrice = invoice.mauUnitPriceCents;
+  return (
+    <Page.P>
+      {invoice.mau !== null
+        ? `${invoice.mau} active ${invoice.mau === 1 ? "user" : "users"} this period`
+        : "MAU billing"}
+      {mauPrice !== null
+        ? ` — ${getPriceAsString({ currency, priceInCents: mauPrice })} per active user.`
+        : "."}
+    </Page.P>
+  );
+}

--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -36,8 +36,8 @@ import { useState } from "react";
 
 const CONTACT_SALES_URL = `${config.getStaticWebsiteUrl()}/home/contact`;
 
-function formatDate(ms: number): string {
-  return new Date(ms).toLocaleDateString("en-US", {
+function formatDate(msEpoch: number): string {
+  return new Date(msEpoch).toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",
     day: "numeric",
@@ -253,12 +253,14 @@ export function MetronomeSubscriptionPanel({
   const isCancellationScheduled =
     subscription.endDate !== null || subscription.requestCancelAt !== null;
 
-  const contractEndingLabel = contract?.contractEndingAt
-    ? formatDate(contract.contractEndingAt)
+  const contractEndingLabel = contract?.contractEndingAtMs
+    ? formatDate(contract.contractEndingAtMs)
     : null;
-  const periodEndLabel = invoice ? formatDate(invoice.currentPeriodEnd) : null;
+  const periodEndLabel = invoice
+    ? formatDate(invoice.currentPeriodEndMs)
+    : null;
   const periodStartLabel = invoice
-    ? formatDate(invoice.currentPeriodStart)
+    ? formatDate(invoice.currentPeriodStartMs)
     : null;
 
   return (

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -1,6 +1,11 @@
+import { MetronomeSubscriptionPanel } from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
 import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
@@ -23,6 +28,7 @@ import type {
   SubscriptionPerSeatPricing,
   SubscriptionType,
 } from "@app/types/plan";
+import { isSubscriptionStripeBilled } from "@app/types/plan";
 import {
   Button,
   ButtonsSwitch,
@@ -189,6 +195,10 @@ function CancelFreeTrialDialog({
 export function SubscriptionPage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const useMetronomePanel =
+    hasFeature("metronome_billing") &&
+    !isSubscriptionStripeBilled(subscription);
   const router = useAppRouter();
   const sendNotification = useSendNotification();
   const type = useSearchParam("type");
@@ -472,166 +482,179 @@ export function SubscriptionPage() {
             </ContentMessage>
           )}
 
-          <div>
-            {isWebhookProcessing ? (
-              <Spinner />
-            ) : (
-              <>
-                <Page.Horizontal gap="sm">
-                  <Chip size="sm" color={chipColor} label={planLabel} />
-                  {!subscription.trialing &&
-                    subscription.stripeSubscriptionId && (
-                      <Button
-                        label="Manage my subscription"
-                        onClick={withTracking(
-                          TRACKING_AREAS.AUTH,
-                          "subscription_manage",
-                          () => {
-                            void handleGoToStripePortal();
-                          }
-                        )}
-                        variant="outline"
-                      />
-                    )}
-                </Page.Horizontal>
-              </>
-            )}
-          </div>
-          {perSeatPricing && subscription.trialing && (
-            <Page.Vertical>
-              <Page.Horizontal gap="sm">
-                <Button
-                  onClick={withTracking(
-                    TRACKING_AREAS.AUTH,
-                    "subscription_skip_trial",
-                    () => {
-                      setShowSkipFreeTrialDialog(true);
-                    }
-                  )}
-                  label="End trial & get full access"
-                />
-                <Button
-                  label="Cancel subscription"
-                  variant="ghost"
-                  onClick={withTracking(
-                    TRACKING_AREAS.AUTH,
-                    "subscription_cancel_trial",
-                    () => {
-                      setShowCancelFreeTrialDialog(true);
-                    }
-                  )}
-                />
-              </Page.Horizontal>
-            </Page.Vertical>
-          )}
-          {subscription.stripeSubscriptionId && (
-            <Page.Vertical gap="sm">
-              <Page.H variant="h5">Billing</Page.H>
-              {perSeatPricing !== null && (
-                <>
-                  <Page.P>
-                    Estimated {perSeatPricing.billingPeriod} billing:{" "}
-                    <span className="font-bold">
-                      {getPriceAsString({
-                        currency: perSeatPricing.seatCurrency,
-                        priceInCents: perSeatPricing.seatPrice * workspaceSeats,
-                      })}
-                    </span>{" "}
-                    (excluding taxes).
-                  </Page.P>
-                  <Page.P>
-                    {workspaceSeats === 1 ? (
-                      <>
-                        {workspaceSeats} member,{" "}
-                        {getPriceAsString({
-                          currency: perSeatPricing.seatCurrency,
-                          priceInCents: perSeatPricing.seatPrice,
-                        })}{" "}
-                        per member.
-                      </>
-                    ) : (
-                      <>
-                        {workspaceSeats} members,{" "}
-                        {getPriceAsString({
-                          currency: perSeatPricing.seatCurrency,
-                          priceInCents: perSeatPricing.seatPrice,
-                        })}{" "}
-                        per member.
-                      </>
-                    )}
-                  </Page.P>
-                </>
-              )}
-              <div className="my-5">
-                <Button
-                  icon={CardIcon}
-                  label="Your billing dashboard on Stripe"
-                  variant="ghost"
-                  onClick={withTracking(
-                    TRACKING_AREAS.AUTH,
-                    "subscription_stripe_portal",
-                    () => {
-                      void handleGoToStripePortal();
-                    }
-                  )}
-                />
-              </div>
-            </Page.Vertical>
-          )}
-          {canUpsellToBusinessPlan && (
-            <Page.Vertical gap="sm">
-              <Page.H variant="h5">Upgrade your plan</Page.H>
-              <Page.P>
-                You are eligible to upgrade to the Enteprise seat-based plan
-                with additional features.
-              </Page.P>
+          {useMetronomePanel ? (
+            <MetronomeSubscriptionPanel
+              owner={owner}
+              subscription={subscription}
+            />
+          ) : (
+            <>
               <div>
-                <Button
-                  label="Upgrade to Enterprise seat-based plan"
-                  variant="primary"
-                  disabled={isProcessing}
-                  onClick={withTracking(
-                    TRACKING_AREAS.AUTH,
-                    "subscription_upgrade_to_business",
-                    () => {
-                      void handleUpgradeToBusiness();
-                    }
-                  )}
-                />
-              </div>
-            </Page.Vertical>
-          )}
-          {displayPricingTable && (
-            <div className="pt-2">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <Page.H variant="h5">Choose a plan</Page.H>
-                  <Page.P>Pick a plan that best suits your team.</Page.P>
-                </div>
-                {!isWorkspaceWhitelistedBusinessPlan && (
-                  <ButtonsSwitchList
-                    defaultValue={billingPeriod}
-                    size="xs"
-                    onValueChange={(v) => {
-                      if (v === "monthly" || v === "yearly") {
-                        setBillingPeriod(v);
-                      }
-                    }}
-                  >
-                    <ButtonsSwitch value="monthly" label="Monthly billing" />
-                    <ButtonsSwitch value="yearly" label="Yearly billing" />
-                  </ButtonsSwitchList>
+                {isWebhookProcessing ? (
+                  <Spinner />
+                ) : (
+                  <>
+                    <Page.Horizontal gap="sm">
+                      <Chip size="sm" color={chipColor} label={planLabel} />
+                      {!subscription.trialing &&
+                        subscription.stripeSubscriptionId && (
+                          <Button
+                            label="Manage my subscription"
+                            onClick={withTracking(
+                              TRACKING_AREAS.AUTH,
+                              "subscription_manage",
+                              () => {
+                                void handleGoToStripePortal();
+                              }
+                            )}
+                            variant="outline"
+                          />
+                        )}
+                    </Page.Horizontal>
+                  </>
                 )}
               </div>
-              <div className="pt-4">
-                <SubscriptionPlanCards
-                  billingPeriod={billingPeriod}
-                  onSubscribe={handleSubscribePlan}
-                  isProcessing={isProcessing}
-                  owner={owner}
-                />
-              </div>
-            </div>
+              {perSeatPricing && subscription.trialing && (
+                <Page.Vertical>
+                  <Page.Horizontal gap="sm">
+                    <Button
+                      onClick={withTracking(
+                        TRACKING_AREAS.AUTH,
+                        "subscription_skip_trial",
+                        () => {
+                          setShowSkipFreeTrialDialog(true);
+                        }
+                      )}
+                      label="End trial & get full access"
+                    />
+                    <Button
+                      label="Cancel subscription"
+                      variant="ghost"
+                      onClick={withTracking(
+                        TRACKING_AREAS.AUTH,
+                        "subscription_cancel_trial",
+                        () => {
+                          setShowCancelFreeTrialDialog(true);
+                        }
+                      )}
+                    />
+                  </Page.Horizontal>
+                </Page.Vertical>
+              )}
+              {subscription.stripeSubscriptionId && (
+                <Page.Vertical gap="sm">
+                  <Page.H variant="h5">Billing</Page.H>
+                  {perSeatPricing !== null && (
+                    <>
+                      <Page.P>
+                        Estimated {perSeatPricing.billingPeriod} billing:{" "}
+                        <span className="font-bold">
+                          {getPriceAsString({
+                            currency: perSeatPricing.seatCurrency,
+                            priceInCents:
+                              perSeatPricing.seatPrice * workspaceSeats,
+                          })}
+                        </span>{" "}
+                        (excluding taxes).
+                      </Page.P>
+                      <Page.P>
+                        {workspaceSeats === 1 ? (
+                          <>
+                            {workspaceSeats} member,{" "}
+                            {getPriceAsString({
+                              currency: perSeatPricing.seatCurrency,
+                              priceInCents: perSeatPricing.seatPrice,
+                            })}{" "}
+                            per member.
+                          </>
+                        ) : (
+                          <>
+                            {workspaceSeats} members,{" "}
+                            {getPriceAsString({
+                              currency: perSeatPricing.seatCurrency,
+                              priceInCents: perSeatPricing.seatPrice,
+                            })}{" "}
+                            per member.
+                          </>
+                        )}
+                      </Page.P>
+                    </>
+                  )}
+                  <div className="my-5">
+                    <Button
+                      icon={CardIcon}
+                      label="Your billing dashboard on Stripe"
+                      variant="ghost"
+                      onClick={withTracking(
+                        TRACKING_AREAS.AUTH,
+                        "subscription_stripe_portal",
+                        () => {
+                          void handleGoToStripePortal();
+                        }
+                      )}
+                    />
+                  </div>
+                </Page.Vertical>
+              )}
+              {canUpsellToBusinessPlan && (
+                <Page.Vertical gap="sm">
+                  <Page.H variant="h5">Upgrade your plan</Page.H>
+                  <Page.P>
+                    You are eligible to upgrade to the Enteprise seat-based plan
+                    with additional features.
+                  </Page.P>
+                  <div>
+                    <Button
+                      label="Upgrade to Enterprise seat-based plan"
+                      variant="primary"
+                      disabled={isProcessing}
+                      onClick={withTracking(
+                        TRACKING_AREAS.AUTH,
+                        "subscription_upgrade_to_business",
+                        () => {
+                          void handleUpgradeToBusiness();
+                        }
+                      )}
+                    />
+                  </div>
+                </Page.Vertical>
+              )}
+              {displayPricingTable && (
+                <div className="pt-2">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <Page.H variant="h5">Choose a plan</Page.H>
+                      <Page.P>Pick a plan that best suits your team.</Page.P>
+                    </div>
+                    {!isWorkspaceWhitelistedBusinessPlan && (
+                      <ButtonsSwitchList
+                        defaultValue={billingPeriod}
+                        size="xs"
+                        onValueChange={(v) => {
+                          if (v === "monthly" || v === "yearly") {
+                            setBillingPeriod(v);
+                          }
+                        }}
+                      >
+                        <ButtonsSwitch
+                          value="monthly"
+                          label="Monthly billing"
+                        />
+                        <ButtonsSwitch value="yearly" label="Yearly billing" />
+                      </ButtonsSwitchList>
+                    )}
+                  </div>
+                  <div className="pt-4">
+                    <SubscriptionPlanCards
+                      billingPeriod={billingPeriod}
+                      onSubscribe={handleSubscribePlan}
+                      isProcessing={isProcessing}
+                      owner={owner}
+                    />
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </Page.Vertical>
       </Page.Vertical>

--- a/front/lib/metronome/amounts.ts
+++ b/front/lib/metronome/amounts.ts
@@ -1,0 +1,36 @@
+import type { SupportedCurrency } from "@app/types/currency";
+/**
+ * Convert a Metronome amount to cents.
+ *
+ * Metronome pricing units depend on currency:
+ * - USD: already expressed in cents
+ * - Other fiat currencies: expressed in whole currency units
+ */
+export function amountCents(
+  amount: number,
+  currency: SupportedCurrency
+): number {
+  if (currency === "usd") {
+    return Math.round(amount);
+  }
+
+  return Math.round(amount * 100);
+}
+
+/**
+ * Convert cents to a Metronome amount.
+ *
+ * Metronome pricing depends on currency:
+ * - USD: expressed in cents
+ * - Other fiat currencies: expressed in whole currency units
+ */
+export function metronomeAmount(
+  amountCents: number,
+  currency: SupportedCurrency
+): number {
+  if (currency === "usd") {
+    return amountCents;
+  }
+
+  return Math.round(amountCents / 100);
+}

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -471,17 +471,14 @@ export async function getMetronomeContractPackageAliases({
   metronomeContractId: string;
 }): Promise<Result<string[], Error>> {
   try {
-    const contractResult = await getMetronomeContractById({
-      metronomeCustomerId,
-      metronomeContractId,
+    // Use v1.contracts.retrieve: only v1 exposes package_id on the response
+    // (Shared.Contract.package_id). v2.contracts.retrieve omits it.
+    const contractResponse = await getMetronomeClient().v1.contracts.retrieve({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
     });
-    if (contractResult.isErr()) {
-      return new Err(contractResult.error);
-    }
 
-    const packageId = (
-      contractResult.value as ContractV2 & { package_id: string } // package_id is missing in ContractV2 but is actually returned
-    ).package_id;
+    const packageId = contractResponse.data.package_id;
     if (!packageId) {
       return new Ok([]);
     }

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -5,6 +5,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import Metronome, { ConflictError } from "@metronome/sdk";
 import type { Commit, ContractV2, Credit } from "@metronome/sdk/resources";
+import type { Invoice } from "@metronome/sdk/resources/v1/customers";
 import type {
   MetronomeBalance,
   MetronomeEvent,
@@ -724,6 +725,38 @@ export async function listMetronomeProducts(): Promise<
   } catch (err) {
     const error = normalizeError(err);
     logger.error({ error }, "[Metronome] Failed to list products");
+    return new Err(error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Invoices
+// ---------------------------------------------------------------------------
+
+/**
+ * List draft invoices for a Metronome customer.
+ * Draft invoices reflect up-to-date spend for the current billing period
+ * before final billing. Used to compute estimated current-period billing.
+ */
+export async function listMetronomeDraftInvoices(
+  metronomeCustomerId: string
+): Promise<Result<Invoice[], Error>> {
+  try {
+    const invoices: Invoice[] = [];
+    for await (const entry of getMetronomeClient().v1.customers.invoices.list({
+      customer_id: metronomeCustomerId,
+      status: "DRAFT",
+      skip_zero_qty_line_items: true,
+    })) {
+      invoices.push(entry);
+    }
+    return new Ok(invoices);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId },
+      "[Metronome] Failed to list draft invoices"
+    );
     return new Err(error);
   }
 }

--- a/front/lib/metronome/contract_lifecycle.ts
+++ b/front/lib/metronome/contract_lifecycle.ts
@@ -1,0 +1,153 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  listMetronomeDraftInvoices,
+  reactivateMetronomeContract as reactivateMetronomeContractRaw,
+  scheduleMetronomeContractEnd,
+} from "@app/lib/metronome/client";
+import { isSubscriptionMetronomeBilled } from "@app/types/plan";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type ContractLifecycleError =
+  | { kind: "invalid_state"; message: string }
+  | { kind: "upstream_error"; message: string };
+
+/**
+ * Schedule the workspace's Metronome contract to end at the current billing
+ * period end, and mark the local subscription as canceled so the "ends on X"
+ * banner surfaces immediately.
+ */
+export async function cancelWorkspaceContractAtPeriodEnd(
+  auth: Authenticator
+): Promise<Result<{ endDate: Date }, ContractLifecycleError>> {
+  const subscription = auth.subscription();
+  if (!subscription) {
+    return new Err({ kind: "invalid_state", message: "No subscription." });
+  }
+  if (subscription.trialing) {
+    return new Err({
+      kind: "invalid_state",
+      message: "Use cancel_free_trial to cancel a trialing subscription.",
+    });
+  }
+
+  if (!isSubscriptionMetronomeBilled(subscription)) {
+    return new Err({
+      kind: "invalid_state",
+      message: "Cancel is only supported for Metronome-billed subscriptions.",
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const { metronomeContractId } = subscription;
+  const { metronomeCustomerId } = owner;
+  if (!metronomeCustomerId) {
+    return new Err({
+      kind: "invalid_state",
+      message: "Cancel is only supported for Metronome-billed subscriptions.",
+    });
+  }
+
+  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
+  if (invoicesResult.isErr()) {
+    return new Err({
+      kind: "upstream_error",
+      message: `Failed to fetch Metronome draft invoices: ${invoicesResult.error.message}`,
+    });
+  }
+
+  const nowMs = Date.now();
+  const currentInvoice = invoicesResult.value.find((inv) => {
+    if (inv.contract_id !== metronomeContractId) {
+      return false;
+    }
+    if (!inv.start_timestamp || !inv.end_timestamp) {
+      return false;
+    }
+    const startMs = new Date(inv.start_timestamp).getTime();
+    const endMs = new Date(inv.end_timestamp).getTime();
+    return startMs <= nowMs && nowMs < endMs;
+  });
+
+  if (!currentInvoice?.end_timestamp) {
+    return new Err({
+      kind: "invalid_state",
+      message:
+        "Could not determine the current billing period end from Metronome.",
+    });
+  }
+
+  const periodEnd = new Date(currentInvoice.end_timestamp);
+
+  const scheduleResult = await scheduleMetronomeContractEnd({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+    endingBefore: periodEnd,
+  });
+  if (scheduleResult.isErr()) {
+    return new Err({
+      kind: "upstream_error",
+      message: `Failed to schedule Metronome contract end: ${scheduleResult.error.message}`,
+    });
+  }
+
+  const subscriptionResource = auth.getNonNullableSubscriptionResource();
+  await subscriptionResource.markAsCanceled({ endDate: periodEnd });
+
+  return new Ok({ endDate: periodEnd });
+}
+
+/**
+ * Clear the scheduled end on the workspace's Metronome contract and unset the
+ * local cancellation markers.
+ */
+export async function reactivateWorkspaceContract(
+  auth: Authenticator
+): Promise<Result<void, ContractLifecycleError>> {
+  const subscription = auth.subscription();
+  if (!subscription) {
+    return new Err({ kind: "invalid_state", message: "No subscription." });
+  }
+
+  if (!isSubscriptionMetronomeBilled(subscription)) {
+    return new Err({
+      kind: "invalid_state",
+      message:
+        "Reactivate is only supported for Metronome-billed subscriptions.",
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const { metronomeContractId } = subscription;
+  const { metronomeCustomerId } = owner;
+  if (!metronomeCustomerId) {
+    return new Err({
+      kind: "invalid_state",
+      message:
+        "Reactivate is only supported for Metronome-billed subscriptions.",
+    });
+  }
+
+  if (!subscription.endDate && !subscription.requestCancelAt) {
+    return new Err({
+      kind: "invalid_state",
+      message: "The subscription is not scheduled for cancellation.",
+    });
+  }
+
+  const reactivateResult = await reactivateMetronomeContractRaw({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+  });
+  if (reactivateResult.isErr()) {
+    return new Err({
+      kind: "upstream_error",
+      message: `Failed to reactivate Metronome contract: ${reactivateResult.error.message}`,
+    });
+  }
+
+  const subscriptionResource = auth.getNonNullableSubscriptionResource();
+  await subscriptionResource.markAsCanceled({ endDate: null });
+
+  return new Ok(undefined);
+}

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -36,11 +36,13 @@ import {
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Logger } from "@app/logger/logger";
 import logger from "@app/logger/logger";
+import type { SupportedCurrency } from "@app/types/currency";
 import { isSupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import type Stripe from "stripe";
+import { metronomeAmount } from "./amounts";
 
 /**
  * Switch a Metronome contract to a different package (end old + create new).
@@ -183,7 +185,7 @@ export interface StripeTierCents {
  */
 export interface EnterprisePricingCents {
   /** Currency of the Stripe price (e.g. "usd", "eur"). */
-  currency: string;
+  currency: SupportedCurrency;
   /** Billing mode: MAU_1/5/10 for MAU-based, FIXED for flat price. */
   billingMode: SupportedEnterpriseReportUsage;
   /** All pricing tiers from Stripe (empty for FIXED). */
@@ -303,6 +305,14 @@ export async function extractEnterprisePricing(
     }
 
     // FIXED pricing: flat monthly fee, no MAU.
+    if (!isSupportedCurrency(item.price.currency)) {
+      pricingLogger.warn(
+        { priceId: item.price.id, currency: item.price.currency },
+        "Unsupported enterprise price currency"
+      );
+      return undefined;
+    }
+
     if (reportUsage === "FIXED") {
       return {
         currency: item.price.currency,
@@ -317,6 +327,14 @@ export async function extractEnterprisePricing(
     const price = await stripe.prices.retrieve(item.price.id, {
       expand: ["tiers"],
     });
+
+    if (!isSupportedCurrency(price.currency)) {
+      pricingLogger.warn(
+        { priceId: price.id, currency: price.currency },
+        "Unsupported enterprise price currency"
+      );
+      return undefined;
+    }
 
     if (!price.tiers || price.tiers.length === 0) {
       pricingLogger.warn(
@@ -455,18 +473,6 @@ function buildMauTiersField(tiers: StripeTierCents[]): string {
 }
 
 /**
- * Convert Stripe cents to Metronome pricing units.
- * USD: Metronome uses cents (same as Stripe) → no conversion.
- * EUR: Metronome uses whole euros → divide by 100.
- */
-function stripeCentsToMetronomePrice(cents: number, currency: string): number {
-  if (currency === "eur") {
-    return Math.round(cents / 100);
-  }
-  return cents;
-}
-
-/**
  * Derive per-tier prices from Stripe tiers for Metronome FLAT rate overrides.
  *
  * Returns one price per tier in Metronome pricing units (cents for USD, euros for EUR).
@@ -478,7 +484,7 @@ function stripeCentsToMetronomePrice(cents: number, currency: string): number {
  */
 function deriveTierPrices(
   tiers: StripeTierCents[],
-  currency: string
+  currency: SupportedCurrency
 ): number[] {
   let previousUpTo = 0;
   return tiers.map((tier, index) => {
@@ -488,13 +494,10 @@ function deriveTierPrices(
     // First tier with floor: derive price from flat_amount / size.
     if (index === 0 && tier.flatAmountCents > 0 && tierSize) {
       // Convert floor to Metronome units first, then divide by tier size.
-      const floorMetronome = stripeCentsToMetronomePrice(
-        tier.flatAmountCents,
-        currency
-      );
+      const floorMetronome = metronomeAmount(tier.flatAmountCents, currency);
       return Math.round(floorMetronome / tierSize);
     }
-    return stripeCentsToMetronomePrice(tier.unitAmountCents, currency);
+    return metronomeAmount(tier.unitAmountCents, currency);
   });
 }
 
@@ -588,7 +591,7 @@ export function buildEnterpriseOverrides({
       ...tierProductIds.map(disableOverride),
     ];
 
-    const floorMetronome = stripeCentsToMetronomePrice(
+    const floorMetronome = metronomeAmount(
       pricing.floorCents,
       pricing.currency
     );
@@ -675,10 +678,7 @@ export function buildEnterpriseOverrides({
 
   // Recurring commit for the floor (flat_amount on first tier).
   // Applicable to MAU Tier 1 so the commit draws down at tier 1's rate.
-  const floorMetronome = stripeCentsToMetronomePrice(
-    pricing.floorCents,
-    pricing.currency
-  );
+  const floorMetronome = metronomeAmount(pricing.floorCents, pricing.currency);
   const recurringCommits =
     pricing.floorCents > 0
       ? [
@@ -879,9 +879,7 @@ export async function provisionEnterpriseMetronomeContract({
   // Resolve the package alias based on the subscription currency.
   const packageAlias = resolvePackageAliasForCurrency(
     LEGACY_ENTERPRISE_PACKAGE_ALIAS,
-    isSupportedCurrency(enterprisePricing.currency)
-      ? enterprisePricing.currency
-      : "usd"
+    enterprisePricing.currency
   );
 
   // Anchor the Metronome contract to the Stripe billing period start so the

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -1,4 +1,4 @@
-import type { PlanType, SubscriptionType } from "@app/types/plan";
+import type { PlanType } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 
 // Current free plans:
@@ -71,10 +71,6 @@ export function isBusinessPlan(plan?: PlanType) {
 
 export function isProOrBusinessPlanCode(plan?: PlanType) {
   return isProPlan(plan) || isBusinessPlan(plan);
-}
-
-export function isMetronomeBilled(subscription: SubscriptionType): boolean {
-  return subscription.metronomeContractId != null;
 }
 
 /**

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -4,10 +4,7 @@ import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization"
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import {
-  getMetronomeContractPackageAliases,
-  scheduleMetronomeContractEnd,
-} from "@app/lib/metronome/client";
+import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
   provisionEnterpriseMetronomeContract,
   switchMetronomeContractPackage,
@@ -18,7 +15,6 @@ import {
   LEGACY_BUSINESS_PACKAGE_ALIAS,
   LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
   LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
-  PRO_OR_BUSINESS_PACKAGE_ALIASES,
 } from "@app/lib/metronome/types";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
@@ -29,6 +25,7 @@ import {
   FREE_TEST_PLAN_CODE,
   isEntreprisePlanPrefix,
   isFreePlan,
+  isProOrBusinessPlanCode,
   isProPlanPrefix,
   isUpgraded,
   isWhitelistedBusinessPlan,
@@ -1503,19 +1500,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       );
     }
 
-    // Check Metronome-billed subscription.
-    if (this.metronomeContractId && owner.metronomeCustomerId) {
-      const aliasesResult = await getMetronomeContractPackageAliases({
-        metronomeCustomerId: owner.metronomeCustomerId,
-        metronomeContractId: this.metronomeContractId,
-      });
-      if (aliasesResult.isErr()) {
-        throw aliasesResult.error;
-      }
-
-      return aliasesResult.value.some((alias) =>
-        PRO_OR_BUSINESS_PACKAGE_ALIASES.has(alias)
-      );
+    // Metronome-billed subscription: trust the DB plan code, which we own and
+    // keep in sync with Metronome contract changes.
+    if (this.metronomeContractId) {
+      return isProOrBusinessPlanCode(this.plan);
     }
 
     return false;

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -24,6 +24,8 @@ import type { GetWorkspaceTopUsersResponse } from "@app/pages/api/w/[wId]/analyt
 import type { GetWorkspaceUsageMetricsResponse } from "@app/pages/api/w/[wId]/analytics/usage-metrics";
 import type { GetWorkspaceAuthContextResponseType } from "@app/pages/api/w/[wId]/auth-context";
 import type { GetJoinResponseBody } from "@app/pages/api/w/[wId]/join";
+import type { GetMetronomeContractResponseBody } from "@app/pages/api/w/[wId]/metronome/contract";
+import type { GetMetronomeInvoiceResponseBody } from "@app/pages/api/w/[wId]/metronome/invoice";
 import type { GetSeatAvailabilityResponseBody } from "@app/pages/api/w/[wId]/seats/availability";
 import type { GetWorkspaceSeatsCountResponseBody } from "@app/pages/api/w/[wId]/seats/count";
 import type { GetSubscriptionsResponseBody } from "@app/pages/api/w/[wId]/subscriptions";
@@ -603,6 +605,62 @@ export function usePerSeatPricing({
     perSeatPricing: data?.perSeatPricing ?? null,
     isPerSeatPricingLoading: !error && !data && !disabled,
     isPerSeatPricingError: error,
+  };
+}
+
+export function useMetronomeContract({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const contractFetcher: Fetcher<GetMetronomeContractResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/metronome/contract`,
+    contractFetcher,
+    {
+      disabled,
+      revalidateOnFocus: false,
+      dedupingInterval: 60_000,
+    }
+  );
+
+  return {
+    contract: data?.contract ?? null,
+    isMetronomeContractLoading: !error && !data && !disabled,
+    isMetronomeContractError: error,
+    mutateMetronomeContract: mutate,
+  };
+}
+
+export function useMetronomeInvoice({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const invoiceFetcher: Fetcher<GetMetronomeInvoiceResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/metronome/invoice`,
+    invoiceFetcher,
+    {
+      disabled,
+      revalidateOnFocus: false,
+      dedupingInterval: 60_000,
+    }
+  );
+
+  return {
+    invoice: data?.invoice ?? null,
+    isMetronomeInvoiceLoading: !error && !data && !disabled,
+    isMetronomeInvoiceError: error,
+    mutateMetronomeInvoice: mutate,
   };
 }
 

--- a/front/pages/api/w/[wId]/metronome/contract.test.ts
+++ b/front/pages/api/w/[wId]/metronome/contract.test.ts
@@ -121,7 +121,7 @@ describe("/api/w/[wId]/metronome/contract", () => {
         contract: {
           planFamily: "pro",
           mauTiers: null,
-          contractEndingAt: new Date("2025-05-01T00:00:00.000Z").getTime(),
+          contractEndingAtMs: new Date("2025-05-01T00:00:00.000Z").getTime(),
         },
       });
       expect(vi.mocked(getMetronomeContractById)).toHaveBeenCalledWith({

--- a/front/pages/api/w/[wId]/metronome/contract.test.ts
+++ b/front/pages/api/w/[wId]/metronome/contract.test.ts
@@ -1,0 +1,256 @@
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", () => ({
+  getMetronomeContractById: vi.fn(),
+  listMetronomeDraftInvoices: vi.fn(),
+  scheduleMetronomeContractEnd: vi.fn(),
+  reactivateMetronomeContract: vi.fn(),
+}));
+
+import {
+  getMetronomeContractById,
+  listMetronomeDraftInvoices,
+  reactivateMetronomeContract,
+  scheduleMetronomeContractEnd,
+} from "@app/lib/metronome/client";
+
+import handler from "./contract";
+
+async function setActiveSubscriptionBilling({
+  workspaceId,
+  stripeSubscriptionId,
+  metronomeContractId,
+}: {
+  workspaceId: number;
+  stripeSubscriptionId: string | null;
+  metronomeContractId: string | null;
+}) {
+  const currentSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspaceId);
+
+  if (!currentSubscription) {
+    throw new Error("Expected an active subscription.");
+  }
+
+  await currentSubscription.markAsEnded("ended");
+
+  await SubscriptionResource.makeNew(
+    {
+      sId: generateRandomModelSId(),
+      workspaceId,
+      planId: currentSubscription.planId,
+      status: "active",
+      trialing: false,
+      startDate: new Date(),
+      endDate: null,
+      stripeSubscriptionId,
+      metronomeContractId,
+    },
+    currentSubscription.getPlan()
+  );
+
+  if (metronomeContractId) {
+    const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
+      workspaceId,
+      "m-customer"
+    );
+
+    if (updateResult.isErr()) {
+      throw updateResult.error;
+    }
+  }
+}
+
+function makeCurrentDraftInvoice({ contractId }: { contractId: string }) {
+  const nowMs = Date.now();
+
+  return {
+    contract_id: contractId,
+    start_timestamp: new Date(nowMs - 60_000).toISOString(),
+    end_timestamp: new Date(nowMs + 60_000).toISOString(),
+  };
+}
+
+describe("/api/w/[wId]/metronome/contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET", () => {
+    it("returns null when the workspace has no Metronome contract", async () => {
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({ contract: null });
+      expect(vi.mocked(getMetronomeContractById)).not.toHaveBeenCalled();
+    });
+
+    it("returns the contract summary for a Metronome-billed workspace", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      await setActiveSubscriptionBilling({
+        workspaceId: workspace.id,
+        stripeSubscriptionId: null,
+        metronomeContractId: "m-contract-get",
+      });
+
+      vi.mocked(getMetronomeContractById).mockResolvedValue(
+        new Ok({
+          custom_fields: {},
+          ending_before: "2025-05-01T00:00:00.000Z",
+        } as never)
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({
+        contract: {
+          planFamily: "pro",
+          mauTiers: null,
+          contractEndingAt: new Date("2025-05-01T00:00:00.000Z").getTime(),
+        },
+      });
+      expect(vi.mocked(getMetronomeContractById)).toHaveBeenCalledWith({
+        metronomeCustomerId: "m-customer",
+        metronomeContractId: "m-contract-get",
+      });
+    });
+  });
+
+  describe("PATCH", () => {
+    it("cancels a true Metronome-billed subscription", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "PATCH",
+        role: "admin",
+      });
+
+      await setActiveSubscriptionBilling({
+        workspaceId: workspace.id,
+        stripeSubscriptionId: null,
+        metronomeContractId: "m-contract-cancel",
+      });
+
+      vi.mocked(listMetronomeDraftInvoices).mockResolvedValue(
+        new Ok([
+          makeCurrentDraftInvoice({ contractId: "m-contract-cancel" }),
+        ] as never)
+      );
+      vi.mocked(scheduleMetronomeContractEnd).mockResolvedValue(
+        new Ok(undefined)
+      );
+
+      req.body = { action: "cancel" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({ success: true });
+      expect(vi.mocked(scheduleMetronomeContractEnd)).toHaveBeenCalledWith({
+        metronomeCustomerId: "m-customer",
+        contractId: "m-contract-cancel",
+        endingBefore: expect.any(Date),
+      });
+
+      const updatedSubscription =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+      expect(updatedSubscription?.endDate).not.toBeNull();
+    });
+
+    it("reactivates a true Metronome-billed subscription", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "PATCH",
+        role: "admin",
+      });
+
+      await setActiveSubscriptionBilling({
+        workspaceId: workspace.id,
+        stripeSubscriptionId: null,
+        metronomeContractId: "m-contract-reactivate",
+      });
+
+      const subscription =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+      if (!subscription) {
+        throw new Error("Expected an active subscription.");
+      }
+      await subscription.markAsCanceled({
+        endDate: new Date(Date.now() + 60_000),
+      });
+
+      vi.mocked(reactivateMetronomeContract).mockResolvedValue(
+        new Ok(undefined)
+      );
+
+      req.body = { action: "reactivate" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({ success: true });
+      expect(vi.mocked(reactivateMetronomeContract)).toHaveBeenCalledWith({
+        metronomeCustomerId: "m-customer",
+        contractId: "m-contract-reactivate",
+      });
+
+      const updatedSubscription =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+      expect(updatedSubscription?.endDate).toBeNull();
+      expect(updatedSubscription?.requestCancelAt).toBeNull();
+    });
+
+    it.each([
+      {
+        title: "stripe-billed subscriptions",
+        stripeSubscriptionId: "sub_stripe_only",
+        metronomeContractId: null,
+      },
+      {
+        title: "shadow-billed subscriptions",
+        stripeSubscriptionId: "sub_shadow",
+        metronomeContractId: "m-contract-shadow",
+      },
+    ])("rejects cancel and reactivate for $title", async ({
+      stripeSubscriptionId,
+      metronomeContractId,
+    }) => {
+      for (const action of ["cancel", "reactivate"] as const) {
+        const { req, res, workspace } = await createPrivateApiMockRequest({
+          method: "PATCH",
+          role: "admin",
+        });
+
+        await setActiveSubscriptionBilling({
+          workspaceId: workspace.id,
+          stripeSubscriptionId,
+          metronomeContractId,
+        });
+
+        req.body = { action };
+
+        await handler(req, res);
+
+        expect(res._getStatusCode()).toBe(400);
+        expect(res._getJSONData().error.type).toBe(
+          "subscription_state_invalid"
+        );
+      }
+
+      expect(vi.mocked(scheduleMetronomeContractEnd)).not.toHaveBeenCalled();
+      expect(vi.mocked(reactivateMetronomeContract)).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/metronome/contract.ts
+++ b/front/pages/api/w/[wId]/metronome/contract.ts
@@ -1,0 +1,199 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getMetronomeContractById } from "@app/lib/metronome/client";
+import {
+  cancelWorkspaceContractAtPeriodEnd,
+  reactivateWorkspaceContract,
+} from "@app/lib/metronome/contract_lifecycle";
+import { parseMauTiers } from "@app/lib/metronome/mau_sync";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type MetronomeContractSummary = {
+  planFamily: "pro" | "enterprise";
+  /**
+   * MAU tier boundaries parsed from the MAU_TIERS contract custom field.
+   * `null` for simple MAU (no tiering) or non-enterprise.
+   * Each tier has `start` (inclusive, 1-indexed) and `end` (exclusive, null = unlimited).
+   */
+  mauTiers: Array<{ start: number; end: number | null }> | null;
+  /** ms epoch — set when the contract is scheduled to end (cancellation or fixed term). */
+  contractEndingAt: number | null;
+};
+
+export type GetMetronomeContractResponseBody = {
+  contract: MetronomeContractSummary | null;
+};
+
+type PatchMetronomeContractResponseBody = {
+  success: boolean;
+};
+
+export const PatchMetronomeContractRequestBody = t.type({
+  action: t.union([t.literal("cancel"), t.literal("reactivate")]),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      GetMetronomeContractResponseBody | PatchMetronomeContractResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      return handleGet(req, res, auth);
+    case "PATCH":
+      return handlePatch(req, res, auth);
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or PATCH is expected.",
+        },
+      });
+  }
+}
+
+async function handleGet(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMetronomeContractResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const subscription = auth.subscription();
+  const owner = auth.workspace();
+  if (!subscription || !owner) {
+    return res.status(200).json({ contract: null });
+  }
+
+  const { metronomeContractId } = subscription;
+  const { metronomeCustomerId } = owner;
+  if (!metronomeContractId || !metronomeCustomerId) {
+    return res.status(200).json({ contract: null });
+  }
+
+  const contractResult = await getMetronomeContractById({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (contractResult.isErr()) {
+    return apiError(req, res, {
+      status_code: 502,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to fetch Metronome contract: ${contractResult.error.message}`,
+      },
+    });
+  }
+
+  const contract = contractResult.value;
+
+  const planFamily: "pro" | "enterprise" = isEntreprisePlanPrefix(
+    subscription.plan.code
+  )
+    ? "enterprise"
+    : "pro";
+
+  const mauTiersField = contract.custom_fields?.MAU_TIERS;
+  const parsed = parseMauTiers(mauTiersField);
+  const mauTiers = parsed
+    ? parsed.map((t) => ({ start: t.start, end: t.end ?? null }))
+    : null;
+
+  const contractEndingAt = contract.ending_before
+    ? new Date(contract.ending_before).getTime()
+    : null;
+
+  return res.status(200).json({
+    contract: {
+      planFamily,
+      mauTiers,
+      contractEndingAt,
+    },
+  });
+}
+
+async function handlePatch(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PatchMetronomeContractResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const bodyValidation = PatchMetronomeContractRequestBody.decode(req.body);
+  if (isLeft(bodyValidation)) {
+    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+
+  const { action } = bodyValidation.right;
+
+  switch (action) {
+    case "cancel": {
+      const result = await cancelWorkspaceContractAtPeriodEnd(auth);
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: result.error.kind === "invalid_state" ? 400 : 502,
+          api_error: {
+            type:
+              result.error.kind === "invalid_state"
+                ? "subscription_state_invalid"
+                : "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
+      break;
+    }
+    case "reactivate": {
+      const result = await reactivateWorkspaceContract(auth);
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: result.error.kind === "invalid_state" ? 400 : 502,
+          api_error: {
+            type:
+              result.error.kind === "invalid_state"
+                ? "subscription_state_invalid"
+                : "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
+      break;
+    }
+    default:
+      assertNever(action);
+  }
+
+  return res.status(200).json({ success: true });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/metronome/contract.ts
+++ b/front/pages/api/w/[wId]/metronome/contract.ts
@@ -25,7 +25,7 @@ export type MetronomeContractSummary = {
    */
   mauTiers: Array<{ start: number; end: number | null }> | null;
   /** ms epoch — set when the contract is scheduled to end (cancellation or fixed term). */
-  contractEndingAt: number | null;
+  contractEndingAtMs: number | null;
 };
 
 export type GetMetronomeContractResponseBody = {
@@ -122,7 +122,7 @@ async function handleGet(
     ? parsed.map((t) => ({ start: t.start, end: t.end ?? null }))
     : null;
 
-  const contractEndingAt = contract.ending_before
+  const contractEndingAtMs = contract.ending_before
     ? new Date(contract.ending_before).getTime()
     : null;
 
@@ -130,7 +130,7 @@ async function handleGet(
     contract: {
       planFamily,
       mauTiers,
-      contractEndingAt,
+      contractEndingAtMs,
     },
   });
 }

--- a/front/pages/api/w/[wId]/metronome/invoice.test.ts
+++ b/front/pages/api/w/[wId]/metronome/invoice.test.ts
@@ -1,0 +1,239 @@
+import {
+  CREDIT_TYPE_EUR_ID,
+  CREDIT_TYPE_USD_ID,
+  getProductMauId,
+  getProductWorkspaceSeatId,
+} from "@app/lib/metronome/constants";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", () => ({
+  listMetronomeDraftInvoices: vi.fn(),
+}));
+
+import { listMetronomeDraftInvoices } from "@app/lib/metronome/client";
+
+import handler from "./invoice";
+
+async function setActiveSubscriptionBilling({
+  workspaceId,
+  stripeSubscriptionId,
+  metronomeContractId,
+}: {
+  workspaceId: number;
+  stripeSubscriptionId: string | null;
+  metronomeContractId: string | null;
+}) {
+  const currentSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspaceId);
+
+  if (!currentSubscription) {
+    throw new Error("Expected an active subscription.");
+  }
+
+  await currentSubscription.markAsEnded("ended");
+
+  await SubscriptionResource.makeNew(
+    {
+      sId: generateRandomModelSId(),
+      workspaceId,
+      planId: currentSubscription.planId,
+      status: "active",
+      trialing: false,
+      startDate: new Date(),
+      endDate: null,
+      stripeSubscriptionId,
+      metronomeContractId,
+    },
+    currentSubscription.getPlan()
+  );
+
+  if (metronomeContractId) {
+    const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
+      workspaceId,
+      "m-customer"
+    );
+
+    if (updateResult.isErr()) {
+      throw updateResult.error;
+    }
+  }
+}
+
+function makeCurrentDraftInvoice({
+  contractId,
+  creditTypeId,
+  total,
+  lineItems,
+}: {
+  contractId: string;
+  creditTypeId: string;
+  total: number;
+  lineItems: Array<{
+    product_id: string;
+    quantity: number;
+    unit_price: number;
+  }>;
+}) {
+  const nowMs = Date.now();
+
+  return {
+    contract_id: contractId,
+    start_timestamp: new Date(nowMs - 60_000).toISOString(),
+    end_timestamp: new Date(nowMs + 60_000).toISOString(),
+    credit_type: { id: creditTypeId },
+    total,
+    line_items: lineItems,
+  };
+}
+
+describe("/api/w/[wId]/metronome/invoice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when the workspace has no Metronome contract", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ invoice: null });
+    expect(vi.mocked(listMetronomeDraftInvoices)).not.toHaveBeenCalled();
+  });
+
+  it("returns a USD invoice summary in cents for a Metronome-billed workspace", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await setActiveSubscriptionBilling({
+      workspaceId: workspace.id,
+      stripeSubscriptionId: null,
+      metronomeContractId: "m-contract-usd",
+    });
+
+    vi.mocked(listMetronomeDraftInvoices).mockResolvedValue(
+      new Ok([
+        makeCurrentDraftInvoice({
+          contractId: "m-contract-usd",
+          creditTypeId: CREDIT_TYPE_USD_ID,
+          total: 8700,
+          lineItems: [
+            {
+              product_id: getProductWorkspaceSeatId(),
+              quantity: 3,
+              unit_price: 2900,
+            },
+          ],
+        }),
+      ] as never)
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      invoice: expect.objectContaining({
+        currency: "usd",
+        estimatedAmountCents: 8700,
+        seatUnitPriceCents: 2900,
+        mau: null,
+        mauUnitPriceCents: null,
+        mauTierUnitPricesCents: null,
+      }),
+    });
+  });
+
+  it("converts EUR Metronome amounts to cents", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await setActiveSubscriptionBilling({
+      workspaceId: workspace.id,
+      stripeSubscriptionId: null,
+      metronomeContractId: "m-contract-eur",
+    });
+
+    vi.mocked(listMetronomeDraftInvoices).mockResolvedValue(
+      new Ok([
+        makeCurrentDraftInvoice({
+          contractId: "m-contract-eur",
+          creditTypeId: CREDIT_TYPE_EUR_ID,
+          total: 87,
+          lineItems: [
+            {
+              product_id: getProductMauId(),
+              quantity: 3,
+              unit_price: 29,
+            },
+          ],
+        }),
+      ] as never)
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      invoice: expect.objectContaining({
+        currency: "eur",
+        estimatedAmountCents: 8700,
+        seatUnitPriceCents: null,
+        mau: 3,
+        mauUnitPriceCents: 2900,
+        mauTierUnitPricesCents: null,
+      }),
+    });
+  });
+
+  it("still returns invoice data for shadow-billed workspaces", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await setActiveSubscriptionBilling({
+      workspaceId: workspace.id,
+      stripeSubscriptionId: "sub_shadow_invoice",
+      metronomeContractId: "m-contract-shadow-invoice",
+    });
+
+    vi.mocked(listMetronomeDraftInvoices).mockResolvedValue(
+      new Ok([
+        makeCurrentDraftInvoice({
+          contractId: "m-contract-shadow-invoice",
+          creditTypeId: CREDIT_TYPE_USD_ID,
+          total: 2900,
+          lineItems: [
+            {
+              product_id: getProductWorkspaceSeatId(),
+              quantity: 1,
+              unit_price: 2900,
+            },
+          ],
+        }),
+      ] as never)
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      invoice: expect.objectContaining({
+        estimatedAmountCents: 2900,
+        seatUnitPriceCents: 2900,
+      }),
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/metronome/invoice.ts
+++ b/front/pages/api/w/[wId]/metronome/invoice.ts
@@ -1,0 +1,201 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { amountCents } from "@app/lib/metronome/amounts";
+import { listMetronomeDraftInvoices } from "@app/lib/metronome/client";
+import {
+  CREDIT_TYPE_EUR_ID,
+  CREDIT_TYPE_USD_ID,
+  getProductMauId,
+  getProductMauTierIds,
+  getProductWorkspaceSeatId,
+} from "@app/lib/metronome/constants";
+import { apiError } from "@app/logger/withlogging";
+import type { SupportedCurrency } from "@app/types/currency";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { BillingPeriod } from "@app/types/plan";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type MetronomeInvoiceSummary = {
+  currency: SupportedCurrency;
+  billingPeriod: BillingPeriod;
+  currentPeriodStart: number; // ms epoch
+  currentPeriodEnd: number; // ms epoch
+  estimatedAmountCents: number;
+  mau: number | null;
+  /** Pro: effective per-seat unit price from the seat line item. */
+  seatUnitPriceCents: number | null;
+  /** Enterprise simple MAU: effective unit price from the MAU line item. */
+  mauUnitPriceCents: number | null;
+  /**
+   * Enterprise tiered MAU: effective per-tier unit prices, indexed by tier
+   * position (same order as getProductMauTierIds()). `null` at a position
+   * means that tier is not present on this contract / not charged this period.
+   */
+  mauTierUnitPricesCents: Array<number | null> | null;
+};
+
+export type GetMetronomeInvoiceResponseBody = {
+  invoice: MetronomeInvoiceSummary | null;
+};
+
+function creditTypeIdToCurrency(
+  creditTypeId: string
+): SupportedCurrency | null {
+  if (creditTypeId === CREDIT_TYPE_USD_ID) {
+    return "usd";
+  }
+  if (creditTypeId === CREDIT_TYPE_EUR_ID) {
+    return "eur";
+  }
+  return null;
+}
+
+function inferBillingPeriod(startMs: number, endMs: number): BillingPeriod {
+  const spanDays = (endMs - startMs) / (1000 * 60 * 60 * 24);
+  return spanDays > 60 ? "yearly" : "monthly";
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMetronomeInvoiceResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const subscription = auth.subscription();
+  const owner = auth.workspace();
+  if (!subscription || !owner) {
+    return res.status(200).json({ invoice: null });
+  }
+
+  const { metronomeContractId } = subscription;
+  const { metronomeCustomerId } = owner;
+  if (!metronomeContractId || !metronomeCustomerId) {
+    return res.status(200).json({ invoice: null });
+  }
+
+  const nowMs = Date.now();
+
+  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
+  if (invoicesResult.isErr()) {
+    return apiError(req, res, {
+      status_code: 502,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to fetch Metronome draft invoices: ${invoicesResult.error.message}`,
+      },
+    });
+  }
+
+  const invoice = invoicesResult.value.find((inv) => {
+    if (inv.contract_id !== metronomeContractId) {
+      return false;
+    }
+    if (!inv.start_timestamp || !inv.end_timestamp) {
+      return false;
+    }
+    const startMs = new Date(inv.start_timestamp).getTime();
+    const endMs = new Date(inv.end_timestamp).getTime();
+    return startMs <= nowMs && nowMs < endMs;
+  });
+
+  if (!invoice || !invoice.start_timestamp || !invoice.end_timestamp) {
+    return res.status(200).json({ invoice: null });
+  }
+
+  const currency = creditTypeIdToCurrency(invoice.credit_type.id);
+  if (!currency) {
+    return res.status(200).json({ invoice: null });
+  }
+
+  const seatProductId = getProductWorkspaceSeatId();
+  const simpleMauProductId = getProductMauId();
+  const tierProductIds = getProductMauTierIds();
+  const tierProductIdToIndex = new Map<string, number>(
+    tierProductIds.map((id, idx) => [id, idx])
+  );
+
+  const mauProductIds = new Set<string>([
+    simpleMauProductId,
+    ...tierProductIds,
+  ]);
+
+  let mau: number | null = null;
+  let seatUnitPriceCents: number | null = null;
+  let mauUnitPriceCents: number | null = null;
+  const mauTierUnitPricesCents: Array<number | null> = tierProductIds.map(
+    () => null
+  );
+  let tieredMauSeenOnInvoice = false;
+
+  for (const item of invoice.line_items) {
+    const productId = item.product_id;
+    if (!productId) {
+      continue;
+    }
+
+    if (mauProductIds.has(productId) && typeof item.quantity === "number") {
+      mau = (mau ?? 0) + item.quantity;
+    }
+
+    if (typeof item.unit_price !== "number") {
+      continue;
+    }
+
+    if (productId === seatProductId) {
+      seatUnitPriceCents = amountCents(item.unit_price, currency);
+    } else if (productId === simpleMauProductId) {
+      mauUnitPriceCents = amountCents(item.unit_price, currency);
+    } else {
+      const tierIndex = tierProductIdToIndex.get(productId);
+      if (tierIndex !== undefined) {
+        mauTierUnitPricesCents[tierIndex] = amountCents(
+          item.unit_price,
+          currency
+        );
+        tieredMauSeenOnInvoice = true;
+      }
+    }
+  }
+
+  const currentPeriodStart = new Date(invoice.start_timestamp).getTime();
+  const currentPeriodEnd = new Date(invoice.end_timestamp).getTime();
+
+  const summary: MetronomeInvoiceSummary = {
+    currency,
+    billingPeriod: inferBillingPeriod(currentPeriodStart, currentPeriodEnd),
+    currentPeriodStart,
+    currentPeriodEnd,
+    estimatedAmountCents: amountCents(invoice.total, currency),
+    mau,
+    seatUnitPriceCents,
+    mauUnitPriceCents,
+    mauTierUnitPricesCents: tieredMauSeenOnInvoice
+      ? mauTierUnitPricesCents
+      : null,
+  };
+
+  return res.status(200).json({ invoice: summary });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/metronome/invoice.ts
+++ b/front/pages/api/w/[wId]/metronome/invoice.ts
@@ -19,8 +19,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 export type MetronomeInvoiceSummary = {
   currency: SupportedCurrency;
   billingPeriod: BillingPeriod;
-  currentPeriodStart: number; // ms epoch
-  currentPeriodEnd: number; // ms epoch
+  currentPeriodStartMs: number;
+  currentPeriodEndMs: number;
   estimatedAmountCents: number;
   mau: number | null;
   /** Pro: effective per-seat unit price from the seat line item. */
@@ -178,14 +178,14 @@ async function handler(
     }
   }
 
-  const currentPeriodStart = new Date(invoice.start_timestamp).getTime();
-  const currentPeriodEnd = new Date(invoice.end_timestamp).getTime();
+  const currentPeriodStartMs = new Date(invoice.start_timestamp).getTime();
+  const currentPeriodEndMs = new Date(invoice.end_timestamp).getTime();
 
   const summary: MetronomeInvoiceSummary = {
     currency,
-    billingPeriod: inferBillingPeriod(currentPeriodStart, currentPeriodEnd),
-    currentPeriodStart,
-    currentPeriodEnd,
+    billingPeriod: inferBillingPeriod(currentPeriodStartMs, currentPeriodEndMs),
+    currentPeriodStartMs,
+    currentPeriodEndMs,
     estimatedAmountCents: amountCents(invoice.total, currency),
     mau,
     seatUnitPriceCents,

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -88,6 +88,30 @@ export type SubscriptionType = {
   requestCancelAt: number | null;
 };
 
+type StripeBilledSubscriptionType = SubscriptionType & {
+  stripeSubscriptionId: string;
+};
+
+type MetronomeBilledSubscriptionType = SubscriptionType & {
+  stripeSubscriptionId: null;
+  metronomeContractId: string;
+};
+
+export function isSubscriptionStripeBilled(
+  subscription: SubscriptionType
+): subscription is StripeBilledSubscriptionType {
+  return subscription.stripeSubscriptionId !== null;
+}
+
+export function isSubscriptionMetronomeBilled(
+  subscription: SubscriptionType
+): subscription is MetronomeBilledSubscriptionType {
+  return (
+    subscription.metronomeContractId !== null &&
+    !isSubscriptionStripeBilled(subscription)
+  );
+}
+
 export type BillingPeriod = "monthly" | "yearly";
 
 export type SubscriptionPerSeatPricing = {


### PR DESCRIPTION
## Description

part of https://github.com/dust-tt/tasks/issues/7772 and https://github.com/dust-tt/tasks/issues/7480

Adds a subscription management panel for Metronome-billed workspaces, with cancel/reactivate flows and current-period billing summary. I applied the same principles as in the Stripe path, which fetch from components instead of using swr. We can do a refacto in a later PR, this one is already big (though many added lines come from tests).


https://github.com/user-attachments/assets/0a6e9f80-dd9c-4879-ac7d-fba2a846593c



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

Unit + local

## Risk

Low, gated by `metronome_billing` flag and condition on full Metronome subscriptions (no Stripe) that don't happen in prod

## Deploy Plan

front
