### PR TITLE
feat(sbx): Add cache invalidation endpoint to egress proxy

### DIFF
--- a/egress-proxy/src/connection.rs
+++ b/egress-proxy/src/connection.rs
@@ -148,7 +148,7 @@ async fn handle_connection_inner(
     };
     drop(raw_token);
 
-    if token.sb_id.is_none() {
+    if token.sb_id.is_none() || token.action.is_some() {
         deny(
             stream,
             DenyReason::InvalidClaims,

--- a/egress-proxy/src/connection.rs
+++ b/egress-proxy/src/connection.rs
@@ -3,7 +3,7 @@ use crate::config::Config;
 use crate::dns::DnsResolver;
 use crate::gcs::GcsPolicyProvider;
 use crate::handshake::{read_handshake, Handshake, HandshakeError, ALLOW_RESPONSE, DENY_RESPONSE};
-use crate::jwt::{JwtValidationError, JwtValidator, ValidatedSandboxToken};
+use crate::jwt::{JwtValidationError, JwtValidator, ValidatedToken};
 use crate::policy::DefaultAllowlist;
 use std::fmt;
 use std::net::SocketAddr;
@@ -148,6 +148,17 @@ async fn handle_connection_inner(
     };
     drop(raw_token);
 
+    if token.sb_id.is_none() {
+        deny(
+            stream,
+            DenyReason::InvalidClaims,
+            Some(&token),
+            Some(&request),
+        )
+        .await;
+        return Err(DenyReason::InvalidClaims);
+    }
+
     if request.domain.is_empty() {
         // TODO(sandbox-egress): Track empty_domain separately from malformed_handshake because
         // this is the expected deny path for non-HTTP/non-TLS connections where dsbx cannot
@@ -181,7 +192,11 @@ async fn handle_connection_inner(
     if !default_allows
         && !state
             .policy_provider
-            .evaluate(token.w_id.as_deref(), &token.sb_id, &request.domain)
+            .evaluate(
+                token.w_id.as_deref(),
+                token.sb_id.as_deref().unwrap(),
+                &request.domain,
+            )
             .await
     {
         deny(
@@ -205,7 +220,7 @@ async fn handle_connection_inner(
         Ok(Ok(addresses)) => addresses,
         Err(_) => {
             warn!(
-                sb_id = %token.sb_id,
+                sb_id = token.sb_id.as_deref().unwrap_or(""),
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 dns_timeout_seconds = DNS_TIMEOUT_SECONDS,
@@ -223,7 +238,7 @@ async fn handle_connection_inner(
         Ok(Err(error)) => {
             warn!(
                 error = %error,
-                sb_id = %token.sb_id,
+                sb_id = token.sb_id.as_deref().unwrap_or(""),
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 "dns resolution failed"
@@ -277,7 +292,7 @@ async fn handle_connection_inner(
         Ok(Ok(upstream)) => upstream,
         Err(_) => {
             warn!(
-                sb_id = %token.sb_id,
+                sb_id = token.sb_id.as_deref().unwrap_or(""),
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 upstream_addr = %upstream_addr,
@@ -296,7 +311,7 @@ async fn handle_connection_inner(
         Ok(Err(error)) => {
             warn!(
                 error = %error,
-                sb_id = %token.sb_id,
+                sb_id = token.sb_id.as_deref().unwrap_or(""),
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 upstream_addr = %upstream_addr,
@@ -321,7 +336,7 @@ async fn handle_connection_inner(
     }
 
     info!(
-        sb_id = %token.sb_id,
+        sb_id = token.sb_id.as_deref().unwrap_or(""),
         domain = %request.domain,
         original_dest_port = request.original_dest_port,
         upstream_addr = %upstream_addr,
@@ -333,7 +348,7 @@ async fn handle_connection_inner(
     match copy_bidirectional(stream, &mut upstream).await {
         Ok((from_client_bytes, from_upstream_bytes)) => {
             info!(
-                sb_id = %token.sb_id,
+                sb_id = token.sb_id.as_deref().unwrap_or(""),
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 upstream_addr = %upstream_addr,
@@ -346,7 +361,7 @@ async fn handle_connection_inner(
         Err(error) => {
             warn!(
                 error = %error,
-                sb_id = %token.sb_id,
+                sb_id = token.sb_id.as_deref().unwrap_or(""),
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 upstream_addr = %upstream_addr,
@@ -360,7 +375,7 @@ async fn handle_connection_inner(
 async fn deny(
     stream: &mut TlsStream<TcpStream>,
     reason: DenyReason,
-    token: Option<&ValidatedSandboxToken>,
+    token: Option<&ValidatedToken>,
     request: Option<&RequestMetadata>,
 ) {
     // TODO(sandbox-egress): Emit allow/deny/JWT/GCS/upstream metrics once service telemetry
@@ -377,13 +392,13 @@ async fn deny(
 
 fn log_deny(
     reason: DenyReason,
-    token: Option<&ValidatedSandboxToken>,
+    token: Option<&ValidatedToken>,
     request: Option<&RequestMetadata>,
     upstream_addr: Option<SocketAddr>,
 ) {
     warn!(
         deny_reason = %reason,
-        sb_id = token.map(|token| token.sb_id.as_str()),
+        sb_id = token.and_then(|token| token.sb_id.as_deref()),
         domain = request.map(|request| request.domain.as_str()),
         original_dest_port = request.map(|request| request.original_dest_port),
         upstream_addr = upstream_addr.map(|address| address.to_string()),

--- a/egress-proxy/src/connection.rs
+++ b/egress-proxy/src/connection.rs
@@ -148,16 +148,19 @@ async fn handle_connection_inner(
     };
     drop(raw_token);
 
-    if token.sb_id.is_none() || token.action.is_some() {
-        deny(
-            stream,
-            DenyReason::InvalidClaims,
-            Some(&token),
-            Some(&request),
-        )
-        .await;
-        return Err(DenyReason::InvalidClaims);
-    }
+    let sb_id = match token.sb_id.as_deref() {
+        Some(sb_id) if token.action.is_none() => sb_id,
+        _ => {
+            deny(
+                stream,
+                DenyReason::InvalidClaims,
+                Some(&token),
+                Some(&request),
+            )
+            .await;
+            return Err(DenyReason::InvalidClaims);
+        }
+    };
 
     if request.domain.is_empty() {
         // TODO(sandbox-egress): Track empty_domain separately from malformed_handshake because
@@ -192,11 +195,7 @@ async fn handle_connection_inner(
     if !default_allows
         && !state
             .policy_provider
-            .evaluate(
-                token.w_id.as_deref(),
-                token.sb_id.as_deref().unwrap(),
-                &request.domain,
-            )
+            .evaluate(token.w_id.as_deref(), sb_id, &request.domain)
             .await
     {
         deny(
@@ -220,7 +219,7 @@ async fn handle_connection_inner(
         Ok(Ok(addresses)) => addresses,
         Err(_) => {
             warn!(
-                sb_id = token.sb_id.as_deref().unwrap_or(""),
+                sb_id = sb_id,
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 dns_timeout_seconds = DNS_TIMEOUT_SECONDS,
@@ -238,7 +237,7 @@ async fn handle_connection_inner(
         Ok(Err(error)) => {
             warn!(
                 error = %error,
-                sb_id = token.sb_id.as_deref().unwrap_or(""),
+                sb_id = sb_id,
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 "dns resolution failed"
@@ -292,7 +291,7 @@ async fn handle_connection_inner(
         Ok(Ok(upstream)) => upstream,
         Err(_) => {
             warn!(
-                sb_id = token.sb_id.as_deref().unwrap_or(""),
+                sb_id = sb_id,
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 upstream_addr = %upstream_addr,
@@ -311,7 +310,7 @@ async fn handle_connection_inner(
         Ok(Err(error)) => {
             warn!(
                 error = %error,
-                sb_id = token.sb_id.as_deref().unwrap_or(""),
+                sb_id = sb_id,
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 upstream_addr = %upstream_addr,
@@ -336,7 +335,7 @@ async fn handle_connection_inner(
     }
 
     info!(
-        sb_id = token.sb_id.as_deref().unwrap_or(""),
+        sb_id = sb_id,
         domain = %request.domain,
         original_dest_port = request.original_dest_port,
         upstream_addr = %upstream_addr,
@@ -348,7 +347,7 @@ async fn handle_connection_inner(
     match copy_bidirectional(stream, &mut upstream).await {
         Ok((from_client_bytes, from_upstream_bytes)) => {
             info!(
-                sb_id = token.sb_id.as_deref().unwrap_or(""),
+                sb_id = sb_id,
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 upstream_addr = %upstream_addr,
@@ -361,7 +360,7 @@ async fn handle_connection_inner(
         Err(error) => {
             warn!(
                 error = %error,
-                sb_id = token.sb_id.as_deref().unwrap_or(""),
+                sb_id = sb_id,
                 domain = %request.domain,
                 original_dest_port = request.original_dest_port,
                 upstream_addr = %upstream_addr,

--- a/egress-proxy/src/gcs.rs
+++ b/egress-proxy/src/gcs.rs
@@ -64,6 +64,10 @@ impl GcsPolicyProvider {
         })
     }
 
+    pub async fn invalidate(&self, cache_key: &str) {
+        self.cache.invalidate(cache_key).await;
+    }
+
     pub async fn get_workspace_policy(&self, w_id: &str) -> Result<Option<Policy>> {
         self.get_policy(&format!("w:{w_id}"), &format!("workspaces/{w_id}.json"))
             .await

--- a/egress-proxy/src/health.rs
+++ b/egress-proxy/src/health.rs
@@ -73,10 +73,15 @@ async fn invalidate_policy(
         StatusCode::UNAUTHORIZED
     })?;
 
-    state.jwt_validator.validate(token).map_err(|error| {
+    let validated = state.jwt_validator.validate(token).map_err(|error| {
         warn!(error = %error, "invalidate-policy: jwt validation failed");
         StatusCode::UNAUTHORIZED
     })?;
+
+    if validated.action.as_deref() != Some("invalidate-policy") {
+        warn!("invalidate-policy: token missing required action claim");
+        return Err(StatusCode::FORBIDDEN);
+    }
 
     if body.keys.is_empty() {
         return Err(StatusCode::BAD_REQUEST);

--- a/egress-proxy/src/health.rs
+++ b/egress-proxy/src/health.rs
@@ -5,7 +5,7 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tokio::net::TcpListener;
 use tokio::sync::watch;
 use tracing::{info, warn};
@@ -18,14 +18,9 @@ struct HealthState {
     jwt_validator: JwtValidator,
 }
 
-#[derive(Deserialize)]
-struct InvalidateRequest {
-    keys: Vec<String>,
-}
-
 #[derive(Serialize)]
 struct InvalidateResponse {
-    invalidated: usize,
+    invalidated: String,
 }
 
 pub async fn serve(
@@ -66,7 +61,6 @@ async fn healthz() -> &'static str {
 async fn invalidate_policy(
     State(state): State<HealthState>,
     headers: HeaderMap,
-    Json(body): Json<InvalidateRequest>,
 ) -> Result<Json<InvalidateResponse>, StatusCode> {
     let token = extract_bearer_token(&headers).ok_or_else(|| {
         warn!("invalidate-policy: missing or malformed authorization header");
@@ -83,18 +77,23 @@ async fn invalidate_policy(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    if body.keys.is_empty() {
-        return Err(StatusCode::BAD_REQUEST);
-    }
+    // Derive the cache key from claims: exactly one of wId or sbId must be set.
+    let cache_key = match (validated.w_id.as_deref(), validated.sb_id.as_deref()) {
+        (Some(w_id), None) => format!("w:{w_id}"),
+        (None, Some(sb_id)) => format!("s:{sb_id}"),
+        _ => {
+            warn!("invalidate-policy: token must have exactly one of wId or sbId");
+            return Err(StatusCode::BAD_REQUEST);
+        }
+    };
 
-    let count = body.keys.len();
-    for key in &body.keys {
-        state.policy_provider.invalidate(key).await;
-    }
+    state.policy_provider.invalidate(&cache_key).await;
 
-    info!(keys = ?body.keys, "invalidated policy cache entries");
+    info!(cache_key = %cache_key, "invalidated policy cache entry");
 
-    Ok(Json(InvalidateResponse { invalidated: count }))
+    Ok(Json(InvalidateResponse {
+        invalidated: cache_key,
+    }))
 }
 
 fn extract_bearer_token(headers: &HeaderMap) -> Option<&str> {

--- a/egress-proxy/src/health.rs
+++ b/egress-proxy/src/health.rs
@@ -89,9 +89,7 @@ async fn invalidate_policy(
 
     info!(keys = ?body.keys, "invalidated policy cache entries");
 
-    Ok(Json(InvalidateResponse {
-        invalidated: count,
-    }))
+    Ok(Json(InvalidateResponse { invalidated: count }))
 }
 
 fn extract_bearer_token(headers: &HeaderMap) -> Option<&str> {

--- a/egress-proxy/src/health.rs
+++ b/egress-proxy/src/health.rs
@@ -1,12 +1,48 @@
+use crate::gcs::GcsPolicyProvider;
+use crate::jwt::JwtValidator;
 use anyhow::Result;
-use axum::{routing::get, Router};
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 use tokio::sync::watch;
-use tracing::info;
+use tracing::{info, warn};
 
-pub async fn serve(listener: TcpListener, mut shutdown: watch::Receiver<bool>) -> Result<()> {
+const BEARER_PREFIX: &str = "Bearer ";
+
+#[derive(Clone)]
+struct HealthState {
+    policy_provider: GcsPolicyProvider,
+    jwt_validator: JwtValidator,
+}
+
+#[derive(Deserialize)]
+struct InvalidateRequest {
+    keys: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct InvalidateResponse {
+    invalidated: usize,
+}
+
+pub async fn serve(
+    listener: TcpListener,
+    mut shutdown: watch::Receiver<bool>,
+    policy_provider: GcsPolicyProvider,
+    jwt_validator: JwtValidator,
+) -> Result<()> {
     let local_addr = listener.local_addr()?;
-    let app = Router::new().route("/healthz", get(healthz));
+    let state = HealthState {
+        policy_provider,
+        jwt_validator,
+    };
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/invalidate-policy", post(invalidate_policy))
+        .with_state(state);
 
     info!(addr = %local_addr, "health server started");
 
@@ -25,4 +61,40 @@ pub async fn serve(listener: TcpListener, mut shutdown: watch::Receiver<bool>) -
 
 async fn healthz() -> &'static str {
     "ok"
+}
+
+async fn invalidate_policy(
+    State(state): State<HealthState>,
+    headers: HeaderMap,
+    Json(body): Json<InvalidateRequest>,
+) -> Result<Json<InvalidateResponse>, StatusCode> {
+    let token = extract_bearer_token(&headers).ok_or_else(|| {
+        warn!("invalidate-policy: missing or malformed authorization header");
+        StatusCode::UNAUTHORIZED
+    })?;
+
+    state.jwt_validator.validate(token).map_err(|error| {
+        warn!(error = %error, "invalidate-policy: jwt validation failed");
+        StatusCode::UNAUTHORIZED
+    })?;
+
+    if body.keys.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let count = body.keys.len();
+    for key in &body.keys {
+        state.policy_provider.invalidate(key).await;
+    }
+
+    info!(keys = ?body.keys, "invalidated policy cache entries");
+
+    Ok(Json(InvalidateResponse {
+        invalidated: count,
+    }))
+}
+
+fn extract_bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let value = headers.get("authorization")?.to_str().ok()?;
+    value.strip_prefix(BEARER_PREFIX)
 }

--- a/egress-proxy/src/jwt.rs
+++ b/egress-proxy/src/jwt.rs
@@ -12,9 +12,10 @@ pub struct JwtValidator {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ValidatedSandboxToken {
-    pub sb_id: String,
+pub struct ValidatedToken {
+    pub sb_id: Option<String>,
     pub w_id: Option<String>,
+    pub action: Option<String>,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -30,9 +31,10 @@ pub enum JwtValidationError {
 #[derive(Debug, Deserialize)]
 struct Claims {
     #[serde(rename = "sbId")]
-    sb_id: String,
+    sb_id: Option<String>,
     #[serde(rename = "wId")]
     w_id: Option<String>,
+    action: Option<String>,
     exp: usize,
 }
 
@@ -43,7 +45,7 @@ impl JwtValidator {
         }
     }
 
-    pub fn validate(&self, raw_token: &str) -> Result<ValidatedSandboxToken, JwtValidationError> {
+    pub fn validate(&self, raw_token: &str) -> Result<ValidatedToken, JwtValidationError> {
         let mut validation = Validation::new(Algorithm::HS256);
         // TODO(sandbox-egress): Nice-to-have once front token minting is wired: make the
         // front/proxy clock-skew tolerance explicit and cover it with a unit test.
@@ -63,11 +65,15 @@ impl JwtValidator {
 
 fn claims_to_validated_token(
     token: TokenData<Claims>,
-) -> Result<ValidatedSandboxToken, JwtValidationError> {
+) -> Result<ValidatedToken, JwtValidationError> {
     let claims = token.claims;
     let now_seconds = current_unix_timestamp_seconds()?;
-    let raw_w_id = claims.w_id;
-    let w_id = raw_w_id.as_ref().and_then(|value| {
+
+    if claims.exp == 0 || claims.exp <= now_seconds {
+        return Err(JwtValidationError::Expired);
+    }
+
+    let sb_id = claims.sb_id.and_then(|value| {
         let trimmed = value.trim();
         if trimmed.is_empty() {
             None
@@ -76,21 +82,28 @@ fn claims_to_validated_token(
         }
     });
 
-    if claims.sb_id.trim().is_empty() || claims.exp == 0 {
-        return Err(JwtValidationError::InvalidClaims);
-    }
+    let w_id = claims.w_id.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    });
 
-    if raw_w_id.is_some() && w_id.is_none() {
-        return Err(JwtValidationError::InvalidClaims);
-    }
+    let action = claims.action.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    });
 
-    if claims.exp <= now_seconds {
-        return Err(JwtValidationError::Expired);
-    }
-
-    Ok(ValidatedSandboxToken {
-        sb_id: claims.sb_id,
+    Ok(ValidatedToken {
+        sb_id,
         w_id,
+        action,
     })
 }
 
@@ -115,91 +128,128 @@ fn map_jwt_error(error: jsonwebtoken::errors::Error) -> JwtValidationError {
 
 #[cfg(test)]
 mod tests {
-    use super::{JwtValidationError, JwtValidator, EXPECTED_AUDIENCE, EXPECTED_ISSUER};
+    use super::{
+        JwtValidationError, JwtValidator, ValidatedToken, EXPECTED_AUDIENCE, EXPECTED_ISSUER,
+    };
     use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
     use serde::Serialize;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[derive(Debug, Serialize)]
     struct TestClaims<'a> {
-        #[serde(rename = "sbId")]
-        sb_id: &'a str,
+        #[serde(rename = "sbId", skip_serializing_if = "Option::is_none")]
+        sb_id: Option<&'a str>,
         #[serde(rename = "wId", skip_serializing_if = "Option::is_none")]
         w_id: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        action: Option<&'a str>,
         iss: &'a str,
         aud: &'a str,
         exp: usize,
     }
 
     #[test]
-    fn validates_expected_claims() {
+    fn validates_sandbox_token_with_all_claims() {
         let validator = JwtValidator::new("secret");
-        let token = token(
-            "secret",
-            "sbx",
-            Some("workspace"),
-            EXPECTED_ISSUER,
-            EXPECTED_AUDIENCE,
-            60,
-        );
+        let token = sandbox_token("secret", "sbx", Some("workspace"), 60);
 
         let validated = validator
             .validate(&token)
             .expect("token with valid claims should validate");
 
-        assert_eq!(validated.sb_id, "sbx");
+        assert_eq!(validated.sb_id.as_deref(), Some("sbx"));
         assert_eq!(validated.w_id.as_deref(), Some("workspace"));
+        assert_eq!(validated.action, None);
+    }
+
+    #[test]
+    fn accepts_tokens_without_sandbox_id() {
+        let validator = JwtValidator::new("secret");
+        let token = token_with_claims(TestClaims {
+            sb_id: None,
+            w_id: None,
+            action: Some("invalidate-policy"),
+            iss: EXPECTED_ISSUER,
+            aud: EXPECTED_AUDIENCE,
+            exp: future_exp(60),
+        });
+
+        let validated = validator
+            .validate(&token)
+            .expect("token without sbId should validate");
+
+        assert_eq!(validated.sb_id, None);
+        assert_eq!(validated.action.as_deref(), Some("invalidate-policy"));
     }
 
     #[test]
     fn accepts_tokens_without_workspace_id() {
         let validator = JwtValidator::new("secret");
-        let token = token(
-            "secret",
-            "sbx",
-            None,
-            EXPECTED_ISSUER,
-            EXPECTED_AUDIENCE,
-            60,
-        );
+        let token = sandbox_token("secret", "sbx", None, 60);
 
         let validated = validator
             .validate(&token)
-            .expect("token without wId should validate during rollout");
+            .expect("token without wId should validate");
 
-        assert_eq!(validated.sb_id, "sbx");
+        assert_eq!(validated.sb_id.as_deref(), Some("sbx"));
         assert_eq!(validated.w_id, None);
     }
 
     #[test]
-    fn rejects_empty_workspace_id_when_present() {
+    fn normalizes_empty_sandbox_id_to_none() {
         let validator = JwtValidator::new("secret");
-        let token = token(
-            "secret",
-            "sbx",
-            Some("   "),
-            EXPECTED_ISSUER,
-            EXPECTED_AUDIENCE,
-            60,
-        );
+        let token = sandbox_token("secret", "   ", None, 60);
+
+        let validated = validator
+            .validate(&token)
+            .expect("empty sbId should normalize to None");
+
+        assert_eq!(validated.sb_id, None);
+    }
+
+    #[test]
+    fn normalizes_empty_workspace_id_to_none() {
+        let validator = JwtValidator::new("secret");
+        let token = sandbox_token("secret", "sbx", Some("   "), 60);
+
+        let validated = validator
+            .validate(&token)
+            .expect("empty wId should normalize to None");
+
+        assert_eq!(validated.sb_id.as_deref(), Some("sbx"));
+        assert_eq!(validated.w_id, None);
+    }
+
+    #[test]
+    fn validates_invalidation_token() {
+        let validator = JwtValidator::new("secret");
+        let token = token_with_claims(TestClaims {
+            sb_id: None,
+            w_id: Some("workspace"),
+            action: Some("invalidate-policy"),
+            iss: EXPECTED_ISSUER,
+            aud: EXPECTED_AUDIENCE,
+            exp: future_exp(60),
+        });
+
+        let validated = validator
+            .validate(&token)
+            .expect("invalidation token should validate");
 
         assert_eq!(
-            validator.validate(&token).unwrap_err(),
-            JwtValidationError::InvalidClaims
+            validated,
+            ValidatedToken {
+                sb_id: None,
+                w_id: Some("workspace".to_string()),
+                action: Some("invalidate-policy".to_string()),
+            }
         );
     }
 
     #[test]
     fn rejects_expired_tokens() {
         let validator = JwtValidator::new("secret");
-        let token = token(
-            "secret",
-            "sbx",
-            Some("workspace"),
-            EXPECTED_ISSUER,
-            EXPECTED_AUDIENCE,
-            -60,
-        );
+        let token = sandbox_token("secret", "sbx", Some("workspace"), -60);
 
         assert_eq!(
             validator.validate(&token).unwrap_err(),
@@ -210,14 +260,14 @@ mod tests {
     #[test]
     fn rejects_wrong_audience() {
         let validator = JwtValidator::new("secret");
-        let token = token(
-            "secret",
-            "sbx",
-            Some("workspace"),
-            EXPECTED_ISSUER,
-            "wrong",
-            60,
-        );
+        let token = token_with_claims(TestClaims {
+            sb_id: Some("sbx"),
+            w_id: Some("workspace"),
+            action: None,
+            iss: EXPECTED_ISSUER,
+            aud: "wrong",
+            exp: future_exp(60),
+        });
 
         assert_eq!(
             validator.validate(&token).unwrap_err(),
@@ -225,29 +275,19 @@ mod tests {
         );
     }
 
-    fn token(
+    fn sandbox_token(
         secret: &str,
         sb_id: &str,
         w_id: Option<&str>,
-        iss: &str,
-        aud: &str,
         exp_offset_seconds: i64,
     ) -> String {
-        let now_seconds = i64::try_from(
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("current time should be after the Unix epoch")
-                .as_secs(),
-        )
-        .expect("current Unix timestamp should fit in i64");
-        let exp_seconds = now_seconds + exp_offset_seconds;
-        let exp = usize::try_from(exp_seconds).expect("expiration timestamp should fit in usize");
         let claims = TestClaims {
-            sb_id,
+            sb_id: Some(sb_id),
             w_id,
-            iss,
-            aud,
-            exp,
+            action: None,
+            iss: EXPECTED_ISSUER,
+            aud: EXPECTED_AUDIENCE,
+            exp: offset_exp(exp_offset_seconds),
         };
 
         encode(
@@ -256,5 +296,30 @@ mod tests {
             &EncodingKey::from_secret(secret.as_bytes()),
         )
         .expect("test helper should encode JWT successfully")
+    }
+
+    fn token_with_claims(claims: TestClaims<'_>) -> String {
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(b"secret"),
+        )
+        .expect("test helper should encode JWT successfully")
+    }
+
+    fn future_exp(offset_seconds: i64) -> usize {
+        offset_exp(offset_seconds)
+    }
+
+    fn offset_exp(offset_seconds: i64) -> usize {
+        let now_seconds = i64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("current time should be after the Unix epoch")
+                .as_secs(),
+        )
+        .expect("current Unix timestamp should fit in i64");
+        let exp_seconds = now_seconds + offset_seconds;
+        usize::try_from(exp_seconds).expect("expiration timestamp should fit in usize")
     }
 }

--- a/egress-proxy/src/server.rs
+++ b/egress-proxy/src/server.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::connection::{handle_connection, ConnectionState};
 use crate::gcs::GcsPolicyProvider;
 use crate::health;
+use crate::jwt::JwtValidator;
 use crate::tls::load_tls_acceptor;
 use anyhow::{anyhow, Result};
 use std::sync::Arc;
@@ -29,11 +30,17 @@ pub async fn run(config: Config) -> Result<()> {
         config.policy_base_url.clone(),
     )
     .await?;
-    let state = Arc::new(ConnectionState::new(&config, policy_provider));
+    let jwt_validator = JwtValidator::new(&config.jwt_secret);
+    let state = Arc::new(ConnectionState::new(&config, policy_provider.clone()));
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-    let mut health_handle = tokio::spawn(health::serve(health_listener, shutdown_rx.clone()));
+    let mut health_handle = tokio::spawn(health::serve(
+        health_listener,
+        shutdown_rx.clone(),
+        policy_provider,
+        jwt_validator,
+    ));
     let mut proxy_handle = tokio::spawn(run_proxy_listener(
         listener,
         tls_acceptor,

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -809,13 +809,8 @@ async fn invalidate_policy_rejects_empty_keys() -> Result<()> {
     let token = make_token(SECRET, 60);
     let body = json!({ "keys": [] }).to_string();
 
-    let status = http_post_status(
-        proxy.health_addr,
-        "/invalidate-policy",
-        &body,
-        Some(&token),
-    )
-    .await?;
+    let status =
+        http_post_status(proxy.health_addr, "/invalidate-policy", &body, Some(&token)).await?;
 
     assert_eq!(status, 400);
     Ok(())

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -68,10 +68,12 @@ const TEST_WORKSPACE_ID: &str = "workspace-456";
 
 #[derive(Debug, Serialize)]
 struct TestClaims {
-    #[serde(rename = "sbId")]
-    sb_id: String,
+    #[serde(rename = "sbId", skip_serializing_if = "Option::is_none")]
+    sb_id: Option<String>,
     #[serde(rename = "wId", skip_serializing_if = "Option::is_none")]
     w_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    action: Option<String>,
     iss: String,
     aud: String,
     exp: usize,
@@ -386,8 +388,9 @@ async fn invalid_issuer_returns_deny() -> Result<()> {
     let token = make_token_with_claims(
         SECRET,
         FullClaims {
-            sb_id: TEST_SANDBOX_ID,
+            sb_id: Some(TEST_SANDBOX_ID),
             w_id: None,
+            action: None,
             iss: "wrong-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds: 60,
@@ -406,8 +409,9 @@ async fn invalid_audience_returns_deny() -> Result<()> {
     let token = make_token_with_claims(
         SECRET,
         FullClaims {
-            sb_id: TEST_SANDBOX_ID,
+            sb_id: Some(TEST_SANDBOX_ID),
             w_id: None,
+            action: None,
             iss: "dust-front",
             aud: "wrong-audience",
             exp_offset_seconds: 60,
@@ -426,8 +430,9 @@ async fn empty_sandbox_id_claim_returns_deny() -> Result<()> {
     let token = make_token_with_claims(
         SECRET,
         FullClaims {
-            sb_id: "   ",
+            sb_id: Some("   "),
             w_id: None,
+            action: None,
             iss: "dust-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds: 60,
@@ -772,8 +777,8 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
     }
 
     // Without invalidation, the cached policy would still allow "localhost".
-    // Invalidate the workspace cache entry.
-    let admin_token = make_token_with_workspace(SECRET, 60);
+    // Invalidate the workspace cache entry using an invalidation token.
+    let admin_token = make_invalidation_token(SECRET, 60);
     let invalidate_body = json!({ "keys": [format!("w:{TEST_WORKSPACE_ID}")] }).to_string();
     let status = http_post_status(
         proxy.health_addr,
@@ -825,13 +830,31 @@ async fn invalidate_policy_rejects_invalid_jwt() -> Result<()> {
 #[tokio::test]
 async fn invalidate_policy_rejects_empty_keys() -> Result<()> {
     let proxy = start_proxy(false, "production").await?;
-    let token = make_token(SECRET, 60);
+    let token = make_invalidation_token(SECRET, 60);
     let body = json!({ "keys": [] }).to_string();
 
     let status =
         http_post_status(proxy.health_addr, "/invalidate-policy", &body, Some(&token)).await?;
 
     assert_eq!(status, 400);
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalidate_policy_rejects_sandbox_token_without_action() -> Result<()> {
+    let proxy = start_proxy(false, "production").await?;
+    let sandbox_token = make_token_with_workspace(SECRET, 60);
+    let body = json!({ "keys": ["w:workspace-1"] }).to_string();
+
+    let status = http_post_status(
+        proxy.health_addr,
+        "/invalidate-policy",
+        &body,
+        Some(&sandbox_token),
+    )
+    .await?;
+
+    assert_eq!(status, 403);
     Ok(())
 }
 
@@ -1141,8 +1164,9 @@ fn make_token(secret: &str, exp_offset_seconds: i64) -> String {
     make_token_with_claims(
         secret,
         FullClaims {
-            sb_id: TEST_SANDBOX_ID,
+            sb_id: Some(TEST_SANDBOX_ID),
             w_id: None,
+            action: None,
             iss: "dust-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds,
@@ -1154,8 +1178,23 @@ fn make_token_with_workspace(secret: &str, exp_offset_seconds: i64) -> String {
     make_token_with_claims(
         secret,
         FullClaims {
-            sb_id: TEST_SANDBOX_ID,
+            sb_id: Some(TEST_SANDBOX_ID),
             w_id: Some(TEST_WORKSPACE_ID),
+            action: None,
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds,
+        },
+    )
+}
+
+fn make_invalidation_token(secret: &str, exp_offset_seconds: i64) -> String {
+    make_token_with_claims(
+        secret,
+        FullClaims {
+            sb_id: None,
+            w_id: Some(TEST_WORKSPACE_ID),
+            action: Some("invalidate-policy"),
             iss: "dust-front",
             aud: "dust-egress-proxy",
             exp_offset_seconds,
@@ -1174,8 +1213,9 @@ fn make_token_with_claims(secret: &str, claims: FullClaims<'_>) -> String {
         now_seconds + claims.exp_offset_seconds.unsigned_abs()
     };
     let claims = TestClaims {
-        sb_id: claims.sb_id.to_string(),
+        sb_id: claims.sb_id.map(|s| s.to_string()),
         w_id: claims.w_id.map(|s| s.to_string()),
+        action: claims.action.map(|s| s.to_string()),
         iss: claims.iss.to_string(),
         aud: claims.aud.to_string(),
         exp: usize::try_from(exp).expect("expiration timestamp should fit in usize"),
@@ -1196,8 +1236,9 @@ struct TestCerts {
 }
 
 struct FullClaims<'a> {
-    sb_id: &'a str,
+    sb_id: Option<&'a str>,
     w_id: Option<&'a str>,
+    action: Option<&'a str>,
     iss: &'a str,
     aud: &'a str,
     exp_offset_seconds: i64,

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -30,10 +30,12 @@ const TEST_BUCKET: &str = "test-egress-policies";
 const TEST_SANDBOX_ID: &str = "sandbox-123";
 static INSTALL_RUSTLS_PROVIDER: Once = Once::new();
 
+type MockGcsObjects = Arc<std::sync::RwLock<HashMap<String, MockGcsResponse>>>;
+
 struct ProxyProcess {
     child: Child,
     _temp_dir: TempDir,
-    _mock_gcs: Option<MockGcsServer>,
+    mock_gcs: Option<MockGcsServer>,
     ca_cert_path: PathBuf,
     proxy_addr: SocketAddr,
     health_addr: SocketAddr,
@@ -42,11 +44,12 @@ struct ProxyProcess {
 struct MockGcsServer {
     addr: SocketAddr,
     handle: tokio::task::JoinHandle<()>,
+    objects: MockGcsObjects,
 }
 
 #[derive(Clone)]
 struct MockGcsState {
-    objects: Arc<HashMap<String, MockGcsResponse>>,
+    objects: MockGcsObjects,
 }
 
 #[derive(Clone)]
@@ -754,11 +757,21 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
     )
     .await?;
 
-    // First request populates the cache.
+    // First request populates the cache with a policy allowing "localhost".
     let token = make_token_with_workspace(SECRET, 60);
     let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
     assert_eq!(response, Some(ALLOW_RESPONSE));
 
+    // Change the backing GCS policy to deny "localhost".
+    {
+        let mut objects = proxy.mock_gcs.as_ref().unwrap().objects.write().unwrap();
+        objects.insert(
+            format!("workspaces/{TEST_WORKSPACE_ID}.json"),
+            policy_response(&["other.example.com"]),
+        );
+    }
+
+    // Without invalidation, the cached policy would still allow "localhost".
     // Invalidate the workspace cache entry.
     let admin_token = make_token_with_workspace(SECRET, 60);
     let invalidate_body = json!({ "keys": [format!("w:{TEST_WORKSPACE_ID}")] }).to_string();
@@ -770,6 +783,12 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
     )
     .await?;
     assert_eq!(status, 200);
+
+    // After invalidation, the proxy re-fetches from GCS and gets the new policy
+    // which no longer allows "localhost" — connection should be denied.
+    let token = make_token_with_workspace(SECRET, 60);
+    let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
+    assert_eq!(response, Some(DENY_RESPONSE));
 
     Ok(())
 }
@@ -883,7 +902,7 @@ async fn start_proxy_with_mock_gcs(
     let mut proxy = ProxyProcess {
         child: command.spawn()?,
         _temp_dir: temp_dir,
-        _mock_gcs: Some(mock_gcs),
+        mock_gcs: Some(mock_gcs),
         ca_cert_path: certs.ca_cert_path,
         proxy_addr,
         health_addr,
@@ -905,8 +924,9 @@ async fn start_mock_gcs_server(policies: MockPolicies) -> Result<MockGcsServer> 
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
+    let objects = Arc::new(std::sync::RwLock::new(objects));
     let state = MockGcsState {
-        objects: Arc::new(objects),
+        objects: objects.clone(),
     };
     let app = Router::new()
         .fallback(any(mock_gcs_handler))
@@ -915,7 +935,11 @@ async fn start_mock_gcs_server(policies: MockPolicies) -> Result<MockGcsServer> 
         let _ = axum::serve(listener, app).await;
     });
 
-    Ok(MockGcsServer { addr, handle })
+    Ok(MockGcsServer {
+        addr,
+        handle,
+        objects,
+    })
 }
 
 async fn mock_gcs_handler(State(state): State<MockGcsState>, uri: Uri) -> Response {
@@ -926,7 +950,8 @@ async fn mock_gcs_handler(State(state): State<MockGcsState>, uri: Uri) -> Respon
         return StatusCode::BAD_REQUEST.into_response();
     };
 
-    match state.objects.get(object_name.as_ref()) {
+    let objects = state.objects.read().unwrap();
+    match objects.get(object_name.as_ref()) {
         Some(MockGcsResponse::Policy(body)) => (
             StatusCode::OK,
             [(header::CONTENT_TYPE, "application/json")],

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -776,14 +776,13 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
         );
     }
 
-    // Without invalidation, the cached policy would still allow "localhost".
-    // Invalidate the workspace cache entry using an invalidation token.
+    // Invalidate the workspace cache entry. The token carries wId which
+    // determines what cache key gets evicted (no request body needed).
     let admin_token = make_invalidation_token(SECRET, 60);
-    let invalidate_body = json!({ "keys": [format!("w:{TEST_WORKSPACE_ID}")] }).to_string();
     let status = http_post_status(
         proxy.health_addr,
         "/invalidate-policy",
-        &invalidate_body,
+        "",
         Some(&admin_token),
     )
     .await?;
@@ -801,9 +800,8 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
 #[tokio::test]
 async fn invalidate_policy_rejects_missing_auth() -> Result<()> {
     let proxy = start_proxy(false, "production").await?;
-    let body = json!({ "keys": ["w:workspace-1"] }).to_string();
 
-    let status = http_post_status(proxy.health_addr, "/invalidate-policy", &body, None).await?;
+    let status = http_post_status(proxy.health_addr, "/invalidate-policy", "", None).await?;
 
     assert_eq!(status, 401);
     Ok(())
@@ -813,12 +811,11 @@ async fn invalidate_policy_rejects_missing_auth() -> Result<()> {
 async fn invalidate_policy_rejects_invalid_jwt() -> Result<()> {
     let proxy = start_proxy(false, "production").await?;
     let bad_token = make_token("wrong-secret", 60);
-    let body = json!({ "keys": ["w:workspace-1"] }).to_string();
 
     let status = http_post_status(
         proxy.health_addr,
         "/invalidate-policy",
-        &body,
+        "",
         Some(&bad_token),
     )
     .await?;
@@ -828,13 +825,23 @@ async fn invalidate_policy_rejects_invalid_jwt() -> Result<()> {
 }
 
 #[tokio::test]
-async fn invalidate_policy_rejects_empty_keys() -> Result<()> {
+async fn invalidate_policy_rejects_token_with_both_wid_and_sbid() -> Result<()> {
     let proxy = start_proxy(false, "production").await?;
-    let token = make_invalidation_token(SECRET, 60);
-    let body = json!({ "keys": [] }).to_string();
+    // Token has both wId AND sbId — ambiguous, should be rejected.
+    let token = make_token_with_claims(
+        SECRET,
+        FullClaims {
+            sb_id: Some(TEST_SANDBOX_ID),
+            w_id: Some(TEST_WORKSPACE_ID),
+            action: Some("invalidate-policy"),
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds: 60,
+        },
+    );
 
     let status =
-        http_post_status(proxy.health_addr, "/invalidate-policy", &body, Some(&token)).await?;
+        http_post_status(proxy.health_addr, "/invalidate-policy", "", Some(&token)).await?;
 
     assert_eq!(status, 400);
     Ok(())
@@ -844,17 +851,28 @@ async fn invalidate_policy_rejects_empty_keys() -> Result<()> {
 async fn invalidate_policy_rejects_sandbox_token_without_action() -> Result<()> {
     let proxy = start_proxy(false, "production").await?;
     let sandbox_token = make_token_with_workspace(SECRET, 60);
-    let body = json!({ "keys": ["w:workspace-1"] }).to_string();
 
     let status = http_post_status(
         proxy.health_addr,
         "/invalidate-policy",
-        &body,
+        "",
         Some(&sandbox_token),
     )
     .await?;
 
     assert_eq!(status, 403);
+    Ok(())
+}
+
+#[tokio::test]
+async fn forwarder_rejects_token_with_action_claim() -> Result<()> {
+    let proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
+    // An invalidation token (has action claim) should be rejected by the forwarder.
+    let token = make_invalidation_token(SECRET, 60);
+
+    let response = send_handshake(&proxy, &token, "localhost", 443).await?;
+
+    assert_eq!(response, Some(DENY_RESPONSE));
     Ok(())
 }
 

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -737,6 +737,90 @@ async fn sigterm_aborts_stuck_tunnel_after_drain_timeout() -> Result<()> {
     Ok(())
 }
 
+// --- Cache invalidation endpoint tests ---
+
+#[tokio::test]
+async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
+    let (upstream_port, _upstream_handles) =
+        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
+    let proxy = start_proxy_with_mock_gcs(
+        MockPolicies {
+            workspace: Some(policy_response(&["localhost"])),
+            sandbox: None,
+        },
+        None,
+        true,
+        "test",
+    )
+    .await?;
+
+    // First request populates the cache.
+    let token = make_token_with_workspace(SECRET, 60);
+    let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
+    assert_eq!(response, Some(ALLOW_RESPONSE));
+
+    // Invalidate the workspace cache entry.
+    let admin_token = make_token_with_workspace(SECRET, 60);
+    let invalidate_body = json!({ "keys": [format!("w:{TEST_WORKSPACE_ID}")] }).to_string();
+    let status = http_post_status(
+        proxy.health_addr,
+        "/invalidate-policy",
+        &invalidate_body,
+        Some(&admin_token),
+    )
+    .await?;
+    assert_eq!(status, 200);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalidate_policy_rejects_missing_auth() -> Result<()> {
+    let proxy = start_proxy(false, "production").await?;
+    let body = json!({ "keys": ["w:workspace-1"] }).to_string();
+
+    let status = http_post_status(proxy.health_addr, "/invalidate-policy", &body, None).await?;
+
+    assert_eq!(status, 401);
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalidate_policy_rejects_invalid_jwt() -> Result<()> {
+    let proxy = start_proxy(false, "production").await?;
+    let bad_token = make_token("wrong-secret", 60);
+    let body = json!({ "keys": ["w:workspace-1"] }).to_string();
+
+    let status = http_post_status(
+        proxy.health_addr,
+        "/invalidate-policy",
+        &body,
+        Some(&bad_token),
+    )
+    .await?;
+
+    assert_eq!(status, 401);
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalidate_policy_rejects_empty_keys() -> Result<()> {
+    let proxy = start_proxy(false, "production").await?;
+    let token = make_token(SECRET, 60);
+    let body = json!({ "keys": [] }).to_string();
+
+    let status = http_post_status(
+        proxy.health_addr,
+        "/invalidate-policy",
+        &body,
+        Some(&token),
+    )
+    .await?;
+
+    assert_eq!(status, 400);
+    Ok(())
+}
+
 async fn start_proxy(unsafe_skip_ssrf_check: bool, environment: &str) -> Result<ProxyProcess> {
     start_proxy_with_mock_gcs(
         MockPolicies::default(),
@@ -921,6 +1005,37 @@ async fn http_get(addr: SocketAddr, path: &str) -> Result<String> {
     let mut response = Vec::new();
     stream.read_to_end(&mut response).await?;
     Ok(String::from_utf8(response)?)
+}
+
+async fn http_post_status(
+    addr: SocketAddr,
+    path: &str,
+    body: &str,
+    bearer_token: Option<&str>,
+) -> Result<u16> {
+    let mut stream = TcpStream::connect(addr).await?;
+    let auth_header = match bearer_token {
+        Some(token) => format!("Authorization: Bearer {token}\r\n"),
+        None => String::new(),
+    };
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{auth_header}\r\n{body}",
+        body.len()
+    );
+    stream.write_all(request.as_bytes()).await?;
+
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).await?;
+    let response_str = String::from_utf8(response)?;
+
+    // Parse status code from "HTTP/1.1 200 OK" line.
+    let status_code = response_str
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| anyhow!("malformed HTTP response: {response_str}"))?
+        .parse::<u16>()?;
+
+    Ok(status_code)
 }
 
 async fn send_handshake(

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -214,6 +214,9 @@ const config = {
   getEgressPolicyBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("EGRESS_PROXY_POLICY_BUCKET");
   },
+  getEgressProxyInternalUrl: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("EGRESS_PROXY_INTERNAL_URL");
+  },
   getOAuthAPIConfig: (): { url: string; apiKey: string | null } => {
     return {
       url: EnvironmentConfig.getEnvVariable("OAUTH_API"),

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -215,7 +215,9 @@ const config = {
     return EnvironmentConfig.getEnvVariable("EGRESS_PROXY_POLICY_BUCKET");
   },
   getEgressProxyInternalUrl: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable("EGRESS_PROXY_INTERNAL_URL");
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "EGRESS_PROXY_INTERNAL_URL"
+    );
   },
   getOAuthAPIConfig: (): { url: string; apiKey: string | null } => {
     return {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -87,6 +87,31 @@ export function mintEgressJwt(providerId: string, workspaceId: string): string {
   );
 }
 
+const INVALIDATION_JWT_TTL_SECONDS = 60;
+
+export function mintEgressInvalidationJwt({
+  workspaceId,
+  sandboxId,
+}: {
+  workspaceId?: string;
+  sandboxId?: string;
+}): string {
+  return jwt.sign(
+    {
+      iss: "dust-front",
+      aud: "dust-egress-proxy",
+      action: "invalidate-policy",
+      ...(workspaceId ? { wId: workspaceId } : {}),
+      ...(sandboxId ? { sbId: sandboxId } : {}),
+    },
+    config.getEgressProxyJwtSecret(),
+    {
+      algorithm: "HS256",
+      expiresIn: INVALIDATION_JWT_TTL_SECONDS,
+    }
+  );
+}
+
 export async function checkEgressForwarderHealth(
   auth: Authenticator,
   sandbox: SandboxResource

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -1,5 +1,5 @@
 import config from "@app/lib/api/config";
-import { mintEgressJwt } from "@app/lib/api/sandbox/egress";
+import { mintEgressInvalidationJwt } from "@app/lib/api/sandbox/egress";
 import type { Authenticator } from "@app/lib/auth";
 import { getBucketInstance } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
@@ -97,7 +97,7 @@ async function invalidateWorkspacePolicyCache(
     }
 
     const workspace = auth.getNonNullableWorkspace();
-    const token = mintEgressJwt("invalidate-cache", workspace.sId);
+    const token = mintEgressInvalidationJwt({ workspaceId: workspace.sId });
 
     const response = await fetch(`${baseUrl}/invalidate-policy`, {
       method: "POST",

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -98,14 +98,13 @@ async function invalidateWorkspacePolicyCache(
 
     const workspace = auth.getNonNullableWorkspace();
     const token = mintEgressInvalidationJwt({ workspaceId: workspace.sId });
+    const url = `${baseUrl.replace(/\/+$/, "")}/invalidate-policy`;
 
-    const response = await fetch(`${baseUrl}/invalidate-policy`, {
+    const response = await fetch(url, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ keys: [`w:${workspace.sId}`] }),
       signal: AbortSignal.timeout(INVALIDATION_TIMEOUT_MS),
     });
 

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -1,7 +1,9 @@
 import config from "@app/lib/api/config";
+import { mintEgressJwt } from "@app/lib/api/sandbox/egress";
 import type { Authenticator } from "@app/lib/auth";
 import { getBucketInstance } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
+import logger from "@app/logger/logger";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import {
   EMPTY_EGRESS_POLICY,
@@ -10,6 +12,8 @@ import {
 } from "@app/types/sandbox/egress_policy";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+const INVALIDATION_TIMEOUT_MS = 5_000;
 
 function getWorkspacePolicyPath(auth: Authenticator): string {
   return `workspaces/${auth.getNonNullableWorkspace().sId}.json`;
@@ -59,6 +63,8 @@ export async function writeWorkspacePolicy(
       filePath: getWorkspacePolicyPath(auth),
     });
 
+    void invalidateWorkspacePolicyCache(auth);
+
     return new Ok(normalizedPolicy.value);
   } catch (error) {
     return new Err(normalizeError(error));
@@ -73,8 +79,46 @@ export async function deleteWorkspacePolicy(
       ignoreNotFound: true,
     });
 
+    void invalidateWorkspacePolicyCache(auth);
+
     return new Ok(undefined);
   } catch (error) {
     return new Err(normalizeError(error));
+  }
+}
+
+async function invalidateWorkspacePolicyCache(
+  auth: Authenticator
+): Promise<void> {
+  const baseUrl = config.getEgressProxyInternalUrl();
+  if (!baseUrl) {
+    return;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const token = mintEgressJwt("invalidate-cache", workspace.sId);
+
+  try {
+    const response = await fetch(`${baseUrl}/invalidate-policy`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ keys: [`w:${workspace.sId}`] }),
+      signal: AbortSignal.timeout(INVALIDATION_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      logger.warn(
+        { statusCode: response.status, workspaceId: workspace.sId },
+        "Egress proxy cache invalidation failed"
+      );
+    }
+  } catch (error) {
+    logger.warn(
+      { error: normalizeError(error), workspaceId: workspace.sId },
+      "Egress proxy cache invalidation error"
+    );
   }
 }

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -90,15 +90,15 @@ export async function deleteWorkspacePolicy(
 async function invalidateWorkspacePolicyCache(
   auth: Authenticator
 ): Promise<void> {
-  const baseUrl = config.getEgressProxyInternalUrl();
-  if (!baseUrl) {
-    return;
-  }
-
-  const workspace = auth.getNonNullableWorkspace();
-  const token = mintEgressJwt("invalidate-cache", workspace.sId);
-
   try {
+    const baseUrl = config.getEgressProxyInternalUrl();
+    if (!baseUrl) {
+      return;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const token = mintEgressJwt("invalidate-cache", workspace.sId);
+
     const response = await fetch(`${baseUrl}/invalidate-policy`, {
       method: "POST",
       headers: {
@@ -117,7 +117,7 @@ async function invalidateWorkspacePolicyCache(
     }
   } catch (error) {
     logger.warn(
-      { error: normalizeError(error), workspaceId: workspace.sId },
+      { error: normalizeError(error) },
       "Egress proxy cache invalidation error"
     );
   }


### PR DESCRIPTION
## Description

Policy changes through the workspace admin UI were taking up to 60s to propagate due to the egress proxy's moka cache TTL. This adds a `POST /invalidate-policy` endpoint on the proxy's internal health listener so front can bust specific cache keys immediately after writing or deleting workspace policy files.

### Proxy side (`egress-proxy/`)

**JWT changes:**
- `sbId` is now optional in JWT claims (normalized to `None` when empty/missing)
- New optional `action` claim for admin operations
- Renamed `ValidatedSandboxToken` → `ValidatedToken` to reflect flexibility

**Forwarder (connection handler):**
- Requires `sbId` to be present (extracted via pattern match, no unwrap)
- Rejects tokens with an `action` claim — admin tokens cannot be used for tunneling

**Invalidation endpoint (health server):**
- `POST /invalidate-policy` — no request body
- Requires JWT with `action: "invalidate-policy"`
- Cache key to evict is derived from the token's claims: exactly one of `wId` or `sbId` must be set (not both)
- `wId` → evicts `w:<wId>`, `sbId` → evicts `s:<sbId>`
- Returns `{ "invalidated": "<cache_key>" }` on success
- Rejects: missing auth (401), invalid JWT (401), no action claim (403), ambiguous claims (400)

### Front side (`front/`)
- `mintEgressInvalidationJwt({ workspaceId?, sandboxId? })` — short-lived (60s TTL), carries `action: "invalidate-policy"` and the relevant ID claim
- `writeWorkspacePolicy` and `deleteWorkspacePolicy` fire-and-forget an invalidation POST after successful GCS writes
- New optional `EGRESS_PROXY_INTERNAL_URL` env var (e.g., `http://sandbox-egress-proxy:8080`); when unset the call is silently skipped
- Trailing-slash safe URL construction
- Entire invalidation helper wrapped in try/catch — failures never block the main operation

## Tests

- 29 unit tests pass (including new JWT tests for optional sbId, action claim, invalidation tokens)
- 36 integration tests pass, including:
  - `invalidate_policy_evicts_cached_workspace_entry` — proves actual eviction by swapping mock GCS backing then asserting DENY after invalidation
  - `invalidate_policy_rejects_missing_auth` (401)
  - `invalidate_policy_rejects_invalid_jwt` (401)
  - `invalidate_policy_rejects_sandbox_token_without_action` (403)
  - `invalidate_policy_rejects_token_with_both_wid_and_sbid` (400)
  - `forwarder_rejects_token_with_action_claim` — admin token denied by tunnel handler
- Front TypeScript typechecks cleanly

## Risk

**Low.** The invalidation endpoint is on the internal health listener (port 8080, blocked by NetworkPolicy to all pods except front — see dust-tt/dust-infra#749). The JWT auth ensures only holders of the shared secret with a valid `action: "invalidate-policy"` claim can invoke it. Invalidation tokens are short-lived (60s). The front-side call is fire-and-forget; failures are logged as warnings and never block the main operation. When `EGRESS_PROXY_INTERNAL_URL` is unset, the feature is a no-op.

## Deploy Plan

1. add `EGRESS_PROXY_INTERNAL_URL` on `front`
2. deploy egress-proxy
3. deploy front

