### PR TITLE
[front] enh(`ask_user_question`): hide cursor while navigating with the keyboard

### DIFF
--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -237,6 +237,31 @@ describe("UserAnswerRequired", () => {
     expect(alphaOption).not.toHaveClass("bg-primary-100");
   });
 
+  it("hides the cursor during keyboard navigation and restores it on mouse movement", async () => {
+    const { container } = render(
+      <UserAnswerRequired
+        blockedAction={makeBlockedAction()}
+        triggeringUser={null}
+        owner={owner}
+        conversationId="conv_1"
+        messageId="msg_1"
+      />
+    );
+
+    const keyboardContainer = getKeyboardContainer(container);
+
+    await waitFor(() => expect(keyboardContainer).toHaveFocus());
+    expect(keyboardContainer).not.toHaveClass("cursor-none");
+
+    fireEvent.keyDown(keyboardContainer, { key: "ArrowDown" });
+
+    expect(keyboardContainer).toHaveClass("cursor-none");
+
+    fireEvent.mouseMove(keyboardContainer);
+
+    expect(keyboardContainer).not.toHaveClass("cursor-none");
+  });
+
   it("submits the active option with Enter in single-select mode", async () => {
     const { container } = render(
       <UserAnswerRequired

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -50,6 +50,7 @@ vi.mock("@dust-tt/sparkle", () => {
     label,
     description,
     selected,
+    disableHover,
     className,
     onClick,
     disabled,
@@ -59,6 +60,7 @@ vi.mock("@dust-tt/sparkle", () => {
     label: string;
     description?: string | null;
     selected?: boolean;
+    disableHover?: boolean;
     className?: string;
     onClick?: () => void;
     disabled?: boolean;
@@ -77,7 +79,7 @@ vi.mock("@dust-tt/sparkle", () => {
       }}
       onMouseEnter={onMouseEnter}
       disabled={disabled}
-      className={className}
+      className={cn(!disableHover && "hover-enabled", className)}
       data-selected={selected ? "true" : "false"}
     >
       <span>{label}</span>
@@ -249,17 +251,21 @@ describe("UserAnswerRequired", () => {
     );
 
     const keyboardContainer = getKeyboardContainer(container);
+    const alphaOption = screen.getByRole("button", { name: /Alpha/i });
 
     await waitFor(() => expect(keyboardContainer).toHaveFocus());
     expect(keyboardContainer).not.toHaveClass("cursor-none");
+    expect(alphaOption).toHaveClass("hover-enabled");
 
     fireEvent.keyDown(keyboardContainer, { key: "ArrowDown" });
 
     expect(keyboardContainer).toHaveClass("cursor-none");
+    expect(alphaOption).not.toHaveClass("hover-enabled");
 
     fireEvent.mouseMove(keyboardContainer);
 
     expect(keyboardContainer).not.toHaveClass("cursor-none");
+    expect(alphaOption).toHaveClass("hover-enabled");
   });
 
   it("submits the active option with Enter in single-select mode", async () => {

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -281,6 +281,7 @@ export function UserAnswerRequired({
               description={option.description}
               counterValue={index + 1}
               selected={selectedOptions.includes(index)}
+              disableHover={isKeyboardNavigating}
               onFocusCapture={() => {
                 setIsCustomResponseFocused(false);
                 setActiveOptionIndex(index);
@@ -308,7 +309,8 @@ export function UserAnswerRequired({
                 ? "bg-primary-100 dark:bg-primary-100-night"
                 : [
                     "bg-background dark:bg-background-night ",
-                    "hover:bg-primary-100 dark:hover:bg-primary-100-night",
+                    !isKeyboardNavigating &&
+                      "hover:bg-primary-100 dark:hover:bg-primary-100-night",
                   ]
             )}
           >

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -51,6 +51,7 @@ export function UserAnswerRequired({
   const [isSkipPending, setIsSkipPending] = useState(false);
   const [activeOptionIndex, setActiveOptionIndex] = useState(0);
   const [isCustomResponseFocused, setIsCustomResponseFocused] = useState(false);
+  const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const customResponseInputRef = useRef<HTMLInputElement>(null);
 
@@ -73,6 +74,7 @@ export function UserAnswerRequired({
   useEffect(() => {
     setActiveOptionIndex(0);
     setIsCustomResponseFocused(false);
+    setIsKeyboardNavigating(false);
     containerRef.current?.focus({ preventScroll: true });
   }, [blockedAction.actionId]);
 
@@ -175,6 +177,7 @@ export function UserAnswerRequired({
     if (e.key === "Escape") {
       e.preventDefault();
       e.stopPropagation();
+      setIsKeyboardNavigating(true);
       handleSkip();
       return;
     }
@@ -190,6 +193,7 @@ export function UserAnswerRequired({
     if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && question.multiSelect) {
       e.preventDefault();
       e.stopPropagation();
+      setIsKeyboardNavigating(true);
       handleSubmit();
     }
   }
@@ -205,6 +209,7 @@ export function UserAnswerRequired({
 
     if (isPrintableKey(e)) {
       e.preventDefault();
+      setIsKeyboardNavigating(true);
       handleStartCustomResponse(e.key);
       return;
     }
@@ -212,12 +217,14 @@ export function UserAnswerRequired({
     switch (e.key) {
       case "ArrowDown":
         e.preventDefault();
+        setIsKeyboardNavigating(true);
         setIsCustomResponseFocused(false);
         moveActiveOption(1);
         containerRef.current?.focus();
         break;
       case "ArrowUp":
         e.preventDefault();
+        setIsKeyboardNavigating(true);
         setIsCustomResponseFocused(false);
         moveActiveOption(-1);
         containerRef.current?.focus();
@@ -226,6 +233,7 @@ export function UserAnswerRequired({
       case " ":
         if (e.currentTarget === e.target) {
           e.preventDefault();
+          setIsKeyboardNavigating(true);
           handleActiveOptionSelection();
         }
         break;
@@ -250,9 +258,11 @@ export function UserAnswerRequired({
       tabIndex={0}
       onKeyDownCapture={handleContainerKeyDownCapture}
       onKeyDown={handleContainerKeyDown}
+      onMouseMove={() => setIsKeyboardNavigating(false)}
       className={cn(
         "flex flex-col gap-4 rounded-2xl border border-dark bg-background p-5 outline-none",
-        "dark:border-dark-night dark:bg-background-night"
+        "dark:border-dark-night dark:bg-background-night",
+        isKeyboardNavigating && "cursor-none"
       )}
     >
       <div className="text-base font-medium leading-tight text-foreground dark:text-foreground-night">
@@ -283,7 +293,8 @@ export function UserAnswerRequired({
                 activeOptionIndex === index &&
                   !isCustomResponseActive &&
                   !selectedOptions.includes(index) &&
-                  "bg-primary-100 dark:bg-primary-100-night"
+                  "bg-primary-100 dark:bg-primary-100-night",
+                isKeyboardNavigating && "cursor-none"
               )}
               onClick={() => handleOptionClick(index)}
               disabled={isAnswerSubmitting}
@@ -316,7 +327,8 @@ export function UserAnswerRequired({
                 "px-0 py-0 text-sm shadow-none",
                 "dark:border-transparent dark:bg-transparent",
                 "focus-visible:border-transparent focus-visible:ring-0",
-                "dark:focus-visible:border-transparent dark:focus-visible:ring-0"
+                "dark:focus-visible:border-transparent dark:focus-visible:ring-0",
+                isKeyboardNavigating && "cursor-none"
               )}
               placeholder="Type something else"
               value={customResponse}
@@ -333,6 +345,7 @@ export function UserAnswerRequired({
                   question.options.length > 0
                 ) {
                   e.preventDefault();
+                  setIsKeyboardNavigating(true);
                   setIsCustomResponseFocused(false);
                   setActiveOptionIndex(question.options.length - 1);
                   containerRef.current?.focus();
@@ -344,6 +357,7 @@ export function UserAnswerRequired({
                   (!question.multiSelect || e.metaKey || e.ctrlKey)
                 ) {
                   e.preventDefault();
+                  setIsKeyboardNavigating(true);
                   handleSubmit();
                 }
               }}

--- a/sparkle/src/components/OptionCard.tsx
+++ b/sparkle/src/components/OptionCard.tsx
@@ -9,6 +9,7 @@ export interface OptionCardProps {
   counterValue?: number;
   selected?: boolean;
   disabled?: boolean;
+  disableHover?: boolean;
   className?: string;
   onClick?: () => void;
   onFocusCapture?: React.FocusEventHandler<HTMLDivElement>;
@@ -21,6 +22,7 @@ export function OptionCard({
   counterValue,
   selected = false,
   disabled = false,
+  disableHover = false,
   className,
   onClick,
   onFocusCapture,
@@ -44,6 +46,7 @@ export function OptionCard({
         !disabled && "s-cursor-pointer",
         disabled && "s-pointer-events-none s-opacity-60",
         !selected &&
+          !disableHover &&
           "hover:s-bg-muted-background/60 dark:hover:s-bg-muted-background-night/60",
         className
       )}


### PR DESCRIPTION
## Description

This PR hides the pointer cursor once a user starts navigating `UserAnswerRequired` with the keyboard, so pointer hover state does not visually compete with the keyboard-highlighted option.

It does this by tracking keyboard navigation mode, applying cursor-none while that mode is active, and restoring the normal cursor as soon as the mouse moves again. The cursor state also resets when a new blocked action replaces the current one.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
