### PR TITLE
feat(sbx): Sandbox-level egress allowlist tool

### DIFF
--- a/front/admin/audit_log_schemas/sandbox_egress_policy.sandbox_updated.json
+++ b/front/admin/audit_log_schemas/sandbox_egress_policy.sandbox_updated.json
@@ -1,0 +1,18 @@
+{
+  "action": "sandbox_egress_policy.sandbox_updated",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "sandbox_egress_policy"
+    }
+  ],
+  "metadata": {
+    "sandboxProviderId": "string",
+    "domain": "string",
+    "added": "string",
+    "reason": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -534,6 +534,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_actions": "never_ask",
   },
   "sandbox": {
+    "add_egress_domain": "high",
     "bash": "never_ask",
     "describe_toolset": "never_ask",
   },

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -58,6 +58,38 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       done: "Describe sandbox toolset",
     },
   },
+  add_egress_domain: {
+    description:
+      "Request user approval to add a single domain to the current " +
+      "sandbox's network allowlist. Each call adds one exact domain " +
+      "(wildcards are not accepted) and requires an explicit user " +
+      "approval. Outbound HTTPS connections that fall outside the " +
+      "allowlist surface as denied entries in `<network_proxy_logs>` in " +
+      "the bash tool output. Allowlist entries added through this tool " +
+      "live for the lifetime of the current sandbox and are discarded " +
+      "when the sandbox is reaped.",
+    schema: {
+      domain: z
+        .string()
+        .min(1)
+        .describe(
+          'Exact domain to allow for this sandbox, e.g. "api.openai.com". ' +
+            "Wildcards are not supported."
+        ),
+      reason: z
+        .string()
+        .min(1)
+        .describe(
+          "Why this domain is needed, in one short sentence the user will " +
+            "see in the approval prompt."
+        ),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Requesting sandbox network access",
+      done: "Allow domain in sandbox",
+    },
+  },
 });
 
 export const SANDBOX_SERVER = {

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -2,8 +2,10 @@ import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  mockAddSandboxPolicyDomain,
   mockCheckEgressForwarderHealth,
   mockReadNewDenyLogEntries,
+  mockEmitAuditLogEvent,
   mockGenerateExecId,
   mockGenerateSandboxExecToken,
   mockGetSandboxImage,
@@ -16,8 +18,10 @@ const {
   mockWrapCommand,
   mockEnsureActive,
 } = vi.hoisted(() => ({
+  mockAddSandboxPolicyDomain: vi.fn(),
   mockCheckEgressForwarderHealth: vi.fn(),
   mockReadNewDenyLogEntries: vi.fn(),
+  mockEmitAuditLogEvent: vi.fn(),
   mockGenerateExecId: vi.fn(),
   mockGenerateSandboxExecToken: vi.fn(),
   mockGetSandboxImage: vi.fn(),
@@ -42,6 +46,28 @@ vi.mock("@app/lib/api/sandbox/egress", () => ({
   checkEgressForwarderHealth: mockCheckEgressForwarderHealth,
   readNewDenyLogEntries: mockReadNewDenyLogEntries,
   setupEgressForwarder: mockSetupEgressForwarder,
+}));
+
+vi.mock("@app/lib/api/sandbox/egress_policy", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/sandbox/egress_policy")>();
+
+  return {
+    ...actual,
+    addSandboxPolicyDomain: mockAddSandboxPolicyDomain,
+  };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", () => ({
+  buildAuditLogTarget: (
+    type: string,
+    resource: { name?: string; sId: string }
+  ) => ({
+    id: resource.sId,
+    name: resource.name ?? resource.sId,
+    type,
+  }),
+  emitAuditLogEvent: mockEmitAuditLogEvent,
 }));
 
 vi.mock("@app/lib/api/sandbox/access_tokens", () => ({
@@ -85,7 +111,7 @@ vi.mock("@app/logger/logger", () => ({
   },
 }));
 
-import { runSandboxBashTool } from "./index";
+import { addEgressDomainTool, runSandboxBashTool } from "./index";
 
 describe("runSandboxBashTool", () => {
   beforeEach(() => {
@@ -108,7 +134,10 @@ describe("runSandboxBashTool", () => {
   function makeExtra() {
     return {
       auth: {
-        getNonNullableWorkspace: () => ({ sId: "workspace-id" }),
+        getNonNullableWorkspace: () => ({
+          name: "Workspace",
+          sId: "workspace-id",
+        }),
       },
       agentLoopContext: {
         runContext: {
@@ -233,5 +262,211 @@ describe("runSandboxBashTool", () => {
       expect(result.error.message).toContain("setup failed");
     }
     expect(sandbox.exec).not.toHaveBeenCalled();
+  });
+});
+
+describe("addEgressDomainTool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAddSandboxPolicyDomain.mockResolvedValue(
+      new Ok({
+        addedDomain: "example.org",
+        policy: { allowedDomains: ["example.org"] },
+      })
+    );
+  });
+
+  function makeExtra() {
+    return {
+      auth: {
+        getNonNullableWorkspace: () => ({
+          name: "Workspace",
+          sId: "workspace-id",
+        }),
+      },
+      agentLoopContext: {
+        runContext: {
+          conversation: { sId: "conversation-id" },
+        },
+      },
+      signal: new AbortController().signal,
+    } as never;
+  }
+
+  it("adds the domain to the active sandbox policy and emits an audit event", async () => {
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox: {
+          providerId: "provider-id",
+          sId: "sandbox-id",
+        },
+        wokeFromSleep: false,
+      })
+    );
+
+    const result = await addEgressDomainTool(
+      {
+        domain: "Example.ORG",
+        reason: "Install package dependencies.",
+      },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockAddSandboxPolicyDomain).toHaveBeenCalledWith(expect.anything(), {
+      domain: "example.org",
+      sandboxProviderId: "provider-id",
+    });
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith({
+      auth: expect.anything(),
+      action: "sandbox_egress_policy.sandbox_updated",
+      targets: [
+        { id: "workspace-id", name: "Workspace", type: "workspace" },
+        {
+          id: "provider-id",
+          name: "Sandbox egress policy sandbox-id",
+          type: "sandbox_egress_policy",
+        },
+      ],
+      metadata: {
+        added: "true",
+        domain: "example.org",
+        reason: "Install package dependencies.",
+        sandboxProviderId: "provider-id",
+      },
+    });
+    if (result.isOk()) {
+      expect(result.value[0].text).toContain("Allowed: example.org");
+    }
+  });
+
+  it("reports the domain as already allowed when nothing changed", async () => {
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox: {
+          providerId: "provider-id",
+          sId: "sandbox-id",
+        },
+        wokeFromSleep: false,
+      })
+    );
+    mockAddSandboxPolicyDomain.mockResolvedValue(
+      new Ok({
+        addedDomain: null,
+        policy: { allowedDomains: ["example.org"] },
+      })
+    );
+
+    const result = await addEgressDomainTool(
+      {
+        domain: "example.org",
+        reason: "Retry a blocked request.",
+      },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value[0].text).toContain("Already allowed: example.org");
+    }
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          added: "false",
+          domain: "example.org",
+        }),
+      })
+    );
+  });
+
+  it("rejects wildcard domains before writing policy", async () => {
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox: {
+          providerId: "provider-id",
+          sId: "sandbox-id",
+        },
+        wokeFromSleep: false,
+      })
+    );
+
+    const result = await addEgressDomainTool(
+      {
+        domain: "*.example.org",
+        reason: "Too broad.",
+      },
+      makeExtra()
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(mockAddSandboxPolicyDomain).not.toHaveBeenCalled();
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns an error without conversation context", async () => {
+    const result = await addEgressDomainTool(
+      {
+        domain: "example.org",
+        reason: "Retry a blocked request.",
+      },
+      {
+        auth: {
+          getNonNullableWorkspace: () => ({
+            name: "Workspace",
+            sId: "workspace-id",
+          }),
+        },
+        agentLoopContext: undefined,
+        signal: new AbortController().signal,
+      } as never
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(mockEnsureActive).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when no active sandbox is available", async () => {
+    mockEnsureActive.mockResolvedValue(new Err(new Error("No active sandbox")));
+
+    const result = await addEgressDomainTool(
+      {
+        domain: "example.org",
+        reason: "Retry a blocked request.",
+      },
+      makeExtra()
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(mockAddSandboxPolicyDomain).not.toHaveBeenCalled();
+  });
+
+  it("surfaces sandbox policy helper errors", async () => {
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox: {
+          providerId: "provider-id",
+          sId: "sandbox-id",
+        },
+        wokeFromSleep: false,
+      })
+    );
+    mockAddSandboxPolicyDomain.mockResolvedValue(
+      new Err(new Error("Sandbox egress policy cannot exceed 100 domains."))
+    );
+
+    const result = await addEgressDomainTool(
+      {
+        domain: "overflow.example.org",
+        reason: "Retry a blocked request.",
+      },
+      makeExtra()
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -7,6 +7,10 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { SANDBOX_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox/metadata";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
 import {
   generateExecId,
@@ -18,6 +22,10 @@ import {
   readNewDenyLogEntries,
   setupEgressForwarder,
 } from "@app/lib/api/sandbox/egress";
+import {
+  addSandboxPolicyDomain,
+  parseExactEgressDomain,
+} from "@app/lib/api/sandbox/egress_policy";
 import {
   mountConversationFiles,
   refreshGcsToken,
@@ -97,6 +105,7 @@ export function createSandboxTools(
 
       return new Ok([{ type: "text" as const, text: output }]);
     },
+    add_egress_domain: addEgressDomainTool,
   };
 
   return buildTools(SANDBOX_TOOLS_METADATA, handlers);
@@ -264,4 +273,62 @@ export async function runSandboxBashTool(
   const output = formatExecOutput(execResult.value, { denyLogEntries });
 
   return new Ok([{ type: "text" as const, text: output }]);
+}
+
+export async function addEgressDomainTool(
+  { domain, reason }: { domain: string; reason: string },
+  { auth, agentLoopContext }: ToolHandlerExtra
+): Promise<Result<Array<{ type: "text"; text: string }>, MCPError>> {
+  const conversation = agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(new MCPError("No conversation context available."));
+  }
+
+  const ensureResult = await SandboxResource.ensureActive(auth, conversation);
+  if (ensureResult.isErr()) {
+    return new Err(new MCPError(ensureResult.error.message));
+  }
+  const { sandbox } = ensureResult.value;
+
+  const parsed = parseExactEgressDomain(domain);
+  if (parsed.isErr()) {
+    return new Err(new MCPError(parsed.error.message));
+  }
+
+  const result = await addSandboxPolicyDomain(auth, {
+    sandboxProviderId: sandbox.providerId,
+    domain: parsed.value,
+  });
+  if (result.isErr()) {
+    return new Err(new MCPError(result.error.message));
+  }
+
+  void emitAuditLogEvent({
+    auth,
+    action: "sandbox_egress_policy.sandbox_updated",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      {
+        type: "sandbox_egress_policy",
+        id: sandbox.providerId,
+        name: `Sandbox egress policy ${sandbox.sId}`,
+      },
+    ],
+    metadata: {
+      sandboxProviderId: sandbox.providerId,
+      domain: parsed.value,
+      added: String(result.value.addedDomain !== null),
+      reason,
+    },
+  });
+
+  const text =
+    result.value.addedDomain !== null
+      ? `Allowed: ${result.value.addedDomain}\n` +
+        "The change is in effect for the current sandbox only and applies to " +
+        "subsequent commands in this conversation."
+      : `Already allowed: ${parsed.value}\n` +
+        "No change made; this domain was already in the sandbox's allowlist.";
+
+  return new Ok([{ type: "text" as const, text }]);
 }

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -57,6 +57,7 @@ type AuditAction =
   | "project.joined"
   | "project.left"
   // Sandbox.
+  | "sandbox_egress_policy.sandbox_updated"
   | "sandbox_egress_policy.updated"
   // SCIM / Directory Sync.
   | "scim.user_provisioned"

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -5,21 +5,32 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockDelete,
   mockFetchFileContent,
+  mockFetch,
   mockGetBucketInstance,
   mockGetEgressPolicyBucket,
+  mockGetEgressProxyInternalUrl,
+  mockMintEgressInvalidationJwt,
   mockUploadRawContentToBucket,
 } = vi.hoisted(() => ({
   mockDelete: vi.fn(),
   mockFetchFileContent: vi.fn(),
+  mockFetch: vi.fn(),
   mockGetBucketInstance: vi.fn(),
   mockGetEgressPolicyBucket: vi.fn(),
+  mockGetEgressProxyInternalUrl: vi.fn(),
+  mockMintEgressInvalidationJwt: vi.fn(),
   mockUploadRawContentToBucket: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/config", () => ({
   default: {
     getEgressPolicyBucket: mockGetEgressPolicyBucket,
+    getEgressProxyInternalUrl: mockGetEgressProxyInternalUrl,
   },
+}));
+
+vi.mock("@app/lib/api/sandbox/egress", () => ({
+  mintEgressInvalidationJwt: mockMintEgressInvalidationJwt,
 }));
 
 vi.mock("@app/lib/file_storage", () => ({
@@ -27,7 +38,11 @@ vi.mock("@app/lib/file_storage", () => ({
 }));
 
 import {
+  addSandboxPolicyDomain,
+  deleteSandboxPolicy,
   deleteWorkspacePolicy,
+  parseExactEgressDomain,
+  readSandboxPolicy,
   readWorkspacePolicy,
   writeWorkspacePolicy,
 } from "./egress_policy";
@@ -41,6 +56,10 @@ describe("workspace egress policy storage", () => {
     vi.clearAllMocks();
 
     mockGetEgressPolicyBucket.mockReturnValue("egress-policy-bucket");
+    mockGetEgressProxyInternalUrl.mockReturnValue("https://egress-proxy");
+    mockMintEgressInvalidationJwt.mockReturnValue("invalidation-token");
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
     mockFetchFileContent.mockResolvedValue(
       JSON.stringify({ allowedDomains: ["API.GitHub.COM"] })
     );
@@ -114,5 +133,188 @@ describe("workspace egress policy storage", () => {
     expect(mockDelete).toHaveBeenCalledWith("workspaces/workspace-sid.json", {
       ignoreNotFound: true,
     });
+  });
+});
+
+describe("sandbox egress policy storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGetEgressPolicyBucket.mockReturnValue("egress-policy-bucket");
+    mockGetEgressProxyInternalUrl.mockReturnValue("https://egress-proxy");
+    mockMintEgressInvalidationJwt.mockReturnValue("invalidation-token");
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetchFileContent.mockResolvedValue(
+      JSON.stringify({ allowedDomains: ["API.GitHub.COM"] })
+    );
+    mockUploadRawContentToBucket.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
+    mockGetBucketInstance.mockReturnValue({
+      delete: mockDelete,
+      fetchFileContent: mockFetchFileContent,
+      uploadRawContentToBucket: mockUploadRawContentToBucket,
+    });
+  });
+
+  it("reads sandbox policy files from the sandbox prefix", async () => {
+    const result = await readSandboxPolicy("provider-id");
+
+    expect(result).toEqual(
+      new Ok({
+        allowedDomains: ["api.github.com"],
+      })
+    );
+    expect(mockFetchFileContent).toHaveBeenCalledWith(
+      "sandboxes/provider-id.json"
+    );
+  });
+
+  it("returns an empty policy when the sandbox policy file is missing", async () => {
+    mockFetchFileContent.mockRejectedValue({ code: 404 });
+
+    const result = await readSandboxPolicy("provider-id");
+
+    expect(result).toEqual(new Ok({ allowedDomains: [] }));
+  });
+
+  it("normalizes a sandbox domain and appends it to the existing policy", async () => {
+    mockFetchFileContent.mockResolvedValue(
+      JSON.stringify({ allowedDomains: ["api.github.com"] })
+    );
+
+    const result = await addSandboxPolicyDomain(mockAuth, {
+      sandboxProviderId: "provider-id",
+      domain: "Registry.NPMJS.org",
+    });
+
+    expect(result).toEqual(
+      new Ok({
+        policy: {
+          allowedDomains: ["api.github.com", "registry.npmjs.org"],
+        },
+        addedDomain: "registry.npmjs.org",
+      })
+    );
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content: JSON.stringify({
+        allowedDomains: ["api.github.com", "registry.npmjs.org"],
+      }),
+      contentType: "application/json",
+      filePath: "sandboxes/provider-id.json",
+    });
+  });
+
+  it("reports addedDomain as null when the domain is already allowed", async () => {
+    mockFetchFileContent.mockResolvedValue(
+      JSON.stringify({ allowedDomains: ["api.github.com"] })
+    );
+
+    const result = await addSandboxPolicyDomain(mockAuth, {
+      sandboxProviderId: "provider-id",
+      domain: "API.GitHub.COM",
+    });
+
+    expect(result).toEqual(
+      new Ok({
+        policy: { allowedDomains: ["api.github.com"] },
+        addedDomain: null,
+      })
+    );
+  });
+
+  it("creates sandbox policy files from an empty start", async () => {
+    mockFetchFileContent.mockRejectedValue({ code: 404 });
+
+    const result = await addSandboxPolicyDomain(mockAuth, {
+      sandboxProviderId: "provider-id",
+      domain: "example.org",
+    });
+
+    expect(result).toEqual(
+      new Ok({
+        policy: { allowedDomains: ["example.org"] },
+        addedDomain: "example.org",
+      })
+    );
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
+      content: JSON.stringify({ allowedDomains: ["example.org"] }),
+      contentType: "application/json",
+      filePath: "sandboxes/provider-id.json",
+    });
+  });
+
+  it("rejects wildcard domains for sandbox policy additions", async () => {
+    const result = await addSandboxPolicyDomain(mockAuth, {
+      sandboxProviderId: "provider-id",
+      domain: "*.example.org",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(mockFetchFileContent).not.toHaveBeenCalled();
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("rejects sandbox policies over the domain cap", async () => {
+    const existingDomains = Array.from(
+      { length: 100 },
+      (_, i) => `domain-${i}.example.com`
+    );
+    mockFetchFileContent.mockResolvedValue(
+      JSON.stringify({ allowedDomains: existingDomains })
+    );
+
+    const result = await addSandboxPolicyDomain(mockAuth, {
+      sandboxProviderId: "provider-id",
+      domain: "overflow.example.com",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the sandbox policy cache after writes", async () => {
+    await addSandboxPolicyDomain(mockAuth, {
+      sandboxProviderId: "provider-id",
+      domain: "example.org",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://egress-proxy/invalidate-policy",
+        expect.objectContaining({
+          headers: {
+            Authorization: "Bearer invalidation-token",
+          },
+          method: "POST",
+        })
+      );
+    });
+    expect(mockMintEgressInvalidationJwt).toHaveBeenCalledWith({
+      sandboxId: "provider-id",
+    });
+  });
+
+  it("deletes sandbox policy files and invalidates cache", async () => {
+    const result = await deleteSandboxPolicy("provider-id");
+
+    expect(result).toEqual(new Ok(undefined));
+    expect(mockDelete).toHaveBeenCalledWith("sandboxes/provider-id.json", {
+      ignoreNotFound: true,
+    });
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://egress-proxy/invalidate-policy",
+        expect.anything()
+      );
+    });
+  });
+
+  it("parses exact domains and rejects malformed entries", () => {
+    expect(parseExactEgressDomain("API.GitHub.COM")).toEqual(
+      new Ok("api.github.com")
+    );
+    expect(parseExactEgressDomain("127.0.0.1").isErr()).toBe(true);
+    expect(parseExactEgressDomain("*.github.com").isErr()).toBe(true);
   });
 });

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -8,15 +8,21 @@ import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import {
   EMPTY_EGRESS_POLICY,
   normalizeEgressPolicy,
+  normalizeEgressPolicyDomain,
   parseEgressPolicy,
 } from "@app/types/sandbox/egress_policy";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const INVALIDATION_TIMEOUT_MS = 5_000;
