### PR TITLE
Enable frames to reference GCS files by scoped path

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -235,6 +235,7 @@ export function CodeDrawer({
 interface VisualizationActionIframeProps {
   agentConfigurationId: string | null;
   conversationId: string | null;
+  spaceId?: string | null;
   isInDrawer?: boolean;
   visualization: Visualization;
   vizUrl: string;
@@ -281,9 +282,23 @@ export const VisualizationActionIframe = forwardRef<
 
   const getFileBlob = useCallback(
     async (fileId: string) => {
-      const response = await clientFetch(
-        `/api/w/${workspaceId}/files/${fileId}?action=view`
-      );
+      let url: string;
+
+      if (fileId.startsWith("conversation/")) {
+        const slashIdx = fileId.indexOf("/");
+        const rel = fileId.slice(slashIdx + 1);
+
+        if (!conversationId) {
+          return null;
+        }
+
+        url = `/api/w/${workspaceId}/assistant/conversations/${conversationId}/files/${rel}`;
+        // TODO(20260428 FILE_SYSTEM): implement space files content endpoint when project-scoped files are added.
+      } else {
+        url = `/api/w/${workspaceId}/files/${fileId}?action=view`;
+      }
+
+      const response = await clientFetch(url);
       if (!response.ok) {
         return null;
       }
@@ -294,7 +309,7 @@ export const VisualizationActionIframe = forwardRef<
         type: response.headers.get("Content-Type") ?? undefined,
       });
     },
-    [workspaceId]
+    [workspaceId, conversationId]
   );
 
   useVisualizationDataHandler({

--- a/front/lib/api/actions/servers/common/viz/instructions.ts
+++ b/front/lib/api/actions/servers/common/viz/instructions.ts
@@ -55,6 +55,7 @@ export const VIZ_STYLING_GUIDELINES = `
   - If you need to generate a legend for a chart, ensure it uses relative positioning or follows the natural flow of the layout, avoiding \`position: absolute\`, to maintain responsiveness and adaptability.
 `;
 
+// TODO(20260428 FILE_SYSTEM): Use other set of instructions once GCS files are exposed to models if new file system FF is on.
 export const VIZ_FILE_HANDLING_GUIDELINES = `
 - Using any file from the \`conversation_files__list_files\` action when available:
   - Files from the conversation as returned by \`conversation_files__list_files\` can be accessed using the \`useFile()\` React hook (all files can be accessed by the hook irrespective of their status).
@@ -122,6 +123,7 @@ export const VIZ_MISCELLANEOUS_GUIDELINES = `
   - If needed, the application must contain buttons or other navigation elements to allow the user to scroll/cycle through the content.
 `;
 
+// TODO(20260428 FILE_SYSTEM): Use other examples once GCS files are exposed to models if new file system FF is on.
 export const VIZ_USE_FILE_EXAMPLES = `
 Example using the \`useFile\` hook:
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -3,6 +3,7 @@
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { extensionsForContentType } from "@app/types/files";
+import { z } from "zod";
 
 export function getBaseMountPathForWorkspace({
   workspaceId,
@@ -76,6 +77,36 @@ export function makeProcessedMountFileName({
     : fileName.substring(lastDot);
 
   return `${dirPart}${basename}.processed${ext}`;
+}
+
+export const scopedFilePathPrefixSchema = z.enum([
+  "conversation",
+  // TODO(20260428 FILE SYSTEM) Add support for project.
+  // "project"
+]);
+export type ScopedFilePathPrefix = z.infer<typeof scopedFilePathPrefixSchema>;
+
+export type ScopedFilePath = {
+  prefix: ScopedFilePathPrefix;
+  rel: string;
+};
+
+/**
+ * Parse a scoped file path like "conversation/chart.png" or "project/report.pdf".
+ * Returns null if the path is missing a valid scope prefix.
+ */
+export function parseScopedFilePath(filePath: string): ScopedFilePath | null {
+  const slashIdx = filePath.indexOf("/");
+  if (slashIdx <= 0) {
+    return null;
+  }
+  const prefixResult = scopedFilePathPrefixSchema.safeParse(
+    filePath.slice(0, slashIdx)
+  );
+  if (!prefixResult.success) {
+    return null;
+  }
+  return { prefix: prefixResult.data, rel: filePath.slice(slashIdx + 1) };
 }
 
 /**

--- a/front/pages/api/v1/viz/files/[...segments].ts
+++ b/front/pages/api/v1/viz/files/[...segments].ts
@@ -1,0 +1,218 @@
+/* eslint-disable dust/enforce-client-types-in-public-api */
+
+import {
+  getConversationFilesBasePath,
+  scopedFilePathPrefixSchema,
+} from "@app/lib/api/files/mount_path";
+import { verifyVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import path from "path";
+
+/**
+ * @ignoreswagger
+ *
+ * Serves GCS-only files referenced from a frame by scoped resource path
+ * (e.g., GET /api/v1/viz/files/conversation/chart.png).
+ * Access is granted via the same JWT used by /api/v1/viz/files/[fileId].
+ *
+ * Single-segment requests (fil_xxx) are routed to [fileId].ts by Next.js.
+ * This catch-all handles multi-segment scoped paths only.
+ */
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<never>>
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { segments } = req.query;
+  if (!Array.isArray(segments) || segments.length < 2) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path: expected /files/{scope}/{rel...}.",
+      },
+    });
+  }
+
+  const [rawScope, ...relParts] = segments;
+
+  const scopeResult = scopedFilePathPrefixSchema.safeParse(rawScope);
+  if (!scopeResult.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: scopeResult.error.message,
+      },
+    });
+  }
+
+  // Extract and validate access token from Authorization header.
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Authorization header with Bearer token required.",
+      },
+    });
+  }
+
+  const accessToken = authHeader.slice("Bearer ".length).trim();
+  if (!accessToken) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Access token is required.",
+      },
+    });
+  }
+
+  const tokenPayload = verifyVizAccessToken(accessToken);
+  if (!tokenPayload) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Invalid or expired access token.",
+      },
+    });
+  }
+
+  // Get file info using the fileToken from the access token.
+  const result = await FileResource.fetchByShareTokenWithContent(
+    tokenPayload.fileToken
+  );
+  if (!result) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: { type: "file_not_found", message: "File not found." },
+    });
+  }
+
+  const { file: frameFile, shareScope } = result;
+
+  // If current share scope differs from token scope, reject. It means share scope changed.
+  if (shareScope !== tokenPayload.shareScope) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: { type: "file_not_found", message: "File not found." },
+    });
+  }
+
+  // Only allow frame files.
+  if (!frameFile.isInteractiveContent) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Only frame files can be shared publicly.",
+      },
+    });
+  }
+
+  const workspace = await WorkspaceResource.fetchByModelId(
+    frameFile.workspaceId
+  );
+  if (!workspace) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: { type: "file_not_found", message: "File not found." },
+    });
+  }
+
+  // If file is shared publicly, ensure workspace allows it.
+  if (
+    shareScope === "public" &&
+    !workspace.canShareInteractiveContentPublicly
+  ) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: { type: "file_not_found", message: "File not found." },
+    });
+  }
+
+  const workspaceId = workspace.sId;
+  const normalizedRel = path.posix.normalize(relParts.join("/"));
+
+  if (normalizedRel.startsWith("..") || normalizedRel.startsWith("/")) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Access denied: path is outside allowed scope.",
+      },
+    });
+  }
+
+  let basePath: string;
+  if (scopeResult.data === "conversation") {
+    const conversationId =
+      frameFile.useCaseMetadata?.conversationId ??
+      frameFile.useCaseMetadata?.sourceConversationId;
+    if (!isString(conversationId)) {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frame has no conversation context for this path.",
+        },
+      });
+    }
+    // TODO(FILE SYSTEM): Files created by sub-agents live under their own sub-conversation
+    // directory and won't be found here. The MCP server needs to define how to expose them
+    // (e.g. flattening into the parent conversation directory at listing time) before this
+    // endpoint can serve them.
+    basePath = getConversationFilesBasePath({ workspaceId, conversationId });
+  } else {
+    // TODO(2026-04-28 FILE SYSTEM): Add project scope support.
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Project scope is not yet supported.",
+      },
+    });
+  }
+
+  const gcsPath = `${basePath}${normalizedRel}`;
+
+  const bucket = getPrivateUploadBucket();
+  const contentTypeResult = await bucket.getFileContentType(gcsPath);
+  if (contentTypeResult.isErr()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: { type: "file_not_found", message: "File not found." },
+    });
+  }
+
+  const contentType = contentTypeResult.value ?? "application/octet-stream";
+  res.setHeader("Content-Type", contentType);
+  const readStream = bucket.file(gcsPath).createReadStream();
+  readStream.on("error", (err) => {
+    logger.error({ err, gcsPath }, "Error streaming scoped file (GCS)");
+    readStream.destroy();
+    res.end();
+  });
+  readStream.pipe(res);
+}
+
+export default handler;

--- a/front/pages/api/v1/viz/files/segments.test.ts
+++ b/front/pages/api/v1/viz/files/segments.test.ts
@@ -1,0 +1,369 @@
+import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { frameContentType } from "@app/types/files";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { PassThrough } from "stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./[...segments]";
+
+vi.mock("@app/lib/utils/rate_limiter", () => ({
+  rateLimiter: vi.fn().mockResolvedValue(999),
+  getTimeframeSecondsFromLiteral: vi.fn().mockReturnValue(60),
+}));
+
+vi.mock("@app/lib/plans/usage/seats", () => ({
+  countActiveSeatsInWorkspace: vi.fn().mockResolvedValue(100),
+  countActiveSeatsInWorkspaceCached: vi.fn().mockResolvedValue(100),
+  invalidateActiveSeatsCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("/api/v1/viz/files/[...segments] security tests", () => {
+  let workspace: LightWorkspaceType;
+  let auth: Awaited<ReturnType<typeof createResourceTest>>["authenticator"];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const setup = await createResourceTest({ role: "user" });
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+  });
+
+  // Call this AFTER makeFrameAndToken so file creation uses the global mock,
+  // and the handler gets the success bucket via mockReturnValueOnce.
+  function mockGcsFound() {
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
+      getFileContentType: vi.fn().mockResolvedValue({
+        isOk: () => true,
+        isErr: () => false,
+        value: "image/png",
+      }),
+      file: vi.fn().mockReturnValue({
+        createReadStream: vi.fn().mockReturnValue(new PassThrough()),
+      }),
+    } as never);
+  }
+
+  async function makeFrameAndToken(
+    useCaseMetadata: Record<string, string>,
+    shareScope: "public" | "workspace" = "public"
+  ) {
+    const frameFile = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "frame.html",
+      fileSize: 1000,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata,
+    });
+
+    const frameShareInfo = await frameFile.getShareInfo();
+    const fileToken = frameShareInfo?.shareUrl.split("/").at(-1);
+    if (!fileToken) {
+      throw new Error("No file token found");
+    }
+
+    const accessToken = generateVizAccessToken({
+      contentType: frameContentType,
+      fileToken,
+      workspaceId: workspace.sId,
+      shareScope,
+    });
+
+    return { frameFile, accessToken };
+  }
+
+  it("should serve a GCS file for a valid conversation-scoped path", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const { frameFile, accessToken } = await makeFrameAndToken({
+      conversationId: conversation.sId,
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["conversation", "chart.png"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: "<html>Frame content</html>",
+      shareScope: "public",
+    });
+
+    mockGcsFound();
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("should resolve conversationId from sourceConversationId for promoted frames", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    // Promoted frame: spaceId + sourceConversationId, no conversationId.
+    const { frameFile, accessToken } = await makeFrameAndToken({
+      spaceId: "vlt_someSpaceId",
+      sourceConversationId: conversation.sId,
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["conversation", "chart.png"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: "<html>Frame content</html>",
+      shareScope: "public",
+    });
+
+    mockGcsFound();
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("should reject when frame has no conversation context", async () => {
+    const { frameFile, accessToken } = await makeFrameAndToken({}); // No conversationId.
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["conversation", "chart.png"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: "<html>Frame content</html>",
+      shareScope: "public",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Frame has no conversation context for this path.",
+      },
+    });
+  });
+
+  it("should reject when shareScope has changed since token was issued", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const { frameFile, accessToken } = await makeFrameAndToken(
+      { conversationId: conversation.sId },
+      "public"
+    );
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["conversation", "chart.png"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: "<html>Frame content</html>",
+      shareScope: "workspace", // Changed from "public".
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it("should reject path traversal attempts", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const { frameFile, accessToken } = await makeFrameAndToken({
+      conversationId: conversation.sId,
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["conversation", "..", "..", "etc", "passwd"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: "<html>Frame content</html>",
+      shareScope: "public",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message: "Access denied: path is outside allowed scope.",
+      },
+    });
+  });
+
+  it("should reject an invalid scope segment", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const { frameFile, accessToken } = await makeFrameAndToken({
+      conversationId: conversation.sId,
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["invalid_scope", "chart.png"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: "<html>Frame content</html>",
+      shareScope: "public",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should return 404 when GCS file does not exist", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const { frameFile, accessToken } = await makeFrameAndToken({
+      conversationId: conversation.sId,
+    });
+
+    // Default mock already returns isErr: () => true — file not found.
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["conversation", "missing.png"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: "<html>Frame content</html>",
+      shareScope: "public",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: { type: "file_not_found", message: "File not found." },
+    });
+  });
+
+  it("should reject requests without Authorization header", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["conversation", "chart.png"] },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+  });
+
+  it("should reject invalid JWT token", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["conversation", "chart.png"] },
+      headers: { authorization: "Bearer invalid.jwt.token" },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message: "Invalid or expired access token.",
+      },
+    });
+  });
+
+  it("should reject non-GET methods", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      query: { segments: ["conversation", "chart.png"] },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it("should reject non-frame files as the frame", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const nonFrameFile = await FileFactory.create(auth, null, {
+      contentType: "image/png",
+      fileName: "avatar.png",
+      fileSize: 1000,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const { accessToken } = await makeFrameAndToken({
+      conversationId: conversation.sId,
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["conversation", "chart.png"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: nonFrameFile,
+      content: "",
+      shareScope: "public",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Only frame files can be shared publicly.",
+      },
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -4,11 +4,9 @@ import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isSupportedImageContentType } from "@app/types/files";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import path from "path";
@@ -28,14 +26,13 @@ async function handler(
     });
   }
 
-  const { cId, filePath } = req.query;
-  if (!isString(cId) || !isString(filePath)) {
+  const { cId, rel } = req.query;
+  if (!isString(cId) || !Array.isArray(rel) || rel.length === 0) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message:
-          "Invalid query parameters, `cId` and `filePath` (strings) are required.",
+        message: "Missing conversation id or file path.",
       },
     });
   }
@@ -54,7 +51,7 @@ async function handler(
   const owner = auth.getNonNullableWorkspace();
 
   // filePath is relative to the conversation's files base. Reject any traversal attempt.
-  const normalizedRelative = path.posix.normalize(filePath);
+  const normalizedRelative = path.posix.normalize(rel.join("/"));
   if (
     normalizedRelative.startsWith("..") ||
     normalizedRelative.startsWith("/")
@@ -72,42 +69,10 @@ async function handler(
     workspaceId: owner.sId,
     conversationId: cId,
   });
-  const normalizedPath = `${basePath}${normalizedRelative}`;
+  const gcsPath = `${basePath}${normalizedRelative}`;
 
-  const [fileResource] = await FileResource.fetchByMountFilePaths(auth, [
-    normalizedPath,
-  ]);
-
-  // If a FileResource exists, stream its best available version (processed if available).
-  if (fileResource) {
-    if (!isSupportedImageContentType(fileResource.contentType)) {
-      return apiError(req, res, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Thumbnail is only supported for image files.",
-        },
-      });
-    }
-    res.setHeader("Content-Type", fileResource.contentType);
-    // It's safe to cache as file resources can't be updated (except for frame files).
-    res.setHeader("Cache-Control", "private, max-age=3600");
-    const readStream = fileResource.getContentReadStream(auth);
-    readStream.on("error", (err) => {
-      logger.error(
-        { err, filePath: normalizedPath },
-        "Error streaming thumbnail (FileResource)"
-      );
-      readStream.destroy();
-      res.end();
-    });
-    readStream.pipe(res);
-    return;
-  }
-
-  // No FileResource, stream directly from GCS (sandbox-generated file).
   const bucket = getPrivateUploadBucket();
-  const contentTypeResult = await bucket.getFileContentType(normalizedPath);
+  const contentTypeResult = await bucket.getFileContentType(gcsPath);
   if (contentTypeResult.isErr()) {
     return apiError(req, res, {
       status_code: 404,
@@ -119,24 +84,10 @@ async function handler(
   }
 
   const contentType = contentTypeResult.value ?? "application/octet-stream";
-  if (!isSupportedImageContentType(contentType)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Thumbnail is only supported for image files.",
-      },
-    });
-  }
-
   res.setHeader("Content-Type", contentType);
-  res.setHeader("Cache-Control", "private, max-age=3600");
-  const readStream = bucket.file(normalizedPath).createReadStream();
+  const readStream = bucket.file(gcsPath).createReadStream();
   readStream.on("error", (err) => {
-    logger.error(
-      { err, filePath: normalizedPath },
-      "Error streaming thumbnail (GCS)"
-    );
+    logger.error({ err, gcsPath }, "Error streaming conversation file (GCS)");
     readStream.destroy();
     res.end();
   });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
@@ -1,0 +1,146 @@
+import handler from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files/[...rel]";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { Err, Ok } from "@app/types/shared/result";
+import type { RequestMethod } from "node-mocks-http";
+import { PassThrough } from "stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetFileContentType, mockCreateReadStream } = vi.hoisted(() => ({
+  mockGetFileContentType: vi.fn(),
+  mockCreateReadStream: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/auth_wrappers", async () => {
+  const actual = await vi.importActual("@app/lib/api/auth_wrappers");
+  return {
+    ...actual,
+    withSessionAuthenticationForWorkspace: (handler: any) => {
+      return async (req: any, res: any) => {
+        return handler(req, res, req.auth);
+      };
+    },
+  };
+});
+
+vi.mock("@app/lib/resources/conversation_resource", () => ({
+  ConversationResource: {
+    fetchById: vi.fn().mockResolvedValue({ sId: "conv_abc" }),
+  },
+}));
+
+vi.mock("@app/lib/file_storage", () => ({
+  getPrivateUploadBucket: () => ({
+    getFileContentType: mockGetFileContentType,
+    file: () => ({ createReadStream: mockCreateReadStream }),
+  }),
+}));
+
+const WORKSPACE_SID = "ws_test123";
+const CONVERSATION_SID = "conv_abc";
+
+async function setupTest(
+  rel: string[],
+  method: RequestMethod = "GET"
+) {
+  const { req, res } = await createPublicApiMockRequest({ method });
+
+  req.query = { wId: WORKSPACE_SID, cId: CONVERSATION_SID, rel };
+  req.auth = {
+    getNonNullableWorkspace: () => ({ sId: WORKSPACE_SID }),
+  };
+
+  return { req, res };
+}
+
+describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/[...rel]", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetFileContentType.mockResolvedValue(new Ok("image/png"));
+    mockCreateReadStream.mockReturnValue(
+      Object.assign(new PassThrough(), {
+        pipe: vi.fn(),
+      })
+    );
+    const { ConversationResource } = await import(
+      "@app/lib/resources/conversation_resource"
+    );
+    vi.mocked(ConversationResource.fetchById).mockResolvedValue({
+      sId: CONVERSATION_SID,
+    } as never);
+  });
+
+  it("should stream a file for a valid path", async () => {
+    const { req, res } = await setupTest(["chart.png"]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader("Content-Type")).toBe("image/png");
+  });
+
+  it("should stream a nested file path", async () => {
+    const { req, res } = await setupTest(["tool_outputs", "report.csv"]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockGetFileContentType).toHaveBeenCalledWith(
+      expect.stringContaining("tool_outputs/report.csv")
+    );
+  });
+
+  it("should return 404 when GCS file does not exist", async () => {
+    mockGetFileContentType.mockResolvedValue(new Err(new Error("not found")));
+    const { req, res } = await setupTest(["missing.png"]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: { type: "file_not_found", message: "File not found." },
+    });
+  });
+
+  it("should reject path traversal attempts", async () => {
+    const { req, res } = await setupTest(["..", "..", "etc", "passwd"]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message: "Access denied: path is outside conversation scope.",
+      },
+    });
+  });
+
+  it("should return 404 when conversation is not found", async () => {
+    const { ConversationResource } = await import(
+      "@app/lib/resources/conversation_resource"
+    );
+    vi.mocked(ConversationResource.fetchById).mockResolvedValue(null);
+
+    const { req, res } = await setupTest(["chart.png"]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  });
+
+  it("should reject non-GET methods", async () => {
+    const { req, res } = await setupTest(["chart.png"], "POST");
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it("should reject missing rel segments", async () => {
+    const { req, res } = await setupTest([]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it("should use conversation-scoped GCS path", async () => {
+    const { req, res } = await setupTest(["chart.png"]);
+    await handler(req, res);
+    expect(mockGetFileContentType).toHaveBeenCalledWith(
+      `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files/chart.png`
+    );
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
@@ -38,10 +38,7 @@ vi.mock("@app/lib/file_storage", () => ({
 const WORKSPACE_SID = "ws_test123";
 const CONVERSATION_SID = "conv_abc";
 
-async function setupTest(
-  rel: string[],
-  method: RequestMethod = "GET"
-) {
+async function setupTest(rel: string[], method: RequestMethod = "GET") {
   const { req, res } = await createPublicApiMockRequest({ method });
 
   req.query = { wId: WORKSPACE_SID, cId: CONVERSATION_SID, rel };

--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -62,8 +62,7 @@ export async function ServerSideVisualizationWrapper({
         // SERVER-SIDE: Fetch all referenced files.
         const fetchedFiles = await Promise.all(
           fileRefs.map(async (ref) => {
-            const key =
-              ref.type === "fileId" ? ref.fileId : ref.scopedPath;
+            const key = ref.type === "fileId" ? ref.fileId : ref.scopedPath;
             const fileEndpoint =
               ref.type === "fileId"
                 ? `${process.env.DUST_FRONT_API}/api/v1/viz/files/${ref.fileId}`

--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -1,7 +1,7 @@
 import { ServerVisualizationWrapperClient } from "@viz/app/content/ServerVisualizationWrapperClient";
 import type { PreFetchedFile } from "@viz/app/lib/data-apis/cache-data-api";
 import logger from "@viz/app/lib/logger";
-import { extractFileIds } from "@viz/app/lib/parseFileIds";
+import { extractFileRefs } from "@viz/app/lib/parseFileRefs";
 
 interface ServerSideVisualizationWrapperProps {
   accessToken: string;
@@ -16,7 +16,7 @@ interface ServerSideVisualizationWrapperProps {
  *
  * This component runs on the server and:
  * 1. Pre-fetches visualization code using the JWT access token
- * 2. Extracts file IDs from the code and pre-fetches all referenced files
+ * 2. Extracts file refs from the code and pre-fetches all referenced files
  * 3. Passes the pre-fetched plain data to the client wrapper
  *
  * This approach avoids the React Server Component serialization boundary issue
@@ -55,16 +55,21 @@ export async function ServerSideVisualizationWrapper({
         return;
       }
 
-      // SERVER-SIDE: Extract string literal fileIds from code.
-      const fileIds = extractFileIds(prefetchedCode);
+      // SERVER-SIDE: Extract file refs from code (both fil_xxx IDs and scoped paths).
+      const fileRefs = extractFileRefs(prefetchedCode);
 
-      if (fileIds.length > 0) {
-        // SERVER-SIDE: Fetch all files.
+      if (fileRefs.length > 0) {
+        // SERVER-SIDE: Fetch all referenced files.
         const fetchedFiles = await Promise.all(
-          fileIds.map(async (fileId) => {
-            try {
-              const fileEndpoint = `${process.env.DUST_FRONT_API}/api/v1/viz/files/${fileId}`;
+          fileRefs.map(async (ref) => {
+            const key =
+              ref.type === "fileId" ? ref.fileId : ref.scopedPath;
+            const fileEndpoint =
+              ref.type === "fileId"
+                ? `${process.env.DUST_FRONT_API}/api/v1/viz/files/${ref.fileId}`
+                : `${process.env.DUST_FRONT_API}/api/v1/viz/files/${ref.scopedPath}`;
 
+            try {
               const fileResponse = await fetch(fileEndpoint, {
                 headers,
                 cache: "no-store",
@@ -72,8 +77,8 @@ export async function ServerSideVisualizationWrapper({
 
               if (!fileResponse.ok) {
                 logger.warn(
-                  { fileId, status: fileResponse.status },
-                  "Failed to fetch file"
+                  { key, status: fileResponse.status },
+                  "Failed to fetch file ref"
                 );
                 return null;
               }
@@ -85,11 +90,11 @@ export async function ServerSideVisualizationWrapper({
 
               return {
                 data: Buffer.from(arrayBuffer).toString("base64"),
-                fileId,
+                fileId: key,
                 mimeType,
               };
             } catch (_err) {
-              logger.error({ fileId }, "Failed to fetch file");
+              logger.error({ key }, "Failed to fetch file ref");
               return null;
             }
           })

--- a/viz/app/lib/parseFileRefs.ts
+++ b/viz/app/lib/parseFileRefs.ts
@@ -2,8 +2,30 @@ import { parse } from "@babel/parser";
 import traverse from "@babel/traverse";
 import logger from "@viz/app/lib/logger";
 
-export function extractFileIds(code: string): string[] {
-  const fileIds = new Set<string>();
+export type FileRef =
+  | { type: "fileId"; fileId: string }
+  | { type: "path"; scopedPath: string };
+
+function isScopedPath(value: string): boolean {
+  // TODO(20260428 FILE SYSTEM) Add support for project.
+  return value.startsWith("conversation/");
+}
+
+export function extractFileRefs(code: string): FileRef[] {
+  const seen = new Set<string>();
+  const refs: FileRef[] = [];
+
+  function add(value: string) {
+    if (seen.has(value)) {
+      return;
+    }
+    seen.add(value);
+    if (/^fil_[a-zA-Z0-9]{10,}$/.test(value)) {
+      refs.push({ type: "fileId", fileId: value });
+    } else if (isScopedPath(value)) {
+      refs.push({ type: "path", scopedPath: value });
+    }
+  }
 
   try {
     const ast = parse(code, {
@@ -15,42 +37,38 @@ export function extractFileIds(code: string): string[] {
     traverse(ast, {
       // Extract useFile() calls.
       CallExpression(path) {
-        // Look for: useFile("fil_xxx").
         if (
           path.node.callee.type === "Identifier" &&
           path.node.callee.name === "useFile" &&
           path.node.arguments.length > 0
         ) {
           const arg = path.node.arguments[0];
-
-          // Only extract string literals (ignore variables).
           if (arg.type === "StringLiteral") {
-            fileIds.add(arg.value);
+            add(arg.value);
           }
         }
       },
-      // Extract file IDs from JSX props like fileId="fil_xxx".
+      // Extract file refs from JSX props like fileId="fil_xxx".
       JSXAttribute(path) {
         if (
           path.node.name.type === "JSXIdentifier" &&
           path.node.name.name === "fileId" &&
           path.node.value?.type === "StringLiteral"
         ) {
-          fileIds.add(path.node.value.value);
+          add(path.node.value.value);
         }
       },
-      // Extract all fil_xx patterns from string literals.
+      // Extract fil_xxx patterns and scoped paths from all string literals.
       StringLiteral(path) {
         const value = path.node.value;
-        if (typeof value === "string" && /^fil_[a-zA-Z0-9]{10,}$/.test(value)) {
-          fileIds.add(value);
+        if (typeof value === "string") {
+          add(value);
         }
       },
     });
   } catch (err) {
-    // If parsing fails, return empty (fail gracefully).
     logger.error({ err }, "Failed to parse frame code:");
   }
 
-  return Array.from(fileIds);
+  return refs;
 }


### PR DESCRIPTION
## Background

As part of the effort to align our files logic closer to an actual structured file system this PR focuses around frame support.

It unlocks this type of code in a frame:
```ts
  const file = useFile("conversation/employees_fake_data.csv");
```

Frames (interactive visualizations) today can only reference files that exist as FileResource rows in the database, fetched via `GET /api/w/:wId/files/:fileId`. This works well for files the user uploaded, or were create through the `FileResource` but it breaks down for files that agents produce at runtime in the sandbox: charts, CSVs, images written directly to GCS through `gcsfuse`. These files have no FileResource record. They live under a deterministic GCS path derived from the workspace
and conversation they belong to.

The upcoming MCP file system server will let models list and read files in that GCS tree, and it will expose those files to frame code using scoped paths like `conversation/chart.png` or `project/report.pdf`. The scope prefix (`conversation`, `project`) is not a raw GCS path. **It is an authorization scope.** The actual GCS location is resolved server-side from the frame's own `useCaseMetadata`, which is signed into the JWT. The model cannot escalate beyond the conversation (or project) that the frame belongs to.

This PR builds the endpoint infrastructure that frames need to load those files. It is intentionally shipped before the MCP server, so that once the LLM are exposed to those new paths, and they starts emitting scoped paths into frame code, the serving layer is already in place and tested.

## Significant changes

- `parseFileRefs` replaces `parseFileIds`. The old module only recognized `fil_xxx` tokens. The new one returns a discriminated union so the SSR pre-fetch layer (used for public viewing of frames) can handle both kinds of reference with a single traversal pass over the frame's AST.

- `GET /api/v1/viz/files/[...segments]` is the new public endpoint for frames served outside an authenticated session (public shares, SSR pre-fetch). A conversation segment resolves to the conversation ID stored in the frame file's `useCaseMetadata`. The `conversationId` is never user-supplied: it comes from the frame's signed `FileResource` record, looked up via the same JWT already used for the frame itself. Path traversal is prevented like on all other endpoints.

- `GET /api/w/[wId]/assistant/conversations/[cId]/files/[...rel]` is the private counterpart for the interactive iframe at runtime. When a logged-in user is viewing a conversation and the frame sends a `getFile` RPC for a `conversation/chart.png` ref, `VisualizationActionIframe` maps the scope prefix to the correct private endpoint and drops the prefix before sending the
relative path. The endpoint validates that the conversation belongs to the workspace, applies the same traversal guard, and streams the GCS object directly.

- Frame instructions are not yet updated since the models have no way to see the GCS files yet.

## Security model

For the public endpoint, the `conversationId` is derived from `frameFile.useCaseMetadata`, not the request. The user controls only the relative path after the scope segment, and that path is normalized and checked for traversal before use. A user who has a valid access token for frame A cannot use it to read files from frame B's conversation because the
`conversationId` is baked into the signed frame record, not inferred from the URL.

## Next steps

- Project-scoped paths (`project/report.pdf`) are stubbed with TODO comments. We currently don't mount projects files in GCS. This will be added once they exist in GCS.

- Files produced by sub-agents live under their own sub-conversation GCS directory (`conversations/{subConvId}/files/`), not under the parent conversation. A frame embedded in the parent conversation that tries to reference a sub-agent file via `conversation/chart.png` will get a 404 today. Still need to think more about this usecase, but we might want to move up the files created by sub agents (TBD).

- The viz system prompt (VIZ_FILE_HANDLING_GUIDELINES) and examples still describe the `fil_xxx` pattern. Once the new MCP server is behind a feature flag and the scoped-path convention is established, those instructions will need a parallel variant enabled by the flag.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
