### PR TITLE
fix: microsoft drive upload with existing folders

### DIFF
--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -349,7 +349,9 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         let parentItemId = "root";
 
         for (const folder of folders) {
-          currentPath = currentPath ? `${currentPath}/${folder}` : folder;
+          currentPath = currentPath
+            ? `${currentPath}/${encodeURIComponent(folder)}`
+            : encodeURIComponent(folder);
 
           try {
             // Try to get the folder


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7836

This PR fixes a bug with Microsoft Drive uploads when dealing with existing folders that contain special characters or spaces in their names.

- Applied `encodeURIComponent()` to folder names when constructing the path

## Tests

No

## Risks

Low.

## Deploy Plan

Standard deployment. No special considerations needed.
