### PR TITLE
GMail: add message archival/label capabilities

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -187,14 +187,15 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "search_advanced": "never_ask",
   },
   "gmail": {
-    "archive_message": "medium",
     "create_draft": "medium",
     "create_reply_draft": "medium",
     "delete_draft": "high",
     "get_attachment": "never_ask",
     "get_drafts": "never_ask",
+    "get_labels": "never_ask",
     "get_messages": "never_ask",
     "send_mail": "high",
+    "set_message_labels": "medium",
   },
   "gong": {
     "get_call": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -187,6 +187,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "search_advanced": "never_ask",
   },
   "gmail": {
+    "archive_message": "medium",
     "create_draft": "medium",
     "create_reply_draft": "medium",
     "delete_draft": "high",

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -167,6 +167,17 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       done: "Create Gmail reply draft",
     },
   },
+  archive_message: {
+    description: "Archive a Gmail message by removing it from the inbox. The message is not deleted and can be found via search or in All Mail.",
+    schema: {
+      messageId: z.string().describe("The ID of the message to archive"),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Archiving Gmail message",
+      done: "Archive Gmail message",
+    },
+  },
   send_mail: {
     description: `Send an email directly via Gmail.
 - The email will be sent immediately without creating a draft.
@@ -212,7 +223,7 @@ export const GMAIL_SERVER = {
       provider: "google_drive",
       supported_use_cases: ["personal_actions", "platform_actions"],
       scope:
-        "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose",
+        "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose https://www.googleapis.com/auth/gmail.modify",
     },
     icon: "GmailLogo",
     documentationUrl: "https://docs.dust.tt/docs/gmail",

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -181,10 +181,7 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     description: `Modify the labels of a message. System label IDs can be used directly (INBOX, SPAM, TRASH, UNREAD, STARRED, IMPORTANT, ...). User labels should be retrieved first via get_labels to get their IDs.`,
     schema: {
       messageId: z.string().describe("The ID of the message to modify."),
-      addLabelIds: z
-        .array(z.string())
-        .optional()
-        .describe("Label IDs to add."),
+      addLabelIds: z.array(z.string()).optional().describe("Label IDs to add."),
       removeLabelIds: z
         .array(z.string())
         .optional()

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -167,16 +167,33 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       done: "Create Gmail reply draft",
     },
   },
-  archive_message: {
+  get_labels: {
     description:
-      "Archive a Gmail message by removing it from the inbox. The message is not deleted and can be found via search or in All Mail.",
+      "Retrieve all Gmail labels, including system labels and user-created labels.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Getting Gmail labels",
+      done: "Get Gmail labels",
+    },
+  },
+  set_message_labels: {
+    description: `Modify the labels of a message. System label IDs can be used directly (INBOX, SPAM, TRASH, UNREAD, STARRED, IMPORTANT, ...). User labels should be retrieved first via get_labels to get their IDs.`,
     schema: {
-      messageId: z.string().describe("The ID of the message to archive"),
+      messageId: z.string().describe("The ID of the message to modify."),
+      addLabelIds: z
+        .array(z.string())
+        .optional()
+        .describe("Label IDs to add."),
+      removeLabelIds: z
+        .array(z.string())
+        .optional()
+        .describe("Label IDs to remove."),
     },
     stake: "medium",
     displayLabels: {
-      running: "Archiving Gmail message",
-      done: "Archive Gmail message",
+      running: "Modifying Gmail message labels",
+      done: "Modify Gmail message labels",
     },
   },
   send_mail: {

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -168,7 +168,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
   },
   archive_message: {
-    description: "Archive a Gmail message by removing it from the inbox. The message is not deleted and can be found via search or in All Mail.",
+    description:
+      "Archive a Gmail message by removing it from the inbox. The message is not deleted and can be found via search or in All Mail.",
     schema: {
       messageId: z.string().describe("The ID of the message to archive"),
     },

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -246,30 +246,88 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     ]);
   },
 
-  archive_message: async ({ messageId }, { authInfo }) => {
+  get_labels: async (_, { authInfo }) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
 
+    const response = await fetchFromGmail(
+      "/gmail/v1/users/me/labels",
+      accessToken,
+      { method: "GET" }
+    );
+
+    if (!response.ok) {
+      const errorText = await getErrorText(response);
+      return new Err(new MCPError(`Failed to get labels: ${errorText}`));
+    }
+
+    const result = await response.json();
+
+    return new Ok([
+      { type: "text" as const, text: "Labels fetched successfully" },
+      {
+        type: "text" as const,
+        text: JSON.stringify({ labels: result.labels ?? [] }, null, 2),
+      },
+    ]);
+  },
+
+  set_message_labels: async (
+    { messageId, addLabelIds, removeLabelIds },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    if (!addLabelIds?.length && !removeLabelIds?.length) {
+      return new Err(
+        new MCPError("At least one label ID must be added or removed")
+      );
+    }
+
     const encodedMessageId = encodeURIComponent(messageId);
+
+    // To archive a message, remove the "INBOX" system label with removeLabelIds: ["INBOX"].
     const response = await fetchFromGmail(
       `/gmail/v1/users/me/messages/${encodedMessageId}/modify`,
       accessToken,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ removeLabelIds: ["INBOX"] }),
+        body: JSON.stringify({
+          addLabelIds: addLabelIds ?? [],
+          removeLabelIds: removeLabelIds ?? [],
+        }),
       }
     );
 
     if (!response.ok) {
       const errorText = await getErrorText(response);
-      return new Err(new MCPError(`Failed to archive message: ${errorText}`));
+      return new Err(
+        new MCPError(`Failed to modify message labels: ${errorText}`)
+      );
     }
 
+    const result = await response.json();
+
     return new Ok([
-      { type: "text" as const, text: "Message archived successfully" },
+      { type: "text" as const, text: "Message labels modified successfully" },
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            messageId: result.id,
+            threadId: result.threadId,
+            labelIds: result.labelIds,
+          },
+          null,
+          2
+        ),
+      },
     ]);
   },
 

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -246,6 +246,35 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     ]);
   },
 
+  archive_message: async ({ messageId }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    const encodedMessageId = encodeURIComponent(messageId);
+    const response = await fetchFromGmail(
+      `/gmail/v1/users/me/messages/${encodedMessageId}/modify`,
+      accessToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ removeLabelIds: ["INBOX"] }),
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await getErrorText(response);
+      return new Err(
+        new MCPError(`Failed to archive message: ${errorText}`)
+      );
+    }
+
+    return new Ok([
+      { type: "text" as const, text: "Message archived successfully" },
+    ]);
+  },
+
   get_messages: async (
     { q, maxResults = 10, pageToken, includeAttachments },
     { authInfo }

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -265,9 +265,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
 
     if (!response.ok) {
       const errorText = await getErrorText(response);
-      return new Err(
-        new MCPError(`Failed to archive message: ${errorText}`)
-      );
+      return new Err(new MCPError(`Failed to archive message: ${errorText}`));
     }
 
     return new Ok([


### PR DESCRIPTION
## Description

Add message labeling/archiving capabilities.

Scope update verification done with Google with video: https://www.youtube.com/shorts/R92dz1-Pu9U

## Tests

Tested locally end-to-end.

## Risk

Low

## Deploy Plan

- [x] await scope verification
- merge and deploy `front`