### PR TITLE
Add thumbnail endpoint for GCS file explorer images

### DIFF
--- a/front/components/assistant/conversation/files_panel/FileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorer.tsx
@@ -281,7 +281,6 @@ export function NewFileExplorer({
                     <FileExplorerFileCard
                       key={entry.path}
                       entry={entry}
-                      owner={owner}
                       viewMode={viewMode}
                       onOpen={handleOpen}
                       onDownload={handleDownload}
@@ -302,7 +301,6 @@ export function NewFileExplorer({
                     <FileExplorerFileCard
                       key={entry.path}
                       entry={entry}
-                      owner={owner}
                       viewMode={viewMode}
                       onOpen={handleOpen}
                       onDownload={handleDownload}

--- a/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
@@ -5,9 +5,7 @@ import {
 } from "@app/components/assistant/conversation/files_panel/utils";
 import { cn } from "@app/components/poke/shadcn/lib/utils";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
-import { getFileProcessedUrl } from "@app/lib/swr/files";
 import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   DropdownMenu,
@@ -185,7 +183,6 @@ export function FileExplorerFolderCard({
 
 export interface FileExplorerFileCardProps {
   entry: GCSMountFileEntry;
-  owner: LightWorkspaceType;
   viewMode: ViewMode;
   onOpen: (entry: GCSMountFileEntry) => void;
   onDownload: (entry: GCSMountFileEntry) => void;
@@ -193,23 +190,17 @@ export interface FileExplorerFileCardProps {
 
 export function FileExplorerFileCard({
   entry,
-  owner,
   viewMode,
   onOpen,
   onDownload,
 }: FileExplorerFileCardProps) {
   const subtitle = getFileSubtitle(entry);
 
-  // TODO(2026-04-27 FILE SYSTEM): Move this thumbnail logic to files endpoint.
   if (getCategoryFromContentType(entry.contentType) === "image") {
-    const thumbnailSrc = entry.fileId
-      ? getFileProcessedUrl(owner, entry.fileId)
-      : null;
-
     return (
       <FileExplorerItem
         kind="thumbnail"
-        thumbnailSrc={thumbnailSrc}
+        thumbnailSrc={entry.thumbnailUrl}
         viewMode={viewMode}
         title={entry.fileName}
         subtitle={subtitle}

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -1,7 +1,9 @@
+import config from "@app/lib/api/config";
 import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { isSupportedImageContentType } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 
@@ -12,6 +14,7 @@ export type GCSMountFileEntry = {
   contentType: string;
   lastModifiedMs: number;
   fileId: string | null;
+  thumbnailUrl: string | null;
 };
 
 type GCSMountPoint = {
@@ -84,6 +87,7 @@ export async function listGCSMountFiles(
           ? new Date(f.metadata.updated).getTime()
           : 0,
         fileId: null,
+        thumbnailUrl: null,
       },
     ];
   });
@@ -91,19 +95,23 @@ export async function listGCSMountFiles(
   const fileEntries: GCSMountFileEntry[] = regularFiles.map((gcsFile) => {
     const fileName = gcsFile.name.split("/").pop() ?? gcsFile.name;
     const metadata = gcsFile.metadata;
+    const contentType = isString(metadata.contentType)
+      ? metadata.contentType
+      : "application/octet-stream";
     const fileResource = fileResourceByMountPath.get(gcsFile.name) ?? null;
 
     return {
       fileName,
       path: gcsFile.name,
       sizeBytes: Number(metadata.size ?? 0),
-      contentType: isString(metadata.contentType)
-        ? metadata.contentType
-        : "application/octet-stream",
+      contentType,
       lastModifiedMs: isString(metadata.updated)
         ? new Date(metadata.updated).getTime()
         : 0,
       fileId: fileResource?.sId ?? null,
+      thumbnailUrl: isSupportedImageContentType(contentType)
+        ? `${config.getClientFacingUrl()}/api/w/${owner.sId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(gcsFile.name)}`
+        : null,
     };
   });
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -110,7 +110,7 @@ export async function listGCSMountFiles(
         : 0,
       fileId: fileResource?.sId ?? null,
       thumbnailUrl: isSupportedImageContentType(contentType)
-        ? `${config.getClientFacingUrl()}/api/w/${owner.sId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(gcsFile.name)}`
+        ? `${config.getClientFacingUrl()}/api/w/${owner.sId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(gcsFile.name.slice(prefix.length))}`
         : null,
     };
   });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.test.ts
@@ -1,0 +1,178 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Err, Ok } from "@app/types/shared/result";
+import { PassThrough } from "stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./thumbnail";
+
+function makeReadStream() {
+  return new PassThrough();
+}
+
+function makeBucket(
+  overrides: Partial<{ getFileContentType: any; createReadStream: any }> = {}
+) {
+  const readStream = overrides.createReadStream ?? vi.fn().mockReturnValue(makeReadStream());
+  return {
+    getFileContentType:
+      overrides.getFileContentType ??
+      vi.fn().mockResolvedValue(new Ok("image/png")),
+    file: vi.fn().mockReturnValue({ createReadStream: readStream }),
+  };
+}
+
+async function setup() {
+  const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+    method: "GET",
+  });
+  const conversation = await createConversation(auth, {
+    title: null,
+    visibility: "unlisted",
+    spaceId: null,
+  });
+  const basePath = getConversationFilesBasePath({
+    workspaceId: workspace.sId,
+    conversationId: conversation.sId,
+  });
+  return { req, res, workspace, auth, conversation, basePath };
+}
+
+describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 405 for non-GET methods", async () => {
+    const { req, res } = await createPrivateApiMockRequest({ method: "POST" });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it("returns 400 when filePath query param is missing", async () => {
+    const { req, res, workspace, conversation } = await setup();
+    req.query = { wId: workspace.sId, cId: conversation.sId };
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 403 for path outside conversation scope", async () => {
+    const { req, res, workspace, conversation } = await setup();
+    req.query = {
+      wId: workspace.sId,
+      cId: conversation.sId,
+      filePath: `w/${workspace.sId}/conversations/other_conv/files/image.png`,
+    };
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error.type).toBe("workspace_auth_error");
+  });
+
+  it("streams from FileResource when one is associated with the path", async () => {
+    const { req, res, workspace, auth, conversation, basePath } = await setup();
+
+    const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+      contentType: "image/png",
+      fileName: "generated.png",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "conversation",
+    });
+    const mountPath = `${basePath}generated.png`;
+    await FileModel.update(
+      { mountFilePath: mountPath },
+      { where: { id: file.id, workspaceId: workspace.id } }
+    );
+
+    const spy = vi
+      .spyOn(FileResource.prototype, "getContentReadStream")
+      .mockReturnValue(makeReadStream() as any);
+
+    req.query = { wId: workspace.sId, cId: conversation.sId, filePath: mountPath };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader("Content-Type")).toBe("image/png");
+    expect(res.getHeader("Cache-Control")).toBe("private, max-age=3600");
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("falls back to GCS when no FileResource is associated with the path", async () => {
+    const { req, res, workspace, conversation, basePath } = await setup();
+
+    const bucket = makeBucket();
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+
+    const mountPath = `${basePath}sandbox_output.png`;
+    req.query = { wId: workspace.sId, cId: conversation.sId, filePath: mountPath };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader("Content-Type")).toBe("image/png");
+    expect(bucket.getFileContentType).toHaveBeenCalledWith(mountPath);
+    expect(bucket.file).toHaveBeenCalledWith(mountPath);
+  });
+
+  it("returns 400 for a FileResource-backed non-image file", async () => {
+    const { req, res, workspace, auth, conversation, basePath } = await setup();
+
+    const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+      contentType: "text/plain",
+      fileName: "report.txt",
+      fileSize: 512,
+      status: "ready",
+      useCase: "conversation",
+    });
+    const mountPath = `${basePath}report.txt`;
+    await FileModel.update(
+      { mountFilePath: mountPath },
+      { where: { id: file.id, workspaceId: workspace.id } }
+    );
+
+    req.query = { wId: workspace.sId, cId: conversation.sId, filePath: mountPath };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for a GCS non-image file", async () => {
+    const { req, res, workspace, conversation, basePath } = await setup();
+
+    const bucket = makeBucket({
+      getFileContentType: vi.fn().mockResolvedValue(new Ok("text/plain")),
+    });
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+
+    const mountPath = `${basePath}report.txt`;
+    req.query = { wId: workspace.sId, cId: conversation.sId, filePath: mountPath };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 when no FileResource and GCS file not found", async () => {
+    const { req, res, workspace, conversation, basePath } = await setup();
+
+    const bucket = makeBucket({
+      getFileContentType: vi
+        .fn()
+        .mockResolvedValue(new Err(new Error("not found"))),
+    });
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+
+    const mountPath = `${basePath}missing.png`;
+    req.query = { wId: workspace.sId, cId: conversation.sId, filePath: mountPath };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("file_not_found");
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.test.ts
@@ -18,7 +18,8 @@ function makeReadStream() {
 function makeBucket(
   overrides: Partial<{ getFileContentType: any; createReadStream: any }> = {}
 ) {
-  const readStream = overrides.createReadStream ?? vi.fn().mockReturnValue(makeReadStream());
+  const readStream =
+    overrides.createReadStream ?? vi.fn().mockReturnValue(makeReadStream());
   return {
     getFileContentType:
       overrides.getFileContentType ??
@@ -62,12 +63,12 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
   });
 
-  it("returns 403 for path outside conversation scope", async () => {
+  it("returns 403 for path traversal attempt", async () => {
     const { req, res, workspace, conversation } = await setup();
     req.query = {
       wId: workspace.sId,
       cId: conversation.sId,
-      filePath: `w/${workspace.sId}/conversations/other_conv/files/image.png`,
+      filePath: "../../secret.txt",
     };
     await handler(req, res);
     expect(res._getStatusCode()).toBe(403);
@@ -84,9 +85,8 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
       status: "ready",
       useCase: "conversation",
     });
-    const mountPath = `${basePath}generated.png`;
     await FileModel.update(
-      { mountFilePath: mountPath },
+      { mountFilePath: `${basePath}generated.png` },
       { where: { id: file.id, workspaceId: workspace.id } }
     );
 
@@ -94,7 +94,11 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
       .spyOn(FileResource.prototype, "getContentReadStream")
       .mockReturnValue(makeReadStream() as any);
 
-    req.query = { wId: workspace.sId, cId: conversation.sId, filePath: mountPath };
+    req.query = {
+      wId: workspace.sId,
+      cId: conversation.sId,
+      filePath: "generated.png",
+    };
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
@@ -109,14 +113,19 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     const bucket = makeBucket();
     vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
 
-    const mountPath = `${basePath}sandbox_output.png`;
-    req.query = { wId: workspace.sId, cId: conversation.sId, filePath: mountPath };
+    req.query = {
+      wId: workspace.sId,
+      cId: conversation.sId,
+      filePath: "sandbox_output.png",
+    };
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
     expect(res.getHeader("Content-Type")).toBe("image/png");
-    expect(bucket.getFileContentType).toHaveBeenCalledWith(mountPath);
-    expect(bucket.file).toHaveBeenCalledWith(mountPath);
+    expect(bucket.getFileContentType).toHaveBeenCalledWith(
+      `${basePath}sandbox_output.png`
+    );
+    expect(bucket.file).toHaveBeenCalledWith(`${basePath}sandbox_output.png`);
   });
 
   it("returns 400 for a FileResource-backed non-image file", async () => {
@@ -129,13 +138,16 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
       status: "ready",
       useCase: "conversation",
     });
-    const mountPath = `${basePath}report.txt`;
     await FileModel.update(
-      { mountFilePath: mountPath },
+      { mountFilePath: `${basePath}report.txt` },
       { where: { id: file.id, workspaceId: workspace.id } }
     );
 
-    req.query = { wId: workspace.sId, cId: conversation.sId, filePath: mountPath };
+    req.query = {
+      wId: workspace.sId,
+      cId: conversation.sId,
+      filePath: "report.txt",
+    };
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(400);
@@ -143,15 +155,18 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
   });
 
   it("returns 400 for a GCS non-image file", async () => {
-    const { req, res, workspace, conversation, basePath } = await setup();
+    const { req, res, workspace, conversation } = await setup();
 
     const bucket = makeBucket({
       getFileContentType: vi.fn().mockResolvedValue(new Ok("text/plain")),
     });
     vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
 
-    const mountPath = `${basePath}report.txt`;
-    req.query = { wId: workspace.sId, cId: conversation.sId, filePath: mountPath };
+    req.query = {
+      wId: workspace.sId,
+      cId: conversation.sId,
+      filePath: "report.txt",
+    };
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(400);
@@ -159,7 +174,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
   });
 
   it("returns 404 when no FileResource and GCS file not found", async () => {
-    const { req, res, workspace, conversation, basePath } = await setup();
+    const { req, res, workspace, conversation } = await setup();
 
     const bucket = makeBucket({
       getFileContentType: vi
@@ -168,8 +183,11 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     });
     vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
 
-    const mountPath = `${basePath}missing.png`;
-    req.query = { wId: workspace.sId, cId: conversation.sId, filePath: mountPath };
+    req.query = {
+      wId: workspace.sId,
+      cId: conversation.sId,
+      filePath: "missing.png",
+    };
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(404);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.test.ts
@@ -2,7 +2,6 @@ import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { FileModel } from "@app/lib/resources/storage/models/files";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Err, Ok } from "@app/types/shared/result";
@@ -76,7 +75,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
   });
 
   it("streams from FileResource when one is associated with the path", async () => {
-    const { req, res, workspace, auth, conversation, basePath } = await setup();
+    const { req, res, workspace, auth, conversation } = await setup();
 
     const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
       contentType: "image/png",
@@ -85,10 +84,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
       status: "ready",
       useCase: "conversation",
     });
