### PR TITLE
[front] fix: prevent duplicate capability adds and partial-render flash in slash dropdown

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -238,7 +238,11 @@ export const InputBar = React.memo(function InputBar({
         return;
       }
 
-      setSelectedMCPServerViews((prev) => [...prev, serverView]);
+      setSelectedMCPServerViews((prev) =>
+        prev.some((sv) => sv.sId === serverView.sId)
+          ? prev
+          : [...prev, serverView]
+      );
       void addTool(serverView.sId);
     },
     [addTool, selectedMCPServerViewIds]
@@ -264,7 +268,9 @@ export const InputBar = React.memo(function InputBar({
         return;
       }
 
-      setSelectedSkills((prev) => [...prev, skill]);
+      setSelectedSkills((prev) =>
+        prev.some((s) => s.sId === skill.sId) ? prev : [...prev, skill]
+      );
       void addSkill(skill.sId);
     },
     [addSkill, selectedSkillIds]

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -234,7 +234,11 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
 
     return (
       <SlashCommandDropdown
-        key={isSkillsLoading && isSpacesLoading && isServerViewsLoading ? "loading" : "loaded"}
+        key={
+          isSkillsLoading && isSpacesLoading && isServerViewsLoading
+            ? "loading"
+            : "loaded"
+        }
         ref={dropdownRef}
         items={capabilityItems}
         command={(item) => {

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -234,7 +234,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
 
     return (
       <SlashCommandDropdown
-        key={(isSkillsLoading && isServerViewsLoading) ? "loading" : "loaded"}
+        key={isSkillsLoading && isServerViewsLoading ? "loading" : "loaded"}
         ref={dropdownRef}
         items={capabilityItems}
         command={(item) => {

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -236,7 +236,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
       <SlashCommandDropdown
         key={isCapabilitiesLoading ? "loading" : "loaded"}
         ref={dropdownRef}
-        items={isCapabilitiesLoading ? [] : capabilityItems}
+        items={capabilityItems}
         command={(item) => {
           const capability = filteredCapabilities.find((capability) =>
             capability.kind === "skill"

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -236,7 +236,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
       <SlashCommandDropdown
         key={isCapabilitiesLoading ? "loading" : "loaded"}
         ref={dropdownRef}
-        items={capabilityItems}
+        items={isCapabilitiesLoading ? [] : capabilityItems}
         command={(item) => {
           const capability = filteredCapabilities.find((capability) =>
             capability.kind === "skill"

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -234,7 +234,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
 
     return (
       <SlashCommandDropdown
-        key={isSkillsLoading && isServerViewsLoading ? "loading" : "loaded"}
+        key={isSkillsLoading && isSpacesLoading && isServerViewsLoading ? "loading" : "loaded"}
         ref={dropdownRef}
         items={capabilityItems}
         command={(item) => {

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -234,7 +234,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
 
     return (
       <SlashCommandDropdown
-        key={isCapabilitiesLoading ? "loading" : "loaded"}
+        key={(isSkillsLoading && isServerViewsLoading) ? "loading" : "loaded"}
         ref={dropdownRef}
         items={capabilityItems}
         command={(item) => {


### PR DESCRIPTION
## Description

This PR fixes two issues in the slash dropdown in the input bar:
- Adding the same capability twice causes it to appear twice in the list due to the optimistic update
- The dropdown blinks when the MCP server views finish loading (the skills load faster and are shown first)

## Tests

- Tested locally

## Risk

- Low. Behind feature flag. Well scoped.

## Deploy Plan

- Deploy front.
