### PR TITLE
Enable Programmatic usage rates

### DIFF
--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -397,7 +397,7 @@ function getRateCards(): RateCardDef[] {
         {
           product_name: "Programmatic Usage",
           starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
+          entitled: true,
           rate_type: "FLAT",
           price: 1,
           credit_type_id: getCreditTypeProgrammaticUsdId(),
@@ -428,7 +428,7 @@ function getRateCards(): RateCardDef[] {
         {
           product_name: "Programmatic Usage",
           starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
+          entitled: true,
           rate_type: "FLAT",
           price: 1,
           credit_type_id: getCreditTypeProgrammaticUsdId(),
@@ -459,7 +459,7 @@ function getRateCards(): RateCardDef[] {
         {
           product_name: "Programmatic Usage",
           starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
+          entitled: true,
           rate_type: "FLAT",
           price: 1,
           credit_type_id: getCreditTypeProgrammaticUsdId(),
@@ -494,7 +494,7 @@ function getRateCards(): RateCardDef[] {
         {
           product_name: "Programmatic Usage",
           starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
+          entitled: true,
           rate_type: "FLAT",
           price: 1,
           credit_type_id: getCreditTypeProgrammaticUsdId(),
@@ -564,7 +564,7 @@ function getRateCards(): RateCardDef[] {
         {
           product_name: "Programmatic Usage",
           starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
+          entitled: true,
           rate_type: "FLAT",
           price: 1,
           credit_type_id: getCreditTypeProgrammaticUsdId(),
@@ -596,7 +596,7 @@ function getRateCards(): RateCardDef[] {
         {
           product_name: "Programmatic Usage",
           starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
+          entitled: true,
           rate_type: "FLAT",
           price: 1,
           credit_type_id: getCreditTypeProgrammaticUsdId(),
@@ -628,7 +628,7 @@ function getRateCards(): RateCardDef[] {
         {
           product_name: "Programmatic Usage",
           starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
+          entitled: true,
           rate_type: "FLAT",
           price: 1,
           credit_type_id: getCreditTypeProgrammaticUsdId(),

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -532,7 +532,7 @@ function getRateCards(): RateCardDef[] {
         {
           product_name: "Programmatic Usage",
           starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
+          entitled: true,
           rate_type: "FLAT",
           price: 1,
           credit_type_id: getCreditTypeProgrammaticUsdId(),


### PR DESCRIPTION
## Description

Enable "Programmatic usage" rates by default in the Metronome packages

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Run `metronome_setup.ts`
