### PR TITLE
fix(project-todo): prevent version churn on multi-source todos

### DIFF
--- a/front/lib/project_todo/deduplicate_candidates.test.ts
+++ b/front/lib/project_todo/deduplicate_candidates.test.ts
@@ -1,5 +1,6 @@
 import {
   type DeduplicateCandidate,
+  pickPrimaryByItemId,
   resolveDeduplicationGroups,
 } from "@app/lib/project_todo/deduplicate_candidates";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -7,13 +8,13 @@ import { describe, expect, it } from "vitest";
 
 // ── Test fixtures ─────────────────────────────────────────────────────────────
 
-// The resolver passes the todo reference through without reading any of its
-// fields, so tests work against a minimal structural stub — no cast to
-// ProjectTodoResource is needed thanks to the resolver's generic parameter.
-type TodoStub = { sId: string };
+// The resolver only reads `id` on existing todos (to pick the oldest as the
+// cluster primary), so tests work against a minimal structural stub — no cast
+// to ProjectTodoResource is needed thanks to the resolver's generic parameter.
+type TodoStub = { sId: string; id: ModelId };
 
-function makeTodo(sId: string): TodoStub {
-  return { sId };
+function makeTodo(sId: string, id: number): TodoStub {
+  return { sId, id: id as ModelId };
 }
 
 function makeCandidate(
@@ -57,7 +58,7 @@ describe("resolveDeduplicationGroups", () => {
 
   it("maps a cluster with a single existing todo into an 'existing' group", () => {
     // Cluster = [existing#0, candidate#0] → one "existing" group.
-    const existing = [makeTodo("todo-1")];
+    const existing = [makeTodo("todo-1", 1)];
     const candidates = [makeCandidate({ itemId: "a" })];
     const result = resolveDeduplicationGroups(candidates, existing, [[0, 1]]);
 
@@ -66,23 +67,23 @@ describe("resolveDeduplicationGroups", () => {
     ]);
   });
 
-  it("picks the first existing when a cluster contains multiple existing todos", () => {
-    // Two existing + one candidate. First existing wins; second existing is
-    // ignored (we don't merge existing todos here).
-    const existing = [makeTodo("todo-1"), makeTodo("todo-2")];
+  it("picks the oldest existing (smallest id) when a cluster contains multiple existing todos", () => {
+    // Two existing + one candidate. The oldest (smallest id) wins regardless
+    // of LLM listing order; the other existing is ignored.
+    const existing = [makeTodo("todo-newer", 42), makeTodo("todo-older", 7)];
     const candidates = [makeCandidate({ itemId: "a" })];
-    // Indexes: 0,1 are existing; 2 is the candidate.
+    // LLM lists the newer one first; the resolver must still pick the oldest.
     const result = resolveDeduplicationGroups(candidates, existing, [
       [0, 1, 2],
     ]);
 
     expect(result).toEqual([
-      { kind: "existing", todo: existing[0], candidates: [candidates[0]] },
+      { kind: "existing", todo: existing[1], candidates: [candidates[0]] },
     ]);
   });
 
-  it("links every candidate in a cluster to the first existing when one exists", () => {
-    const existing = [makeTodo("todo-1")];
+  it("links every candidate in a cluster to the existing todo when one exists", () => {
+    const existing = [makeTodo("todo-1", 1)];
     const candidates = [
       makeCandidate({ itemId: "a" }),
       makeCandidate({ itemId: "b" }),
@@ -125,7 +126,7 @@ describe("resolveDeduplicationGroups", () => {
   it("honors an index only in the first cluster it appears in", () => {
     // If the LLM lists the same candidate in two clusters, the second
     // occurrence is dropped so a candidate can't be silently reassigned.
-    const existing = [makeTodo("todo-1")];
+    const existing = [makeTodo("todo-1", 1)];
     const candidates = [
       makeCandidate({ itemId: "a" }),
       makeCandidate({ itemId: "b" }),
@@ -146,7 +147,7 @@ describe("resolveDeduplicationGroups", () => {
   it("ignores clusters that contain no candidate", () => {
     // A cluster of two existing todos and no candidate → dropped. The lone
     // candidate in its own cluster survives as a "new" group.
-    const existing = [makeTodo("todo-1"), makeTodo("todo-2")];
+    const existing = [makeTodo("todo-1", 1), makeTodo("todo-2", 2)];
     const candidates = [makeCandidate({ itemId: "a" })];
     const result = resolveDeduplicationGroups(candidates, existing, [
       [0, 1],
@@ -160,7 +161,7 @@ describe("resolveDeduplicationGroups", () => {
     // The LLM grouped candidate a with the existing todo but forgot about
     // candidate b — b must still end up in its own group so its source is
     // not dropped.
-    const existing = [makeTodo("todo-1")];
+    const existing = [makeTodo("todo-1", 1)];
     const candidates = [
       makeCandidate({ itemId: "a" }),
       makeCandidate({ itemId: "b" }),
@@ -171,5 +172,35 @@ describe("resolveDeduplicationGroups", () => {
       { kind: "existing", todo: existing[0], candidates: [candidates[0]] },
       { kind: "new", candidates: [candidates[1]] },
     ]);
+  });
+});
+
+// ── pickPrimaryByItemId ───────────────────────────────────────────────────────
+
+describe("pickPrimaryByItemId", () => {
+  it("returns the only candidate when there is one", () => {
+    const c = makeCandidate({ itemId: "only" });
+    expect(pickPrimaryByItemId([c])).toBe(c);
+  });
+
+  it("picks the candidate with the smallest itemId", () => {
+    const a = makeCandidate({ itemId: "item-a", text: "phrasing A" });
+    const b = makeCandidate({ itemId: "item-b", text: "phrasing B" });
+    const c = makeCandidate({ itemId: "item-c", text: "phrasing C" });
+
+    expect(pickPrimaryByItemId([b, c, a])).toBe(a);
+    expect(pickPrimaryByItemId([c, a, b])).toBe(a);
+  });
+
+  it("is stable: same set returns the same primary regardless of input order", () => {
+    // Phase 3 used to pick candidates[0], whose order depends on the LLM's
+    // listing — that produced one new todo version per merge when the picked
+    // text disagreed with previous runs. Smallest-itemId selection removes
+    // that dependency.
+    const a = makeCandidate({ itemId: "item-a", text: "first wording" });
+    const b = makeCandidate({ itemId: "item-b", text: "second wording" });
+
+    expect(pickPrimaryByItemId([a, b]).text).toBe("first wording");
+    expect(pickPrimaryByItemId([b, a]).text).toBe("first wording");
   });
 });

--- a/front/lib/project_todo/deduplicate_candidates.ts
+++ b/front/lib/project_todo/deduplicate_candidates.ts
@@ -60,10 +60,25 @@ export type DeduplicatedGroup =
     }
   | {
       kind: "new";
-      // Non-empty. candidates[0] drives the new todo's content; later entries
-      // attach their sources to that todo.
+      // Non-empty. The caller picks one candidate (typically by smallest
+      // itemId for stability) to drive the new todo's content, and attaches
+      // every other candidate's source to that todo.
       candidates: DeduplicateCandidate[];
     };
+
+// Picks the candidate with the smallest itemId. Used by Phase 3 to choose a
+// stable "primary" within a dedup group: the chosen candidate's blob drives
+// the existing todo update or the new todo creation, while every other
+// candidate's source is attached. Stability matters because the alternative
+// (depending on LLM listing order) makes the chosen content jitter across
+// merges and produces a new todo version every run.
+//
+// Precondition: candidates is non-empty.
+export function pickPrimaryByItemId(
+  candidates: DeduplicateCandidate[]
+): DeduplicateCandidate {
+  return candidates.reduce((min, c) => (c.itemId < min.itemId ? c : min));
+}
 
 // Nested map shape for existing todos passed in by the caller:
 // userId → todos.
@@ -237,8 +252,12 @@ export async function runDeduplicationLLMCall(
 // ── Group resolution ─────────────────────────────────────────────────────────
 
 // Generic over the todo type so unit tests can pass a minimal structural stub
-// instead of a full ProjectTodoResource.
-type ResolvedGroupOf<TTodo> =
+// instead of a full ProjectTodoResource. Requires an `id` field so the resolver
+// can pick the oldest existing todo (smallest id) as the cluster primary,
+// independent of the order the LLM listed them.
+type TodoWithId = { id: ModelId };
+
+type ResolvedGroupOf<TTodo extends TodoWithId> =
   | { kind: "existing"; todo: TTodo; candidates: DeduplicateCandidate[] }
   | { kind: "new"; candidates: DeduplicateCandidate[] };
 
@@ -254,13 +273,13 @@ type ResolvedGroupOf<TTodo> =
 //
 // Per-cluster resolution:
 //   - No candidate → cluster dropped.
-//   - ≥1 existing  → "existing" group pointing at the first existing (extras
-//                    ignored).
+//   - ≥1 existing  → "existing" group pointing at the oldest existing todo
+//                    (smallest id); extras ignored.
 //   - No existing  → "new" group (first candidate drives content).
 //
 // Any candidate the LLM forgot to place in a cluster is emitted as its own
 // singleton "new" group so no source ever disappears.
-export function resolveDeduplicationGroups<TTodo>(
+export function resolveDeduplicationGroups<TTodo extends TodoWithId>(
   candidates: DeduplicateCandidate[],
   existingTodos: TTodo[],
   groups: number[][]
@@ -291,9 +310,14 @@ export function resolveDeduplicationGroups<TTodo>(
     }
 
     if (existingInGroup.length >= 1) {
+      // Pick the oldest existing todo (smallest id) so the chosen primary is
+      // stable regardless of the order the LLM listed them in the cluster.
+      const primary = existingInGroup.reduce((min, t) =>
+        t.id < min.id ? t : min
+      );
       result.push({
         kind: "existing",
-        todo: existingInGroup[0],
+        todo: primary,
         candidates: candidatesInGroup,
       });
     } else {

--- a/front/lib/project_todo/deduplicate_candidates.ts
+++ b/front/lib/project_todo/deduplicate_candidates.ts
@@ -252,12 +252,7 @@ export async function runDeduplicationLLMCall(
 // ── Group resolution ─────────────────────────────────────────────────────────
 
 // Generic over the todo type so unit tests can pass a minimal structural stub
-// instead of a full ProjectTodoResource. Requires an `id` field so the resolver
-// can pick the oldest existing todo (smallest id) as the cluster primary,
-// independent of the order the LLM listed them.
-type TodoWithId = { id: ModelId };
-
-type ResolvedGroupOf<TTodo extends TodoWithId> =
+type ResolvedGroupOf<TTodo extends { id: ModelId }> =
   | { kind: "existing"; todo: TTodo; candidates: DeduplicateCandidate[] }
   | { kind: "new"; candidates: DeduplicateCandidate[] };
 
@@ -279,7 +274,7 @@ type ResolvedGroupOf<TTodo extends TodoWithId> =
 //
 // Any candidate the LLM forgot to place in a cluster is emitted as its own
 // singleton "new" group so no source ever disappears.
-export function resolveDeduplicationGroups<TTodo extends TodoWithId>(
+export function resolveDeduplicationGroups<TTodo extends { id: ModelId }>(
   candidates: DeduplicateCandidate[],
   existingTodos: TTodo[],
   groups: number[][]

--- a/front/lib/project_todo/merge_into_project.test.ts
+++ b/front/lib/project_todo/merge_into_project.test.ts
@@ -1,7 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
   actionItemBlob,
-  dedupeUpdateIntentsByTodoId,
+  mergeUpdateIntentsByTodoId,
   updateTodoIfChanged,
 } from "@app/lib/project_todo/merge_into_project";
 import type { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
@@ -235,76 +235,168 @@ describe("updateTodoIfChanged", () => {
   });
 });
 
-// ── dedupeUpdateIntentsByTodoId ───────────────────────────────────────────────
+// ── mergeUpdateIntentsByTodoId ────────────────────────────────────────────────
 
-// Structural stub for intents — the helper only reads `todo.id` and `itemId`.
+type StubBlob = {
+  text: string;
+  status: "todo" | "done";
+  doneAt: Date | null;
+  reasoningDoneAt: string | null;
+};
+
 type IntentStub = {
   todo: { id: ModelId };
   itemId: string;
-  tag: string;
+  blob: StubBlob;
 };
 
-function makeIntent(todoId: number, itemId: string, tag: string): IntentStub {
-  return { todo: { id: todoId as ModelId }, itemId, tag };
+function makeStubBlob(overrides: Partial<StubBlob> = {}): StubBlob {
+  return {
+    text: "default text",
+    status: "todo",
+    doneAt: null,
+    reasoningDoneAt: null,
+    ...overrides,
+  };
 }
 
-describe("dedupeUpdateIntentsByTodoId", () => {
+function makeIntent(
+  todoId: number,
+  itemId: string,
+  blobOverrides: Partial<StubBlob> = {}
+): IntentStub {
+  return {
+    todo: { id: todoId as ModelId },
+    itemId,
+    blob: makeStubBlob(blobOverrides),
+  };
+}
+
+describe("mergeUpdateIntentsByTodoId", () => {
   it("returns an empty array when there are no intents", () => {
-    expect(dedupeUpdateIntentsByTodoId([])).toEqual([]);
+    expect(mergeUpdateIntentsByTodoId([])).toEqual([]);
   });
 
-  it("keeps a single intent for a single todo as-is", () => {
-    const intent = makeIntent(1, "item-a", "only");
-    expect(dedupeUpdateIntentsByTodoId([intent])).toEqual([intent]);
+  it("keeps a single intent's blob as-is for a single todo", () => {
+    const intent = makeIntent(1, "item-a", { text: "only" });
+    const result = mergeUpdateIntentsByTodoId([intent]);
+    expect(result).toEqual([{ todo: intent.todo, blob: intent.blob }]);
   });
 
-  it("collapses multiple intents on the same todo to the smallest itemId", () => {
-    // Reproduces the version-churn bug: same todo linked to 3 sources whose
-    // action items have different content. Only the smallest-itemId intent
-    // should survive so the picked content is stable across merge runs.
+  it("emits one merged update per distinct todo, with text from the smallest itemId", () => {
+    // Reproduces the version-churn case: 3 sources on the same todo with
+    // different wording. The merged text must come from the smallest-itemId
+    // source so it stays stable across runs.
     const intents = [
-      makeIntent(42, "item-c", "third"),
-      makeIntent(42, "item-a", "first"),
-      makeIntent(42, "item-b", "second"),
+      makeIntent(42, "item-c", { text: "third phrasing" }),
+      makeIntent(42, "item-a", { text: "first phrasing" }),
+      makeIntent(42, "item-b", { text: "second phrasing" }),
     ];
 
-    const result = dedupeUpdateIntentsByTodoId(intents);
+    const result = mergeUpdateIntentsByTodoId(intents);
 
     expect(result).toHaveLength(1);
-    expect(result[0].itemId).toBe("item-a");
-    expect(result[0].tag).toBe("first");
+    expect(result[0].blob.text).toBe("first phrasing");
   });
 
-  it("emits one survivor per distinct todo", () => {
-    // Two todos, three intents on the first one and one on the second.
+  it("emits one merged update per distinct todo", () => {
     const intents = [
-      makeIntent(1, "item-z", "todo1-z"),
-      makeIntent(2, "item-q", "todo2-q"),
-      makeIntent(1, "item-a", "todo1-a"),
-      makeIntent(1, "item-m", "todo1-m"),
+      makeIntent(1, "item-z", { text: "todo1-z" }),
+      makeIntent(2, "item-q", { text: "todo2-q" }),
+      makeIntent(1, "item-a", { text: "todo1-a" }),
+      makeIntent(1, "item-m", { text: "todo1-m" }),
     ];
 
-    const result = dedupeUpdateIntentsByTodoId(intents);
-    const byTodoId = new Map(result.map((i) => [i.todo.id, i]));
+    const result = mergeUpdateIntentsByTodoId(intents);
+    const byTodoId = new Map(result.map((r) => [r.todo.id, r]));
 
     expect(result).toHaveLength(2);
-    expect(byTodoId.get(1 as ModelId)?.itemId).toBe("item-a");
-    expect(byTodoId.get(2 as ModelId)?.itemId).toBe("item-q");
+    expect(byTodoId.get(1 as ModelId)?.blob.text).toBe("todo1-a");
+    expect(byTodoId.get(2 as ModelId)?.blob.text).toBe("todo2-q");
   });
 
-  it("is order-independent (same input set → same survivor regardless of input order)", () => {
-    // Stability property: the result must not depend on the order intents
-    // were collected in (e.g. across parallel takeaway processing).
-    const a = makeIntent(7, "item-a", "a");
-    const b = makeIntent(7, "item-b", "b");
-    const c = makeIntent(7, "item-c", "c");
+  it("keeps status='todo' when no source reports done", () => {
+    const intents = [
+      makeIntent(1, "item-a", { status: "todo", text: "stable" }),
+      makeIntent(1, "item-b", { status: "todo", text: "other" }),
+    ];
 
-    const r1 = dedupeUpdateIntentsByTodoId([a, b, c]);
-    const r2 = dedupeUpdateIntentsByTodoId([c, b, a]);
-    const r3 = dedupeUpdateIntentsByTodoId([b, c, a]);
+    const [r] = mergeUpdateIntentsByTodoId(intents);
+
+    expect(r.blob.status).toBe("todo");
+    expect(r.blob.doneAt).toBeNull();
+    expect(r.blob.reasoningDoneAt).toBeNull();
+    expect(r.blob.text).toBe("stable");
+  });
+
+  it("flips to 'done' when any source reports done, even if it is not the text primary", () => {
+    // Concrete scenario behind this rule: the smallest-itemId source still
+    // reports the task as open, but a later takeaway extracted the same task
+    // and detected it as done. The "done" signal must propagate.
+    const doneAt = new Date("2026-04-22T00:00:00.000Z");
+    const intents = [
+      makeIntent(1, "item-a", { status: "todo", text: "stable text" }),
+      makeIntent(1, "item-b", {
+        status: "done",
+        doneAt,
+        reasoningDoneAt: "completed in PR #123",
+        text: "alternate phrasing",
+      }),
+    ];
+
+    const [r] = mergeUpdateIntentsByTodoId(intents);
+
+    expect(r.blob.status).toBe("done");
+    expect(r.blob.doneAt).toEqual(doneAt);
+    expect(r.blob.reasoningDoneAt).toBe("completed in PR #123");
+    // Text stays from the smallest-itemId source for stability.
+    expect(r.blob.text).toBe("stable text");
+  });
+
+  it("uses the smallest-itemId done source for status fields when multiple sources report done", () => {
+    const earlier = new Date("2026-04-20T00:00:00.000Z");
+    const later = new Date("2026-04-22T00:00:00.000Z");
+    const intents = [
+      makeIntent(1, "item-a", { status: "todo", text: "stable text" }),
+      makeIntent(1, "item-c", {
+        status: "done",
+        doneAt: later,
+        reasoningDoneAt: "reason-c",
+      }),
+      makeIntent(1, "item-b", {
+        status: "done",
+        doneAt: earlier,
+        reasoningDoneAt: "reason-b",
+      }),
+    ];
+
+    const [r] = mergeUpdateIntentsByTodoId(intents);
+
+    expect(r.blob.status).toBe("done");
+    expect(r.blob.doneAt).toEqual(earlier);
+    expect(r.blob.reasoningDoneAt).toBe("reason-b");
+    expect(r.blob.text).toBe("stable text");
+  });
+
+  it("is order-independent (same input set → same merged result regardless of input order)", () => {
+    const a = makeIntent(7, "item-a", { text: "A", status: "todo" });
+    const b = makeIntent(7, "item-b", {
+      text: "B",
+      status: "done",
+      doneAt: new Date("2026-04-22T00:00:00.000Z"),
+      reasoningDoneAt: "rb",
+    });
+    const c = makeIntent(7, "item-c", { text: "C", status: "todo" });
+
+    const r1 = mergeUpdateIntentsByTodoId([a, b, c]);
+    const r2 = mergeUpdateIntentsByTodoId([c, b, a]);
+    const r3 = mergeUpdateIntentsByTodoId([b, c, a]);
 
     expect(r1).toEqual(r2);
     expect(r2).toEqual(r3);
-    expect(r1[0].itemId).toBe("item-a");
+    // Sanity: text from a (smallest itemId), status fields from b (only done).
+    expect(r1[0].blob.text).toBe("A");
+    expect(r1[0].blob.status).toBe("done");
+    expect(r1[0].blob.reasoningDoneAt).toBe("rb");
   });
 });

--- a/front/lib/project_todo/merge_into_project.test.ts
+++ b/front/lib/project_todo/merge_into_project.test.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
   actionItemBlob,
+  dedupeUpdateIntentsByTodoId,
   updateTodoIfChanged,
 } from "@app/lib/project_todo/merge_into_project";
 import type { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
@@ -8,6 +9,7 @@ import type {
   ProjectTodoActorType,
   ProjectTodoStatus,
 } from "@app/types/project_todo";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { TodoVersionedActionItem } from "@app/types/takeaways";
 import { describe, expect, it, vi } from "vitest";
 
@@ -230,5 +232,79 @@ describe("updateTodoIfChanged", () => {
       doneAt: null,
       actorRationale: null,
     });
+  });
+});
+
+// ── dedupeUpdateIntentsByTodoId ───────────────────────────────────────────────
+
+// Structural stub for intents — the helper only reads `todo.id` and `itemId`.
+type IntentStub = {
+  todo: { id: ModelId };
+  itemId: string;
+  tag: string;
+};
+
+function makeIntent(todoId: number, itemId: string, tag: string): IntentStub {
+  return { todo: { id: todoId as ModelId }, itemId, tag };
+}
+
+describe("dedupeUpdateIntentsByTodoId", () => {
+  it("returns an empty array when there are no intents", () => {
+    expect(dedupeUpdateIntentsByTodoId([])).toEqual([]);
+  });
+
+  it("keeps a single intent for a single todo as-is", () => {
+    const intent = makeIntent(1, "item-a", "only");
+    expect(dedupeUpdateIntentsByTodoId([intent])).toEqual([intent]);
+  });
+
+  it("collapses multiple intents on the same todo to the smallest itemId", () => {
+    // Reproduces the version-churn bug: same todo linked to 3 sources whose
+    // action items have different content. Only the smallest-itemId intent
+    // should survive so the picked content is stable across merge runs.
+    const intents = [
+      makeIntent(42, "item-c", "third"),
+      makeIntent(42, "item-a", "first"),
+      makeIntent(42, "item-b", "second"),
+    ];
+
+    const result = dedupeUpdateIntentsByTodoId(intents);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].itemId).toBe("item-a");
+    expect(result[0].tag).toBe("first");
+  });
+
+  it("emits one survivor per distinct todo", () => {
+    // Two todos, three intents on the first one and one on the second.
+    const intents = [
+      makeIntent(1, "item-z", "todo1-z"),
+      makeIntent(2, "item-q", "todo2-q"),
+      makeIntent(1, "item-a", "todo1-a"),
+      makeIntent(1, "item-m", "todo1-m"),
+    ];
+
+    const result = dedupeUpdateIntentsByTodoId(intents);
+    const byTodoId = new Map(result.map((i) => [i.todo.id, i]));
+
+    expect(result).toHaveLength(2);
+    expect(byTodoId.get(1 as ModelId)?.itemId).toBe("item-a");
+    expect(byTodoId.get(2 as ModelId)?.itemId).toBe("item-q");
+  });
+
+  it("is order-independent (same input set → same survivor regardless of input order)", () => {
+    // Stability property: the result must not depend on the order intents
+    // were collected in (e.g. across parallel takeaway processing).
+    const a = makeIntent(7, "item-a", "a");
+    const b = makeIntent(7, "item-b", "b");
+    const c = makeIntent(7, "item-c", "c");
+
+    const r1 = dedupeUpdateIntentsByTodoId([a, b, c]);
+    const r2 = dedupeUpdateIntentsByTodoId([c, b, a]);
+    const r3 = dedupeUpdateIntentsByTodoId([b, c, a]);
+
+    expect(r1).toEqual(r2);
+    expect(r2).toEqual(r3);
+    expect(r1[0].itemId).toBe("item-a");
   });
 });

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -39,6 +39,7 @@ import {
   type DeduplicateCandidate,
   type DeduplicatedGroup,
   type ExistingTodosByUser,
+  pickPrimaryByItemId,
 } from "@app/lib/project_todo/deduplicate_candidates";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
@@ -75,6 +76,38 @@ type PendingCandidate = {
   blob: TodoBlob;
   source: ProjectTodoSourceInfo;
 };
+
+// One pending content update for an already-linked (todo, user) pair. Several
+// intents can target the same todo when it is linked to multiple sources whose
+// action items disagree on text/status/rationale (typical when the same task
+// is extracted from N different takeaways with slightly different wording).
+// Phase 1 deduplicates intents per todo before applying so sources do not
+// take turns overwriting each other and producing one new version per source
+// per merge run.
+export type ExistingUpdateIntent = {
+  todo: ProjectTodoResource;
+  userId: ModelId;
+  itemId: string;
+  blob: TodoBlob;
+};
+
+// Picks at most one intent per todo, keeping the one with the smallest itemId.
+// Stability across runs is what fixes the version-churn bug: once the picked
+// blob lands on the todo, the next merge sees no diff and does not cut a new
+// version. Generic so unit tests can pass a structural stub instead of a real
+// ProjectTodoResource.
+export function dedupeUpdateIntentsByTodoId<
+  TIntent extends { todo: { id: ModelId }; itemId: string },
+>(intents: TIntent[]): TIntent[] {
+  const byTodoId = new Map<ModelId, TIntent>();
+  for (const intent of intents) {
+    const current = byTodoId.get(intent.todo.id);
+    if (current === undefined || intent.itemId < current.itemId) {
+      byTodoId.set(intent.todo.id, intent);
+    }
+  }
+  return [...byTodoId.values()];
+}
 
 // ── Stats ─────────────────────────────────────────────────────────────────────
 
@@ -185,8 +218,13 @@ export async function mergeTakeawaysIntoProject({
 // ── Phase 1 ───────────────────────────────────────────────────────────────────
 
 // For each (takeaway, item, targetUser) triple: if a source link already exists,
-// update the todo's content if it has changed. Otherwise, push the item to the
+// record an intent to update the todo's content. Otherwise, push the item to the
 // returned candidates list for semantic dedup in phase 2.
+//
+// All intents are collected first and then deduplicated per todo before being
+// applied: a todo linked to N sources whose action items have slightly
+// different text would otherwise see N updates per merge, with each source
+// overwriting the previous, producing N new versions every run.
 async function collectNewCandidates(
   auth: Authenticator,
   {
@@ -198,7 +236,7 @@ async function collectNewCandidates(
   }
 ): Promise<{ candidates: PendingCandidate[]; existingUpdated: number }> {
   const newCandidates: PendingCandidate[] = [];
-  let existingUpdated = 0;
+  const allIntents: ExistingUpdateIntent[] = [];
 
   await concurrentExecutor(
     latestTakeawaysWithSource,
@@ -208,7 +246,21 @@ async function collectNewCandidates(
         usersById,
       });
       newCandidates.push(...result.candidates);
-      existingUpdated += result.existingUpdated;
+      allIntents.push(...result.existingUpdateIntents);
+    },
+    { concurrency: 4 }
+  );
+
+  const dedupedIntents = dedupeUpdateIntentsByTodoId(allIntents);
+
+  let existingUpdated = 0;
+  await concurrentExecutor(
+    dedupedIntents,
+    async (intent) => {
+      const updated = await updateTodoIfChanged(intent.todo, auth, intent.blob);
+      if (updated) {
+        existingUpdated++;
+      }
     },
     { concurrency: 4 }
   );
@@ -216,8 +268,11 @@ async function collectNewCandidates(
   return { candidates: newCandidates, existingUpdated };
 }
 
-// Processes one document's takeaway: updates todos whose source link already
-// exists and returns items that need to go through dedup + creation.
+// Processes one document's takeaway: returns intents to update todos whose
+// source link already exists, and items that need to go through dedup +
+// creation. Updates are not applied here — the caller deduplicates intents
+// across all takeaways before applying so a todo linked to multiple sources
+// is only updated once per merge.
 async function collectDocumentCandidates(
   auth: Authenticator,
   {
@@ -227,7 +282,10 @@ async function collectDocumentCandidates(
     takeawayWithSource: TakeawaysWithSource;
     usersById: Map<string, UserResource>;
   }
-): Promise<{ candidates: PendingCandidate[]; existingUpdated: number }> {
+): Promise<{
+  candidates: PendingCandidate[];
+  existingUpdateIntents: ExistingUpdateIntent[];
+}> {
   function resolveTargetUserIds(userSIds: string[]): ModelId[] {
     return userSIds
       .map((sId) => usersById.get(sId)?.id)
@@ -257,32 +315,24 @@ async function collectDocumentCandidates(
   });
 
   const candidates: PendingCandidate[] = [];
-  let existingUpdated = 0;
-  for (const { itemId, targetUserIds, blob: actionItemBlob } of actionItems) {
+  const existingUpdateIntents: ExistingUpdateIntent[] = [];
+  for (const { itemId, targetUserIds, blob } of actionItems) {
     for (const userId of targetUserIds) {
       const existing = existingByKey.get(itemId)?.get(userId) ?? null;
       if (existing !== null) {
-        // Source link exists — update content if it has changed.
-        const updated = await updateTodoIfChanged(
-          existing,
-          auth,
-          actionItemBlob
-        );
-        if (updated) {
-          existingUpdated++;
-        }
+        existingUpdateIntents.push({ todo: existing, userId, itemId, blob });
       } else {
         candidates.push({
           itemId,
           userId,
-          blob: actionItemBlob,
+          blob,
           source: takeawayWithSource.source,
         });
       }
     }
   }
 
-  return { candidates, existingUpdated };
+  return { candidates, existingUpdateIntents };
 }
 
 // ── Phase 2 ───────────────────────────────────────────────────────────────────
@@ -388,8 +438,11 @@ async function createOrLinkTodos(
       if (group.kind === "existing") {
         // Attach every candidate's source to the existing todo. The update
         // guard lives in updateTodoIfChanged — no-op when the target todo was
-        // created by a user or already marked done by one.
-        const primary = lookupPending(group.candidates[0]);
+        // created by a user or already marked done by one. Pick the primary
+        // by smallest itemId so the blob driving the update is stable across
+        // runs and we do not re-version on every merge when candidates'
+        // texts disagree.
+        const primary = lookupPending(pickPrimaryByItemId(group.candidates));
         if (primary) {
           await updateTodoIfChanged(group.todo, auth, primary.blob);
         }
@@ -418,9 +471,12 @@ async function createOrLinkTodos(
         return;
       }
 
-      // kind === "new": create one todo from the first candidate, attach every
-      // other candidate's source to it.
-      const primary = lookupPending(group.candidates[0]);
+      // kind === "new": create one todo using the candidate with the smallest
+      // itemId as the content source, then attach every other candidate's
+      // source to it. Smallest-itemId selection keeps the chosen primary
+      // stable across runs.
+      const primaryCandidate = pickPrimaryByItemId(group.candidates);
+      const primary = lookupPending(primaryCandidate);
       if (!primary) {
         return;
       }
@@ -451,8 +507,11 @@ async function createOrLinkTodos(
         "Project todo merge: created new todo"
       );
 
-      for (let i = 1; i < group.candidates.length; i++) {
-        const pending = lookupPending(group.candidates[i]);
+      for (const candidate of group.candidates) {
+        if (candidate.itemId === primaryCandidate.itemId) {
+          continue;
+        }
+        const pending = lookupPending(candidate);
         if (!pending) {
           continue;
         }

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -91,22 +91,66 @@ export type ExistingUpdateIntent = {
   blob: TodoBlob;
 };
 
-// Picks at most one intent per todo, keeping the one with the smallest itemId.
-// Stability across runs is what fixes the version-churn bug: once the picked
-// blob lands on the todo, the next merge sees no diff and does not cut a new
-// version. Generic so unit tests can pass a structural stub instead of a real
-// ProjectTodoResource.
-export function dedupeUpdateIntentsByTodoId<
-  TIntent extends { todo: { id: ModelId }; itemId: string },
->(intents: TIntent[]): TIntent[] {
-  const byTodoId = new Map<ModelId, TIntent>();
+// Merges the intents targeting each todo down to a single update so a todo
+// linked to N sources with disagreeing action items only produces at most one
+// new version per merge run. Two stability rules drive the merge:
+//
+//   - text comes from the smallest-itemId source ("text primary"), so the
+//     applied text does not jitter across runs when several sources report
+//     slightly different wording for the same task;
+//   - status / doneAt / reasoningDoneAt come from the smallest-itemId source
+//     reporting status="done" if any does, otherwise from the text primary.
+//     A "done" signal carried by any source therefore wins — even when that
+//     source is not the text primary — and the choice stays deterministic.
+//
+// As a consequence the merged text and reasoning may come from different
+// sources. That is preferred over silently dropping a "done" signal carried
+// by a non-winner source, which is what a strict "smallest-itemId wins
+// everything" policy would do.
+//
+// Generic so unit tests can pass a minimal structural stub instead of a real
+// ProjectTodoResource / TodoBlob.
+export function mergeUpdateIntentsByTodoId<
+  TTodo extends { id: ModelId },
+  TBlob extends {
+    status: "todo" | "done";
+    doneAt: Date | null;
+    reasoningDoneAt: string | null;
+  },
+>(
+  intents: Array<{ todo: TTodo; itemId: string; blob: TBlob }>
+): Array<{ todo: TTodo; blob: TBlob }> {
+  type Intent = { todo: TTodo; itemId: string; blob: TBlob };
+  const groups = new Map<ModelId, Intent[]>();
   for (const intent of intents) {
-    const current = byTodoId.get(intent.todo.id);
-    if (current === undefined || intent.itemId < current.itemId) {
-      byTodoId.set(intent.todo.id, intent);
-    }
+    const bucket = groups.get(intent.todo.id) ?? [];
+    bucket.push(intent);
+    groups.set(intent.todo.id, bucket);
   }
-  return [...byTodoId.values()];
+
+  const result: Array<{ todo: TTodo; blob: TBlob }> = [];
+  for (const bucket of groups.values()) {
+    const textPrimary = bucket.reduce((min, i) =>
+      i.itemId < min.itemId ? i : min
+    );
+
+    const doneIntents = bucket.filter((i) => i.blob.status === "done");
+    const statusPrimary =
+      doneIntents.length > 0
+        ? doneIntents.reduce((min, i) => (i.itemId < min.itemId ? i : min))
+        : textPrimary;
+
+    result.push({
+      todo: textPrimary.todo,
+      blob: {
+        ...textPrimary.blob,
+        status: statusPrimary.blob.status,
+        doneAt: statusPrimary.blob.doneAt,
+        reasoningDoneAt: statusPrimary.blob.reasoningDoneAt,
+      },
+    });
+  }
+  return result;
 }
 
 // ── Stats ─────────────────────────────────────────────────────────────────────
@@ -251,13 +295,13 @@ async function collectNewCandidates(
     { concurrency: 4 }
   );
 
-  const dedupedIntents = dedupeUpdateIntentsByTodoId(allIntents);
+  const mergedUpdates = mergeUpdateIntentsByTodoId(allIntents);
 
   let existingUpdated = 0;
   await concurrentExecutor(
-    dedupedIntents,
-    async (intent) => {
-      const updated = await updateTodoIfChanged(intent.todo, auth, intent.blob);
+    mergedUpdates,
+    async ({ todo, blob }) => {
+      const updated = await updateTodoIfChanged(todo, auth, blob);
       if (updated) {
         existingUpdated++;
       }


### PR DESCRIPTION
## Description

Two bugs in the project-todo merge caused unbounded version churn on todos linked to multiple sources.

**Bug 1 — Phase 1 update loop (the 1300-versions case).** `collectDocumentCandidates` called `updateTodoIfChanged` once per source link. A todo linked to N takeaway items got N update attempts per merge run, and because the items had slightly different wording, each source overwrote the previous one's text → 1 new version per source per run.

Fix — `mergeUpdateIntentsByTodoId`: collect all "existing-todo update" intents from every takeaway, merge them per `todo.id` into a single update, and apply at most one update per todo per run. The merge follows two rules so it stays both stable and semantically correct:
- `text` comes from the smallest-`itemId` source ("text primary"). Stable across runs, so once it lands, the next merge sees no diff.
- `status` / `doneAt` / `reasoningDoneAt` come from the smallest-`itemId` source reporting `status="done"` if any does, otherwise from the text primary. A "done" signal carried by any source therefore wins — even when that source is not the text primary. Without this rule, the naive "smallest-itemId wins everything" approach would silently drop done signals from non-winner sources.

As a tradeoff, the merged `text` and `reasoningDoneAt` may come from different sources when only a non-text-primary source reports done. Preferred over losing the done signal entirely.

**Bug 2 — Phase 3 unstable primary selection.** Both branches in `createOrLinkTodos` used `group.candidates[0]` (and `existingInGroup[0]` in `resolveDeduplicationGroups`), whose order depends on how the LLM listed indexes — different across runs. The picked content (and the picked existing todo when a cluster contained several) jittered between runs, producing a new version each time.

Fix: pick the candidate with the smallest `itemId` as the primary in both Phase 3 branches via a new `pickPrimaryByItemId` helper, and pick the oldest existing todo (smallest `id`) as the cluster primary in `resolveDeduplicationGroups`. Both selections are now deterministic and stable across runs.

## Tests

