### PR TITLE
[front] enh: improve performances of `/mcp/views` endpoint

### DIFF
--- a/front/lib/api/mcp_oauth_prerequisites.ts
+++ b/front/lib/api/mcp_oauth_prerequisites.ts
@@ -1,8 +1,5 @@
-import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import { getProviderStrategy } from "@app/lib/api/oauth";
-import type { Authenticator } from "@app/lib/auth";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 
 export function oauthProviderRequiresWorkspaceConnectionForPersonalAuth(
@@ -12,36 +9,6 @@ export function oauthProviderRequiresWorkspaceConnectionForPersonalAuth(
     getProviderStrategy(provider).requiresWorkspaceConnectionForPersonalAuth ===
     true
   );
-}
-
-export async function listWorkspaceConnectedMCPServerIds(
-  auth: Authenticator
-): Promise<Set<string>> {
-  const workspaceConnections =
-    await MCPServerConnectionResource.listByWorkspace(auth, {
-      connectionType: "workspace",
-    });
-
-  const workspaceId = auth.getNonNullableWorkspace().id;
-  const serverIds = new Set<string>();
-
-  for (const connection of workspaceConnections) {
-    if (connection.internalMCPServerId) {
-      serverIds.add(connection.internalMCPServerId);
-      continue;
-    }
-
-    if (connection.remoteMCPServerId) {
-      serverIds.add(
-        remoteMCPServerNameToSId({
-          remoteMCPServerId: connection.remoteMCPServerId,
-          workspaceId,
-        })
-      );
-    }
-  }
-
-  return serverIds;
 }
 
 export function withWorkspaceConnectionRequirement(

--- a/front/lib/resources/mcp_server_connection_resource.test.ts
+++ b/front/lib/resources/mcp_server_connection_resource.test.ts
@@ -1,3 +1,4 @@
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -129,6 +130,74 @@ describe("MCPServerConnectionResource", () => {
       if (originalUserResult.isOk()) {
         expect(originalUserResult.value.sId).toBe(connection1.sId);
       }
+    });
+  });
+
+  describe("listWorkspaceConnectionsByMCPServerIds", () => {
+    it("returns workspace connection resources for requested MCP servers only", async () => {
+      const { workspace, auth } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+      const connectedRemoteServer =
+        await RemoteMCPServerFactory.create(workspace);
+      const personalOnlyRemoteServer =
+        await RemoteMCPServerFactory.create(workspace);
+      const unrequestedRemoteServer =
+        await RemoteMCPServerFactory.create(workspace);
+      const connectedInternalMCPServerId = internalMCPServerNameToSId({
+        name: "agent_memory",
+        workspaceId: workspace.id,
+        prefix: 1,
+      });
+      const unrequestedInternalMCPServerId = internalMCPServerNameToSId({
+        name: "agent_memory",
+        workspaceId: workspace.id,
+        prefix: 2,
+      });
+
+      await MCPServerConnectionFactory.remote(
+        auth,
+        connectedRemoteServer,
+        "workspace"
+      );
+      await MCPServerConnectionFactory.remote(
+        auth,
+        personalOnlyRemoteServer,
+        "personal"
+      );
+      await MCPServerConnectionFactory.remote(
+        auth,
+        unrequestedRemoteServer,
+        "workspace"
+      );
+      await MCPServerConnectionFactory.internal(
+        auth,
+        connectedInternalMCPServerId,
+        "workspace"
+      );
+      await MCPServerConnectionFactory.internal(
+        auth,
+        unrequestedInternalMCPServerId,
+        "workspace"
+      );
+
+      const connections =
+        await MCPServerConnectionResource.listWorkspaceConnectionsByMCPServerIds(
+          auth,
+          {
+            mcpServerIds: [
+              connectedRemoteServer.sId,
+              personalOnlyRemoteServer.sId,
+              connectedInternalMCPServerId,
+            ],
+          }
+        );
+
+      expect(connections).toHaveLength(2);
+      expect(connections.map((c) => c.mcpServerId).sort()).toEqual(
+        [connectedInternalMCPServerId, connectedRemoteServer.sId].sort()
+      );
     });
   });
 });

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -22,6 +22,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { formatUserFullName } from "@app/types/user";
@@ -33,6 +34,11 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
+
+type MCPServerConnectionResourceFindOptions =
+  ResourceFindOptions<MCPServerConnectionModel> & {
+    includeUser?: boolean;
+  };
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -107,21 +113,32 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
 
   private static async baseFetch(
     auth: Authenticator,
-    { where, limit, order }: ResourceFindOptions<MCPServerConnectionModel> = {}
+    {
+      attributes,
+      where,
+      limit,
+      order,
+      includeUser = true,
+    }: MCPServerConnectionResourceFindOptions = {}
   ) {
     const connections = await this.model.findAll({
+      attributes,
       where: {
         ...where,
         workspaceId: auth.getNonNullableWorkspace().id,
       } as WhereOptions<MCPServerConnectionModel>,
       limit,
       order,
-      include: [
-        {
-          model: UserModel,
-          as: "user",
-        },
-      ],
+      ...(includeUser
+        ? {
+            include: [
+              {
+                model: UserModel,
+                as: "user",
+              },
+            ],
+          }
+        : {}),
     });
     return connections.map(
       (b) =>
@@ -304,6 +321,64 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
     return Array.from(latestConnectionsMap.values());
   }
 
+  static async listWorkspaceConnectionsByMCPServerIds(
+    auth: Authenticator,
+    { mcpServerIds }: { mcpServerIds: string[] }
+  ): Promise<MCPServerConnectionResource[]> {
+    const uniqueMCPServerIds = [...new Set(mcpServerIds)];
+    const internalMCPServerIds: string[] = [];
+    const remoteMCPServerModelIds: ModelId[] = [];
+
+    for (const mcpServerId of uniqueMCPServerIds) {
+      const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
+
+      if (serverType === "internal") {
+        internalMCPServerIds.push(mcpServerId);
+      } else {
+        remoteMCPServerModelIds.push(id);
+      }
+    }
+
+    const serverFilters: WhereOptions<MCPServerConnectionModel>[] = [];
+
+    if (internalMCPServerIds.length > 0) {
+      serverFilters.push({
+        serverType: "internal",
+        internalMCPServerId: {
+          [Op.in]: internalMCPServerIds,
+        },
+      });
+    }
+
+    if (remoteMCPServerModelIds.length > 0) {
+      serverFilters.push({
+        serverType: "remote",
+        remoteMCPServerId: {
+          [Op.in]: remoteMCPServerModelIds,
+        },
+      });
+    }
+
+    if (serverFilters.length === 0) {
+      return [];
+    }
+
+    return this.baseFetch(auth, {
+      attributes: [
+        "id",
+        "workspaceId",
+        "serverType",
+        "internalMCPServerId",
+        "remoteMCPServerId",
+      ],
+      where: {
+        connectionType: "workspace",
+        [Op.or]: serverFilters,
+      },
+      includeUser: false,
+    });
+  }
+
   // Deletion.
 
   static async deleteAllForWorkspace(auth: Authenticator) {
@@ -432,6 +507,34 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       id: this.id,
       workspaceId: this.workspaceId,
     });
