### PR TITLE
[front] enh: polish input bar slash suggestion scrolling

### DIFF
--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -30,9 +30,7 @@ import {
 import type { InputBarSlashSuggestionCapability } from "./InputBarSlashSuggestionTypes";
 
 // Capability rows are 3.25rem tall, and we want to show 7 of them.
-const ITEM_HEIGHT_REM = 3.25;
-const VISIBLE_ITEMS = 7;
-const LIST_MAX_HEIGHT = `${ITEM_HEIGHT_REM * VISIBLE_ITEMS}rem`;
+const LIST_MAX_HEIGHT_CLASS_NAME = "max-h-[22.75rem]";
 
 function matchesCapabilityQuery({
   label,
@@ -260,7 +258,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
             : "No capabilities found"
         }
         header="Capabilities"
-        listMaxHeight={LIST_MAX_HEIGHT}
+        listMaxHeightClassName={LIST_MAX_HEIGHT_CLASS_NAME}
         onClose={onClose}
         showScrollFade
         size="wide"

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -29,6 +29,11 @@ import {
 
 import type { InputBarSlashSuggestionCapability } from "./InputBarSlashSuggestionTypes";
 
+// Capability rows are 3.25rem tall, and we want to show 7 of them.
+const ITEM_HEIGHT_REM = 3.25;
+const VISIBLE_ITEMS = 7;
+const LIST_MAX_HEIGHT = `${ITEM_HEIGHT_REM * VISIBLE_ITEMS}rem`;
+
 function matchesCapabilityQuery({
   label,
   query,
@@ -255,7 +260,9 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
             : "No capabilities found"
         }
         header="Capabilities"
+        listMaxHeight={LIST_MAX_HEIGHT}
         onClose={onClose}
+        showScrollFade
         size="wide"
       />
     );

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -294,7 +294,7 @@ export const SlashCommandDropdown = forwardRef<
               </div>
               <div
                 className={cn(
-                  "pointer-events-none absolute inset-x-0 top-0 h-8 bg-gradient-to-t from-transparent via-background/85 to-background opacity-0 transition-opacity duration-150 dark:via-muted-background-night/85 dark:to-muted-background-night",
+                  "pointer-events-none absolute inset-x-0 top-0 h-12 bg-gradient-to-t from-transparent via-background/70 to-background opacity-0 transition-opacity duration-200 dark:via-muted-background-night/70 dark:to-muted-background-night",
                   showScrollFade &&
                     scrollFadeState.hasContentAbove &&
                     "opacity-100"
@@ -303,7 +303,7 @@ export const SlashCommandDropdown = forwardRef<
               />
               <div
                 className={cn(
-                  "pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent via-background/85 to-background opacity-0 transition-opacity duration-150 dark:via-muted-background-night/85 dark:to-muted-background-night",
+                  "pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-b from-transparent via-background/70 to-background opacity-0 transition-opacity duration-200 dark:via-muted-background-night/70 dark:to-muted-background-night",
                   showScrollFade &&
                     scrollFadeState.hasContentBelow &&
                     "opacity-100"

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -1,4 +1,5 @@
 import {
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -12,6 +13,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useRef,
   useState,
 } from "react";
 
@@ -21,6 +23,7 @@ interface SlashCommandTooltip {
 }
 
 const DEFAULT_EMPTY_MESSAGE = "No commands found";
+const DEFAULT_LIST_MAX_HEIGHT = "24rem";
 export interface SlashCommand {
   action: string;
   description?: string;
@@ -37,7 +40,9 @@ export interface SlashCommandDropdownProps
   > {
   emptyMessage?: string;
   header?: string;
+  listMaxHeight?: string;
   onClose?: () => void;
+  showScrollFade?: boolean;
   size?: "default" | "wide";
 }
 
@@ -56,12 +61,17 @@ export const SlashCommandDropdown = forwardRef<
       clientRect,
       emptyMessage = DEFAULT_EMPTY_MESSAGE,
       header,
+      listMaxHeight = DEFAULT_LIST_MAX_HEIGHT,
       onClose,
+      showScrollFade = false,
       size = "default",
     },
     ref
   ) => {
     const [selectedIndex, setSelectedIndex] = useState(0);
+    const [canScrollDown, setCanScrollDown] = useState(false);
+    const itemCount = items.length;
+    const listRef = useRef<HTMLDivElement>(null);
     const [virtualTriggerStyle, setVirtualTriggerStyle] =
       useState<React.CSSProperties>({});
 
@@ -112,11 +122,43 @@ export const SlashCommandDropdown = forwardRef<
       [selectItem, selectedIndex, items.length]
     );
 
+    const updateCanScrollDown = useCallback(() => {
+      const list = listRef.current;
+
+      if (!showScrollFade || !list) {
+        setCanScrollDown(false);
+        return;
+      }
+
+      setCanScrollDown(
+        list.scrollTop + list.clientHeight < list.scrollHeight - 1
+      );
+    }, [showScrollFade]);
+
     // Reset selected index when items change.
     // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
     useEffect(() => {
       setSelectedIndex(0);
     }, [items]);
+
+    useEffect(() => {
+      if (itemCount === 0) {
+        setCanScrollDown(false);
+        return;
+      }
+
+      updateCanScrollDown();
+
+      const list = listRef.current;
+      if (!list || typeof ResizeObserver === "undefined") {
+        return;
+      }
+
+      const resizeObserver = new ResizeObserver(updateCanScrollDown);
+      resizeObserver.observe(list);
+
+      return () => resizeObserver.disconnect();
+    }, [itemCount, updateCanScrollDown]);
 
     // Update virtual trigger position.
     const updateTriggerPosition = useCallback(() => {
@@ -176,43 +218,57 @@ export const SlashCommandDropdown = forwardRef<
               {emptyMessage}
             </div>
           ) : (
-            <div className="max-h-96 overflow-y-auto">
-              {items.map((item, index) => {
-                const menuItem = (
-                  <DropdownMenuItem
-                    key={item.id}
-                    icon={item.icon}
-                    itemId={item.id}
-                    label={item.label}
-                    description={item.description}
-                    truncateText
-                    onClick={() => selectItem(index)}
-                    onMouseEnter={() => setSelectedIndex(index)}
-                    className={
-                      index === selectedIndex
-                        ? "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
-                        : ""
-                    }
-                  />
-                );
-
-                // Wrap with DropdownTooltipTrigger if command has tooltip property.
-                if (item.tooltip) {
-                  return (
-                    <DropdownTooltipTrigger
+            <div className="relative">
+              <div
+                ref={listRef}
+                className="overflow-y-auto"
+                onScroll={updateCanScrollDown}
+                style={{ maxHeight: listMaxHeight }}
+              >
+                {items.map((item, index) => {
+                  const menuItem = (
+                    <DropdownMenuItem
                       key={item.id}
-                      description={item.tooltip.description}
-                      media={item.tooltip.media}
-                      side="right"
-                      sideOffset={8}
-                    >
-                      {menuItem}
-                    </DropdownTooltipTrigger>
+                      icon={item.icon}
+                      itemId={item.id}
+                      label={item.label}
+                      description={item.description}
+                      truncateText
+                      onClick={() => selectItem(index)}
+                      onMouseEnter={() => setSelectedIndex(index)}
+                      className={
+                        index === selectedIndex
+                          ? "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
+                          : ""
+                      }
+                    />
                   );
-                }
 
-                return menuItem;
-              })}
+                  // Wrap with DropdownTooltipTrigger if command has tooltip property.
+                  if (item.tooltip) {
+                    return (
+                      <DropdownTooltipTrigger
+                        key={item.id}
+                        description={item.tooltip.description}
+                        media={item.tooltip.media}
+                        side="right"
+                        sideOffset={8}
+                      >
+                        {menuItem}
+                      </DropdownTooltipTrigger>
+                    );
+                  }
+
+                  return menuItem;
+                })}
+              </div>
+              <div
+                className={cn(
+                  "pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent via-background/85 to-background opacity-0 transition-opacity duration-150 dark:via-muted-background-night/85 dark:to-muted-background-night",
+                  showScrollFade && canScrollDown && "opacity-100"
+                )}
+                aria-hidden
+              />
             </div>
           )}
         </DropdownMenuContent>

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -30,6 +30,11 @@ interface ScrollFadeState {
   hasContentBelow: boolean;
 }
 
+const EMPTY_SCROLL_FADE_STATE: ScrollFadeState = {
+  hasContentAbove: false,
+  hasContentBelow: false,
+};
+
 export interface SlashCommand {
   action: string;
   description?: string;
@@ -75,10 +80,9 @@ export const SlashCommandDropdown = forwardRef<
     ref
   ) => {
     const [selectedIndex, setSelectedIndex] = useState(0);
-    const [scrollFadeState, setScrollFadeState] = useState<ScrollFadeState>({
-      hasContentAbove: false,
-      hasContentBelow: false,
-    });
+    const [scrollFadeState, setScrollFadeState] = useState<ScrollFadeState>(
+      EMPTY_SCROLL_FADE_STATE
+    );
     const itemCount = items.length;
     const listRef = useRef<HTMLDivElement>(null);
     const [virtualTriggerStyle, setVirtualTriggerStyle] =
@@ -134,11 +138,8 @@ export const SlashCommandDropdown = forwardRef<
     const updateScrollFadeState = useCallback(() => {
       const list = listRef.current;
 
-      if (!showScrollFade || !list) {
-        setScrollFadeState({
-          hasContentAbove: false,
-          hasContentBelow: false,
-        });
+      if (!list) {
+        setScrollFadeState(EMPTY_SCROLL_FADE_STATE);
         return;
       }
 
@@ -154,7 +155,7 @@ export const SlashCommandDropdown = forwardRef<
           ? previousState
           : nextState
       );
-    }, [showScrollFade]);
+    }, []);
 
     // Reset selected index when items change.
     // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -163,11 +164,12 @@ export const SlashCommandDropdown = forwardRef<
     }, [items]);
 
     useEffect(() => {
-      if (itemCount === 0) {
-        setScrollFadeState({
-          hasContentAbove: false,
-          hasContentBelow: false,
-        });
+      if (!showScrollFade || itemCount === 0) {
+        setScrollFadeState((previousState) =>
+          previousState.hasContentAbove || previousState.hasContentBelow
+            ? EMPTY_SCROLL_FADE_STATE
+            : previousState
+        );
         return;
       }
 
@@ -188,7 +190,7 @@ export const SlashCommandDropdown = forwardRef<
         window.cancelAnimationFrame(animationFrame);
         resizeObserver.disconnect();
       };
-    }, [itemCount, updateScrollFadeState]);
+    }, [itemCount, showScrollFade, updateScrollFadeState]);
 
     // Update virtual trigger position.
     const updateTriggerPosition = useCallback(() => {
@@ -252,7 +254,7 @@ export const SlashCommandDropdown = forwardRef<
               <div
                 ref={listRef}
                 className={cn("overflow-y-auto", listMaxHeightClassName)}
-                onScroll={updateScrollFadeState}
+                onScroll={showScrollFade ? updateScrollFadeState : undefined}
               >
                 {items.map((item, index) => {
                   const menuItem = (

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -24,6 +24,12 @@ interface SlashCommandTooltip {
 
 const DEFAULT_EMPTY_MESSAGE = "No commands found";
 const DEFAULT_LIST_MAX_HEIGHT = "24rem";
+
+interface ScrollFadeState {
+  hasContentAbove: boolean;
+  hasContentBelow: boolean;
+}
+
 export interface SlashCommand {
   action: string;
   description?: string;
@@ -69,7 +75,10 @@ export const SlashCommandDropdown = forwardRef<
     ref
   ) => {
     const [selectedIndex, setSelectedIndex] = useState(0);
-    const [canScrollDown, setCanScrollDown] = useState(false);
+    const [scrollFadeState, setScrollFadeState] = useState<ScrollFadeState>({
+      hasContentAbove: false,
+      hasContentBelow: false,
+    });
     const itemCount = items.length;
     const listRef = useRef<HTMLDivElement>(null);
     const [virtualTriggerStyle, setVirtualTriggerStyle] =
@@ -122,16 +131,28 @@ export const SlashCommandDropdown = forwardRef<
       [selectItem, selectedIndex, items.length]
     );
 
-    const updateCanScrollDown = useCallback(() => {
+    const updateScrollFadeState = useCallback(() => {
       const list = listRef.current;
 
       if (!showScrollFade || !list) {
-        setCanScrollDown(false);
+        setScrollFadeState({
+          hasContentAbove: false,
+          hasContentBelow: false,
+        });
         return;
       }
 
-      setCanScrollDown(
-        list.scrollTop + list.clientHeight < list.scrollHeight - 1
+      const nextState = {
+        hasContentAbove: list.scrollTop > 1,
+        hasContentBelow:
+          list.scrollTop + list.clientHeight < list.scrollHeight - 1,
+      };
+
+      setScrollFadeState((previousState) =>
+        previousState.hasContentAbove === nextState.hasContentAbove &&
+        previousState.hasContentBelow === nextState.hasContentBelow
+          ? previousState
+          : nextState
       );
     }, [showScrollFade]);
 
@@ -143,22 +164,31 @@ export const SlashCommandDropdown = forwardRef<
 
     useEffect(() => {
       if (itemCount === 0) {
-        setCanScrollDown(false);
+        setScrollFadeState({
+          hasContentAbove: false,
+          hasContentBelow: false,
+        });
         return;
       }
 
-      updateCanScrollDown();
+      updateScrollFadeState();
+      const animationFrame = window.requestAnimationFrame(
+        updateScrollFadeState
+      );
 
       const list = listRef.current;
       if (!list || typeof ResizeObserver === "undefined") {
-        return;
+        return () => window.cancelAnimationFrame(animationFrame);
       }
 
-      const resizeObserver = new ResizeObserver(updateCanScrollDown);
+      const resizeObserver = new ResizeObserver(updateScrollFadeState);
       resizeObserver.observe(list);
 
-      return () => resizeObserver.disconnect();
-    }, [itemCount, updateCanScrollDown]);
+      return () => {
+        window.cancelAnimationFrame(animationFrame);
+        resizeObserver.disconnect();
+      };
+    }, [itemCount, updateScrollFadeState]);
 
     // Update virtual trigger position.
     const updateTriggerPosition = useCallback(() => {
@@ -222,7 +252,7 @@ export const SlashCommandDropdown = forwardRef<
               <div
                 ref={listRef}
                 className="overflow-y-auto"
-                onScroll={updateCanScrollDown}
+                onScroll={updateScrollFadeState}
                 style={{ maxHeight: listMaxHeight }}
               >
                 {items.map((item, index) => {
@@ -264,8 +294,19 @@ export const SlashCommandDropdown = forwardRef<
               </div>
               <div
                 className={cn(
+                  "pointer-events-none absolute inset-x-0 top-0 h-8 bg-gradient-to-t from-transparent via-background/85 to-background opacity-0 transition-opacity duration-150 dark:via-muted-background-night/85 dark:to-muted-background-night",
+                  showScrollFade &&
+                    scrollFadeState.hasContentAbove &&
+                    "opacity-100"
+                )}
+                aria-hidden
+              />
+              <div
+                className={cn(
                   "pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent via-background/85 to-background opacity-0 transition-opacity duration-150 dark:via-muted-background-night/85 dark:to-muted-background-night",
-                  showScrollFade && canScrollDown && "opacity-100"
+                  showScrollFade &&
+                    scrollFadeState.hasContentBelow &&
+                    "opacity-100"
                 )}
                 aria-hidden
               />

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -294,9 +294,9 @@ export const SlashCommandDropdown = forwardRef<
               </div>
               <div
                 className={cn(
-                  "pointer-events-none absolute inset-x-0 top-0 h-12 bg-gradient-to-t",
-                  "from-transparent via-background/70 to-background opacity-0 transition-opacity duration-200",
-                  "dark:via-muted-background-night/70 dark:to-muted-background-night",
+                  "pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-t",
+                  "from-transparent via-background/65 to-background opacity-0 transition-opacity duration-200",
+                  "dark:via-muted-background-night/65 dark:to-muted-background-night",
                   showScrollFade &&
                     scrollFadeState.hasContentAbove &&
                     "opacity-100"
@@ -305,9 +305,9 @@ export const SlashCommandDropdown = forwardRef<
               />
               <div
                 className={cn(
-                  "pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-b",
-                  "from-transparent via-background/70 to-background opacity-0 transition-opacity duration-200",
-                  "dark:via-muted-background-night/70 dark:to-muted-background-night",
+                  "pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b",
+                  "from-transparent via-background/65 to-background opacity-0 transition-opacity duration-200",
+                  "dark:via-muted-background-night/65 dark:to-muted-background-night",
                   showScrollFade &&
                     scrollFadeState.hasContentBelow &&
                     "opacity-100"

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -294,7 +294,9 @@ export const SlashCommandDropdown = forwardRef<
               </div>
               <div
                 className={cn(
-                  "pointer-events-none absolute inset-x-0 top-0 h-12 bg-gradient-to-t from-transparent via-background/70 to-background opacity-0 transition-opacity duration-200 dark:via-muted-background-night/70 dark:to-muted-background-night",
+                  "pointer-events-none absolute inset-x-0 top-0 h-12 bg-gradient-to-t",
+                  "from-transparent via-background/70 to-background opacity-0 transition-opacity duration-200",
+                  "dark:via-muted-background-night/70 dark:to-muted-background-night",
                   showScrollFade &&
                     scrollFadeState.hasContentAbove &&
                     "opacity-100"
@@ -303,7 +305,9 @@ export const SlashCommandDropdown = forwardRef<
               />
               <div
                 className={cn(
-                  "pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-b from-transparent via-background/70 to-background opacity-0 transition-opacity duration-200 dark:via-muted-background-night/70 dark:to-muted-background-night",
+                  "pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-b",
+                  "from-transparent via-background/70 to-background opacity-0 transition-opacity duration-200",
+                  "dark:via-muted-background-night/70 dark:to-muted-background-night",
                   showScrollFade &&
                     scrollFadeState.hasContentBelow &&
                     "opacity-100"

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -23,7 +23,7 @@ interface SlashCommandTooltip {
 }
 
 const DEFAULT_EMPTY_MESSAGE = "No commands found";
-const DEFAULT_LIST_MAX_HEIGHT = "24rem";
+const DEFAULT_LIST_MAX_HEIGHT_CLASS_NAME = "max-h-96";
 
 interface ScrollFadeState {
   hasContentAbove: boolean;
@@ -46,7 +46,7 @@ export interface SlashCommandDropdownProps
   > {
   emptyMessage?: string;
   header?: string;
-  listMaxHeight?: string;
+  listMaxHeightClassName?: string;
   onClose?: () => void;
   showScrollFade?: boolean;
   size?: "default" | "wide";
@@ -67,7 +67,7 @@ export const SlashCommandDropdown = forwardRef<
       clientRect,
       emptyMessage = DEFAULT_EMPTY_MESSAGE,
       header,
-      listMaxHeight = DEFAULT_LIST_MAX_HEIGHT,
+      listMaxHeightClassName = DEFAULT_LIST_MAX_HEIGHT_CLASS_NAME,
       onClose,
       showScrollFade = false,
       size = "default",
@@ -251,9 +251,8 @@ export const SlashCommandDropdown = forwardRef<
             <div className="relative">
               <div
                 ref={listRef}
-                className="overflow-y-auto"
+                className={cn("overflow-y-auto", listMaxHeightClassName)}
                 onScroll={updateScrollFadeState}
-                style={{ maxHeight: listMaxHeight }}
               >
                 {items.map((item, index) => {
                   const menuItem = (


### PR DESCRIPTION
## Description

This PR improves the input bar slash suggestion dropdown so it does not cut one row in half.

It makes the shared slash dropdown support a configurable max list height and optional scroll fade indicators. The dropdown now shows fade indicators at the bottom or top when there is more content in that direction.

## Tests

- Tested locally.

## Risk

- Low. Behind feature flag. Well scoped.

## Deploy Plan

- Deploy front.
