### PR TITLE
Add footer to cards which conversations on which the suggestion is based

### DIFF
--- a/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
+++ b/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
@@ -136,6 +136,7 @@ export function SkillSuggestionDetailsPage() {
             <SkillSuggestionCard
               suggestion={suggestion}
               getSkillInstructionsHtml={getSkillInstructionsHtml}
+              workspaceId={owner.sId}
             />
           </MCPServerViewsContext.Provider>
         </div>

--- a/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
+++ b/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
@@ -160,6 +160,7 @@ export function SkillBuilderSuggestionsPanel() {
                 getSkillInstructionsHtml={getSkillInstructionsHtml}
                 isSelected={selectedSuggestionId === suggestion.sId}
                 onSelect={() => handleSelect(suggestion.sId)}
+                workspaceId={owner.sId}
               />
             ))
           )}

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -168,7 +168,8 @@ function ConversationFooter({
 
   return (
     <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-      Based on conversation{shownIds.length > 1 || remainingCount > 0 ? "s" : ""}{" "}
+      Based on conversation
+      {shownIds.length > 1 || remainingCount > 0 ? "s" : ""}{" "}
       {indexedLinks.map((link, i) => (
         <span key={shownIds[i]}>
           {i > 0 &&

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -139,26 +139,13 @@ function ConversationFooter({
     return null;
   }
 
-  const visibleCount = visibleSourceConversationIds.length;
   const shownIds = visibleSourceConversationIds.slice(
     0,
     MAX_VISIBLE_CONVERSATIONS
   );
   const remainingCount = sourceConversationsCount - shownIds.length;
 
-  const conversationLink = (conversationId: string) => (
-    <Hoverable
-      key={conversationId}
-      variant="primary"
-      href={`/w/${workspaceId}/conversation/${conversationId}`}
-      target="_blank"
-      onClick={(e) => e.stopPropagation()}
-    >
-      {conversationId}
-    </Hoverable>
-  );
-
-  if (visibleCount === 0) {
+  if (shownIds.length === 0) {
     return (
       <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
         Based on {sourceConversationsCount} conversation
@@ -167,22 +154,34 @@ function ConversationFooter({
     );
   }
 
-  const links = shownIds.map((id) => conversationLink(id));
+  const indexedLinks = shownIds.map((id, i) => (
+    <Hoverable
+      key={id}
+      variant="primary"
+      href={`/w/${workspaceId}/conversation/${id}`}
+      target="_blank"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {i + 1}
+    </Hoverable>
+  ));
 
   return (
     <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-      Based on{" "}
-      {links.map((link, i) => (
+      Based on conversation{shownIds.length > 1 || remainingCount > 0 ? "s" : ""}{" "}
+      {indexedLinks.map((link, i) => (
         <span key={shownIds[i]}>
           {i > 0 &&
-            (remainingCount === 0 && i === links.length - 1 ? " and " : ", ")}
+            (remainingCount === 0 && i === indexedLinks.length - 1
+              ? " and "
+              : ", ")}
           {link}
         </span>
       ))}
       {remainingCount > 0 && (
         <>
           {" "}
-          and {remainingCount} other conversation
+          and {remainingCount} other
           {remainingCount > 1 ? "s" : ""}
         </>
       )}

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -7,9 +7,11 @@ import type {
   SkillSuggestionType,
   SkillToolEditItemType,
 } from "@app/types/suggestions/skill_suggestion";
-import { Button, Card, Chip, DiffBlock } from "@dust-tt/sparkle";
+import { Button, Card, Chip, DiffBlock, Hoverable } from "@dust-tt/sparkle";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { useMemo } from "react";
+
+const MAX_VISIBLE_CONVERSATIONS = 3;
 
 function useToolDisplayNames(
   toolEdits: SkillToolEditItemType[]
@@ -122,6 +124,72 @@ function InstructionEditDiffBlock({
   return <DiffBlock>{editor && <EditorContent editor={editor} />}</DiffBlock>;
 }
 
+interface ConversationFooterProps {
+  visibleSourceConversationIds: string[];
+  sourceConversationsCount: number;
+  workspaceId: string;
+}
+
+function ConversationFooter({
+  visibleSourceConversationIds,
+  sourceConversationsCount,
+  workspaceId,
+}: ConversationFooterProps) {
+  if (sourceConversationsCount === 0) {
+    return null;
+  }
+
+  const visibleCount = visibleSourceConversationIds.length;
+  const shownIds = visibleSourceConversationIds.slice(
+    0,
+    MAX_VISIBLE_CONVERSATIONS
+  );
+  const remainingCount = sourceConversationsCount - shownIds.length;
+
+  const conversationLink = (conversationId: string) => (
+    <Hoverable
+      key={conversationId}
+      variant="primary"
+      href={`/w/${workspaceId}/conversation/${conversationId}`}
+      target="_blank"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {conversationId}
+    </Hoverable>
+  );
+
+  if (visibleCount === 0) {
+    return (
+      <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+        Based on {sourceConversationsCount} conversation
+        {sourceConversationsCount > 1 ? "s" : ""}
+      </p>
+    );
+  }
+
+  const links = shownIds.map((id) => conversationLink(id));
+
+  return (
+    <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+      Based on{" "}
+      {links.map((link, i) => (
+        <span key={shownIds[i]}>
+          {i > 0 &&
+            (remainingCount === 0 && i === links.length - 1 ? " and " : ", ")}
+          {link}
+        </span>
+      ))}
+      {remainingCount > 0 && (
+        <>
+          {" "}
+          and {remainingCount} other conversation
+          {remainingCount > 1 ? "s" : ""}
+        </>
+      )}
+    </p>
+  );
+}
+
 interface SkillSuggestionCardProps {
   suggestion: SkillSuggestionType;
   onAccept?: (suggestion: SkillSuggestionType) => void;
@@ -129,6 +197,7 @@ interface SkillSuggestionCardProps {
   getSkillInstructionsHtml: () => string;
   isSelected?: boolean;
   onSelect?: () => void;
+  workspaceId: string;
 }
 
 export function SkillSuggestionCard({
@@ -138,6 +207,7 @@ export function SkillSuggestionCard({
   getSkillInstructionsHtml,
   isSelected = false,
   onSelect,
+  workspaceId,
 }: SkillSuggestionCardProps) {
   const { instructionEdits, toolEdits } = suggestion.suggestion;
   const isClickable = !!onSelect;
@@ -195,6 +265,12 @@ export function SkillSuggestionCard({
             ))}
           </div>
         )}
+
+        <ConversationFooter
+          visibleSourceConversationIds={suggestion.visibleSourceConversationIds}
+          sourceConversationsCount={suggestion.sourceConversationsCount}
+          workspaceId={workspaceId}
+        />
       </Card>
     </div>
   );

--- a/front/scripts/seed/factories/seedSkillSuggestions.ts
+++ b/front/scripts/seed/factories/seedSkillSuggestions.ts
@@ -123,10 +123,10 @@ export async function seedSkillSuggestions(
 
 async function resolveConversationModelIds(
   ctx: SeedContext,
-  conversationSIds: string[]
+  conversationIds: string[]
 ): Promise<number[]> {
   const modelIds: number[] = [];
-  for (const sId of conversationSIds) {
+  for (const sId of conversationIds) {
     const conversation = await ConversationResource.fetchById(ctx.auth, sId, {
       dangerouslySkipPermissionFiltering: true,
     });

--- a/front/scripts/seed/factories/seedSkillSuggestions.ts
+++ b/front/scripts/seed/factories/seedSkillSuggestions.ts
@@ -3,6 +3,7 @@ import {
   isAutoInternalMCPServerName,
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
@@ -95,6 +96,14 @@ export async function seedSkillSuggestions(
         );
       }
 
+      let sourceConversationIds: number[] | null = null;
+      if (suggestionAsset.sourceConversationIds) {
+        sourceConversationIds = await resolveConversationIds(
+          ctx,
+          suggestionAsset.sourceConversationIds
+        );
+      }
+
       const created = await SkillSuggestionFactory.create(auth, skill, {
         kind: suggestionAsset.kind,
         suggestion: resolvedSuggestion,
@@ -102,6 +111,7 @@ export async function seedSkillSuggestions(
         title: suggestionAsset.title ?? null,
         state: suggestionAsset.state,
         source: suggestionAsset.source,
+        sourceConversationIds,
       });
       logger.info(
         { sId: created.sId, skillName: suggestionAsset.skillName },
@@ -109,4 +119,25 @@ export async function seedSkillSuggestions(
       );
     }
   }
+}
+
+async function resolveConversationIds(
+  ctx: SeedContext,
+  conversationSIds: string[]
+): Promise<number[]> {
+  const ids: number[] = [];
+  for (const sId of conversationSIds) {
+    const conversation = await ConversationResource.fetchById(ctx.auth, sId, {
+      dangerouslySkipPermissionFiltering: true,
+    });
+    if (conversation) {
+      ids.push(conversation.id);
+    } else {
+      ctx.logger.warn(
+        { conversationSId: sId },
+        "Conversation not found for skill suggestion source, skipping"
+      );
+    }
+  }
+  return ids;
 }

--- a/front/scripts/seed/factories/seedSkillSuggestions.ts
+++ b/front/scripts/seed/factories/seedSkillSuggestions.ts
@@ -98,7 +98,7 @@ export async function seedSkillSuggestions(
 
       let sourceConversationIds: number[] | null = null;
       if (suggestionAsset.sourceConversationIds) {
-        sourceConversationIds = await resolveConversationIds(
+        sourceConversationIds = await resolveConversationModelIds(
           ctx,
           suggestionAsset.sourceConversationIds
         );
@@ -121,17 +121,17 @@ export async function seedSkillSuggestions(
   }
 }
 
-async function resolveConversationIds(
+async function resolveConversationModelIds(
   ctx: SeedContext,
   conversationSIds: string[]
 ): Promise<number[]> {
-  const ids: number[] = [];
+  const modelIds: number[] = [];
   for (const sId of conversationSIds) {
     const conversation = await ConversationResource.fetchById(ctx.auth, sId, {
       dangerouslySkipPermissionFiltering: true,
     });
     if (conversation) {
-      ids.push(conversation.id);
+      modelIds.push(conversation.id);
     } else {
       ctx.logger.warn(
         { conversationSId: sId },
@@ -139,5 +139,5 @@ async function resolveConversationIds(
       );
     }
   }
-  return ids;
+  return modelIds;
 }

--- a/front/scripts/seed/factories/types.ts
+++ b/front/scripts/seed/factories/types.ts
@@ -47,6 +47,7 @@ export interface SkillSuggestionAsset {
   analysis: string | null;
   state: "pending" | "approved" | "rejected" | "outdated";
   source: "reinforcement" | "synthetic";
+  sourceConversationIds?: string[];
   suggestion: {
     instructionEdits?: {
       targetBlockId: string;

--- a/front/scripts/seed/reinforced-agents/assets/bookkeeper-conversations.json
+++ b/front/scripts/seed/reinforced-agents/assets/bookkeeper-conversations.json
@@ -1,0 +1,37 @@
+[
+  {
+    "sId": "RABookConv01",
+    "title": "Recommend a Python book",
+    "agentName": "Dust",
+    "exchanges": [
+      {
+        "user": {
+          "sId": "RABKUMsg01",
+          "content": ":mention[Dust]{sId=dust} Can you recommend a good Python book? I've been learning the basics and want to go deeper."
+        },
+        "agent": {
+          "sId": "RABKAMsg01",
+          "content": "I'd recommend **Fluent Python** by Luciano Ramalho. It's an excellent intermediate-to-advanced book that covers Python's data model, iterators, generators, concurrency, and metaprogramming. It's currently in stock on shelf B-12.\n\nAnother great option is **Python Cookbook** by David Beazley, available on shelf C-03. It's more recipe-based and great for learning practical patterns."
+        }
+      }
+    ]
+  },
+  {
+    "sId": "RABookConv02",
+    "title": "Looking for a book on distributed systems",
+    "agentName": "Dust",
+    "userId": "otherUser",
+    "exchanges": [
+      {
+        "user": {
+          "sId": "RABKUMsg02",
+          "content": ":mention[Dust]{sId=dust} Do we have any books on distributed systems? I already read Designing Data-Intensive Applications last year."
+        },
+        "agent": {
+          "sId": "RABKAMsg02",
+          "content": "Yes! We have **Distributed Systems** by Maarten van Steen in the catalog. It's on shelf A-07 and currently available.\n\nSince you've already read Designing Data-Intensive Applications, you might also enjoy **Site Reliability Engineering** by Betsy Beyer which covers distributed systems from an operational perspective. It's on shelf A-09."
+        }
+      }
+    ]
+  }
+]

--- a/front/scripts/seed/reinforced-agents/assets/skill_suggestions.json
+++ b/front/scripts/seed/reinforced-agents/assets/skill_suggestions.json
@@ -6,6 +6,7 @@
     "analysis": "The skill should leverage web search to find up-to-date contact information and include instructions on how to use the web search tool effectively.",
     "state": "pending",
     "source": "reinforcement",
+    "sourceConversationIds": ["RADustConv04"],
     "suggestion": {
       "instructionEdits": [
         {
@@ -85,6 +86,7 @@
     "analysis": "Before recommending a book, the skill should check the loan history to avoid suggesting a book the user has already borrowed. This requires referencing the borrowers.csv knowledge.",
     "state": "pending",
     "source": "reinforcement",
+    "sourceConversationIds": ["RABookConv01", "RABookConv02"],
     "suggestion": {
       "instructionEdits": [
         {

--- a/front/scripts/seed/reinforced-agents/seedReinforcedAgents.ts
+++ b/front/scripts/seed/reinforced-agents/seedReinforcedAgents.ts
@@ -39,6 +39,7 @@ const OTHER_USER: UserAsset = {
 
 interface Assets {
   agents: AgentAsset[];
+  bookKeeperConversations: ConversationAsset[];
   conversations: ConversationAsset[];
   dataSources: DataSourceAsset[];
   dustConversations: ConversationAsset[];
@@ -71,6 +72,12 @@ function loadAssets(): Assets {
         : doc.content,
     })),
   }));
+  const bookKeeperConversations = JSON.parse(
+    fs.readFileSync(
+      path.join(assetsDir, "bookkeeper-conversations.json"),
+      "utf-8"
+    )
+  );
   const dustConversations = JSON.parse(
     fs.readFileSync(path.join(assetsDir, "dust-conversations.json"), "utf-8")
   );
@@ -85,6 +92,7 @@ function loadAssets(): Assets {
   );
   return {
     agents,
+    bookKeeperConversations,
     conversations,
     dataSources,
     dustConversations,
@@ -100,6 +108,7 @@ export async function seedReinforcement(
 ): Promise<void> {
   const {
     agents,
+    bookKeeperConversations,
     conversations,
     dataSources,
     dustConversations,
@@ -183,6 +192,12 @@ export async function seedReinforcement(
     additionalUsers,
   });
 
+  ctx.logger.info("Seeding BookKeeper conversations...");
+  await seedConversations(ctx, bookKeeperConversations, {
+    agents: createdAgents,
+    additionalUsers,
+  });
+
   // Activate the Poem Analyser skill as JIT skill in Dust conversations
   if (ctx.execute && poemAnalyserSkill) {
     ctx.logger.info("Activating JIT skills in Dust conversations...");
@@ -229,7 +244,11 @@ export async function seedReinforcement(
 
   if (!skipAnalytics) {
     ctx.logger.info("Indexing analytics to Elasticsearch...");
-    const allConversations = [...conversations, ...dustConversations];
+    const allConversations = [
+      ...conversations,
+      ...dustConversations,
+      ...bookKeeperConversations,
+    ];
     const conversationIds = allConversations.map((c) => c.sId);
     await seedAnalytics(ctx, conversationIds);
   }


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/7112

 - Add a footer to cards to display the origin conversations of the suggestions.
 - Add some dust hive suggestions and conversations to test it quickly

<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/16dbe302-c16a-484d-9947-5cd15e623583" />

<img width="600" height="700" alt="image" src="https://github.com/user-attachments/assets/c71a329c-cb5e-48c4-a6f2-2f48b94f9b3d" />

<img width="600" height="380" alt="image" src="https://github.com/user-attachments/assets/4f78a3a4-5dac-44a0-a289-457cfee23ebf" />



## Tests

Tested locally



## Risk

May expose link to hidden conversations
But the conversations are filtered to only show the one listed on the left side bar (personal convs + project convs) so no private conv are exposed.

## Deploy Plan

deploy front 
