### PR TITLE
Unified GCS file explorer behind feature flag

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -10,12 +10,12 @@ import {
   type MinimalFileForPreview,
 } from "@app/components/spaces/FilePreviewSheet";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { downloadSandboxFile } from "@app/lib/swr/files";
 import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -1,4 +1,5 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { NewFileExplorer } from "@app/components/assistant/conversation/files_panel/FileExplorer";
 import { FilesTab } from "@app/components/assistant/conversation/files_panel/FilesTab";
 import { SandboxStatusChip } from "@app/components/assistant/conversation/files_panel/SandboxStatusChip";
 import { SandboxTab } from "@app/components/assistant/conversation/files_panel/SandboxTab";
@@ -9,7 +10,9 @@ import {
   type MinimalFileForPreview,
 } from "@app/components/spaces/FilePreviewSheet";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
+import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
@@ -37,6 +40,9 @@ export function ConversationFilesPanel({
   conversation,
   owner,
 }: ConversationFilesPanelProps) {
+  const { hasFeature } = useFeatureFlags();
+  const isNewFileExplorer = hasFeature("new_file_explorer");
+
   const [activeTab, setActiveTab] = useState("files");
   const [previewFile, setPreviewFile] = useState<MinimalFileForPreview | null>(
     null
@@ -51,11 +57,19 @@ export function ConversationFilesPanel({
     useConversationAttachments({
       conversationId: conversation.sId,
       owner,
+      options: { disabled: isNewFileExplorer },
     });
 
   const { sandboxStatus } = useConversationSandboxStatus({
     conversationId: conversation.sId,
     owner,
+    options: { disabled: isNewFileExplorer },
+  });
+
+  const { sandboxFiles, isSandboxFilesLoading } = useConversationSandboxFiles({
+    conversationId: conversation.sId,
+    owner,
+    options: { disabled: !isNewFileExplorer },
   });
 
   const openFile = useCallback(
@@ -143,6 +157,18 @@ export function ConversationFilesPanel({
         .map((a) => conversationAttachmentToRow(a, handleAttachmentClick)),
     [attachments, handleAttachmentClick]
   );
+
+  if (isNewFileExplorer) {
+    return (
+      <NewFileExplorer
+        conversation={conversation}
+        files={sandboxFiles}
+        isLoading={isSandboxFilesLoading}
+        onClose={closePanel}
+        owner={owner}
+      />
+    );
+  }
 
   const hasSandbox = sandboxStatus !== null;
 

--- a/front/components/assistant/conversation/files_panel/FileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorer.tsx
@@ -1,0 +1,327 @@
+import {
+  FileExplorerEmptyState,
+  FileExplorerFileCard,
+  FileExplorerFolderCard,
+  type ViewMode,
+} from "@app/components/assistant/conversation/files_panel/FileExplorerItem";
+import { SandboxStatusChip } from "@app/components/assistant/conversation/files_panel/SandboxStatusChip";
+import type { SandboxTreeNode } from "@app/components/assistant/conversation/files_panel/types";
+import { buildSandboxTree } from "@app/components/assistant/conversation/files_panel/utils";
+import {
+  FilePreviewSheet,
+  type MinimalFileForPreview,
+} from "@app/components/spaces/FilePreviewSheet";
+import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
+import { downloadSandboxFile } from "@app/lib/swr/files";
+import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { isInteractiveContentType } from "@app/types/files";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  type BreadcrumbItem,
+  Breadcrumbs,
+  Button,
+  CardGrid,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  ListCheckIcon,
+  ListIcon,
+  ScrollArea,
+  Spinner,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+// TODO(2026-04-27 FILE SYSTEM): Candidate for Sparkle once the GCS file explorer pattern stabilises.
+interface FileExplorerBreadcrumbProps {
+  folderStack: SandboxTreeNode[];
+  onNavigate: (index: number) => void;
+}
+
+function FileExplorerBreadcrumb({
+  folderStack,
+  onNavigate,
+}: FileExplorerBreadcrumbProps) {
+  const items: BreadcrumbItem[] = [
+    { label: "All files", onClick: () => onNavigate(-1) },
+    ...folderStack.map((node, i) => ({
+      label: node.name,
+      onClick: () => onNavigate(i),
+    })),
+  ];
+
+  return <Breadcrumbs items={items} size="sm" />;
+}
+
+// TODO(2026-04-27 FILE SYSTEM): Candidate for Sparkle once the GCS file explorer pattern stabilises.
+interface FileExplorerViewToggleProps {
+  value: ViewMode;
+  onValueChange: (v: ViewMode) => void;
+}
+
+function FileExplorerViewToggle({
+  value,
+  onValueChange,
+}: FileExplorerViewToggleProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          icon={value === "grid" ? ListIcon : ListCheckIcon}
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem label="Grid" onClick={() => onValueChange("grid")} />
+        <DropdownMenuItem label="List" onClick={() => onValueChange("list")} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface NewFileExplorerProps {
+  conversation: ConversationWithoutContentType;
+  files: GCSMountFileEntry[];
+  isLoading: boolean;
+  onClose: () => void;
+  owner: LightWorkspaceType;
+}
+
+export function NewFileExplorer({
+  conversation,
+  files,
+  isLoading,
+  onClose,
+  owner,
+}: NewFileExplorerProps) {
+  const [folderStack, setFolderStack] = useState<SandboxTreeNode[]>([]);
+  const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  const [previewFile, setPreviewFile] = useState<MinimalFileForPreview | null>(
+    null
+  );
+  const [showPreviewSheet, setShowPreviewSheet] = useState(false);
+  const isDownloadingRef = useRef(false);
+  const blobUrlRef = useRef<string | null>(null);
+
+  const { sandboxStatus } = useConversationSandboxStatus({
+    conversationId: conversation.sId,
+    owner,
+  });
+
+  const tree = useMemo(() => buildSandboxTree(files), [files]);
+
+  // Map from tree-relative path → original GCSMountFileEntry (for metadata).
+  const entryByRelativePath = useMemo(() => {
+    if (files.length === 0) {
+      return new Map<string, GCSMountFileEntry>();
+    }
+    const commonPrefix = files[0].path.substring(
+      0,
+      files[0].path.indexOf("/files/") + "/files/".length
+    );
+    const map = new Map<string, GCSMountFileEntry>();
+    for (const f of files) {
+      const relativePath = f.path.startsWith(commonPrefix)
+        ? f.path.slice(commonPrefix.length)
+        : f.path;
+      map.set(relativePath, f);
+    }
+    return map;
+  }, [files]);
+
+  const currentNodes = useMemo(() => {
+    if (folderStack.length === 0) {
+      return tree;
+    }
+    return folderStack.at(-1)?.children ?? [];
+  }, [tree, folderStack]);
+
+  const { folders, filesAtLevel } = useMemo(() => {
+    const folders: SandboxTreeNode[] = [];
+    const filesAtLevel: GCSMountFileEntry[] = [];
+
+    for (const node of currentNodes) {
+      if (node.name.startsWith(".")) {
+        continue;
+      }
+      if (node.contentType === "inode/directory") {
+        folders.push(node);
+      } else {
+        const entry = entryByRelativePath.get(node.path);
+        if (entry) {
+          filesAtLevel.push(entry);
+        }
+      }
+    }
+
+    folders.sort((a, b) => a.name.localeCompare(b.name));
+    filesAtLevel.sort((a, b) => a.fileName.localeCompare(b.fileName));
+
+    return { folders, filesAtLevel };
+  }, [currentNodes, entryByRelativePath]);
+
+  const totalFileCount = filesAtLevel.length;
+
+  const handleBreadcrumbNavigate = useCallback((index: number) => {
+    if (index < 0) {
+      setFolderStack([]);
+    } else {
+      setFolderStack((prev) => prev.slice(0, index + 1));
+    }
+  }, []);
+
+  const handleFolderNavigate = useCallback((node: SandboxTreeNode) => {
+    setFolderStack((prev) => [...prev, node]);
+  }, []);
+
+  const handleOpen = useCallback((entry: GCSMountFileEntry) => {
+    if (!entry.fileId) {
+      return;
+    }
+    if (isInteractiveContentType(entry.contentType)) {
+      return;
+    }
+    setPreviewFile({
+      sId: entry.fileId,
+      fileName: entry.fileName,
+      contentType: entry.contentType,
+    });
+    setShowPreviewSheet(true);
+  }, []);
+
+  const handleDownload = useCallback(
+    async (entry: GCSMountFileEntry) => {
+      if (isDownloadingRef.current) {
+        return;
+      }
+      isDownloadingRef.current = true;
+      try {
+        const res = await downloadSandboxFile(
+          owner,
+          conversation.sId,
+          entry.path
+        );
+        const blob = await res.blob();
+        if (blobUrlRef.current) {
+          URL.revokeObjectURL(blobUrlRef.current);
+        }
+        const url = URL.createObjectURL(blob);
+        blobUrlRef.current = url;
+
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = entry.fileName;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+      } finally {
+        isDownloadingRef.current = false;
+      }
+    },
+    [owner, conversation.sId]
+  );
+
+  return (
+    <>
+      <div className="flex h-full flex-col">
+        <AppLayoutTitle>
+          <div className="flex h-full items-center justify-between">
+            <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+              File explorer
+            </span>
+            <div className="flex items-center gap-2">
+              {sandboxStatus && <SandboxStatusChip status={sandboxStatus} />}
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={XMarkIcon}
+                onClick={onClose}
+              />
+            </div>
+          </div>
+        </AppLayoutTitle>
+
+        <div className="flex flex-1 flex-col overflow-hidden gap-5 pt-5 px-4">
+          <div className="flex shrink-0 items-center justify-between">
+            <FileExplorerBreadcrumb
+              folderStack={folderStack}
+              onNavigate={handleBreadcrumbNavigate}
+            />
+            <FileExplorerViewToggle
+              value={viewMode}
+              onValueChange={setViewMode}
+            />
+          </div>
+
+          {isLoading ? (
+            <div className="flex flex-1 items-center justify-center">
+              <Spinner />
+            </div>
+          ) : totalFileCount === 0 && folders.length === 0 ? (
+            <FileExplorerEmptyState />
+          ) : (
+            <ScrollArea className="flex-1">
+              {/* TODO(2026-04-27 FILE_SYSTEM) Candidate for Sparkle CardGrid extension */}
+              {viewMode === "list" ? (
+                <div className="flex flex-col divide-y divide-separator dark:divide-separator-night">
+                  {folders.map((node) => (
+                    <FileExplorerFolderCard
+                      key={node.path}
+                      node={node}
+                      viewMode={viewMode}
+                      onNavigate={handleFolderNavigate}
+                    />
+                  ))}
+                  {filesAtLevel.map((entry) => (
+                    <FileExplorerFileCard
+                      key={entry.path}
+                      entry={entry}
+                      owner={owner}
+                      viewMode={viewMode}
+                      onOpen={handleOpen}
+                      onDownload={handleDownload}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <CardGrid>
+                  {folders.map((node) => (
+                    <FileExplorerFolderCard
+                      key={node.path}
+                      node={node}
+                      viewMode={viewMode}
+                      onNavigate={handleFolderNavigate}
+                    />
+                  ))}
+                  {filesAtLevel.map((entry) => (
+                    <FileExplorerFileCard
+                      key={entry.path}
+                      entry={entry}
+                      owner={owner}
+                      viewMode={viewMode}
+                      onOpen={handleOpen}
+                      onDownload={handleDownload}
+                    />
+                  ))}
+                </CardGrid>
+              )}
+            </ScrollArea>
+          )}
+        </div>
+      </div>
+
+      {/* TODO(2026-04-27 FILE_SYSTEM) Implement new design in dialog */}
+      <FilePreviewSheet
+        owner={owner}
+        file={previewFile}
+        isOpen={showPreviewSheet}
+        onOpenChange={setShowPreviewSheet}
+      />
+    </>
+  );
+}

--- a/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
@@ -1,0 +1,249 @@
+import type { SandboxTreeNode } from "@app/components/assistant/conversation/files_panel/types";
+import {
+  getCategoryFromContentType,
+  getSingularFileCategoryLabelForContentType,
+} from "@app/components/assistant/conversation/files_panel/utils";
+import { cn } from "@app/components/poke/shadcn/lib/utils";
+import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import { getFileProcessedUrl } from "@app/lib/swr/files";
+import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  FolderIcon,
+  FolderOpenIcon,
+  Icon,
+  MoreIcon,
+  Spinner,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import moment from "moment";
+
+export type ViewMode = "grid" | "list";
+
+export type FileExplorerItemProps = {
+  onDownload?: () => void;
+  onOpen: () => void;
+  subtitle: string;
+  title: string;
+  viewMode: ViewMode;
+} & (
+  | { kind: "icon"; visual: React.ComponentType }
+  | { kind: "thumbnail"; thumbnailSrc: string | null }
+);
+
+// TODO(2026-04-27 FILE SYSTEM): Candidate for Sparkle once the GCS file explorer pattern stabilises.
+export function FileExplorerItem(props: FileExplorerItemProps) {
+  const { onDownload, onOpen, subtitle, title, viewMode } = props;
+
+  const thumbnailContent =
+    props.kind === "icon" ? (
+      <Icon visual={props.visual} size={viewMode === "list" ? "sm" : "lg"} />
+    ) : props.thumbnailSrc ? (
+      <img
+        src={props.thumbnailSrc}
+        alt={title}
+        className="h-full w-full object-cover"
+      />
+    ) : (
+      <div className="flex h-full items-center justify-center">
+        <Spinner size="sm" />
+      </div>
+    );
+
+  const menu = onDownload && (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="xs"
+          icon={MoreIcon}
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem
+          label="Download"
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            onDownload();
+          }}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const info = (
+    <div className="flex min-w-0 flex-1 flex-col">
+      <Tooltip
+        tooltipTriggerAsChild
+        label={title}
+        trigger={
+          <span
+            className={cn(
+              "text-sm font-medium truncate text-foreground dark:text-foreground-night leading-5",
+              "justify-start"
+            )}
+          >
+            {title}
+          </span>
+        }
+      />
+      <span
+        className={cn(
+          "font-normal text-xs text-muted-foreground dark:text-muted-foreground-night leading-4",
+          "justify-start"
+        )}
+      >
+        {subtitle}
+      </span>
+    </div>
+  );
+
+  if (viewMode === "list") {
+    return (
+      <div
+        className={cn(
+          "flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-4 transition-colors",
+          "hover:bg-muted-background dark:hover:bg-muted-background-night"
+        )}
+        onClick={onOpen}
+      >
+        <div className="flex h-4 w-4 shrink-0 items-center justify-center">
+          {thumbnailContent}
+        </div>
+        {info}
+        {menu}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div
+        className={cn(
+          "flex h-24 cursor-pointer items-center justify-center overflow-hidden rounded-xl",
+          "bg-muted-background transition-colors hover:brightness-95 dark:bg-muted-background-night",
+          props.kind === "icon" && "p-4"
+        )}
+        onClick={onOpen}
+      >
+        {thumbnailContent}
+      </div>
+      <div className="flex items-start justify-between gap-1">
+        {info}
+        {menu}
+      </div>
+    </div>
+  );
+}
+
+function getFileSubtitle(entry: GCSMountFileEntry): string {
+  const typeLabel = getSingularFileCategoryLabelForContentType(
+    entry.contentType
+  );
+  const timeLabel = entry.lastModifiedMs
+    ? moment(entry.lastModifiedMs).fromNow()
+    : null;
+  return [typeLabel, timeLabel].filter(Boolean).join(" - ");
+}
+
+export interface FileExplorerFolderCardProps {
+  node: SandboxTreeNode;
+  viewMode: ViewMode;
+  onNavigate: (node: SandboxTreeNode) => void;
+}
+
+export function FileExplorerFolderCard({
+  node,
+  viewMode,
+  onNavigate,
+}: FileExplorerFolderCardProps) {
+  const childCount = node.children.length;
+  const subtitle =
+    childCount === 0
+      ? "Empty"
+      : childCount === 1
+        ? "1 item"
+        : `${childCount} items`;
+
+  return (
+    <FileExplorerItem
+      kind="icon"
+      visual={FolderIcon}
+      viewMode={viewMode}
+      title={node.name}
+      subtitle={subtitle}
+      onOpen={() => onNavigate(node)}
+    />
+  );
+}
+
+export interface FileExplorerFileCardProps {
+  entry: GCSMountFileEntry;
+  owner: LightWorkspaceType;
+  viewMode: ViewMode;
+  onOpen: (entry: GCSMountFileEntry) => void;
+  onDownload: (entry: GCSMountFileEntry) => void;
+}
+
+export function FileExplorerFileCard({
+  entry,
+  owner,
+  viewMode,
+  onOpen,
+  onDownload,
+}: FileExplorerFileCardProps) {
+  const subtitle = getFileSubtitle(entry);
+
+  // TODO(2026-04-27 FILE SYSTEM): Move this thumbnail logic to files endpoint.
+  if (getCategoryFromContentType(entry.contentType) === "image") {
+    const thumbnailSrc = entry.fileId
+      ? getFileProcessedUrl(owner, entry.fileId)
+      : null;
+
+    return (
+      <FileExplorerItem
+        kind="thumbnail"
+        thumbnailSrc={thumbnailSrc}
+        viewMode={viewMode}
+        title={entry.fileName}
+        subtitle={subtitle}
+        onOpen={() => onOpen(entry)}
+        onDownload={() => onDownload(entry)}
+      />
+    );
+  }
+
+  const FileIcon = getFileTypeIcon(entry.contentType, entry.fileName);
+  return (
+    <FileExplorerItem
+      kind="icon"
+      visual={FileIcon}
+      viewMode={viewMode}
+      title={entry.fileName}
+      subtitle={subtitle}
+      onOpen={() => onOpen(entry)}
+      onDownload={() => onDownload(entry)}
+    />
+  );
+}
+
+export function FileExplorerEmptyState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3">
+      <Icon
+        visual={FolderOpenIcon}
+        size="lg"
+        className="text-muted-foreground dark:text-muted-foreground-night"
+      />
+      <p className="copy-base text-center text-muted-foreground dark:text-muted-foreground-night">
+        Nothing to see here
+      </p>
+    </div>
+  );
+}

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -43,13 +43,19 @@ export async function listGCSMountFiles(
   const bucket = getPrivateUploadBucket();
   const gcsFiles = await bucket.getFiles({ prefix, maxResults: 200 });
 
-  // Filter out .processed.* files (internal processing artifacts).
-  const filteredFiles = gcsFiles.filter((f) => {
+  // GCS folder placeholders are zero-byte objects whose path ends with "/".
+  // Split them out early so we can represent them as inode/directory entries
+  // without fetching FileResources for them.
+  const folderPlaceholders = gcsFiles.filter((f) => f.name.endsWith("/"));
+  const regularFiles = gcsFiles.filter((f) => {
+    if (f.name.endsWith("/")) {
+      return false;
+    }
     const name = f.name.split("/").pop() ?? "";
     return !name.includes(".processed.");
   });
 
-  const mountPaths = filteredFiles.map((f) => f.name);
+  const mountPaths = regularFiles.map((f) => f.name);
   const fileResources = await FileResource.fetchByMountFilePaths(
     auth,
     mountPaths
@@ -61,7 +67,28 @@ export async function listGCSMountFiles(
     }
   }
 
-  return filteredFiles.map((gcsFile) => {
+  const folderEntries: GCSMountFileEntry[] = folderPlaceholders.flatMap((f) => {
+    const trimmed = f.name.replace(/\/$/, "");
+    const name = trimmed.split("/").pop() ?? "";
+    // Skip hidden folders (name starting with ".").
+    if (!name || name.startsWith(".")) {
+      return [];
+    }
+    return [
+      {
+        fileName: name,
+        path: trimmed,
+        sizeBytes: 0,
+        contentType: "inode/directory",
+        lastModifiedMs: isString(f.metadata.updated)
+          ? new Date(f.metadata.updated).getTime()
+          : 0,
+        fileId: null,
+      },
+    ];
+  });
+
+  const fileEntries: GCSMountFileEntry[] = regularFiles.map((gcsFile) => {
     const fileName = gcsFile.name.split("/").pop() ?? gcsFile.name;
     const metadata = gcsFile.metadata;
     const fileResource = fileResourceByMountPath.get(gcsFile.name) ?? null;
@@ -79,4 +106,6 @@ export async function listGCSMountFiles(
       fileId: fileResource?.sId ?? null,
     };
   });
+
+  return [...folderEntries, ...fileEntries];
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -320,6 +320,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable the wakeups MCP server, letting agents schedule wake-ups in a conversation.",
     stage: "dust_only",
   },
+  new_file_explorer: {
+    description:
+      "Unified GCS-backed file explorer with folder hierarchy, replacing the two-tab files panel.",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -756,6 +756,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "conversation_search_indexing"
   | "conversation_search_read"
   | "enable_wakeups"
+  | "new_file_explorer"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Replaces the two-tab files panel (Working Files / Mounted Files) with a single unified file explorer backed by GCS, gated behind the `new_file_explorer` feature flag. When the flag is off, existing behaviour is unchanged.

See design [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=5655-53355&m=dev).

The explorer shows the full folder hierarchy from GCS with breadcrumb navigation, a grid/list toggle, and
per-file download. Folders are sorted alphabetically first, files alphabetically after. Navigating into a folder
updates the breadcrumb. Clicking any segment navigates back up.

On the API side, GCS folder placeholder objects (zero-byte paths ending with `/`) are now converted to proper
`inode/directory` entries instead of being passed through as empty-named files, so empty folders appear correctly
in the tree.

<img width="714" height="1682" alt="NewFileExplorer" src="https://github.com/user-attachments/assets/5d6770f8-3e05-455a-9126-3a957a20e000" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
