### PR TITLE
Move from official_notion_mcp to allow_old_notion_mcp flag

### DIFF
--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -189,6 +189,11 @@ export function getMcpServerDisplayName(
     if (serverConfig.isPreview === true) {
       displayName += " (Preview)";
     }
+    // Only matches the old internal Notion server; the new official Notion is a remote
+    // MCP server, so its sId doesn't decode here and this branch is skipped.
+    if (res.value.name === "notion") {
+      displayName += " (old)";
+    }
     // Will append Dust App name.
     if (res.value.name === "run_dust_app" && action) {
       displayName += " - " + action.name;

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -328,7 +328,7 @@ export const INTERNAL_MCP_SERVERS = {
     availability: "manual",
     allowMultipleInstances: true,
     isRestricted: ({ featureFlags }) =>
-      featureFlags.includes("official_notion_mcp"),
+      !featureFlags.includes("allow_old_notion_mcp"),
     isPreview: false,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,

--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -1192,7 +1192,6 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
     documentationUrl:
       "https://developers.notion.com/guides/mcp/get-started-with-mcp",
     authMethod: "oauth-dynamic",
-    featureFlag: "official_notion_mcp",
     toolStakes: {
       "notion-search": "never_ask",
       "notion-fetch": "never_ask",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -276,9 +276,9 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable the Plan Mode skill: agents maintain a live plan.md for non-trivial tasks, with an optional human-approval checkpoint.",
     stage: "dust_only",
   },
-  official_notion_mcp: {
+  allow_old_notion_mcp: {
     description:
-      "Use the official Notion MCP server instead of the internal one",
+      "Allow individual workspaces to keep using the old internal Notion MCP server alongside the official one",
     stage: "dust_only",
   },
   use_dust_keys: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -719,7 +719,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "netsuite_mcp"
   | "noop_model_feature"
   | "notion_private_integration"
-  | "official_notion_mcp"
+  | "allow_old_notion_mcp"
   | "openai_o1_custom_assistants_feature"
   | "openai_o1_feature"
   | "openai_o1_high_reasoning_feature"


### PR DESCRIPTION
## Description

Summary

- Removes the official_notion_mcp feature flag — the official remote Notion MCP server is now available to everyone unconditionally.
- Adds a new allow_old_notion_mcp flag (dust_only) that lets specific users keep access to the legacy internal Notion MCP server alongside the new official one. Hopefully, it won't be needed, but it's available just in case.
- Renames the legacy server to "Notion (old)" in the UI so users with both servers enabled can tell them apart.

Flag semantics

The two flags are inverses of each other in intent (but not exactly):

```
┌───────────────────────────────┬───────────────────────────────────┬─────────────────────────────┬───────────────────────────────────────────────────────┐
│             Flag              │             Direction             │      Default behavior       │                    Effect when set                    │
├───────────────────────────────┼───────────────────────────────────┼─────────────────────────────┼───────────────────────────────────────────────────────┤
│ official_notion_mcp (removed) │ Opt in to the new official server │ Internal Notion server only │ Hide internal server, show official remote server     │
├───────────────────────────────┼───────────────────────────────────┼─────────────────────────────┼───────────────────────────────────────────────────────┤
│ allow_old_notion_mcp (added)  │ Opt in to keeping the old server  │ Official remote server only │ Also show the legacy internal server (both available) │
└───────────────────────────────┴───────────────────────────────────┴─────────────────────────────┴───────────────────────────────────────────────────────┘
```

The default has flipped: previously the old internal server was the default and the flag granted access to the new one; now the new official server is the default and the flag grants continued access to the old one for users who still need it.

## Tests

Manual

## Risk

Low

## Deploy Plan

Front