### PR TITLE
Exclude drafts in the zendesk connectors

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_article.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_article.ts
@@ -83,6 +83,22 @@ export async function syncArticle({
     brandId: category.brandId,
     articleId: article.id,
   });
+
+  // Drafts (unpublished articles) must not be exposed in the data source. If the article was
+  // previously synced as published and is now a draft, remove the existing data.
+  if (article.draft) {
+    if (articleInDb) {
+      await deleteArticle({
+        connectorId,
+        brandId: category.brandId,
+        articleId: article.id,
+        dataSourceConfig,
+        loggerArgs,
+      });
+    }
+    return;
+  }
+
   const updatedAtDate = new Date(article.updated_at);
 
   // we either create a new article or update the existing one

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -213,6 +213,7 @@ export const ZendeskArticleSchema = z
     vote_sum: z.number(),
     name: z.string(),
     label_names: z.array(z.string()).optional(),
+    draft: z.boolean(),
   })
   .passthrough();
 

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -213,7 +213,7 @@ export const ZendeskArticleSchema = z
     vote_sum: z.number(),
     name: z.string(),
     label_names: z.array(z.string()).optional(),
-    draft: z.boolean(),
+    draft: z.boolean().optional(),
   })
   .passthrough();
 

--- a/front/lib/api/actions/servers/zendesk/types.ts
+++ b/front/lib/api/actions/servers/zendesk/types.ts
@@ -213,6 +213,7 @@ export const ZendeskArticleSchema = z
     vote_sum: z.number(),
     name: z.string(),
     label_names: z.array(z.string()).optional(),
+    draft: z.boolean().optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Description

- Adds draft to ZendeskArticleSchema so we can read article publication status.
- In syncArticle, early-returns when article.draft === true. If the article was previously synced (i.e., it transitioned from published → draft), it is first deleted from the data source and DB so unpublished content is no longer exposed to agents.

Fixes https://github.com/dust-tt/tasks/issues/7911

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Some customers may actually expect drafts to sync, but that seems unlikely.

## Deploy Plan

Connectors.