### PR TITLE
fix: upgrade to enterpise form

### DIFF
--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -74,7 +74,7 @@ export default function EnterpriseUpgradeDialog({
       stripeSubscriptionId: !hasMetronomeBilling
         ? (subscription.stripeSubscriptionId ?? "")
         : undefined,
-      metronomeContractId: "",
+      metronomeContractId: hasMetronomeBilling ? "" : undefined,
       planCode: "",
       freeCreditsOverrideEnabled: freeCreditMicroUsd !== null,
       freeCreditsDollars:


### PR DESCRIPTION
## Description

This PR fixes the enterprise upgrade form submit button not working when Metronome billing is not enabled.

Fixes https://github.com/dust-tt/tasks/issues/7808

- Changed `metronomeContractId` to conditionally set to `undefined` when `hasMetronomeBilling` is false (instead of an empty string).
- The empty string value was preventing form validation from passing, blocking the submit button.

## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment - no special considerations required.
