### PR TITLE
Pricing for short and long context messages

### DIFF
--- a/front/lib/api/assistant/token_pricing.test.ts
+++ b/front/lib/api/assistant/token_pricing.test.ts
@@ -1,0 +1,75 @@
+import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
+import { describe, expect, it } from "vitest";
+
+describe("computeTokensCostForUsageInMicroUsd - long context tiering", () => {
+  it("prices gpt-5.5 at short-context rates just below the threshold", () => {
+    const cost = computeTokensCostForUsageInMicroUsd({
+      modelId: "gpt-5.5",
+      promptTokens: 271_999,
+      completionTokens: 1_000,
+      cachedTokens: 0,
+    });
+
+    expect(cost).toBe(271_999 * 5 + 1_000 * 30);
+  });
+
+  it("switches gpt-5.5 to long-context rates at exactly the threshold", () => {
+    const cost = computeTokensCostForUsageInMicroUsd({
+      modelId: "gpt-5.5",
+      promptTokens: 272_000,
+      completionTokens: 1_000,
+      cachedTokens: 0,
+    });
+
+    // 272_000 * 10 + 1_000 * 45
+    expect(cost).toBe(272_000 * 10 + 1_000 * 45);
+  });
+
+  it("applies long-context cached-read rate above the threshold", () => {
+    const promptTokens = 300_000;
+    const cachedTokens = 100_000;
+    const completionTokens = 2_000;
+
+    const cost = computeTokensCostForUsageInMicroUsd({
+      modelId: "gpt-5.5",
+      promptTokens,
+      completionTokens,
+      cachedTokens,
+    });
+
+    // Base prompt at long input (10) + cached-read delta (1 - 10) + output (45).
+    const expected =
+      promptTokens * 10 + cachedTokens * (1 - 10) + completionTokens * 45;
+    expect(cost).toBe(expected);
+  });
+
+  it("prices gpt-5.4 using the correct tier on each side of the threshold", () => {
+    const below = computeTokensCostForUsageInMicroUsd({
+      modelId: "gpt-5.4",
+      promptTokens: 100_000,
+      completionTokens: 1_000,
+      cachedTokens: 0,
+    });
+    const above = computeTokensCostForUsageInMicroUsd({
+      modelId: "gpt-5.4",
+      promptTokens: 500_000,
+      completionTokens: 1_000,
+      cachedTokens: 0,
+    });
+
+    expect(below).toBe(100_000 * 2.5 + 1_000 * 15);
+    expect(above).toBe(500_000 * 5 + 1_000 * 22.5);
+  });
+
+  it("leaves models without long-context pricing unaffected at large prompt sizes", () => {
+    const cost = computeTokensCostForUsageInMicroUsd({
+      modelId: "gpt-4o",
+      promptTokens: 1_000_000,
+      completionTokens: 1_000,
+      cachedTokens: 0,
+    });
+
+    // gpt-4o has flat pricing: 2.5 / 10.
+    expect(cost).toBe(1_000_000 * 2.5 + 1_000 * 10);
+  });
+});

