### PR TITLE
improve poke display for skill suggestions

### DIFF
--- a/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
+++ b/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
@@ -3,9 +3,11 @@ import { SkillSuggestionCard } from "@app/components/skill_builder/SkillSuggesti
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { usePokeMCPServerViews } from "@app/poke/swr/mcp_server_views";
 import { usePokeSkillSuggestionDetails } from "@app/poke/swr/skill_suggestion_details";
-import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import type { SkillSuggestionState } from "@app/types/suggestions/skill_suggestion";
+import { Chip, LinkWrapper, Spinner } from "@dust-tt/sparkle";
 import { useCallback, useMemo } from "react";
 
 export function SkillSuggestionDetailsPage() {
@@ -56,9 +58,29 @@ export function SkillSuggestionDetailsPage() {
 
   const { suggestion } = data;
 
+  const stateColorMap: Record<
+    SkillSuggestionState,
+    "info" | "primary" | "warning" | "rose"
+  > = {
+    pending: "warning",
+    approved: "primary",
+    rejected: "rose",
+    outdated: "info",
+  };
+
   return (
     <div>
-      <h2 className="text-2xl font-bold">{suggestion.title ?? "Suggestion"}</h2>
+      <div className="flex items-center gap-3">
+        <h2 className="text-2xl font-bold">
+          {suggestion.title ?? "Suggestion"}
+        </h2>
+        <Chip color={stateColorMap[suggestion.state]} size="sm">
+          {suggestion.state}
+        </Chip>
+        <Chip color="info" size="sm">
+          {suggestion.source}
+        </Chip>
+      </div>
       <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
         {suggestion.sId} · Skill&nbsp;
         <LinkWrapper
@@ -79,6 +101,33 @@ export function SkillSuggestionDetailsPage() {
           </>
         )}
       </p>
+      {suggestion.updatedBy && (
+        <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Updated by{" "}
+          <span title={suggestion.updatedBy.email}>
+            {suggestion.updatedBy.fullName}
+          </span>{" "}
+          on {formatTimestampToFriendlyDate(suggestion.updatedAt)}
+        </p>
+      )}
+      {suggestion.visibleSourceConversationIds.length > 0 && (
+        <div className="mt-2">
+          <span className="text-sm font-medium">
+            Source conversations ({suggestion.sourceConversationsCount}):
+          </span>
+          <div className="mt-1 flex flex-wrap gap-2">
+            {suggestion.visibleSourceConversationIds.map((conversationId) => (
+              <LinkWrapper
+                key={conversationId}
+                href={`/poke/${owner.sId}/conversation/${conversationId}`}
+                className="text-sm text-highlight-500"
+              >
+                {conversationId}
+              </LinkWrapper>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="mt-4 space-y-6">
         <div>

--- a/front/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -56,7 +56,8 @@ async function handler(
 
   const suggestion = await SkillSuggestionResource.fetchById(
     auth,
-    suggestionId
+    suggestionId,
+    { dangerouslyBypassConversationsVisibilityCheck: true }
   );
   if (!suggestion) {
     return apiError(req, res, {


### PR DESCRIPTION
## Description

 - add source (synthetic/reinforcement), status, source conversations and updatedBy

<img width="1071" height="550" alt="Screenshot 2026-04-24 at 15 43 54" src="https://github.com/user-attachments/assets/4959b8e7-8175-4bcc-8fe5-099b73a2ea67" />


<img width="1143" height="581" alt="Screenshot 2026-04-24 at 15 45 10" src="https://github.com/user-attachments/assets/b2e3c682-c9ff-405b-8f7d-f77713d806e9" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low, this is poke

## Deploy Plan

deploy front
