### PR TITLE
Return id when credit/commit  already exist

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -633,10 +633,27 @@ export async function createMetronomeCommit({
     return new Ok(response.data);
   } catch (err) {
     if (err instanceof ConflictError) {
-      // Idempotency key conflict — commit already created, safe to ignore.
+      // Idempotency key conflict — commit already created, look it up by
+      // uniqueness_key so the caller can persist the existing id.
+      const existing = await findMetronomeCommitByUniquenessKey({
+        metronomeCustomerId,
+        uniquenessKey: idempotencyKey,
+        coveringDate: roundedStartingAt,
+      });
+      if (existing.isOk() && existing.value) {
+        logger.info(
+          {
+            metronomeCustomerId,
+            idempotencyKey,
+            metronomeCommitId: existing.value.id,
+          },
+          "[Metronome] Commit already exists (idempotent), reusing id"
+        );
+        return new Ok({ id: existing.value.id });
+      }
       logger.info(
         { metronomeCustomerId, idempotencyKey },
-        "[Metronome] Commit already exists (idempotent)"
+        "[Metronome] Commit already exists (idempotent) but lookup did not find it"
       );
       return new Ok(null);
     }
@@ -655,6 +672,31 @@ export async function createMetronomeCommit({
     );
     return new Err(error);
   }
+}
+
+/**
+ * Find a customer-level commit by its uniqueness_key.
+ * Used to recover the id after a 409 conflict on creation.
+ * Scoped via covering_date so we don't paginate through expired commits.
+ */
+export async function findMetronomeCommitByUniquenessKey({
+  metronomeCustomerId,
+  uniquenessKey,
+  coveringDate,
+}: {
+  metronomeCustomerId: string;
+  uniquenessKey: string;
+  coveringDate: string;
+}): Promise<Result<{ id: string } | null, Error>> {
+  const result = await listMetronomeCustomerCommits({
+    metronomeCustomerId,
+    coveringDate,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  const match = result.value.find((c) => c.uniqueness_key === uniquenessKey);
+  return new Ok(match ? { id: match.id } : null);
 }
 
 // ---------------------------------------------------------------------------
@@ -917,10 +959,27 @@ export async function createMetronomeCredit({
     return new Ok(response.data);
   } catch (err) {
     if (err instanceof ConflictError) {
-      // Idempotency key conflict — credit already granted, safe to ignore.
+      // Idempotency key conflict — credit already granted, look it up by
+      // uniqueness_key so the caller can persist the existing id.
+      const existing = await findMetronomeCreditByUniquenessKey({
+        metronomeCustomerId,
+        uniquenessKey: idempotencyKey,
+        coveringDate: roundedStartingAt,
+      });
+      if (existing.isOk() && existing.value) {
+        logger.info(
+          {
+            metronomeCustomerId,
+            idempotencyKey,
+            metronomeCreditId: existing.value.id,
+          },
+          "[Metronome] Credit grant already exists (idempotent), reusing id"
+        );
+        return new Ok({ id: existing.value.id });
+      }
       logger.info(
         { metronomeCustomerId, idempotencyKey },
-        "[Metronome] Credit grant already exists (idempotent)"
+        "[Metronome] Credit grant already exists (idempotent) but lookup did not find it"
       );
       return new Ok(null);
     }
@@ -935,6 +994,31 @@ export async function createMetronomeCredit({
 }
 
 /**
+ * Find a customer-level credit by its uniqueness_key.
+ * Used to recover the id after a 409 conflict on creation.
+ * Scoped via covering_date so we don't paginate through expired credits.
+ */
+export async function findMetronomeCreditByUniquenessKey({
+  metronomeCustomerId,
+  uniquenessKey,
+  coveringDate,
+}: {
+  metronomeCustomerId: string;
+  uniquenessKey: string;
+  coveringDate: string;
+}): Promise<Result<{ id: string } | null, Error>> {
+  const result = await listMetronomeCustomerCredits({
+    metronomeCustomerId,
+    coveringDate,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  const match = result.value.find((c) => c.uniqueness_key === uniquenessKey);
+  return new Ok(match ? { id: match.id } : null);
+}
+
+/**
  * List customer-level credits for a Metronome customer.
  * Optionally filter by a specific credit id.
  */
@@ -943,23 +1027,23 @@ export async function listMetronomeCustomerCredits({
   creditId,
   includeContractCredits = false,
   includeBalance = false,
+  coveringDate,
 }: {
   metronomeCustomerId: string;
   creditId?: string;
   includeContractCredits?: boolean;
   includeBalance?: boolean;
+  coveringDate?: string;
 }): Promise<Result<Credit[], Error>> {
   try {
-    const credits: Credit[] = [];
-    for await (const entry of getMetronomeClient().v1.customers.credits.list({
+    const page = await getMetronomeClient().v1.customers.credits.list({
       customer_id: metronomeCustomerId,
       ...(creditId ? { credit_id: creditId } : {}),
+      ...(coveringDate ? { covering_date: coveringDate } : {}),
       include_contract_credits: includeContractCredits,
       include_balance: includeBalance,
-    })) {
-      credits.push(entry);
-    }
-    return new Ok(credits);
+    });
+    return new Ok(page.data);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
@@ -979,23 +1063,23 @@ export async function listMetronomeCustomerCommits({
   commitId,
   includeContractCommits = false,
   includeBalance = false,
+  coveringDate,
 }: {
   metronomeCustomerId: string;
   commitId?: string;
   includeContractCommits?: boolean;
   includeBalance?: boolean;
+  coveringDate?: string;
 }): Promise<Result<Commit[], Error>> {
   try {
-    const commits: Commit[] = [];
-    for await (const entry of getMetronomeClient().v1.customers.commits.list({
+    const page = await getMetronomeClient().v1.customers.commits.list({
       customer_id: metronomeCustomerId,
       ...(commitId ? { commit_id: commitId } : {}),
+      ...(coveringDate ? { covering_date: coveringDate } : {}),
       include_contract_commits: includeContractCommits,
       include_balance: includeBalance,
-    })) {
-      commits.push(entry);
-    }
-    return new Ok(commits);
+    });
+    return new Ok(page.data);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(

--- a/front/scripts/backfill_metronome_credits.ts
+++ b/front/scripts/backfill_metronome_credits.ts
@@ -154,9 +154,11 @@ async function backfillCreditsOfType(
           const client = getMetronomeClient();
           const contractsResponse = await client.v2.contracts.list({
             customer_id: metronomeCustomerId,
+            covering_date: new Date().toISOString(),
           });
           const contract = contractsResponse.data[0];
           const freeCreditProductId = getProductFreeMonthlyCreditId();
+
           const existingRecurringCredit = contract.recurring_credits?.find(
             (rc) => rc.product.id === freeCreditProductId
           );


### PR DESCRIPTION
## Description

When `createMetronomeCommit` / `createMetronomeCredit` hit a 409 due to the
`uniqueness_key`, we previously returned `Ok(null)` and lost the id of the
existing entry. Callers (`backfill_metronome_credits.ts`, the "buy programmatic
usage credits" Poke plugin, and the commit purchase flow in
`lib/credits/committed.ts`) all guard their `credit.setMetronomeCreditId(...)`
on `result.value`, so a conflict left the DB row unlinked even though the
commit/credit existed in Metronome.

This PR adds two helpers — `findMetronomeCommitByUniquenessKey` and
`findMetronomeCreditByUniquenessKey` — that look the existing entry up by its
`uniqueness_key` (exposed on both `Commit` and `Credit` SDK types) and return
its id. On `ConflictError`, the create functions now call these helpers and
return `Ok({ id })` instead of `Ok(null)`. If the lookup somehow misses, we
fall back to `Ok(null)` so the existing skip path still acts as a safety net.

To keep the lookup cheap, the find helpers require a `coveringDate` and pass
it through to Metronome's `covering_date` filter, scoping the listing to
entries active on that date — we never need to page through expired
commits/credits. The conflict branches pass the same `roundedStartingAt` we
just used to attempt creation, which is guaranteed to cover the colliding
entry.

While in there, simplified `listMetronomeCustomerCommits` and
`listMetronomeCustomerCredits` to a plain `await` returning `page.data`
instead of `for await` auto-pagination. Both helpers are only used internally
for narrow lookups (by id or by `covering_date` + `uniqueness_key`), so a
single page is always sufficient.

Net effect: re-running the backfill now links previously-conflicted rows, and
new conflicts in the Poke plugin / commit purchase flow also write
`metronomeCreditId` instead of silently leaving it empty.

## Tests

Manual: type-check passes (`npx tsgo --noEmit`). No unit tests existed for
these helpers; behavior is covered end-to-end by re-running
`scripts/backfill_metronome_credits.ts` on a workspace whose row was previously
left unlinked due to a conflict and verifying `metronomeCreditId` is populated.

## Risk

- Each 409 now triggers an additional list call, but it's scoped via
  `covering_date` to a single Metronome page — bounded cost.
- A 409 thrown for a non-uniqueness-key reason would result in a wasted list
  call and `Ok(null)` — same outcome as before.
- Concurrent dual-create with the same idempotency key: if Metronome has any
  read-after-write delay, the lookup may miss and fall back to `Ok(null)`,
  i.e. current behavior. Self-heals on the next backfill run.
- Dropping `for await` on the two list helpers means we now look at a single
  page only. Both internal callers narrow the result set (by id, or by
  `covering_date` + `uniqueness_key`) so a page is enough; no production caller
  relied on multi-page iteration.
- No DB schema, endpoint contract, or public API change. Safe to roll back by
  reverting the commit.

## Deploy Plan

Standard deploy. After it ships, re-run
\`npx tsx scripts/backfill_metronome_credits.ts --execute\` to link the
workspaces whose rows were left unlinked by previous conflicts.