### PR TITLE
[sessions]: Clean up wakeup banner text

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -18,7 +18,7 @@ import { useCancelMessage, useConversation } from "@app/hooks/conversations";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
-import { formatWakeUpTime } from "@app/lib/utils/wakeup_description";
+import { describeWakeUpSchedule } from "@app/lib/utils/wakeup_description";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   isRichAgentMention,
@@ -115,7 +115,7 @@ export const AgentInputBar = ({
   const isActiveWakeUpOwner = activeWakeUp?.user.sId === context.user.sId;
   const wakeUpBlockMessage =
     activeWakeUp && !isActiveWakeUpOwner
-      ? `Conversation paused - a wake-up is scheduled for ${formatWakeUpTime(activeWakeUp)}`
+      ? `Conversation paused - a wake-up is scheduled ${describeWakeUpSchedule(activeWakeUp)}`
       : null;
 
   const autoMentions = useMemo(() => {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -58,6 +58,7 @@ import { FILE_ID_PATTERN } from "@app/lib/files";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
+import { getNextWakeUpFireAt } from "@app/lib/utils/wakeup_description";
 import type { FetchConversationMessageResponseLight } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]";
 import {
   canShowAgentConversationActions,
@@ -384,10 +385,9 @@ export function AgentMessage({
               void mutateWakeUps().then((updated) => {
                 const activeWakeUp =
                   updated?.wakeUps.find(isActiveWakeUp) ?? null;
-                const nextWakeupAt =
-                  activeWakeUp?.scheduleConfig.type === "one_shot"
-                    ? activeWakeUp.scheduleConfig.fireAt
-                    : null;
+                const nextWakeupAt = activeWakeUp
+                  ? getNextWakeUpFireAt(activeWakeUp)
+                  : null;
                 void mutateConversations(
                   (currentData: ConversationListItemType[] | undefined) =>
                     currentData?.map((c) =>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -47,7 +47,7 @@ import {
   getProjectRoute,
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
-import { formatWakeUpTimeOfDay } from "@app/lib/utils/wakeup_description";
+import { formatWakeUpSidebarLabel } from "@app/lib/utils/wakeup_description";
 import {
   type ConversationListItemType,
   type ConversationWithoutContentType,
@@ -1211,7 +1211,7 @@ function WakeUpSuffix({ nextWakeupAt }: WakeUpSuffixProps) {
   return (
     <span className="copy-xs flex items-center gap-1 text-muted-foreground dark:text-muted-foreground-night">
       <Icon visual={ActionTimeIcon} size="xs" />
-      {formatWakeUpTimeOfDay(nextWakeupAt)}
+      {formatWakeUpSidebarLabel(nextWakeupAt)}
     </span>
   );
 }

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -47,6 +47,7 @@ import {
   getProjectRoute,
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
+import { formatWakeUpTimeOfDay } from "@app/lib/utils/wakeup_description";
 import {
   type ConversationListItemType,
   type ConversationWithoutContentType,
@@ -1207,15 +1208,10 @@ interface WakeUpSuffixProps {
 }
 
 function WakeUpSuffix({ nextWakeupAt }: WakeUpSuffixProps) {
-  const date = new Date(nextWakeupAt);
-  const hours = date.getHours() % 12 || 12;
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-  const timeStr = `${hours}:${minutes}`;
-
   return (
     <span className="copy-xs flex items-center gap-1 text-muted-foreground dark:text-muted-foreground-night">
       <Icon visual={ActionTimeIcon} size="xs" />
-      {timeStr}
+      {formatWakeUpTimeOfDay(nextWakeupAt)}
     </span>
   );
 }

--- a/front/components/assistant/conversation/WakeUpBanner.tsx
+++ b/front/components/assistant/conversation/WakeUpBanner.tsx
@@ -40,7 +40,7 @@ export const WakeUpBanner = ({
           normal foreground color, let the schedule text inherit the muted
           color. */}
       <div className="flex min-w-0 items-center gap-2">
-        <span className="min-w-0 flex-1 truncate text-foreground dark:text-foreground-night">
+        <span className="min-w-0 truncate text-foreground dark:text-foreground-night">
           {wakeUp.reason}
         </span>
         <span className="shrink-0">{scheduleDescription}</span>

--- a/front/components/assistant/conversation/WakeUpBanner.tsx
+++ b/front/components/assistant/conversation/WakeUpBanner.tsx
@@ -39,10 +39,12 @@ export const WakeUpBanner = ({
           in text-muted-foreground by default; override the reason to the
           normal foreground color, let the schedule text inherit the muted
           color. */}
-      <span className="text-foreground dark:text-foreground-night">
-        {wakeUp.reason}
-      </span>
-      <span className="ml-2">{scheduleDescription}</span>
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="min-w-0 flex-1 truncate text-foreground dark:text-foreground-night">
+          {wakeUp.reason}
+        </span>
+        <span className="shrink-0">{scheduleDescription}</span>
+      </div>
       {isOwner && (
         <ContentMessageAction
           icon={ActionTrashIcon}

--- a/front/lib/utils/wakeup_description.test.ts
+++ b/front/lib/utils/wakeup_description.test.ts
@@ -1,9 +1,10 @@
 import {
   describeWakeUpSchedule,
+  formatWakeUpSidebarLabel,
   formatWakeUpTimeOfDay,
 } from "@app/lib/utils/wakeup_description";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Builds a WakeUpType with placeholder fields so tests can focus on
 // scheduleConfig, the only field describeWakeUpSchedule reads.
@@ -137,5 +138,47 @@ describe("describeWakeUpSchedule (cron)", () => {
       timezone: "America/New_York",
     });
     expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 AM, every 3 days");
+  });
+});
+
+describe("formatWakeUpSidebarLabel", () => {
+  // Anchor "now" at a known instant so the >24h cutoff is deterministic.
+  // 2026-04-27 is a Monday in local time (the date we use elsewhere in
+  // the file).
+  const NOW = new Date(2026, 3, 27, 12, 0).getTime();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the time of day when the wake-up is within 24h", () => {
+    const oneHourLater = NOW + 60 * 60 * 1000;
+    expect(formatWakeUpSidebarLabel(oneHourLater)).toBe("1:00");
+  });
+
+  it("renders the time of day for a wake-up exactly 24h away", () => {
+    const exactlyOneDay = NOW + 24 * 60 * 60 * 1000;
+    expect(formatWakeUpSidebarLabel(exactlyOneDay)).toBe("12:00");
+  });
+
+  it("renders the abbreviated weekday when the wake-up is more than 24h away", () => {
+    // 25h after Monday noon -> Tuesday afternoon.
+    const justOverADay = NOW + 25 * 60 * 60 * 1000;
+    expect(formatWakeUpSidebarLabel(justOverADay)).toBe("Tue");
+  });
+
+  it("renders the abbreviated weekday for far-future wake-ups", () => {
+    const fiveDays = NOW + 5 * 24 * 60 * 60 * 1000;
+    expect(formatWakeUpSidebarLabel(fiveDays)).toBe("Sat");
+  });
+
+  it("renders the time of day for past timestamps", () => {
+    const oneHourAgo = NOW - 60 * 60 * 1000;
+    expect(formatWakeUpSidebarLabel(oneHourAgo)).toBe("11:00");
   });
 });

--- a/front/lib/utils/wakeup_description.test.ts
+++ b/front/lib/utils/wakeup_description.test.ts
@@ -44,24 +44,24 @@ function localTimestamp(hour: number, minute: number): number {
 }
 
 describe("formatWakeUpTimeOfDay", () => {
-  it("renders single-digit hours without a leading zero", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(9, 5))).toBe("9:05 AM");
+  it("zero-pads single-digit hours", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(9, 5))).toBe("09:05");
   });
 
-  it("pads minutes to two digits", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(14, 0))).toBe("2:00 PM");
+  it("renders afternoon hours in 24-hour form", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(14, 0))).toBe("14:00");
   });
 
-  it("renders midnight as 12:00 AM", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(0, 0))).toBe("12:00 AM");
+  it("renders midnight as 00:00", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(0, 0))).toBe("00:00");
   });
 
-  it("renders noon as 12:00 PM", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(12, 0))).toBe("12:00 PM");
+  it("renders noon as 12:00", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(12, 0))).toBe("12:00");
   });
 
