### PR TITLE
Transform FREE_MONTHLY_RECURRING_CREDITS to getter

### DIFF
--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -748,74 +748,76 @@ const BILLING_CYCLE_CONFIG = {
 // Package names and contract_name are auto-versioned at sync time (e.g., "Legacy Pro USD v3").
 // The version is derived from existing packages in Metronome: if the current package matches,
 // keep its version; if it needs recreation, increment by 1.
-const PACKAGES: PackageDef[] = [
-  {
-    name: "Legacy Pro USD",
-    aliases: [{ name: "legacy-pro-monthly" }],
-    rate_card_name: "Legacy Pro USD",
-    subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [getFreeMonthlyRecurringCredits()],
-    ...BILLING_CYCLE_CONFIG,
-  },
-  {
-    name: "Legacy Business USD",
-    aliases: [{ name: "legacy-business" }],
-    rate_card_name: "Legacy Business USD",
-    subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [getFreeMonthlyRecurringCredits()],
-    ...BILLING_CYCLE_CONFIG,
-  },
-  {
-    name: "Legacy Pro Annual USD",
-    aliases: [{ name: "legacy-pro-annual" }],
-    rate_card_name: "Legacy Pro Annual USD",
-    subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [getFreeMonthlyRecurringCredits()],
-    ...BILLING_CYCLE_CONFIG,
-  },
-  // Enterprise: MAU-based billing, no seat subscriptions.
-  {
-    name: "Legacy Enterprise USD",
-    aliases: [{ name: "legacy-enterprise" }],
-    rate_card_name: "Legacy Enterprise MAU USD",
-    scheduled_charges_on_usage_invoices: "ALL",
-    recurring_credits: [getFreeMonthlyRecurringCredits()],
-    ...BILLING_CYCLE_CONFIG,
-  },
-  // EUR variants
-  {
-    name: "Legacy Pro EUR",
-    aliases: [{ name: "legacy-pro-monthly-eur" }],
-    rate_card_name: "Legacy Pro EUR",
-    subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [getFreeMonthlyRecurringCredits()],
-    ...BILLING_CYCLE_CONFIG,
-  },
-  {
-    name: "Legacy Business EUR",
-    aliases: [{ name: "legacy-business-eur" }],
-    rate_card_name: "Legacy Business EUR",
-    subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [getFreeMonthlyRecurringCredits()],
-    ...BILLING_CYCLE_CONFIG,
-  },
-  {
-    name: "Legacy Pro Annual EUR",
-    aliases: [{ name: "legacy-pro-annual-eur" }],
-    rate_card_name: "Legacy Pro Annual EUR",
-    subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [getFreeMonthlyRecurringCredits()],
-    ...BILLING_CYCLE_CONFIG,
-  },
-  {
-    name: "Legacy Enterprise EUR",
-    aliases: [{ name: "legacy-enterprise-eur" }],
-    rate_card_name: "Legacy Enterprise MAU EUR",
-    scheduled_charges_on_usage_invoices: "ALL",
-    recurring_credits: [getFreeMonthlyRecurringCredits()],
-    ...BILLING_CYCLE_CONFIG,
-  },
-];
+function getPackages(): PackageDef[] {
+  return [
+    {
+      name: "Legacy Pro USD",
+      aliases: [{ name: "legacy-pro-monthly" }],
+      rate_card_name: "Legacy Pro USD",
+      subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Legacy Business USD",
+      aliases: [{ name: "legacy-business" }],
+      rate_card_name: "Legacy Business USD",
+      subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Legacy Pro Annual USD",
+      aliases: [{ name: "legacy-pro-annual" }],
+      rate_card_name: "Legacy Pro Annual USD",
+      subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    // Enterprise: MAU-based billing, no seat subscriptions.
+    {
+      name: "Legacy Enterprise USD",
+      aliases: [{ name: "legacy-enterprise" }],
+      rate_card_name: "Legacy Enterprise MAU USD",
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    // EUR variants
+    {
+      name: "Legacy Pro EUR",
+      aliases: [{ name: "legacy-pro-monthly-eur" }],
+      rate_card_name: "Legacy Pro EUR",
+      subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Legacy Business EUR",
+      aliases: [{ name: "legacy-business-eur" }],
+      rate_card_name: "Legacy Business EUR",
+      subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Legacy Pro Annual EUR",
+      aliases: [{ name: "legacy-pro-annual-eur" }],
+      rate_card_name: "Legacy Pro Annual EUR",
+      subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
+      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Legacy Enterprise EUR",
+      aliases: [{ name: "legacy-enterprise-eur" }],
+      rate_card_name: "Legacy Enterprise MAU EUR",
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      ...BILLING_CYCLE_CONFIG,
+    },
+  ];
+}
 
 // ---------------------------------------------------------------------------
 // State tracking
@@ -1533,7 +1535,7 @@ async function syncPackages(): Promise<void> {
 
   // Collect all desired aliases to identify stale packages.
   const desiredAliases = new Set(
-    PACKAGES.flatMap((p) => p.aliases.map((a) => a.name))
+    getPackages().flatMap((p) => p.aliases.map((a) => a.name))
   );
 
   // Archive packages whose aliases are not in the desired set (and not test objects).
@@ -1554,7 +1556,7 @@ async function syncPackages(): Promise<void> {
     }
   }
 
-  for (const desired of PACKAGES) {
+  for (const desired of getPackages()) {
     // Find existing package by alias (not name — name changes on version bumps).
     const primaryAlias = desired.aliases[0]?.name;
     const ex = primaryAlias ? byAlias.get(primaryAlias) : undefined;

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -699,20 +699,22 @@ function getRateCards(): RateCardDef[] {
 // Recurring free credit definition shared by all packages.
 // Quantity starts at 0 — the credit.segment.start webhook updates it each period
 // to the actual user-based amount.
-const FREE_MONTHLY_RECURRING_CREDITS: RecurringCreditDef = {
-  product_name: "Free Monthly Credits",
-  access_amount: {
-    credit_type_id: getCreditTypeProgrammaticUsdId(),
-    unit_price: 0,
-    quantity: 1,
-  },
-  commit_duration: { value: 1, unit: "PERIODS" },
-  priority: 1,
-  starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
-  applicable_product_tags: [USAGE_TAG],
-  recurrence_frequency: "MONTHLY",
-  name: "Free Monthly Credits",
-};
+function getFreeMonthlyRecurringCredits(): RecurringCreditDef {
+  return {
+    product_name: "Free Monthly Credits",
+    access_amount: {
+      credit_type_id: getCreditTypeProgrammaticUsdId(),
+      unit_price: 0,
+      quantity: 1,
+    },
+    commit_duration: { value: 1, unit: "PERIODS" },
+    priority: 1,
+    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
+    applicable_product_tags: [USAGE_TAG],
+    recurrence_frequency: "MONTHLY",
+    name: "Free Monthly Credits",
+  };
+}
 
 // Seat subscription definition shared by all legacy packages.
 const LEGACY_SEAT_SUBSCRIPTION: PackageSubscription = {
@@ -752,7 +754,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-monthly" }],
     rate_card_name: "Legacy Pro USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [getFreeMonthlyRecurringCredits()],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -760,7 +762,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-business" }],
     rate_card_name: "Legacy Business USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [getFreeMonthlyRecurringCredits()],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -768,7 +770,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-annual" }],
     rate_card_name: "Legacy Pro Annual USD",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [getFreeMonthlyRecurringCredits()],
     ...BILLING_CYCLE_CONFIG,
   },
   // Enterprise: MAU-based billing, no seat subscriptions.
@@ -777,7 +779,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-enterprise" }],
     rate_card_name: "Legacy Enterprise MAU USD",
     scheduled_charges_on_usage_invoices: "ALL",
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [getFreeMonthlyRecurringCredits()],
     ...BILLING_CYCLE_CONFIG,
   },
   // EUR variants
@@ -786,7 +788,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-monthly-eur" }],
     rate_card_name: "Legacy Pro EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [getFreeMonthlyRecurringCredits()],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -794,7 +796,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-business-eur" }],
     rate_card_name: "Legacy Business EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [getFreeMonthlyRecurringCredits()],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -802,7 +804,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-pro-annual-eur" }],
     rate_card_name: "Legacy Pro Annual EUR",
     subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [getFreeMonthlyRecurringCredits()],
     ...BILLING_CYCLE_CONFIG,
   },
   {
@@ -810,7 +812,7 @@ const PACKAGES: PackageDef[] = [
     aliases: [{ name: "legacy-enterprise-eur" }],
     rate_card_name: "Legacy Enterprise MAU EUR",
     scheduled_charges_on_usage_invoices: "ALL",
-    recurring_credits: [FREE_MONTHLY_RECURRING_CREDITS],
+    recurring_credits: [getFreeMonthlyRecurringCredits()],
     ...BILLING_CYCLE_CONFIG,
   },
 ];

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -1533,9 +1533,11 @@ async function syncPackages(): Promise<void> {
     }
   }
 
