### PR TITLE
Metronome credits backfill script improvement

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -176,7 +176,7 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
 
     // Handle free credit creation (no Stripe invoice).
     if (validatedArgs.isFreeCredit) {
-      const idempotencyKey = `free-poke-${workspace.sId}-${startDate.getTime()}-${expirationDate.getTime()}`;
+      const idempotencyKey = `free-poke-${workspace.sId}-${Date.now()}`;
 
       const credit = await CreditResource.makeNew(auth, {
         type: "free",
@@ -207,7 +207,7 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
           startingAt: startResult.value.startDate.toISOString(),
           endingBefore: startResult.value.expirationDate.toISOString(),
           name: `Free poke credit ($${originalAmount.toFixed(2)})`,
-          idempotencyKey,
+          idempotencyKey: `free-poke-${workspace.sId}-${startDate.getTime()}-${expirationDate.getTime()}`,
         });
 
         if (metronomeResult.isErr()) {

--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -176,7 +176,7 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
 
     // Handle free credit creation (no Stripe invoice).
     if (validatedArgs.isFreeCredit) {
-      const idempotencyKey = `createCredit-${workspace.sId}-${startDate.getTime()}-${expirationDate.getTime()}`;
+      const idempotencyKey = `free-poke-${workspace.sId}-${startDate.getTime()}-${expirationDate.getTime()}`;
 
       const credit = await CreditResource.makeNew(auth, {
         type: "free",

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -836,7 +836,7 @@ export async function updateMetronomeCreditSegmentAmount({
   creditId: string;
   segmentId: string;
   amount: number;
-}): Promise<Result<void, Error>> {
+}): Promise<Result<{ id: string }, Error>> {
   try {
     await getMetronomeClient().v2.contracts.edit({
       customer_id: metronomeCustomerId,
@@ -860,7 +860,7 @@ export async function updateMetronomeCreditSegmentAmount({
       { metronomeCustomerId, contractId, creditId, segmentId, amount },
       "[Metronome] Free credit segment amount updated"
     );
-    return new Ok(undefined);
+    return new Ok({ id: creditId });
   } catch (err) {
     const error = normalizeError(err);
     logger.error(

--- a/front/scripts/backfill_metronome_credits.ts
+++ b/front/scripts/backfill_metronome_credits.ts
@@ -188,7 +188,7 @@ async function backfillCreditsOfType(
         result = await updateMetronomeCreditSegmentAmount({
           metronomeCustomerId,
           contractId: contract.id,
-          creditId: existingRecurringCredit.id,
+          creditId: currentRecurringCredit.id,
           segmentId,
           amount: initialAmount,
         });

--- a/front/scripts/backfill_metronome_credits.ts
+++ b/front/scripts/backfill_metronome_credits.ts
@@ -202,7 +202,7 @@ async function backfillCreditsOfType(
           startingAt: startingAt.toISOString(),
           endingBefore: endingBefore.toISOString(),
           name: `Free poke credit backfill (${startingAt.toISOString().split("T")[0]})`,
-          idempotencyKey: `free-poke-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
+          idempotencyKey: `createCredit-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
         });
       }
     }

--- a/front/scripts/backfill_metronome_credits.ts
+++ b/front/scripts/backfill_metronome_credits.ts
@@ -126,85 +126,95 @@ async function backfillCreditsOfType(
 
     let result: Result<{ id: string } | null, Error>;
 
-    if (type === "committed") {
-      result = await createMetronomeCommit({
-        metronomeCustomerId,
-        productId: getProductPrepaidCommitId(),
-        creditTypeId: getCreditTypeProgrammaticUsdId(),
-        amount: initialAmount,
-        startingAt,
-        endingBefore,
-        name: `Prepaid commit backfill (${startingAt.toISOString().split("T")[0]})`,
-        idempotencyKey: `createCommit-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
-      });
-    } else {
-      if (!credit?.invoiceOrLineItemId) {
-        logger.warn(
-          {
-            workspaceId: workspace.sId,
-            creditId: credit.id,
-          },
-          `[Backfill] Credit missing invoiceOrLineItemId, cannot determine if "free-renewal-sub" or "free-poke", skipping`
-        );
-        continue;
-      }
-      if (credit.invoiceOrLineItemId.startsWith("free-renewal-sub")) {
-        const client = getMetronomeClient();
-        const contractsResponse = await client.v2.contracts.list({
-          customer_id: metronomeCustomerId,
-        });
-        const contract = contractsResponse.data[0];
-        const freeCreditProductId = getProductFreeMonthlyCreditId();
-        const existingRecurringCredit = contract.recurring_credits?.find(
-          (rc) => rc.product.id === freeCreditProductId
-        );
-
-        if (!existingRecurringCredit) {
-          logger.info(
-            { workspaceId: workspace.sId, contractId: contract.id },
-            "[Backfill] Recurring credit does not exist on contract, skipping"
-          );
-          continue;
-        }
-        const creditsResponse = await client.v1.customers.credits.list({
-          customer_id: metronomeCustomerId,
-          covering_date: new Date().toISOString(),
-          include_contract_credits: true,
-        });
-        const currentRecurringCredit = creditsResponse.data.find(
-          (c) => c.recurring_credit_id === existingRecurringCredit.id
-        );
-        const segmentId =
-          currentRecurringCredit?.access_schedule?.schedule_items[0]?.id;
-
-        if (!segmentId) {
-          logger.info(
-            { workspaceId: workspace.sId, contractId: contract.id },
-            "[Backfill] No active segment found for recurring credit, skipping"
-          );
-          continue;
-        }
-
-        result = await updateMetronomeCreditSegmentAmount({
+    switch (type) {
+      case "committed":
+        result = await createMetronomeCommit({
           metronomeCustomerId,
-          contractId: contract.id,
-          creditId: currentRecurringCredit.id,
-          segmentId,
-          amount: initialAmount,
-        });
-      } else {
-        // "free-poke" credits
-        result = await createMetronomeCredit({
-          metronomeCustomerId,
-          productId: getProductFreeMonthlyCreditId(),
+          productId: getProductPrepaidCommitId(),
           creditTypeId: getCreditTypeProgrammaticUsdId(),
           amount: initialAmount,
-          startingAt: startingAt.toISOString(),
-          endingBefore: endingBefore.toISOString(),
-          name: `Free poke credit backfill (${startingAt.toISOString().split("T")[0]})`,
-          idempotencyKey: `createCredit-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
+          startingAt,
+          endingBefore,
+          name: `Prepaid commit backfill (${startingAt.toISOString().split("T")[0]})`,
+          idempotencyKey: `createCommit-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
         });
+        break;
+      case "free": {
+        if (!credit?.invoiceOrLineItemId) {
+          logger.warn(
+            {
+              workspaceId: workspace.sId,
+              creditId: credit.id,
+            },
+            `[Backfill] Credit missing invoiceOrLineItemId, cannot determine if "free-renewal-sub" or "free-poke", skipping`
+          );
+          continue;
+        }
+        if (credit.invoiceOrLineItemId.startsWith("free-renewal-sub")) {
+          const client = getMetronomeClient();
+          const contractsResponse = await client.v2.contracts.list({
+            customer_id: metronomeCustomerId,
+          });
+          const contract = contractsResponse.data[0];
+          const freeCreditProductId = getProductFreeMonthlyCreditId();
+          const existingRecurringCredit = contract.recurring_credits?.find(
+            (rc) => rc.product.id === freeCreditProductId
+          );
+
+          if (!existingRecurringCredit) {
+            logger.info(
+              { workspaceId: workspace.sId, contractId: contract.id },
+              "[Backfill] Recurring credit does not exist on contract, skipping"
+            );
+            continue;
+          }
+          const creditsResponse = await client.v1.customers.credits.list({
+            customer_id: metronomeCustomerId,
+            covering_date: new Date().toISOString(),
+            include_contract_credits: true,
+          });
+          const currentRecurringCredit = creditsResponse.data.find(
+            (c) => c.recurring_credit_id === existingRecurringCredit.id
+          );
+          const segmentId =
+            currentRecurringCredit?.access_schedule?.schedule_items[0]?.id;
+
+          if (!segmentId) {
+            logger.info(
+              { workspaceId: workspace.sId, contractId: contract.id },
+              "[Backfill] No active segment found for recurring credit, skipping"
+            );
+            continue;
+          }
+
+          result = await updateMetronomeCreditSegmentAmount({
+            metronomeCustomerId,
+            contractId: contract.id,
+            creditId: currentRecurringCredit.id,
+            segmentId,
+            amount: initialAmount,
+          });
+        } else {
+          // "free-poke" credits
+          result = await createMetronomeCredit({
+            metronomeCustomerId,
+            productId: getProductFreeMonthlyCreditId(),
+            creditTypeId: getCreditTypeProgrammaticUsdId(),
+            amount: initialAmount,
+            startingAt: startingAt.toISOString(),
+            endingBefore: endingBefore.toISOString(),
+            name: `Free poke credit backfill (${startingAt.toISOString().split("T")[0]})`,
+            idempotencyKey: `createCredit-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
+          });
+        }
+        break;
       }
+      default:
+        logger.error(
+          { workspaceId: workspace.sId, creditId: credit.id, type },
+          `[Backfill] Unknown credit type "${type}", skipping`
+        );
+        continue;
     }
 
     if (result.isErr()) {

--- a/front/scripts/backfill_metronome_credits.ts
+++ b/front/scripts/backfill_metronome_credits.ts
@@ -19,6 +19,8 @@ import { Authenticator } from "@app/lib/auth";
 import {
   createMetronomeCommit,
   createMetronomeCredit,
+  getMetronomeClient,
+  updateMetronomeCreditSegmentAmount,
 } from "@app/lib/metronome/client";
 import {
   getCreditTypeProgrammaticUsdId,
@@ -28,6 +30,7 @@ import {
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import type { Logger } from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 
 import { makeScript } from "./helpers";
@@ -121,28 +124,88 @@ async function backfillCreditsOfType(
       continue;
     }
 
-    const result =
-      type === "free"
-        ? await createMetronomeCredit({
-            metronomeCustomerId,
-            productId: getProductFreeMonthlyCreditId(),
-            creditTypeId: getCreditTypeProgrammaticUsdId(),
-            amount: initialAmount,
-            startingAt: startingAt.toISOString(),
-            endingBefore: endingBefore.toISOString(),
-            name: `Monthly credit backfill (${startingAt.toISOString().split("T")[0]})`,
-            idempotencyKey: `createCredit-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
-          })
-        : await createMetronomeCommit({
-            metronomeCustomerId,
-            productId: getProductPrepaidCommitId(),
-            creditTypeId: getCreditTypeProgrammaticUsdId(),
-            amount: initialAmount,
-            startingAt,
-            endingBefore,
-            name: `Prepaid commit backfill (${startingAt.toISOString().split("T")[0]})`,
-            idempotencyKey: `createCommit-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
-          });
+    let result: Result<{ id: string } | null, Error>;
+
+    if (type === "committed") {
+      result = await createMetronomeCommit({
+        metronomeCustomerId,
+        productId: getProductPrepaidCommitId(),
+        creditTypeId: getCreditTypeProgrammaticUsdId(),
+        amount: initialAmount,
+        startingAt,
+        endingBefore,
+        name: `Prepaid commit backfill (${startingAt.toISOString().split("T")[0]})`,
+        idempotencyKey: `createCommit-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
+      });
+    } else {
+      if (!credit?.invoiceOrLineItemId) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            creditId: credit.id,
+          },
+          `[Backfill] Credit missing invoiceOrLineItemId, cannot determine if "free-renewal-sub" or "free-poke", skipping`
+        );
+        continue;
+      }
+      if (credit.invoiceOrLineItemId.startsWith("free-renewal-sub")) {
+        const client = getMetronomeClient();
+        const contractsResponse = await client.v2.contracts.list({
+          customer_id: metronomeCustomerId,
+        });
+        const contract = contractsResponse.data[0];
+        const freeCreditProductId = getProductFreeMonthlyCreditId();
+        const existingRecurringCredit = contract.recurring_credits?.find(
+          (rc) => rc.product.id === freeCreditProductId
+        );
+
+        if (!existingRecurringCredit) {
+          logger.info(
+            { workspaceId: workspace.sId, contractId: contract.id },
+            "[Backfill] Recurring credit does not exist on contract, skipping"
+          );
+          continue;
+        }
+        const creditsResponse = await client.v1.customers.credits.list({
+          customer_id: metronomeCustomerId,
+          covering_date: new Date().toISOString(),
+          include_contract_credits: true,
+        });
+        const currentRecurringCredit = creditsResponse.data.find(
+          (c) => c.recurring_credit_id === existingRecurringCredit.id
+        );
+        const segmentId =
+          currentRecurringCredit?.access_schedule?.schedule_items[0]?.id;
+
+        if (!segmentId) {
+          logger.info(
+            { workspaceId: workspace.sId, contractId: contract.id },
+            "[Backfill] No active segment found for recurring credit, skipping"
+          );
+          continue;
+        }
+
+        result = await updateMetronomeCreditSegmentAmount({
+          metronomeCustomerId,
+          contractId: contract.id,
+          creditId: existingRecurringCredit.id,
+          segmentId,
+          amount: initialAmount,
+        });
+      } else {
+        // "free-poke" credits
+        result = await createMetronomeCredit({
+          metronomeCustomerId,
+          productId: getProductFreeMonthlyCreditId(),
+          creditTypeId: getCreditTypeProgrammaticUsdId(),
+          amount: initialAmount,
+          startingAt: startingAt.toISOString(),
+          endingBefore: endingBefore.toISOString(),
+          name: `Free poke credit backfill (${startingAt.toISOString().split("T")[0]})`,
+          idempotencyKey: `free-poke-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
+        });
+      }
+    }
 
     if (result.isErr()) {
       logger.error(


### PR DESCRIPTION
## Description

This PR improves the Metronome credits backfill script to properly distinguish between two types of free credits: those created via recurring credit renewal (`free-renewal-sub`) and those created via the Poke plugin (`free-poke`). The script now checks the `invoiceOrLineItemId` field to determine the credit type and handles each appropriately:

- For `free-renewal-sub` credits: updates the existing recurring credit segment amount on the contract
- For `free-poke` credits: creates a new one-time credit grant in Metronome

Additionally, the PR fixes the return type of `updateMetronomeCreditSegmentAmount()` to return `{ id: string }` instead of `void`, and updates the idempotency key for poke credits from `createCredit-` to `free-poke-` to avoid conflicts with other credit types.

## Tests

Manually tested the backfill script in dry-run and execute mode with workspaces containing both types of free credits.

## Risk

Low. The script remains idempotent and only affects workspaces with Metronome contracts. Credits without an `invoiceOrLineItemId` are skipped with a warning.

## Deploy front