### PR TITLE
Stable sort skills to avoid cache bursting

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -243,6 +243,13 @@ function constructSkillsSection({
     "perspective on the currently available context.\n" +
     "Decisions taken prior to enabling a skill may need to be revisited after enabling it.\n";
 
+  // Sort all skill arrays by name for stable prompt caching.
+  const sortByName = <T extends { name: string }>(arr: T[]): T[] =>
+    [...arr].sort((a, b) => a.name.localeCompare(b.name));
+  const sortedSystemSkills = sortByName(systemSkills);
+  const sortedEnabledSkills = sortByName(enabledSkills);
+  const sortedEquippedSkills = sortByName(equippedSkills);
+
   if (!systemSkills.length && !enabledSkills.length && !equippedSkills.length) {
     skillsSection +=
       "\nNo skills are currently available or enabled for this agent.\n";
@@ -250,27 +257,27 @@ function constructSkillsSection({
   }
 
   // Enabled skills - inject their full instructions.
-  if (systemSkills.length > 0 || enabledSkills.length > 0) {
+  if (sortedSystemSkills.length > 0 || sortedEnabledSkills.length > 0) {
     skillsSection += "\n### ENABLED SKILLS\n";
     skillsSection += "The following skills are currently enabled:\n";
 
     const skillInstructions = [
-      ...systemSkills.map(
+      ...sortedSystemSkills.map(
         (skill) => `<${skill.name}>\n${skill.instructions}\n</${skill.name}>`
       ),
-      ...enabledSkills.map((skill) => getEnabledSkillInstructions(skill)),
+      ...sortedEnabledSkills.map((skill) => getEnabledSkillInstructions(skill)),
     ];
 
     skillsSection += skillInstructions.join("\n");
   }
 
   // Equipped but not yet enabled skills - show name and description only
-  if (equippedSkills && equippedSkills.length > 0) {
+  if (sortedEquippedSkills.length > 0) {
     skillsSection += "\n### AVAILABLE SKILLS\n";
     skillsSection +=
       `These skills can be enabled using the \`${ENABLE_SKILL_TOOL_NAME}\` tool. ` +
       "Review their descriptions and enable the appropriate skill when relevant:\n";
-    const skillList = equippedSkills
+    const skillList = sortedEquippedSkills
       .map(
         ({ name, agentFacingDescription }) =>
           `- **${name}**: ${agentFacingDescription}`


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
All three skill arrays (`systemSkills`, `enabledSkills`, `equippedSkills`) are now sorted alphabetically by name before being rendered into the system prompt. Without this, non-deterministic ordering from the caller would produce different prompt strings across requests, busting the Anthropic prompt cache unnecessarily.

I'll send a follow up PR with a daily job to compute cache ratio and get monitor when we worsen it.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
