### PR TITLE
Make the seeding script runnable without dust-hive

### DIFF
--- a/front/scripts/seed/README.md
+++ b/front/scripts/seed/README.md
@@ -8,6 +8,12 @@ Each folder contains a `seed.ts` file. Run with:
 npx tsx scripts/seed/<folder>/seed.ts --execute
 ```
 
+By default, seeds target the `DevWkSpace` workspace created by dust-hive. To target a different workspace, set `DEV_WORKSPACE_SID`:
+
+```bash
+DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/<folder>/seed.ts --execute
+```
+
 ## Folders
 
 - `basics/` - Creates a custom agent with skills and sample conversations

--- a/front/scripts/seed/basics/README.md
+++ b/front/scripts/seed/basics/README.md
@@ -23,3 +23,9 @@ Run
 ```
 npx tsx scripts/seed/basics/seed.ts --execute
 ```
+
+To target a different workspace:
+
+```
+DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/basics/seed.ts --execute
+```

--- a/front/scripts/seed/byok/seed.ts
+++ b/front/scripts/seed/byok/seed.ts
@@ -3,9 +3,8 @@ import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
+import { WORKSPACE_SID } from "@app/scripts/seed/factories/seedContext";
 
-// The workspace sId created by dust-hive seed.
-const WORKSPACE_ID = "DevWkSpace";
 const BYOK_PLAN_CODE = "FREE_BYOK";
 
 // Based on FREE_UPGRADED_PLAN with isByok = true.
@@ -39,10 +38,10 @@ const FREE_BYOK_PLAN_DATA: PlanAttributes = {
 };
 
 makeScript({}, async ({ execute }, logger) => {
-  const workspace = await WorkspaceResource.fetchById(WORKSPACE_ID);
+  const workspace = await WorkspaceResource.fetchById(WORKSPACE_SID);
   if (!workspace) {
     throw new Error(
-      `Workspace ${WORKSPACE_ID} not found. Make sure dust-hive seed has run first.`
+      `Workspace ${WORKSPACE_SID} not found. Make sure dust-hive seed has run first.`
     );
   }
 
@@ -59,20 +58,20 @@ makeScript({}, async ({ execute }, logger) => {
     await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
   if (activeSubscription?.getPlan().code === BYOK_PLAN_CODE) {
     logger.info(
-      `Workspace ${WORKSPACE_ID} already on ${BYOK_PLAN_CODE} — skipping.`
+      `Workspace ${WORKSPACE_SID} already on ${BYOK_PLAN_CODE} — skipping.`
     );
     return;
   }
 
   if (execute) {
     await SubscriptionResource.internalSubscribeWorkspaceToFreePlan({
-      workspaceId: WORKSPACE_ID,
+      workspaceId: WORKSPACE_SID,
       planCode: BYOK_PLAN_CODE,
       endDate: null,
     });
   }
 
   logger.info(
-    `${execute ? "" : "[DRYRUN]: "}Switched ${WORKSPACE_ID} subscription to ${BYOK_PLAN_CODE}.`
+    `${execute ? "" : "[DRYRUN]: "}Switched ${WORKSPACE_SID} subscription to ${BYOK_PLAN_CODE}.`
   );
 });

--- a/front/scripts/seed/factories/seedContext.ts
+++ b/front/scripts/seed/factories/seedContext.ts
@@ -6,8 +6,8 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
 import type { SeedContext } from "@app/scripts/seed/factories/types";
 
-// The workspace sId created by dust-hive seed
-const WORKSPACE_SID = "DevWkSpace";
+// The workspace sId created by dust-hive seed, overridable via DEV_WORKSPACE_SID.
+export const WORKSPACE_SID = process.env.DEV_WORKSPACE_SID || "DevWkSpace";
 
 export async function createSeedContext({
   execute,

--- a/front/scripts/seed/reinforced-agents/README.md
+++ b/front/scripts/seed/reinforced-agents/README.md
@@ -1,0 +1,15 @@
+# Reinforced Agents Seed
+
+Creates agents with conversations, feedbacks, Dust conversations with JIT skills for testing reinforcement. Enables the `reinforced_agents` and `reinforcement_ui` feature flags.
+
+## Usage
+
+```bash
+npx tsx scripts/seed/reinforced-agents/seed.ts --execute
+```
+
+To target a different workspace:
+
+```bash
+DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/reinforced-agents/seed.ts --execute
+```

--- a/front/scripts/seed/sidekick/README.md
+++ b/front/scripts/seed/sidekick/README.md
@@ -15,3 +15,9 @@ Run:
 ```bash
 npx tsx scripts/seed/sidekick/seed.ts --execute
 ```
+
+To target a different workspace:
+
+```bash
+DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/sidekick/seed.ts --execute
+```

--- a/front/scripts/seed/triggers/README.md
+++ b/front/scripts/seed/triggers/README.md
@@ -18,3 +18,9 @@ Depends on agents from `basics/` seed. The script will create them if they don't
 ```bash
 npx tsx scripts/seed/triggers/seed.ts --execute
 ```
+
+To target a different workspace:
+
+```bash
+DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/triggers/seed.ts --execute
+```


### PR DESCRIPTION
## Description

Allow non dust-hive users to set `DEV_WORKSPACE_SID` env variable so they can use seed scripts.
Useful for in-site too so they can quickly fill their workspace.

## Tests

no

## Risk

low, it's dust-hive

## Deploy Plan

none
