### PR TITLE
[front] feat: add public endpoint for listing skills

### DIFF
--- a/front/pages/api/v1/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.test.ts
@@ -1,7 +1,11 @@
+import { Authenticator } from "@app/lib/auth";
 import {
   createPublicApiAuthenticationTests,
   createPublicApiMockRequest,
 } from "@app/tests/utils/generic_public_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
@@ -27,6 +31,71 @@ describe(
   createPublicApiAuthenticationTests(handler)
 );
 
+describe("GET /api/v1/w/[wId]/skills", () => {
+  it("returns active skills by default", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest();
+    const user = await UserFactory.basic();
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+
+    await SkillFactory.create(auth, {
+      name: "Active API Skill",
+      instructions: "Test skill instructions",
+    });
+    await SkillFactory.create(auth, {
+      name: "Archived API Skill",
+      status: "archived",
+      instructions: "Test skill instructions",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    const skillNames = data.skills.map((skill: { name: string }) => skill.name);
+
+    expect(skillNames).toContain("Active API Skill");
+    expect(skillNames).not.toContain("Archived API Skill");
+  });
+
+  it("returns skills matching the requested status", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest();
+    const user = await UserFactory.basic();
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+
+    await SkillFactory.create(auth, {
+      name: "Active API Skill",
+      instructions: "Test skill instructions",
+    });
+    await SkillFactory.create(auth, {
+      name: "Archived API Skill",
+      status: "archived",
+      instructions: "Test skill instructions",
+    });
+    req.query = { ...req.query, status: "archived" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    const skillNames = data.skills.map((skill: { name: string }) => skill.name);
+
+    expect(skillNames).toContain("Archived API Skill");
+    expect(skillNames).not.toContain("Active API Skill");
+  });
+});
+
 describe("POST /api/v1/w/[wId]/skills", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -47,22 +116,6 @@ describe("POST /api/v1/w/[wId]/skills", () => {
       error: {
         type: "invalid_request_error",
         message: "No files uploaded.",
-      },
-    });
-  });
-
-  it("returns 405 for unsupported methods", async () => {
-    const { req, res } = await createPublicApiMockRequest({
-      method: "GET",
-    });
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(405);
-    expect(res._getJSONData()).toEqual({
-      error: {
-        type: "method_not_supported_error",
-        message: "The method passed is not supported, POST is expected.",
       },
     });
   });