+  const packages = getPackages();
+
   // Collect all desired aliases to identify stale packages.
   const desiredAliases = new Set(
-    getPackages().flatMap((p) => p.aliases.map((a) => a.name))
+    packages.flatMap((p) => p.aliases.map((a) => a.name))
   );
 
   // Archive packages whose aliases are not in the desired set (and not test objects).
@@ -1556,7 +1558,7 @@ async function syncPackages(): Promise<void> {
     }
   }
 
-  for (const desired of getPackages()) {
+  for (const desired of packages) {
     // Find existing package by alias (not name — name changes on version bumps).
     const primaryAlias = desired.aliases[0]?.name;
     const ex = primaryAlias ? byAlias.get(primaryAlias) : undefined;


### PR DESCRIPTION
## Description

Transforms `FREE_MONTHLY_RECURRING_CREDITS` from a constant to a getter function `getFreeMonthlyRecurringCredits()`. This ensures the credit type ID returned by `getCreditTypeProgrammaticUsdId()` is evaluated at runtime after the script-level `ENV` variable is initialized by `detectEnvironment()`, rather than at module initialization time when `ENV` is still set to its default value (`"sandbox"`).

## Tests

Manually verified by running `metronome_setup.ts` in dry-run mode to ensure the recurring credits are correctly configured with the environment-appropriate credit type ID.

## Risk

None. This is a refactoring with no behavioral change—the recurring credit configuration remains identical, only the timing of the credit type ID evaluation changes.

## Deploy Plan

Deploy front.