### PR TITLE
[Branching] Store compaction source as conversation FK

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2790,14 +2790,33 @@ export async function compactConversation(
       transaction: t,
     });
 
+    let sourceConversationId: string | undefined;
+    let sourceConversationModelId: ModelId | undefined;
+
+    if (
+      sourceConversation?.conversationId &&
+      sourceConversation.conversationId !== conversation.sId
+    ) {
+      const sourceConversationRow = await ConversationModel.findOne({
+        attributes: ["id"],
+        where: {
+          workspaceId: owner.id,
+          sId: sourceConversation.conversationId,
+        },
+        transaction: t,
+      });
+
+      if (sourceConversationRow) {
+        sourceConversationId = sourceConversation.conversationId;
+        sourceConversationModelId = sourceConversationRow.id;
+      }
+    }
+
     const compactionMessage = await createCompactionMessage(auth, {
       conversation,
       rank: nextMessageRank,
-      sourceConversationId:
-        sourceConversation?.conversationId &&
-        sourceConversation.conversationId !== conversation.sId
-          ? sourceConversation.conversationId
-          : undefined,
+      sourceConversationId,
+      sourceConversationModelId,
       transaction: t,
     });
 

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -648,11 +648,13 @@ export async function createCompactionMessage(
     conversation,
     rank,
     sourceConversationId,
+    sourceConversationModelId,
     transaction,
   }: {
     conversation: ConversationWithoutContentType;
     rank: number;
     sourceConversationId?: string;
+    sourceConversationModelId?: ModelId;
     transaction: Transaction;
   }
 ): Promise<CompactionMessageType> {
@@ -663,7 +665,7 @@ export async function createCompactionMessage(
       status: "created",
       content: null,
       runIds: null,
-      sourceConversationId: sourceConversationId ?? null,
+      sourceConversationId: sourceConversationModelId ?? null,
       workspaceId: workspace.id,
     },
     { transaction }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -8,6 +8,7 @@ import {
   getCoTDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
 import {
+  ConversationModel,
   MentionModel,
   MessageModel,
   UserMessageModel,
@@ -903,10 +904,26 @@ async function batchRenderContentFragment(
 }
 
 async function batchRenderCompactionMessages(
-  _auth: Authenticator,
+  auth: Authenticator,
   messages: MessageModel[]
 ): Promise<CompactionMessageType[]> {
   const compactionMessages = messages.filter((m) => !!m.compactionMessage);
+  const sourceConversationIds = removeNulls(
+    compactionMessages.map((m) => m.compactionMessage?.sourceConversationId)
+  );
+  const sourceConversations = await ConversationModel.findAll({
+    attributes: ["id", "sId"],
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      id: { [Op.in]: sourceConversationIds },
+    },
+  });
+  const sourceConversationIdMap = new Map(
+    sourceConversations.map((conversation) => [
+      conversation.id,
+      conversation.sId,
+    ])
+  );
 
   return compactionMessages.map((m) => {
     if (!m.compactionMessage) {
@@ -927,8 +944,13 @@ async function batchRenderCompactionMessages(
       branchId: m.getBranchId(),
       status: compactionMessage.status,
       content: compactionMessage.content,
-      ...(compactionMessage.sourceConversationId
-        ? { sourceConversationId: compactionMessage.sourceConversationId }
+      ...(compactionMessage.sourceConversationId &&
+      sourceConversationIdMap.has(compactionMessage.sourceConversationId)
+        ? {
+            sourceConversationId: sourceConversationIdMap.get(
+              compactionMessage.sourceConversationId
+            ),
+          }
         : {}),
     };
   });

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -666,7 +666,7 @@ export class CompactionMessageModel extends WorkspaceAwareModel<CompactionMessag
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare runIds: string[] | null;
-  declare sourceConversationId: string | null;
+  declare sourceConversationId: ForeignKey<ConversationModel["id"]> | null;
 
   declare status: CompactionMessageStatus;
   declare content: string | null;
@@ -689,7 +689,7 @@ CompactionMessageModel.init(
       allowNull: true,
     },
     sourceConversationId: {
-      type: DataTypes.STRING,
+      type: DataTypes.BIGINT,
       allowNull: true,
     },
     status: {
@@ -708,6 +708,11 @@ CompactionMessageModel.init(
     indexes: [
       {
         fields: ["workspaceId"],
+        concurrently: true,
+      },
+      {
+        fields: ["sourceConversationId"],
+        name: "compaction_messages_source_conversation_id",
         concurrently: true,
       },
     ],

--- a/front/migrations/db/migration_604.sql
+++ b/front/migrations/db/migration_604.sql
@@ -1,0 +1,24 @@
+ALTER TABLE "compaction_messages"
+ADD COLUMN "sourceConversationModelId" BIGINT;
+
+UPDATE "compaction_messages" AS "cm"
+SET "sourceConversationModelId" = "c"."id"
+FROM "conversations" AS "c"
+WHERE "cm"."sourceConversationId" = "c"."sId"
+  AND "cm"."workspaceId" = "c"."workspaceId";
+
+ALTER TABLE "compaction_messages"
+DROP COLUMN "sourceConversationId";
+
+ALTER TABLE "compaction_messages"
+RENAME COLUMN "sourceConversationModelId" TO "sourceConversationId";
+
+ALTER TABLE "compaction_messages"
+ADD CONSTRAINT "compaction_messages_source_conversation_id_fkey"
+FOREIGN KEY ("sourceConversationId")
+REFERENCES "conversations" ("id")
+ON DELETE SET NULL
+ON UPDATE CASCADE;
+
+CREATE INDEX CONCURRENTLY "compaction_messages_source_conversation_id"
+ON "compaction_messages" ("sourceConversationId");


### PR DESCRIPTION
## Description
Supersedes https://github.com/dust-tt/dust/pull/24823.
Follows https://github.com/dust-tt/dust/pull/24789.
Stores the compaction source conversation as a foreign key to `conversations.id`, while keeping the serialized message payload on `sourceConversationId` as the source conversation `sId`. The migration backfills existing rows by joining on `(workspaceId, sId)` before replacing the column with the FK.

## Risks
Blast radius: compaction message persistence and serialization.
Risk: low

## Deploy Plan
- run `front/migrations/db/migration_604.sql`
- deploy front