--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -5,13 +5,27 @@ import type {
 import type { ModelIdType } from "@app/types/assistant/models/types";
 
 // All pricing are in USD per million tokens (equivalent to micro-USD per token).
-type PricingEntry = {
+type TieredRates = {
   input: number;
   output: number;
   // Optional cached-token pricing.
   cache_creation_input_tokens?: number;
   cache_read_input_tokens?: number;
 };
+
+// Some providers charge a higher rate card once the prompt reaches a token
+// threshold (e.g. OpenAI gpt-5.x at 272k, Gemini 3 Pro at 200k). The higher
+// tier applies to the entire request when `promptTokens >= thresholdTokens`,
+// not just to the tokens above the threshold.
+type LongContextPricing = TieredRates & { thresholdTokens: number };
+
+type PricingEntry = TieredRates & {
+  longContext?: LongContextPricing;
+};
+
+// https://developers.openai.com/api/docs/pricing — gpt-5.x flagship models
+// switch to long-context pricing once the prompt exceeds 272k input tokens.
+const OPENAI_LONG_CONTEXT_THRESHOLD = 272_000;
 
 export const DUST_MARKUP_PERCENT = 30;
 
@@ -31,11 +45,23 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     input: 5.0,
     output: 30.0,
     cache_read_input_tokens: 0.5,
+    longContext: {
+      thresholdTokens: OPENAI_LONG_CONTEXT_THRESHOLD,
+      input: 10.0,
+      output: 45.0,
+      cache_read_input_tokens: 1.0,
+    },
   },
   "gpt-5.4": {
     input: 2.5,
     output: 15.0,
     cache_read_input_tokens: 0.25,
+    longContext: {
+      thresholdTokens: OPENAI_LONG_CONTEXT_THRESHOLD,
+      input: 5.0,
+      output: 22.5,
+      cache_read_input_tokens: 0.5,
+    },
   },
   "gpt-5.2": {
     input: 1.75,
@@ -553,16 +579,24 @@ export function computeTokensCostForUsageInMicroUsd({
 }): number {
   const pricing = MODEL_PRICING[modelId] ?? DEFAULT_PRICING;
 
+  // promptTokens is the total input tokens for the request (including cached
+  // reads, per the note above), which matches the quantity providers compare
+  // against their long-context threshold.
+  const rates: TieredRates =
+    pricing.longContext && promptTokens >= pricing.longContext.thresholdTokens
+      ? pricing.longContext
+      : pricing;
+
   const cachedReadTokens = cachedTokens ?? 0;
   const cacheWriteTokens = cacheCreationTokens ?? 0;
 
-  const cachedReadRate = pricing.cache_read_input_tokens ?? pricing.input;
-  const cacheWriteRate = pricing.cache_creation_input_tokens ?? pricing.input;
+  const cachedReadRate = rates.cache_read_input_tokens ?? rates.input;
+  const cacheWriteRate = rates.cache_creation_input_tokens ?? rates.input;
 
-  const basePromptCost = promptTokens * pricing.input;
-  const cachedReadDelta = cachedReadTokens * (cachedReadRate - pricing.input);
-  const cacheWriteDelta = cacheWriteTokens * (cacheWriteRate - pricing.input);
-  const outputCost = completionTokens * pricing.output;
+  const basePromptCost = promptTokens * rates.input;
+  const cachedReadDelta = cachedReadTokens * (cachedReadRate - rates.input);
+  const cacheWriteDelta = cacheWriteTokens * (cacheWriteRate - rates.input);
+  const outputCost = completionTokens * rates.output;
 
   const cost = basePromptCost + cachedReadDelta + cacheWriteDelta + outputCost;
 

--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -13,18 +13,16 @@ type TieredRates = {
   cache_read_input_tokens?: number;
 };
 
-// Some providers charge a higher rate card once the prompt reaches a token
-// threshold (e.g. OpenAI gpt-5.x at 272k, Gemini 3 Pro at 200k). The higher
-// tier applies to the entire request when `promptTokens >= thresholdTokens`,
-// not just to the tokens above the threshold.
+// Optional higher rate card applied to the entire request when
+// promptTokens >= thresholdTokens.
 type LongContextPricing = TieredRates & { thresholdTokens: number };
 
 type PricingEntry = TieredRates & {
   longContext?: LongContextPricing;
 };
 
-// https://developers.openai.com/api/docs/pricing — gpt-5.x flagship models
-// switch to long-context pricing once the prompt exceeds 272k input tokens.
+// https://developers.openai.com/api/docs/pricing — gpt-5.x uses long-context
+// pricing at >=272k input tokens.
 const OPENAI_LONG_CONTEXT_THRESHOLD = 272_000;
 
 export const DUST_MARKUP_PERCENT = 30;
@@ -579,9 +577,6 @@ export function computeTokensCostForUsageInMicroUsd({
 }): number {
   const pricing = MODEL_PRICING[modelId] ?? DEFAULT_PRICING;
 
-  // promptTokens is the total input tokens for the request (including cached
-  // reads, per the note above), which matches the quantity providers compare
-  // against their long-context threshold.
   const rates: TieredRates =
     pricing.longContext && promptTokens >= pricing.longContext.thresholdTokens
       ? pricing.longContext


### PR DESCRIPTION
## Description

Introduce long-context pricing support and implement it for OpenAI's gpt-5.5 and `gpt-5.4`, which switch to a higher rate at >=272k input tokens (see https://developers.openai.com/api/docs/pricing).

- Extend `PricingEntry` with an optional `longContext` block (thresholdTokens + its own input/output/cached rates). 
- `computeTokensCostForUsageInMicroUsd` picks the tier based on `promptTokens` before costs are computed; models without `longContext` are unaffected.
- Populate gpt-5.5 and gpt-5.4 with their published long-context rates.

## Tests

Added `front/lib/api/assistant/token_pricing.test.ts` covering: 
- boundary selection at 271,999 vs 272,000 for gpt-5.5
- long-context cached-read rate applied above the threshold 
- gpt-5.4 short vs long tiers on both sides
- flat-priced models (gpt-4o) unaffected at 1M tokens

## Risk

Low but rollback-safe.

## Deploy Plan

Standard