-    await FileModel.update(
-      { mountFilePath: `${basePath}generated.png` },
-      { where: { id: file.id, workspaceId: workspace.id } }
-    );
+    await file.setUseCaseMetadata(auth, { conversationId: conversation.sId });
 
     const spy = vi
       .spyOn(FileResource.prototype, "getContentReadStream")
@@ -111,7 +107,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     const { req, res, workspace, conversation, basePath } = await setup();
 
     const bucket = makeBucket();
-    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce(bucket as any);
 
     req.query = {
       wId: workspace.sId,
@@ -129,7 +125,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
   });
 
   it("returns 400 for a FileResource-backed non-image file", async () => {
-    const { req, res, workspace, auth, conversation, basePath } = await setup();
+    const { req, res, workspace, auth, conversation } = await setup();
 
     const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
       contentType: "text/plain",
@@ -138,10 +134,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
       status: "ready",
       useCase: "conversation",
     });
-    await FileModel.update(
-      { mountFilePath: `${basePath}report.txt` },
-      { where: { id: file.id, workspaceId: workspace.id } }
-    );
+    await file.setUseCaseMetadata(auth, { conversationId: conversation.sId });
 
     req.query = {
       wId: workspace.sId,
@@ -160,7 +153,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     const bucket = makeBucket({
       getFileContentType: vi.fn().mockResolvedValue(new Ok("text/plain")),
     });
-    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce(bucket as any);
 
     req.query = {
       wId: workspace.sId,
@@ -181,7 +174,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
         .fn()
         .mockResolvedValue(new Err(new Error("not found"))),
     });
