### PR TITLE
fix: allow creating subscription if default payment method is not set

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -595,12 +595,6 @@ export async function createStripeBusinessSubscription({
   const defaultPaymentMethodId =
     getDefaultPaymentMethodId(existingSubscription);
 
-  if (!defaultPaymentMethodId) {
-    return new Err(
-      new Error("Existing subscription has no default payment method")
-    );
-  }
-
   const quantity = await MembershipResource.countActiveSeatsInWorkspace(
     owner.sId
   );
@@ -684,10 +678,10 @@ export function getCustomerId(subscription: Stripe.Subscription): string {
 
 export function getDefaultPaymentMethodId(
   subscription: Stripe.Subscription
-): string | null {
+): string | undefined {
   return isString(subscription.default_payment_method)
     ? subscription.default_payment_method
-    : (subscription.default_payment_method?.id ?? null);
+    : subscription.default_payment_method?.id;
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7827

This PR fixes an issue preventing subscription creation when an existing subscription does not have a default payment method set.

If not set invoices will use the customer's invoice_settings.default_payment_method or default_source.

## Tests

No

## Risk

Low.

## Deploy Plan

Standard deployment - no special steps required.
