### PR TITLE
Use stripe subscription creation date

### DIFF
--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -1,6 +1,7 @@
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
+import { floorToHourISO } from "@app/lib/metronome/client";
 import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import {
@@ -98,6 +99,7 @@ export async function handleMetronomeSetupCheckout({
     stripeCustomerId,
     packageAlias: resolvedPackageAlias,
     uniquenessKey: sessionId,
+    startingAt: new Date(floorToHourISO(now)),
   });
   if (provisionResult.isErr()) {
     return new Err(

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -282,22 +282,21 @@ export async function createMetronomeContract({
   metronomeCustomerId,
   packageAlias,
   uniquenessKey,
-  startingAt: startingAtOverride,
+  startingAt,
 }: {
   metronomeCustomerId: string;
   packageAlias: string;
   uniquenessKey?: string;
-  startingAt?: Date;
-}): Promise<Result<{ contractId: string; startingAt: string }, Error>> {
-  // Metronome requires starting_at on an hour boundary — round down to current hour.
-  // Callers may pass an explicit startingAt (e.g. to align with a contract end time).
-  const startingAt = floorToHourISO(startingAtOverride ?? new Date());
+  // Must already be on an hour boundary (Metronome requirement).
+  startingAt: Date;
+}): Promise<Result<{ contractId: string }, Error>> {
+  const startingAtISO = startingAt.toISOString();
 
   try {
     const response = await getMetronomeClient().v1.contracts.create({
       customer_id: metronomeCustomerId,
       package_alias: packageAlias,
-      starting_at: startingAt,
+      starting_at: startingAtISO,
       ...(uniquenessKey ? { uniqueness_key: uniquenessKey } : {}),
     });
 
@@ -309,16 +308,13 @@ export async function createMetronomeContract({
       },
       "[Metronome] Contract created"
     );
-    return new Ok({ contractId: response.data.id, startingAt });
+    return new Ok({ contractId: response.data.id });
   } catch (err) {
     if (err instanceof ConflictError) {
       const existingContract =
         await getMetronomeActiveContract(metronomeCustomerId);
       if (existingContract.isOk() && existingContract.value) {
-        return new Ok({
-          contractId: existingContract.value.contractId,
-          startingAt,
-        });
+        return new Ok({ contractId: existingContract.value.contractId });
       }
     }
 

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -110,6 +110,9 @@ const CONTRACT = {
 };
 
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(START_DATE));
+
   mockPrices.retrieve.mockReset();
 
   mockFindMetronomeCustomerByAlias.mockReset();
@@ -122,7 +125,7 @@ beforeEach(() => {
 
   mockCreateMetronomeContract.mockReset();
   mockCreateMetronomeContract.mockResolvedValue(
-    new Ok({ contractId: "m-contract", startingAt: START_DATE })
+    new Ok({ contractId: "m-contract" })
   );
 
   mockScheduleMetronomeContractEnd.mockReset();
@@ -676,6 +679,7 @@ describe("provisionMetronomeCustomerAndContract", () => {
       stripeCustomerId: "stripe-customer",
       packageAlias: "legacy-pro-monthly",
       uniquenessKey: "uniq_123",
+      startingAt: new Date(START_DATE),
     });
 
     expect(result.isOk()).toBe(true);
@@ -713,6 +717,7 @@ describe("provisionMetronomeCustomerAndContract", () => {
       stripeCustomerId: "stripe-customer",
       packageAlias: "legacy-enterprise",
       uniquenessKey: "uniq_123",
+      startingAt: new Date(START_DATE),
     });
 
     expect(result.isOk()).toBe(true);
@@ -728,6 +733,7 @@ describe("provisionMetronomeCustomerAndContract", () => {
       stripeCustomerId: "stripe-customer",
       packageAlias: "legacy-pro-monthly",
       uniquenessKey: "uniq_123",
+      startingAt: new Date(START_DATE),
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -2,8 +2,8 @@ import {
   ceilToHourISO,
   createMetronomeContract,
   createMetronomeCustomer,
-  epochSecondsToFloorHourISO,
   findMetronomeCustomerByAlias,
+  floorToHourISO,
   getMetronomeClient,
   getMetronomeContractById,
   scheduleMetronomeContractEnd,
@@ -57,9 +57,8 @@ export async function switchMetronomeContractPackage({
   workspace: LightWorkspaceType;
   packageAlias: string;
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
-  // Pre-round to the next hour boundary so both functions (which apply ceil
-  // and floor respectively) resolve to the same timestamp, ensuring the new
-  // contract starts exactly when the old one ends.
+  // Round up to the next hour boundary (Metronome requires hour-aligned dates)
+  // so the new contract starts exactly when the old one ends.
   const switchAt = new Date(ceilToHourISO(new Date()));
 
   const endResult = await scheduleMetronomeContractEnd({
@@ -80,12 +79,12 @@ export async function switchMetronomeContractPackage({
     return new Err(contractResult.error);
   }
 
-  const { contractId: metronomeContractId, startingAt } = contractResult.value;
+  const { contractId: metronomeContractId } = contractResult.value;
   const syncResult = await syncContractQuantities(
     metronomeCustomerId,
     metronomeContractId,
     workspace,
-    startingAt
+    switchAt.toISOString()
   );
   if (syncResult.isErr()) {
     return new Err(syncResult.error);
@@ -104,11 +103,14 @@ export async function provisionMetronomeCustomerAndContract({
   stripeCustomerId,
   packageAlias,
   uniquenessKey,
+  startingAt,
 }: {
   workspace: LightWorkspaceType;
   stripeCustomerId: string;
   packageAlias: string;
   uniquenessKey: string;
+  // Must already be on an hour boundary (Metronome requirement).
+  startingAt: Date;
 }): Promise<
   Result<{ metronomeCustomerId: string; metronomeContractId: string }, Error>
 > {
@@ -136,17 +138,18 @@ export async function provisionMetronomeCustomerAndContract({
     metronomeCustomerId,
     packageAlias,
     uniquenessKey,
+    startingAt,
   });
   if (contractResult.isErr()) {
     return new Err(contractResult.error);
   }
 
-  const { contractId: metronomeContractId, startingAt } = contractResult.value;
+  const { contractId: metronomeContractId } = contractResult.value;
   const syncResult = await syncContractQuantities(
     metronomeCustomerId,
     metronomeContractId,
     workspace,
-    startingAt
+    startingAt.toISOString()
   );
   if (syncResult.isErr()) {
     return new Err(syncResult.error);
@@ -881,23 +884,26 @@ export async function provisionEnterpriseMetronomeContract({
       : "usd"
   );
 
+  // Anchor the Metronome contract to the Stripe billing period start so the
+  // recurring commit (which uses the same date) cannot start before the
+  // contract — Metronome rejects that as a 400.
+  const startDate = floorToHourISO(
+    new Date(stripeSubscription.current_period_start * 1000)
+  );
+
   // Provision Metronome customer and contract (also syncs seats + MAU).
   const provisionResult = await provisionMetronomeCustomerAndContract({
     workspace,
     stripeCustomerId,
     packageAlias,
     uniquenessKey: stripeSubscription.id,
+    startingAt: new Date(startDate),
   });
   if (provisionResult.isErr()) {
     return new Err(provisionResult.error);
   }
 
   const { metronomeCustomerId, metronomeContractId } = provisionResult.value;
-
-  // Use current billing period start, rounded to hour boundary.
-  const startDate = epochSecondsToFloorHourISO(
-    stripeSubscription.current_period_start
-  );
 
   // Count MAUs for initial subscription quantities on the first invoice.
   const initialMauCount = await countMauForWorkspace(

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -24,6 +24,7 @@ import {
 } from "@app/lib/credits/payg";
 import { handleMetronomeSetupCheckout } from "@app/lib/metronome/checkout";
 import {
+  floorToHourISO,
   reactivateMetronomeContract,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
@@ -117,12 +118,14 @@ async function shadowProvisionMetronome({
   metronomePackageAlias,
   sessionId,
   subscriptionModelId,
+  periodStart,
 }: {
   workspace: WorkspaceResource;
   stripeCustomerId: string;
   metronomePackageAlias: string;
   sessionId: string;
   subscriptionModelId: ModelId;
+  periodStart: Date;
 }): Promise<void> {
   try {
     const result = await provisionMetronomeCustomerAndContract({
@@ -130,6 +133,7 @@ async function shadowProvisionMetronome({
       stripeCustomerId,
       packageAlias: metronomePackageAlias,
       uniquenessKey: sessionId,
+      startingAt: periodStart,
     });
 
     if (result.isErr()) {
@@ -443,6 +447,10 @@ async function handler(
               newSubscription &&
               isString(checkoutStripeSubscription.customer)
             ) {
+              const currentPeriodStart = new Date(
+                checkoutStripeSubscription.current_period_start * 1000
+              );
+
               // Resolve EUR variant based on Stripe subscription currency.
               const subscriptionCurrency =
                 checkoutStripeSubscription.currency === "eur" ? "eur" : "usd";
@@ -456,6 +464,7 @@ async function handler(
                 metronomePackageAlias: resolvedAlias,
                 sessionId: session.id,
                 subscriptionModelId: newSubscription.id,
+                periodStart: new Date(floorToHourISO(currentPeriodStart)),
               });
             }
 


### PR DESCRIPTION
## Description

Fix a 400 from Metronome (`contract starting at date must be at or before recurring commit starting at date`) when calling `provisionEnterpriseMetronomeContract` → `applyEnterpriseOverrides` → `add_overrides` / `add_recurring_commits`.

Root cause: the contract and its recurring commits were anchored to two different dates that could fall in different hour buckets:

- `createMetronomeContract` defaulted `starting_at` to `floor(now)` (current hour, wall clock).
- `applyEnterpriseOverrides` used `floor(stripeSubscription.current_period_start)` for the recurring commit.

Whenever Stripe's `current_period_start` was in a strictly earlier hour than `now`, `commit.starting_at < contract.starting_at` and Metronome rejected the edit.

related issue https://github.com/dust-tt/tasks/issues/7808

### Fix

Anchor both to the same hour-aligned timestamp derived from `stripeSubscription.current_period_start`.

### Cleanup

- `createMetronomeContract`: `startingAt: Date` is now required and must be pre-floored by the caller. Stops returning `startingAt` since it's the input.
- `provisionMetronomeCustomerAndContract`: `startingAt: Date` is now required (pre-floored). Used for both the contract and the seat/MAU sync.
- `provisionEnterpriseMetronomeContract`: floors `current_period_start` once into `startDate` and reuses it as the contract anchor and the override anchor.
- `shadowProvisionMetronome` (Stripe webhook): now passes a floored `current_period_start` so shadow-provisioned contracts are aligned for the day a recurring commit is added.
- `handleMetronomeSetupCheckout`: passes `floor(now)`.
- `switchMetronomeContractPackage`: `switchAt` (already on an hour boundary via `ceilToHourISO`) is now the single source of truth.

## Tests

- Updated `contracts.test.ts`:
  - Mock for `createMetronomeContract` no longer returns `startingAt`.
  - `provisionMetronomeCustomerAndContract` cases now pass `startingAt: new Date(START_DATE)`.
  - Pinned system time with `vi.useFakeTimers()` + `vi.setSystemTime(START_DATE)` so `switchMetronomeContractPackage`'s wall-clock-derived `switchAt` is deterministic.
- `npx tsgo --noEmit` clean on the touched files.
- `npx biome check` clean on the touched files.

## Risk

- Behavioral change: enterprise Metronome contracts will now be backdated to the Stripe subscription's `current_period_start` instead of "now". This is intentional — it aligns Metronome's billing window with Stripe's, and is required for the recurring commit anchor to be valid.
- Shadow-provisioned (non-enterprise) contracts will also be backdated to `current_period_start`, but in the checkout path that's essentially "now ± an hour" and matches Stripe's actual subscription period.
- Setup-Intent checkout (`handleMetronomeSetupCheckout`) has no Stripe subscription, so it falls back to `floor(now)` — same as before.
- Rollback is safe: revert the PR.

## Deploy Plan

Standard deploy. No migration, no env changes, no client coordination.