### PR TITLE
feat(sbx): document egress proxy in sandbox skill instructions

### DIFF
--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -63,9 +63,8 @@ ${formatWorkspaceAllowlist(workspaceDomains)}
 When you plan to hit a domain that is not on the workspace allowlist, you
 should call \`add_egress_domain\` **before** running the command, with the
 **exact** domain (wildcards are not accepted) and a one-sentence reason
-the user will see in the approval prompt. One call adds one domain; if
-you need several, request them one at a time, each with its own reason.
-This is preferable to running the command first and reacting to a denial.
+the user will see in the approval prompt. This is preferable to running
+the command first and reacting to a denial.
 
 If a request does get blocked — for example because you missed a domain or
 a redirect chain hits an unexpected host — the bash tool output will

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -1,3 +1,4 @@
+import { readWorkspacePolicy } from "@app/lib/api/sandbox/egress_policy";
 import {
   createToolManifest,
   getSandboxImage,
@@ -7,6 +8,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { Ok } from "@app/types/shared/result";
@@ -22,10 +24,64 @@ const SANDBOX_INSTRUCTIONS =
   "Use it with `dsbx tools [SERVER_NAME] [TOOL_NAME] [ARGS]...`. Run `dsbx tools --help` for more information. " +
   "Write output files (scripts, results, exports) to /files/conversation to make them available to the user.";
 
+function formatWorkspaceAllowlist(domains: string[]): string {
+  if (domains.length === 0) {
+    return "_(none — this workspace has no preapproved domains)_";
+  }
+  return domains.map((d) => `- \`${d}\``).join("\n");
+}
+
+async function buildNetworkAccessSection(auth: Authenticator): Promise<string> {
+  const policyResult = await readWorkspacePolicy(auth);
+  let workspaceDomains: string[] = [];
+  if (policyResult.isErr()) {
+    logger.warn(
+      { err: policyResult.error },
+      "Failed to read workspace egress policy for sandbox skill instructions"
+    );
+  } else {
+    workspaceDomains = policyResult.value.allowedDomains;
+  }
+
+  return `#### Sandbox Network Access
+
+All outbound network traffic from the sandbox is routed through an egress
+proxy that **denies every request by default**. Only domains on the
+sandbox's allowlist can be reached.
+
+The allowlist is the union of two sources:
+
+1. **Workspace allowlist** — domains preapproved by the workspace admin
+   for every sandbox in this workspace:
+
+${formatWorkspaceAllowlist(workspaceDomains)}
+
+2. **Sandbox allowlist** — domains added during this conversation via the
+   \`add_egress_domain\` tool. These live for the lifetime of the current
+   sandbox only and are discarded when the sandbox is reaped.
+
+When you plan to hit a domain that is not on the workspace allowlist, you
+should call \`add_egress_domain\` **before** running the command, with the
+**exact** domain (wildcards are not accepted) and a one-sentence reason
+the user will see in the approval prompt. One call adds one domain; if
+you need several, request them one at a time, each with its own reason.
+This is preferable to running the command first and reacting to a denial.
+
+If a request does get blocked — for example because you missed a domain or
+a redirect chain hits an unexpected host — the bash tool output will
+include a \`<network_proxy_logs>\` block listing the denied domain(s).
+Use that block to identify the missing domain and call
+\`add_egress_domain\` to unblock the next attempt. If a request mysteriously
+hangs or fails with TLS/DNS errors, check the \`<network_proxy_logs>\`
+block first; a denied egress is the most likely cause.`;
+}
+
 async function buildSandboxInstructions(
   auth: Authenticator,
   providerId?: ModelProviderIdType
 ): Promise<string> {
+  const networkAccessSection = await buildNetworkAccessSection(auth);
+
   let toolsResult;
 
   if (providerId) {
@@ -33,19 +89,21 @@ async function buildSandboxInstructions(
   } else {
     const imageResult = getSandboxImage(auth);
     if (imageResult.isErr()) {
-      return SANDBOX_INSTRUCTIONS;
+      return `${SANDBOX_INSTRUCTIONS}\n\n${networkAccessSection}`;
     }
     toolsResult = new Ok(imageResult.value.tools);
   }
 
   if (toolsResult.isErr()) {
-    return SANDBOX_INSTRUCTIONS;
+    return `${SANDBOX_INSTRUCTIONS}\n\n${networkAccessSection}`;
   }
 
   const manifest = createToolManifest(toolsResult.value);
   const manifestYaml = toolManifestToYAML(manifest);
 
   return `${SANDBOX_INSTRUCTIONS}
+
+${networkAccessSection}
 
 #### Sandbox Available Tools and Libraries
 

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -72,7 +72,7 @@ include a \`<network_proxy_logs>\` block listing the denied domain(s).
 Use that block to identify the missing domain and call
 \`add_egress_domain\` to unblock the next attempt. If a request mysteriously
 hangs or fails with TLS/DNS errors, check the \`<network_proxy_logs>\`
-block first; a denied egress is the most likely cause.`;
+block first; a denied egress is a possible cause.`;
 }
 
 async function buildSandboxInstructions(


### PR DESCRIPTION
## Description

Make the sandbox-using agent aware of the egress proxy.

The sandbox runs behind a deny-by-default egress proxy, with three layers of allowlist (global, workspace, sandbox) merged on every connection. Until now the sandbox skill instructions said nothing about this, so the only signal an agent could act on was the `<network_proxy_logs>` block appended to bash output after a denial — purely reactive, one round trip per missing domain.

This change appends a "Sandbox Network Access" section to the instructions returned by `sandboxSkill.fetchInstructions`. The section:

- Explains that traffic is proxied and deny-by-default.
- Lists the **current workspace's** preapproved domains, fetched live from the workspace egress policy in GCS via `readWorkspacePolicy(auth)`. Falls back to "(none)" if the workspace has no policy or the read fails (warning logged).
- Instructs the agent to call `add_egress_domain` **before** running a command that needs an unallowed domain (one exact domain per call, with a one-sentence reason that surfaces in the user approval prompt).
- Documents the deny-log fallback path for when the agent missed a domain or hit an unexpected redirect.

No global default allowlist is documented (we don't currently maintain one for prod). Wildcard support exists at the workspace and global layers but `add_egress_domain` only accepts exact domains, which is reflected in the wording.

## Tests

- `npx tsc --noEmit` clean.
- Biome clean on the modified file.
- Manual: read-through of the rendered instruction string for empty-allowlist and populated-allowlist cases.

## Risk

Low. The only behavior change is a longer system prompt for sandbox-enabled conversations, plus one extra GCS read (`workspaces/{wId}.json`) per skill-instruction build. The GCS read is cached by the existing `getBucketInstance` plumbing and degrades gracefully on error (logs a warning, treats workspace allowlist as empty). No request-path code changes — the proxy enforcement is unchanged.

Rollback is trivial (revert).

## Deploy Plan

Standard deploy. No migrations, no infra changes, no feature flag needed (the sandbox skill is already gated on the `sandbox_tools` flag).