### PR TITLE
[front] enh: expand details by default for sandbox add_egress_domain approval

### DIFF
--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -23,9 +23,10 @@ type ToolOverride = {
     agentName: string,
     inputs: Record<string, unknown>
   ) => string;
+  detailsExpanded?: boolean;
 };
 
-/** Overrides title and alwaysAllowLabel for specific MCP tools */
+/** Overrides title, alwaysAllowLabel, and details expansion for specific MCP tools */
 const MCP_TOOL_OVERRIDES: Partial<
   Record<string, Partial<Record<string, ToolOverride>>>
 > = {
@@ -42,6 +43,11 @@ const MCP_TOOL_OVERRIDES: Partial<
       title: (agentName, inputs) =>
         `Allow ${asDisplayName(agentName)} to ${inputs.humanReadableDescription}?`,
       alwaysAllowLabel: () => "Allow all the interactions with this tab",
+    },
+  },
+  sandbox: {
+    add_egress_domain: {
+      detailsExpanded: true,
     },
   },
 };
@@ -166,7 +172,11 @@ export function MCPToolValidationRequired({
     >
       {isTriggeredByCurrentUser ? (
         <>
-          <ToolValidationDetails blockedAction={blockedAction} user={user} />
+          <ToolValidationDetails
+            blockedAction={blockedAction}
+            user={user}
+            defaultExpanded={toolOverride?.detailsExpanded}
+          />
           {errorMessage && (
             <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
               {errorMessage}

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -55,11 +55,13 @@ interface DisplayableInput {
 interface ToolValidationDetailsProps {
   blockedAction: BlockedToolExecution;
   user: UserType;
+  defaultExpanded?: boolean;
 }
 
 export function ToolValidationDetails({
   blockedAction,
   user,
+  defaultExpanded = false,
 }: ToolValidationDetailsProps) {
   const displayableInputs: DisplayableInput[] = useMemo(() => {
     if (!blockedAction.inputs) {
@@ -101,7 +103,7 @@ export function ToolValidationDetails({
   }
 
   return (
-    <Collapsible>
+    <Collapsible defaultOpen={defaultExpanded}>
       <CollapsibleTrigger>
         <span className="my-2 font-medium">Details</span>
       </CollapsibleTrigger>


### PR DESCRIPTION
## Description

Follow-up to #24894. The sandbox `add_egress_domain` approval prompt only carries one piece of information that matters for the user's decision (the domain being requested + the reason), and that information lives inside the collapsed "Details" section. Users had to click to expand before they could decide.

This adds a `detailsExpanded` knob to the existing `MCP_TOOL_OVERRIDES` map and opts `sandbox.add_egress_domain` into expanded-by-default. Behavior for every other tool is unchanged.

Implementation:
- `ToolValidationDetails` accepts a new `defaultExpanded` prop (default `false`) wired to the Sparkle `Collapsible`'s `defaultOpen`.
- `MCPToolValidationRequired` reads the override and forwards it.

Before / after:
- Before: collapsed `Details` with a chevron, two clicks to act.
- After: domain + reason shown immediately for this tool only.

## Tests

Manually verified locally: opened the sandbox egress approval prompt and confirmed the Details section is expanded on first render, while other tool approvals remain collapsed by default.

## Risk

Very low. The change is UI-only, scoped to a single tool via the existing override pattern, and the prop defaults to the previous behavior for every other consumer.

## Deploy Plan

Standard front deploy, no migration or coordination needed.