### PR TITLE
Reinforcement: drop the source column from agent suggestions

### DIFF
--- a/front/components/poke/suggestions/columns.tsx
+++ b/front/components/poke/suggestions/columns.tsx
@@ -130,15 +130,6 @@ export function makeColumnsForSuggestions(
       },
     },
     {
-      accessorKey: "source",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Source" />
-      ),
-      filterFn: (row, id, value) => {
-        return value.includes(row.getValue(id));
-      },
-    },
-    {
       accessorKey: "conversationId",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Conversation" />

--- a/front/components/poke/suggestions/table.tsx
+++ b/front/components/poke/suggestions/table.tsx
@@ -7,7 +7,6 @@ import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import {
   AGENT_SUGGESTION_KINDS,
-  AGENT_SUGGESTION_SOURCES,
   AGENT_SUGGESTION_STATES,
 } from "@app/types/suggestions/agent_suggestion";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -90,14 +89,6 @@ export function SuggestionDataTable({
       options: AGENT_SUGGESTION_STATES.map((state) => ({
         label: asDisplayName(state),
         value: state,
-      })),
-    },
-    {
-      columnId: "source",
-      title: "Source",
-      options: AGENT_SUGGESTION_SOURCES.map((source) => ({
-        label: asDisplayName(source),
-        value: source,
       })),
     },
   ];

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -64,7 +64,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import type {
-  AgentSuggestionSource,
   AgentSuggestionState,
   KnowledgeSuggestionType,
   SubAgentSuggestionType,
@@ -196,13 +195,11 @@ export async function createInstructionSuggestions({
   auth,
   agentConfigurationId,
   suggestions,
-  source,
   conversation,
 }: {
   auth: Authenticator;
   agentConfigurationId: string;
   suggestions: InstructionSuggestionInput[];
-  source: AgentSuggestionSource;
   conversation?: ConversationResource;
 }): Promise<
   Result<{ sId: string; kind: string; targetBlockId: string }[], string>
@@ -274,7 +271,6 @@ export async function createInstructionSuggestions({
         suggestion: suggestionData,
         analysis: analysis ?? null,
         state: "pending",
-        source,
         conversationId: conversation?.id ?? null,
       }
     );
@@ -307,13 +303,11 @@ export async function createToolsSuggestions({
   auth,
   agentConfigurationId,
   suggestions,
-  source,
   conversation,
 }: {
   auth: Authenticator;
   agentConfigurationId: string;
   suggestions: ToolsSuggestionInput[];
-  source: AgentSuggestionSource;
   conversation?: ConversationResource;
 }): Promise<Result<{ sId: string; kind: string }[], string>> {
   // Reject batches where multiple suggestions target the same tool.
@@ -403,7 +397,6 @@ export async function createToolsSuggestions({
         suggestion,
         analysis: analysis ?? null,
         state: "pending",
-        source,
         conversationId: conversation?.id ?? null,
       }
     );
@@ -426,13 +419,11 @@ export async function createSkillsSuggestions({
   auth,
   agentConfigurationId,
   suggestions,
-  source,
   conversation,
 }: {
   auth: Authenticator;
   agentConfigurationId: string;
   suggestions: SkillsSuggestionInput[];
-  source: AgentSuggestionSource;
   conversation?: ConversationResource;
 }): Promise<Result<{ sId: string; kind: string }[], string>> {
   // Reject batches where multiple suggestions target the same skill.
@@ -509,7 +500,6 @@ export async function createSkillsSuggestions({
         suggestion: { action, skillId },
         analysis: analysis ?? null,
         state: "pending",
-        source,
         conversationId: conversation?.id ?? null,
       }
     );
@@ -888,7 +878,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         auth,
         agentConfigurationId,
         suggestions: params.suggestions,
-        source: "sidekick",
       });
 
       if (result.isErr()) {
@@ -933,7 +922,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         auth,
         agentConfigurationId,
         suggestions: params.suggestions,
-        source: "sidekick",
       });
 
       if (result.isErr()) {
@@ -1062,7 +1050,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
             suggestion,
             analysis: params.analysis ?? null,
             state: "pending",
-            source: "sidekick",
           }
         );
 
@@ -1100,7 +1087,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
         auth,
         agentConfigurationId,
         suggestions: params.suggestions,
-        source: "sidekick",
       });
 
       if (result.isErr()) {
@@ -1176,7 +1162,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
           suggestion: params.suggestion,
           analysis: params.analysis ?? null,
           state: "pending",
-          source: "sidekick",
         }
       );
 