+const SANDBOX_POLICY_MAX_DOMAINS = 100;
 
 function getWorkspacePolicyPath(auth: Authenticator): string {
   return `workspaces/${auth.getNonNullableWorkspace().sId}.json`;
+}
+
+function getSandboxPolicyPath(sandboxProviderId: string): string {
+  return `sandboxes/${sandboxProviderId}.json`;
 }
 
 function getPolicyBucket() {
@@ -87,6 +93,112 @@ export async function deleteWorkspacePolicy(
   }
 }
 
+export function parseExactEgressDomain(value: string): Result<string, Error> {
+  if (value.trim().startsWith("*.")) {
+    return new Err(
+      new Error(
+        `${value}: Wildcard domains are not supported for sandbox egress requests.`
+      )
+    );
+  }
+
+  const normalized = normalizeEgressPolicyDomain(value);
+  if (normalized.isErr()) {
+    return new Err(new Error(`${value}: ${normalized.error.message}`));
+  }
+
+  return new Ok(normalized.value);
+}
+
+export async function readSandboxPolicy(
+  sandboxProviderId: string
+): Promise<Result<EgressPolicy, Error>> {
+  try {
+    const content = await getPolicyBucket().fetchFileContent(
+      getSandboxPolicyPath(sandboxProviderId)
+    );
+    const parsed = parseEgressPolicy(JSON.parse(content));
+
+    if (parsed.isErr()) {
+      return parsed;
+    }
+
+    return new Ok(parsed.value);
+  } catch (error) {
+    if (isGCSNotFoundError(error)) {
+      return new Ok(EMPTY_EGRESS_POLICY);
+    }
+
+    return new Err(normalizeError(error));
+  }
+}
+
+export async function addSandboxPolicyDomain(
+  _auth: Authenticator,
+  { sandboxProviderId, domain }: { sandboxProviderId: string; domain: string }
+): Promise<
+  Result<{ policy: EgressPolicy; addedDomain: string | null }, Error>
+> {
+  const parsedDomain = parseExactEgressDomain(domain);
+  if (parsedDomain.isErr()) {
+    return new Err(parsedDomain.error);
+  }
+
+  const currentPolicy = await readSandboxPolicy(sandboxProviderId);
+  if (currentPolicy.isErr()) {
+    return new Err(currentPolicy.error);
+  }
+
+  const alreadyAllowed = currentPolicy.value.allowedDomains.includes(
+    parsedDomain.value
+  );
+  const addedDomain = alreadyAllowed ? null : parsedDomain.value;
+  const policy: EgressPolicy = {
+    allowedDomains: alreadyAllowed
+      ? currentPolicy.value.allowedDomains
+      : [...currentPolicy.value.allowedDomains, parsedDomain.value],
+  };
+
+  if (policy.allowedDomains.length > SANDBOX_POLICY_MAX_DOMAINS) {
+    return new Err(
+      new Error(
+        `Sandbox egress policy cannot exceed ${SANDBOX_POLICY_MAX_DOMAINS} domains.`
+      )
+    );
+  }
+
+  try {
+    // Last-writer-wins is acceptable here because sandbox policy updates are user-approved and rare.
+    await getPolicyBucket().uploadRawContentToBucket({
+      content: JSON.stringify(policy),
+      contentType: "application/json",
+      filePath: getSandboxPolicyPath(sandboxProviderId),
+    });
+
+    void invalidateSandboxPolicyCache(sandboxProviderId);
+
+    return new Ok({ policy, addedDomain });
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+export async function deleteSandboxPolicy(
+  sandboxProviderId: string
+): Promise<Result<void, Error>> {
+  try {
+    await getPolicyBucket().delete(getSandboxPolicyPath(sandboxProviderId), {
+      ignoreNotFound: true,
+    });
+
+    void invalidateSandboxPolicyCache(sandboxProviderId);
+
+    return new Ok(undefined);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
 async function invalidateWorkspacePolicyCache(
   auth: Authenticator
 ): Promise<void> {
@@ -117,6 +229,40 @@ async function invalidateWorkspacePolicyCache(
   } catch (error) {
     logger.warn(
       { error: normalizeError(error) },
+      "Egress proxy cache invalidation error"
+    );
+  }
+}
+
+async function invalidateSandboxPolicyCache(
+  sandboxProviderId: string
+): Promise<void> {
+  try {
+    const baseUrl = config.getEgressProxyInternalUrl();
+    if (!baseUrl) {
+      return;
+    }
+
+    const token = mintEgressInvalidationJwt({ sandboxId: sandboxProviderId });
+    const url = `${baseUrl.replace(/\/+$/, "")}/invalidate-policy`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      signal: AbortSignal.timeout(INVALIDATION_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      logger.warn(
+        { statusCode: response.status, sandboxProviderId },
+        "Egress proxy cache invalidation failed"
+      );
+    }
+  } catch (error) {
+    logger.warn(
+      { error: normalizeError(error), sandboxProviderId },
       "Egress proxy cache invalidation error"
     );
   }

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -1,11 +1,42 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockDistribution = vi.fn();
+const {
+  mockDeleteSandboxPolicy,
+  mockDistribution,
+  mockExecuteWithLock,
+  mockGetSandboxProvider,
+  mockProviderDestroy,
+  mockRevokeAllExecTokensForSandbox,
+} = vi.hoisted(() => ({
+  mockDeleteSandboxPolicy: vi.fn(),
+  mockDistribution: vi.fn(),
+  mockExecuteWithLock: vi.fn(),
+  mockGetSandboxProvider: vi.fn(),
+  mockProviderDestroy: vi.fn(),
+  mockRevokeAllExecTokensForSandbox: vi.fn(),
+}));
+
 vi.mock("@app/lib/utils/statsd", () => ({
   getStatsDClient: () => ({
     increment: vi.fn(),
     distribution: mockDistribution,
   }),
+}));
+
+vi.mock("@app/lib/api/sandbox", () => ({
+  getSandboxProvider: mockGetSandboxProvider,
+}));
+
+vi.mock("@app/lib/api/sandbox/access_tokens", () => ({
+  revokeAllExecTokensForSandbox: mockRevokeAllExecTokensForSandbox,
+}));
+
+vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
+  deleteSandboxPolicy: mockDeleteSandboxPolicy,
+}));
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: mockExecuteWithLock,
 }));
 
 import type { Authenticator } from "@app/lib/auth";
