### PR TITLE
Turn context usage indicator into a popover

### DIFF
--- a/front/components/assistant/conversation/CompactionMessage.tsx
+++ b/front/components/assistant/conversation/CompactionMessage.tsx
@@ -73,7 +73,7 @@ export function CompactionMessage({
         <div className="flex items-center justify-center gap-1.5">
           <Spinner size="xs" />
           <AnimatedText variant="muted" className="text-sm">
-            Compacting context…
+            Compacting context, this may take a moment…
           </AnimatedText>
         </div>
       );

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -5,6 +5,7 @@ import {
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
+  LinkWrapper,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
@@ -110,14 +111,14 @@ export function ContextUsageIndicator({
                   isLoading={isCompacting}
                 />
               )}
-              <a
+              <LinkWrapper
                 href={COMPACTION_GUIDE_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-sm text-highlight underline hover:text-highlight-light dark:text-highlight-night dark:hover:text-highlight-light-night"
               >
                 Learn more
-              </a>
+              </LinkWrapper>
             </div>
           </div>
         </PopoverContent>

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -5,10 +5,9 @@ import {
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
-  TooltipContent,
-  TooltipProvider,
-  TooltipRoot,
-  TooltipTrigger,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
 } from "@dust-tt/sparkle";
 
 interface ContextUsageIndicatorProps {
@@ -23,6 +22,7 @@ interface CircleProgressProps {
 }
 
 const CONTEXT_USAGE_PERCENT_THRESHOLD = 33;
+const COMPACTION_GUIDE_URL = "https://docs.dust.tt/docs/context";
 
 function CircleProgress({ percentage, size = 16 }: CircleProgressProps) {
   const strokeWidth = size * 0.14;
@@ -80,21 +80,22 @@ export function ContextUsageIndicator({
       : 0;
 
   return (
-    <div className="hidden md:block">
-      <TooltipProvider>
-        <TooltipRoot>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost-secondary"
-              size={buttonSize}
-              icon={() => <CircleProgress percentage={percentage} size={16} />}
-            />
-          </TooltipTrigger>
-          <TooltipContent side="top" className="p-3">
-            <div className="flex flex-col items-start gap-3">
-              <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                The current context usage is at {percentage}%
-              </span>
+    <div className="hidden md:block" onClick={(e) => e.stopPropagation()}>
+      <PopoverRoot>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost-secondary"
+            size={buttonSize}
+            icon={() => <CircleProgress percentage={percentage} size={16} />}
+            tooltip={`${percentage}% of context used.`}
+          />
+        </PopoverTrigger>
+        <PopoverContent side="top" align="end" className="w-auto p-3">
+          <div className="flex flex-col items-start gap-3">
+            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {percentage}% of context used.
+            </span>
+            <div className="flex items-center gap-3">
               {percentage > CONTEXT_USAGE_PERCENT_THRESHOLD && (
                 <Button
                   variant="outline"
@@ -109,10 +110,18 @@ export function ContextUsageIndicator({
                   isLoading={isCompacting}
                 />
               )}
+              <a
+                href={COMPACTION_GUIDE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-highlight underline hover:text-highlight-light dark:text-highlight-night dark:hover:text-highlight-light-night"
+              >
+                Learn more
+              </a>
             </div>
-          </TooltipContent>
-        </TooltipRoot>
-      </TooltipProvider>
+          </div>
+        </PopoverContent>
+      </PopoverRoot>
     </div>
   );
 }

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -23,7 +23,8 @@ interface CircleProgressProps {
 }
 
 const CONTEXT_USAGE_PERCENT_THRESHOLD = 33;
-const COMPACTION_GUIDE_URL = "https://docs.dust.tt/docs/context";
+const COMPACTION_GUIDE_URL =
+  "https://docs.dust.tt/update/docs/context-compaction";
 
 function CircleProgress({ percentage, size = 16 }: CircleProgressProps) {
   const strokeWidth = size * 0.14;


### PR DESCRIPTION
## Description

 Replaces the hover tooltip on the context usage indicator with a click-to-open popover, so it behaves like the other input bar dropdowns. Hovering still shows a short tooltip with the percentage. The popover keeps the existing "Compact now" action and adds a "Learn more" link to https://docs.dust.tt/docs/context.

Also clarifies the in-progress wording during compaction from "Compacting context…" to "Compacting context, this may take a moment…", since the action can take 10 to 20 seconds.

<kbd>
<img width="778" height="176" alt="Screenshot 2026-04-28 at 14 29 09" src="https://github.com/user-attachments/assets/b89dd5be-7970-4871-89c5-faa7ebb93e90" />
</kbd>


## Tests

Locally. 

## Risk

We should not forget to write the documentation before shipping: use the same link, or update this one

## Deploy Plan

Deploy front. 