-  it("renders 1 PM as 1:00 PM", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(13, 0))).toBe("1:00 PM");
+  it("renders 1 PM as 13:00", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(13, 0))).toBe("13:00");
   });
 });
 
@@ -71,7 +71,7 @@ describe("describeWakeUpSchedule (one_shot)", () => {
       type: "one_shot",
       fireAt: localTimestamp(9, 30),
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 9:30 AM");
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:30");
   });
 });
 
@@ -82,7 +82,7 @@ describe("describeWakeUpSchedule (cron)", () => {
       cron: "0 9 * * 1",
       timezone: "America/New_York",
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 AM, only on Monday");
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00, only on Monday");
   });
 
   it("describes a weekday range", () => {
@@ -92,7 +92,7 @@ describe("describeWakeUpSchedule (cron)", () => {
       timezone: "America/New_York",
     });
     expect(describeWakeUpSchedule(wakeUp)).toBe(
-      "at 08:30 AM, Monday through Friday"
+      "at 08:30, Monday through Friday"
     );
   });
 
@@ -114,13 +114,13 @@ describe("describeWakeUpSchedule (cron)", () => {
     expect(describeWakeUpSchedule(wakeUp)).toBe("every hour");
   });
 
-  it("preserves AM/PM on multi-time crons so morning/afternoon stay distinct", () => {
+  it("renders multi-time crons in 24-hour form", () => {
     const wakeUp = makeWakeUp({
       type: "cron",
       cron: "0 9,17 * * *",
       timezone: "America/New_York",
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 AM and 05:00 PM");
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 and 17:00");
   });
 
   it("rewords every-other-day DOM steps", () => {
@@ -129,7 +129,7 @@ describe("describeWakeUpSchedule (cron)", () => {
       cron: "0 9 */2 * *",
       timezone: "America/New_York",
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 AM, every other day");
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00, every other day");
   });
 
   it("rewords larger DOM steps", () => {
@@ -138,7 +138,7 @@ describe("describeWakeUpSchedule (cron)", () => {
       cron: "0 9 */3 * *",
       timezone: "America/New_York",
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 AM, every 3 days");
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00, every 3 days");
   });
 });
 
@@ -159,12 +159,12 @@ describe("formatWakeUpSidebarLabel", () => {
 
   it("renders the time of day when the wake-up is within 24h", () => {
     const oneHourLaterMs = NOW_MS + 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(oneHourLaterMs)).toBe("1:00 PM");
+    expect(formatWakeUpSidebarLabel(oneHourLaterMs)).toBe("13:00");
   });
 
   it("renders the time of day for a wake-up exactly 24h away", () => {
     const exactlyOneDayMs = NOW_MS + 24 * 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(exactlyOneDayMs)).toBe("12:00 PM");
+    expect(formatWakeUpSidebarLabel(exactlyOneDayMs)).toBe("12:00");
   });
 
   it("renders the abbreviated weekday when the wake-up is more than 24h away", () => {
@@ -180,7 +180,7 @@ describe("formatWakeUpSidebarLabel", () => {
 
   it("renders the time of day for past timestamps", () => {
     const oneHourAgoMs = NOW_MS - 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(oneHourAgoMs)).toBe("11:00 AM");
+    expect(formatWakeUpSidebarLabel(oneHourAgoMs)).toBe("11:00");
   });
 });
 

--- a/front/lib/utils/wakeup_description.test.ts
+++ b/front/lib/utils/wakeup_description.test.ts
@@ -120,4 +120,22 @@ describe("describeWakeUpSchedule (cron)", () => {
     });
     expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 AM and 05:00 PM");
   });
+
+  it("rewords every-other-day DOM steps", () => {
+    const wakeUp = makeWakeUp({
+      type: "cron",
+      cron: "0 9 */2 * *",
+      timezone: "America/New_York",
+    });
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 AM, every other day");
+  });
+
+  it("rewords larger DOM steps", () => {
+    const wakeUp = makeWakeUp({
+      type: "cron",
+      cron: "0 9 */3 * *",
+      timezone: "America/New_York",
+    });
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 AM, every 3 days");
+  });
 });

--- a/front/lib/utils/wakeup_description.test.ts
+++ b/front/lib/utils/wakeup_description.test.ts
@@ -146,11 +146,11 @@ describe("formatWakeUpSidebarLabel", () => {
   // Anchor "now" at a known instant so the >24h cutoff is deterministic.
   // 2026-04-27 is a Monday in local time (the date we use elsewhere in
   // the file).
-  const NOW = new Date(2026, 3, 27, 12, 0).getTime();
+  const NOW_MS = new Date(2026, 3, 27, 12, 0).getTime();
 
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(NOW));
+    vi.setSystemTime(new Date(NOW_MS));
   });
 
   afterEach(() => {
@@ -158,29 +158,29 @@ describe("formatWakeUpSidebarLabel", () => {
   });
 
   it("renders the time of day when the wake-up is within 24h", () => {
-    const oneHourLater = NOW + 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(oneHourLater)).toBe("1:00");
+    const oneHourLaterMs = NOW_MS + 60 * 60 * 1000;
+    expect(formatWakeUpSidebarLabel(oneHourLaterMs)).toBe("1:00");
   });
 
   it("renders the time of day for a wake-up exactly 24h away", () => {
-    const exactlyOneDay = NOW + 24 * 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(exactlyOneDay)).toBe("12:00");
+    const exactlyOneDayMs = NOW_MS + 24 * 60 * 60 * 1000;
+    expect(formatWakeUpSidebarLabel(exactlyOneDayMs)).toBe("12:00");
   });
 
   it("renders the abbreviated weekday when the wake-up is more than 24h away", () => {
     // 25h after Monday noon -> Tuesday afternoon.
-    const justOverADay = NOW + 25 * 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(justOverADay)).toBe("Tue");
+    const justOverADayMs = NOW_MS + 25 * 60 * 60 * 1000;
+    expect(formatWakeUpSidebarLabel(justOverADayMs)).toBe("Tue");
   });
 
   it("renders the abbreviated weekday for far-future wake-ups", () => {
-    const fiveDays = NOW + 5 * 24 * 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(fiveDays)).toBe("Sat");
+    const fiveDaysMs = NOW_MS + 5 * 24 * 60 * 60 * 1000;
+    expect(formatWakeUpSidebarLabel(fiveDaysMs)).toBe("Sat");
   });
 
   it("renders the time of day for past timestamps", () => {
-    const oneHourAgo = NOW - 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(oneHourAgo)).toBe("11:00");
+    const oneHourAgoMs = NOW_MS - 60 * 60 * 1000;
+    expect(formatWakeUpSidebarLabel(oneHourAgoMs)).toBe("11:00");
   });
 });
 