@@ -15,13 +46,23 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
+import { Ok } from "@app/types/shared/result";
 
 describe("SandboxResource.updateStatus", () => {
   let authenticator: Authenticator;
   let conversation: ConversationType;
 
   beforeEach(async () => {
-    mockDistribution.mockClear();
+    vi.clearAllMocks();
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      destroy: mockProviderDestroy,
+    });
+    mockProviderDestroy.mockResolvedValue(new Ok(undefined));
+    mockDeleteSandboxPolicy.mockResolvedValue(new Ok(undefined));
+    mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
 
     const testSetup = await createResourceTest({ role: "admin" });
     authenticator = testSetup.authenticator;
@@ -113,5 +154,56 @@ describe("SandboxResource.updateStatus", () => {
     expect(reloaded?.statusChangedAt?.getTime()).toBeLessThanOrEqual(
       afterTransition
     );
+  });
+});
+
+describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
+  let authenticator: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      destroy: mockProviderDestroy,
+    });
+    mockProviderDestroy.mockResolvedValue(new Ok(undefined));
+    mockDeleteSandboxPolicy.mockResolvedValue(new Ok(undefined));
+    mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
+
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+  });
+
+  it("deletes the sandbox egress policy after provider destroy succeeds", async () => {
+    const sandbox = await SandboxFactory.create(authenticator, conversation, {
+      status: "sleeping",
+    });
+
+    const result = await SandboxResource.dangerouslyDestroyIfSleeping(
+      authenticator,
+      conversation.sId
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockProviderDestroy).toHaveBeenCalledWith(sandbox.providerId, {
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+    expect(mockDeleteSandboxPolicy).toHaveBeenCalledWith(sandbox.providerId);
+
+    const reloaded = await SandboxResource.fetchByConversationId(
+      authenticator,
+      conversation.sId
+    );
+    expect(reloaded?.status).toBe("deleted");
   });
 });

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { revokeAllExecTokensForSandbox } from "@app/lib/api/sandbox/access_tokens";
+import { deleteSandboxPolicy } from "@app/lib/api/sandbox/egress_policy";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import {
   recordLifecycleOperation,
@@ -47,6 +48,21 @@ export interface SandboxResource extends ReadonlyAttributesType<SandboxModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SandboxResource extends BaseResource<SandboxModel> {
   static model: ModelStaticWorkspaceAware<SandboxModel> = SandboxModel;
+
+  private static deleteEgressPolicyAfterDestroy(
+    sandbox: SandboxResource
+  ): void {
+    void deleteSandboxPolicy(sandbox.providerId).catch((err) =>
+      logger.warn(
+        {
+          err,
+          sandboxId: sandbox.sId,
+          sandboxProviderId: sandbox.providerId,
+        },
+        "Failed to delete sandbox egress policy"
+      )
+    );
+  }
 
   constructor(
     _model: ModelStatic<SandboxModel>,
@@ -274,6 +290,8 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             { sandbox: sandbox.toLogJSON(), error: result.error.message },
             "Failed to destroy sandbox at provider — proceeding with DB cleanup."
           );
+        } else {
+          SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
         }
       }
 
