### PR TITLE
chore(core): scoping countpoints per datasource to shard key  

### DIFF
--- a/core/bin/qdrant/count_points_per_data_source.rs
+++ b/core/bin/qdrant/count_points_per_data_source.rs
@@ -1,18 +1,36 @@
 use anyhow::{anyhow, Result};
 use chrono::{Duration, Utc};
+use clap::Parser;
 use csv::Writer;
 use dust::{
     data_sources::{
         data_source::{DataSource, DataSourceConfig},
-        qdrant::QdrantClients,
+        qdrant::{DustQdrantClient, QdrantClients, SHARD_KEY_COUNT},
     },
     project::Project,
     stores::{postgres::PostgresStore, store::Store},
 };
 use std::env;
 
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Shard key id to scan (0..SHARD_KEY_COUNT). If provided, only data sources that
+    /// map to this shard key will be counted. If omitted, all data sources are counted.
+    #[arg(short, long)]
+    shard_key_id: Option<u64>,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    if let Some(shard_key_id) = args.shard_key_id {
+        if shard_key_id >= SHARD_KEY_COUNT {
+            return Err(anyhow!("shard_key_id must be in [0, {})", SHARD_KEY_COUNT));
+        }
+    }
+
     let store = PostgresStore::new(
         &env::var("CORE_DATABASE_URI").map_err(|_| anyhow!("CORE_DATABASE_URI is required"))?,
     )
@@ -35,10 +53,38 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    println!("Found {} data sources from the past 4 months", rows.len());
+    let filtered: Vec<_> = match args.shard_key_id {
+        Some(shard_key_id) => rows
+            .iter()
+            .filter(|row| {
+                let internal_id: String = row.get(2);
+                match DustQdrantClient::shard_key_id_from_internal_id(&internal_id) {
+                    Ok(key_id) => key_id == shard_key_id,
+                    Err(_) => false,
+                }
+            })
+            .collect(),
+        None => rows.iter().collect(),
+    };
 
-    let output_path = "data_sources_qdrant_counts.csv";
-    let mut wtr = Writer::from_path(output_path)?;
+    match args.shard_key_id {
+        Some(shard_key_id) => println!(
+            "Found {} data sources from the past 4 months on shard key {} (out of {} total)",
+            filtered.len(),
+            shard_key_id,
+            rows.len()
+        ),
+        None => println!(
+            "Found {} data sources from the past 4 months",
+            filtered.len()
+        ),
+    }
+
+    let output_path = match args.shard_key_id {
+        Some(shard_key_id) => format!("data_sources_qdrant_counts_shard_{}.csv", shard_key_id),
+        None => "data_sources_qdrant_counts.csv".to_string(),
+    };
+    let mut wtr = Writer::from_path(output_path.clone())?;
     wtr.write_record([
         "project_id",
         "data_source_id",
@@ -49,7 +95,7 @@ async fn main() -> Result<()> {
         "error",
     ])?;
 
-    for (i, row) in rows.iter().enumerate() {
+    for (i, row) in filtered.iter().enumerate() {
         let project_id: i64 = row.get(0);
         let data_source_id: String = row.get(1);
         let internal_id: String = row.get(2);
@@ -63,7 +109,7 @@ async fn main() -> Result<()> {
                 eprintln!(
                     "[{}/{}] failed to parse config for {}: {}",
                     i + 1,
-                    rows.len(),
+                    filtered.len(),
                     internal_id,
                     e
                 );
@@ -109,7 +155,7 @@ async fn main() -> Result<()> {
                 eprintln!(
                     "[{}/{}] qdrant error for {}: {}",
                     i + 1,
-                    rows.len(),
+                    filtered.len(),
                     internal_id,
                     e
                 );
@@ -120,7 +166,7 @@ async fn main() -> Result<()> {
         println!(
             "[{}/{}] {} (project={}) => {} points",
             i + 1,
-            rows.len(),
+            filtered.len(),
             internal_id,
             project_id,
             point_count_str

--- a/core/src/data_sources/qdrant.rs
+++ b/core/src/data_sources/qdrant.rs
@@ -153,7 +153,7 @@ impl DustQdrantClient {
         )
     }
 
-    fn shard_key_id_from_internal_id(internal_id: &str) -> Result<u64> {
+    pub fn shard_key_id_from_internal_id(internal_id: &str) -> Result<u64> {
         // `internal_id` is the hexadecimal representation of a blake3 hash (massive number). We want
         // to get a u64 out of it so we take the first 16 characters which will turn into a fully
         // random u64. Taking the modulo SHARD_KEY_COUNT will give us a random shard key. 16=2^4 and


### PR DESCRIPTION
## Summary
- Add an optional `--shard-key-id` flag to the `qdrant_count_points_per_data_source` bin so we can run the count over data sources mapped to a single Qdrant shard key, rather than always sweeping all data sources from the past 4 months.
- Without the flag, behavior is unchanged: all recent data sources are processed and results are written to `data_sources_qdrant_counts.csv`.
- With the flag, postgres rows are filtered client-side using the same `internal_id → shard_key_id` mapping Qdrant, and results are written to `data_sources_qdrant_counts_shard_<id>.csv`.
- Promote `DustQdrantClient::shard_key_id_from_internal_id` from private to `pub` so the bin can compute the shard key the exact same way the client does (avoids drift if the hashing rule ever changes).

## Why
Sweeping every recent data source in a single run is slow and noisy. When investigating a specific shard (e.g., to triage a hot or unbalanced one), we want to limit work to that shard's data sources only.

## Test plan
- [ ] `cargo check --bin qdrant_count_points_per_data_source` passes (verified locally).
- [ ] Run with no args — produces `data_sources_qdrant_counts.csv` with all recent data sources (legacy behavior).
- [ ] Run with `--shard-key-id 0` — produces `data_sources_qdrant_counts_shard_0.csv`, only data sources whose `internal_id` hashes to shard 0.
- [ ] Run with `--shard-key-id 24` — fails with a clear error (`shard_key_id must be in [0, 24)`).

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Merge and run in EU for some shards