### PR TITLE
Add SDK steering stream support

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -126,7 +126,6 @@ async function handler(
       for await (const event of eventStream) {
         // Internal events are not exposed via the public API.
         if (
-          event.data.type === "user_message_promoted" ||
           event.data.type === "compaction_message_new" ||
           event.data.type === "compaction_message_done" ||
           event.data.type === "plan_updated"

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -964,6 +964,8 @@ export class DustAPI {
     return new Ok(r.value);
   }
 
+  // Wait for the parent user message to move to `visible` when the agent message is not direclty
+  // found in the conversation. This provides natural suoport for steering through the SDK.
   async waitForAgentMessage({
     conversation,
     parentUserMessageId,

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -51,7 +51,6 @@ import type {
   Result,
   SearchRequestBodyType,
   SearchWarningCode,
-  UserMessageType,
   ValidateActionRequestBodyType,
   ValidateActionResponseType,
 } from "./types";
@@ -965,6 +964,78 @@ export class DustAPI {
     return new Ok(r.value);
   }
 
+  async waitForAgentMessage({
+    conversation,
+    parentUserMessageId,
+    signal,
+  }: {
+    conversation: ConversationPublicType;
+    parentUserMessageId: string;
+    signal?: AbortSignal;
+  }): Promise<
+    Result<
+      AgentMessagePublicType | null,
+      { type: string; message: string } | Error
+    >
+  > {
+    let agentMessage =
+      conversation.content
+        .map((versions) => versions[versions.length - 1])
+        .find((message): message is AgentMessagePublicType => {
+          return (
+            message?.type === "agent_message" &&
+            message.parentMessageId === parentUserMessageId
+          );
+        }) ?? null;
+    if (agentMessage) {
+      return new Ok(agentMessage);
+    }
+
+    const streamRes = await this.streamConversationEvents({
+      conversationId: conversation.sId,
+      signal,
+    });
+    if (streamRes.isErr()) {
+      return streamRes;
+    }
+
+    for await (const event of streamRes.value.eventStream) {
+      if (
+        event.type === "user_message_new" &&
+        event.messageId === parentUserMessageId &&
+        event.message.visibility === "visible"
+      ) {
+        break;
+      }
+
+      if (
+        event.type === "user_message_promoted" &&
+        event.messageId === parentUserMessageId
+      ) {
+        break;
+      }
+    }
+
+    const conversationRes = await this.getConversation({
+      conversationId: conversation.sId,
+    });
+    if (conversationRes.isErr()) {
+      return conversationRes;
+    }
+
+    agentMessage =
+      conversationRes.value.content
+        .map((versions) => versions[versions.length - 1])
+        .find((message): message is AgentMessagePublicType => {
+          return (
+            message?.type === "agent_message" &&
+            message.parentMessageId === parentUserMessageId
+          );
+        }) ?? null;
+
+    return new Ok(agentMessage);
+  }
+
   async streamAgentAnswerEvents({
     conversation,
     userMessageId,
@@ -991,22 +1062,21 @@ export class DustAPI {
       { type: string; message: string } | Error
     >
   > {
-    const agentMessages = conversation.content
-      .map((versions) => {
-        const m = versions[versions.length - 1];
-        return m;
-      })
-      .filter((m): m is AgentMessagePublicType => {
-        return (
-          m && m.type === "agent_message" && m.parentMessageId === userMessageId
-        );
-      });
+    const agentMessageRes = await this.waitForAgentMessage({
+      conversation,
+      parentUserMessageId: userMessageId,
+      signal,
+    });
+    if (agentMessageRes.isErr()) {
+      return agentMessageRes;
+    }
 
-    if (agentMessages.length === 0) {
+    const agentMessage = agentMessageRes.value;
+
+    if (agentMessage === null) {
       return new Err(new Error("Failed to retrieve agent message"));
     }
 
-    const agentMessage = agentMessages[0];
     return this.streamAgentMessageEvents({
       conversationId: conversation.sId,
       agentMessageId: agentMessage.sId,
@@ -1018,55 +1088,6 @@ export class DustAPI {
         autoReconnect: options.autoReconnect ?? true,
       },
     });
-  }
-
-  async waitForAgentMessage({
-    conversation,
-    userMessage,
-  }: {
-    conversation: ConversationPublicType;
-    userMessage: UserMessageType;
-  }): Promise<
-    Result<AgentMessagePublicType, { type: string; message: string } | Error>
-  > {
-    for (const versions of conversation.content) {
-      const message = versions[versions.length - 1];
-
-      if (
-        message?.type === "agent_message" &&
-        message.parentMessageId === userMessage.sId
-      ) {
-        return new Ok(message);
-      }
-    }
-
-    const streamRes = await this.streamConversationEvents({
-      conversationId: conversation.sId,
-    });
-    if (streamRes.isErr()) {
-      return streamRes;
-    }
-
-    for await (const event of streamRes.value.eventStream) {
-      if (
-        event.type === "user_message_new" &&
-        event.messageId === userMessage.sId &&
-        event.message.visibility === "visible"
-      ) {
-        // TODO: Fetch the updated conversation and return the newly created agent message.
-        break;
-      }
-
-      if (
-        event.type === "user_message_promoted" &&
-        event.messageId === userMessage.sId
-      ) {
-        // TODO: Fetch the updated conversation and return the newly created agent message.
-        break;
-      }
-    }
-
-    return new Err(new Error("Failed to retrieve agent message"));
   }
 
   async streamConversationEvents({

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -51,6 +51,7 @@ import type {
   Result,
   SearchRequestBodyType,
   SearchWarningCode,
+  UserMessageType,
   ValidateActionRequestBodyType,
   ValidateActionResponseType,
 } from "./types";
@@ -1017,6 +1018,55 @@ export class DustAPI {
         autoReconnect: options.autoReconnect ?? true,
       },
     });
+  }
+
+  async waitForAgentMessage({
+    conversation,
+    userMessage,
+  }: {
+    conversation: ConversationPublicType;
+    userMessage: UserMessageType;
+  }): Promise<
+    Result<AgentMessagePublicType, { type: string; message: string } | Error>
+  > {
+    for (const versions of conversation.content) {
+      const message = versions[versions.length - 1];
+
+      if (
+        message?.type === "agent_message" &&
+        message.parentMessageId === userMessage.sId
+      ) {
+        return new Ok(message);
+      }
+    }
+
+    const streamRes = await this.streamConversationEvents({
+      conversationId: conversation.sId,
+    });
+    if (streamRes.isErr()) {
+      return streamRes;
+    }
+
+    for await (const event of streamRes.value.eventStream) {
+      if (
+        event.type === "user_message_new" &&
+        event.messageId === userMessage.sId &&
+        event.message.visibility === "visible"
+      ) {
+        // TODO: Fetch the updated conversation and return the newly created agent message.
+        break;
+      }
+
+      if (
+        event.type === "user_message_promoted" &&
+        event.messageId === userMessage.sId
+      ) {
+        // TODO: Fetch the updated conversation and return the newly created agent message.
+        break;
+      }
+    }
+
+    return new Err(new Error("Failed to retrieve agent message"));
   }
 
   async streamConversationEvents({


### PR DESCRIPTION
## Description

Add SDK support for steered user messages by waiting for the parent user message to become visible before resolving the corresponding agent message. This also exposes `user_message_promoted` on the public conversation events stream so SDK clients can observe pending-message promotion.

Fixes: https://github.com/dust-tt/tasks/issues/7713

## Tests

N/A, tested locally with `cd sdks/js && npm run build`.

## Risk

Low. The change of behavior only applies when an agent message was not directly created after a post user message.

## Deploy Plan

- deploy `front`
- deploy `connectors`