@@ -631,12 +649,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             "Sandbox not found at provider during destroy — marking deleted."
           );
           await sandbox.updateStatus("deleted", { ctx });
+          SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
           return new Ok(undefined);
         }
         return result;
       }
 
       await sandbox.updateStatus("deleted", { ctx });
+      SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
       recordLifecycleOperation("destroy", ctx);
 
       void revokeAllExecTokensForSandbox(sandbox.sId).catch((err) =>


### PR DESCRIPTION
## Description

Adds a new `add_egress_domain` tool to the sandbox internal MCP server. When invoked, the tool appends a single user-approved exact domain to the current sandbox's policy file in GCS (`sandboxes/{providerId}.json`), which the egress proxy already merges with the workspace policy on every connection (see `egress-proxy/src/gcs.rs`).

The tool is approval-gated (`stake: "high"`) and accepts a single exact domain per call — wildcards are rejected with a clear error so the agent can retry with a tighter scope. To grant several domains the agent calls the tool once per domain, getting an explicit user approval for each.

On success it fires a fire-and-forget POST to the proxy admin endpoint to invalidate the `s:{providerId}` cache entry, so the change applies on the next connection without waiting for the moka TTL.

The sandbox resource also deletes the GCS object after the provider destroy succeeds, so we don't keep orphaned policies around after a sandbox is reaped.

Audit-logged as `sandbox_egress_policy.sandbox_updated` (workspace + sandbox-egress-policy targets, with `domain`, `added` (boolean as string), and the agent-supplied `reason` in metadata).

## Tests

New unit tests on the helper (`addSandboxPolicyDomain`, `readSandboxPolicy`, `deleteSandboxPolicy`, `parseExactEgressDomain`): empty start, normalize + append, already-allowed (no-op write returns `addedDomain: null`), 404 → empty, wildcard reject, max-domains cap, invalidation fired, delete-then-invalidate.

New unit tests on the tool handler: success path with audit emission, already-allowed domain reported back with `added: "false"` audit metadata, wildcards rejected before write, missing conversation context, missing active sandbox, helper errors surfaced.

New DB-backed test on `SandboxResource.dangerouslyDestroyIfSleeping` asserting `deleteSandboxPolicy` runs after a successful provider destroy.

```
✓ lib/api/sandbox/egress_policy.test.ts (15 tests)
✓ lib/api/actions/servers/sandbox/tools/index.test.ts (9 tests)
✓ lib/resources/sandbox_resource.test.ts (5 tests)
```

Typecheck (`npx tsc --noEmit`): no new errors in any of the touched files. `npm run format:changed` (biome): clean.

## Risk

**Approval gate.** `stake: "high"` requires explicit approval per call by default, but a user can choose "always approve" in the same conversation, which short-circuits subsequent prompts. If we want literal per-call approval with no opt-out, we need an additional flag on the approval card — out of scope for this PR.

**GCS write race.** Read-modify-write on `sandboxes/{providerId}.json` is theoretically racy but in practice each conversation has one agent loop and the tool is approval-gated, so concurrent writes are vanishingly unlikely. Last-writer-wins is documented at the call site.

**Cache invalidation failure.** The call is fire-and-forget with a 5s timeout; on failure we log a warning. The next connection will still see the new policy after the moka TTL expires.

**Reaper cleanup is best-effort.** Failures are logged but do not block sandbox destroy. Worst case we leave a stale JSON in GCS — a separate bucket lifecycle rule will clean those up if added later.

Rollback is safe: revert the PR. Any sandbox-level entries already in GCS would remain readable by the proxy, but no new ones would be written.

## Deploy Plan

Standard front rollout. No infra changes required — the egress proxy side already supports `sandboxes/{providerId}.json` lookups and `s:{providerId}` cache invalidation (shipped in #24866 and its predecessors).

After deploy, manual verification:

1. In a `sandbox_tools`-enabled workspace, run a `bash` command that contacts a non-allowlisted domain and confirm it's blocked (`<network_proxy_logs>` in the tool output).
2. Have the agent call `add_egress_domain` with that domain. Approve the prompt.
3. Re-run the curl. It should succeed.
4. Tail egress-proxy logs and confirm `"invalidated policy cache entry","cache_key":"s:<providerId>"` appears at approval time.