### PR TITLE
[front] enh: add keyboard shortcut to skip in `UserAnswerRequired`

### DIFF
--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -264,6 +264,33 @@ describe("UserAnswerRequired", () => {
     expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
   });
 
+  it("skips when Escape is pressed while the component is focused", async () => {
+    const { container } = render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        conversationId="conv_1"
+        messageId="msg_1"
+      />
+    );
+
+    const keyboardContainer = getKeyboardContainer(container);
+
+    await waitFor(() => expect(keyboardContainer).toHaveFocus());
+    fireEvent.keyDown(keyboardContainer, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(answerQuestionMock).toHaveBeenCalledWith({
+        conversationId: "conv_1",
+        messageId: "msg_1",
+        actionId: "action_1",
+        answer: { selectedOptions: [] },
+      });
+    });
+    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
+  });
+
   it("toggles options with Space and Enter, then submits with Cmd+Enter in multi-select mode", async () => {
     const { container } = render(
       <UserAnswerRequired

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -172,6 +172,13 @@ export function UserAnswerRequired({
   }
 
   function handleContainerKeyDownCapture(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      handleSkip();
+      return;
+    }
+
     if (
       e.target instanceof HTMLInputElement ||
       e.target instanceof HTMLTextAreaElement ||


### PR DESCRIPTION
## Description

- This PR extends the keyboard navigation features for the `UserAnswerRequired` component that displays the questions asked by a model via the `ask_user_question` tool.
- Adds a shortcut on the Escape key to do the same as pressing Skip when focused.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
