### PR TITLE
fix: get latest transcript teams mcp

### DIFF
--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -609,7 +609,18 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       }
 
       // Get the content of the most recent transcript in text format.
-      const transcriptId = transcripts[transcripts.length - 1].id;
+      // Transcripts are not returned in a guaranteed order, so sort by
+      // createdDateTime descending and pick the first.
+      const latestTranscript = [...transcripts].sort((a, b) => {
+        const aMs = a.createdDateTime
+          ? new Date(a.createdDateTime).getTime() || 0
+          : 0;
+        const bMs = b.createdDateTime
+          ? new Date(b.createdDateTime).getTime() || 0
+          : 0;
+        return bMs - aMs;
+      })[0];
+      const transcriptId = latestTranscript.id;
       const contentResponse = await client
         .api(
           `/me/onlineMeetings/${meetingId}/transcripts/${transcriptId}/content`


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7830


This PR fixes the logic for retrieving the most recent transcript in the Microsoft Teams MCP tool.

This endpoint does not support the orderBy parameter, see the documentation [here](https://learn.microsoft.com/en-us/graph/api/onlinemeeting-list-transcripts?view=graph-rest-1.0&tabs=http)

- Replaces array indexing (`transcripts[transcripts.length - 1]`) with proper date-based sorting
- Sorts transcripts by `createdDateTime` in descending order to reliably identify the latest transcript

## Tests

No

## Risks

Low.

## Deploy Plan

Standard deployment.
