### PR TITLE
[front] enh: prevent opening the slash command dropdown on pasted content

### DIFF
--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -94,6 +94,9 @@ export const InputBarSlashSuggestionExtension =
             (editor.isFocused || isActive) &&
             extensionStorage.dismissedTriggerStart !== range.from &&
             isAllowedSlashQuery(state, range),
+          shouldShow: ({ transaction }) =>
+            !transaction.getMeta("paste") &&
+            transaction.getMeta("uiEvent") !== "paste",
           command: ({ editor, range, props }) => {
             extensionStorage.dismissedTriggerStart = null;
             editor.chain().focus().deleteRange(range).run();

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -211,7 +211,7 @@ describe("buildEditorExtensions", () => {
   it("does not open slash suggestions for pasted slashes", () => {
     editor.destroy();
     editor = createSlashSuggestionEditor();
-    editor.storage.inputBarSlashSuggestion.hasBeenFocused = true;
+    editor.commands.focus();
 
     editor.view.dispatch(
       editor.state.tr
@@ -224,5 +224,4 @@ describe("buildEditorExtensions", () => {
       false
     );
   });
-
 });

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -220,8 +220,8 @@ describe("buildEditorExtensions", () => {
         .setMeta("uiEvent", "paste")
     );
 
-    expect(inputBarSlashSuggestionPluginKey.getState(editor.state)?.active).toBe(
-      false
-    );
+    expect(
+      inputBarSlashSuggestionPluginKey.getState(editor.state)?.active
+    ).toBe(false);
   });
 });

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -1,26 +1,47 @@
+import {
+  InputBarSlashSuggestionExtension,
+  inputBarSlashSuggestionPluginKey,
+} from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension";
 import { buildEditorExtensions } from "@app/components/editor/input_bar/useCustomEditor";
 import type { WorkspaceType } from "@app/types/user";
 import { Editor } from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("buildEditorExtensions", () => {
   let editor: Editor;
+  const owner = {
+    id: 0,
+    sId: "wId",
+    name: "MeMeMe AlwaysMe",
+    role: "user",
+    segmentation: null,
+    whiteListedProviders: null,
+    defaultEmbeddingProvider: null,
+    metadata: null,
+    metronomeCustomerId: null,
+    sharingPolicy: "all_scopes",
+  } satisfies WorkspaceType;
+
+  function createSlashSuggestionEditor() {
+    return new Editor({
+      extensions: [
+        StarterKit,
+        InputBarSlashSuggestionExtension.configure({
+          owner,
+          enabledRef: { current: true },
+          onSelectRef: { current: undefined },
+          selectedMCPServerViewIdsRef: { current: new Set<string>() },
+          selectedSkillIdsRef: { current: new Set<string>() },
+        }),
+      ],
+    });
+  }
 
   beforeEach(() => {
     editor = new Editor({
       extensions: buildEditorExtensions({
-        owner: {
-          id: 0,
-          sId: "wId",
-          name: "MeMeMe AlwaysMe",
-          role: "user",
-          segmentation: null,
-          whiteListedProviders: null,
-          defaultEmbeddingProvider: null,
-          metadata: null,
-          metronomeCustomerId: null,
-          sharingPolicy: "all_scopes",
-        } satisfies WorkspaceType,
+        owner,
         conversationId: "cId",
         onInlineText: () => {},
         onUrlDetected: () => {},
@@ -186,4 +207,22 @@ describe("buildEditorExtensions", () => {
 
 &nbsp;`);
   });
+
+  it("does not open slash suggestions for pasted slashes", () => {
+    editor.destroy();
+    editor = createSlashSuggestionEditor();
+    editor.storage.inputBarSlashSuggestion.hasBeenFocused = true;
+
+    editor.view.dispatch(
+      editor.state.tr
+        .insertText("/help", 1)
+        .setMeta("paste", true)
+        .setMeta("uiEvent", "paste")
+    );
+
+    expect(inputBarSlashSuggestionPluginKey.getState(editor.state)?.active).toBe(
+      false
+    );
+  });
+
 });


### PR DESCRIPTION
## Description

- This PR prevents opening the slash command dropdown in the input bar when pasting content that contains a slash.
- There are many types of content that naturally contain slashes (URLs, regular text) for which the intent is not to open the dropdown.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
