### PR TITLE
add userId option to filter old-domain members by specific user

### DIFF
--- a/front/scripts/merge_domain_user_identities.ts
+++ b/front/scripts/merge_domain_user_identities.ts
@@ -24,8 +24,13 @@ makeScript(
       type: "string" as const,
       demandOption: true,
     },
+    userId: {
+      describe:
+        "Optional sId of a single old-domain (secondary) user to process",
+      type: "string" as const,
+    },
   },
-  async ({ workspaceId, oldDomain, newDomain, execute }, logger) => {
+  async ({ workspaceId, oldDomain, newDomain, userId, execute }, logger) => {
     if (oldDomain === newDomain) {
       logger.error({ oldDomain, newDomain }, "Old and new domains must differ");
       return;
@@ -59,7 +64,7 @@ makeScript(
     );
 
     // Secondary users have an email on the old domain.
-    const oldDomainMembers = members.filter((m) => {
+    let oldDomainMembers = members.filter((m) => {
       const [, domain] = m.email.split("@");
       return domain === oldDomain;
     });
@@ -68,6 +73,18 @@ makeScript(
       { oldDomainMemberCount: oldDomainMembers.length },
       "Found old-domain members"
     );
+
+    if (userId) {
+      oldDomainMembers = oldDomainMembers.filter((m) => m.sId === userId);
+      if (oldDomainMembers.length === 0) {
+        logger.error(
+          { userId, oldDomain },
+          "No old-domain member found with the provided userId"
+        );
+        return;
+      }
+      logger.info({ userId }, "Filtered to single user");
+    }
 
     const results = {
       successful: [] as Array<{ primary: string; secondary: string }>,


### PR DESCRIPTION
## Description

- Added an optional userId flag to scripts/merge_domain_user_identities.ts to restrict the merge to a single old-domain (secondary) user, identified by their sId.
- When the flag is set but no matching old-domain member is found, the script logs an error and exits early.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
