### PR TITLE
Reiforcement: don't retry when fails with context exceeded

### DIFF
--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -1,5 +1,6 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import { categorizeConversationRenderErrorMessage } from "@app/lib/api/assistant/errors";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
@@ -18,6 +19,7 @@ import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import logger from "@app/logger/logger";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
 import {
   type AgentMessageStatus,
@@ -266,7 +268,11 @@ export async function storeLlmResult(
  * Create (or reuse) conversations, store the new user messages, reconstruct the
  * full conversation from DB, and submit a batch to the LLM.
  *
- * Returns the batch ID and the conversation sIds in the same order as the input array.
+ * Returns the batch ID and the conversation sIds in the same order as the input
+ * array. Conversations whose rendering fails because the context window is
+ * exceeded are skipped (returned as `null` in `conversationIds`) since
+ * retrying would not help. If every conversation is skipped, returns
+ * `Ok(null)` to signal that no batch was sent.
  */
 export async function sendBatchCallToLlm(
   auth: Authenticator,
@@ -276,12 +282,12 @@ export async function sendBatchCallToLlm(
   Result<
     {
       batchId: string;
-      conversationIds: string[];
-    },
+      conversationIds: (string | null)[];
+    } | null,
     Error
   >
 > {
-  const conversationIds: string[] = [];
+  const conversationIds: (string | null)[] = [];
   const batchMap = new Map<string, LLMStreamParameters>();
 
   const modelConfig = llm.getModelConfig();
@@ -293,7 +299,6 @@ export async function sendBatchCallToLlm(
       return writeBatchResult;
     }
     const conversationResource = writeBatchResult.value;
-    conversationIds.push(conversationResource.sId);
 
     // Reconstruct the full conversation from DB.
     const conversationRes = await getConversation(
@@ -323,13 +328,34 @@ export async function sendBatchCallToLlm(
     });
 
     if (modelConversationRes.isErr()) {
+      // Context window exceeded is non-recoverable for this conversation:
+      // skip it and continue with the rest of the batch instead of failing.
+      if (
+        categorizeConversationRenderErrorMessage(modelConversationRes.error)
+          ?.category === "context_window_exceeded"
+      ) {
+        logger.warn(
+          {
+            conversationId: conversationResource.sId,
+            error: modelConversationRes.error.message,
+          },
+          "sendBatchCallToLlm: skipping conversation, context window exceeded"
+        );
+        conversationIds.push(null);
+        continue;
+      }
       return modelConversationRes;
     }
 
+    conversationIds.push(conversationResource.sId);
     batchMap.set(conversationResource.sId, {
       conversation: modelConversationRes.value.modelConversation,
       ...input,
     });
+  }
+
+  if (batchMap.size === 0) {
+    return new Ok(null);
   }
 
   const batchId = await llm.sendBatchProcessing(batchMap);

--- a/front/lib/api/llm/tests/batch_llm_store.test.ts
+++ b/front/lib/api/llm/tests/batch_llm_store.test.ts
@@ -132,11 +132,17 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
         if (sendBatchResult.isErr()) {
           throw sendBatchResult.error;
         }
+        if (!sendBatchResult.value) {
+          throw new Error("Expected a batch to be sent");
+        }
         const { batchId, conversationIds } = sendBatchResult.value;
 
         expect(batchId).toBeTruthy();
         expect(conversationIds).toHaveLength(1);
         const conversationId = conversationIds[0];
+        if (!conversationId) {
+          throw new Error("Expected a conversation id");
+        }
 
         // Verify conversation was created.
         const conversation = await ConversationResource.fetchById(
@@ -175,7 +181,7 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
           authenticator,
           llm,
           batchId,
-          conversationIds,
+          conversationIds.filter((id): id is string => id !== null),
           agentConfigurationId
         );
 
@@ -335,10 +341,16 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
         if (sendBatchCallResult1.isErr()) {
           throw sendBatchCallResult1.error;
         }
+        if (!sendBatchCallResult1.value) {
+          throw new Error("Expected a batch to be sent");
+        }
         const { batchId: batchId1, conversationIds: conversationIds1 } =
           sendBatchCallResult1.value;
 
         const conversationId = conversationIds1[0];
+        if (!conversationId) {
+          throw new Error("Expected a conversation id");
+        }
 
         await awaitBatch(llm, batchId1);
 
@@ -347,7 +359,7 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
           authenticator,
           llm,
           batchId1,
-          conversationIds1,
+          conversationIds1.filter((id): id is string => id !== null),
           agentConfigurationId
         );
 
@@ -365,6 +377,9 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
         if (sendBatchCallResult2.isErr()) {
           throw sendBatchCallResult2.error;
         }
+        if (!sendBatchCallResult2.value) {
+          throw new Error("Expected a batch to be sent");
+        }
         const { batchId: batchId2, conversationIds: conversationIds2 } =
           sendBatchCallResult2.value;
 
@@ -378,7 +393,7 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
           authenticator,
           llm,
           batchId2,
-          conversationIds2,
+          conversationIds2.filter((id): id is string => id !== null),
           agentConfigurationId
         );
 

--- a/front/lib/api/llm/tests/batch_llm_store.test.ts
+++ b/front/lib/api/llm/tests/batch_llm_store.test.ts
@@ -412,7 +412,7 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
     it(
       "sendBatchCallToLlm skips conversations that exceed the context window",
       async () => {
-        const { authenticator, llm } = await setupTest();
+        const { authenticator, llm, agentConfigurationId } = await setupTest();
 
         // The mocked tokenizer counts 1 char as 1 token, and the test model
         // has a 190k-token context window. A 250k-char message guarantees the
@@ -441,6 +441,32 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
         expect(conversationIds).toHaveLength(2);
         expect(typeof conversationIds[0]).toBe("string");
         expect(conversationIds[1]).toBeNull();
+
+        // Wait for the batch to finish and verify the surviving conversation
+        // produced a real result (proving the batch was submitted correctly
+        // even with one conversation skipped).
+        const survivingConversationId = conversationIds[0];
+        if (typeof survivingConversationId !== "string") {
+          throw new Error("Expected a surviving conversation id");
+        }
+        await awaitBatch(llm, batchId);
+
+        const results = await downloadBatchResultFromLlm(
+          authenticator,
+          llm,
+          batchId,
+          [survivingConversationId],
+          agentConfigurationId
+        );
+
+        expect(results.events.size).toBe(1);
+        const events = results.events.get(survivingConversationId);
+        expect(events).toBeDefined();
+        const textEvent = events?.find((e) => e.type === "text_generated");
+        expect(textEvent).toBeDefined();
+        if (textEvent?.type === "text_generated") {
+          expect(textEvent.content.text).toContain("2");
+        }
       },
       TEST_TIMEOUT_MS
     );

--- a/front/lib/api/llm/tests/batch_llm_store.test.ts
+++ b/front/lib/api/llm/tests/batch_llm_store.test.ts
@@ -408,5 +408,62 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
       },
       TEST_TIMEOUT_MS
     );
