### PR TITLE
Fix: merge todos process model and tweak prompt for action items

### DIFF
--- a/front/lib/project_todo/analyze_document/action_items.ts
+++ b/front/lib/project_todo/analyze_document/action_items.ts
@@ -41,16 +41,16 @@ export function buildPromptActionItems(
     "Action item guidelines:\n" +
     "Most documents contain few or no action items. Prefer fewer, high-confidence items " +
     "over a noisy list. When in doubt, leave it out.\n\n" +
-    "Only extract an action item if it passes ALL four tests:\n" +
-    "1. **Commitment**: someone explicitly committed to doing a concrete task, or was " +
+    "Only extract an action item if it passes ALL criterias:\n" +
+    "1. **Humans**: ignore any action items that was assigned or completed by an agent, assistant or bot." +
+    "2. **Commitment**: someone explicitly committed to doing a concrete task, or was " +
     "clearly asked to do one. Only extract tasks with a clear deliverable — 'I'll fix X' " +
     "qualifies, 'I'll think about it' does not.\n" +
-    "2. **Durability**: the task is still relevant — if it was already resolved within " +
+    "3. **Durability**: the task is still relevant — if it was already resolved within " +
     "the same conversation, set status to 'done'; if the request was immediately " +
     "fulfilled inline (e.g., answering a question), do not extract it at all.\n" +
-    "3. **Distinctness**: it is not a duplicate of another action item or a rephrasing " +
-    "of a key decision.\n" +
-    "4. **Relevance**: the task is work-related and project-relevant. Purely social plans " +
+    "4. **Distinctness**: it is not a duplicate of another action item or a rephrasing " +
+    "5. **Relevance**: the task is work-related and project-relevant. Purely social plans " +
     "(birthday lunches, personal events, casual meetups) are not action items even if someone " +
     "commits to arranging them.\n\n" +
     "Formatting rules:\n" +

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -32,7 +32,7 @@
 //   keyDecisions (decided) → "to_know", status: "todo"
 //   notableFacts           → "to_know", status: "todo"
 
-import { getFastestWhitelistedModel } from "@app/lib/assistant";
+import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import {
   batchDeduplicateCandidates,
@@ -338,7 +338,7 @@ async function buildDeduplicationGroups(
     })
   );
 
-  const model = getFastestWhitelistedModel(auth);
+  const model = getSmallWhitelistedModel(auth);
   if (!model) {
     localLogger.warn(
       "Project todo merge: no whitelisted model, skipping deduplication"


### PR DESCRIPTION
## Description

Two small fixes to the todo extraction and merge pipeline.

- **Switch merge deduplication model from `getFastestWhitelistedModel` to `getSmallWhitelistedModel`** — consistent with the extractor (#24436);
- **Add "Humans" rule to the action items prompt** — agents, assistants, and bots frequently produce commitments in conversation transcripts (e.g. "I'll summarize this for you") that should never become action items. The new rule explicitly instructs the extractor to ignore any task assigned to or completed by a non-human actor

## Tests

Local

## Risk

Low — prompt addition is purely restrictive (fewer false positives); model swap is consistent with existing extractor behavior

## Deploy Plan

Deploy `front`
