### PR TITLE
feat: add script to merge user identities across domains

### DIFF
--- a/front/scripts/merge_domain_user_identities.ts
+++ b/front/scripts/merge_domain_user_identities.ts
@@ -1,0 +1,187 @@
+import { getMembers } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import { mergeUserIdentities } from "@app/lib/iam/users";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+import { makeScript } from "./helpers";
+
+makeScript(
+  {
+    workspaceId: {
+      alias: "w",
+      describe: "WorkspaceId to process",
+      type: "string" as const,
+      demandOption: true,
+    },
+    oldDomain: {
+      describe: "Old email domain (e.g. old.com) — secondary accounts",
+      type: "string" as const,
+      demandOption: true,
+    },
+    newDomain: {
+      describe: "New email domain (e.g. new.com) — primary accounts",
+      type: "string" as const,
+      demandOption: true,
+    },
+  },
+  async ({ workspaceId, oldDomain, newDomain, execute }, logger) => {
+    if (oldDomain === newDomain) {
+      logger.error({ oldDomain, newDomain }, "Old and new domains must differ");
+      return;
+    }
+
+    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    if (!workspace) {
+      logger.error({ workspaceId }, "Workspace not found");
+      return;
+    }
+
+    logger.info({ workspaceId, name: workspace.name }, "Found workspace");
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const { members } = await getMembers(auth, { activeOnly: true });
+
+    logger.info({ memberCount: members.length }, "Fetched workspace members");
+
+    // Build a map local -> member for new-domain members (primary accounts).
+    const primaryByLocal = new Map(
+      members
+        .filter((m) => {
+          const [, domain] = m.email.split("@");
+          return domain === newDomain;
+        })
+        .map((m) => {
+          const [local] = m.email.split("@");
+          return [local, m];
+        })
+    );
+
+    // Secondary users have an email on the old domain.
+    const oldDomainMembers = members.filter((m) => {
+      const [, domain] = m.email.split("@");
+      return domain === oldDomain;
+    });
+
+    logger.info(
+      { oldDomainMemberCount: oldDomainMembers.length },
+      "Found old-domain members"
+    );
+
+    const results = {
+      successful: [] as Array<{ primary: string; secondary: string }>,
+      skipped: [] as Array<{ email: string; reason: string }>,
+      failed: [] as Array<{
+        primary: string;
+        secondary: string;
+        error: string;
+      }>,
+    };
+
+    for (const secondaryMember of oldDomainMembers) {
+      const [local] = secondaryMember.email.split("@");
+      const newEmail = `${local}@${newDomain}`;
+      const primaryMember = primaryByLocal.get(local);
+
+      if (!primaryMember) {
+        logger.info(
+          { oldEmail: secondaryMember.email, newEmail },
+          "No matching primary member found, skipping"
+        );
+        results.skipped.push({
+          email: secondaryMember.email,
+          reason: `No primary member found for new-domain email ${newEmail}`,
+        });
+        continue;
+      }
+
+      logger.info(
+        {
+          primaryUserId: primaryMember.sId,
+          primaryEmail: primaryMember.email,
+          secondaryUserId: secondaryMember.sId,
+          secondaryEmail: secondaryMember.email,
+        },
+        execute ? "Merging users" : "Would merge users"
+      );
+
+      if (!execute) {
+        results.successful.push({
+          primary: primaryMember.sId,
+          secondary: secondaryMember.sId,
+        });
+        continue;
+      }
+
+      try {
+        const result = await mergeUserIdentities({
+          auth,
+          primaryUserId: primaryMember.sId,
+          secondaryUserId: secondaryMember.sId,
+          enforceEmailMatch: false,
+          revokeSecondaryUser: true,
+        });
+
+        if (result.isErr()) {
+          logger.error(
+            {
+              primaryUserId: primaryMember.sId,
+              secondaryUserId: secondaryMember.sId,
+              error: result.error,
+            },
+            "Failed to merge users"
+          );
+          results.failed.push({
+            primary: primaryMember.sId,
+            secondary: secondaryMember.sId,
+            error: result.error.message,
+          });
+          continue;
+        }
+
+        logger.info(
+          {
+            primaryUserId: primaryMember.sId,
+            secondaryUserId: secondaryMember.sId,
+          },
+          "Successfully merged users"
+        );
+
+        results.successful.push({
+          primary: primaryMember.sId,
+          secondary: secondaryMember.sId,
+        });
+      } catch (error) {
+        const normalizedError = normalizeError(error);
+        logger.error(
+          {
+            primaryUserId: primaryMember.sId,
+            secondaryUserId: secondaryMember.sId,
+            error: normalizedError,
+          },
+          "Exception during merge"
+        );
+        results.failed.push({
+          primary: primaryMember.sId,
+          secondary: secondaryMember.sId,
+          error: normalizedError.message,
+        });
+      }
+    }
+
+    logger.info(
+      {
+        successful: results.successful.length,
+        skipped: results.skipped.length,
+        failed: results.failed.length,
+        execute,
+      },
+      "Done"
+    );
+
+    if (results.failed.length > 0) {
+      logger.error({ failures: results.failed }, "Failed merges");
+    }
+  }
+);


### PR DESCRIPTION
## Description

It's modeled on merge_xx_user_identities.ts with these adaptations:

- Takes --oldDomain and --newDomain args alongside --workspaceId.
- Builds a local -> member map of new-domain (primary) members, then iterates old-domain (secondary) members and merges by matching local part.
- Same mergeUserIdentities call with enforceEmailMatch: false (since the emails differ by domain) and revokeSecondaryUser: true.
- Same dry-run / execute / skipped / failed reporting structure.

Run with e.g.:
```
npx tsx scripts/merge_domain_user_identities.ts -w <wId> --oldDomain old.com --newDomain new.com           # dry-run
npx tsx scripts/merge_domain_user_identities.ts -w <wId> --oldDomain old.com --newDomain new.com --execute
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Manual script