### PR TITLE
Fix: todos load correctly on focus.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -361,7 +361,7 @@ function ReadOnlyTodoItem({
 
   return (
     <div className="flex items-start gap-3 overflow-hidden">
-      <div className="mt-1 shrink-0">
+      <div className="mt-0.5 shrink-0">
         <Checkbox size="xs" checked={isDone} disabled />
       </div>
       <TodoMetadataTooltip todo={todo} agentNameById={agentNameById}>
@@ -490,7 +490,7 @@ function EditableTodoItem({
             : "max-h-[1000px] opacity-100"
       )}
     >
-      <div className="mt-1 shrink-0">
+      <div className="mt-0.5 shrink-0">
         <Checkbox
           size="xs"
           checked={isDone}
@@ -688,8 +688,6 @@ function EditableProjectTodosPanel({
     workspaceId: owner.sId,
     options: { disabled: true },
   });
-  const markReadRef = useRef(markRead);
-  markReadRef.current = markRead;
 
   // Tracks todos being animated out during a clean operation.
   const [pendingRemovalIds, setPendingRemovalIds] = useState<Set<string>>(
@@ -745,29 +743,62 @@ function EditableProjectTodosPanel({
   const startRaf1Ref = useRef<number | null>(null);
   const startRaf2Ref = useRef<number | null>(null);
   const cleanupTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const hasRunRef = useRef(false);
+  const inFlightAddedKeysRef = useRef<Set<string>>(new Set());
+  const flashedDoneKeysRef = useRef<Set<string>>(new Set());
 
-  // diffKeys is intentionally excluded: it is memoized and stable during
-  // animation (no SWR updates occur while animation state updates fire).\
-  // markReadRef is a ref — .current is updated synchronously every render so
-  // it never needs to be a dep. Including either would cause the cleanup to
-  // fire on every animation state update and cancel the in-flight timeouts.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional one-shot effect, see comment above
   useEffect(() => {
-    if (isTodosLoading || frozenLastReadAt === undefined || hasRunRef.current) {
+    if (isTodosLoading || frozenLastReadAt === undefined) {
       return;
     }
-    hasRunRef.current = true;
 
-    const { added, newlyDone } = diffKeys;
+    const added = new Set<string>();
+    for (const sId of diffKeys.added) {
+      if (!enteredKeys.has(sId) && !inFlightAddedKeysRef.current.has(sId)) {
+        added.add(sId);
+      }
+    }
+
+    const newlyDone = new Set<string>();
+    for (const sId of diffKeys.newlyDone) {
+      if (!flashedDoneKeysRef.current.has(sId)) {
+        newlyDone.add(sId);
+      }
+    }
 
     if (added.size === 0 && newlyDone.size === 0) {
-      void markReadRef.current();
       return;
     }
 
-    setTypingKeys(new Set(added));
-    setDoneFlashKeys(new Set(newlyDone));
+    // Mark as read immediately so navigating away/back during animation
+    // doesn't cause the same items to re-animate on next mount.
+    void markRead();
+
+    for (const sId of newlyDone) {
+      flashedDoneKeysRef.current.add(sId);
+    }
+
+    if (added.size > 0) {
+      inFlightAddedKeysRef.current = new Set(added);
+      setTypingKeys(new Set(added));
+    }
+    setDoneFlashKeys((prev) => new Set([...prev, ...newlyDone]));
+
+    // If a revalidation triggers another pass while an animation is in-flight,
+    // reschedule from the latest keys instead of letting React's effect cleanup
+    // cancel the previous run and leave items collapsed.
+    if (startRaf1Ref.current !== null) {
+      cancelAnimationFrame(startRaf1Ref.current);
+      startRaf1Ref.current = null;
+    }
+    if (startRaf2Ref.current !== null) {
+      cancelAnimationFrame(startRaf2Ref.current);
+      startRaf2Ref.current = null;
+    }
+    if (cleanupTimeoutRef.current !== null) {
+      clearTimeout(cleanupTimeoutRef.current);
+      cleanupTimeoutRef.current = null;
+    }
+    inFlightAddedKeysRef.current = new Set();
 
     // Double-RAF: wait for the browser to paint the initial hidden state of
     // new items (isAdded && !isEntering → max-h-0 opacity-0) before triggering
@@ -782,13 +813,18 @@ function EditableProjectTodosPanel({
     });
 
     cleanupTimeoutRef.current = setTimeout(() => {
-      void markReadRef.current();
       setEnteringKeys(new Set());
-      setEnteredKeys(new Set(added));
+      setEnteredKeys((prev) => new Set([...prev, ...added]));
+      inFlightAddedKeysRef.current = new Set();
       cleanupTimeoutRef.current = null;
     }, SUMMARY_ITEM_TRANSITION_MS);
+  }, [diffKeys, frozenLastReadAt, isTodosLoading, markRead, enteredKeys]);
 
+  // Cleanup only on unmount.
+  useEffect(() => {
     return () => {
+      const hadInFlightAnimation = inFlightAddedKeysRef.current.size > 0;
+
       if (startRaf1Ref.current !== null) {
         cancelAnimationFrame(startRaf1Ref.current);
       }
@@ -798,8 +834,15 @@ function EditableProjectTodosPanel({
       if (cleanupTimeoutRef.current !== null) {
         clearTimeout(cleanupTimeoutRef.current);
       }
+      inFlightAddedKeysRef.current = new Set();
+
+      // If the user navigates away before the animation cleanup timeout runs,
+      // persist the read marker so the same items don't re-animate on remount.
+      if (hadInFlightAnimation) {
+        void markRead();
+      }
     };
-  }, [isTodosLoading, frozenLastReadAt]);
+  }, [markRead]);
 
   const usersBySId = useMemo(
     () => new Map(users.map((user) => [user.sId, user])),

--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -114,7 +114,7 @@ function TodoMetadataTooltip({
     : null;
 
   const isAssistantWorkInProgress =
-    !!todo.conversationId && todo.status !== "done";
+    !!todo.conversationId && todo.status === "in_progress";
 
   const label = (
     <div className="flex flex-col gap-1">
@@ -462,8 +462,11 @@ function EditableTodoItem({
 }: EditableTodoItemProps) {
   const router = useAppRouter();
   const isDone = todo.status === "done";
+  const hasConversationLink =
+    (todo.status === "in_progress" || todo.status === "done") &&
+    !!todo.conversationId;
   const canEdit = viewerUserId !== null && todo.userId === viewerUserId;
-  const showInProgressTextAnimation = !!todo.conversationId && !isDone;
+  const showInProgressTextAnimation = todo.status === "in_progress";
   const [isFlashing, setIsFlashing] = useState(isNewlyDone);
 
   useEffect(() => {
@@ -529,24 +532,28 @@ function EditableTodoItem({
           </div>
         </button>
       </TodoMetadataTooltip>
-      {canEdit && (
-        <div className="mt-0.5 flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover/todo:opacity-100">
-          {todo.conversationId ? (
-            <IconButton
-              icon={ChatBubbleLeftRightIcon}
-              size="xs"
-              variant="ghost"
-              className="!text-muted-foreground hover:!text-foreground"
-              tooltip={"Open todo conversation"}
-              onClick={() => {
-                void router.push(
-                  getConversationRoute(owner.sId, todo.conversationId),
-                  undefined,
-                  { shallow: true }
-                );
-              }}
-            />
-          ) : (
+      <div className="mt-0.5 flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover/todo:opacity-100">
+        {hasConversationLink ? (
+          <IconButton
+            icon={ChatBubbleLeftRightIcon}
+            size="xs"
+            variant="ghost"
+            className="!text-muted-foreground hover:!text-foreground"
+            tooltip={"Open todo conversation"}
+            onClick={() => {
+              if (!todo.conversationId) {
+                return;
+              }
+              void router.push(
+                getConversationRoute(owner.sId, todo.conversationId),
+                undefined,
+                { shallow: true }
+              );
+            }}
+          />
+        ) : (
+          canEdit &&
+          !hasConversationLink && (
             <IconButton
               icon={PlayIcon}
               size="xs"
@@ -556,7 +563,9 @@ function EditableTodoItem({
               disabled={isStarting}
               onClick={() => onStartWorking(todo)}
             />
-          )}
+          )
+        )}
+        {canEdit && (
           <IconButton
             icon={TrashIcon}
             size="xs"
@@ -565,8 +574,8 @@ function EditableTodoItem({
             tooltip="Delete todo"
             onClick={() => onDelete(todo)}
           />
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }
@@ -1033,7 +1042,16 @@ function EditableProjectTodosPanel({
             viewerUserId: prev?.viewerUserId ?? viewerUserId,
             users: prev?.users ?? [],
             todos: (prev?.todos ?? []).map((t) =>
-              t.sId === todo.sId ? { ...t, conversationId } : t
+              t.sId === todo.sId
+                ? {
+                    ...t,
+                    status: "in_progress",
+                    doneAt: null,
+                    markedAsDoneByType: null,
+                    markedAsDoneByAgentConfigurationId: null,
+                    conversationId,
+                  }
+                : t
             ),
           }),
           { revalidate: false }

--- a/front/lib/project_todo/start_agent.ts
+++ b/front/lib/project_todo/start_agent.ts
@@ -183,9 +183,17 @@ export async function startAgentForProjectTodo(
   const [assigneeUser] = await UserResource.fetchByModelIds([todo.userId]);
   const assigneeId = assigneeUser?.sId ?? "";
 
+  const updatedTodo = await todo.updateWithVersion(auth, {
+    status: "in_progress",
+    doneAt: null,
+    markedAsDoneByType: null,
+    markedAsDoneByUserId: null,
+    markedAsDoneByAgentConfigurationId: null,
+  });
+
   return new Ok({
     todo: {
-      ...todo.toJSON({ assigneeId }),
+      ...updatedTodo.toJSON({ assigneeId }),
       conversationId,
     },
     conversationId,

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -24,8 +24,8 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useMemo } from "react";
-import type { Fetcher } from "swr";
+import { useCallback, useMemo } from "react";
+import { type Fetcher, useSWRConfig } from "swr";
 
 export function useProjectContextAttachments({
   owner,
@@ -336,15 +336,7 @@ export function useProjectTodos({
 
   const { data, error, mutate } = useSWRWithDefaults(
     disabled ? null : todosUrl,
-    todosFetcher,
-    {
-      // Ensure project todos refresh when the user returns to this page,
-      // even if SWR already has cached data for the key.
-      revalidateOnMount: true,
-      revalidateIfStale: true,
-      revalidateOnFocus: true,
-      revalidateOnReconnect: true,
-    }
+    todosFetcher
   );
 
   return {
@@ -365,7 +357,25 @@ export function useMarkProjectTodosRead({
   owner: LightWorkspaceType;
   spaceId: string;
 }) {
-  return async (): Promise<void> => {
+  const { mutate } = useSWRConfig();
+
+  return useCallback(async (): Promise<void> => {
+    const immediateReadAt = new Date().toISOString();
+    const todosKey = `/api/w/${owner.sId}/spaces/${spaceId}/project_todos`;
+
+    // Keep local UI state in sync immediately to avoid replaying new-item
+    // animations when navigating away/back before the network round-trip ends.
+    await mutate(
+      todosKey,
+      (prev: GetProjectTodosResponseBody | undefined) => ({
+        todos: prev?.todos ?? [],
+        users: prev?.users ?? [],
+        viewerUserId: prev?.viewerUserId ?? null,
+        lastReadAt: immediateReadAt,
+      }),
+      { revalidate: false }
+    );
+
     try {
       await clientFetch(
         `/api/w/${owner.sId}/spaces/${spaceId}/project_todos/mark_read`,
@@ -374,7 +384,7 @@ export function useMarkProjectTodosRead({
     } catch {
       // Silent — mark_read is best-effort.
     }
-  };
+  }, [mutate, owner.sId, spaceId]);
 }
 
 export function useUpdateProjectTodo({

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
@@ -45,6 +45,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start", () =
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
     expect(data.todo.sId).toBe(todo.sId);
+    expect(data.todo.status).toBe("in_progress");
     expect(data.todo.conversationId).toBeTruthy();
   });
 


### PR DESCRIPTION
## Description

Two fixes to the todo animation and status lifecycle.

**Todos re-animating on focus:** The one-shot `hasRunRef` guard prevented the effect from re-running when SWR revalidated on window focus, but also prevented new items from animating after navigation. Replacing it with `inFlightAddedKeysRef` and `flashedDoneKeysRef` tracks exactly which items have already been animated, allowing subsequent SWR updates to add new items correctly without replaying old ones. `markRead` is now called immediately (before the animation) rather than after the cleanup timeout, so navigating away mid-animation no longer causes re-animation on remount.

**`in_progress` status on agent start:** When `startAgentForProjectTodo` created a conversation, the todo's status stayed `"to_do"`. The todo is now transitioned to `"in_progress"` in `start_agent.ts` and optimistically reflected in the SWR cache. The progress text animation and conversation link visibility are updated to check `status === "in_progress"` instead of `!!conversationId && !isDone`.

- Replace `hasRunRef` with `inFlightAddedKeysRef` + `flashedDoneKeysRef` in the animation effect
- Call `markRead` immediately and update `useMarkProjectTodosRead` to also optimistically set `lastReadAt` in the SWR cache (avoids round-trip race)
- Set status to `"in_progress"` in `startAgentForProjectTodo` (server) and in the SWR optimistic update (client)
- Show conversation link only when `status === "in_progress" || status === "done"` and `conversationId` is set
- Show `PlayIcon` (start) only when `canEdit && !hasConversationLink`

## Tests

Local + green (test updated to assert `status === "in_progress"`)

## Risk

Low

## Deploy Plan

Deploy `front`
