### PR TITLE
fix: agent builder datasource cancel button

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -352,7 +352,7 @@ function KnowledgeConfigurationSheetContent({
         label: "Cancel",
         variant: "outline",
         onClick: async () => {
-          if (isManageSelectionMode) {
+          if (isManageSelectionMode && isEditing) {
             setSheetPageId(CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION);
           } else {
             await onCancel();
@@ -372,7 +372,14 @@ function KnowledgeConfigurationSheetContent({
         },
       },
     };
-  }, [currentPageId, hasSourceSelection, setSheetPageId, onCancel, onSave]);
+  }, [
+    currentPageId,
+    hasSourceSelection,
+    isEditing,
+    onCancel,
+    onSave,
+    setSheetPageId,
+  ]);
 
   const pages: MultiPageSheetPage[] = [
     {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7807

This PR fixes the cancel button behavior in the agent builder's knowledge datasource configuration sheet.

When adding a new datasource, the cancel button should not bring the user to the configuration page.

- Updated the cancel button condition to check both `isManageSelectionMode` AND `isEditing` states before navigating back to the configuration page

## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment. No special steps required.
