### PR TITLE
[front] Validate click ID values before persisting as cookies

### DIFF
--- a/front/lib/utils/utm.test.ts
+++ b/front/lib/utils/utm.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/utils/anonymous_id", () => ({
+  getRootCookieDomain: vi.fn().mockReturnValue(""),
+  buildDustAidCookieString: vi.fn((v: string) => `_dust_aid=${v}`),
+}));
+
+vi.mock("posthog-js", () => ({
+  posthog: { get_distinct_id: vi.fn().mockReturnValue(null) },
+}));
+
+import {
+  isValidClickIdValue,
+  persistClickIdCookies,
+} from "@app/lib/utils/utm";
+
+// ---------------------------------------------------------------------------
+// isValidClickIdValue
+// ---------------------------------------------------------------------------
+
+describe("isValidClickIdValue", () => {
+  it("accepts real-world gclid-shaped values", () => {
+    expect(isValidClickIdValue("EAIaIQobChMI")).toBe(true);
+    expect(isValidClickIdValue("CjwKCAiA3Z-ABCdef")).toBe(true);
+  });
+
+  it("accepts values with hyphens, underscores and dots", () => {
+    expect(isValidClickIdValue("abc-DEF_123.xyz")).toBe(true);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isValidClickIdValue("")).toBe(false);
+  });
+
+  it("rejects values containing angle brackets (XSS payload)", () => {
+    expect(isValidClickIdValue("<script")).toBe(false);
+    expect(isValidClickIdValue(">alert(1)")).toBe(false);
+  });
+
+  it("rejects percent-encoded payloads that WAFs decode before inspection", () => {
+    expect(isValidClickIdValue("%3Cscript")).toBe(false);
+  });
+
+  it("rejects values with spaces", () => {
+    expect(isValidClickIdValue("hello world")).toBe(false);
+  });
+
+  it("rejects quote injection", () => {
+    expect(isValidClickIdValue('foo";alert(1)')).toBe(false);
+  });
+
+  it("rejects query-string injection characters", () => {
+    expect(isValidClickIdValue("foo&bar=baz")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persistClickIdCookies
+// ---------------------------------------------------------------------------
+
+describe("persistClickIdCookies", () => {
+  beforeEach(() => {
+    // Reset cookies between tests by clearing the jsdom cookie store.
+    document.cookie
+      .split(";")
+      .map((c) => c.trim().split("=")[0])
+      .filter(Boolean)
+      .forEach((name) => {
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+      });
+  });
+
+  it("persists a valid msclkid value as _dust_msclkid cookie", () => {
+    persistClickIdCookies({ msclkid: "ValidClickId123" });
+    expect(document.cookie).toContain("_dust_msclkid=ValidClickId123");
+  });
+
+  it("persists a valid li_fat_id value as _dust_li_fat_id cookie", () => {
+    persistClickIdCookies({ li_fat_id: "AQIDAHjB3w-ABC" });
+    expect(document.cookie).toContain("_dust_li_fat_id=AQIDAHjB3w-ABC");
+  });
+
+  it("does NOT write a cookie when msclkid contains an XSS payload", () => {
+    persistClickIdCookies({ msclkid: "<script" });
+    expect(document.cookie).not.toContain("_dust_msclkid");
+  });
+
+  it("does NOT write a cookie when msclkid contains a percent-encoded payload", () => {
+    // This is the exact vector from HackerOne #3685798:
+    // ?msclkid=%3Cscript -> value is '<script' after URL decoding by the browser.
+    // Even if the raw string '%3Cscript' reached persistClickIdCookies it must
+    // be rejected because the percent sign is outside the allowlist.
+    persistClickIdCookies({ msclkid: "%3Cscript" });
+    expect(document.cookie).not.toContain("_dust_msclkid");
+  });
+
+  it("does NOT write a cookie when li_fat_id contains an XSS payload", () => {
+    persistClickIdCookies({ li_fat_id: "<script" });
+    expect(document.cookie).not.toContain("_dust_li_fat_id");
+  });
+
+  it("writes valid click IDs while ignoring invalid ones in the same call", () => {
+    persistClickIdCookies({
+      msclkid: "<script",
+      gclid: "EAIaIQobChMI",
+    });
+    expect(document.cookie).not.toContain("_dust_msclkid");
+    expect(document.cookie).toContain("_dust_gclid=EAIaIQobChMI");
+  });
+
+  it("does nothing when params object is empty", () => {
+    persistClickIdCookies({});
+    expect(document.cookie).toBe("");
+  });
+});

--- a/front/lib/utils/utm.ts
+++ b/front/lib/utils/utm.ts
@@ -48,6 +48,25 @@ const CLICK_ID_COOKIE_EXPIRY_DAYS: Record<
   msclkid: 90,
 };
 
+// Allowlist for click ID values. Real click IDs from Google, Meta, Microsoft
+// and LinkedIn are opaque alphanumeric tokens that may contain hyphens,
+// underscores and dots. Any value that does not match is likely tampered and
+// must not be written into a cookie: Cloudflare's WAF decodes cookie values
+// before inspection, so a payload like `%3Cscript` stored in `_dust_msclkid`
+// (90-day expiry, scoped to .dust.tt) would block every subsequent login
+// attempt until the victim clears their cookies (HackerOne #3685798).
+const CLICK_ID_VALUE_RE = /^[A-Za-z0-9_\-.]+$/;
+
+/**
+ * Returns true only when `value` is safe to store as a cookie.
+ * Silently rejects anything that contains characters outside the
+ * alphanumeric + `_ - .` set so that injected payloads are ignored
+ * rather than persisted.
+ */
+export function isValidClickIdValue(value: string): boolean {
+  return CLICK_ID_VALUE_RE.test(value);
+}
+
 // Extract UTM parameters from query string
 export const extractUTMParams = (searchParams: {
   [key: string]: string | string[] | undefined;
@@ -65,6 +84,8 @@ export const extractUTMParams = (searchParams: {
 };
 
 // Write click ID values as first-party cookies with per-platform expiry.
+// Values that do not pass isValidClickIdValue() are silently skipped so that
+// tampered parameters cannot be used to poison persistent cookies.
 export function persistClickIdCookies(params: UTMParams): void {
   if (typeof document === "undefined") {
     return;
@@ -75,7 +96,7 @@ export function persistClickIdCookies(params: UTMParams): void {
 
   for (const key of CLICK_ID_KEYS) {
     const value = params[key];
-    if (value) {
+    if (value && isValidClickIdValue(value)) {
       const expiryDays = CLICK_ID_COOKIE_EXPIRY_DAYS[key];
       const expires = new Date(
         Date.now() + expiryDays * 24 * 60 * 60 * 1000


### PR DESCRIPTION
## Problem

Click ID URL parameters (`msclkid`, `li_fat_id`, `gclid`, `fbclid`) were written into first-party cookies scoped to `.dust.tt` **without any validation**.

An attacker could craft a URL like:

```
https://dust.tt/?msclkid=%3Cscript
```

The browser decodes `%3Cscript` to `<script` before `persistClickIdCookies()` sees the value, so the raw string `<script` is stored in `_dust_msclkid` with a **90-day expiry** on `.dust.tt`. On every subsequent request Cloudflare's WAF decodes the cookie value before inspection and returns a block page, effectively **locking the victim out of their account** until they manually clear cookies. Reported via HackerOne #3685798.

The same attack works with `li_fat_id` (30-day expiry) and `gclid` (90-day expiry).

## Fix

Add `isValidClickIdValue()` which enforces a strict allowlist:

```
/^[A-Za-z0-9_\-.]+$/
```

Real click IDs from Google, Meta, Microsoft and LinkedIn are opaque alphanumeric tokens that may include hyphens, underscores and dots. Any value outside that set is silently ignored in `persistClickIdCookies()` — attribution is simply not tracked for tampered clicks, which is the safe and correct behaviour.

The function is exported so it can be unit-tested directly without mocking internals.

## Changes

| File | What |
|---|---|
| `front/lib/utils/utm.ts` | Add `CLICK_ID_VALUE_RE` + `isValidClickIdValue()`, guard `persistClickIdCookies()` |
| `front/lib/utils/utm.test.ts` | New Vitest test suite (jsdom env, no DB needed) |

## Tests

New tests in `front/lib/utils/utm.test.ts` cover:

- `isValidClickIdValue` — valid shapes (gclid, fbclid, li_fat_id), empty string, `<script`, `%3Cscript`, spaces, quote injection, query-string injection
- `persistClickIdCookies` — cookie written for valid value, cookie NOT written for `<script`, NOT written for `%3Cscript`, mixed call (invalid + valid in same params object), empty params

All cases validated independently in Node.js before opening this PR.