+
+    it(
+      "sendBatchCallToLlm skips conversations that exceed the context window",
+      async () => {
+        const { authenticator, llm } = await setupTest();
+
+        // The mocked tokenizer counts 1 char as 1 token, and the test model
+        // has a 190k-token context window. A 250k-char message guarantees the
+        // render step returns "Context window exceeded".
+        const oversizedMessage = "x".repeat(250_000);
+
+        const result = await sendBatchCallToLlm(authenticator, llm, [
+          makeConversationOptions("What is 1+1? Reply with just the number.", {
+            title: "Skip Test - Normal",
+          }),
+          makeConversationOptions(oversizedMessage, {
+            title: "Skip Test - Oversized",
+          }),
+        ]);
+
+        if (result.isErr()) {
+          throw result.error;
+        }
+        expect(result.value).not.toBeNull();
+        if (!result.value) {
+          return;
+        }
+        const { batchId, conversationIds } = result.value;
+
+        expect(batchId).toBeTruthy();
+        expect(conversationIds).toHaveLength(2);
+        expect(typeof conversationIds[0]).toBe("string");
+        expect(conversationIds[1]).toBeNull();
+      },
+      TEST_TIMEOUT_MS
+    );
+
+    it(
+      "sendBatchCallToLlm returns null when every conversation exceeds the context window",
+      async () => {
+        const { authenticator, llm } = await setupTest();
+
+        const oversizedMessage = "x".repeat(250_000);
+
+        const result = await sendBatchCallToLlm(authenticator, llm, [
+          makeConversationOptions(oversizedMessage, {
+            title: "All-Skipped Test",
+          }),
+        ]);
+
+        if (result.isErr()) {
+          throw result.error;
+        }
+        expect(result.value).toBeNull();
+      },
+      TEST_TIMEOUT_MS
+    );
   }
 );

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -664,14 +664,22 @@ export async function startSkillConversationAnalysisBatchActivity({
   if (result.isErr()) {
     throw result.error;
   }
+  if (!result.value) {
+    return null;
+  }
 
   // Build the map of analysed conversation ID -> reinforcement conversation ID.
+  // Conversations skipped by sendBatchCallToLlm (e.g. context window exceeded)
+  // appear as null in conversationIds and are dropped from the map.
   const reinforcementConversationMap: Record<string, string> = {
     ...(existingReinforcementConversationMap ?? {}),
   };
   for (let i = 0; i < orderedAnalysedConversationIds.length; i++) {
-    reinforcementConversationMap[orderedAnalysedConversationIds[i]] =
-      result.value.conversationIds[i];
+    const conversationId = result.value.conversationIds[i];
+    if (conversationId !== null) {
+      reinforcementConversationMap[orderedAnalysedConversationIds[i]] =
+        conversationId;
+    }
   }
 
   logger.info(
@@ -896,6 +904,9 @@ export async function startSkillAggregationBatchActivity({
   if (sendResult.isErr()) {
     throw sendResult.error;
   }
+  if (!sendResult.value) {
+    return null;
+  }
   const { batchId, conversationIds } = sendResult.value;
 
   logger.info(
@@ -907,7 +918,13 @@ export async function startSkillAggregationBatchActivity({
     "ReinforcedSkills: started aggregation batch"
   );
 
-  return { batchId, reinforcementConversationIds: conversationIds };
+  // Drop null entries (conversations skipped by sendBatchCallToLlm).
+  return {
+    batchId,
+    reinforcementConversationIds: conversationIds.filter(
+      (id): id is string => id !== null
+    ),
+  };
 }
 
 /**


### PR DESCRIPTION
## Description

- When rendering a conversation for an LLM batch hits Context window exceeded: at least one message is required, retrying won't help — the conversation is just too large.
- Previously this would bubble up from sendBatchCallToLlm, fail the activity, and consume all retry attempts before failing the workflow for the entire workspace.
- Now the offending conversation is skipped (with a warning log) and the batch proceeds with the remaining conversations.

## Tests

Added

## Risk

Low

## Deploy Plan

Front