--- a/front/lib/utils/wakeup_description.test.ts
+++ b/front/lib/utils/wakeup_description.test.ts
@@ -2,6 +2,7 @@ import {
   describeWakeUpSchedule,
   formatWakeUpSidebarLabel,
   formatWakeUpTimeOfDay,
+  getNextWakeUpFireAt,
 } from "@app/lib/utils/wakeup_description";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -180,5 +181,28 @@ describe("formatWakeUpSidebarLabel", () => {
   it("renders the time of day for past timestamps", () => {
     const oneHourAgo = NOW - 60 * 60 * 1000;
     expect(formatWakeUpSidebarLabel(oneHourAgo)).toBe("11:00");
+  });
+});
+
+describe("getNextWakeUpFireAt", () => {
+  it("returns fireAt as-is for one-shot schedules", () => {
+    const fireAt = new Date(2026, 3, 27, 9, 0).getTime();
+    const wakeUp = makeWakeUp({ type: "one_shot", fireAt });
+    expect(getNextWakeUpFireAt(wakeUp)).toBe(fireAt);
+  });
+
+  it("resolves the next cron firing in the schedule's stored timezone", () => {
+    // Anchor "now" so cron-parser's "next" is deterministic. 2026-04-27
+    // is a Monday.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 27, 12, 0));
+    const wakeUp = makeWakeUp({
+      type: "cron",
+      cron: "0 9 * * *",
+      timezone: "America/New_York",
+    });
+    const nextFire = getNextWakeUpFireAt(wakeUp);
+    expect(nextFire).toBeGreaterThan(Date.now());
+    vi.useRealTimers();
   });
 });

