### PR TITLE
Skill editor: scroll to first edit of the suggestion

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -272,6 +272,16 @@ export function SkillBuilderInstructionsEditor({
     // may be null if no suggestion is selected
     editor.commands.setHighlightedSuggestion(selectedSuggestionId);
 
+    // Scroll the editor to the first edit of the selected suggestion.
+    if (selectedSuggestionId) {
+      requestAnimationFrame(() => {
+        const firstEdit = editor.view.dom.querySelector(
+          `[data-suggestion-id^="${selectedSuggestionId}:"]`
+        );
+        firstEdit?.scrollIntoView({ behavior: "smooth", block: "center" });
+      });
+    }
+
     // Make the editor read-only while suggestion diffs are displayed.
     if (!isDiffMode) {
       editor.setEditable(!hasSuggestions);


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/7850

Scroll to the fist edit when clicking on a suggestion.
Nothing happens if the suggestion has no prompt edit


https://github.com/user-attachments/assets/8a17fc34-a8a4-446c-a336-e11a48075a7a

## Tests

Tested locally

## Risk

low

## Deploy Plan

deploy front
