### PR TITLE
Bypass cache for expired access tokens

### DIFF
--- a/connectors/src/connectors/github/lib/github_code.ts
+++ b/connectors/src/connectors/github/lib/github_code.ts
@@ -4,6 +4,7 @@ import {
   isTransientNetworkError,
   RepositoryNotFoundError,
 } from "@connectors/connectors/github/lib/errors";
+import { getOctokit } from "@connectors/connectors/github/lib/github_api";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -21,7 +22,7 @@ export type RepositoryInfo = Pick<
 >;
 
 export async function getRepoInfo(
-  octokit: Octokit,
+  connector: ConnectorResource,
   {
     repoLogin,
     repoName,
@@ -31,6 +32,8 @@ export async function getRepoInfo(
   }
 ): Promise<Result<RepositoryInfo, RepositoryNotFoundError>> {
   try {
+    const octokit = await getOctokit(connector);
+
     const response = await octokit.rest.repos.get({
       owner: repoLogin,
       repo: repoName,

--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -104,10 +104,7 @@ export async function githubExtractToGcsActivity({
     });
   };
 
-  // Get GitHub client.
-  const octokit = await getOctokit(connector);
-
-  const repoInfoRes = await getRepoInfo(octokit, {
+  const repoInfoRes = await getRepoInfo(connector, {
     repoLogin,
     repoName,
   });
@@ -131,6 +128,8 @@ export async function githubExtractToGcsActivity({
   const tarballStreamProvider: TarballStreamProvider = {
     getStream: async () => {
       logger.info("Fetching GitHub repository tarball");
+
+      const octokit = await getOctokit(connector);
 
       try {
         const response = await octokit.request(

--- a/connectors/src/types/oauth/client/access_token.ts
+++ b/connectors/src/types/oauth/client/access_token.ts
@@ -45,7 +45,15 @@ export async function getOAuthConnectionAccessToken({
   const cached = CACHE.get(connectionId);
 
   if (cached && cached.local_expiry > Date.now()) {
-    return new Ok(cached);
+    const isValid =
+      cached.access_token_expiry === null ||
+      cached.access_token_expiry > Date.now();
+
+    if (isValid) {
+      return new Ok(cached);
+    }
+
+    logger.warn({ connectionId, provider }, "Local cache has expired tokens");
   }
 
   const res = await new OAuthAPI(config, logger).getAccessToken({

--- a/connectors/src/types/oauth/client/access_token.ts
+++ b/connectors/src/types/oauth/client/access_token.ts
@@ -7,6 +7,8 @@ import { OAuthAPI } from "../../oauth/oauth_api";
 
 const OAUTH_ACCESS_TOKEN_CACHE_TTL = 1000 * 60 * 5;
 const CACHE_CLEAR_INTERVAL = 1000 * 60;
+// Mirror the OAuth server's refresh buffer so we never serve a token the server would already refresh.
+const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 1000 * 60 * 10;
 
 const CACHE = new Map<
   string,
@@ -47,7 +49,7 @@ export async function getOAuthConnectionAccessToken({
   if (cached && cached.local_expiry > Date.now()) {
     const isValid =
       cached.access_token_expiry === null ||
-      cached.access_token_expiry > Date.now();
+      cached.access_token_expiry > Date.now() + ACCESS_TOKEN_EXPIRY_BUFFER_MS;
 
     if (isValid) {
       return new Ok(cached);

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -57,6 +57,8 @@ pub fn provider_timeout_seconds(provider: ConnectionProvider) -> u64 {
 }
 // Buffer of time in ms before the expiry of an access token within which we will attempt to
 // refresh it.
+// NOTE: connectors/src/types/oauth/client/access_token.ts mirrors this value as
+// ACCESS_TOKEN_EXPIRY_BUFFER_MS. If you change this constant, update that file too.
 pub static ACCESS_TOKEN_REFRESH_BUFFER_MILLIS: u64 = 10 * 60 * 1000;
 
 pub static CONNECTION_ID_PREFIX: &str = "con";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is an attempt at fixing sporadic Bad credentials error in our Github connector that are not legitimate as after testing a few connectors, access token is valid.

The in-memory OAuth token cache (`getOAuthConnectionAccessToken`) was only checking its own local TTL (5 minutes)
before returning a cached token. It never checked `access_token_expiry`. The actual expiry time returned by the
provider. This meant a token that had already expired could be served from cache for up to 5 minutes, causing 401s
downstream.

The fix adds a check on `access_token_expiry` to apply a 10-minute buffer, mirroring the OAuth server's own `ACCESS_TOKEN_REFRESH_BUFFER_MILLIS`. Since this cache is local per pod with no coordination, the
simplest safe behavior is to stay in sync with the server's refresh window: if the server would already be
refreshing the token, the local cache should not serve it either.

Additionally, `githubExtractToGcsActivity` was fetching the Octokit client once at activity start and closing over it
in `tarballStreamProvider.getStream()`. For large repositories with slow downloads, the token baked into that client
could expire before or between retries. The fix fetches a fresh client on each `getStream()` call instead.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