@@ -1404,7 +1389,6 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
             suggestion,
             analysis: params.analysis ?? null,
             state: "pending",
-            source: "sidekick",
           }
         );
 

--- a/front/lib/api/poke/plugins/agents/clean_suggestions.ts
+++ b/front/lib/api/poke/plugins/agents/clean_suggestions.ts
@@ -41,7 +41,6 @@ export const cleanSuggestionsPlugin = createPlugin({
         resource.sId,
         {
           states: selectedStates,
-          sources: ["sidekick"],
         }
       );
 

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -4,7 +4,6 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   AgentSuggestionKind,
-  AgentSuggestionSource,
   AgentSuggestionState,
   SuggestionPayload,
 } from "@app/types/suggestions/agent_suggestion";
@@ -22,7 +21,6 @@ export class AgentSuggestionModel extends WorkspaceAwareModel<AgentSuggestionMod
   declare analysis: string | null;
 
   declare state: AgentSuggestionState;
-  declare source: AgentSuggestionSource;
   declare conversationId: ForeignKey<ConversationModel["id"]> | null;
 
   declare agentConfiguration: NonAttribute<AgentConfigurationModel>;
@@ -68,11 +66,6 @@ AgentSuggestionModel.init(
       allowNull: false,
       comment:
         "Current state of the suggestion (e.g., pending, accepted, rejected...)",
-    },
-    source: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      comment: "Origin of the suggestion such as reinforcement or sidekick",
     },
     conversationId: {
       type: DataTypes.BIGINT,

--- a/front/lib/resources/agent_suggestion_resource.test.ts
+++ b/front/lib/resources/agent_suggestion_resource.test.ts
@@ -135,13 +135,11 @@ describe("AgentSuggestionResource", () => {
             action: "add",
             skillId: "data_analysis",
           },
-          source: "sidekick",
         }
       );
 
       expect(suggestion).toBeDefined();
       expect(suggestion.kind).toBe("skills");
-      expect(suggestion.source).toBe("sidekick");
 
       const fetched = await AgentSuggestionResource.fetchById(
         authenticator,
@@ -166,13 +164,11 @@ describe("AgentSuggestionResource", () => {
             action: "remove",
             skillId: "old_skill",
           },
-          source: "sidekick",
         }
       );
 
       expect(suggestion).toBeDefined();
       expect(suggestion.kind).toBe("skills");
-      expect(suggestion.source).toBe("sidekick");
 
       const fetched = await AgentSuggestionResource.fetchById(
         authenticator,
@@ -395,7 +391,6 @@ describe("AgentSuggestionResource", () => {
             },
             analysis: null,
             state: "pending",
-            source: "sidekick",
           }
         )
       ).rejects.toThrow("User does not have permission to edit this agent");

--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -15,7 +15,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type {
   AgentSuggestionKind,
-  AgentSuggestionSource,
   AgentSuggestionState,
   AgentSuggestionType,
 } from "@app/types/suggestions/agent_suggestion";
@@ -264,7 +263,6 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
     agentId: string,
     filters?: {
       states?: AgentSuggestionState[];
-      sources?: AgentSuggestionSource[];
       kind?: AgentSuggestionKind;
       limit?: number;
     }
@@ -286,19 +284,10 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
 
     const agentConfigIds = agentConfigs.map((ac) => ac.id);
 
-    // Build the where clause with optional filters.
-    // By default, exclude synthetic suggestions (internal to the reinforcement
-    // pipeline) unless an explicit sources filter is provided.
-    const sourceFilter =
-      filters?.sources && filters.sources.length > 0
-        ? { source: filters.sources }
-        : { source: { [Op.ne]: "synthetic" } };
-
     const whereClause: WhereOptions<AgentSuggestionModel> = {
       agentConfigurationId: agentConfigIds,
       ...(filters?.states &&
         filters.states.length > 0 && { state: filters.states }),
-      ...sourceFilter,
       ...(filters?.kind && { kind: filters.kind }),
     };
 
@@ -440,37 +429,9 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
       agentConfigurationId: this.agentConfigurationId,
       analysis: this.analysis,
       state: this.state,
-      source: this.source,
       conversationId: this._conversationId,
       ...suggestionData,
     };