--- a/front/pages/api/v1/w/[wId]/skills/index.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.ts
@@ -1,4 +1,3 @@
-/** @ignoreswagger */
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import {
   importSkillsFromFiles,
@@ -6,12 +5,16 @@ import {
 } from "@app/lib/api/skills/detection/files/import_skills";
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
 import type { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { ImportSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/import";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import formidable from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export const config = {
   api: {
@@ -19,84 +22,238 @@ export const config = {
   },
 };
 
+export type GetPublicSkillsResponseBody = {
+  skills: SkillType[];
+};
+
+const GetSkillsQuerySchema = z.object({
+  status: z.enum(["active", "archived", "suggested"]).optional(),
+});
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/skills:
+ *   get:
+ *     summary: List skills
+ *     description: Retrieves the custom skills in the workspace. Active skills are returned by default.
+ *     tags:
+ *       - Skills
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: Unique string identifier for the workspace
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: status
+ *         required: false
+ *         description: Filter skills by status. Defaults to active.
+ *         schema:
+ *           type: string
+ *           enum: [active, archived, suggested]
+ *     responses:
+ *       200:
+ *         description: Skills available in the workspace.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 skills:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Skill'
+ *       400:
+ *         description: Bad Request. Missing or invalid parameters.
+ *       401:
+ *         description: Unauthorized. Invalid or missing authentication token.
+ *       404:
+ *         description: Workspace not found.
+ *       405:
+ *         description: Method not supported.
+ *   post:
+ *     summary: Import skills from uploaded files
+ *     description: Imports skills from uploaded files or ZIP archives into the workspace.
+ *     tags:
+ *       - Skills
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: Unique string identifier for the workspace
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - files
+ *             properties:
+ *               files:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   format: binary
+ *                 description: Skill files or ZIP archives to import.
+ *               names:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                 description: Optional skill names to import from the uploaded files.
+ *               onConflict:
+ *                 type: string
+ *                 enum: [error, skip, override]
+ *                 description: Conflict handling strategy. Defaults to error.
+ *     responses:
+ *       200:
+ *         description: Skills import result.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 imported:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Skill'
+ *                 updated:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Skill'
+ *                 skipped:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       name:
+ *                         type: string
+ *                       message:
+ *                         type: string
+ *       400:
+ *         description: Bad Request. Missing or invalid uploaded files.
+ *       401:
+ *         description: Unauthorized. Invalid or missing authentication token.
+ *       404:
+ *         description: Workspace not found.
+ *       405:
+ *         description: Method not supported.
+ */
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<ImportSkillsResponseBody>>,
+  res: NextApiResponse<
+    WithAPIErrorResponse<ImportSkillsResponseBody | GetPublicSkillsResponseBody>
+  >,
   auth: Authenticator
 ): Promise<void> {
-  if (req.method !== "POST") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message: "The method passed is not supported, POST is expected.",
-      },
-    });
+  switch (req.method) {
+    case "GET": {
+      const r = GetSkillsQuerySchema.safeParse(req.query);
+      if (r.error) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${fromError(r.error).toString()}`,
+          },
+        });
+      }
+
+      const { status } = r.data;
+
+      const skills = await SkillResource.listByWorkspace(auth, {
+        status,
+        onlyCustom: true,
+      });
+
+      return res.status(200).json({
+        skills: skills.map((skill) => skill.toJSON(auth)),
+      });
+    }
+
+    case "POST": {
+      let fields: formidable.Fields;
+      let files: formidable.Files;
+      try {
+        const form = formidable({
+          multiples: true,
+          maxFileSize: MAX_ZIP_SIZE_BYTES,
+        });
+        [fields, files] = await form.parse(req);
+      } catch (err) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `File upload failed: ${normalizeError(err).message}`,
+          },
+        });
+      }
+
+      const uploadedFiles = files.files;
+      if (!uploadedFiles || uploadedFiles.length === 0) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "No files uploaded.",
+          },
+        });
+      }
+
+      const { names } = fields;
+
+      const onConflict = fields.onConflict?.[0] ?? "error";
+      if (!isImportConflictStrategy(onConflict)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid onConflict value: "${onConflict}". Must be one of: error, skip, override.`,
+          },
+        });
+      }
+
+      const result = await importSkillsFromFiles(auth, {
+        uploadedFiles,
+        names,
+        source: "api",
+        onConflict,
+      });
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        imported: result.value.imported.map((skill) => skill.toJSON(auth)),
+        updated: result.value.updated.map((skill) => skill.toJSON(auth)),
+        skipped: result.value.skipped,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
   }
