### PR TITLE
fix: front mcp tools endpoint

### DIFF
--- a/front/lib/api/actions/servers/front/tools/index.ts
+++ b/front/lib/api/actions/servers/front/tools/index.ts
@@ -46,9 +46,9 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
 
       const data = (await makeFrontAPIRequest({
         method: "GET",
-        endpoint: "conversations",
+        endpoint: `conversations/search/${encodeURIComponent(q)}`,
         apiToken,
-        params: { q, limit: Math.min(limit, 100) },
+        params: { limit: Math.min(limit, 100) },
       })) as FrontListResponse;
 
       const conversations = data._results ?? [];
@@ -172,22 +172,11 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
           apiToken,
         });
       } else if (email) {
-        const searchData = (await makeFrontAPIRequest({
+        data = await makeFrontAPIRequest({
           method: "GET",
-          endpoint: "contacts",
+          endpoint: `contacts/alt:email:${encodeURIComponent(email)}`,
           apiToken,
-          params: { q: email },
-        })) as FrontListResponse;
-        const contacts = searchData._results ?? [];
-        if (contacts.length === 0) {
-          return new Ok([
-            {
-              type: "text" as const,
-              text: `No contact found with email: ${email}`,
-            },
-          ]);
-        }
-        data = contacts[0];
+        });
       } else {
         throw new MCPError("Either email or contact_id must be provided");
       }
@@ -287,10 +276,9 @@ const handlers: ToolHandlers<typeof FRONT_TOOLS_METADATA> = {
 
       const data = (await makeFrontAPIRequest({
         method: "GET",
-        endpoint: "conversations",
+        endpoint: `conversations/search/${encodeURIComponent(`from:${customer_email}`)}`,
         apiToken,
         params: {
-          q: `from:${customer_email}`,
           limit: Math.min(limit, 100),
         },
       })) as FrontListResponse;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7845

Fixes 3 bugs in the Front MCP server where tools were silently returning wrong results due to calling the wrong Front API endpoints.

All three tools were passing a string `q` parameter to list endpoints that don't support text search — the query was silently ignored and the tools returned unfiltered results.

**`search_conversations`**: switch from `GET /conversations` (list endpoint, ignores string `q`) to `GET /conversations/search/{query}` (the actual search endpoint, supports `inbox:`, `tag:`, `is:`, etc.)

**`get_customer_history`**: same fix — switch from `GET /conversations` with `q: "from:email"` to `GET /conversations/search/from:email`

**`get_contact`**: switch from `GET /contacts` with `q: email` (list endpoint, `q` only accepts timestamp filters) to `GET /contacts/alt:email:{email}` using Front's resource alias pattern for direct email lookup

**Root cause**

The Front API has two distinct conversation endpoints:
- `GET /conversations` — lists conversations, `q` accepts only a status object (`{ statuses: [...] }`)
- `GET /conversations/search/{query}` — full-text search with filter syntax (`from:`, `inbox:`, `tag:`, etc.)

Similarly, `GET /contacts` does not support email search via `q`. The correct approach is the `alt:email:{handle}` resource alias on `GET /contacts/{contact_id}`.

**References**

[List conversations — ](https://dev.frontapp.com/reference/list-conversations)GET /conversations — q accepts only a status object, not a search string

[Search conversations — ](https://dev.frontapp.com/reference/search-conversations)GET /conversations/search/{query} — the correct endpoint for full-text/filter search

[List contacts — ](https://dev.frontapp.com/reference/list-contacts)GET /contacts — q accepts only timestamp filters

[Resource aliases](https://dev.frontapp.com/docs/resource-aliases-1) — documents the alt:email:{handle} pattern for direct contact lookup by email

## Tests
No

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
