### PR TITLE
[front] enh: improve slash command autocomplete matching

### DIFF
--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
@@ -1,0 +1,66 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { describe, expect, it } from "vitest";
+
+import { filterInputBarSlashSuggestions } from "./InputBarSlashSuggestionDropdown";
+
+describe("filterInputBarSlashSuggestions", () => {
+  it("filters capabilities by name only", async () => {
+    const { auth, globalSpace, workspace } =
+      await createPrivateApiMockRequest();
+    const skill = await SkillFactory.create(auth, {
+      name: "Summarize",
+      userFacingDescription: "Search spreadsheets and documents.",
+    });
+    const calendarServer = await RemoteMCPServerFactory.create(workspace, {
+      name: "Calendar",
+      description: "Search spreadsheets and documents.",
+    });
+    const calendarServerView = await MCPServerViewFactory.create(
+      workspace,
+      calendarServer.sId,
+      globalSpace
+    );
+
+    const result = filterInputBarSlashSuggestions({
+      query: "spreadsheet",
+      selectedMCPServerViewIds: new Set(),
+      selectedSkillIds: new Set(),
+      serverViews: [calendarServerView.toJSON()],
+      skills: [skill.toJSON(auth)],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("orders non-substring matches by fuzzy relevance", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+    const generateDailyReportSkill = await SkillFactory.create(auth, {
+      name: "Generate Daily Report",
+      userFacingDescription: "",
+    });
+    const googleDriveSkill = await SkillFactory.create(auth, {
+      name: "Google Drive",
+      userFacingDescription: "",
+    });
+
+    const result = filterInputBarSlashSuggestions({
+      query: "gd",
+      selectedMCPServerViewIds: new Set(),
+      selectedSkillIds: new Set(),
+      serverViews: [],
+      skills: [
+        generateDailyReportSkill.toJSON(auth),
+        googleDriveSkill.toJSON(auth),
+      ],
+    });
+
+    expect(
+      result.map((capability) =>
+        capability.kind === "skill" ? capability.skill.name : ""
+      )
+    ).toEqual(["Google Drive", "Generate Daily Report"]);
+  });
+});

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -14,6 +14,7 @@ import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
+import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -29,11 +30,9 @@ import {
 import type { InputBarSlashSuggestionCapability } from "./InputBarSlashSuggestionTypes";
 
 function matchesCapabilityQuery({
-  description,
   label,
   query,
 }: {
-  description?: string;
   label: string;
   query: string;
 }) {
@@ -41,10 +40,7 @@ function matchesCapabilityQuery({
     return true;
   }
 
-  return (
-    label.toLowerCase().includes(query) ||
-    description?.toLowerCase().includes(query) === true
-  );
+  return subFilter(query, label.toLowerCase());
 }
 
 export function filterInputBarSlashSuggestions({
@@ -70,7 +66,6 @@ export function filterInputBarSlashSuggestions({
       .filter((skill) =>
         matchesCapabilityQuery({
           label: skill.name,
-          description: skill.userFacingDescription,
           query: normalizedQuery,
         })
       )
@@ -85,7 +80,6 @@ export function filterInputBarSlashSuggestions({
       .filter((serverView) =>
         matchesCapabilityQuery({
           label: getMcpServerViewDisplayName(serverView),
-          description: getMcpServerViewDescription(serverView),
           query: normalizedQuery,
         })
       )
@@ -97,7 +91,16 @@ export function filterInputBarSlashSuggestions({
   ];
 
   return capabilities
-    .toSorted((a, b) => a.sortName.localeCompare(b.sortName))
+    .toSorted((a, b) => {
+      if (normalizedQuery.length > 0) {
+        return (
+          compareForFuzzySort(normalizedQuery, a.sortName, b.sortName) ||
+          a.sortName.localeCompare(b.sortName)
+        );
+      }
+
+      return a.sortName.localeCompare(b.sortName);
+    })
     .map(({ sortName: _sortName, ...capability }) => capability);
 }
 


### PR DESCRIPTION
## Description

This PR makes the input bar slash command dropdown behave more like an autocomplete.

Existing behavior: we filter capabilities whose name or description contain the query, then sort by name.

New behavior:  we match only against the displayed capability name, not the description. Non-empty queries also use the same fuzzy matching/sorting helpers used by agent mentions, so compact queries like `auq` can rank `Ask User Question` ahead of weaker character matches.

## Tests

- Tested locally.
- Added a test.

## Risk

- Low. Behind feature flag and well scoped change.

## Deploy Plan

- Deploy front.