--- a/front/lib/utils/wakeup_description.test.ts
+++ b/front/lib/utils/wakeup_description.test.ts
@@ -45,23 +45,23 @@ function localTimestamp(hour: number, minute: number): number {
 
 describe("formatWakeUpTimeOfDay", () => {
   it("renders single-digit hours without a leading zero", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(9, 5))).toBe("9:05");
+    expect(formatWakeUpTimeOfDay(localTimestamp(9, 5))).toBe("9:05 AM");
   });
 
   it("pads minutes to two digits", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(14, 0))).toBe("2:00");
+    expect(formatWakeUpTimeOfDay(localTimestamp(14, 0))).toBe("2:00 PM");
   });
 
-  it("renders midnight as 12:00 (12-hour, no AM/PM)", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(0, 0))).toBe("12:00");
+  it("renders midnight as 12:00 AM", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(0, 0))).toBe("12:00 AM");
   });
 
-  it("renders noon as 12:00", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(12, 0))).toBe("12:00");
+  it("renders noon as 12:00 PM", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(12, 0))).toBe("12:00 PM");
   });
 
-  it("renders 1 PM as 1:00 (no AM/PM suffix)", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(13, 0))).toBe("1:00");
+  it("renders 1 PM as 1:00 PM", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(13, 0))).toBe("1:00 PM");
   });
 });
 
