### PR TITLE
fix(input-bar): restore send-only disable for agent-switch block

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -495,6 +495,7 @@ export const InputBar = React.memo(function InputBar({
             disableAgentSelector={
               isBlockedByAgentSwitch || submitBlockMessage !== null
             }
+            disableInput={submitBlockMessage !== null}
             submitBlockMessage={submitBlockMessage ?? agentSwitchBlockMessage}
             onShake={handleShake}
           />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -125,6 +125,12 @@ export interface InputBarContainerProps {
   allAgents: LightAgentConfigurationType[];
   attachedNodes: DataSourceViewContentNode[];
   disableAgentSelector: boolean;
+  // When true, the editor is made non-editable and every picker (agent,
+  // tools, attachment, voice) is disabled. Reserved for states where the user
+  // cannot interact at all (e.g. non-owner viewing a conversation with an
+  // active wake-up, or compaction in progress). `submitBlockMessage` on its
+  // own only mutes the send button.
+  disableInput: boolean;
   submitBlockMessage: string | null;
   onShake: () => void;
   conversation?: ConversationWithoutContentType;
@@ -185,6 +191,7 @@ const InputBarContainer = ({
   saveDraft,
   user,
   disableAgentSelector,
+  disableInput,
   submitBlockMessage,
   onShake,
 }: InputBarContainerProps) => {
@@ -509,7 +516,7 @@ const InputBarContainer = ({
       selectedMCPServerViewIdsRef,
       selectedSkillIdsRef,
     },
-    placeholderOverride: submitBlockMessage,
+    placeholderOverride: disableInput ? submitBlockMessage : null,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";
       let inserted = false;
@@ -605,16 +612,18 @@ const InputBarContainer = ({
     },
   });
 
-  // Keep the editor non-editable while submission is blocked (e.g. a non-owner
-  // viewing a conversation with an active wake-up). The placeholder already
+  // Keep the editor non-editable while the input is fully disabled (e.g. a
+  // non-owner viewing a conversation with an active wake-up). The placeholder
   // reads the block reason via `placeholderOverride`; disabling editability
-  // prevents typing into the field.
+  // prevents typing. Note: this must not fire for send-button-only blocks
+  // (such as "another agent is answering"), otherwise the user loses the
+  // ability to steer while the other agent is still generating.
   useEffect(() => {
     if (!editor || editor.isDestroyed) {
       return;
     }
-    editor.setEditable(!isSubmitBlocked);
-  }, [editor, isSubmitBlocked]);
+    editor.setEditable(!disableInput);
+  }, [editor, disableInput]);
 
   // Ref to expose the current selectedSingleAgent to the editor update listener
   // without re-registering it on every selection change.
@@ -1105,7 +1114,7 @@ const InputBarContainer = ({
                     fileInputRef={fileInputRef}
                     fileUploaderService={fileUploaderService}
                     handleSingleAgentSelect={handleSingleAgentSelect}
-                    isInputDisabled={isSubmitBlocked}
+                    isInputDisabled={disableInput}
                     onMCPServerViewSelect={onMCPServerViewSelect}
                     onNodeSelect={onNodeSelect}
                     onNodeUnselect={onNodeUnselect}
@@ -1213,7 +1222,7 @@ const InputBarContainer = ({
                   externalOpen={showKnowledgePicker}
                   onExternalOpenChange={setShowKnowledgePicker}
                   anchorRef={plusButtonRef}
-                  disabled={isSubmitBlocked}
+                  disabled={disableInput}
                 />
               )}
             </>
@@ -1237,7 +1246,7 @@ const InputBarContainer = ({
                   onRecordStop={voiceTranscriberService.stopRecording}
                   size={buttonSize}
                   showStopLabel={!isMobile}
-                  disabled={isSubmitBlocked}
+                  disabled={disableInput}
                 />
               )}
           </div>


### PR DESCRIPTION
## Description

 PR #24667 routed submitBlockMessage into a full input bar disable (editor non-editable, every picker disabled, TipTap rebuilt on placeholder change). That was right for the wake-up viewer case but also caught  agentSwitchBlockMessage (another agent mid-answer with a different agent selected), which used to just mute the send button. Result: user couldn't type, switch agents, or use pickers while agent A was generating, and the editor rebuild wiped any typed @mention so the chip refreshed back to the former agent.

Fix splits the prop. submitBlockMessage keeps send-button-only semantics. New disableInput gates setEditable, picker disabled, and placeholderOverride. InputBar sets disableInput only for blocks coming from AgentInputBar (wake-up viewer, compaction), never from agentSwitchBlockMessage.


## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