-  }
-
-  /**
-   * Deletes all synthetic suggestions older than the given cutoff date.
-   * Requires admin permissions. Returns the number of deleted rows.
-   */
-  static async deleteExpiredSynthetic(
-    auth: Authenticator,
-    cutoffDate: Date,
-    { limit }: { limit?: number } = {}
-  ): Promise<number> {
-    if (!auth.isAdmin()) {
-      throw new Error(
-        "Only workspace admins can delete expired synthetic suggestions"
-      );
-    }
-
-    const owner = auth.getNonNullableWorkspace();
-
-    return AgentSuggestionModel.destroy({
-      where: {
-        workspaceId: owner.id,
-        source: "synthetic",
-        createdAt: { [Op.lt]: cutoffDate },
-      },
-      limit,
-    });
   }
 
   /**
@@ -490,7 +451,6 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
     agentIds: string[],
     filters?: {
       states?: AgentSuggestionState[];
-      sources?: AgentSuggestionSource[];
       kind?: AgentSuggestionKind;
       limit?: number;
       createdAfter?: Date;
@@ -521,8 +481,6 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
       agentConfigurationId: agentConfigIds,
       ...(filters?.states &&
         filters.states.length > 0 && { state: filters.states }),
-      ...(filters?.sources &&
-        filters.sources.length > 0 && { source: filters.sources }),
       ...(filters?.kind && { kind: filters.kind }),
       ...(filters?.createdAfter && {
         createdAt: { [Op.gte]: filters.createdAfter },

--- a/front/migrations/db/migration_605.sql
+++ b/front/migrations/db/migration_605.sql
@@ -1,0 +1,3 @@
+-- Migration created on Apr 28, 2026
+ALTER TABLE agent_suggestions
+  ALTER COLUMN source SET DEFAULT 'sidekick';

--- a/front/migrations/db/migration_606.sql
+++ b/front/migrations/db/migration_606.sql
@@ -1,0 +1,5 @@
+-- Migration created on Apr 28, 2026
+
+DELETE FROM agent_suggestions WHERE source != 'sidekick';
+
+ALTER TABLE agent_suggestions DROP COLUMN IF EXISTS source;

--- a/front/pages/api/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
@@ -7,7 +7,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
-import { AGENT_SUGGESTION_SOURCES } from "@app/types/suggestions/agent_suggestion";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type PokeListSuggestions = {
@@ -46,9 +45,7 @@ async function handler(
   switch (req.method) {
     case "GET": {
       const suggestions =
-        await AgentSuggestionResource.listByAgentConfigurationId(auth, aId, {
-          sources: [...AGENT_SUGGESTION_SOURCES],
-        });
+        await AgentSuggestionResource.listByAgentConfigurationId(auth, aId);
 
       return res.status(200).json({
         suggestions: suggestions.map((s) => s.toJSON()),

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
@@ -224,7 +224,6 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/suggestions", 
         },
         analysis: "Test analysis",
         state: "pending",
-        source: "sidekick",
       }
     );
 
@@ -244,7 +243,6 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/suggestions", 
       state: "approved",
       kind: "instructions",
       analysis: "Test analysis",
-      source: "sidekick",
       suggestion: {
         content: "<p>new text</p>",
         targetBlockId: "block123",

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
@@ -127,7 +127,6 @@ async function handler(
           agentConfigurationId,
           {
             states,
-            sources: ["sidekick"],
             kind,
             limit: parsedLimit,
           }

--- a/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/existing.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/existing.ts
@@ -26,7 +26,7 @@ function buildFirstMessage({
 }: {
   feedbackMarkdown: string | null;
   insightsMarkdown: string | null;
-  pendingSuggestions: Array<{ sId: string; kind: string; source: string }>;
+  pendingSuggestions: Array<{ sId: string; kind: string }>;
 }): string {
   const dataSections = [feedbackMarkdown, insightsMarkdown]
     .filter(Boolean)
@@ -227,7 +227,6 @@ async function handler(
             agentConfigurationId,
             {
               states: ["pending"],
-              sources: ["sidekick"],
               limit: MAX_PENDING_SUGGESTIONS_IN_FIRST_MESSAGE,
             }
           ),
@@ -240,7 +239,6 @@ async function handler(
           pendingSuggestions: pendingSuggestions.map((s) => ({
             sId: s.sId,
             kind: s.kind,
-            source: s.source,
           })),
         })
       );

--- a/front/scripts/seed/factories/seedAgentSuggestions.ts
+++ b/front/scripts/seed/factories/seedAgentSuggestions.ts
@@ -226,7 +226,6 @@ export async function seedAgentSuggestions(
           suggestion: resolvedSuggestion,
           analysis: suggestionAsset.analysis,
           state: "pending",
-          source: "sidekick",
         }
       );
 

--- a/front/tests/utils/AgentSuggestionFactory.ts
+++ b/front/tests/utils/AgentSuggestionFactory.ts
@@ -3,7 +3,6 @@ import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_res
 import { frontSequelize } from "@app/lib/resources/storage";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
-  AgentSuggestionSource,
   AgentSuggestionState,
   InstructionsSuggestionSchemaType,
   ModelSuggestionType,
@@ -20,7 +19,6 @@ export class AgentSuggestionFactory {
       suggestion: InstructionsSuggestionSchemaType;
       analysis: string | null;
       state: AgentSuggestionState;
-      source: AgentSuggestionSource;
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.createSuggestionForAgent(
@@ -36,7 +34,6 @@ export class AgentSuggestionFactory {
         analysis:
           overrides.analysis ?? "Improved instructions for better coding help",
         state: overrides.state ?? "pending",
-        source: overrides.source ?? "sidekick",
       }
     );
   }
@@ -48,7 +45,6 @@ export class AgentSuggestionFactory {
       suggestion: ToolsSuggestionType;
       analysis: string | null;
       state: AgentSuggestionState;
-      source: AgentSuggestionSource;
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.createSuggestionForAgent(
@@ -62,7 +58,6 @@ export class AgentSuggestionFactory {
         },
         analysis: overrides.analysis ?? "Added useful integration",
         state: overrides.state ?? "pending",
-        source: overrides.source ?? "sidekick",
       }
     );
   }
@@ -74,7 +69,6 @@ export class AgentSuggestionFactory {
       suggestion: SubAgentSuggestionType;
       analysis: string | null;
       state: AgentSuggestionState;
-      source: AgentSuggestionSource;
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.createSuggestionForAgent(
@@ -89,7 +83,6 @@ export class AgentSuggestionFactory {
         },
         analysis: overrides.analysis ?? "Added sub-agent delegation",
         state: overrides.state ?? "pending",
-        source: overrides.source ?? "sidekick",
       }
     );
   }
@@ -101,7 +94,6 @@ export class AgentSuggestionFactory {
       suggestion: SkillsSuggestionType;
       analysis: string | null;
       state: AgentSuggestionState;
-      source: AgentSuggestionSource;
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.createSuggestionForAgent(
@@ -115,7 +107,6 @@ export class AgentSuggestionFactory {
         },
         analysis: overrides.analysis ?? "Added skill for better assistance",
         state: overrides.state ?? "pending",
-        source: overrides.source ?? "sidekick",
       }
     );
   }
@@ -127,7 +118,6 @@ export class AgentSuggestionFactory {
       suggestion: ModelSuggestionType;
       analysis: string | null;
       state: AgentSuggestionState;
-      source: AgentSuggestionSource;
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.createSuggestionForAgent(
@@ -141,7 +131,6 @@ export class AgentSuggestionFactory {
         },
         analysis: overrides.analysis ?? "Suggested a more capable model",
         state: overrides.state ?? "pending",
-        source: overrides.source ?? "sidekick",
       }
     );
   }

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -26,11 +26,6 @@ export const AGENT_SUGGESTION_STATES = [
 
 export type AgentSuggestionState = (typeof AGENT_SUGGESTION_STATES)[number];
 
-// TODO(fabien) drop this column
-export const AGENT_SUGGESTION_SOURCES = ["sidekick"] as const;
-
-export type AgentSuggestionSource = (typeof AGENT_SUGGESTION_SOURCES)[number];
-
 export const INSTRUCTIONS_ROOT_TARGET_BLOCK_ID = "instructions-root";
 
 const ToolsSuggestionSchema = z.object({
@@ -159,7 +154,6 @@ const BaseAgentSuggestionSchema = z.object({
   agentConfigurationId: z.number(),
   analysis: z.string().nullable(),
   state: z.enum(AGENT_SUGGESTION_STATES),
-  source: z.enum(AGENT_SUGGESTION_SOURCES),
   conversationId: z.string().nullable(),
 });
 


### PR DESCRIPTION
## Description

This is no longer use, so let's simplify the codebase

## Tests

unit tests still there
tested migration locally

## Risk

low

## Deploy Plan

lock front
merge PR
apply first migration to add default value
deploy front
wait
run migration to delete column
unlock front