@@ -71,7 +71,7 @@ describe("describeWakeUpSchedule (one_shot)", () => {
       type: "one_shot",
       fireAt: localTimestamp(9, 30),
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 9:30");
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 9:30 AM");
   });
 });
 
@@ -159,12 +159,12 @@ describe("formatWakeUpSidebarLabel", () => {
 
   it("renders the time of day when the wake-up is within 24h", () => {
     const oneHourLaterMs = NOW_MS + 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(oneHourLaterMs)).toBe("1:00");
+    expect(formatWakeUpSidebarLabel(oneHourLaterMs)).toBe("1:00 PM");
   });
 
   it("renders the time of day for a wake-up exactly 24h away", () => {
     const exactlyOneDayMs = NOW_MS + 24 * 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(exactlyOneDayMs)).toBe("12:00");
+    expect(formatWakeUpSidebarLabel(exactlyOneDayMs)).toBe("12:00 PM");
   });
 
   it("renders the abbreviated weekday when the wake-up is more than 24h away", () => {
@@ -180,7 +180,7 @@ describe("formatWakeUpSidebarLabel", () => {
 
   it("renders the time of day for past timestamps", () => {
     const oneHourAgoMs = NOW_MS - 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(oneHourAgoMs)).toBe("11:00");
+    expect(formatWakeUpSidebarLabel(oneHourAgoMs)).toBe("11:00 AM");
   });
 });
 

--- a/front/lib/utils/wakeup_description.test.ts
+++ b/front/lib/utils/wakeup_description.test.ts
@@ -1,0 +1,123 @@
+import {
+  describeWakeUpSchedule,
+  formatWakeUpTimeOfDay,
+} from "@app/lib/utils/wakeup_description";
+import type { WakeUpType } from "@app/types/assistant/wakeups";
+import { describe, expect, it } from "vitest";
+
+// Builds a WakeUpType with placeholder fields so tests can focus on
+// scheduleConfig, the only field describeWakeUpSchedule reads.
+function makeWakeUp(scheduleConfig: WakeUpType["scheduleConfig"]): WakeUpType {
+  return {
+    id: 1,
+    sId: "wu_test",
+    createdAt: 0,
+    agentConfigurationId: "agent_test",
+    scheduleConfig,
+    reason: "Test",
+    status: "scheduled",
+    fireCount: 0,
+    maxFires: 1,
+    user: {
+      sId: "u_test",
+      id: 1,
+      createdAt: 0,
+      provider: null,
+      username: "tester",
+      email: "tester@example.com",
+      firstName: "Test",
+      lastName: null,
+      fullName: "Test",
+      image: null,
+      lastLoginAt: null,
+    },
+  };
+}
+
+// `new Date(year, month, day, hour, minute)` interprets its arguments in
+// the local timezone, so .getHours() / .getMinutes() return those exact
+// values regardless of the test environment's zone.
+function localTimestamp(hour: number, minute: number): number {
+  return new Date(2026, 3, 27, hour, minute).getTime();
+}
+
+describe("formatWakeUpTimeOfDay", () => {
+  it("renders single-digit hours without a leading zero", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(9, 5))).toBe("9:05");
+  });
+
+  it("pads minutes to two digits", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(14, 0))).toBe("2:00");
+  });
+
+  it("renders midnight as 12:00 (12-hour, no AM/PM)", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(0, 0))).toBe("12:00");
+  });
+
+  it("renders noon as 12:00", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(12, 0))).toBe("12:00");
+  });
+
+  it("renders 1 PM as 1:00 (no AM/PM suffix)", () => {
+    expect(formatWakeUpTimeOfDay(localTimestamp(13, 0))).toBe("1:00");
+  });
+});
+
+describe("describeWakeUpSchedule (one_shot)", () => {
+  it("prefixes the time with 'at'", () => {
+    const wakeUp = makeWakeUp({
+      type: "one_shot",
+      fireAt: localTimestamp(9, 30),
+    });
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 9:30");
+  });
+});
+
+describe("describeWakeUpSchedule (cron)", () => {
+  it("describes a single weekday at a fixed time", () => {
+    const wakeUp = makeWakeUp({
+      type: "cron",
+      cron: "0 9 * * 1",
+      timezone: "America/New_York",
+    });
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 AM, only on Monday");
+  });
+
+  it("describes a weekday range", () => {
+    const wakeUp = makeWakeUp({
+      type: "cron",
+      cron: "30 8 * * 1-5",
+      timezone: "America/New_York",
+    });
+    expect(describeWakeUpSchedule(wakeUp)).toBe(
+      "at 08:30 AM, Monday through Friday"
+    );
+  });
+
+  it("describes an interval cron without referencing a time", () => {
+    const wakeUp = makeWakeUp({
+      type: "cron",
+      cron: "*/15 * * * *",
+      timezone: "America/New_York",
+    });
+    expect(describeWakeUpSchedule(wakeUp)).toBe("every 15 minutes");
+  });
+
+  it("describes hourly cron", () => {
+    const wakeUp = makeWakeUp({
+      type: "cron",
+      cron: "0 * * * *",
+      timezone: "America/New_York",
+    });
+    expect(describeWakeUpSchedule(wakeUp)).toBe("every hour");
+  });
+
+  it("preserves AM/PM on multi-time crons so morning/afternoon stay distinct", () => {
+    const wakeUp = makeWakeUp({
+      type: "cron",
+      cron: "0 9,17 * * *",
+      timezone: "America/New_York",
+    });
+    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 AM and 05:00 PM");
+  });
+});

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -3,12 +3,26 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import cronstrue from "cronstrue";
 
 // Render an instant as "h:mm" (12-hour, no AM/PM) in the viewer's local
