### PR TITLE
refactor(project-todo): split takeaway extraction into new vs updated items

### DIFF
--- a/front/lib/project_todo/analyze_document/action_items.test.ts
+++ b/front/lib/project_todo/analyze_document/action_items.test.ts
@@ -2,106 +2,225 @@ import {
   buildActionItems,
   buildPromptActionItems,
 } from "@app/lib/project_todo/analyze_document/action_items";
+import logger from "@app/logger/logger";
 import type { TodoVersionedActionItem } from "@app/types/takeaways";
 import { describe, expect, it } from "vitest";
 
-describe("buildActionItems", () => {
-  it("reuses sId when it matches a previous sId", () => {
-    const knownId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
-    const raw = [
-      {
-        sId: knownId,
-        short_description: "Review PR",
-        status: "open" as const,
-      },
-    ];
-    const result = buildActionItems(raw, [{ sId: knownId }], new Set());
-    expect(result[0].sId).toBe(knownId);
-  });
+function makePrev(
+  overrides: Partial<TodoVersionedActionItem> = {}
+): TodoVersionedActionItem {
+  return {
+    sId: "prev-1",
+    shortDescription: "Existing task",
+    assigneeUserId: null,
+    assigneeName: null,
+    status: "open",
+    detectedDoneAt: null,
+    detectedDoneRationale: null,
+    ...overrides,
+  };
+}
 
-  it("maps open status correctly", () => {
-    const raw = [
+describe("buildActionItems — new items", () => {
+  it("appends a new item with a fresh sId when assignee is a known member", () => {
+    const result = buildActionItems(
       {
-        short_description: "Fix bug",
-        status: "open" as const,
+        newItems: [
+          {
+            short_description: "Review PR",
+            assignee_name: "Alice",
+            assignee_user_id: "user-abc",
+          },
+        ],
+        updatedItems: [],
       },
-    ];
-    const result = buildActionItems(raw, [], new Set());
+      [],
+      new Set(["user-abc"]),
+      logger
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sId).not.toBe("");
+    expect(result[0].shortDescription).toBe("Review PR");
+    expect(result[0].assigneeName).toBe("Alice");
+    expect(result[0].assigneeUserId).toBe("user-abc");
     expect(result[0].status).toBe("open");
     expect(result[0].detectedDoneAt).toBeNull();
     expect(result[0].detectedDoneRationale).toBeNull();
   });
 
-  it("maps done status and sets detectedDoneAt to now", () => {
-    const before = new Date().toISOString();
-    const raw = [
+  it("drops new items whose assignee is not a project member", () => {
+    const result = buildActionItems(
       {
-        short_description: "Send report",
-        status: "done" as const,
-        detected_done_rationale: "User confirmed it was sent",
+        newItems: [
+          {
+            short_description: "Call client",
+            assignee_name: "Stranger",
+            assignee_user_id: "unknown-id",
+          },
+        ],
+        updatedItems: [],
       },
-    ];
-    const result = buildActionItems(raw, [], new Set());
+      [],
+      new Set(["user-abc"]),
+      logger
+    );
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("buildActionItems — updated items", () => {
+  it("preserves a previous item untouched when no update is emitted", () => {
+    const prev = makePrev({
+      sId: "prev-1",
+      shortDescription: "Refactor auth",
+      assigneeName: "Bob",
+      assigneeUserId: "user-bob",
+    });
+    const result = buildActionItems(
+      { newItems: [], updatedItems: [] },
+      [prev],
+      new Set(["user-bob"]),
+      logger
+    );
+
+    expect(result).toEqual([prev]);
+  });
+
+  it("updates the description when short_description is provided", () => {
+    const prev = makePrev({ shortDescription: "Old description" });
+    const result = buildActionItems(
+      {
+        newItems: [],
+        updatedItems: [{ sId: prev.sId, short_description: "New description" }],
+      },
+      [prev],
+      new Set(),
+      logger
+    );
+
+    expect(result[0].shortDescription).toBe("New description");
+  });
+
+  it("applies the assignee tuple when user_id is a known member", () => {
+    const prev = makePrev({
+      assigneeName: "Bob",
+      assigneeUserId: "user-bob",
+    });
+    const result = buildActionItems(
+      {
+        newItems: [],
+        updatedItems: [
+          {
+            sId: prev.sId,
+            assignee: { user_id: "user-alice", name: "Alice" },
+          },
+        ],
+      },
+      [prev],
+      new Set(["user-alice"]),
+      logger
+    );
+
+    expect(result[0].assigneeUserId).toBe("user-alice");
+    expect(result[0].assigneeName).toBe("Alice");
+  });
+
+  it("ignores the assignee tuple when user_id is not a known member", () => {
+    const prev = makePrev({
+      assigneeName: "Bob",
+      assigneeUserId: "user-bob",
+    });
+    const result = buildActionItems(
+      {
+        newItems: [],
+        updatedItems: [
+          {
+            sId: prev.sId,
+            assignee: { user_id: "unknown-id", name: "Stranger" },
+          },
+        ],
+      },
+      [prev],
+      new Set(["user-bob"]),
+      logger
+    );
+
+    expect(result[0].assigneeUserId).toBe("user-bob");
+    expect(result[0].assigneeName).toBe("Bob");
+  });
+
+  it("transitions an open item to done and sets detectedDoneAt to now", () => {
+    const before = new Date().toISOString();
+    const prev = makePrev({ status: "open" });
+    const result = buildActionItems(
+      {
+        newItems: [],
+        updatedItems: [
+          {
+            sId: prev.sId,
+            done: { detected_done_rationale: "User confirmed it shipped" },
+          },
+        ],
+      },
+      [prev],
+      new Set(),
+      logger
+    );
     const after = new Date().toISOString();
 
     expect(result[0].status).toBe("done");
     expect(result[0].detectedDoneAt).not.toBeNull();
     expect(result[0].detectedDoneAt! >= before).toBe(true);
     expect(result[0].detectedDoneAt! <= after).toBe(true);
-    expect(result[0].detectedDoneRationale).toBe("User confirmed it was sent");
+    expect(result[0].detectedDoneRationale).toBe("User confirmed it shipped");
   });
 
-  it("maps assignee_name to assigneeName, null when absent", () => {
-    const raw = [
+  it("does not overwrite detectedDoneAt when an item is already done", () => {
+    const prev = makePrev({
+      status: "done",
+      detectedDoneAt: "2024-01-01T00:00:00.000Z",
+      detectedDoneRationale: "Original rationale",
+    });
+    const result = buildActionItems(
       {
-        short_description: "Call client",
-        status: "open" as const,
-        assignee_name: "Alice",
+        newItems: [],
+        updatedItems: [
+          {
+            sId: prev.sId,
+            done: { detected_done_rationale: "Mentioned again" },
+          },
+        ],
       },
-      {
-        short_description: "Write docs",
-        status: "open" as const,
-      },
-    ];
-    const result = buildActionItems(raw, [], new Set());
-    expect(result[0].assigneeName).toBe("Alice");
-    expect(result[1].assigneeName).toBeNull();
+      [prev],
+      new Set(),
+      logger
+    );
+
+    expect(result[0].status).toBe("done");
+    expect(result[0].detectedDoneAt).toBe("2024-01-01T00:00:00.000Z");
+    expect(result[0].detectedDoneRationale).toBe("Mentioned again");
   });
 
-  it("sets assigneeUserId to null when no participants match", () => {
-    const raw = [{ short_description: "Task", status: "open" as const }];
-    const result = buildActionItems(raw, [], new Set());
-    expect(result[0].assigneeUserId).toBeNull();
-  });
-
-  it("resolves assigneeUserId when assignee_user_id matches a participant", () => {
-    const raw = [
+  it("drops updates referencing an unknown sId", () => {
+    const prev = makePrev({ sId: "prev-1" });
+    const result = buildActionItems(
       {
-        short_description: "Review PR",
-        status: "open" as const,
-        assignee_name: "Alice",
-        assignee_user_id: "user-abc",
+        newItems: [],
+        updatedItems: [
+          {
+            sId: "unknown-sid",
+            short_description: "Should be ignored",
+          },
+        ],
       },
-    ];
-    const participants = new Set(["user-abc", "user-def"]);
-    const result = buildActionItems(raw, [], participants);
-    expect(result[0].assigneeUserId).toBe("user-abc");
-    expect(result[0].assigneeName).toBe("Alice");
-  });
+      [prev],
+      new Set(),
+      logger
+    );
 
-  it("discards assigneeUserId when it does not match any participant", () => {
-    const raw = [
-      {
-        short_description: "Review PR",
-        status: "open" as const,
-        assignee_name: "Alice",
-        assignee_user_id: "unknown-id",
-      },
-    ];
-    const participants = new Set(["user-abc"]);
-    const result = buildActionItems(raw, [], participants);
-    expect(result[0].assigneeUserId).toBeNull();
-    expect(result[0].assigneeName).toBe("Alice");
+    expect(result).toEqual([prev]);
   });
 });
 
@@ -109,7 +228,7 @@ describe("buildPromptActionItems", () => {
   it("returns a prompt with guidelines only when no previous items", () => {
     const prompt = buildPromptActionItems([]);
     expect(prompt).toContain("action items");
-    expect(prompt).not.toContain("Known action items:");
+    expect(prompt).not.toContain("Previously tracked action items");
   });
 
   it("includes known items section when previous items exist", () => {
@@ -134,16 +253,12 @@ describe("buildPromptActionItems", () => {
       },
     ];
     const prompt = buildPromptActionItems(items);
-    expect(prompt).toContain("Known action items:");
+    expect(prompt).toContain("Previously tracked action items");
     expect(prompt).toContain(
       `<action_item sId="abc" status="open"><short_description>Refactor auth</short_description><assignee name="Bob" /></action_item>`
     );
     expect(prompt).toContain(
       `<action_item sId="def" status="done"><short_description>Ship feature</short_description></action_item>`
-    );
-    // The second item has no assignee, so no assignee tag should be present for it.
-    expect(prompt).not.toContain(
-      `<action_item sId="def" status="done"><short_description>Ship feature</short_description><assignee`
     );
   });
 });

--- a/front/lib/project_todo/analyze_document/action_items.ts
+++ b/front/lib/project_todo/analyze_document/action_items.ts
@@ -1,37 +1,88 @@
-import type { ActionItem } from "@app/lib/project_todo/analyze_document/types";
+import type {
+  NewActionItem,
+  UpdatedActionItem,
+} from "@app/lib/project_todo/analyze_document/types";
+import type { Logger } from "@app/logger/logger";
 import type { TodoVersionedActionItem } from "@app/types/takeaways";
 import { v4 as uuidv4 } from "uuid";
 
+// Builds the next version of action items by:
+// - keeping every previously tracked item (only mutated when the LLM emits an
+//   update for it),
+// - applying optional updates from `updatedItems` keyed by sId — updates
+//   targeting an unknown sId are dropped,
+// - appending each `newItems` entry with a freshly generated sId — items whose
+//   assignee_user_id is not a known project member are dropped.
 export function buildActionItems(
-  rawItems: ActionItem[],
-  previousItems: ActionItem[],
-  validUserIds: Set<string>
+  {
+    newItems,
+    updatedItems,
+  }: {
+    newItems: NewActionItem[];
+    updatedItems: UpdatedActionItem[];
+  },
+  previousItems: TodoVersionedActionItem[],
+  validUserIds: Set<string>,
+  localLogger: Logger
 ): TodoVersionedActionItem[] {
-  const previousItemsBySId = new Map(
-    previousItems.map((item) => [item.sId, item])
-  );
   const now = new Date().toISOString();
-  return rawItems.map((item) => {
-    const previousItem = previousItemsBySId.get(item.sId);
+  const updatesBySId = new Map(updatedItems.map((u) => [u.sId, u]));
+
+  const merged: TodoVersionedActionItem[] = previousItems.map((prev) => {
+    const update = updatesBySId.get(prev.sId);
+    if (!update) {
+      return prev;
+    }
+
+    // Apply assignee change only when the new user_id maps to a known project
+    // member; otherwise keep the previous assignee untouched.
+    const validAssigneeChange =
+      update.assignee && validUserIds.has(update.assignee.user_id)
+        ? update.assignee
+        : null;
+
+    const transitioningToDone = update.done && prev.status !== "done";
 
     return {
-      sId: previousItem?.sId ?? uuidv4(),
-      shortDescription:
-        item.short_description ?? previousItem?.short_description ?? "",
-      assigneeUserId:
-        item.assignee_user_id && validUserIds.has(item.assignee_user_id)
-          ? item.assignee_user_id
-          : null,
-      assigneeName: item.assignee_name ?? null,
-      status: item.status ?? previousItem?.status ?? "open",
-      detectedDoneAt:
-        item.status === "done" && previousItem?.status !== "done" ? now : null,
+      sId: prev.sId,
+      shortDescription: update.short_description ?? prev.shortDescription,
+      assigneeUserId: validAssigneeChange
+        ? validAssigneeChange.user_id
+        : prev.assigneeUserId,
+      assigneeName: validAssigneeChange
+        ? validAssigneeChange.name
+        : prev.assigneeName,
+      status: update.done ? "done" : prev.status,
+      detectedDoneAt: transitioningToDone ? now : prev.detectedDoneAt,
       detectedDoneRationale:
-        item.detected_done_rationale ??
-        previousItem?.detected_done_rationale ??
-        null,
+        update.done?.detected_done_rationale ?? prev.detectedDoneRationale,
     };
   });
+
+  for (const item of newItems) {
+    if (!validUserIds.has(item.assignee_user_id)) {
+      localLogger.warn(
+        {
+          assigneeUserId: item.assignee_user_id,
+          assigneeName: item.assignee_name,
+          shortDescription: item.short_description,
+        },
+        "Document takeaway: dropping new action item with unknown assignee"
+      );
+      continue;
+    }
+    merged.push({
+      sId: uuidv4(),
+      shortDescription: item.short_description,
+      assigneeUserId: item.assignee_user_id,
+      assigneeName: item.assignee_name,
+      status: "open",
+      detectedDoneAt: null,
+      detectedDoneRationale: null,
+    });
+  }
+
+  return merged;
 }
 
 export function buildPromptActionItems(
@@ -47,28 +98,29 @@ export function buildPromptActionItems(
     "clearly asked to do one. Only extract tasks with a clear deliverable — 'I'll fix X' " +
     "qualifies, 'I'll think about it' does not.\n" +
     "3. **Durability**: the task is still relevant — if it was already resolved within " +
-    "the same conversation, set status to 'done'; if the request was immediately " +
+    "the same conversation, mark it done; if the request was immediately " +
     "fulfilled inline (e.g., answering a question), do not extract it at all.\n" +
     "4. **Distinctness**: it is not a duplicate of another action item or a rephrasing " +
     "5. **Relevance**: the task is work-related and project-relevant. Purely social plans " +
     "(birthday lunches, personal events, casual meetups) are not action items even if someone " +
     "commits to arranging them.\n\n" +
-    "Formatting rules:\n" +
-    "- If an action item was explicitly completed or resolved in the document, set status to 'done'.\n" +
-    "- Include an assignee_name only when clearly stated in the document.\n" +
-    "- Include an assignee_user_id (from the project members list) when the assignee matches a known project member.\n" +
+    "Output rules:\n" +
+    "- Place brand-new action items in `new_action_items`. They MUST have a clear assignee " +
+    "matching one of the project members; if you cannot identify a project member as assignee, " +
+    "do not extract the item.\n" +
+    "- Place changes to previously tracked items in `updated_action_items`, keyed by their sId. " +
+    "Only include fields that materially changed in this document; omit unchanged fields. " +
+    "Do not include items that have not changed at all.\n" +
+    "- Mark an item as done by setting the `done` object with a brief rationale. Items can only " +
+    "transition to done; never back to open.\n" +
     "- Be concise: one action item per distinct task.\n" +
     "- Make descriptions self-sufficient: include both the action AND its subject so the item is understandable without opening the source document. Prefer specific over vague — not 'Fix the bug' but 'Fix crash in batchRenderMessages when agent config is unavailable'; not 'Review PR' but 'Review PR #24679 — improves takeaway extraction prompts'.\n" +
     "- In the description, mention users and agents by their name, NOT via their id or via a generic term like User, Agent or Bot.\n" +
     "- In the description, refer to the assignee by Your pronouns (e.g., 'You', 'Your', 'Yours'), not by their name.\n\n";
   if (previousActionItems.length > 0) {
     prompt +=
-      "The following action items were tracked in a previous analysis of this document. " +
-      "You MUST always include ALL previously tracked items in your output — never drop them. " +
-      "For each previously tracked item: copy its sId verbatim and update status or description " +
-      "only when the document explicitly provides new information (e.g., the assignee reports it is done). " +
-      "Omit the sId field only for brand-new tasks that were not previously tracked.\n\n" +
-      "Known action items:\n";
+      "Previously tracked action items (reference their sId in `updated_action_items` " +
+      "to record changes):\n";
     for (const item of previousActionItems) {
       prompt += `<action_item sId="${item.sId}" status="${item.status}">`;
       prompt += `<short_description>${item.shortDescription}</short_description>`;

--- a/front/lib/project_todo/analyze_document/index.ts
+++ b/front/lib/project_todo/analyze_document/index.ts
@@ -183,21 +183,26 @@ export async function extractDocumentTakeaways(
     return null;
   }
 
-  // Fetch all assignees from the action items.
-  const assignees = await UserResource.fetchByIds(
-    removeNulls([
-      ...new Set([
-        ...extraction.action_items.map((item) => item.assignee_user_id),
-      ]),
-    ])
-  );
+  // Fetch all assignees referenced by either new or updated items, so we can
+  // validate that each assignee_user_id maps to a real project member.
+  const assigneeUserIds = removeNulls([
+    ...extraction.new_action_items.map((item) => item.assignee_user_id),
+    ...extraction.updated_action_items.map((item) => item.assignee?.user_id),
+  ]);
+  const assignees = await UserResource.fetchByIds([
+    ...new Set(assigneeUserIds),
+  ]);
 
   const validAssigneesUserIds = new Set(assignees.map((u) => u.sId));
 
   const actionItems = buildActionItems(
-    extraction.action_items,
+    {
+      newItems: extraction.new_action_items,
+      updatedItems: extraction.updated_action_items,
+    },
     previousActionItems,
-    validAssigneesUserIds
+    validAssigneesUserIds,
+    localLogger
   );
 
   const stats: ExtractedTakeawayStats = {

--- a/front/lib/project_todo/analyze_document/types.ts
+++ b/front/lib/project_todo/analyze_document/types.ts
@@ -3,49 +3,70 @@ import { z } from "zod";
 export const EXTRACT_DOCUMENT_TAKEAWAYS_FUNCTION_NAME =
   "extract_document_takeaways";
 
-const ActionItemSchema = z.object({
-  // Present when the item matches a previously known action item. The LLM
-  // should copy the sId verbatim from the list provided in the prompt.
+// New items require an assignee_user_id matching a known project member. Items
+// whose assignee cannot be resolved to a project member are intentionally
+// dropped — we'd rather miss an item than track one we can't route to a real
+// user, since the assignee drives downstream notifications and ownership.
+const NewActionItemSchema = z.object({
+  short_description: z
+    .string()
+    .describe("Short description of the action item."),
+  assignee_name: z
+    .string()
+    .describe("Name of the assignee, as it appears in the document."),
+  assignee_user_id: z
+    .string()
+    .describe(
+      "The participant id of the assigned person. Must be one of the participant ids listed in the prompt."
+    ),
+});
+
+export type NewActionItem = z.infer<typeof NewActionItemSchema>;
+
+const UpdatedActionItemSchema = z.object({
   sId: z
     .string()
-    .optional()
     .describe(
-      "Stable identifier for this action item. Copy verbatim from the known action items list if this task was previously tracked. Omit for brand-new tasks."
+      "Stable identifier of a previously tracked action item. Copy verbatim from the known action items list."
     ),
   short_description: z
     .string()
     .optional()
-    .describe("Short description of the action item."),
-  assignee_name: z.string().optional(),
-  assignee_user_id: z
-    .string()
-    .optional()
     .describe(
-      "The participant id of the assigned person. Must be one of the participant ids listed in the prompt. Only set when an assignee is clearly identified."
+      "Updated description. Only set when the document materially changes the description; omit otherwise."
     ),
-  status: z
-    .enum(["open", "done"])
+  assignee: z
+    .object({
+      user_id: z
+        .string()
+        .describe(
+          "Participant id of the new assignee. Must be one of the participant ids listed in the prompt."
+        ),
+      name: z
+        .string()
+        .describe("Name of the new assignee, as it appears in the document."),
+    })
     .optional()
     .describe(
-      "'done' if the item was explicitly resolved in the document, 'open' otherwise."
+      "Set together when the assignee changes. Both fields are required when present; omit otherwise."
     ),
-  detected_done_rationale: z
-    .string()
+  done: z
+    .object({
+      detected_done_rationale: z
+        .string()
+        .describe("Brief explanation of why the item is considered done."),
+    })
     .optional()
     .describe(
-      "Brief explanation of why the item is considered done, if status is 'done'."
+      "Set only when the item was explicitly resolved in the document. Items can only transition to done; never back to open."
     ),
 });
 
-export type ActionItem = z.infer<typeof ActionItemSchema>;
+export type UpdatedActionItem = z.infer<typeof UpdatedActionItemSchema>;
 
 export const ExtractTakeawaysInputSchema = z.object({
-  topic: z
-    .string()
-    .describe(
-      "One-line summary of the document topic, e.g. 'Debugging the embed timeout issue'."
-    ),
-  action_items: z.array(ActionItemSchema),
+  new_action_items: z.array(NewActionItemSchema),
+  updated_action_items: z.array(UpdatedActionItemSchema),
 });
 
 export type ExtractionResult = z.infer<typeof ExtractTakeawaysInputSchema>;

--- a/front/tests/takeaway-evals/lib/takeaway-executor.ts
+++ b/front/tests/takeaway-evals/lib/takeaway-executor.ts
@@ -12,6 +12,7 @@ import {
 } from "@app/lib/project_todo/analyze_document/types";
 import { buildSpec } from "@app/lib/project_todo/analyze_document/utils";
 import type { TakeawaySourceDocument } from "@app/lib/resources/takeaways_resource";
+import logger from "@app/logger/logger";
 import { MODEL_ID } from "@app/tests/takeaway-evals/lib/config";
 import type {
   MockProjectMember,
@@ -155,9 +156,13 @@ export async function executeTakeawayExtraction(
   // set of valid user IDs.
   const validUserIds = new Set(testCase.members.map((m) => m.sId));
   const actionItems = buildActionItems(
-    extraction.action_items,
+    {
+      newItems: extraction.new_action_items,
+      updatedItems: extraction.updated_action_items,
+    },
     previousActionItems,
-    validUserIds
+    validUserIds,
+    logger
   );
 
   return { extraction, actionItems };


### PR DESCRIPTION
## Description

Improve takeaways detection by giving clearer instructions (and output) to the model.

Splits the takeaway extraction LLM tool-call schema into two arrays — `new_action_items` (required `short_description`, `assignee_name`, `assignee_user_id`) and `updated_action_items` (required `sId` + optional patches with grouped `assignee` and `done` tuples) — and rewires `buildActionItems` to merge updates onto the previous version by `sId`. Items not echoed in `updated_action_items` are kept untouched, dropping the previous "you MUST echo every prior item verbatim" instruction. New items whose assignee can't be resolved to a project member are dropped on purpose: the assignee drives downstream notifications, so we'd rather miss an item than track one we can't route.

## Tests

Unit tests in `action_items.test.ts` rewritten for the new shape
