### PR TITLE
Add recurring free credits on packages

### DIFF
--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -711,7 +711,7 @@ const FREE_MONTHLY_RECURRING_CREDITS: RecurringCreditDef = {
   starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
   applicable_product_tags: [USAGE_TAG],
   recurrence_frequency: "MONTHLY",
-  name: "Monthly Free Credits",
+  name: "Free Monthly Credit",
 };
 
 // Seat subscription definition shared by all legacy packages.

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -139,23 +139,23 @@ interface PackageSubscription {
   };
 }
 
-// interface RecurringCreditDef {
-//   product_name: string; // resolved to product ID at runtime
-//   access_amount: {
-//     credit_type_id: string; // evaluated after detectEnvironment()
-//     unit_price: number;
-//     quantity?: number;
-//   };
-//   commit_duration: { value: number; unit?: "PERIODS" };
-//   priority: number;
-//   starting_at_offset: {
-//     unit: "DAYS" | "WEEKS" | "MONTHS" | "YEARS";
-//     value: number;
-//   };
-//   applicable_product_tags?: string[];
-//   recurrence_frequency?: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
-//   name?: string;
-// }
+interface RecurringCreditDef {
+  product_name: string; // resolved to product ID at runtime
+  access_amount: {
+    credit_type_id: string; // evaluated after detectEnvironment()
+    unit_price: number;
+    quantity?: number;
+  };
+  commit_duration: { value: number; unit?: "PERIODS" };
+  priority: number;
+  starting_at_offset: {
+    unit: "DAYS" | "WEEKS" | "MONTHS" | "YEARS";
+    value: number;
+  };
+  applicable_product_tags?: string[];
+  recurrence_frequency?: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
+  name?: string;
+}
 
 interface PackageDef {
   // Base name without version suffix. Version is auto-computed at sync time.
@@ -171,7 +171,7 @@ interface PackageDef {
   };
   // Consolidate scheduled/commit charges onto the usage invoice instead of separate invoices.
   scheduled_charges_on_usage_invoices?: "ALL";
-  // recurring_credits?: RecurringCreditDef[];
+  recurring_credits?: RecurringCreditDef[];
 }
 
 // ---------------------------------------------------------------------------
@@ -699,20 +699,20 @@ function getRateCards(): RateCardDef[] {
 // Recurring free credit definition shared by all packages.
 // Quantity starts at 0 — the credit.segment.start webhook updates it each period
 // to the actual user-based amount.
-// const FREE_MONTHLY_RECURRING_CREDITS: RecurringCreditDef = {
-//   product_name: "Free Monthly Credits",
-//   access_amount: {
-//     credit_type_id: getCreditTypeProgrammaticUsdId(),
-//     unit_price: 0,
-//     quantity: 0,
-//   },
-//   commit_duration: { value: 1 },
-//   priority: 1,
-//   starting_at_offset: { unit: "DAYS", value: 0 },
-//   applicable_product_tags: [USAGE_TAG],
-//   recurrence_frequency: "MONTHLY",
-//   name: "Free Monthly Credits",
-// };
+const FREE_MONTHLY_RECURRING_CREDITS: RecurringCreditDef = {
+  product_name: "Free Monthly Credits",
+  access_amount: {
+    credit_type_id: getCreditTypeProgrammaticUsdId(),
+    unit_price: 0,
+    quantity: 1,
+  },
+  commit_duration: { value: 1, unit: "PERIODS" },
+  priority: 1,
+  starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
+  applicable_product_tags: [USAGE_TAG],
+  recurrence_frequency: "MONTHLY",
+  name: "Monthly Free Credits",
+};
 
 // Seat subscription definition shared by all legacy packages.
 const LEGACY_SEAT_SUBSCRIPTION: PackageSubscription = {
@@ -752,7 +752,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-monthly" }],
     rate_card_name: "Legacy Pro USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -760,7 +760,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-business" }],
     rate_card_name: "Legacy Business USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -768,7 +768,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-annual" }],
     rate_card_name: "Legacy Pro Annual USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   // Enterprise: MAU-based billing, no seat subscriptions.
@@ -777,7 +777,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-enterprise" }],
     rate_card_name: "Legacy Enterprise MAU USD",
     scheduled_charges_on_usage_invoices: "ALL",
-    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   // EUR variants
@@ -786,7 +786,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-monthly-eur" }],
     rate_card_name: "Legacy Pro EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -794,7 +794,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-business-eur" }],
     rate_card_name: "Legacy Business EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -802,7 +802,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-annual-eur" }],
     rate_card_name: "Legacy Pro Annual EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -810,7 +810,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-enterprise-eur" }],
     rate_card_name: "Legacy Enterprise MAU EUR",
     scheduled_charges_on_usage_invoices: "ALL",
-    // recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
     ...BILLING_CYCLE_CONFIG,
   },
 ];
@@ -1402,19 +1402,19 @@ interface ExistingPackage {
     quantity_management_mode?: string;
     seat_config?: { seat_group_key: string };
   }>;
-  // recurring_credits?: Array<{
-  //   product: { id: string };
-  //   access_amount: {
-  //     credit_type_id: string;
-  //     unit_price: number;
-  //     quantity?: number;
-  //   };
-  //   commit_duration: { value: number };
-  //   priority: number;
-  //   starting_at_offset: { unit: string; value: number };
-  //   applicable_product_tags?: string[];
-  //   recurrence_frequency?: string;
-  // }>;
+  recurring_credits?: Array<{
+    product: { id: string };
+    access_amount: {
+      credit_type_id: string;
+      unit_price: number;
+      quantity?: number;
+    };
+    commit_duration: { value: number };
+    priority: number;
+    starting_at_offset: { unit: string; value: number };
+    applicable_product_tags?: string[];
+    recurrence_frequency?: string;
+  }>;
 }
 
 function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
