### PR TITLE
chore: fix n+1 query on invitations related code

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -14,13 +14,16 @@ import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invit
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { isEmailValid } from "@app/lib/utils";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
 import type { SubscriptionType } from "@app/types/plan";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { sanitizeString } from "@app/types/shared/utils/string_utils";
 import type {
   ActiveRoleType,
@@ -35,6 +38,8 @@ import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 import { MembershipInvitationResource } from "../resources/membership_invitation_resource";
+
+const EMAIL_CONCURRENCY = 8;
 
 export async function getInvitation(
   auth: Authenticator,
@@ -59,41 +64,6 @@ export async function getInvitation(
   }
 
   return invitation.toJSON();
-}
-
-export async function updateOrCreateInvitation(
-  auth: Authenticator,
-  inviteEmail: string,
-  initialRole: ActiveRoleType,
-  transaction?: Transaction
-): Promise<MembershipInvitationType> {
-  // check for prior existing pending invitation
-  const existingInvitation =
-    await MembershipInvitationResource.getPendingForEmailAndWorkspace({
-      email: sanitizeString(inviteEmail),
-      includeExpired: true,
-      workspace: auth.getNonNullableWorkspace(),
-      transaction,
-    });
-
-  if (existingInvitation && existingInvitation.isExpired()) {
-    await existingInvitation.revoke(transaction);
-  } else if (existingInvitation) {
-    await existingInvitation.updateRole(initialRole, transaction);
-    return existingInvitation.toJSON();
-  }
-
-  const newInvitation = await MembershipInvitationResource.makeNew(
-    auth,
-    {
-      inviteEmail: sanitizeString(inviteEmail),
-      status: "pending",
-      initialRole,
-    },
-    transaction
-  );
-
-  return newInvitation.toJSON();
 }
 
 export function getMembershipInvitationToken(
@@ -195,6 +165,16 @@ export interface HandleMembershipInvitationResult {
   error_message?: string;
 }
 
+interface InvitationToEmail {
+  invitation: MembershipInvitationType;
+  email: string;
+}
+
+interface InvitationTransactionPayload {
+  resultsWithoutEmail: HandleMembershipInvitationResult[];
+  invitationsToEmail: InvitationToEmail[];
+}
+
 export async function handleMembershipInvitations(
   auth: Authenticator,
   {
@@ -213,13 +193,14 @@ export async function handleMembershipInvitations(
 ): Promise<Result<HandleMembershipInvitationResult[], APIErrorWithStatusCode>> {
   const { maxUsers } = subscription.plan.limits.users;
 
-  const result = await withTransaction(
+  // Emails are sent after the transaction commits so the DB transaction is
+  // not held open during SendGrid calls.
+  const transactionResult = await withTransaction(
     async (
       t
     ): Promise<
-      Result<HandleMembershipInvitationResult[], APIErrorWithStatusCode>
+      Result<InvitationTransactionPayload, APIErrorWithStatusCode>
     > => {
-      // Only lock and check seats available if the workspace has a limits
       if (maxUsers !== -1) {
         await getWorkspaceAdministrationVersionLock(owner, t);
 
@@ -296,7 +277,7 @@ export async function handleMembershipInvitations(
         invitationRequests.map((r) => r.email.toLowerCase().trim())
       );
       const emailsToSendInvitations = force
-        ? invitationRequests // If force is true, send to all requested emails
+        ? invitationRequests
         : invitationRequests.filter(
             (r) =>
               !emailsWithRecentUnconsumedInvitations.has(
@@ -304,7 +285,7 @@ export async function handleMembershipInvitations(
               )
           );
       const invitationsToUnrevoke = force
-        ? [] // If force is true, don't unrevoke any invitations
+        ? []
         : unconsumedInvitations.revoked.filter((i) =>
             requestedEmails.has(i.inviteEmail.toLowerCase().trim())
           );
@@ -313,7 +294,7 @@ export async function handleMembershipInvitations(
         !emailsToSendInvitations.length &&
         !invitationsToUnrevoke.length &&
         invitationRequests.length > 0 &&
-        !force // Only return this error if force is false
+        !force
       ) {
         return new Err({
           status_code: 400,
@@ -330,75 +311,181 @@ export async function handleMembershipInvitations(
         t
       );
 
-      const unrevokedResults: HandleMembershipInvitationResult[] =
+      const resultsWithoutEmail: HandleMembershipInvitationResult[] =
         invitationsToUnrevoke.map((i) => ({
           success: true,
           email: i.inviteEmail,
         }));
 
-      const invitationResults = await Promise.all(
-        emailsToSendInvitations.map(async ({ email, role }) => {
-          if (existingMembers.find((m) => m.email === email)) {
-            return {
-              success: false,
-              email,
-              error_message:
-                "Cannot send invitation to existing active member.",
-            };
-          }
-
-          try {
-            const invitation = await updateOrCreateInvitation(
-              auth,
-              email,
-              role,
-              t
-            );
-            await sendWorkspaceInvitationEmail(owner, user, invitation);
-          } catch (e) {
-            logger.error(
-              {
-                error: e,
-                message: "Failed to send invitation email",
-                email,
-              },
-              "Failed to send invitation email"
-            );
-
-            return {
-              success: false,
-              email,
-              error_message: e instanceof Error ? e.message : "Unknown error",
-            };
-          }
-          return {
-            success: true,
-            email,
-          };
-        })
-      );
-
-      const allResults = [...invitationResults, ...unrevokedResults];
-
-      const successfulInvites = allResults.filter((r) => r.success);
-      if (successfulInvites.length > 0) {
-        void emitAuditLogEvent({
-          auth,
-          action: "member.invited",
-          targets: successfulInvites.map((r) =>
-            buildAuditLogTarget("user", { sId: r.email, name: r.email })
-          ),
-          context: getAuditLogContext(auth),
-          metadata: {
-            invitedCount: String(successfulInvites.length),
-            emails: successfulInvites.map((r) => r.email).join(","),
-          },
-        });
+      const existingMemberEmails = new Set(existingMembers.map((m) => m.email));
+      const dbCandidates: {
+        originalEmail: string;
+        sanitizedEmail: string;
+        role: ActiveRoleType;
+      }[] = [];
+      for (const req of emailsToSendInvitations) {
+        if (existingMemberEmails.has(req.email)) {
+          resultsWithoutEmail.push({
+            success: false,
+            email: req.email,
+            error_message: "Cannot send invitation to existing active member.",
+          });
+        } else {
+          dbCandidates.push({
+            originalEmail: req.email,
+            sanitizedEmail: sanitizeString(req.email),
+            role: req.role,
+          });
+        }
       }
 
-      return new Ok(allResults);
+      // If the caller sends the same address twice, last role wins.
+      const uniqueCandidateBySanitizedEmail = new Map(
+        dbCandidates.map((c) => [c.sanitizedEmail, c])
+      );
+
+      const existingInvitations =
+        await MembershipInvitationResource.listPendingForEmailsAndWorkspace({
+          emails: Array.from(uniqueCandidateBySanitizedEmail.keys()),
+          workspace: owner,
+          includeExpired: true,
+          transaction: t,
+        });
+      const existingByEmail = new Map(
+        existingInvitations.map((inv) => [inv.inviteEmail, inv])
+      );
+
+      const toRevokeModelIds: ModelId[] = [];
+      const toCreate: {
+        inviteEmail: string;
+        initialRole: ActiveRoleType;
+      }[] = [];
+      // Group role updates by target role so we issue one UPDATE per distinct
+      // role (bounded by the number of active roles) instead of per invitation.
+      const toUpdateRoleByRole = new Map<ActiveRoleType, ModelId[]>();
+      const invitationBySanitizedEmail = new Map<
+        string,
+        MembershipInvitationType
+      >();
+
+      for (const {
+        sanitizedEmail,
+        role,
+      } of uniqueCandidateBySanitizedEmail.values()) {
+        const existing = existingByEmail.get(sanitizedEmail);
+        if (!existing || existing.isExpired()) {
+          if (existing) {
+            toRevokeModelIds.push(existing.id);
+          }
+          toCreate.push({
+            inviteEmail: sanitizedEmail,
+            initialRole: role,
+          });
+        } else {
+          if (existing.initialRole !== role) {
+            const group = toUpdateRoleByRole.get(role) ?? [];
+            group.push(existing.id);
+            toUpdateRoleByRole.set(role, group);
+          }
+          invitationBySanitizedEmail.set(sanitizedEmail, {
+            ...existing.toJSON(),
+            initialRole: role,
+          });
+        }
+      }
+
+      await MembershipInvitationResource.bulkRevokeByModelIds(
+        auth,
+        toRevokeModelIds,
+        t
+      );
+
+      for (const [role, modelIds] of toUpdateRoleByRole) {
+        await MembershipInvitationResource.bulkUpdateInitialRoleByModelIds(
+          auth,
+          modelIds,
+          role,
+          t
+        );
+      }
+
+      const created = await MembershipInvitationResource.bulkMakeNewPending(
+        auth,
+        toCreate,
+        t
+      );
+      for (const invitation of created) {
+        invitationBySanitizedEmail.set(
+          invitation.inviteEmail,
+          invitation.toJSON()
+        );
+      }
+
+      // One entry per original request so the response count matches the
+      // caller; duplicate addresses share the same underlying invitation row.
+      const invitationsToEmail: InvitationToEmail[] = [];
+      for (const { originalEmail, sanitizedEmail } of dbCandidates) {
+        const invitation = invitationBySanitizedEmail.get(sanitizedEmail);
+        if (invitation) {
+          invitationsToEmail.push({ invitation, email: originalEmail });
+        }
+      }
+
+      return new Ok({ resultsWithoutEmail, invitationsToEmail });
     }
   );
 
-  return result;
+  if (transactionResult.isErr()) {
+    return transactionResult;
+  }
+
+  const { resultsWithoutEmail, invitationsToEmail } = transactionResult.value;
+
+  const emailResults = await concurrentExecutor(
+    invitationsToEmail,
+    async ({ invitation, email }) => {
+      try {
+        await sendWorkspaceInvitationEmail(owner, user, invitation);
+        return { success: true, email };
+      } catch (e) {
+        logger.error(
+          {
+            error: e,
+            message: "Failed to send invitation email",
+            email,
+          },
+          "Failed to send invitation email"
+        );
+        return {
+          success: false,
+          email,
+          error_message: normalizeError(e).message,
+        };
+      }
+    },
+    { concurrency: EMAIL_CONCURRENCY }
+  );
+
+  const allResults: HandleMembershipInvitationResult[] = [
+    ...resultsWithoutEmail,
+    ...emailResults,
+  ];
+
+  const successfulInvites = allResults.filter((r) => r.success);
+  if (successfulInvites.length > 0) {
+    void emitAuditLogEvent({
+      auth,
+      action: "member.invited",
+      targets: successfulInvites.map((r) =>
+        buildAuditLogTarget("user", { sId: r.email, name: r.email })
+      ),
+      context: getAuditLogContext(auth),
+      metadata: {
+        invitedCount: String(successfulInvites.length),
+        emails: successfulInvites.map((r) => r.email).join(","),
+      },
+    });
+  }
+
+  return new Ok(allResults);
 }

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -394,25 +394,21 @@ export async function handleMembershipInvitations(
         }
       }
 
-      await MembershipInvitationResource.bulkRevokeByModelIds(
-        auth,
-        toRevokeModelIds,
-        t
-      );
+      await MembershipInvitationResource.bulkRevokeByModelIds(auth, {
+        modelIds: toRevokeModelIds,
+        transaction: t,
+      });
 
       for (const [role, modelIds] of toUpdateRoleByRole) {
         await MembershipInvitationResource.bulkUpdateInitialRoleByModelIds(
           auth,
-          modelIds,
-          role,
-          t
+          { modelIds, role, transaction: t }
         );
       }
 
       const created = await MembershipInvitationResource.bulkMakeNewPending(
         auth,
-        toCreate,
-        t
+        { blobs: toCreate, transaction: t }
       );
       for (const invitation of created) {
         invitationBySanitizedEmail.set(

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -10,6 +10,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import type { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { ActiveRoleType, LightWorkspaceType } from "@app/types/user";
@@ -174,6 +175,44 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
       );
   }
 
+  static async listPendingForEmailsAndWorkspace({
+    emails,
+    workspace,
+    includeExpired = false,
+    transaction,
+  }: {
+    emails: string[];
+    workspace: LightWorkspaceType | WorkspaceResource;
+    includeExpired?: boolean;
+    transaction?: Transaction;
+  }): Promise<MembershipInvitationResource[]> {
+    if (emails.length === 0) {
+      return [];
+    }
+
+    const invitations = await this.model.findAll({
+      where: {
+        inviteEmail: { [Op.in]: emails },
+        workspaceId: workspace.id,
+        status: "pending",
+      },
+      include: [WorkspaceModel],
+      transaction,
+    });
+
+    return invitations
+      .filter(
+        (invitation) =>
+          includeExpired || !this.invitationExpired(invitation.createdAt)
+      )
+      .map(
+        (invitation) =>
+          new MembershipInvitationResource(this.model, invitation.get(), {
+            workspace: invitation.workspace,
+          })
+      );
+  }
+
   static async getPendingForEmailAndWorkspace({
     email,
     workspace,
@@ -185,26 +224,85 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     includeExpired?: boolean;
     transaction?: Transaction;
   }): Promise<MembershipInvitationResource | null> {
-    const invitation = await this.model.findOne({
-      where: {
-        inviteEmail: email,
-        workspaceId: workspace.id,
-        status: "pending",
-      },
-      include: [WorkspaceModel],
+    const [invitation] = await this.listPendingForEmailsAndWorkspace({
+      emails: [email],
+      workspace,
+      includeExpired,
       transaction,
     });
+    return invitation ?? null;
+  }
 
-    if (
-      !invitation ||
-      (!includeExpired && this.invitationExpired(invitation.createdAt))
-    ) {
-      return null;
+  static async bulkMakeNewPending(
+    auth: Authenticator,
+    blobs: { inviteEmail: string; initialRole: ActiveRoleType }[],
+    transaction?: Transaction
+  ): Promise<MembershipInvitationResource[]> {
+    if (blobs.length === 0) {
+      return [];
     }
+    const workspace = auth.getNonNullableWorkspace();
+    const invitations = await this.model.bulkCreate(
+      blobs.map((b) => ({
+        ...b,
+        status: "pending" as const,
+        workspaceId: workspace.id,
+        sId: generateRandomModelSId(),
+      })),
+      { transaction }
+    );
+    return invitations.map(
+      (invitation) =>
+        new this(this.model, invitation.get(), {
+          workspace: invitation.workspace,
+        })
+    );
+  }
 
-    return new MembershipInvitationResource(this.model, invitation.get(), {
-      workspace: invitation.workspace,
+  private static async bulkUpdateByModelIds(
+    auth: Authenticator,
+    modelIds: ModelId[],
+    values: Partial<Attributes<MembershipInvitationModel>>,
+    transaction?: Transaction
+  ): Promise<void> {
+    if (modelIds.length === 0) {
+      return;
+    }
+    const workspace = auth.getNonNullableWorkspace();
+    await this.model.update(values, {
+      where: {
+        id: { [Op.in]: modelIds },
+        workspaceId: workspace.id,
+      },
+      transaction,
     });
+  }
+
+  static async bulkRevokeByModelIds(
+    auth: Authenticator,
+    modelIds: ModelId[],
+    transaction?: Transaction
+  ): Promise<void> {
+    await this.bulkUpdateByModelIds(
+      auth,
+      modelIds,
+      { status: "revoked" },
+      transaction
+    );
+  }
+
+  static async bulkUpdateInitialRoleByModelIds(
+    auth: Authenticator,
+    modelIds: ModelId[],
+    role: ActiveRoleType,
+    transaction?: Transaction
+  ): Promise<void> {
+    await this.bulkUpdateByModelIds(
+      auth,
+      modelIds,
+      { initialRole: role },
+      transaction
+    );
   }
 
   static async getPendingInvitations(

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -235,8 +235,13 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
 
   static async bulkMakeNewPending(
     auth: Authenticator,
-    blobs: { inviteEmail: string; initialRole: ActiveRoleType }[],
-    transaction?: Transaction
+    {
+      blobs,
+      transaction,
+    }: {
+      blobs: { inviteEmail: string; initialRole: ActiveRoleType }[];
+      transaction?: Transaction;
+    }
   ): Promise<MembershipInvitationResource[]> {
     if (blobs.length === 0) {
       return [];
@@ -261,9 +266,15 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
 
   private static async bulkUpdateByModelIds(
     auth: Authenticator,
-    modelIds: ModelId[],
-    values: Partial<Attributes<MembershipInvitationModel>>,
-    transaction?: Transaction
+    {
+      modelIds,
+      values,
+      transaction,
+    }: {
+      modelIds: ModelId[];
+      values: Partial<Attributes<MembershipInvitationModel>>;
+      transaction?: Transaction;
+    }
   ): Promise<void> {
     if (modelIds.length === 0) {
       return;
@@ -280,29 +291,38 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
 
   static async bulkRevokeByModelIds(
     auth: Authenticator,
-    modelIds: ModelId[],
-    transaction?: Transaction
-  ): Promise<void> {
-    await this.bulkUpdateByModelIds(
-      auth,
+    {
       modelIds,
-      { status: "revoked" },
-      transaction
-    );
+      transaction,
+    }: {
+      modelIds: ModelId[];
+      transaction?: Transaction;
+    }
+  ): Promise<void> {
+    await this.bulkUpdateByModelIds(auth, {
+      modelIds,
+      values: { status: "revoked" },
+      transaction,
+    });
   }
 
   static async bulkUpdateInitialRoleByModelIds(
     auth: Authenticator,
-    modelIds: ModelId[],
-    role: ActiveRoleType,
-    transaction?: Transaction
-  ): Promise<void> {
-    await this.bulkUpdateByModelIds(
-      auth,
+    {
       modelIds,
-      { initialRole: role },
-      transaction
-    );
+      role,
+      transaction,
+    }: {
+      modelIds: ModelId[];
+      role: ActiveRoleType;
+      transaction?: Transaction;
+    }
+  ): Promise<void> {
+    await this.bulkUpdateByModelIds(auth, {
+      modelIds,
+      values: { initialRole: role },
+      transaction,
+    });
   }
 
   static async getPendingInvitations(

--- a/front/pages/api/w/[wId]/invitations/index.test.ts
+++ b/front/pages/api/w/[wId]/invitations/index.test.ts
@@ -1,0 +1,267 @@
+import { Authenticator } from "@app/lib/auth";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipInvitationFactory } from "@app/tests/utils/MembershipInvitationFactory";
+import sgMail from "@sendgrid/mail";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./index";
+
+vi.spyOn(sgMail, "setApiKey").mockImplementation(() => {});
+const sgSendMock = vi
+  .spyOn(sgMail, "send")
+  .mockResolvedValue([{ statusCode: 202, headers: {}, body: {} }, {}] as never);
+
+vi.mock(import("@app/lib/api/config"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    default: {
+      ...mod.default,
+      getSendgridApiKey: vi.fn().mockReturnValue("SG.test"),
+      getInvitationEmailTemplate: vi.fn().mockReturnValue("d-test"),
+      getSupportEmailAddress: vi.fn().mockReturnValue("test@dust.tt"),
+      getAppUrl: vi.fn().mockReturnValue("http://localhost:3000"),
+      getDustInviteTokenSecret: vi
+        .fn()
+        .mockReturnValue("test-invite-secret-32chars!!!!!"),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/w/[wId]/invitations", () => {
+  it("creates invitations for multiple new emails in a single request", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = [
+      { email: "new-user-1@example.com", role: "user" },
+      { email: "new-user-2@example.com", role: "builder" },
+      { email: "new-user-3@example.com", role: "admin" },
+    ];
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toHaveLength(3);
+    expect(data.every((r: { success: boolean }) => r.success)).toBe(true);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const invitations =
+      await MembershipInvitationResource.getPendingInvitations(adminAuth);
+    expect(invitations).toHaveLength(3);
+
+    const byEmail = new Map(invitations.map((i) => [i.inviteEmail, i]));
+    expect(byEmail.get("new-user-1@example.com")?.initialRole).toBe("user");
+    expect(byEmail.get("new-user-2@example.com")?.initialRole).toBe("builder");
+    expect(byEmail.get("new-user-3@example.com")?.initialRole).toBe("admin");
+
+    expect(sgSendMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("updates the role on an existing pending invitation without creating a new row", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    // Invitations created in the last 24h hit the "already sent recently"
+    // rate limit, so age the existing invitation past that window but stay
+    // under the 7-day expiration so the role-update path fires.
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+    const existing = await MembershipInvitationFactory.create(workspace, {
+      inviteEmail: "role-change@example.com",
+      status: "pending",
+      initialRole: "user",
+      createdAt: twoDaysAgo,
+    });
+
+    req.body = [{ email: "role-change@example.com", role: "admin" }];
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toEqual([{ success: true, email: "role-change@example.com" }]);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const invitations =
+      await MembershipInvitationResource.getPendingInvitations(adminAuth);
+    expect(invitations).toHaveLength(1);
+    expect(invitations[0].sId).toBe(existing.sId);
+    expect(invitations[0].initialRole).toBe("admin");
+  });
+
+  it("revokes an expired invitation and creates a fresh one", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    // 7-day expiration window, use 8 days ago to force expiration.
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+    const expired = await MembershipInvitationFactory.create(workspace, {
+      inviteEmail: "expired@example.com",
+      status: "pending",
+      initialRole: "user",
+      createdAt: eightDaysAgo,
+    });
+
+    req.body = [{ email: "expired@example.com", role: "builder" }];
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toEqual([{ success: true, email: "expired@example.com" }]);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const oldInvitation = await MembershipInvitationResource.fetchById(
+      adminAuth,
+      expired.sId
+    );
+    expect(oldInvitation?.status).toBe("revoked");
+
+    const pending =
+      await MembershipInvitationResource.getPendingForEmailAndWorkspace({
+        email: "expired@example.com",
+        workspace,
+      });
+    expect(pending).not.toBeNull();
+    expect(pending!.sId).not.toBe(expired.sId);
+    expect(pending!.initialRole).toBe("builder");
+  });
+
+  it("deduplicates same-email requests to a single DB row but sends all emails", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = [
+      { email: "dup@example.com", role: "user" },
+      { email: "dup@example.com", role: "admin" },
+    ];
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toHaveLength(2);
+    expect(data.every((r: { success: boolean }) => r.success)).toBe(true);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const invitations =
+      await MembershipInvitationResource.getPendingInvitations(adminAuth);
+    expect(invitations).toHaveLength(1);
+    // Last role in the request wins.
+    expect(invitations[0].initialRole).toBe("admin");
+
+    expect(sgSendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects invitations for existing active members without creating a row", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = [
+      { email: user.email, role: "user" },
+      { email: "brand-new@example.com", role: "user" },
+    ];
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData() as {
+      success: boolean;
+      email: string;
+      error_message?: string;
+    }[];
+    expect(data).toHaveLength(2);
+
+    const byEmail = new Map(data.map((r) => [r.email, r]));
+    expect(byEmail.get(user.email)?.success).toBe(false);
+    expect(byEmail.get(user.email)?.error_message).toMatch(
+      /existing active member/i
+    );
+    expect(byEmail.get("brand-new@example.com")?.success).toBe(true);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const invitations =
+      await MembershipInvitationResource.getPendingInvitations(adminAuth);
+    expect(invitations).toHaveLength(1);
+    expect(invitations[0].inviteEmail).toBe("brand-new@example.com");
+
+    expect(sgSendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 for invalid email addresses without creating any invitation", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = [
+      { email: "valid@example.com", role: "user" },
+      { email: "not-an-email", role: "user" },
+    ];
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const invitations =
+      await MembershipInvitationResource.getPendingInvitations(adminAuth);
+    expect(invitations).toHaveLength(0);
+    expect(sgSendMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the invitation in the DB even when the email send fails", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    sgSendMock.mockRejectedValueOnce(new Error("SendGrid down"));
+
+    req.body = [{ email: "email-fails@example.com", role: "user" }];
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toHaveLength(1);
+    expect(data[0].success).toBe(false);
+    expect(data[0].email).toBe("email-fails@example.com");
+
+    const pending =
+      await MembershipInvitationResource.getPendingForEmailAndWorkspace({
+        email: "email-fails@example.com",
+        workspace,
+      });
+    expect(pending).not.toBeNull();
+    expect(pending!.status).toBe("pending");
+  });
+});

--- a/front/pages/api/w/[wId]/invitations/index.test.ts
+++ b/front/pages/api/w/[wId]/invitations/index.test.ts
@@ -1,3 +1,4 @@
+import type { HandleMembershipInvitationResult } from "@app/lib/api/invitation";
 import { Authenticator } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -189,11 +190,7 @@ describe("POST /api/w/[wId]/invitations", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    const data = res._getJSONData() as {
-      success: boolean;
-      email: string;
-      error_message?: string;
-    }[];
+    const data: HandleMembershipInvitationResult[] = res._getJSONData();
     expect(data).toHaveLength(2);
 
     const byEmail = new Map(data.map((r) => [r.email, r]));


### PR DESCRIPTION
## Description

Fixes N+1 query pattern in `handleMembershipInvitations`. When inviting N addresses in a single request, the old path issued 1 SELECT + 1 UPDATE/INSERT per invitation inside a transaction, plus made N SendGrid calls while the transaction was still open.

The new path does O(1) queries regardless of batch size:
- 1 SELECT via `listPendingForEmailsAndWorkspace` for all candidate emails
- 1 bulk UPDATE to revoke expired invitations
- ≤3 UPDATEs grouped by target role (bounded by `ActiveRoleType`)
- 1 `bulkCreate` for new invitations

SendGrid calls are now fanned out **after** the transaction commits (concurrency-bounded via `concurrentExecutor`, `EMAIL_CONCURRENCY = 8`), so the DB transaction no longer stays open for the duration of external email delivery. The audit log emit also moves after commit (aligns with `[AUDIT4]`).

Duplicate addresses in a single request are deduped to one DB row while still sending one email per original entry (last role wins).

New Resource methods: `listPendingForEmailsAndWorkspace`, `bulkMakeNewPending`, `bulkRevokeByModelIds`, `bulkUpdateInitialRoleByModelIds`. The legacy `updateOrCreateInvitation` helper is removed (no remaining callers).

## Tests

- Added functional tests at `front/pages/api/w/[wId]/invitations/index.test.ts` covering:
  - Bulk creation across multiple roles in one request
  - Role update on an existing pending invitation (no new row)
  - Expired invitation → revoke + fresh create
  - Duplicate emails in one request → single DB row, one email per entry
  - Existing active member rejection without row creation
  - Invalid email → 400, no partial writes
  - Email send failure → DB row persists, per-entry failure result returned
- `npx tsgo --noEmit` passes
- `npm run format:changed` clean

## Risk

Low. Behavior for single-invitation requests is unchanged (same SELECT → update-or-create flow, just via bulk methods of size 1). Bulk requests benefit the most and are the paths previously at risk of long transactions / connection-pool pressure. Rollback is safe, pure backend refactor, no schema migration, no API contract change. Response shape is identical.

## Deploy Plan

Merge.
