### PR TITLE
Move dynamic project context to the ephemeral part.

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -466,6 +466,7 @@ export function constructPromptMultiActions(
     toolsetsContext,
     userContext,
     workspaceContext,
+    projectContext,
   }: {
     userMessage: UserMessageType;
     agentConfiguration: AgentConfigurationType;
@@ -484,6 +485,7 @@ export function constructPromptMultiActions(
     toolsetsContext?: string;
     userContext?: string;
     workspaceContext?: string;
+    projectContext?: string;
   }
 ): SystemPromptSections {
   const owner = auth.workspace();
@@ -512,6 +514,7 @@ export function constructPromptMultiActions(
     userMessage,
   });
   const branchContextSection = constructBranchContextSection({ conversation });
+
   const toolsSection = constructToolsSection({
     hasAvailableActions,
     model,
@@ -563,6 +566,7 @@ export function constructPromptMultiActions(
       { role: "context" as const, content: branchContextSection },
       { role: "context" as const, content: memoriesContext ?? "" },
       { role: "context" as const, content: userContext ?? "" },
+      { role: "context" as const, content: projectContext ?? "" },
     ].filter((s) => s.content.trim() !== "");
 
     const structured: StructuredSystemPrompt = {
@@ -588,6 +592,7 @@ export function constructPromptMultiActions(
     { role: "context" as const, content: memoriesContext ?? "" },
     { role: "context" as const, content: userContext ?? "" },
     { role: "context" as const, content: workspaceContext ?? "" },
+    { role: "context" as const, content: projectContext ?? "" },
   ].filter((s) => s.content.trim() !== "");
 
   return allSections;

--- a/front/lib/resources/skill/code_defined/projects.ts
+++ b/front/lib/resources/skill/code_defined/projects.ts
@@ -8,8 +8,10 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
-import { isProjectConversation } from "@app/types/assistant/conversation";
+import {
+  type ConversationWithoutContentType,
+  isProjectConversation,
+} from "@app/types/assistant/conversation";
 
 export const projectsSkill = {
   sId: "projects",
@@ -18,26 +20,7 @@ export const projectsSkill = {
     "Allow agents to create conversations & messages in projects, leverage projects knowledge.",
   agentFacingDescription:
     "Use project context instructions and tools for project knowledge retrieval and search. Allow agents to create conversations and messages in projects.",
-  fetchInstructions: async (
-    auth: Authenticator,
-    {
-      agentLoopData,
-    }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
-  ) => {
-    const conversation = agentLoopData?.conversation;
-
-    let instructions = "";
-
-    // Add important note for project conversations to strongly emphasize the importance of using project tools first.
-    if (conversation && isProjectConversation(conversation)) {
-      const space = await SpaceResource.fetchById(auth, conversation.spaceId);
-      instructions += `
-IMPORTANT: This conversation (id: ${conversation.sId}) is part of the project "${space?.name}" (id: ${space?.sId}).
-Therefore, ALWAYS start by using the project tools to search for information before using company-wide tools.
-`;
-    }
-
-    instructions += `
+  instructions: `
 The project provides:
 - Persistent knowledge storage shared accross this project
 - Project metadata (description, URLs, members, etc.) for organizational context
@@ -64,10 +47,8 @@ When you need to find information, uses this order (skip steps if the relevant t
 2. **This conversation's attachments** (only when \`${CONVERSATION_FILES_SERVER_NAME}\` is available): \`${CONVERSATION_SEARCH_FILES_ACTION_NAME}\` on \`${CONVERSATION_FILES_SERVER_NAME}\` — search files attached to the current conversation.
 3. **Project-wide search**: \`${PROJECT_MANAGER_SERVER_NAME}\` \`semantic_search\` — search project knowledge and/or conversations in the project; usually the best source for project-specific questions.
 4. **Company-wide**: If still insufficient, use \`company_data_*\` tools and \`${SEARCH_SERVER_NAME}\` for broader company data sources.
-`;
+`,
 
-    return instructions;
-  },
   mcpServers: [{ name: "project_manager" }, { name: "project_todos" }],
   version: 1,
   icon: "ActionFolderIcon",
@@ -78,3 +59,25 @@ When you need to find information, uses this order (skip steps if the relevant t
   },
   // Note: we auto enabled in listForAgentLoop for project conversations.
 } as const satisfies GlobalSkillDefinition;
+
+export async function constructProjectContext(
+  auth: Authenticator,
+  {
+    conversation,
+  }: {
+    conversation?: ConversationWithoutContentType;
+  }
+): Promise<string> {
+  let instructions = "";
+
+  // Add important note for project conversations to strongly emphasize the importance of using project tools first.
+  if (conversation && isProjectConversation(conversation)) {
+    const space = await SpaceResource.fetchById(auth, conversation.spaceId);
+    instructions += `
+IMPORTANT: This conversation (id: ${conversation.sId}) is part of the project "${space?.name}" (id: ${space?.sId}).
+Therefore, ALWAYS start by using the project tools to search for information before using company-wide tools.
+`;
+  }
+
+  return instructions;
+}

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -17,6 +17,7 @@ import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { constructProjectContext } from "@app/lib/resources/skill/code_defined/projects";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { tokenCountForTexts } from "@app/lib/tokenization";
@@ -258,6 +259,10 @@ async function handler(
           })
         : null;
 
+      const projectContext = await constructProjectContext(auth, {
+        conversation,
+      });
+
       const promptSections = constructPromptMultiActions(auth, {
         userMessage,
         agentConfiguration,
@@ -272,6 +277,7 @@ async function handler(
         systemSkills,
         equippedSkills,
         renderSkillsAsUserMessages,
+        projectContext,
       });
       const prompt = systemPromptToText(promptSections);
       const leadingMessages = renderSkillsAsUserMessages

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -57,6 +57,7 @@ import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
+import { constructProjectContext } from "@app/lib/resources/skill/code_defined/projects";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -381,6 +382,10 @@ export async function runModel(
     workspaceContext = await buildWorkspaceContext(auth);
   }
 
+  const projectContext = await constructProjectContext(auth, {
+    conversation,
+  });
+
   const prompt = constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
@@ -399,6 +404,7 @@ export async function runModel(
     toolsetsContext,
     userContext,
     workspaceContext,
+    projectContext,
   });
   const leadingMessages = renderSkillsAsUserMessages
     ? removeNulls([renderEquippedSkillsUserMessage(equippedSkills)])


### PR DESCRIPTION
## Description

The `projects` skill's `fetchInstructions` was computing the project context (conversation sId, space name) at skill-load time, making it part of the static skill instructions that feed into the prompt cache. Since this content is conversation-specific, it invalidated the cache on every new project conversation.

Separating it into a dedicated `constructProjectContext` function that's called at prompt-construction time — alongside `workspaceContext`, `userContext`, etc. — places it in the ephemeral part of the prompt where it belongs, without polluting the cached skill instructions.

- Convert `projects` skill from `fetchInstructions` (async, dynamic) to a static `instructions` string — no more async skill loading for project context
- Extract `constructProjectContext` as a standalone function in `projects.ts` — resolves the space name from the conversation's `spaceId` and injects the "IMPORTANT: this conversation is part of project X" preamble only when needed
- Call `constructProjectContext` in `run_model.ts` and the poke render endpoint alongside other ephemeral context builders
- Pass `projectContext` through `constructPromptMultiActions` as a new optional `context` section

## Tests

Local

## Risk

Low — prompt content is unchanged; only where in the pipeline it's computed changes

## Deploy Plan

Deploy `front`
