### PR TITLE
fix(sbx): preserve shell variable references in bash tool

### DIFF
--- a/front/lib/api/sandbox/image/profile.exec.test.ts
+++ b/front/lib/api/sandbox/image/profile.exec.test.ts
@@ -1,0 +1,151 @@
+import { spawnSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { describe, expect, it } from "vitest";
+
+import { wrapCommand, wrapCommandWithCapture } from "./profile";
+
+interface ExecResult {
+  code: number;
+  stderr: string;
+  stdout: string;
+}
+
+let execCounter = 0;
+
+function nextExecId(): string {
+  execCounter += 1;
+  return `profile-exec-${process.pid}-${execCounter}`;
+}
+
+function stripProfileSource(wrapped: string): string {
+  const stripped = wrapped.replace(/^source \S+ && /m, "");
+
+  if (stripped === wrapped) {
+    throw new Error("Expected wrapped command to contain a source prefix.");
+  }
+
+  return stripped;
+}
+
+function execWrapped(wrapped: string): ExecResult {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "profile-exec-test-"));
+  const scriptPath = path.join(tempDir, "wrapped.sh");
+  const script = [
+    `shell() { bash -c "$1"; }`,
+    stripProfileSource(wrapped),
+  ].join("\n");
+
+  try {
+    fs.writeFileSync(scriptPath, script);
+    const result = spawnSync("bash", ["--norc", scriptPath], {
+      cwd: tempDir,
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    return {
+      code: result.status ?? 1,
+      stderr: result.stderr ?? "",
+      stdout: result.stdout ?? "",
+    };
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+function execWrapCommand(cmd: string): ExecResult {
+  return execWrapped(wrapCommand(cmd, "anthropic"));
+}
+
+function execWrapCommandWithCapture(cmd: string): ExecResult {
+  const execId = nextExecId();
+
+  try {
+    return execWrapped(wrapCommandWithCapture(cmd, execId, "anthropic"));
+  } finally {
+    fs.rmSync(`/tmp/dust_exec_${execId}.out`, { force: true });
+    fs.rmSync(`/tmp/dust_exec_${execId}.exit`, { force: true });
+  }
+}
+
+const shellExpansionCases = [
+  {
+    cmd: `MY_VAR="hello world"\necho "$MY_VAR"`,
+    name: "variable assignment and reference",
+    stdout: "hello world\n",
+  },
+  {
+    cmd: `MY_VAR=inner\necho "$(echo "$MY_VAR")"`,
+    name: "command substitution",
+    stdout: "inner\n",
+  },
+  {
+    cmd: 'MY_VAR=inner\necho `echo "$MY_VAR"`',
+    name: "backtick command substitution",
+    stdout: "inner\n",
+  },
+  {
+    cmd: `MESSAGE='hello "world"'\necho "$MESSAGE"`,
+    name: "nested quotes",
+    stdout: `hello "world"\n`,
+  },
+  {
+    cmd: `FIRST=hello\nSECOND=world\necho "$FIRST $SECOND"`,
+    name: "multi-line command",
+    stdout: "hello world\n",
+  },
+  {
+    cmd: `echo '$NOT_EXPANDED'`,
+    name: "literal dollar in single quotes",
+    stdout: "$NOT_EXPANDED\n",
+  },
+  {
+    cmd: `cat <<'EOF'\n$NOT_EXPANDED\nEOF`,
+    name: "single-quoted heredoc in user command",
+    stdout: "$NOT_EXPANDED\n",
+  },
+];
+
+describe.each([
+  { exec: execWrapCommand, name: "wrapCommand" },
+  { exec: execWrapCommandWithCapture, name: "wrapCommandWithCapture" },
+])("$name execution", ({ exec }) => {
+  it.each(shellExpansionCases)("preserves $name", ({ cmd, stdout }) => {
+    const result = exec(cmd);
+
+    expect(result).toEqual({
+      code: 0,
+      stderr: "",
+      stdout,
+    });
+  });
+});
+
+describe("reserved heredoc delimiter", () => {
+  it("throws when wrapCommand receives the delimiter on its own line", () => {
+    expect(() =>
+      wrapCommand("echo before\nDUST_CMD_EOF\necho after", "anthropic"),
+    ).toThrow(
+      "Command contains the reserved heredoc delimiter 'DUST_CMD_EOF'.",
+    );
+  });
+
+  it("throws when wrapCommandWithCapture receives the delimiter on its own line", () => {
+    expect(() =>
+      wrapCommandWithCapture(
+        "echo before\nDUST_CMD_EOF\necho after",
+        "exec-id",
+        "anthropic",
+      ),
+    ).toThrow(
+      "Command contains the reserved heredoc delimiter 'DUST_CMD_EOF'.",
+    );
+  });
+});

--- a/front/lib/api/sandbox/image/profile.exec.test.ts
+++ b/front/lib/api/sandbox/image/profile.exec.test.ts
@@ -131,9 +131,9 @@ describe.each([
 describe("reserved heredoc delimiter", () => {
   it("throws when wrapCommand receives the delimiter on its own line", () => {
     expect(() =>
-      wrapCommand("echo before\nDUST_CMD_EOF\necho after", "anthropic"),
+      wrapCommand("echo before\nDUST_CMD_EOF\necho after", "anthropic")
     ).toThrow(
-      "Command contains the reserved heredoc delimiter 'DUST_CMD_EOF'.",
+      "Command contains the reserved heredoc delimiter 'DUST_CMD_EOF'."
     );
   });
 
@@ -142,10 +142,10 @@ describe("reserved heredoc delimiter", () => {
       wrapCommandWithCapture(
         "echo before\nDUST_CMD_EOF\necho after",
         "exec-id",
-        "anthropic",
-      ),
+        "anthropic"
+      )
     ).toThrow(
-      "Command contains the reserved heredoc delimiter 'DUST_CMD_EOF'.",
+      "Command contains the reserved heredoc delimiter 'DUST_CMD_EOF'."
     );
   });
 });

--- a/front/lib/api/sandbox/image/profile.test.ts
+++ b/front/lib/api/sandbox/image/profile.test.ts
@@ -6,6 +6,15 @@ import {
   wrapCommandWithCapture,
 } from "./profile";
 
+function expectedWrappedCommand(cmd: string, timeoutSec = 60): string {
+  return [
+    `source /opt/dust/profile/common.sh && shell "$(cat <<'DUST_CMD_EOF'`,
+    cmd,
+    "DUST_CMD_EOF",
+    `)" ${timeoutSec}`,
+  ].join("\n");
+}
+
 describe("wrapCommandWithCapture", () => {
   it("includes tee redirect to output file", () => {
     const result = wrapCommandWithCapture("ls -la", "abc123", "anthropic");
@@ -19,18 +28,16 @@ describe("wrapCommandWithCapture", () => {
 
   it("sources the profile and wraps the command", () => {
     const result = wrapCommandWithCapture("echo hello", "abc123", "anthropic");
-    expect(result).toContain(
-      'source /opt/dust/profile/common.sh && shell "echo hello" 60'
-    );
+    expect(result).toContain(expectedWrappedCommand("echo hello"));
   });
 
-  it("escapes double quotes and backslashes", () => {
+  it("preserves double quotes and backslashes", () => {
     const result = wrapCommandWithCapture(
       'echo "hello \\ world"',
       "abc123",
-      "anthropic"
+      "anthropic",
     );
-    expect(result).toContain('shell "echo \\"hello \\\\ world\\"" 60');
+    expect(result).toContain(expectedWrappedCommand('echo "hello \\ world"'));
   });
 
   it("respects custom timeout", () => {
@@ -55,7 +62,7 @@ describe("buildWaitAndCollectCommand", () => {
   it("waits for exit sentinel", () => {
     const result = buildWaitAndCollectCommand("abc123");
     expect(result).toContain(
-      "while [ ! -f /tmp/dust_exec_abc123.exit ]; do sleep 0.5; done"
+      "while [ ! -f /tmp/dust_exec_abc123.exit ]; do sleep 0.5; done",
     );
   });
 
@@ -73,8 +80,6 @@ describe("buildWaitAndCollectCommand", () => {
 describe("wrapCommand", () => {
   it("still works unchanged", () => {
     const result = wrapCommand("echo hi", "anthropic");
-    expect(result).toBe(
-      'source /opt/dust/profile/common.sh && shell "echo hi" 60'
-    );
+    expect(result).toBe(expectedWrappedCommand("echo hi"));
   });
 });

--- a/front/lib/api/sandbox/image/profile.test.ts
+++ b/front/lib/api/sandbox/image/profile.test.ts
@@ -35,7 +35,7 @@ describe("wrapCommandWithCapture", () => {
     const result = wrapCommandWithCapture(
       'echo "hello \\ world"',
       "abc123",
-      "anthropic",
+      "anthropic"
     );
     expect(result).toContain(expectedWrappedCommand('echo "hello \\ world"'));
   });
@@ -62,7 +62,7 @@ describe("buildWaitAndCollectCommand", () => {
   it("waits for exit sentinel", () => {
     const result = buildWaitAndCollectCommand("abc123");
     expect(result).toContain(
-      "while [ ! -f /tmp/dust_exec_abc123.exit ]; do sleep 0.5; done",
+      "while [ ! -f /tmp/dust_exec_abc123.exit ]; do sleep 0.5; done"
     );
   });
 

--- a/front/lib/api/sandbox/image/profile.ts
+++ b/front/lib/api/sandbox/image/profile.ts
@@ -16,14 +16,14 @@ function getProfileName(_providerId: ModelProviderIdType): string {
 export function wrapCommand(
   cmd: string,
   providerId: ModelProviderIdType,
-  opts?: WrapCommandOptions,
+  opts?: WrapCommandOptions
 ): string {
   const profile = getProfileName(providerId);
   const timeoutSec = opts?.timeoutSec ?? 60;
 
   if (cmd.split("\n").includes(COMMAND_HEREDOC_DELIMITER)) {
     throw new Error(
-      `Command contains the reserved heredoc delimiter '${COMMAND_HEREDOC_DELIMITER}'.`,
+      `Command contains the reserved heredoc delimiter '${COMMAND_HEREDOC_DELIMITER}'.`
     );
   }
 
@@ -39,7 +39,7 @@ export function wrapCommandWithCapture(
   cmd: string,
   execId: string,
   providerId: ModelProviderIdType,
-  opts?: WrapCommandOptions,
+  opts?: WrapCommandOptions
 ): string {
   const baseCommand = wrapCommand(cmd, providerId, opts);
   const outFile = `/tmp/dust_exec_${execId}.out`;

--- a/front/lib/api/sandbox/image/profile.ts
+++ b/front/lib/api/sandbox/image/profile.ts
@@ -1,6 +1,7 @@
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 
 export const PROFILE_DIR = "/opt/dust/profile";
+const COMMAND_HEREDOC_DELIMITER = "DUST_CMD_EOF";
 
 export interface WrapCommandOptions {
   timeoutSec?: number;
@@ -15,20 +16,30 @@ function getProfileName(_providerId: ModelProviderIdType): string {
 export function wrapCommand(
   cmd: string,
   providerId: ModelProviderIdType,
-  opts?: WrapCommandOptions
+  opts?: WrapCommandOptions,
 ): string {
   const profile = getProfileName(providerId);
   const timeoutSec = opts?.timeoutSec ?? 60;
-  // Escape double quotes and backslashes in command for safe embedding
-  const escapedCmd = cmd.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-  return `source ${PROFILE_DIR}/${profile} && shell "${escapedCmd}" ${timeoutSec}`;
+
+  if (cmd.split("\n").includes(COMMAND_HEREDOC_DELIMITER)) {
+    throw new Error(
+      `Command contains the reserved heredoc delimiter '${COMMAND_HEREDOC_DELIMITER}'.`,
+    );
+  }
+
+  return [
+    `source ${PROFILE_DIR}/${profile} && shell "$(cat <<'${COMMAND_HEREDOC_DELIMITER}'`,
+    cmd,
+    COMMAND_HEREDOC_DELIMITER,
+    `)" ${timeoutSec}`,
+  ].join("\n");
 }
 
 export function wrapCommandWithCapture(
   cmd: string,
   execId: string,
   providerId: ModelProviderIdType,
-  opts?: WrapCommandOptions
+  opts?: WrapCommandOptions,
 ): string {
   const baseCommand = wrapCommand(cmd, providerId, opts);
   const outFile = `/tmp/dust_exec_${execId}.out`;

--- a/front/lib/api/sandbox/image/profile/tests/wrap_command.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/wrap_command.test.ts
@@ -44,9 +44,9 @@ describe("wrapCommand", () => {
 
   it("throws when the command contains the reserved heredoc delimiter", () => {
     expect(() =>
-      wrapCommand("echo before\nDUST_CMD_EOF\necho after", "anthropic"),
+      wrapCommand("echo before\nDUST_CMD_EOF\necho after", "anthropic")
     ).toThrow(
-      "Command contains the reserved heredoc delimiter 'DUST_CMD_EOF'.",
+      "Command contains the reserved heredoc delimiter 'DUST_CMD_EOF'."
     );
   });
 });

--- a/front/lib/api/sandbox/image/profile/tests/wrap_command.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/wrap_command.test.ts
@@ -2,42 +2,51 @@ import { describe, expect, it } from "vitest";
 
 import { PROFILE_DIR, wrapCommand } from "../../profile";
 
+function expectedWrappedCommand(cmd: string, timeoutSec = 60): string {
+  return [
+    `source ${PROFILE_DIR}/common.sh && shell "$(cat <<'DUST_CMD_EOF'`,
+    cmd,
+    "DUST_CMD_EOF",
+    `)" ${timeoutSec}`,
+  ].join("\n");
+}
+
 describe("wrapCommand", () => {
   it("wraps command with shell function for anthropic provider", () => {
     const result = wrapCommand("ls -la", "anthropic");
-    expect(result).toBe(`source ${PROFILE_DIR}/common.sh && shell "ls -la" 60`);
+    expect(result).toBe(expectedWrappedCommand("ls -la"));
   });
 
   it("wraps command with shell function for openai provider", () => {
     const result = wrapCommand("pwd", "openai");
-    expect(result).toBe(`source ${PROFILE_DIR}/common.sh && shell "pwd" 60`);
+    expect(result).toBe(expectedWrappedCommand("pwd"));
   });
 
   it("wraps command with shell function for google_ai_studio provider", () => {
     const result = wrapCommand("echo hello", "google_ai_studio");
-    expect(result).toBe(
-      `source ${PROFILE_DIR}/common.sh && shell "echo hello" 60`
-    );
+    expect(result).toBe(expectedWrappedCommand("echo hello"));
   });
 
   it("passes timeoutSec to shell wrapper", () => {
     const result = wrapCommand("long-cmd", "anthropic", { timeoutSec: 120 });
-    expect(result).toBe(
-      `source ${PROFILE_DIR}/common.sh && shell "long-cmd" 120`
-    );
+    expect(result).toBe(expectedWrappedCommand("long-cmd", 120));
   });
 
-  it("escapes double quotes in command", () => {
+  it("preserves double quotes in command", () => {
     const result = wrapCommand('echo "hello world"', "anthropic");
-    expect(result).toBe(
-      `source ${PROFILE_DIR}/common.sh && shell "echo \\"hello world\\"" 60`
-    );
+    expect(result).toBe(expectedWrappedCommand('echo "hello world"'));
   });
 
-  it("escapes backslashes in command", () => {
+  it("preserves backslashes in command", () => {
     const result = wrapCommand("echo \\n", "anthropic");
-    expect(result).toBe(
-      `source ${PROFILE_DIR}/common.sh && shell "echo \\\\n" 60`
+    expect(result).toBe(expectedWrappedCommand("echo \\n"));
+  });
+
+  it("throws when the command contains the reserved heredoc delimiter", () => {
+    expect(() =>
+      wrapCommand("echo before\nDUST_CMD_EOF\necho after", "anthropic"),
+    ).toThrow(
+      "Command contains the reserved heredoc delimiter 'DUST_CMD_EOF'.",
     );
   });
 });


### PR DESCRIPTION
## Description

The sandbox `bash` tool silently dropped every reference to a user-defined shell variable. Assignments looked fine, but `$VAR`, `$(...)` and backticks all evaluated to the empty string:

```bash
MY_VAR="hello world"
echo "$MY_VAR"
# Expected: hello world
# Actual:   (empty)
```

### Root cause

`wrapCommand` in `front/lib/api/sandbox/image/profile.ts` embedded the user's command inside a **double-quoted** bash string and only escaped `\` and `"`. The wrapped string was then handed to `sandbox.commands.run(...)`, which executes through a shell on the sandbox. That outer shell still performed parameter expansion (`$VAR`, `${VAR}`) and command substitution (`$(...)`, backticks) inside the double quotes, against its own environment, where those variables are undefined, **before** the inner `shell` function (and the `bash -c "$cmd"` it eventually runs) ever saw the user's command.

By the time `bash -c` ran, `echo "$MY_VAR"` had already been rewritten to `echo ""`. No error, because bash's default behavior on undefined variables is empty-string expansion.

### Fix

Wrap the user's command in a **single-quoted heredoc** (`<<'DUST_CMD_EOF'`). The quoted delimiter disables every form of expansion in the heredoc body, so the user's command reaches the inner `shell` function byte-for-byte intact.

Guard against the (vanishingly unlikely) case where the user's command contains a line consisting solely of `DUST_CMD_EOF` by throwing. Failing loudly is preferable to silently truncating the command.

## Tests

Added `profile.exec.test.ts`, execution-level tests that strip the `source` prefix, prepend a stub `shell()` that runs `bash -c "$1"`, and actually execute the wrapped output. These run against both `wrapCommand` and `wrapCommandWithCapture`. Cases covered:

- Variable assignment + reference
- `$(...)` command substitution
- Backtick command substitution
- Nested quotes
- Multi-line commands
- Literal `$` inside single quotes (must not be expanded)
- A user-supplied `<<'EOF'` heredoc inside the command
- Delimiter collision (asserts `wrapCommand` and `wrapCommandWithCapture` throw)

Existing snapshot tests in `profile.test.ts` and `profile/tests/wrap_command.test.ts` were updated for the new heredoc shape and now also assert the throw on collision.

The original snapshot tests passed against the buggy implementation, which is exactly why this bug shipped. The new execution tests close that gap.

```
Test Files  3 passed (3)
     Tests  34 passed (34)
```

## Risk

Low. The change is local to how `wrapCommand` formats the string passed to `sandbox.commands.run`. No contract change, no schema change, no migration. Behavior change is strictly: variable references that previously expanded to empty now expand to their actual value (i.e. bash works as users expect).

The only new failure mode is the throw on `DUST_CMD_EOF` collision, which is bounded to a string the agent would have to deliberately produce.

Rollback is trivial: revert the commit.

## Deploy Plan

Standard `front` deploy. No coordinated changes needed. Effective for any new sandbox `bash` tool invocation immediately after rollout.