### PR TITLE
fix(project-todo): set createdByUserId to null for agent-created todos in merge

### DIFF
--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -462,6 +462,7 @@ async function createOrLinkTodos(
           spaceId: spaceModelId,
           userId: primary.userId,
           createdByType: "agent",
+          createdByUserId: null,
           createdByAgentConfigurationId: BUTLER_AGENT_SID,
           category: primary.blob.category,
           text: primary.blob.text,

--- a/front/lib/resources/project_todo_resource.test.ts
+++ b/front/lib/resources/project_todo_resource.test.ts
@@ -73,6 +73,53 @@ describe("ProjectTodoResource", () => {
 
       expect(todo.sId).toBe(computed);
     });
+
+    // Regression: the merge workflow creates agent-owned todos. The Sequelize
+    // createdByXor validator compares `this.createdByUserId !== null`, so the
+    // field must be explicitly null — omitting it leaves it undefined and
+    // trips the validator.
+    it("should create an agent-owned todo when createdByUserId is explicitly null", async () => {
+      const todo = await ProjectTodoResource.makeNew(auth, {
+        spaceId: space.id,
+        userId: user.id,
+        createdByType: "agent",
+        createdByUserId: null,
+        createdByAgentConfigurationId: "butler",
+        markedAsDoneByType: null,
+        markedAsDoneByUserId: null,
+        markedAsDoneByAgentConfigurationId: null,
+        category: "to_do",
+        text: "Agent-created todo",
+        status: "todo",
+        doneAt: null,
+        actorRationale: null,
+      });
+
+      expect(todo.createdByType).toBe("agent");
+      expect(todo.createdByUserId).toBeNull();
+      expect(todo.createdByAgentConfigurationId).toBe("butler");
+    });
+
+    it("should reject an agent-owned todo when createdByUserId is omitted", async () => {
+      await expect(
+        ProjectTodoResource.makeNew(auth, {
+          spaceId: space.id,
+          userId: user.id,
+          createdByType: "agent",
+          createdByAgentConfigurationId: "butler",
+          markedAsDoneByType: null,
+          markedAsDoneByUserId: null,
+          markedAsDoneByAgentConfigurationId: null,
+          category: "to_do",
+          text: "Agent-created todo",
+          status: "todo",
+          doneAt: null,
+          actorRationale: null,
+        } as unknown as CreationAttributes<ProjectTodoModel>)
+      ).rejects.toThrow(
+        "createdByType is agent: createdByAgentConfigurationId must be set and createdByUserId must be null."
+      );
+    });
   });
 
   describe("fetchBySId", () => {


### PR DESCRIPTION
## Description

`mergeTodosForProjectActivity` was failing with a `SequelizeValidationError` whenever it tried to create a new agent-owned todo:

> createdByType is agent: createdByAgentConfigurationId must be set and createdByUserId must be null.

The `createdByXor` validator on `ProjectTodoModel` checks `this.createdByUserId !== null`. The merge blob in `createOrLinkTodos` omitted `createdByUserId`, so during pre-save validation it was `undefined`, and `undefined !== null` evaluates to `true` — tripping the XOR. Every other creation site (tool handlers, test factories) sets the field explicitly; the merge path was the only one missing it.

Fix: add `createdByUserId: null` to the blob passed to `ProjectTodoResource.makeNewWithSource`.

## Tests

- Added two tests in `project_todo_resource.test.ts`:
  - Happy path: agent-owned todo with `createdByUserId: null` persists correctly.
  - Regression guard: omitting `createdByUserId` on an agent blob throws the exact validator error.
