### PR TITLE
[front] enh: fix dropdown highlight scrolling in slash command

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -176,42 +176,44 @@ export const SlashCommandDropdown = forwardRef<
               {emptyMessage}
             </div>
           ) : (
-            items.map((item, index) => {
-              const menuItem = (
-                <DropdownMenuItem
-                  key={item.id}
-                  icon={item.icon}
-                  itemId={item.id}
-                  label={item.label}
-                  description={item.description}
-                  truncateText
-                  onClick={() => selectItem(index)}
-                  onMouseEnter={() => setSelectedIndex(index)}
-                  className={
-                    index === selectedIndex
-                      ? "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
-                      : ""
-                  }
-                />
-              );
-
-              // Wrap with DropdownTooltipTrigger if command has tooltip property.
-              if (item.tooltip) {
-                return (
-                  <DropdownTooltipTrigger
+            <div className="max-h-96 overflow-y-auto">
+              {items.map((item, index) => {
+                const menuItem = (
+                  <DropdownMenuItem
                     key={item.id}
-                    description={item.tooltip.description}
-                    media={item.tooltip.media}
-                    side="right"
-                    sideOffset={8}
-                  >
-                    {menuItem}
-                  </DropdownTooltipTrigger>
+                    icon={item.icon}
+                    itemId={item.id}
+                    label={item.label}
+                    description={item.description}
+                    truncateText
+                    onClick={() => selectItem(index)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    className={
+                      index === selectedIndex
+                        ? "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
+                        : ""
+                    }
+                  />
                 );
-              }
 
-              return menuItem;
-            })
+                // Wrap with DropdownTooltipTrigger if command has tooltip property.
+                if (item.tooltip) {
+                  return (
+                    <DropdownTooltipTrigger
+                      key={item.id}
+                      description={item.tooltip.description}
+                      media={item.tooltip.media}
+                      side="right"
+                      sideOffset={8}
+                    >
+                      {menuItem}
+                    </DropdownTooltipTrigger>
+                  );
+                }
+
+                return menuItem;
+              })}
+            </div>
           )}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -157,12 +157,14 @@ export const SlashCommandDropdown = forwardRef<
           align="start"
           avoidCollisions
           collisionPadding={12}
+          highlightedItemId={items[selectedIndex]?.id}
           side="bottom"
           sideOffset={4}
           onEscapeKeyDown={onClose}
           onInteractOutside={onClose}
           onCloseAutoFocus={(e) => e.preventDefault()}
           onOpenAutoFocus={(e) => e.preventDefault()}
+          scrollHighlightedItemIntoView
         >
           {header ? (
             <div className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
@@ -174,43 +176,42 @@ export const SlashCommandDropdown = forwardRef<
               {emptyMessage}
             </div>
           ) : (
-            <div className="max-h-96 overflow-y-auto">
-              {items.map((item, index) => {
-                const menuItem = (
-                  <DropdownMenuItem
+            items.map((item, index) => {
+              const menuItem = (
+                <DropdownMenuItem
+                  key={item.id}
+                  icon={item.icon}
+                  itemId={item.id}
+                  label={item.label}
+                  description={item.description}
+                  truncateText
+                  onClick={() => selectItem(index)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  className={
+                    index === selectedIndex
+                      ? "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
+                      : ""
+                  }
+                />
+              );
+
+              // Wrap with DropdownTooltipTrigger if command has tooltip property.
+              if (item.tooltip) {
+                return (
+                  <DropdownTooltipTrigger
                     key={item.id}
-                    icon={item.icon}
-                    label={item.label}
-                    description={item.description}
-                    truncateText
-                    onClick={() => selectItem(index)}
-                    onMouseEnter={() => setSelectedIndex(index)}
-                    className={
-                      index === selectedIndex
-                        ? "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
-                        : ""
-                    }
-                  />
+                    description={item.tooltip.description}
+                    media={item.tooltip.media}
+                    side="right"
+                    sideOffset={8}
+                  >
+                    {menuItem}
+                  </DropdownTooltipTrigger>
                 );
+              }
 
-                // Wrap with DropdownTooltipTrigger if command has tooltip property.
-                if (item.tooltip) {
-                  return (
-                    <DropdownTooltipTrigger
-                      key={item.id}
-                      description={item.tooltip.description}
-                      media={item.tooltip.media}
-                      side="right"
-                      sideOffset={8}
-                    >
-                      {menuItem}
-                    </DropdownTooltipTrigger>
-                  );
-                }
-
-                return menuItem;
-              })}
-            </div>
+              return menuItem;
+            })
           )}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -444,6 +444,11 @@ const DropdownMenuContent = React.forwardRef<
       []
     );
 
+    const itemRegistryContextValue = React.useMemo(
+      () => ({ registerItem }),
+      [registerItem]
+    );
+
     React.useEffect(() => {
       if (!scrollHighlightedItemIntoView || !highlightedItemId) {
         return;
@@ -485,7 +490,9 @@ const DropdownMenuContent = React.forwardRef<
           )}
           viewportRef={viewportRef}
         >
-          <DropdownItemRegistryContext.Provider value={{ registerItem }}>
+          <DropdownItemRegistryContext.Provider
+            value={itemRegistryContextValue}
+          >
             {children}
           </DropdownItemRegistryContext.Provider>
         </ScrollArea>

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -119,6 +119,13 @@ type MutuallyExclusiveProps<BaseProps, ExtraProps> = Simplify<
   EitherChildrenOrProps<BaseProps, ExtraProps>
 >;
 
+interface DropdownItemRegistryContextType {
+  registerItem: (itemId: string, element: HTMLElement | null) => void;
+}
+
+const DropdownItemRegistryContext =
+  React.createContext<DropdownItemRegistryContextType | null>(null);
+
 interface ItemWithLabelIconAndDescriptionProps {
   label?: string;
   icon?: React.ComponentType | React.ReactNode;
@@ -334,9 +341,11 @@ interface DropdownMenuContentProps
   mountPortal?: boolean;
   mountPortalContainer?: HTMLElement;
   dropdownHeaders?: React.ReactNode;
+  highlightedItemId?: string;
   preventAutoFocusOnClose?: boolean;
   onOpenAutoFocus?: (e: React.FocusEvent<HTMLDivElement>) => void;
   searchInputRef?: React.RefObject<HTMLInputElement | null>;
+  scrollHighlightedItemIntoView?: boolean;
 }
 
 const DropdownMenuContent = React.forwardRef<
@@ -350,16 +359,21 @@ const DropdownMenuContent = React.forwardRef<
       mountPortal = true,
       mountPortalContainer,
       dropdownHeaders,
+      highlightedItemId,
       preventAutoFocusOnClose = true,
       onCloseAutoFocus,
       onKeyDownCapture,
       onKeyDown,
       searchInputRef,
+      scrollHighlightedItemIntoView = false,
       children,
       ...props
     },
     ref
   ) => {
+    const viewportRef = React.useRef<HTMLDivElement>(null);
+    const itemElementsRef = React.useRef(new Map<string, HTMLElement>());
+
     const handleKeyDownCapture = (e: React.KeyboardEvent<HTMLDivElement>) => {
       onKeyDownCapture?.(e);
       if (e.defaultPrevented) {
@@ -419,6 +433,32 @@ const DropdownMenuContent = React.forwardRef<
       [preventAutoFocusOnClose, onCloseAutoFocus]
     );
 
+    const registerItem = React.useCallback(
+      (itemId: string, element: HTMLElement | null) => {
+        if (element) {
+          itemElementsRef.current.set(itemId, element);
+        } else {
+          itemElementsRef.current.delete(itemId);
+        }
+      },
+      []
+    );
+
+    React.useEffect(() => {
+      if (!scrollHighlightedItemIntoView || !highlightedItemId) {
+        return;
+      }
+
+      const viewport = viewportRef.current;
+      if (!viewport) {
+        return;
+      }
+
+      const highlightedItem = itemElementsRef.current.get(highlightedItemId);
+
+      highlightedItem?.scrollIntoView({ block: "nearest" });
+    }, [highlightedItemId, scrollHighlightedItemIntoView]);
+
     const content = (
       <DropdownMenuPrimitive.Content
         ref={ref}
@@ -443,8 +483,11 @@ const DropdownMenuContent = React.forwardRef<
             "s-flex-1",
             "s-max-h-[calc(var(--radix-dropdown-menu-content-available-height)-var(--header-height,20px))]"
           )}
+          viewportRef={viewportRef}
         >
-          {children}
+          <DropdownItemRegistryContext.Provider value={{ registerItem }}>
+            {children}
+          </DropdownItemRegistryContext.Provider>
         </ScrollArea>
       </DropdownMenuPrimitive.Content>
     );
@@ -465,6 +508,7 @@ DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 export type DropdownMenuItemProps = MutuallyExclusiveProps<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean;
+    itemId?: string;
     variant?: ItemVariantType;
   } & Omit<LinkWrapperProps, "children" | "className">,
   LabelAndIconProps & {
@@ -486,6 +530,7 @@ const DropdownMenuItem = React.forwardRef<
       className,
       inset,
       icon,
+      itemId,
       truncateText,
       label,
       href,
@@ -500,6 +545,23 @@ const DropdownMenuItem = React.forwardRef<
     },
     ref
   ) => {
+    const dropdownItemRegistry = React.useContext(DropdownItemRegistryContext);
+
+    const handleItemRef = React.useCallback(
+      (element: React.ElementRef<typeof DropdownMenuPrimitive.Item> | null) => {
+        if (typeof ref === "function") {
+          ref(element);
+        } else if (ref) {
+          ref.current = element;
+        }
+
+        if (itemId) {
+          dropdownItemRegistry?.registerItem(itemId, element);
+        }
+      },
+      [dropdownItemRegistry, itemId, ref]
+    );
+
     return (
       <LinkWrapper
         href={href}
@@ -510,7 +572,7 @@ const DropdownMenuItem = React.forwardRef<
         prefetch={prefetch}
       >
         <DropdownMenuPrimitive.Item
-          ref={ref}
+          ref={handleItemRef}
           className={cn(
             menuStyleClasses.item({ variant }),
             inset ? menuStyleClasses.inset : "",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -25,7 +25,7 @@ import { CheckIcon, ChevronRightIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
 import * as React from "react";
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 
 const ITEM_VARIANTS = ["default", "warning"] as const;
 
@@ -371,8 +371,8 @@ const DropdownMenuContent = React.forwardRef<
     },
     ref
   ) => {
-    const viewportRef = React.useRef<HTMLDivElement>(null);
-    const itemElementsRef = React.useRef(new Map<string, HTMLElement>());
+    const viewportRef = useRef<HTMLDivElement>(null);
+    const itemElementsRef = useRef(new Map<string, HTMLElement>());
 
     const handleKeyDownCapture = (e: React.KeyboardEvent<HTMLDivElement>) => {
       onKeyDownCapture?.(e);
@@ -444,7 +444,7 @@ const DropdownMenuContent = React.forwardRef<
       []
     );
 
-    const itemRegistryContextValue = React.useMemo(
+    const itemRegistryContextValue = useMemo(
       () => ({ registerItem }),
       [registerItem]
     );


### PR DESCRIPTION
## Description

This PR fixes highlighted-item scrolling in the slash dropdown list.
Currently, navigating with the arrow key does not scroll in the list to show the highlighted item.

The dropdown component keeps a small item registry so it can scroll the highlighted item into view. The slash dropdown just has to pass the currently highlighted item id and it'll get scrolled into view.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
