### PR TITLE
Remove to know category.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -18,11 +18,9 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetProjectTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index";
 import type {
   ProjectTodoActorType,
-  ProjectTodoCategory,
   ProjectTodoStatus,
   ProjectTodoType,
 } from "@app/types/project_todo";
-import { PROJECT_TODO_CATEGORIES } from "@app/types/project_todo";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -42,10 +40,8 @@ import {
   PlayIcon,
   SlackLogo,
   Spinner,
-  SquareIcon,
   Tooltip,
   TrashIcon,
-  TriangleIcon,
   TypingAnimation,
   WindIcon,
 } from "@dust-tt/sparkle";
@@ -53,30 +49,6 @@ import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const SUMMARY_ITEM_TRANSITION_MS = 240;
-
-// ── Category display configuration ────────────────────────────────────────────
-
-type CategoryConfig = {
-  label: string;
-  icon: React.ComponentType;
-  iconClassName: string;
-};
-
-const CATEGORY_CONFIG: Record<ProjectTodoCategory, CategoryConfig> = {
-  to_do: {
-    label: "Need to do",
-    icon: TriangleIcon,
-    iconClassName: "text-warning-300 dark:text-warning-300-night",
-  },
-  to_know: {
-    label: "Need to know",
-    icon: SquareIcon,
-    iconClassName: "text-golden-300 dark:text-golden-300-night",
-  },
-};
-
-// Stable display order for categories.
-const ORDERED_CATEGORIES: ProjectTodoCategory[] = [...PROJECT_TODO_CATEGORIES];
 
 // ── Metadata tooltip ──────────────────────────────────────────────────────────
 