+  }
+
+  get mcpServerId(): string {
+    switch (this.serverType) {
+      case "internal": {
+        if (!this.internalMCPServerId) {
+          throw new Error(
+            "This MCP server connection is missing an internal MCP server ID"
+          );
+        }
+
+        return this.internalMCPServerId;
+      }
+      case "remote": {
+        if (!this.remoteMCPServerId) {
+          throw new Error(
+            "This MCP server connection is missing a remote MCP server ID"
+          );
+        }
+
+        return remoteMCPServerNameToSId({
+          remoteMCPServerId: this.remoteMCPServerId,
+          workspaceId: this.workspaceId,
+        });
+      }
+      default:
+        return assertNever(this.serverType);
+    }
   }
 
   static modelIdToSId({

--- a/front/pages/api/w/[wId]/mcp/views/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/index.ts
@@ -77,10 +77,6 @@ async function handler(
 
       const query = r.data;
 
-      if (auth.isAdmin()) {
-        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-      }
-
       const views = await MCPServerViewResource.listBySpaceIds(
         auth,
         query.spaceIds

--- a/front/pages/api/w/[wId]/mcp/views/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/index.ts
@@ -2,11 +2,11 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
-  listWorkspaceConnectedMCPServerIds,
   oauthProviderRequiresWorkspaceConnectionForPersonalAuth,
   withWorkspaceConnectionRequirement,
 } from "@app/lib/api/mcp_oauth_prerequisites";
 import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -93,24 +93,38 @@ async function handler(
       // Some OAuth providers require a workspace-level connection before users
       // can set up personal connections. We enrich the authorization info so the
       // client can block the OAuth popup and show an inline error instead.
-      // The DB query is only made when at least one server in the list needs it.
-      const needsWorkspaceConnectionEnrichment = flattenedServerViews.some(
-        (v) =>
-          v.server.authorization !== null &&
-          oauthProviderRequiresWorkspaceConnectionForPersonalAuth(
-            v.server.authorization.provider
-          )
-      );
+      // The DB query is only made for servers in the list that need it.
+      const mcpServerIdsRequiringWorkspaceConnection = [
+        ...new Set(
+          flattenedServerViews
+            .filter(
+              (v) =>
+                v.server.authorization !== null &&
+                oauthProviderRequiresWorkspaceConnectionForPersonalAuth(
+                  v.server.authorization.provider
+                )
+            )
+            .map((v) => v.server.sId)
+        ),
+      ];
 
-      if (!needsWorkspaceConnectionEnrichment) {
+      if (mcpServerIdsRequiringWorkspaceConnection.length === 0) {
         return res.status(200).json({
           success: true,
           serverViews: flattenedServerViews,
         });
       }
 
-      const workspaceConnectedMCPServerIds =
-        await listWorkspaceConnectedMCPServerIds(auth);
+      const workspaceConnections =
+        await MCPServerConnectionResource.listWorkspaceConnectionsByMCPServerIds(
+          auth,
+          {
+            mcpServerIds: mcpServerIdsRequiringWorkspaceConnection,
+          }
+        );
+      const workspaceConnectedMCPServerIds = new Set(
+        workspaceConnections.map((connection) => connection.mcpServerId)
+      );
 
       return res.status(200).json({
         success: true,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -4,13 +4,13 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { sendMCPGlobalSharingReconfigurationEmail } from "@app/lib/api/email";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
-  listWorkspaceConnectedMCPServerIds,
   oauthProviderRequiresWorkspaceConnectionForPersonalAuth,
   withWorkspaceConnectionRequirement,
 } from "@app/lib/api/mcp_oauth_prerequisites";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import { getActiveAdminEmails } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -158,24 +158,38 @@ async function handler(
       // Some OAuth providers require a workspace-level connection before users
       // can set up personal connections. We enrich the authorization info so the
       // client can block the OAuth popup and show an inline error instead.
-      // The DB query is only made when at least one server in the list needs it.
-      const needsWorkspaceConnectionEnrichment = filteredServerViews.some(
-        (s) =>
-          s.server.authorization !== null &&
-          oauthProviderRequiresWorkspaceConnectionForPersonalAuth(
-            s.server.authorization.provider
-          )
-      );
+      // The DB query is only made for servers in the list that need it.
+      const mcpServerIdsRequiringWorkspaceConnection = [
+        ...new Set(
+          filteredServerViews
+            .filter(
+              (s) =>
+                s.server.authorization !== null &&
+                oauthProviderRequiresWorkspaceConnectionForPersonalAuth(
+                  s.server.authorization.provider
+                )
+            )
+            .map((s) => s.server.sId)
+        ),
+      ];
 
-      if (!needsWorkspaceConnectionEnrichment) {
+      if (mcpServerIdsRequiringWorkspaceConnection.length === 0) {
         return res.status(200).json({
           success: true,
           serverViews: filteredServerViews,
         });
       }
 
-      const workspaceConnectedMCPServerIds =
-        await listWorkspaceConnectedMCPServerIds(auth);
+      const workspaceConnections =
+        await MCPServerConnectionResource.listWorkspaceConnectionsByMCPServerIds(
+          auth,
+          {
+            mcpServerIds: mcpServerIdsRequiringWorkspaceConnection,
+          }
+        );
+      const workspaceConnectedMCPServerIds = new Set(
+        workspaceConnections.map((connection) => connection.mcpServerId)
+      );
 
       return res.status(200).json({
         success: true,


### PR DESCRIPTION
## Description

This PR improves the performances of the `/mcp/views` endpoint.
As it is called when opening the slash suggestion dropdown list we need it to be fast.

- Remove `ensureAllAutoToolsAreCreated`. Adds ~80ms of latency for admins and seems quite arbitrary to have it here (traces [here](https://app.datadoghq.eu/apm/traces?query=env%3Aprod%20resource_name%3AensureAllAutoToolsAreCreated&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_span.count%2C%40_duration.by_service&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&sort_by=%40duration&sort_order=desc&spanType=all&storage=hot&target-span=a&tq_query_translation_version=v0&traceQuery=a&view=spans&viz=stream&start=1777194062504&end=1777366862504&paused=false)).
- Filter MCP server connections to fetch instead of listing all connections on the workspace.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
