### PR TITLE
fix: handle antrophic empty messages

### DIFF
--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -508,17 +508,6 @@ export async function getOutputFromLLMStream(
     }
   }
 
-  if (contents.length === 0 && actions.length === 0) {
-    return new Err({
-      type: "shouldRetryMessage",
-      content: {
-        type: "unknown_error",
-        message: "Agent execution didn't complete.",
-        isRetryable: true,
-      },
-    });
-  }
-
   return new Ok({
     output: {
       actions,


### PR DESCRIPTION
## Description

This PR removes the error thrown when an LLM stream returns no contents and no actions.

Previously, when the stream completed with both `contents` and `actions` being empty, we were throwing a retryable error ("Agent execution didn't complete"). This check is no longer needed because we already handle genuine stream failures above. An empty message that reaches this point has completed successfully from the stream's perspective.

The actual problem being fixed: Anthropic models can legitimately produce a successful message with no text content and no tool calls. This happens, for example, when the model is asked to call a tool and then not generate any other text. An example trace can be found here: https://langfuse.dust.tt/project/cmi4ft2qm00061707q4a9azyc/traces?filter=metadata%3BstringObject%3BconversationId%3B%3D%3B6tRYHrNIVI&peek=9ed8fc9dfe596edfe740b90fef1c81ec&timestamp=2026-04-24T14%3A43%3A36.393Z&observation=cabd0b1564de84eb

Other examples can be found from [datadog](https://app.datadoghq.eu/logs?query=%22LLM%20error%20%28unknown_error%29%3A%20An%20unexpected%20error%20occurred.%20Please%20try%20again%20or%20contact%20support%20if%20the%20issue%20persists.%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1776440207735&to_ts=1777045007735&live=true)

## Reproduction

Ask an Anthropic model to call a tool, then end the message without any other content. The model will return a successful response with no text and no tool calls, which previously triggered a spurious retry.

## Tests

Manually tested.

## Risks

Low. The safety net for genuine failures is preserved via the error event check higher up in the stream handling. The only behavioral change is that legitimate empty completions from Anthropic are now handled gracefully instead of being retried.

## Deploy Plan

Standard deployment — no special considerations needed.