### PR TITLE
[Files] Use GCS direct copy for FileResource.copy

### DIFF
--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -226,16 +226,22 @@ export class FileStorage {
   }
 
   /**
-   * Copy a file within the same bucket with retry logic.
+   * Copy a file within Cloud Storage with retry logic.
    *
    * The GCS SDK's built-in autoRetry is effectively disabled for copy operations and
    * "socket hang up" errors aren't in the SDK's retryable error list anyway.
    * Since copy is idempotent (same source, same destination), retrying is safe.
    */
-  async copyFile(srcPath: string, destPath: string): Promise<void> {
+  async copyFile(
+    srcPath: string,
+    destPath: string,
+    destinationStorage: FileStorage = this
+  ): Promise<void> {
+    const destinationFile = destinationStorage.file(destPath);
+
     for (let attempt = 1; attempt <= GCS_COPY_MAX_RETRIES; attempt++) {
       try {
-        await this.bucket.file(srcPath).copy(this.bucket.file(destPath));
+        await this.file(srcPath).copy(destinationFile);
         return;
       } catch (err) {
         if (attempt === GCS_COPY_MAX_RETRIES) {
@@ -247,7 +253,9 @@ export class FileStorage {
         logger.warn(
           {
             error: normalizeError(err),
+            srcBucket: this.name,
             srcPath,
+            destBucket: destinationStorage.name,
             destPath,
             attempt,
             maxRetries: GCS_COPY_MAX_RETRIES,

--- a/front/lib/utils/files.test.ts
+++ b/front/lib/utils/files.test.ts
@@ -14,6 +14,10 @@ function makeSourceFile(contentType: AllSupportedFileContentType) {
       copyFile: vi.fn(),
       name: "source-processed-bucket",
     },
+    public: {
+      copyFile: vi.fn(),
+      name: "source-public-bucket",
+    },
   };
 
   return {
@@ -40,6 +44,7 @@ function makeTargetFile() {
   const targetBuckets = {
     original: { name: "target-original-bucket" },
     processed: { name: "target-processed-bucket" },
+    public: { name: "target-public-bucket" },
   };
 
   return {

--- a/front/lib/utils/files.test.ts
+++ b/front/lib/utils/files.test.ts
@@ -1,79 +1,59 @@
-import { getProcessedContentType } from "@app/lib/api/files/processing";
+import type { Authenticator } from "@app/lib/auth";
 import type { FileVersion } from "@app/lib/resources/file_resource";
 import { copyContent } from "@app/lib/utils/files";
-import { FileFactory } from "@app/tests/utils/FileFactory";
-import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { AllSupportedFileContentType } from "@app/types/files";
-import { Readable, Writable } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const ORIGINAL_CONTENT = Buffer.from("original-content");
-const PROCESSED_CONTENT = Buffer.from("processed-content");
-
-function makeWritable(chunks: Buffer[]) {
-  return new Writable({
-    write(chunk, _encoding, callback) {
-      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-      callback();
+function makeSourceFile(contentType: AllSupportedFileContentType) {
+  const sourceBuckets = {
+    original: {
+      copyFile: vi.fn(),
+      name: "source-original-bucket",
     },
-  });
-}
-
-async function createCopyTestContext(contentType: AllSupportedFileContentType) {
-  const { authenticator: auth } = await createResourceTest({
-    role: "admin",
-  });
-
-  const fileExtension = contentType === "application/pdf" ? "pdf" : "txt";
-  const sourceFile = await FileFactory.create(auth, null, {
-    contentType,
-    fileName: `source.${fileExtension}`,
-    fileSize: ORIGINAL_CONTENT.length,
-    status: "created",
-    useCase: "conversation",
-  });
-  const targetFile = await FileFactory.create(auth, null, {
-    contentType,
-    fileName: `copy.${fileExtension}`,
-    fileSize: ORIGINAL_CONTENT.length,
-    status: "created",
-    useCase: "conversation",
-  });
-
-  const originalChunks: Buffer[] = [];
-  const processedChunks: Buffer[] = [];
-
-  const getReadStreamSpy = vi
-    .spyOn(sourceFile, "getReadStream")
-    .mockImplementation(
-      ({ version }: { auth: typeof auth; version: FileVersion }) =>
-        Readable.from([
-          version === "original" ? ORIGINAL_CONTENT : PROCESSED_CONTENT,
-        ])
-    );
-  const getWriteStreamSpy = vi
-    .spyOn(targetFile, "getWriteStream")
-    .mockImplementation(
-      ({
-        version,
-      }: {
-        auth: typeof auth;
-        version: FileVersion;
-        overrideContentType?: string;
-      }) =>
-        version === "original"
-          ? makeWritable(originalChunks)
-          : makeWritable(processedChunks)
-    );
+    processed: {
+      copyFile: vi.fn(),
+      name: "source-processed-bucket",
+    },
+  };
 
   return {
-    auth,
-    sourceFile,
-    targetFile,
-    originalChunks,
-    processedChunks,
-    getReadStreamSpy,
-    getWriteStreamSpy,
+    contentType,
+    getBucketForVersion: vi.fn(
+      (version: FileVersion) => sourceBuckets[version]
+    ),
+    getCloudStoragePath: vi.fn(
+      (_auth: Authenticator, version: FileVersion) => `source/${version}`
+    ),
+    sourceBuckets,
+  } satisfies {
+    contentType: AllSupportedFileContentType;
+    getBucketForVersion: ReturnType<typeof vi.fn>;
+    getCloudStoragePath: ReturnType<typeof vi.fn>;
+    sourceBuckets: Record<
+      FileVersion,
+      { copyFile: ReturnType<typeof vi.fn>; name: string }
+    >;
+  };
+}
+
+function makeTargetFile() {
+  const targetBuckets = {
+    original: { name: "target-original-bucket" },
+    processed: { name: "target-processed-bucket" },
+  };
+
+  return {
+    getBucketForVersion: vi.fn(
+      (version: FileVersion) => targetBuckets[version]
+    ),
+    getCloudStoragePath: vi.fn(
+      (_auth: Authenticator, version: FileVersion) => `target/${version}`
+    ),
+    targetBuckets,
+  } satisfies {
+    getBucketForVersion: ReturnType<typeof vi.fn>;
+    getCloudStoragePath: ReturnType<typeof vi.fn>;
+    targetBuckets: Record<FileVersion, { name: string }>;
   };
 }
 
@@ -83,72 +63,80 @@ describe("copyContent", () => {
   });
 
   it("copies only the original version for files without processing", async () => {
-    const context = await createCopyTestContext("text/plain");
+    const auth = {} as Authenticator;
+    const sourceFile = makeSourceFile("text/plain");
+    const targetFile = makeTargetFile();
 
-    await copyContent(context.auth, context.sourceFile, context.targetFile);
+    await copyContent(
+      auth,
+      sourceFile as unknown as Parameters<typeof copyContent>[1],
+      targetFile as unknown as Parameters<typeof copyContent>[2]
+    );
 
-    expect(context.getReadStreamSpy).toHaveBeenCalledTimes(1);
-    expect(context.getReadStreamSpy).toHaveBeenCalledWith({
-      auth: context.auth,
-      version: "original",
-    });
-    expect(context.getWriteStreamSpy).toHaveBeenCalledTimes(1);
-    expect(context.getWriteStreamSpy).toHaveBeenCalledWith({
-      auth: context.auth,
-      version: "original",
-    });
-    expect(Buffer.concat(context.originalChunks)).toEqual(ORIGINAL_CONTENT);
-    expect(context.processedChunks).toHaveLength(0);
+    expect(sourceFile.getCloudStoragePath).toHaveBeenCalledTimes(1);
+    expect(sourceFile.getCloudStoragePath).toHaveBeenCalledWith(
+      auth,
+      "original"
+    );
+    expect(targetFile.getCloudStoragePath).toHaveBeenCalledTimes(1);
+    expect(targetFile.getCloudStoragePath).toHaveBeenCalledWith(
+      auth,
+      "original"
+    );
+    expect(sourceFile.sourceBuckets.original.copyFile).toHaveBeenCalledTimes(1);
+    expect(sourceFile.sourceBuckets.original.copyFile).toHaveBeenCalledWith(
+      "source/original",
+      "target/original",
+      targetFile.targetBuckets.original
+    );
+    expect(sourceFile.sourceBuckets.processed.copyFile).not.toHaveBeenCalled();
   });
 
   it("copies only the original version for processed files by default", async () => {
-    const context = await createCopyTestContext("application/pdf");
+    const auth = {} as Authenticator;
+    const sourceFile = makeSourceFile("application/pdf");
+    const targetFile = makeTargetFile();
 
-    await copyContent(context.auth, context.sourceFile, context.targetFile);
+    await copyContent(
+      auth,
+      sourceFile as unknown as Parameters<typeof copyContent>[1],
+      targetFile as unknown as Parameters<typeof copyContent>[2]
+    );
 
-    expect(context.getReadStreamSpy).toHaveBeenCalledTimes(1);
-    expect(context.getReadStreamSpy).toHaveBeenCalledWith({
-      auth: context.auth,
-      version: "original",
-    });
-    expect(context.getWriteStreamSpy).toHaveBeenCalledTimes(1);
-    expect(context.getWriteStreamSpy).toHaveBeenCalledWith({
-      auth: context.auth,
-      version: "original",
-    });
-    expect(Buffer.concat(context.originalChunks)).toEqual(ORIGINAL_CONTENT);
-    expect(context.processedChunks).toHaveLength(0);
+    expect(sourceFile.sourceBuckets.original.copyFile).toHaveBeenCalledTimes(1);
+    expect(sourceFile.sourceBuckets.original.copyFile).toHaveBeenCalledWith(
+      "source/original",
+      "target/original",
+      targetFile.targetBuckets.original
+    );
+    expect(sourceFile.sourceBuckets.processed.copyFile).not.toHaveBeenCalled();
   });
 
   it("copies both original and processed versions when requested", async () => {
-    const context = await createCopyTestContext("application/pdf");
+    const auth = {} as Authenticator;
+    const sourceFile = makeSourceFile("application/pdf");
+    const targetFile = makeTargetFile();
 
-    await copyContent(context.auth, context.sourceFile, context.targetFile, {
-      includeProcessedVersion: true,
-    });
+    await copyContent(
+      auth,
+      sourceFile as unknown as Parameters<typeof copyContent>[1],
+      targetFile as unknown as Parameters<typeof copyContent>[2],
+      { includeProcessedVersion: true }
+    );
 
-    expect(context.getReadStreamSpy).toHaveBeenCalledTimes(2);
-    expect(context.getReadStreamSpy).toHaveBeenNthCalledWith(1, {
-      auth: context.auth,
-      version: "original",
-    });
-    expect(context.getReadStreamSpy).toHaveBeenNthCalledWith(2, {
-      auth: context.auth,
-      version: "processed",
-    });
-    expect(context.getWriteStreamSpy).toHaveBeenCalledTimes(2);
-    expect(context.getWriteStreamSpy).toHaveBeenNthCalledWith(1, {
-      auth: context.auth,
-      version: "original",
-    });
-    expect(context.getWriteStreamSpy).toHaveBeenNthCalledWith(2, {
-      auth: context.auth,
-      version: "processed",
-      overrideContentType: getProcessedContentType(
-        context.sourceFile.contentType
-      ),
-    });
-    expect(Buffer.concat(context.originalChunks)).toEqual(ORIGINAL_CONTENT);
-    expect(Buffer.concat(context.processedChunks)).toEqual(PROCESSED_CONTENT);
+    expect(sourceFile.sourceBuckets.original.copyFile).toHaveBeenCalledTimes(1);
+    expect(sourceFile.sourceBuckets.original.copyFile).toHaveBeenCalledWith(
+      "source/original",
+      "target/original",
+      targetFile.targetBuckets.original
+    );
+    expect(sourceFile.sourceBuckets.processed.copyFile).toHaveBeenCalledTimes(
+      1
+    );
+    expect(sourceFile.sourceBuckets.processed.copyFile).toHaveBeenCalledWith(
+      "source/processed",
+      "target/processed",
+      targetFile.targetBuckets.processed
+    );
   });
 });

--- a/front/lib/utils/files.ts
+++ b/front/lib/utils/files.ts
@@ -1,11 +1,21 @@
-import {
-  getProcessedContentType,
-  hasProcessedVersion,
-} from "@app/lib/api/files/processing";
+import { hasProcessedVersion } from "@app/lib/api/files/processing";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
-import assert from "assert";
-import { pipeline } from "stream/promises";
+
+async function copyVersion(
+  auth: Authenticator,
+  sourceFile: FileResource,
+  targetFile: FileResource,
+  version: "original" | "processed"
+) {
+  await sourceFile
+    .getBucketForVersion(version)
+    .copyFile(
+      sourceFile.getCloudStoragePath(auth, version),
+      targetFile.getCloudStoragePath(auth, version),
+      targetFile.getBucketForVersion(version)
+    );
+}
 
 export async function copyContent(
   auth: Authenticator,
@@ -15,17 +25,7 @@ export async function copyContent(
     includeProcessedVersion = false,
   }: { includeProcessedVersion?: boolean } = {}
 ) {
-  // Get a read stream from the source file's original version.
-  const readStream = sourceFile.getReadStream({
-    auth,
-    version: "original",
-  });
-
-  // Write a copy of the source file's content to the new file.
-  await pipeline(
-    readStream,
-    targetFile.getWriteStream({ auth, version: "original" })
-  );
+  await copyVersion(auth, sourceFile, targetFile, "original");
 
   if (
     !includeProcessedVersion ||
@@ -34,15 +34,5 @@ export async function copyContent(
     return;
   }
 
-  const processedContentType = getProcessedContentType(sourceFile.contentType);
-  assert(processedContentType);
-
-  await pipeline(
-    sourceFile.getReadStream({ auth, version: "processed" }),
-    targetFile.getWriteStream({
-      auth,
-      version: "processed",
-      overrideContentType: processedContentType,
-    })
-  );
+  await copyVersion(auth, sourceFile, targetFile, "processed");
 }


### PR DESCRIPTION
## Description
- Replace `copyContent`'s stream round-trip through front with server-side GCS object copies.
- Generalize `FileStorage.copyFile()` so `FileResource.copy()` can reuse the existing retry logic even when the source and destination resolve to different buckets.

## Risks
Blast radius: file duplication paths in front, including `FileResource.copy()` and other callers of `FileStorage.copyFile()`.
Risk: low

## Deploy Plan
- pmrr
- deploy front