@@ -1488,27 +1488,27 @@ function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
   }
 
   // Check recurring credits count and product IDs (implicit product recreation cascade).
-  // const desiredCredits = desired.recurring_credits ?? [];
-  // const existingCredits = ex.recurring_credits ?? [];
-  // if (desiredCredits.length !== existingCredits.length) {
-  //   return false;
-  // }
-  // for (const desiredCredit of desiredCredits) {
-  //   const productId = ids.products[desiredCredit.product_name];
-  //   const match = existingCredits.find((c) => c.product.id === productId);
-  //   if (!match) {
-  //     return false;
-  //   }
-  //   if (
-  //     match.access_amount.credit_type_id !==
-  //     desiredCredit.access_amount.credit_type_id
-  //   ) {
-  //     return false;
-  //   }
-  //   if (match.priority !== desiredCredit.priority) {
-  //     return false;
-  //   }
-  // }
+  const desiredCredits = desired.recurring_credits ?? [];
+  const existingCredits = ex.recurring_credits ?? [];
+  if (desiredCredits.length !== existingCredits.length) {
+    return false;
+  }
+  for (const desiredCredit of desiredCredits) {
+    const productId = ids.products[desiredCredit.product_name];
+    const match = existingCredits.find((c) => c.product.id === productId);
+    if (!match) {
+      return false;
+    }
+    if (
+      match.access_amount.credit_type_id !==
+      desiredCredit.access_amount.credit_type_id
+    ) {
+      return false;
+    }
+    if (match.priority !== desiredCredit.priority) {
+      return false;
+    }
+  }
 
   return true;
 }
@@ -1617,30 +1617,30 @@ async function syncPackages(): Promise<void> {
         });
 
         // Resolve recurring credit product IDs
-        // const recurringCredits = (desired.recurring_credits ?? []).map(
-        //   (credit) => {
-        //     const productId = ids.products[credit.product_name];
-        //     if (!productId) {
-        //       throw new Error(
-        //         `Product not found for recurring credit: ${credit.product_name}`
-        //       );
-        //     }
-        //     return {
-        //       product_id: productId,
-        //       access_amount: credit.access_amount,
-        //       commit_duration: credit.commit_duration,
-        //       priority: credit.priority,
-        //       starting_at_offset: credit.starting_at_offset,
-        //       ...(credit.applicable_product_tags
-        //         ? { applicable_product_tags: credit.applicable_product_tags }
-        //         : {}),
-        //       ...(credit.recurrence_frequency
-        //         ? { recurrence_frequency: credit.recurrence_frequency }
-        //         : {}),
-        //       ...(credit.name ? { name: credit.name } : {}),
-        //     };
-        //   }
-        // );
+        const recurringCredits = (desired.recurring_credits ?? []).map(
+          (credit) => {
+            const productId = ids.products[credit.product_name];
+            if (!productId) {
+              throw new Error(
+                `Product not found for recurring credit: ${credit.product_name}`
+              );
+            }
+            return {
+              product_id: productId,
+              access_amount: credit.access_amount,
+              commit_duration: credit.commit_duration,
+              priority: credit.priority,
+              starting_at_offset: credit.starting_at_offset,
+              ...(credit.applicable_product_tags
+                ? { applicable_product_tags: credit.applicable_product_tags }
+                : {}),
+              ...(credit.recurrence_frequency
+                ? { recurrence_frequency: credit.recurrence_frequency }
+                : {}),
+              ...(credit.name ? { name: credit.name } : {}),
+            };
+          }
+        );
 
         const created = await client.v1.packages.create({
           name: versionedName,
@@ -1652,9 +1652,9 @@ async function syncPackages(): Promise<void> {
             ? { usage_statement_schedule: desired.usage_statement_schedule }
             : {}),
           ...(subscriptions.length > 0 ? { subscriptions } : {}),
-          // ...(recurringCredits.length > 0
-          //   ? { recurring_credits: recurringCredits }
-          //   : {}),
+          ...(recurringCredits.length > 0
+            ? { recurring_credits: recurringCredits }
+            : {}),
           ...(desired.scheduled_charges_on_usage_invoices
             ? {
                 scheduled_charges_on_usage_invoices:

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -711,7 +711,7 @@ const FREE_MONTHLY_RECURRING_CREDITS: RecurringCreditDef = {
   starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
   applicable_product_tags: [USAGE_TAG],
   recurrence_frequency: "MONTHLY",
-  name: "Free Monthly Credit",
+  name: "Free Monthly Credits",
 };
 
 // Seat subscription definition shared by all legacy packages.


### PR DESCRIPTION
## Description

Enables recurring monthly free credits on all legacy Metronome packages by uncommenting the `recurring_credits` field. This activates the free credit infrastructure on the package definitions so new contracts automatically include the monthly recurring credit with the "Free Monthly Credits" product. The recurring credit is configured with `quantity: 1` and starts immediately (`starting_at_offset: { unit: "DAYS", value: 0 }`). The actual amount is dynamically updated each billing period via the `credit.segment.start` webhook handler implemented in #24354.

## Tests

Manually tested by running the `metronome_setup.ts` script in dry-run mode and on sandbox to verify package payloads include the recurring credits.

## Risk

Low. This only affects new contracts created after deployment. Existing contracts already have recurring credits via the backfill script (#24384).

## Deploy Plan

Deploy front.