-
-  let fields: formidable.Fields;
-  let files: formidable.Files;
-  try {
-    const form = formidable({
-      multiples: true,
-      maxFileSize: MAX_ZIP_SIZE_BYTES,
-    });
-    [fields, files] = await form.parse(req);
-  } catch (err) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `File upload failed: ${normalizeError(err).message}`,
-      },
-    });
-  }
-
-  const uploadedFiles = files.files;
-  if (!uploadedFiles || uploadedFiles.length === 0) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "No files uploaded.",
-      },
-    });
-  }
-
-  const { names } = fields;
-
-  const onConflict = fields.onConflict?.[0] ?? "error";
-  if (!isImportConflictStrategy(onConflict)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Invalid onConflict value: "${onConflict}". Must be one of: error, skip, override.`,
-      },
-    });
-  }
-
-  const result = await importSkillsFromFiles(auth, {
-    uploadedFiles,
-    names,
-    source: "api",
-    onConflict,
-  });
-  if (result.isErr()) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: result.error.message,
-      },
-    });
-  }
-
-  return res.status(200).json({
-    imported: result.value.imported.map((skill) => skill.toJSON(auth)),
-    updated: result.value.updated.map((skill) => skill.toJSON(auth)),
-    skipped: result.value.skipped,
-  });
 }
 
 export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -585,10 +585,6 @@
  *     Skill:
  *       type: object
  *       properties:
- *         id:
- *           type: integer
- *           description: Numeric identifier for the skill
- *           example: 12345
  *         sId:
  *           type: string
  *           description: Unique string identifier for the skill

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -582,7 +582,7 @@
  *           type: string
  *           description: Path to the source skill file
  *           example: "support/SKILL.md"
- *     SkillSummary:
+ *     Skill:
  *       type: object
  *       properties:
  *         id:
@@ -674,23 +674,18 @@
  *           type: string
  *           nullable: true
  *           description: Identifier of the extended skill, when applicable
- *     Skill:
- *       allOf:
- *         - $ref: '#/components/schemas/SkillSummary'
- *         - type: object
- *           properties:
- *             instructions:
- *               type: string
- *               nullable: true
- *               description: Instructions used by the agent when running the skill
- *             instructionsHtml:
- *               type: string
- *               nullable: true
- *               description: HTML representation of the skill instructions
- *             tools:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/MCPServerView'
+ *         instructions:
+ *           type: string
+ *           nullable: true
+ *           description: Instructions used by the agent when running the skill
+ *         instructionsHtml:
+ *           type: string
+ *           nullable: true
+ *           description: HTML representation of the skill instructions
+ *         tools:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/MCPServerView'
  *     Run:
  *       type: object
  *       properties:

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -571,6 +571,126 @@
  *         spaceId:
  *           type: string
  *           description: ID of the space containing the data source view
+ *     SkillSourceMetadata:
+ *       type: object
+ *       properties:
+ *         repoUrl:
+ *           type: string
+ *           description: URL of the source repository, when applicable
+ *           example: "https://github.com/dust-tt/skills"
+ *         filePath:
+ *           type: string
+ *           description: Path to the source skill file
+ *           example: "support/SKILL.md"
+ *     SkillSummary:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *           description: Numeric identifier for the skill
+ *           example: 12345
+ *         sId:
+ *           type: string
+ *           description: Unique string identifier for the skill
+ *           example: "skill_abc123"
+ *         createdAt:
+ *           type: number
+ *           nullable: true
+ *           description: Timestamp of when the skill was created
+ *         updatedAt:
+ *           type: number
+ *           nullable: true
+ *           description: Timestamp of when the skill was last updated
+ *         editedBy:
+ *           type: integer
+ *           nullable: true
+ *           description: Numeric identifier of the last editor
+ *         status:
+ *           type: string
+ *           enum: [active, archived, suggested]
+ *           description: Current status of the skill
+ *           example: "active"
+ *         name:
+ *           type: string
+ *           description: Name of the skill
+ *           example: "Customer Support"
+ *         agentFacingDescription:
+ *           type: string
+ *           description: Description shown to agents when selecting or using the skill
+ *           example: "Use this skill to answer customer support questions."
+ *         userFacingDescription:
+ *           type: string
+ *           description: Description shown to workspace users
+ *           example: "Answers support questions with the right workspace context."
+ *         icon:
+ *           type: string
+ *           nullable: true
+ *           description: Icon identifier for the skill
+ *           example: "ActionRobotIcon"
+ *         source:
+ *           type: string
+ *           nullable: true
+ *           enum: [web_app, github, api, local_file]
+ *           description: Source used to create or import the skill
+ *         sourceMetadata:
+ *           type: object
+ *           nullable: true
+ *           allOf:
+ *             - $ref: '#/components/schemas/SkillSourceMetadata'
+ *         reinforcement:
+ *           type: string
+ *           enum: [auto, "on", "off"]
+ *           description: Reinforcement setting for the skill
+ *         lastReinforcementAnalysisAt:
+ *           type: string
+ *           nullable: true
+ *           description: Timestamp of the last reinforcement analysis, when available
+ *         requestedSpaceIds:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: Space identifiers the skill needs access to
+ *         fileAttachments:
+ *           type: array
+ *           items:
+ *             type: object
+ *             properties:
+ *               fileId:
+ *                 type: string
+ *                 description: Unique string identifier for the attached file
+ *               fileName:
+ *                 type: string
+ *                 description: Name of the attached file
+ *         canWrite:
+ *           type: boolean
+ *           description: Whether the authenticated actor can edit the skill
+ *         isExtendable:
+ *           type: boolean
+ *           description: Whether this skill can be extended by another skill
+ *         isDefault:
+ *           type: boolean
+ *           description: Whether this skill is enabled by default
+ *         extendedSkillId:
+ *           type: string
+ *           nullable: true
+ *           description: Identifier of the extended skill, when applicable
+ *     Skill:
+ *       allOf:
+ *         - $ref: '#/components/schemas/SkillSummary'
+ *         - type: object
+ *           properties:
+ *             instructions:
+ *               type: string
+ *               nullable: true
+ *               description: Instructions used by the agent when running the skill
+ *             instructionsHtml:
+ *               type: string
+ *               nullable: true
+ *               description: HTML representation of the skill instructions
+ *             tools:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/MCPServerView'
  *     Run:
  *       type: object
  *       properties:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -13376,7 +13376,7 @@
           }
         }
       },
-      "SkillSummary": {
+      "Skill": {
         "type": "object",
         "properties": {
           "id": {
@@ -13508,36 +13508,24 @@
             "type": "string",
             "nullable": true,
             "description": "Identifier of the extended skill, when applicable"
-          }
-        }
-      },
-      "Skill": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/SkillSummary"
           },
-          {
-            "type": "object",
-            "properties": {
-              "instructions": {
-                "type": "string",
-                "nullable": true,
-                "description": "Instructions used by the agent when running the skill"
-              },
-              "instructionsHtml": {
-                "type": "string",
-                "nullable": true,
-                "description": "HTML representation of the skill instructions"
-              },
-              "tools": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/MCPServerView"
-                }
-              }
+          "instructions": {
+            "type": "string",
+            "nullable": true,
+            "description": "Instructions used by the agent when running the skill"
+          },
+          "instructionsHtml": {
+            "type": "string",
+            "nullable": true,
+            "description": "HTML representation of the skill instructions"
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MCPServerView"
             }
           }
-        ]
+        }
       },
       "Run": {
         "type": "object",

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -13379,11 +13379,6 @@
       "Skill": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "integer",
-            "description": "Numeric identifier for the skill",
-            "example": 12345
-          },
           "sId": {
             "type": "string",
             "description": "Unique string identifier for the skill",

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -65,6 +65,10 @@
       "description": "Triggers"
     },
     {
+      "name": "Skills",
+      "description": "Skills"
+    },
+    {
       "name": "Spaces",
       "description": "Spaces"
     },
@@ -3282,6 +3286,191 @@
           },
           "500": {
             "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/w/{wId}/skills": {
+      "get": {
+        "summary": "List skills",
+        "description": "Retrieves the custom skills in the workspace. Active skills are returned by default.",
+        "tags": [
+          "Skills"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "Unique string identifier for the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "description": "Filter skills by status. Defaults to active.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "archived",
+                "suggested"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skills available in the workspace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "skills": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Skill"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Missing or invalid parameters."
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing authentication token."
+          },
+          "404": {
+            "description": "Workspace not found."
+          },
+          "405": {
+            "description": "Method not supported."
+          }
+        }
+      },
+      "post": {
+        "summary": "Import skills from uploaded files",
+        "description": "Imports skills from uploaded files or ZIP archives into the workspace.",
+        "tags": [
+          "Skills"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "Unique string identifier for the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "files"
+                ],
+                "properties": {
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "description": "Skill files or ZIP archives to import."
+                  },
+                  "names": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Optional skill names to import from the uploaded files."
+                  },
+                  "onConflict": {
+                    "type": "string",
+                    "enum": [
+                      "error",
+                      "skip",
+                      "override"
+                    ],
+                    "description": "Conflict handling strategy. Defaults to error."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Skills import result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "imported": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Skill"
+                      }
+                    },
+                    "updated": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Skill"
+                      }
+                    },
+                    "skipped": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Missing or invalid uploaded files."
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing authentication token."
+          },
+          "404": {
+            "description": "Workspace not found."
+          },
+          "405": {
+            "description": "Method not supported."
           }
         }
       }
@@ -13171,6 +13360,184 @@
             "description": "ID of the space containing the data source view"
           }
         }
+      },
+      "SkillSourceMetadata": {
+        "type": "object",
+        "properties": {
+          "repoUrl": {
+            "type": "string",
+            "description": "URL of the source repository, when applicable",
+            "example": "https://github.com/dust-tt/skills"
+          },
+          "filePath": {
+            "type": "string",
+            "description": "Path to the source skill file",
+            "example": "support/SKILL.md"
+          }
+        }
+      },
+      "SkillSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Numeric identifier for the skill",
+            "example": 12345
+          },
+          "sId": {
+            "type": "string",
+            "description": "Unique string identifier for the skill",
+            "example": "skill_abc123"
+          },
+          "createdAt": {
+            "type": "number",
+            "nullable": true,
+            "description": "Timestamp of when the skill was created"
+          },
+          "updatedAt": {
+            "type": "number",
+            "nullable": true,
+            "description": "Timestamp of when the skill was last updated"
+          },
+          "editedBy": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Numeric identifier of the last editor"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "archived",
+              "suggested"
+            ],
+            "description": "Current status of the skill",
+            "example": "active"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the skill",
+            "example": "Customer Support"
+          },
+          "agentFacingDescription": {
+            "type": "string",
+            "description": "Description shown to agents when selecting or using the skill",
+            "example": "Use this skill to answer customer support questions."
+          },
+          "userFacingDescription": {
+            "type": "string",
+            "description": "Description shown to workspace users",
+            "example": "Answers support questions with the right workspace context."
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true,
+            "description": "Icon identifier for the skill",
+            "example": "ActionRobotIcon"
+          },
+          "source": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "web_app",
+              "github",
+              "api",
+              "local_file"
+            ],
+            "description": "Source used to create or import the skill"
+          },
+          "sourceMetadata": {
+            "type": "object",
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SkillSourceMetadata"
+              }
+            ]
+          },
+          "reinforcement": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "on",
+              "off"
+            ],
+            "description": "Reinforcement setting for the skill"
+          },
+          "lastReinforcementAnalysisAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "Timestamp of the last reinforcement analysis, when available"
+          },
+          "requestedSpaceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Space identifiers the skill needs access to"
+          },
+          "fileAttachments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "fileId": {
+                  "type": "string",
+                  "description": "Unique string identifier for the attached file"
+                },
+                "fileName": {
+                  "type": "string",
+                  "description": "Name of the attached file"
+                }
+              }
+            }
+          },
+          "canWrite": {
+            "type": "boolean",
+            "description": "Whether the authenticated actor can edit the skill"
+          },
+          "isExtendable": {
+            "type": "boolean",
+            "description": "Whether this skill can be extended by another skill"
+          },
+          "isDefault": {
+            "type": "boolean",
+            "description": "Whether this skill is enabled by default"
+          },
+          "extendedSkillId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Identifier of the extended skill, when applicable"
+          }
+        }
+      },
+      "Skill": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SkillSummary"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "instructions": {
+                "type": "string",
+                "nullable": true,
+                "description": "Instructions used by the agent when running the skill"
+              },
+              "instructionsHtml": {
+                "type": "string",
+                "nullable": true,
+                "description": "HTML representation of the skill instructions"
+              },
+              "tools": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/MCPServerView"
+                }
+              }
+            }
+          }
+        ]
       },
       "Run": {
         "type": "object",

--- a/front/swagger.json
+++ b/front/swagger.json
@@ -34,6 +34,7 @@
       { "name": "Search", "description": "Search" },
       { "name": "Tools", "description": "Tools" },
       { "name": "Triggers", "description": "Triggers" },
+      { "name": "Skills", "description": "Skills" },
       { "name": "Spaces", "description": "Spaces" },
       { "name": "Workspace", "description": "Workspace" },
       { "name": "Private User", "description": "Private API - User" },


### PR DESCRIPTION
## Description

- This PR adds an endpoint in `api/v1` to list skills.
- Supports filtering by status, defaulting to active skills.
- Only returns custom skills.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