@@ -132,9 +104,7 @@ function TodoMetadataTooltip({
     : null;
 
   const isAssistantWorkInProgress =
-    todo.category === "to_do" &&
-    !!todo.conversationId &&
-    todo.status !== "done";
+    !!todo.conversationId && todo.status !== "done";
 
   const label = (
     <div className="flex flex-col gap-1">
@@ -293,35 +263,6 @@ function TodoSources({
   );
 }
 
-function CategorySectionHeader({ config }: { config: CategoryConfig }) {
-  return (
-    <div className="flex items-center gap-3 pt-2">
-      <div className="flex h-4 w-4 items-center">
-        <Icon visual={config.icon} size="xs" className={config.iconClassName} />
-      </div>
-      <h4 className="heading-lg text-foreground dark:text-foreground-night">
-        {config.label}
-      </h4>
-    </div>
-  );
-}
-
-function groupTodosByCategory(todos: ProjectTodoType[]) {
-  const todosByCategory = todos.reduce<
-    Partial<Record<ProjectTodoCategory, ProjectTodoType[]>>
-  >((acc, todo) => {
-    const cat = todo.category;
-    const existing = acc[cat] ?? [];
-    return { ...acc, [cat]: [...existing, todo] };
-  }, {});
-
-  const activeSections = ORDERED_CATEGORIES.filter(
-    (cat) => (todosByCategory[cat]?.length ?? 0) > 0
-  );
-
-  return { todosByCategory, activeSections };
-}
-
 // ── Collapsible wrapper ──────────────────────────────────────────────────────
 
 const COLLAPSED_MAX_HEIGHT_PX = 260;
@@ -430,12 +371,11 @@ function ReadOnlyProjectTodosPanel({
 }) {
   const { todos, isTodosLoading } = useProjectTodos({ owner, spaceId });
   const agentNameById = useAgentNameById(owner);
-  const { todosByCategory, activeSections } = groupTodosByCategory(todos);
 
   return (
     <div className="flex flex-col gap-3">
       <h3 className="heading-2xl text-foreground dark:text-foreground-night">
-        What's new?
+        To-dos
       </h3>
       {isTodosLoading ? (
         <div className="flex justify-center py-4">
@@ -443,28 +383,17 @@ function ReadOnlyProjectTodosPanel({
         </div>
       ) : (
         <CollapsibleTodoList>
-          {activeSections.map((cat) => {
-            const config = CATEGORY_CONFIG[cat];
-            const items = todosByCategory[cat] ?? [];
-
-            return (
-              <div key={cat} className="flex flex-col gap-1">
-                <CategorySectionHeader config={config} />
-                <div className="flex flex-col">
-                  {items.map((todo) => (
-                    <ReadOnlyTodoItem
-                      key={todo.sId}
-                      todo={todo}
-                      owner={owner}
-                      agentNameById={agentNameById}
-                    />
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-
-          {activeSections.length === 0 && (
+          <div className="flex flex-col">
+            {todos.map((todo) => (
+              <ReadOnlyTodoItem
+                key={todo.sId}
+                todo={todo}
+                owner={owner}
+                agentNameById={agentNameById}
+              />
+            ))}
+          </div>
+          {todos.length === 0 && (
             <p className="text-base italic text-faint dark:text-faint-night">
               You're all caught up!
             </p>
@@ -508,8 +437,7 @@ function EditableTodoItem({
 }: EditableTodoItemProps) {
   const router = useAppRouter();
   const isDone = todo.status === "done";
-  const showInProgressTextAnimation =
-    todo.category === "to_do" && !!todo.conversationId && !isDone;
+  const showInProgressTextAnimation = !!todo.conversationId && !isDone;
   const [isFlashing, setIsFlashing] = useState(isNewlyDone);
 
   useEffect(() => {
@@ -572,33 +500,32 @@ function EditableTodoItem({
         </button>
       </TodoMetadataTooltip>
       <div className="mt-0.5 flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover/todo:opacity-100">
-        {todo.category === "to_do" &&
-          (todo.conversationId ? (
-            <IconButton
-              icon={ChatBubbleLeftRightIcon}
-              size="xs"
-              variant="ghost"
-              className="!text-muted-foreground hover:!text-foreground"
-              tooltip={"Open todo conversation"}
-              onClick={() => {
-                void router.push(
-                  getConversationRoute(owner.sId, todo.conversationId),
-                  undefined,
-                  { shallow: true }
-                );
-              }}
-            />
-          ) : (
-            <IconButton
-              icon={PlayIcon}
-              size="xs"
-              variant="ghost"
-              className="!text-muted-foreground hover:!text-foreground"
-              tooltip="Start working on todo"
-              disabled={isStarting}
-              onClick={() => onStartWorking(todo)}
-            />
-          ))}
+        {todo.conversationId ? (
+          <IconButton
+            icon={ChatBubbleLeftRightIcon}
+            size="xs"
+            variant="ghost"
+            className="!text-muted-foreground hover:!text-foreground"
+            tooltip={"Open todo conversation"}
+            onClick={() => {
+              void router.push(
+                getConversationRoute(owner.sId, todo.conversationId),
+                undefined,
+                { shallow: true }
+              );
+            }}
+          />
+        ) : (
+          <IconButton
+            icon={PlayIcon}
+            size="xs"
+            variant="ghost"
+            className="!text-muted-foreground hover:!text-foreground"
+            tooltip="Start working on todo"
+            disabled={isStarting}
+            onClick={() => onStartWorking(todo)}
+          />
+        )}
         <IconButton
           icon={TrashIcon}
           size="xs"
@@ -762,8 +689,6 @@ function EditableProjectTodosPanel({
 
   const hasDoneItems = todos.some((t) => t.status === "done");
 
-  const { todosByCategory, activeSections } = groupTodosByCategory(todos);
-
   // Optimistically update a todo's status in the SWR cache and send the PATCH.
   // On failure the cache is revalidated from the server.
   const handleSetStatus = useCallback(
@@ -799,10 +724,9 @@ function EditableProjectTodosPanel({
 
   // Bulk set the status of every todo in a category in a single request.
   // Optimistically updates the SWR cache, then revalidates on failure.
-  const handleSetStatusForSection = useCallback(
-    async (category: ProjectTodoCategory, status: ProjectTodoStatus) => {
-      const sectionTodos = todosByCategory[category] ?? [];
-      const targetIds = sectionTodos
+  const _handleSetStatusForSection = useCallback(
+    async (status: ProjectTodoStatus) => {
+      const targetIds = todos
         .filter((t) => t.status !== status)
         .map((t) => t.sId);
 
@@ -825,7 +749,7 @@ function EditableProjectTodosPanel({
         void mutateTodos();
       }
     },
-    [doBulkUpdateStatus, mutateTodos, todosByCategory]
+    [doBulkUpdateStatus, mutateTodos, todos]
   );
 
   const handleClean = useCallback(async () => {
@@ -908,7 +832,7 @@ function EditableProjectTodosPanel({
       {/* Header */}
       <div className="inline-flex items-center gap-2">
         <h3 className="heading-2xl text-foreground dark:text-foreground-night">
-          What's new?
+          To-dos
         </h3>
         <div className="flex-1" />
         {hasDoneItems && (
@@ -931,73 +855,31 @@ function EditableProjectTodosPanel({
         </div>
       ) : (
         <CollapsibleTodoList>
-          {/* Per-category sections */}
-          {activeSections.map((cat) => {
-            const config = CATEGORY_CONFIG[cat];
-            const items = todosByCategory[cat] ?? [];
-            const allDone =
-              items.length > 0 && items.every((t) => t.status === "done");
-
-            return (
-              <div key={cat} className="flex flex-col gap-1">
-                {/* Section header: icon by default, checkbox on hover */}
-                <div className="group/section-title flex items-center gap-3 pt-2">
-                  <div className="flex h-4 w-4 items-center">
-                    <Icon
-                      visual={config.icon}
-                      size="xs"
-                      className={cn(
-                        "group-hover/section-title:hidden",
-                        config.iconClassName
-                      )}
-                    />
-                    <Checkbox
-                      size="xs"
-                      className="hidden group-hover/section-title:inline-block"
-                      checked={allDone}
-                      onCheckedChange={(checked) => {
-                        if (checked === true) {
-                          void handleSetStatusForSection(cat, "done");
-                        } else if (checked === false) {
-                          void handleSetStatusForSection(cat, "todo");
-                        }
-                      }}
-                    />
-                  </div>
-                  <h4 className="heading-lg text-foreground dark:text-foreground-night">
-                    {config.label}
-                  </h4>
-                </div>
-
-                {/* Todo items */}
-                <div className="flex flex-col">
-                  {items.map((todo) => (
-                    <EditableTodoItem
-                      key={todo.sId}
-                      todo={todo}
-                      onToggleDone={handleToggleDone}
-                      onDelete={handleDelete}
-                      onStartWorking={handleStartWorking}
-                      owner={owner}
-                      agentNameById={agentNameById}
-                      isExiting={pendingRemovalIds.has(todo.sId)}
-                      isAdded={
-                        diffKeys.added.has(todo.sId) &&
-                        !enteredKeys.has(todo.sId)
-                      }
-                      isEntering={enteringKeys.has(todo.sId)}
-                      isTyping={typingKeys.has(todo.sId)}
-                      isNewlyDone={doneFlashKeys.has(todo.sId)}
-                      isStarting={startingTodoIds.has(todo.sId)}
-                    />
-                  ))}
-                </div>
-              </div>
-            );
-          })}
+          {/* Todo items */}
+          <div className="flex flex-col">
+            {todos.map((todo) => (
+              <EditableTodoItem
+                key={todo.sId}
+                todo={todo}
+                onToggleDone={handleToggleDone}
+                onDelete={handleDelete}
+                onStartWorking={handleStartWorking}
+                owner={owner}
+                agentNameById={agentNameById}
+                isExiting={pendingRemovalIds.has(todo.sId)}
+                isAdded={
+                  diffKeys.added.has(todo.sId) && !enteredKeys.has(todo.sId)
+                }
+                isEntering={enteringKeys.has(todo.sId)}
+                isTyping={typingKeys.has(todo.sId)}
+                isNewlyDone={doneFlashKeys.has(todo.sId)}
+                isStarting={startingTodoIds.has(todo.sId)}
+              />
+            ))}
+          </div>
 
           {/* Empty state */}
-          {activeSections.length === 0 && (
+          {todos.length === 0 && (
             <p className="text-base italic text-faint dark:text-faint-night">
               You're all caught up!
             </p>

--- a/front/lib/api/actions/servers/project_todos/metadata.ts
+++ b/front/lib/api/actions/servers/project_todos/metadata.ts
@@ -1,7 +1,6 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { PROJECT_TODO_CATEGORIES } from "@app/types/project_todo";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
@@ -30,10 +29,6 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
         .describe(
           "When status is 'done' or 'all', limit completed TODOs to this many days back. Defaults to 7."
         ),
-      category: z
-        .enum(PROJECT_TODO_CATEGORIES)
-        .optional()
-        .describe("Filter by category."),
       dustProject: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
       ]
@@ -57,14 +52,6 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
           "Who has the initiative of creating the TODO ? Use 'user' when the user explicitely asked for it."
         ),
       text: z.string().min(1).describe("The TODO description."),
-      category: z
-        .enum(PROJECT_TODO_CATEGORIES)
-        .optional()
-        .describe(
-          "Category. Defaults to 'to_do'. " +
-            "to_do: action items and follow-ups; " +
-            "to_know: key decisions, notable updates, and things to remember."
-        ),
       dustProject: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
       ]
@@ -93,10 +80,6 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
         .array(
           z.object({
             text: z.string().min(1).describe("The TODO description."),
-            category: z
-              .enum(PROJECT_TODO_CATEGORIES)
-              .optional()
-              .describe("Category. Defaults to 'to_do'."),
           })
         )
         .min(1)

--- a/front/lib/api/actions/servers/project_todos/tools/index.ts
+++ b/front/lib/api/actions/servers/project_todos/tools/index.ts
@@ -18,7 +18,6 @@ import { startAgentForProjectTodo } from "@app/lib/project_todo/start_agent";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { ProjectTodoCategory } from "@app/types/project_todo";
 import { Err, Ok } from "@app/types/shared/result";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -68,12 +67,7 @@ export function createProjectTodosTools(
 ): ToolDefinition[] {
   const owner = auth.getNonNullableWorkspace();
   const handlers: ToolHandlers<typeof PROJECT_TODOS_TOOLS_METADATA> = {
-    list_todos: async ({
-      status = "open",
-      daysAgo = 7,
-      category,
-      dustProject,
-    }) => {
+    list_todos: async ({ status = "open", daysAgo = 7, dustProject }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -105,10 +99,6 @@ export function createProjectTodosTools(
           );
         }
 
-        if (category) {
-          todos = todos.filter((t) => t.category === category);
-        }
-
         if (todos.length === 0) {
           return new Ok([{ type: "text" as const, text: "No TODOs found." }]);
         }
@@ -125,33 +115,21 @@ export function createProjectTodosTools(
           }
           return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
         }
-
-        // "open" or "all": group by category.
-        const grouped = new Map<ProjectTodoCategory, ProjectTodoResource[]>();
-        for (const todo of todos) {
-          const list = grouped.get(todo.category) ?? [];
-          list.push(todo);
-          grouped.set(todo.category, list);
-        }
-
         const label =
           status === "open"
             ? `Found ${todos.length} open TODO(s):\n`
             : `Found ${todos.length} TODO(s):\n`;
+
         const lines: string[] = [label];
-        for (const [cat, items] of grouped) {
-          lines.push(`### ${cat}`);
-          for (const todo of items) {
-            lines.push(formatTodo(todo));
-          }
-          lines.push("");
+        for (const todo of todos) {
+          lines.push(formatTodo(todo));
         }
 
         return new Ok([{ type: "text" as const, text: lines.join("\n") }]);
       }, "Failed to list TODOs");
     },
 
-    create_todo: async ({ creatorType, text, category, dustProject }) => {
+    create_todo: async ({ creatorType, text, dustProject }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -173,7 +151,6 @@ export function createProjectTodosTools(
               ? (agentLoopContext?.runContext?.agentConfiguration?.sId ?? null)
               : null,
           createdByUserId: creatorType === "user" ? currentUser.id : null,
-          category: category ?? "to_do",
           text,
           status: "todo",
           doneAt: null,
@@ -213,7 +190,6 @@ export function createProjectTodosTools(
             createdByAgentConfigurationId:
               creatorType === "agent" ? agentConfigId : null,
             createdByUserId: creatorType === "user" ? currentUser.id : null,
-            category: item.category ?? "to_do",
             text: item.text,
             status: "todo",
             doneAt: null,

--- a/front/lib/project_todo/deduplicate_candidates.test.ts
+++ b/front/lib/project_todo/deduplicate_candidates.test.ts
@@ -22,7 +22,6 @@ function makeCandidate(
   return {
     userId: 1 as ModelId,
     text: "Write the report",
-    category: "to_do",
     ...overrides,
   };
 }

--- a/front/lib/project_todo/deduplicate_candidates.ts
+++ b/front/lib/project_todo/deduplicate_candidates.ts
@@ -37,7 +37,6 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
-import type { ProjectTodoCategory } from "@app/types/project_todo";
 import type { ModelId } from "@app/types/shared/model_id";
 import { startActiveObservation } from "@langfuse/tracing";
 import { z } from "zod";
@@ -48,7 +47,6 @@ export type DeduplicateCandidate = {
   itemId: string;
   userId: ModelId;
   text: string;
-  category: ProjectTodoCategory;
 };
 
 // One todo that Phase 3 will touch. A group's candidates all share the same
@@ -68,11 +66,8 @@ export type DeduplicatedGroup =
     };
 
 // Nested map shape for existing todos passed in by the caller:
-// userId → category → todos.
-export type ExistingTodosByGroup = Map<
-  ModelId,
-  Map<ProjectTodoCategory, ProjectTodoResource[]>
->;
+// userId → todos.
+export type ExistingTodosByUser = Map<ModelId, ProjectTodoResource[]>;
 
 // ── LLM tool ─────────────────────────────────────────────────────────────────
 
@@ -112,12 +107,9 @@ function buildDeduplicationSpec(): AgentActionSpecification {
 // partitions groups back into (existing, candidates) by index in
 // resolveDeduplicationGroups.
 function buildDeduplicationPrompt(
-  category: ProjectTodoCategory,
   existingTodos: ProjectTodoResource[],
   candidates: DeduplicateCandidate[]
 ): string {
-  const categoryLabel = category.replace(/_/g, " ");
-
   const lines: string[] = [];
   let i = 0;
   for (const t of existingTodos) {
@@ -130,7 +122,7 @@ function buildDeduplicationPrompt(
   }
 
   return [
-    `Group TODO items for category "${categoryLabel}" that describe the same underlying task.`,
+    `Group TODO items that describe the same underlying task.`,
     "",
     "Two items are duplicates only if completing one would make the other",
     "redundant. If both could independently appear on a task list without",
@@ -172,8 +164,7 @@ export async function runDeduplicationLLMCall(
   }
 ): Promise<number[][]> {
   const owner = auth.getNonNullableWorkspace();
-  const category = candidates[0].category;
-  const prompt = buildDeduplicationPrompt(category, existingTodos, candidates);
+  const prompt = buildDeduplicationPrompt(existingTodos, candidates);
   const specification = buildDeduplicationSpec();
 
   const conv: ModelConversationTypeMultiActions = {
@@ -332,62 +323,53 @@ export async function batchDeduplicateCandidates(
   {
     model,
     candidates,
-    existingTodosByGroup,
+    existingTodosByUser,
   }: {
     model: ModelConfigurationType;
     candidates: DeduplicateCandidate[];
-    existingTodosByGroup: ExistingTodosByGroup;
+    existingTodosByUser: ExistingTodosByUser;
   }
 ): Promise<DeduplicatedGroup[]> {
   const results: DeduplicatedGroup[] = [];
 
-  // Group candidates by userId → category → candidates.
-  const candidatesByGroup = new Map<
-    ModelId,
-    Map<ProjectTodoCategory, DeduplicateCandidate[]>
-  >();
+  // Group candidates by userId → candidates.
+  const candidatesByUserId = new Map<ModelId, DeduplicateCandidate[]>();
   for (const candidate of candidates) {
-    const byCategory =
-      candidatesByGroup.get(candidate.userId) ??
-      new Map<ProjectTodoCategory, DeduplicateCandidate[]>();
-    const bucket = byCategory.get(candidate.category) ?? [];
+    const bucket = candidatesByUserId.get(candidate.userId) ?? [];
+
     bucket.push(candidate);
-    byCategory.set(candidate.category, bucket);
-    candidatesByGroup.set(candidate.userId, byCategory);
+    candidatesByUserId.set(candidate.userId, bucket);
   }
 
   // Flatten to a list of (candidates, existingTodos) jobs so the executor
   // can schedule them at a fixed parallelism.
   const jobs: Array<{
-    groupCandidates: DeduplicateCandidate[];
+    candidates: DeduplicateCandidate[];
     existingTodos: ProjectTodoResource[];
   }> = [];
-  for (const [userId, byCategory] of candidatesByGroup) {
-    const existingByCategory = existingTodosByGroup.get(userId);
-    for (const [category, groupCandidates] of byCategory) {
-      const existingTodos = existingByCategory?.get(category) ?? [];
-      jobs.push({ groupCandidates, existingTodos });
-    }
+  for (const [userId, candidates] of candidatesByUserId) {
+    const existingTodos = existingTodosByUser.get(userId) ?? [];
+    jobs.push({ candidates, existingTodos });
   }
 
   await concurrentExecutor(
     jobs,
-    async ({ groupCandidates, existingTodos }) => {
+    async ({ candidates, existingTodos }) => {
       // Fast path: one candidate, no existing. No LLM call needed; emit a
       // singleton "new" group directly.
-      if (existingTodos.length === 0 && groupCandidates.length <= 1) {
-        results.push({ kind: "new", candidates: groupCandidates });
+      if (existingTodos.length === 0 && candidates.length <= 1) {
+        results.push({ kind: "new", candidates });
         return;
       }
 
       const llmGroups = await runDeduplicationLLMCall(auth, {
         model,
-        candidates: groupCandidates,
+        candidates,
         existingTodos,
       });
 
       results.push(
-        ...resolveDeduplicationGroups(groupCandidates, existingTodos, llmGroups)
+        ...resolveDeduplicationGroups(candidates, existingTodos, llmGroups)
       );
     },
     { concurrency: 4 }

--- a/front/lib/project_todo/merge_into_project.test.ts
+++ b/front/lib/project_todo/merge_into_project.test.ts
@@ -1,21 +1,14 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
   actionItemBlob,
-  keyDecisionBlob,
-  notableFactBlob,
   updateTodoIfChanged,
 } from "@app/lib/project_todo/merge_into_project";
 import type { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import type {
   ProjectTodoActorType,
-  ProjectTodoCategory,
   ProjectTodoStatus,
 } from "@app/types/project_todo";
-import type {
-  TodoVersionedActionItem,
-  TodoVersionedKeyDecision,
-  TodoVersionedNotableFact,
-} from "@app/types/takeaways";
+import type { TodoVersionedActionItem } from "@app/types/takeaways";
 import { describe, expect, it, vi } from "vitest";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -35,37 +28,9 @@ function makeActionItem(
   };
 }
 
-function makeKeyDecision(
-  overrides: Partial<TodoVersionedKeyDecision> = {}
-): TodoVersionedKeyDecision {
-  return {
-    sId: "decision-1",
-    shortDescription: "Use PostgreSQL",
-    relevantUserIds: [],
-    status: "decided",
-    ...overrides,
-  };
-}
-
-function makeNotableFact(
-  overrides: Partial<TodoVersionedNotableFact> = {}
-): TodoVersionedNotableFact {
-  return {
-    sId: "fact-1",
-    shortDescription: "Budget capped at €50k",
-    relevantUserIds: [],
-    ...overrides,
-  };
-}
-
 // ── actionItemBlob ────────────────────────────────────────────────────────────
 
 describe("actionItemBlob", () => {
-  it("maps to to_do category", () => {
-    const blob = actionItemBlob(makeActionItem());
-    expect(blob.category).toBe("to_do");
-  });
-
   it("maps open status to todo", () => {
     const blob = actionItemBlob(makeActionItem({ status: "open" }));
     expect(blob.status).toBe("todo");
@@ -97,63 +62,6 @@ describe("actionItemBlob", () => {
   });
 });
 
-// ── keyDecisionBlob ───────────────────────────────────────────────────────────
-
-describe("keyDecisionBlob", () => {
-  it("maps to to_know category", () => {
-    const blob = keyDecisionBlob(makeKeyDecision());
-    expect(blob.category).toBe("to_know");
-  });
-
-  it("maps decided status to done", () => {
-    const blob = keyDecisionBlob(makeKeyDecision({ status: "decided" }));
-    expect(blob.status).toBe("todo");
-  });
-
-  it("maps open status to todo", () => {
-    const blob = keyDecisionBlob(makeKeyDecision({ status: "open" }));
-    expect(blob.status).toBe("todo");
-  });
-
-  it("always sets doneAt to null", () => {
-    const blob = keyDecisionBlob(makeKeyDecision({ status: "decided" }));
-    expect(blob.doneAt).toBeNull();
-  });
-
-  it("preserves text", () => {
-    const blob = keyDecisionBlob(
-      makeKeyDecision({ shortDescription: "Go monorepo" })
-    );
-    expect(blob.text).toBe("Go monorepo");
-  });
-});
-
-// ── notableFactBlob ───────────────────────────────────────────────────────────
-
-describe("notableFactBlob", () => {
-  it("maps to to_know category", () => {
-    const blob = notableFactBlob(makeNotableFact());
-    expect(blob.category).toBe("to_know");
-  });
-
-  it("always sets status to todo", () => {
-    const blob = notableFactBlob(makeNotableFact());
-    expect(blob.status).toBe("todo");
-  });
-
-  it("always sets doneAt to null", () => {
-    const blob = notableFactBlob(makeNotableFact());
-    expect(blob.doneAt).toBeNull();
-  });
-
-  it("preserves shortDescription", () => {
-    const blob = notableFactBlob(
-      makeNotableFact({ shortDescription: "Team is 12 people" })
-    );
-    expect(blob.text).toBe("Team is 12 people");
-  });
-});
-
 // ── updateTodoIfChanged ───────────────────────────────────────────────────────
 
 type TodoStub = {
@@ -179,14 +87,12 @@ function makeTodoStub(overrides: Partial<TodoStub> = {}): TodoStub {
 
 function makeBlob(
   overrides: Partial<{
-    category: ProjectTodoCategory;
     text: string;
     status: "todo" | "done";
     doneAt: Date | null;
   }> = {}
 ) {
   return {
-    category: "to_do" as ProjectTodoCategory,
     text: "Write the report",
     status: "todo" as const,
     doneAt: null,

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -38,7 +38,7 @@ import {
   batchDeduplicateCandidates,
   type DeduplicateCandidate,
   type DeduplicatedGroup,
-  type ExistingTodosByGroup,
+  type ExistingTodosByUser,
 } from "@app/lib/project_todo/deduplicate_candidates";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
@@ -48,16 +48,9 @@ import {
 } from "@app/lib/resources/takeaways_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type {
-  ProjectTodoCategory,
-  ProjectTodoSourceInfo,
-} from "@app/types/project_todo";
+import type { ProjectTodoSourceInfo } from "@app/types/project_todo";
 import type { ModelId } from "@app/types/shared/model_id";
-import type {
-  TodoVersionedActionItem,
-  TodoVersionedKeyDecision,
-  TodoVersionedNotableFact,
-} from "@app/types/takeaways";
+import type { TodoVersionedActionItem } from "@app/types/takeaways";
 import type { Logger } from "pino";
 
 // Stable identifier used when recording the creating actor for butler-created
@@ -68,7 +61,6 @@ const BUTLER_AGENT_SID = "butler";
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 type TodoBlob = {
-  category: "to_do" | "to_know";
   text: string;
   status: "todo" | "done";
   doneAt: Date | null;
@@ -144,16 +136,6 @@ export async function mergeTakeawaysIntoProject({
     for (const item of takeaway.actionItems) {
       if (item.assigneeUserId) {
         allUserIds.add(item.assigneeUserId);
-      }
-    }
-    for (const item of takeaway.keyDecisions) {
-      for (const userId of item.relevantUserIds) {
-        allUserIds.add(userId);
-      }
-    }
-    for (const item of takeaway.notableFacts) {
-      for (const userId of item.relevantUserIds) {
-        allUserIds.add(userId);
       }
     }
   }
@@ -267,16 +249,6 @@ async function collectDocumentCandidates(
       ),
       blob: actionItemBlob(item),
     })),
-    ...takeawayWithSource.takeaway.keyDecisions.map((item) => ({
-      itemId: item.sId,
-      targetUserIds: resolveTargetUserIds(item.relevantUserIds),
-      blob: keyDecisionBlob(item),
-    })),
-    ...takeawayWithSource.takeaway.notableFacts.map((item) => ({
-      itemId: item.sId,
-      targetUserIds: resolveTargetUserIds(item.relevantUserIds),
-      blob: notableFactBlob(item),
-    })),
   ];
 
   // Batch-fetch existing todos by itemId. The result map is keyed by
@@ -334,7 +306,6 @@ async function buildDeduplicationGroups(
       itemId: c.itemId,
       userId: c.userId,
       text: c.blob.text,
-      category: c.blob.category,
     })
   );
 
@@ -350,7 +321,7 @@ async function buildDeduplicationGroups(
   // then nest them under userId → category → todos for lookup by the LLM
   // calls.
   const uniqueUserIds = [...new Set(newCandidates.map((c) => c.userId))];
-  const existingTodosByGroup: ExistingTodosByGroup = new Map();
+  const existingTodosByUser: ExistingTodosByUser = new Map();
 
   await concurrentExecutor(
     uniqueUserIds,
@@ -359,15 +330,11 @@ async function buildDeduplicationGroups(
         spaceId: spaceModelId,
         userId,
       });
-      const byCategory =
-        existingTodosByGroup.get(userId) ??
-        new Map<ProjectTodoCategory, ProjectTodoResource[]>();
       for (const todo of todos) {
-        const bucket = byCategory.get(todo.category) ?? [];
+        const bucket = existingTodosByUser.get(todo.userId) ?? [];
         bucket.push(todo);
-        byCategory.set(todo.category, bucket);
+        existingTodosByUser.set(todo.userId, bucket);
       }
-      existingTodosByGroup.set(userId, byCategory);
     },
     { concurrency: 4 }
   );
@@ -375,7 +342,7 @@ async function buildDeduplicationGroups(
   return batchDeduplicateCandidates(auth, {
     model,
     candidates: deduplicateCandidates,
-    existingTodosByGroup,
+    existingTodosByUser,
   });
 }
 
@@ -464,7 +431,6 @@ async function createOrLinkTodos(
           createdByType: "agent",
           createdByUserId: null,
           createdByAgentConfigurationId: BUTLER_AGENT_SID,
-          category: primary.blob.category,
           text: primary.blob.text,
           status: primary.blob.status,
           doneAt: primary.blob.doneAt,
@@ -556,28 +522,9 @@ export async function updateTodoIfChanged(
 export function actionItemBlob(item: TodoVersionedActionItem): TodoBlob {
   const isDone = item.status === "done";
   return {
-    category: "to_do",
     text: item.shortDescription,
     status: isDone ? "done" : "todo",
     doneAt:
       isDone && item.detectedDoneAt ? new Date(item.detectedDoneAt) : null,
-  };
-}
-
-export function keyDecisionBlob(item: TodoVersionedKeyDecision): TodoBlob {
-  return {
-    category: "to_know",
-    text: item.shortDescription,
-    status: "todo",
-    doneAt: null,
-  };
-}
-
-export function notableFactBlob(item: TodoVersionedNotableFact): TodoBlob {
-  return {
-    category: "to_know",
-    text: item.shortDescription,
-    status: "todo",
-    doneAt: null,
   };
 }

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -122,7 +122,7 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
   }
 
   async updateLastTodoAnalysisAt(
-    lastTodoAnalysisAt: Date,
+    lastTodoAnalysisAt: Date | null,
     transaction?: Transaction
   ) {
     await this.update({ lastTodoAnalysisAt }, transaction);

--- a/front/lib/resources/project_todo_resource.test.ts
+++ b/front/lib/resources/project_todo_resource.test.ts
@@ -88,7 +88,6 @@ describe("ProjectTodoResource", () => {
         markedAsDoneByType: null,
         markedAsDoneByUserId: null,
         markedAsDoneByAgentConfigurationId: null,
-        category: "to_do",
         text: "Agent-created todo",
         status: "todo",
         doneAt: null,

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -72,7 +72,10 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
   static async makeNew(
     auth: Authenticator,
-    blob: Omit<CreationAttributes<ProjectTodoModel>, "workspaceId">,
+    blob: Omit<
+      CreationAttributes<ProjectTodoModel>,
+      "workspaceId" | "category"
+    >,
     transaction?: Transaction
   ): Promise<ProjectTodoResource> {
     return withTransaction(async (t) => {
@@ -80,6 +83,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
         {
           ...blob,
           workspaceId: auth.getNonNullableWorkspace().id,
+          category: "to_do",
         },
         { transaction: t }
       );
@@ -473,7 +477,10 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       itemId,
       source,
     }: {
-      blob: Omit<CreationAttributes<ProjectTodoModel>, "workspaceId">;
+      blob: Omit<
+        CreationAttributes<ProjectTodoModel>,
+        "workspaceId" | "category"
+      >;
       itemId: string;
       source: ProjectTodoSourceInfo;
     },
@@ -493,7 +500,6 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       id: this.id,
       sId: this.sId,
       conversationId: null,
-      category: this.category,
       text: this.text,
       status: this.status,
       doneAt: this.doneAt,

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -5,7 +5,6 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   ProjectTodoActorType,
-  ProjectTodoCategory,
   ProjectTodoSourceType,
   ProjectTodoStatus,
 } from "@app/types/project_todo";
@@ -127,7 +126,7 @@ export class ProjectTodoModel extends WorkspaceAwareModel<ProjectTodoModel> {
   declare markedAsDoneByUserId: ForeignKey<UserModel["id"]> | null;
   declare markedAsDoneByAgentConfigurationId: string | null;
 
-  declare category: ProjectTodoCategory;
+  declare category: "to_do";
   declare text: string;
   declare status: ProjectTodoStatus;
   declare doneAt: Date | null;

--- a/front/lib/resources/storage/models/takeaways.ts
+++ b/front/lib/resources/storage/models/takeaways.ts
@@ -2,11 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ProjectTodoSourceType } from "@app/types/project_todo";
-import type {
-  TodoVersionedActionItem,
-  TodoVersionedKeyDecision,
-  TodoVersionedNotableFact,
-} from "@app/types/takeaways";
+import type { TodoVersionedActionItem } from "@app/types/takeaways";
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
@@ -66,8 +62,8 @@ export class TakeawaysModel extends WorkspaceAwareModel<TakeawaysModel> {
 
   // Rolling state — full replacement on each butler run.
   declare actionItems: TodoVersionedActionItem[];
-  declare notableFacts: TodoVersionedNotableFact[];
-  declare keyDecisions: TodoVersionedKeyDecision[];
+  declare notableFacts: [];
+  declare keyDecisions: [];
 }
 
 TakeawaysModel.init(

--- a/front/lib/resources/takeaways_resource.test.ts
+++ b/front/lib/resources/takeaways_resource.test.ts
@@ -125,8 +125,6 @@ describe("TakeawaysResource", () => {
         conversationId,
         spaceId: space.sId,
         actionItems: [],
-        notableFacts: [],
-        keyDecisions: [],
       });
 
       expect(takeaway.sId).toMatch(/^tka_/);
@@ -149,16 +147,12 @@ describe("TakeawaysResource", () => {
         conversationId,
         spaceId: space.sId,
         actionItems: [],
-        notableFacts: [],
-        keyDecisions: [],
       });
 
       const second = await TakeawaysResource.makeNewForConversation(auth, {
         conversationId,
         spaceId: space.sId,
         actionItems: [actionItem],
-        keyDecisions: [],
-        notableFacts: [],
       });
 
       // Same stable identity — the main row was updated in place.
@@ -177,8 +171,6 @@ describe("TakeawaysResource", () => {
         conversationId,
         spaceId: space.sId,
         actionItems: [],
-        notableFacts: [],
-        keyDecisions: [],
       });
 
       const fetched = await TakeawaysResource.fetchLatestByConversationId(
@@ -205,8 +197,6 @@ describe("TakeawaysResource", () => {
         conversationId,
         spaceId: space.sId,
         actionItems: [],
-        notableFacts: [],
-        keyDecisions: [],
       });
 
       const otherSetup = await createResourceTest({ role: "user" });
@@ -227,8 +217,6 @@ describe("TakeawaysResource", () => {
         conversationId,
         spaceId: space.sId,
         actionItems: [],
-        notableFacts: [],
-        keyDecisions: [],
       });
 
       expect(takeaway).not.toBeNull();
@@ -260,8 +248,6 @@ describe("TakeawaysResource", () => {
         conversationId,
         spaceId: space.sId,
         actionItems: [],
-        notableFacts: [],
-        keyDecisions: [],
       });
 
       // Create a version snapshot.

--- a/front/lib/resources/takeaways_resource.ts
+++ b/front/lib/resources/takeaways_resource.ts
@@ -16,11 +16,7 @@ import type {
 } from "@app/types/project_todo";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Ok, type Result } from "@app/types/shared/result";
-import type {
-  TodoVersionedActionItem,
-  TodoVersionedKeyDecision,
-  TodoVersionedNotableFact,
-} from "@app/types/takeaways";
+import type { TodoVersionedActionItem } from "@app/types/takeaways";
 import type {
   Attributes,
   CreationAttributes,
@@ -464,14 +460,10 @@ export class TakeawaysResource extends BaseResource<TakeawaysModel> {
       conversationId,
       spaceId,
       actionItems,
-      notableFacts,
-      keyDecisions,
     }: {
       conversationId: string;
       spaceId: string;
       actionItems: TodoVersionedActionItem[];
-      notableFacts: TodoVersionedNotableFact[];
-      keyDecisions: TodoVersionedKeyDecision[];
     },
     transaction?: Transaction
   ): Promise<TakeawaysResource> {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
@@ -34,7 +34,6 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start", () =
     const project = await SpaceFactory.project(workspace, user.id);
     const todo = await ProjectTodoFactory.create(workspace, project, {
       userId: user.id,
-      category: "to_do",
       text: "Prepare launch checklist",
     });
 
@@ -49,29 +48,11 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start", () =
     expect(data.todo.conversationId).toBeTruthy();
   });
 
-  it("returns 400 when starting a non to_do todo", async () => {
-    const { user } = await setup();
-    const project = await SpaceFactory.project(workspace, user.id);
-    const todo = await ProjectTodoFactory.create(workspace, project, {
-      userId: user.id,
-      category: "to_know",
-    });
-
-    req.query.spaceId = project.sId;
-    req.query.todoId = todo.sId;
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(400);
-    expect(res._getJSONData().error.type).toBe("invalid_request_error");
-  });
-
   it("returns 405 for unsupported methods", async () => {
     const { user } = await setup("GET");
     const project = await SpaceFactory.project(workspace, user.id);
     const todo = await ProjectTodoFactory.create(workspace, project, {
       userId: user.id,
-      category: "to_do",
     });
 
     req.query.spaceId = project.sId;

--- a/front/scripts/clean_project_todos.ts
+++ b/front/scripts/clean_project_todos.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import {
@@ -118,6 +119,11 @@ makeScript(
     });
 
     await frontSequelize.transaction(async (transaction) => {
+      const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+      if (metadata) {
+        await metadata.updateLastTodoAnalysisAt(null, transaction);
+      }
+
       if (todoIds.length > 0) {
         const todoChildWhere = { workspaceId, projectTodoId: todoIds };
 

--- a/front/scripts/dev/seed_project_todos.ts
+++ b/front/scripts/dev/seed_project_todos.ts
@@ -130,7 +130,6 @@ makeScript(
         markedAsDoneByType: null,
         markedAsDoneByUserId: null,
         markedAsDoneByAgentConfigurationId: null,
-        category: "to_do",
         text: seed.text,
         status: "todo",
         doneAt: null,

--- a/front/tests/takeaway-evals/lib/types.ts
+++ b/front/tests/takeaway-evals/lib/types.ts
@@ -1,10 +1,6 @@
 import type { ExtractionResult } from "@app/lib/project_todo/analyze_document/types";
 import type { ProjectTodoSourceType } from "@app/types/project_todo";
-import type {
-  TodoVersionedActionItem,
-  TodoVersionedKeyDecision,
-  TodoVersionedNotableFact,
-} from "@app/types/takeaways";
+import type { TodoVersionedActionItem } from "@app/types/takeaways";
 
 // ── Mock data types ─────────────────────────────────────────────────────────
 
@@ -24,8 +20,6 @@ export interface MockDocument {
 
 export interface MockPreviousVersion {
   actionItems: TodoVersionedActionItem[];
-  notableFacts: TodoVersionedNotableFact[];
-  keyDecisions: TodoVersionedKeyDecision[];
 }
 
 // ── Assertions ──────────────────────────────────────────────────────────────

--- a/front/tests/takeaway-evals/test-suites/action-items.ts
+++ b/front/tests/takeaway-evals/test-suites/action-items.ts
@@ -133,8 +133,6 @@ Score 3 if only Alice's action item is extracted, agent responses correctly igno
             detectedDoneRationale: null,
           },
         ],
-        notableFacts: [],
-        keyDecisions: [],
       },
       expectedAssertions: [
         shouldExtractActionItem("migration", { status: "done" }),

--- a/front/tests/utils/ProjectTodoFactory.ts
+++ b/front/tests/utils/ProjectTodoFactory.ts
@@ -1,7 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import type { ProjectTodoCategory } from "@app/types/project_todo";
 import type { WorkspaceType } from "@app/types/user";
 
 export class ProjectTodoFactory {
@@ -10,7 +9,6 @@ export class ProjectTodoFactory {
     space: SpaceResource,
     params: {
       userId: number;
-      category?: ProjectTodoCategory;
       text?: string;
     }
   ): Promise<ProjectTodoResource> {
@@ -25,7 +23,6 @@ export class ProjectTodoFactory {
       markedAsDoneByType: null,
       markedAsDoneByUserId: null,
       markedAsDoneByAgentConfigurationId: null,
-      category: params.category ?? "to_do",
       text: params.text ?? "A test todo item.",
       status: "todo",
       doneAt: null,

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -1,9 +1,5 @@
 import type { ModelId } from "@app/types/shared/model_id";
 
-export const PROJECT_TODO_CATEGORIES = ["to_do", "to_know"] as const;
-
-export type ProjectTodoCategory = (typeof PROJECT_TODO_CATEGORIES)[number];
-
 export const PROJECT_TODO_STATUSES = ["todo", "in_progress", "done"] as const;
 
 export type ProjectTodoStatus = (typeof PROJECT_TODO_STATUSES)[number];
@@ -37,7 +33,6 @@ export type ProjectTodoType = {
   id: ModelId;
   sId: string;
   conversationId: string | null;
-  category: ProjectTodoCategory;
   text: string;
   status: ProjectTodoStatus;
   doneAt: Date | null;

--- a/front/types/takeaways.ts
+++ b/front/types/takeaways.ts
@@ -9,18 +9,3 @@ export type TodoVersionedActionItem = {
   detectedDoneAt: string | null;
   detectedDoneRationale: string | null;
 };
-
-export type TodoVersionedNotableFact = {
-  sId: string;
-  shortDescription: string;
-  relevantUserIds: string[];
-};
-
-export type TodoVersionedKeyDecisionStatus = "decided" | "open";
-
-export type TodoVersionedKeyDecision = {
-  sId: string;
-  shortDescription: string;
-  relevantUserIds: string[];
-  status: TodoVersionedKeyDecisionStatus;
-};


### PR DESCRIPTION
## Description

The `to_do` / `to_know` category split was adding UI and logic complexity. Everything is an action item now that key decisions and notable facts are gone (#24847).

- Remove `to_know` from `ProjectTodoCategory`, `PROJECT_TODO_CATEGORIES`, and all downstream references
- Remove `CATEGORY_CONFIG`, `ORDERED_CATEGORIES`, `CategorySectionHeader`, `groupTodosByCategory` from `ProjectTodosPanel`
- Flatten both `ReadOnlyProjectTodosPanel` and `EditableProjectTodosPanel` to a single list (no section headers)
- Rename panel heading "What's new?" → "To-dos"
- Remove `to_do` category guard from `showInProgressTextAnimation` and `isAssistantWorkInProgress` — conversation progress indicator now applies to all todos regardless of category
- Remove `SquareIcon` and `TriangleIcon` imports
- Update `project_todos` tool descriptions and `start` API endpoint to drop category restriction references

## Tests

Local

## Risk

Low — `to_know` todos in DB will no longer render (category no longer valid); existing data can be migrated or left to expire naturally

## Deploy Plan

Deploy `front`
