### PR TITLE
[front] feat: GA input bar slash suggestions

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -200,9 +200,6 @@ const InputBarContainer = ({
   const isMobile = useIsMobile();
   const { hasFeature } = useFeatureFlags();
   const isCompactionEnabled = hasFeature("enable_compaction");
-  const isInputBarSlashSuggestionsEnabled = hasFeature(
-    "input_bar_slash_suggestions"
-  );
   const { selectedSingleAgent, setSelectedSingleAgent } =
     useContext(InputBarContext);
 
@@ -241,8 +238,7 @@ const InputBarContainer = ({
   const [showKnowledgePicker, setShowKnowledgePicker] = useState(false);
   const plusButtonRef = useRef<HTMLDivElement>(null);
   const clientType = useClientType();
-  const shouldEnableSlashSuggestion =
-    actions.includes("capabilities") && isInputBarSlashSuggestionsEnabled;
+  const shouldEnableSlashSuggestion = actions.includes("capabilities");
 
   const [selectedNode, setSelectedNode] =
     useState<DataSourceViewContentNode | null>(null);

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -23,6 +23,7 @@ interface SlashCommandTooltip {
 }
 
 const DEFAULT_EMPTY_MESSAGE = "No commands found";
+
 const DEFAULT_LIST_MAX_HEIGHT_CLASS_NAME = "max-h-96";
 
 interface ScrollFadeState {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -301,11 +301,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Show the browser extension MCP tools toggle in workspace access settings",
     stage: "dust_only",
   },
-  input_bar_slash_suggestions: {
-    description:
-      "Enable slash-triggered suggestions in the conversation input bar",
-    stage: "dust_only",
-  },
   sensitivity_labels: {
     description:
       "Enable Microsoft sensitivity labels for data classification on connectors and MCP servers",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -709,7 +709,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "gpt_image_2_feature"
   | "hootl_subscriptions"
   | "http_client_tool"
-  | "input_bar_slash_suggestions"
   | "index_private_slack_channel"
   | "labs_mcp_actions_dashboard"
   | "labs_transcripts"


### PR DESCRIPTION
## Description

- This PR makes the input bar slash suggestion dropdown generally available.
- Removes the `input_bar_slash_suggestions` feature flag, and enables slash suggestions in the input bar

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
