### PR TITLE
fix(sbx): allow userless sandbox tokens for non-human triggers

### DIFF
--- a/front/lib/api/sandbox/access_tokens.ts
+++ b/front/lib/api/sandbox/access_tokens.ts
@@ -18,7 +18,9 @@ export const SANDBOX_TOKEN_PREFIX = "sbt-";
 const SandboxExecTokenPayloadSchema = z.object({
   wId: z.string(),
   cId: z.string(),
-  uId: z.string(),
+  // Optional: omitted when the conversation is driven by a non-human actor
+  // (e.g. a Slack bot user with no associated Dust user).
+  uId: z.string().optional(),
   aId: z.string(),
   mId: z.string(),
   sbId: z.string(),
@@ -111,7 +113,7 @@ export async function generateSandboxExecToken(
   const payload: SandboxExecTokenPayload = {
     wId: auth.getNonNullableWorkspace().sId,
     cId: conversation.sId,
-    uId: auth.getNonNullableUser().sId,
+    uId: auth.user()?.sId,
     aId: agentConfiguration.sId,
     mId: agentMessage.sId,
     sbId: sandbox.sId,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -485,7 +485,7 @@ export class Authenticator {
 
     const [workspace, user] = await Promise.all([
       WorkspaceResource.fetchById(wId),
-      UserResource.fetchById(claims.uId),
+      claims.uId ? UserResource.fetchById(claims.uId) : Promise.resolve(null),
     ]);
 
     if (!workspace) {
@@ -498,7 +498,7 @@ export class Authenticator {
       });
     }
 
-    if (!user) {
+    if (claims.uId && !user) {
       return new Err({
         status_code: 401,
         api_error: {
@@ -508,42 +508,65 @@ export class Authenticator {
       });
     }
 
-    const authData = await this.fetchRoleGroupsAndSubscription({
-      user,
-      workspace,
-    });
+    let role: RoleType;
+    let baseGroupModelIds: ModelId[];
+    let subscription: SubscriptionResource | null;
 
-    if (authData.role === "none") {
-      return new Err({
-        status_code: 401,
-        api_error: {
-          type: "invalid_sandbox_token_error",
-          message: "The user is not a member of this workspace.",
-        },
+    if (user) {
+      const authData = await this.fetchRoleGroupsAndSubscription({
+        user,
+        workspace,
       });
+
+      if (authData.role === "none") {
+        return new Err({
+          status_code: 401,
+          api_error: {
+            type: "invalid_sandbox_token_error",
+            message: "The user is not a member of this workspace.",
+          },
+        });
+      }
+
+      role = authData.role;
+      baseGroupModelIds = authData.groupModelIds;
+      subscription = authData.subscription;
+    } else {
+      // Userless sandbox token: conversation was driven by a non-human actor
+      // (e.g. Slack bot user). Grant the lowest authenticated workspace role
+      // and start from the workspace global group; conversation-space
+      // restriction below still applies.
+      const [globalGroup, activeSubscription] = await Promise.all([
+        GroupResource.internalFetchWorkspaceGlobalGroup(workspace.id),
+        SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id),
+      ]);
+
+      role = "user";
+      baseGroupModelIds = globalGroup ? [globalGroup.id] : [];
+      subscription = activeSubscription;
     }
 
     // Restrict groups to the conversation's spaces so the sandbox auth can only
     // access resources visible to the conversation, not everything the user can.
     const groupModelIds = await this.restrictGroupsToConversationSpaces(
-      authData.groupModelIds,
+      baseGroupModelIds,
       claims.cId,
       workspace.id
     );
 
     const providersHealth = await this.fetchByokProvidersHealth(
       workspace,
-      authData.subscription
+      subscription
     );
 
     return new Ok(
       new Authenticator({
         authMethod: "sandbox_token",
         workspace,
-        user,
-        role: authData.role,
+        user: user ?? undefined,
+        role,
         groupModelIds,
-        subscription: authData.subscription,
+        subscription,
         providersHealth,
       })
     );

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -541,8 +541,19 @@ export class Authenticator {
         SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id),
       ]);
 
+      if (!globalGroup) {
+        return new Err({
+          status_code: 500,
+          api_error: {
+            type: "invalid_sandbox_token_error",
+            message:
+              "Could not resolve workspace global group for userless sandbox token.",
+          },
+        });
+      }
+
       role = "user";
-      baseGroupModelIds = globalGroup ? [globalGroup.id] : [];
+      baseGroupModelIds = [globalGroup.id];
       subscription = activeSubscription;
     }
 


### PR DESCRIPTION
## Description

When a conversation is driven by a Slack workflow (a bot user with no associated Dust user), the bash sandbox tool currently throws `Unexpected unauthenticated call to getNonNullableUser.` before any command runs — `auth.getNonNullableUser().sId` is required when minting the sandbox exec token in `generateSandboxExecToken`. The model gets an opaque error and loses sandbox access for the rest of the conversation.

This PR makes the sandbox tokenless of a user when the conversation has no human actor:

- `front/lib/api/sandbox/access_tokens.ts`: `uId` is now optional in the JWT payload schema; the token is minted with `auth.user()?.sId`.
- `front/lib/auth.ts` `Authenticator.fromSandboxToken`: when `claims.uId` is absent, the authenticator is built with `role: "user"` and the workspace global group as the base set, then run through the same `restrictGroupsToConversationSpaces` so the sandbox stays scoped to the conversation's spaces.

When `uId` is present (the standard human-user path), behavior is unchanged.

## Tests

- Typecheck passes (`npx tsc --noEmit` in `front`).
- The existing `access_tokens.test.ts` still asserts `uId` is set in the human-user case — covered by the unchanged code path.
- Manual verification path: a Slack workflow-triggered conversation no longer fails on trivial sandbox commands; standard human-triggered conversations remain unaffected.

## Risk

- The two sandbox callback endpoints (`/api/v1/w/[wId]/sandbox/tools` and `.../mcp_server_views/[svId]/call_tool`) don't deref `auth.user()` directly; they gate on `auth.isUser()` (true because role is `"user"`) and group-based resource access. The userless auth has the workspace global group restricted to the conversation's spaces, equivalent to a regular workspace member's view of those spaces.
- Individual MCP tools called from inside the sandbox could still call `getNonNullableUser()` internally (e.g. tools relying on personal OAuth or user-favorited data). Tools that declare personal auth degrade cleanly via the existing `personal_auth_required` path; other tools that implicitly assume a user would surface a tool-level error rather than crashing the sandbox. This is a clean degradation vs. the prior state where the sandbox could not run at all.
- No change to the human-user code path; rollback is a straightforward revert.

## Deploy Plan

- Standard deploy. No migrations, no config changes.
- After deploy, re-trigger a Slack workflow conversation that previously failed on `echo`-style commands to confirm.