-    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce(bucket as any);
 
     req.query = {
       wId: workspace.sId,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
@@ -52,12 +52,13 @@ async function handler(
   }
 
   const owner = auth.getNonNullableWorkspace();
-  const expectedPrefix = getConversationFilesBasePath({
-    workspaceId: owner.sId,
-    conversationId: cId,
-  });
-  const normalizedPath = path.posix.normalize(filePath);
-  if (!normalizedPath.startsWith(expectedPrefix)) {
+
+  // filePath is relative to the conversation's files base. Reject any traversal attempt.
+  const normalizedRelative = path.posix.normalize(filePath);
+  if (
+    normalizedRelative.startsWith("..") ||
+    normalizedRelative.startsWith("/")
+  ) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
@@ -66,6 +67,12 @@ async function handler(
       },
     });
   }
+
+  const basePath = getConversationFilesBasePath({
+    workspaceId: owner.sId,
+    conversationId: cId,
+  });
+  const normalizedPath = `${basePath}${normalizedRelative}`;
 
   const [fileResource] = await FileResource.fetchByMountFilePaths(auth, [
     normalizedPath,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
@@ -1,0 +1,138 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isSupportedImageContentType } from "@app/types/files";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import path from "path";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<never>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { cId, filePath } = req.query;
+  if (!isString(cId) || !isString(filePath)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Invalid query parameters, `cId` and `filePath` (strings) are required.",
+      },
+    });
+  }
+
+  const conversation = await ConversationResource.fetchById(auth, cId);
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const expectedPrefix = getConversationFilesBasePath({
+    workspaceId: owner.sId,
+    conversationId: cId,
+  });
+  const normalizedPath = path.posix.normalize(filePath);
+  if (!normalizedPath.startsWith(expectedPrefix)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Access denied: path is outside conversation scope.",
+      },
+    });
+  }
+
+  const [fileResource] = await FileResource.fetchByMountFilePaths(auth, [
+    normalizedPath,
+  ]);
+
+  // If a FileResource exists, stream its best available version (processed if available).
+  if (fileResource) {
+    if (!isSupportedImageContentType(fileResource.contentType)) {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Thumbnail is only supported for image files.",
+        },
+      });
+    }
+    res.setHeader("Content-Type", fileResource.contentType);
+    res.setHeader("Cache-Control", "private, max-age=3600");
+    const readStream = fileResource.getContentReadStream(auth);
+    readStream.on("error", (err) => {
+      logger.error(
+        { err, filePath: normalizedPath },
+        "Error streaming thumbnail (FileResource)"
+      );
+      readStream.destroy();
+      res.end();
+    });
+    readStream.pipe(res);
+    return;
+  }
+
+  // No FileResource, stream directly from GCS (sandbox-generated file).
+  const bucket = getPrivateUploadBucket();
+  const contentTypeResult = await bucket.getFileContentType(normalizedPath);
+  if (contentTypeResult.isErr()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  }
+
+  const contentType = contentTypeResult.value ?? "application/octet-stream";
+  if (!isSupportedImageContentType(contentType)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Thumbnail is only supported for image files.",
+      },
+    });
+  }
+
+  res.setHeader("Content-Type", contentType);
+  res.setHeader("Cache-Control", "private, max-age=3600");
+  const readStream = bucket.file(normalizedPath).createReadStream();
+  readStream.on("error", (err) => {
+    logger.error(
+      { err, filePath: normalizedPath },
+      "Error streaming thumbnail (GCS)"
+    );
+    readStream.destroy();
+    res.end();
+  });
+  readStream.pipe(res);
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -68,7 +68,9 @@ class FileStorageMock {
     return {
       file: vi.fn((path: string) => this.createMockGCSFile(path)),
       name: "mock-bucket",
-      getFileContentType: vi.fn().mockResolvedValue({ isOk: () => false, isErr: () => true }),
+      getFileContentType: vi
+        .fn()
+        .mockResolvedValue({ isOk: () => false, isErr: () => true }),
       getSignedUrl: vi.fn().mockResolvedValue("https://signed-url.test"),
       uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
       uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -68,6 +68,7 @@ class FileStorageMock {
     return {
       file: vi.fn((path: string) => this.createMockGCSFile(path)),
       name: "mock-bucket",
+      getFileContentType: vi.fn().mockResolvedValue({ isOk: () => false, isErr: () => true }),
       getSignedUrl: vi.fn().mockResolvedValue("https://signed-url.test"),
       uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
       uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Images generated directly by sandbox scripts are written straight to the GCS mount without going through
`FileResource`, so they had no `fileId` and the file explorer could not show thumbnails for them.

This PR adds a dedicated `GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail` endpoint that checks for a
`FileResource` first. If found, it streams the processed (resized) version, otherwise it streams the raw file directly
from GCS. This covers both user-uploaded images (which have a `FileResource`) and sandbox-generated images (which do
not).

`thumbnailUrl` is now computed at list time in `listGCSMountFiles` as an absolute URL so that it resolves correctly when used as an `<img src>` from the SPA 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
