### PR TITLE
[front] chore: add composite index to speed up remote mcp server fetch

### DIFF
--- a/front/lib/models/agent/actions/remote_mcp_server.ts
+++ b/front/lib/models/agent/actions/remote_mcp_server.ts
@@ -95,6 +95,9 @@ RemoteMCPServerModel.init(
   {
     sequelize: frontSequelize,
     modelName: "remote_mcp_server",
-    indexes: [{ fields: ["workspaceId"], concurrently: true }],
+    indexes: [
+      { fields: ["workspaceId"], concurrently: true },
+      { fields: ["workspaceId", "id"], concurrently: true },
+    ],
   }
 );

--- a/front/migrations/db/migration_604.sql
+++ b/front/migrations/db/migration_604.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 27, 2026
+CREATE INDEX CONCURRENTLY "remote_mcp_server_workspace_id_id" ON "remote_mcp_servers" ("workspaceId", "id");


### PR DESCRIPTION
## Description

- This PR adds a composite index on workspace ID and ID on the table `remote_mcp_servers` to speed up the query that fetches the remote MCP servers
- Goal is to reduce the latency of the `/mcp/views` endpoint
- Example of query plan [here](https://console.cloud.google.com/sql/instances/cell-00000-front-db/insights;database=front;duration=P1D;trace=94ae1aad01fcd4eca1d5f09a7eb943a0;span=4bfd52d5719a0a37;route='%252Fapi%252Fw%252F%255BwId%255D%252Fmcp%252Fviews';sort_by=TOTAL_EXEC_TIME/executed?project=or1g1n-186209&rapt=AEjHL4MWpM_fDvH8EXGDjINqY_TUX2MKqhO6HJt4L0a39yLwmOJyXeul-zvfnyUZsoDgxj8jwbAhCtbRDS9k6mIapA-rB541lBncnUvQaNQ8SP8pOUaaw1s), we do a bitmap heap scan, then bitmapAnd on the two separate indexes (we have too many ids in the clause but that's a separate issue)

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Run migration 604
