### PR TITLE
Stop busting the Anthropic prompt cache with a timestamp in the tool manifest

### DIFF
--- a/front/lib/api/sandbox/image/tool_manifest.test.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.test.ts
@@ -14,13 +14,6 @@ describe("createToolManifest()", () => {
     expect(manifest.version).toBe("1.0");
   });
 
-  test("includes generatedAt timestamp", () => {
-    const manifest = createToolManifest([]);
-
-    expect(manifest.generatedAt).toBeDefined();
-    expect(() => new Date(manifest.generatedAt)).not.toThrow();
-  });
-
   test("groups tools by runtime", () => {
     const tools: ToolEntry[] = [
       { name: "curl", description: "HTTP client", runtime: "system" },
@@ -121,7 +114,6 @@ describe("toolManifestToJSON()", () => {
     const parsed = JSON.parse(jsonString);
 
     expect(parsed.version).toBe("1.0");
-    expect(parsed.generatedAt).toBeDefined();
     expect(parsed.tools.system).toHaveLength(1);
   });
 });

--- a/front/lib/api/sandbox/image/tool_manifest.ts
+++ b/front/lib/api/sandbox/image/tool_manifest.ts
@@ -36,7 +36,6 @@ export function createToolManifest(tools: readonly ToolEntry[]): ToolManifest {
 
   return {
     version: "1.0",
-    generatedAt: new Date().toISOString(),
     tools: filteredTools,
   };
 }

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -118,7 +118,6 @@ export interface ManifestToolEntry {
 
 export interface ToolManifest {
   readonly version: "1.0";
-  readonly generatedAt: string;
   readonly tools: Readonly<
     Partial<Record<ToolRuntime, readonly ManifestToolEntry[]>>
   >;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The tool manifest YAML (used for sandbox) gets injected directly into the system prompt.
The manifest included a `generatedAt` timestamp that changed on every single request, meaning we were guaranteed to get a cache miss every time. Completely defeating the purpose of caching.

This removes `generatedAt` from the manifest. It served no purpose for the model and was the only thing making the prompt non-deterministic across requests.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
