### PR TITLE
Remove connector agent mention injection

### DIFF
--- a/connectors/src/api/webhooks/discord/bot.ts
+++ b/connectors/src/api/webhooks/discord/bot.ts
@@ -50,10 +50,8 @@ export async function sendMessageToAgent(
     logger
   );
 
-  const messageWithMention = `:mention[${agentConfiguration.name}]{sId=${agentConfiguration.sId}} ${message}`;
-
   const messageReqBody = {
-    content: messageWithMention,
+    content: message,
     mentions: [{ configurationId: agentConfiguration.sId }],
     context: {
       timezone: "UTC",

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1179,11 +1179,6 @@ async function answerMessage(
     );
   };
 
-  if (!message.includes(":mention")) {
-    // if the message does not contain the mention, we add it as a prefix.
-    message = `:mention[${mention.agentName}]{sId=${mention.agentId}} ${message}`;
-  }
-
   const origin = slackBotId ? "slack_workflow" : "slack";
 
   const messageReqBody: PublicPostMessagesRequestBody = {

--- a/connectors/src/lib/bot/mentions.ts
+++ b/connectors/src/lib/bot/mentions.ts
@@ -63,10 +63,7 @@ export function processMentions({
     agentId: bestCandidate.agentId,
     agentName: bestCandidate.agentName,
   };
-  const processedMessage = message.replace(
-    mentionCandidate,
-    `:mention[${bestCandidate.agentName}]{sId=${bestCandidate.agentId}}`
-  );
+  const processedMessage = message.replace(mentionCandidate, "").trim();
 
   return new Ok({
     mention,
@@ -163,11 +160,6 @@ export function processMessageForMention({
       agentId: defaultAgent.sId,
       agentName: defaultAgent.name,
     };
-  }
-
-  if (!processedMessage.includes(":mention")) {
-    // if the message does not contain the mention, we add it as a prefix.
-    processedMessage = `:mention[${mention.agentName}]{sId=${mention.agentId}} ${processedMessage}`;
   }
 
   return new Ok({


### PR DESCRIPTION
## Description

Remove rich agent mention markup injection from Slack, Discord, and the shared connector mention helper. Connectors still pass `mentions: [{ configurationId }]` for routing, but no longer add `:mention[...]` to the submitted message body.

## Tests

N/A, tested locally end to end.

## Risk

Low

## Deploy Plan

- deploy `connectors`
