### PR TITLE
[devx] chore: Bump up tsgo version

### DIFF
--- a/connectors/tsconfig.json
+++ b/connectors/tsconfig.json
@@ -11,7 +11,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2017",
     "module": "esnext",
     "lib": ["esnext", "dom", "dom.iterable"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "composite": false,
     "declaration": false,

--- a/front/hooks/useEnableBrowserNotification.tsx
+++ b/front/hooks/useEnableBrowserNotification.tsx
@@ -1,3 +1,4 @@
+/// <reference types="chrome" />
 import { ConfirmContext } from "@app/components/Confirm";
 import { useUser } from "@app/lib/swr/user";
 import { isChromeExtension } from "@app/lib/utils/extension";

--- a/front/hooks/useVoiceTranscriberService.ts
+++ b/front/hooks/useVoiceTranscriberService.ts
@@ -1,3 +1,4 @@
+/// <reference types="chrome" />
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       ],
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
-        "@typescript/native-preview": "^7.0.0-dev.20260224.1",
+        "@typescript/native-preview": "^7.0.0-dev.20260420.1",
         "knip": "^5.80.0",
         "lefthook": "^2.1.0",
         "wrangler": "4.80.0"
@@ -23770,28 +23770,28 @@
       }
     },
     "node_modules/@typescript/native-preview": {
-      "version": "7.0.0-dev.20260303.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260303.1.tgz",
-      "integrity": "sha512-BDHJjXlPldInEogbzAc7OCLvT75p3rdkmb5YIA6Je0vjg+5z1UQp3moAvcBGvZQflO/gusOd9a74EfrMVUU/4g==",
+      "version": "7.0.0-dev.20260420.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260420.1.tgz",
+      "integrity": "sha512-XYMYZ1OAvO1OWJMntCGW5yoJvJjdrsgmNJxXEPO3Za2kFmQ69TdHOAzg9adurMgAXNpaDWtf28bfEveMRnvpZA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsgo": "bin/tsgo.js"
       },
       "optionalDependencies": {
-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260303.1",
-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260303.1",
-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260303.1",
-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260303.1",
-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260303.1",
-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260303.1",
-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260303.1"
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260420.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260420.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260420.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260420.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260420.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260420.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260420.1"
       }
     },
     "node_modules/@typescript/native-preview-darwin-arm64": {
-      "version": "7.0.0-dev.20260303.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260303.1.tgz",
-      "integrity": "sha512-jIIQWmFi0bJY4ML8/7eyz1EGpkI6E0R1E5l4lxJdV/orpMr91vYfAajKICs7DUiMGEJX9HpeiA6TD2piw4DKPQ==",
+      "version": "7.0.0-dev.20260420.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260420.1.tgz",
+      "integrity": "sha512-WMVphWuSmPuDzdutP2OM7ZhvlgdrBQ6ufQia+cJz6jqLd2MjPaYlS+/ACEcTgf6+PsTXygUOUvcqv9j5s7QC8w==",
       "cpu": [
         "arm64"
       ],
@@ -23803,9 +23803,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-darwin-x64": {
-      "version": "7.0.0-dev.20260303.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260303.1.tgz",
-      "integrity": "sha512-UkaK+J3f185VXBiAGNG4UKHjGzn4R/nhAz5tArnCKHnIUI7rEnsIm4Xlo5YwmgIATFMU1sVwWUwRshVkMVeFAw==",
+      "version": "7.0.0-dev.20260420.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260420.1.tgz",
+      "integrity": "sha512-ChRf5ZpdM5CmplmtfCHGFd/UjYDkld9Z27h5HeC41NGxkbe7NeNQYjwPcbZynca2swISZvFr8Wwlo4nNZG/51A==",
       "cpu": [
         "x64"
       ],
@@ -23817,9 +23817,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-arm": {
-      "version": "7.0.0-dev.20260303.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260303.1.tgz",
-      "integrity": "sha512-H84jTRYqUfc/vhuVGQ6VKcBvJoZ4YmomWDx9U4uwYgW6eoUcRpDXqv3S3YqcNJcUmz22d/tTwIYz8ssXNLa/Qw==",
+      "version": "7.0.0-dev.20260420.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260420.1.tgz",
+      "integrity": "sha512-8+Ey5WZ1jiJXFuN8oQxu3N6pTi6UvigNXTWmB/e+2q6cu6ytFNgiVic6xXtcxOqBpqYMKwXzTZkECjs3NtT6og==",
       "cpu": [
         "arm"
       ],
@@ -23831,9 +23831,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-arm64": {
-      "version": "7.0.0-dev.20260303.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260303.1.tgz",
-      "integrity": "sha512-ELJSV2Q4/mK+ampttssOl4H9s9ZBCc3k7y/u5ivJX8TdlMvZuH/JHqI6cS4Y00flt0R5wc70X+Nlcor4I4+rpw==",
+      "version": "7.0.0-dev.20260420.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260420.1.tgz",
+      "integrity": "sha512-AmRuZ5R1TTrBNMInIACxd3AGvXS8X0PCAheftIMSa/1YOsNbfvPCbzZTleSaIx0ETabPeKQArur0uTPwnKjJbg==",
       "cpu": [
         "arm64"
       ],
@@ -23845,9 +23845,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-x64": {
-      "version": "7.0.0-dev.20260303.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260303.1.tgz",
-      "integrity": "sha512-HkddFrPJ0jcrohe+HnCqVTv8PunjqNs7FisRmtIAnc36+ccraDB6MVFEdPyAIL3PUID+TP/ESquqeKNnB7HdrQ==",
+      "version": "7.0.0-dev.20260420.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260420.1.tgz",
+      "integrity": "sha512-zk6y0AX1+SjuYXZfIRTkpRttp+gfpnz6ELFDWLuhtTJtnxgm8BRSKPup2rcm4xkfpRrVv9dhPGSjJYGNR9z9tg==",
       "cpu": [
         "x64"
       ],
@@ -23859,9 +23859,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-win32-arm64": {
-      "version": "7.0.0-dev.20260303.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260303.1.tgz",
-      "integrity": "sha512-kTTMrBpWuxbHPt9hAFQSWeP//5Oa0KOdAEvceOfXUJhTS8RAA/kZSlFGE/Zw1EtrFLQx2J7uTHUZnYxH1hYXNw==",
+      "version": "7.0.0-dev.20260420.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260420.1.tgz",
+      "integrity": "sha512-TopcWdHwUGaocYuoj0qEZmZa1SLFm9hY0jKrzi5Xa9Xt/gvUnSLJYRBVblibM+/s8S9ZaV94Gc+CUn9EeSsJ9A==",
       "cpu": [
         "arm64"
       ],
@@ -23873,9 +23873,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-win32-x64": {
-      "version": "7.0.0-dev.20260303.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260303.1.tgz",
-      "integrity": "sha512-UcVZbf4pra46Yx/eFV6m9F+awvihliPEud4Rq+A8Q3q3zI67VRaNH6R2/qeo4AqqKRahmiEdLM6Tnm+gPtLRQQ==",
+      "version": "7.0.0-dev.20260420.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260420.1.tgz",
+      "integrity": "sha512-9P6DDMOCncgXGbFfxRpZE0sWzjyymRON67T9J1u885NLp+AmIdns8e91nzD6ipB0EdZimyR4ZjdSZfqetAQSrQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
-    "@typescript/native-preview": "^7.0.0-dev.20260224.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260420.1",
     "knip": "^5.80.0",
     "lefthook": "^2.1.0",
     "wrangler": "4.80.0"

--- a/sdks/js/tsconfig.json
+++ b/sdks/js/tsconfig.json
@@ -4,6 +4,8 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "bundler",
+    "lib": ["es2020", "dom"],
+    "types": ["node"],
     "rootDir": "src",
     "paths": {
       "@modelcontextprotocol/sdk/*": [

--- a/sparkle/tsconfig.json
+++ b/sparkle/tsconfig.json
@@ -10,12 +10,12 @@
     "outDir": "./dist/esm",
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
+    "types": ["node", "react", "react-dom", "react-syntax-highlighter"],
     "resolveJsonModule": true,
     "importHelpers": true,
     "isolatedModules": true,
     "jsx": "react",
-    "downlevelIteration": true,
     "paths": {
       "@sparkle/*": ["./src/*"]
     },


### PR DESCRIPTION
## Description

Current tsgo version (from march) was eating all my computer's memory along with its CPU. After some search it seems some users reported the [same behaviour multiple times](https://github.com/microsoft/typescript-go/issues?q=is%3Aissue%20state%3Aclosed%20memory) across time, it comes and goes 🤷.
I tried an upgrade to 20260420 and on my machine it's fixed. tsgo stays at 2.5GiB, tried multiple times under the same conditions with 20260303 and it's day and night.

## Tests

None

## Risk

Low

## Deploy Plan

Merge and npm i on your machine