### PR TITLE
fix: list calendars with null owner

### DIFF
--- a/front/lib/api/actions/servers/outlook/outlook_api_helper.ts
+++ b/front/lib/api/actions/servers/outlook/outlook_api_helper.ts
@@ -15,7 +15,7 @@ export const OutlookCalendarSchema = z.object({
       name: z.string().optional(),
       address: z.string().optional(),
     })
-    .optional(),
+    .nullish(),
 });
 
 export const OutlookEventSchema = z.object({


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7837

This PR fixes a validation issue when listing Outlook calendars that have a `null` owner field.

- Updated the `OutlookCalendarSchema` to use `.nullish()` instead of `.optional()` for the `owner` field

Datadog logs [here](https://app.datadoghq.eu/logs?query=%22Invalid%20calendar%20data%20format%3A%20%22%20%40error.type%3AZodError&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1774708135530&to_ts=1777300135530&live=true)

## Tests

No

## Risks

Low.

## Deploy Plan

Standard deployment - no special considerations needed.