-// timezone. Used by the sidebar conversation-list wake-up indicator.
+// timezone.
 export function formatWakeUpTimeOfDay(timestamp: number): string {
   const date = new Date(timestamp);
   const hours = date.getHours() % 12 || 12;
   const minutes = String(date.getMinutes()).padStart(2, "0");
   return `${hours}:${minutes}`;
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+// Compact label for the sidebar conversation-list wake-up indicator. When
+// the next firing is more than a day away the time of day on its own gives
+// the viewer no sense of when — show the abbreviated weekday instead.
+export function formatWakeUpSidebarLabel(timestamp: number): string {
+  if (timestamp - Date.now() > ONE_DAY_MS) {
+    return new Date(timestamp).toLocaleDateString("en-US", {
+      weekday: "short",
+    });
+  }
+  return formatWakeUpTimeOfDay(timestamp);
 }
 
 // Human-friendly schedule phrase used in the wake-up banner and the

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -3,13 +3,13 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { CronExpressionParser } from "cron-parser";
 import cronstrue from "cronstrue";
 
-// Render an instant as "h:mm AM/PM" (12-hour) in the viewer's local timezone.
+// Render an instant as "HH:mm" (24-hour) in the viewer's local timezone, to
+// match the rest of the platform.
 export function formatWakeUpTimeOfDay(timestamp: number): string {
   const date = new Date(timestamp);
-  const hours = date.getHours() % 12 || 12;
+  const hours = String(date.getHours()).padStart(2, "0");
   const minutes = String(date.getMinutes()).padStart(2, "0");
-  const meridiem = date.getHours() < 12 ? "AM" : "PM";
-  return `${hours}:${minutes} ${meridiem}`;
+  return `${hours}:${minutes}`;
 }
 
 // Compute the millisecond timestamp of the next time a wake-up fires. For
@@ -49,8 +49,8 @@ export function formatWakeUpSidebarLabel(timestamp: number): string {
 
 // Human-friendly schedule phrase used in the wake-up banner and the
 // "scheduled …" message in the input bar. Examples:
-//   one_shot         -> "at 9:00 AM"
-//   "0 9 * * 1"      -> "at 09:00 AM, only on Monday"
+//   one_shot         -> "at 09:00"
+//   "0 9 * * 1"      -> "at 09:00, only on Monday"
 //   "0 * * * *"      -> "every hour"
 //   "*/15 * * * *"   -> "every 15 minutes"
 // Cron times are shown verbatim from the schedule's stored timezone — no
@@ -61,7 +61,10 @@ export function describeWakeUpSchedule(wakeUp: WakeUpType): string {
     case "one_shot":
       return `at ${formatWakeUpTimeOfDay(config.fireAt)}`;
     case "cron": {
-      let description = cronstrue.toString(config.cron, { verbose: false });
+      let description = cronstrue.toString(config.cron, {
+        verbose: false,
+        use24HourTimeFormat: true,
+      });
       // cronstrue renders DOM steps as ", every N days in a month", which
       // reads awkwardly. Reword to natural English; "every 2" becomes
       // "every other".
@@ -71,7 +74,7 @@ export function describeWakeUpSchedule(wakeUp: WakeUpType): string {
           n === "2" ? ", every other day" : `, every ${n} days`
       );
       // Lowercase the first character so the phrase reads naturally after
-      // the wake-up reason ("{reason} at 09:00 AM, only on Monday").
+      // the wake-up reason ("{reason} at 09:00, only on Monday").
       return description.charAt(0).toLowerCase() + description.slice(1);
     }
     default:

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -1,5 +1,5 @@
 import type { WakeUpType } from "@app/types/assistant/wakeups";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { CronExpressionParser } from "cron-parser";
 import cronstrue from "cronstrue";
 
@@ -26,7 +26,10 @@ export function getNextWakeUpFireAt(wakeUp: WakeUpType): number {
         .toDate()
         .getTime();
     default:
-      return assertNever(config);
+      assertNeverAndIgnore(config);
+      // Unknown schedule type from a newer server: treat as "fires now" so
+      // the optimistic-clear timer clears the indicator on the next tick.
+      return Date.now();
   }
 }
 
@@ -72,6 +75,7 @@ export function describeWakeUpSchedule(wakeUp: WakeUpType): string {
       return description.charAt(0).toLowerCase() + description.slice(1);
     }
     default:
-      return assertNever(config);
+      assertNeverAndIgnore(config);
+      return "";
   }
 }

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -3,13 +3,13 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { CronExpressionParser } from "cron-parser";
 import cronstrue from "cronstrue";
 
