### PR TITLE
Lower access token expiry buffer

### DIFF
--- a/connectors/src/types/oauth/client/access_token.ts
+++ b/connectors/src/types/oauth/client/access_token.ts
@@ -8,7 +8,7 @@ import { OAuthAPI } from "../../oauth/oauth_api";
 const OAUTH_ACCESS_TOKEN_CACHE_TTL = 1000 * 60 * 5;
 const CACHE_CLEAR_INTERVAL = 1000 * 60;
 // Mirror the OAuth server's refresh buffer so we never serve a token the server would already refresh.
-const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 1000 * 60 * 10;
+const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 1000 * 60 * 8;
 
 const CACHE = new Map<
   string,

--- a/connectors/src/types/oauth/client/access_token.ts
+++ b/connectors/src/types/oauth/client/access_token.ts
@@ -8,7 +8,7 @@ import { OAuthAPI } from "../../oauth/oauth_api";
 const OAUTH_ACCESS_TOKEN_CACHE_TTL = 1000 * 60 * 5;
 const CACHE_CLEAR_INTERVAL = 1000 * 60;
 // Mirror the OAuth server's refresh buffer so we never serve a token the server would already refresh.
-const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 1000 * 60 * 8;
+const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 1000 * 60 * 5;
 
 const CACHE = new Map<
   string,
@@ -55,7 +55,14 @@ export async function getOAuthConnectionAccessToken({
       return new Ok(cached);
     }
 
-    logger.warn({ connectionId, provider }, "Local cache has expired tokens");
+    logger.warn(
+      {
+        access_token_expiry: cached.access_token_expiry,
+        connectionId,
+        provider,
+      },
+      "Local cache has expired tokens"
+    );
   }
 
   const res = await new OAuthAPI(config, logger).getAccessToken({

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -59,7 +59,7 @@ pub fn provider_timeout_seconds(provider: ConnectionProvider) -> u64 {
 // refresh it.
 // NOTE: connectors/src/types/oauth/client/access_token.ts mirrors this value as
 // ACCESS_TOKEN_EXPIRY_BUFFER_MS. If you change this constant, update that file too.
-pub static ACCESS_TOKEN_REFRESH_BUFFER_MILLIS: u64 = 10 * 60 * 1000;
+pub static ACCESS_TOKEN_REFRESH_BUFFER_MILLIS: u64 = 8 * 60 * 1000;
 
 pub static CONNECTION_ID_PREFIX: &str = "con";
 

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -59,7 +59,7 @@ pub fn provider_timeout_seconds(provider: ConnectionProvider) -> u64 {
 // refresh it.
 // NOTE: connectors/src/types/oauth/client/access_token.ts mirrors this value as
 // ACCESS_TOKEN_EXPIRY_BUFFER_MS. If you change this constant, update that file too.
-pub static ACCESS_TOKEN_REFRESH_BUFFER_MILLIS: u64 = 8 * 60 * 1000;
+pub static ACCESS_TOKEN_REFRESH_BUFFER_MILLIS: u64 = 5 * 60 * 1000;
 
 pub static CONNECTION_ID_PREFIX: &str = "con";
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/24898. It flagged a lot of tokens, zooming a bit Microsoft seems the most impacted. This stems from the fact that access tokens issued by Microsoft are only valid for 10 minutes. This PR lowers the access token expiry buffer to 5 minutes.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Deploy core first
- [ ] Then deploy connectors