-// Render an instant as "h:mm" (12-hour, no AM/PM) in the viewer's local
-// timezone.
+// Render an instant as "h:mm AM/PM" (12-hour) in the viewer's local timezone.
 export function formatWakeUpTimeOfDay(timestamp: number): string {
   const date = new Date(timestamp);
   const hours = date.getHours() % 12 || 12;
   const minutes = String(date.getMinutes()).padStart(2, "0");
-  return `${hours}:${minutes}`;
+  const meridiem = date.getHours() < 12 ? "AM" : "PM";
+  return `${hours}:${minutes} ${meridiem}`;
 }
 
 // Compute the millisecond timestamp of the next time a wake-up fires. For
@@ -49,7 +49,7 @@ export function formatWakeUpSidebarLabel(timestamp: number): string {
 
 // Human-friendly schedule phrase used in the wake-up banner and the
 // "scheduled …" message in the input bar. Examples:
-//   one_shot         -> "at 9:00"
+//   one_shot         -> "at 9:00 AM"
 //   "0 9 * * 1"      -> "at 09:00 AM, only on Monday"
 //   "0 * * * *"      -> "every hour"
 //   "*/15 * * * *"   -> "every 15 minutes"

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -1,23 +1,36 @@
 import type { WakeUpType } from "@app/types/assistant/wakeups";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import cronstrue from "cronstrue";
 
-// Short time label for the next firing of a wake-up. V1 only handles the
-// two supported scheduleConfig shapes; PR 7 will replace this with richer
-// formatting when we support non-daily cron patterns.
-export function formatWakeUpTime(wakeUp: WakeUpType): string {
-  if (wakeUp.scheduleConfig.type === "one_shot") {
-    return new Date(wakeUp.scheduleConfig.fireAt).toLocaleTimeString("en-US", {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  }
-  const [minute, hour] = wakeUp.scheduleConfig.cron.split(/\s+/);
-  return `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`;
+// Render an instant as "h:mm" (12-hour, no AM/PM) in the viewer's local
+// timezone. Used by the sidebar conversation-list wake-up indicator.
+export function formatWakeUpTimeOfDay(timestamp: number): string {
+  const date = new Date(timestamp);
+  const hours = date.getHours() % 12 || 12;
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${hours}:${minutes}`;
 }
 
-// Human-friendly schedule phrase for the banner.
+// Human-friendly schedule phrase used in the wake-up banner and the
+// "scheduled …" message in the input bar. Examples:
+//   one_shot         -> "at 9:00"
+//   "0 9 * * 1"      -> "at 09:00 AM, only on Monday"
+//   "0 * * * *"      -> "every hour"
+//   "*/15 * * * *"   -> "every 15 minutes"
+// Cron times are shown verbatim from the schedule's stored timezone — no
+// shift to the viewer's zone, no zone suffix.
 export function describeWakeUpSchedule(wakeUp: WakeUpType): string {
-  const time = formatWakeUpTime(wakeUp);
-  return wakeUp.scheduleConfig.type === "one_shot"
-    ? `at ${time}`
-    : `Run everyday at ${time}`;
+  const config = wakeUp.scheduleConfig;
+  switch (config.type) {
+    case "one_shot":
+      return `at ${formatWakeUpTimeOfDay(config.fireAt)}`;
+    case "cron": {
+      const description = cronstrue.toString(config.cron, { verbose: false });
+      // Lowercase the first character so the phrase reads naturally after
+      // the wake-up reason ("{reason} at 09:00 AM, only on Monday").
+      return description.charAt(0).toLowerCase() + description.slice(1);
+    }
+    default:
+      return assertNever(config);
+  }
 }

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -1,5 +1,6 @@
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { CronExpressionParser } from "cron-parser";
 import cronstrue from "cronstrue";
 
 // Render an instant as "h:mm" (12-hour, no AM/PM) in the viewer's local
@@ -9,6 +10,24 @@ export function formatWakeUpTimeOfDay(timestamp: number): string {
   const hours = date.getHours() % 12 || 12;
   const minutes = String(date.getMinutes()).padStart(2, "0");
   return `${hours}:${minutes}`;
+}
+
+// Compute the millisecond timestamp of the next time a wake-up fires. For
+// one-shot schedules this is the stored `fireAt`; for cron schedules we
+// resolve the next firing in the schedule's stored timezone.
+export function getNextWakeUpFireAt(wakeUp: WakeUpType): number {
+  const config = wakeUp.scheduleConfig;
+  switch (config.type) {
+    case "one_shot":
+      return config.fireAt;
+    case "cron":
+      return CronExpressionParser.parse(config.cron, { tz: config.timezone })
+        .next()
+        .toDate()
+        .getTime();
+    default:
+      return assertNever(config);
+  }
 }
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -25,7 +25,15 @@ export function describeWakeUpSchedule(wakeUp: WakeUpType): string {
     case "one_shot":
       return `at ${formatWakeUpTimeOfDay(config.fireAt)}`;
     case "cron": {
-      const description = cronstrue.toString(config.cron, { verbose: false });
+      let description = cronstrue.toString(config.cron, { verbose: false });
+      // cronstrue renders DOM steps as ", every N days in a month", which
+      // reads awkwardly. Reword to natural English; "every 2" becomes
+      // "every other".
+      description = description.replace(
+        /, every (\d+) days in a month/,
+        (_, n: string) =>
+          n === "2" ? ", every other day" : `, every ${n} days`
+      );
       // Lowercase the first character so the phrase reads naturally after
       // the wake-up reason ("{reason} at 09:00 AM, only on Monday").
       return description.charAt(0).toLowerCase() + description.slice(1);

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -218,7 +218,7 @@ function ContentMessageInline({
       {icon && (
         <Icon size="sm" visual={icon} className={iconVariants({ variant })} />
       )}
-      <div className={cn("s-flex-1", textVariants({ variant }))}>
+      <div className={cn("s-flex-1 s-min-w-0", textVariants({ variant }))}>
         {title && <span className={titleVariants({ variant })}>{title}</span>}
         {title && contentChildren.length > 0 && ": "}
         {contentChildren}


### PR DESCRIPTION

## Description
1. Truncate wakeup description to one line on web and mobile to prevent long message making it hard to read the rest of the conversation
2. Add more descriptive text parsing for cron schedules to give accurate description in wakeup banner
3. Show same time format in user's timezone for both conversation sidebar and wakeup banner
4. Add logic to conversation view to show abbreviated day of the week of the next run instead of the time if its more than 24 hours away (ie show Mon instead of 9:15)
5. Fix sidebar optimistic update not working for cron

I'm thinking it may be best to adapt the conversation list view to be a day of the week if the wakeup is more than a day away instead of the time since just 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
