### PR TITLE
fix(project-todo): preserve first version text on todo updates

### DIFF
--- a/front/lib/project_todo/merge_into_project.test.ts
+++ b/front/lib/project_todo/merge_into_project.test.ts
@@ -167,7 +167,7 @@ describe("updateTodoIfChanged", () => {
     expect(todo.updateWithVersion).not.toHaveBeenCalled();
   });
 
-  it("updates an agent-created todo when the text changed", async () => {
+  it("ignores text changes on an agent-created todo (first version wins)", async () => {
     const todo = makeTodoStub({ text: "Old text" });
     const blob = makeBlob({ text: "New text" });
 
@@ -177,12 +177,30 @@ describe("updateTodoIfChanged", () => {
       blob
     );
 
-    expect(updated).toBe(true);
-    expect(todo.updateWithVersion).toHaveBeenCalledTimes(1);
-    expect(todo.updateWithVersion).toHaveBeenCalledWith(fakeAuth, {
+    expect(updated).toBe(false);
+    expect(todo.updateWithVersion).not.toHaveBeenCalled();
+  });
+
+  it("preserves the original text when status changes on an agent-created todo", async () => {
+    const doneAt = new Date("2026-04-21T12:00:00.000Z");
+    const todo = makeTodoStub({ text: "Old text", status: "todo" });
+    const blob = makeBlob({
       text: "New text",
-      status: "todo",
-      doneAt: null,
+      status: "done",
+      doneAt,
+    });
+
+    const updated = await updateTodoIfChanged(
+      todo as unknown as ProjectTodoResource,
+      fakeAuth,
+      blob
+    );
+
+    expect(updated).toBe(true);
+    expect(todo.updateWithVersion).toHaveBeenCalledWith(fakeAuth, {
+      text: "Old text",
+      status: "done",
+      doneAt,
       actorRationale: null,
     });
   });

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -8,7 +8,8 @@
 //   Phase 1 — Collect new candidates.
 //     For every (takeaway, item, targetUser) triple:
 //       - fetchBySourceId(itemId, userId):
-//           found     → update text/status/doneAt if changed (no new row)
+//           found     → update status/doneAt if changed (no new row, text
+//                       always preserved from the first version)
 //           not found → push to newCandidates[]
 //
 //   Phase 2 — Semantic deduplication.
@@ -22,7 +23,8 @@
 //     For each candidate in newCandidates:
 //       - Key in dedupMap → addSource on existing todo.
 //           If existing todo is user-created: preserve text/status (user wins).
-//           If existing todo is agent-created: also update if content changed.
+//           If existing todo is agent-created: update status/doneAt if
+//           changed (text is always preserved from the first version).
 //       - Not in dedupMap → makeNew + addSource (current behaviour).
 //
 // Category mapping:
@@ -481,9 +483,10 @@ async function createOrLinkTodos(
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-// Creates a new version of a todo only when text, status, or doneAt has
-// changed, AND the todo's state is not user-owned. Returns true if an update
-// was performed.
+// Creates a new version of a todo only when status or doneAt has changed, AND
+// the todo's state is not user-owned. Returns true if an update was performed.
+// Text is intentionally never updated: the first version's wording is
+// preserved across re-extractions.
 //
 // The agent path must never overwrite user-owned state:
 //   - If the todo was created by a user, the user's phrasing and status win.
@@ -502,20 +505,14 @@ export async function updateTodoIfChanged(
     return false;
   }
 
-  const textChanged = todo.text !== blob.text;
   const statusChanged = todo.status !== blob.status;
   const doneAtChanged =
     todo.doneAt?.toISOString() !== blob.doneAt?.toISOString();
   const actorRationaleAtChanged = todo.actorRationale !== blob.reasoningDoneAt;
 
-  if (
-    textChanged ||
-    statusChanged ||
-    doneAtChanged ||
-    actorRationaleAtChanged
-  ) {
+  if (statusChanged || doneAtChanged || actorRationaleAtChanged) {
     await todo.updateWithVersion(auth, {
-      text: blob.text,
+      text: todo.text,
       status: blob.status,
       doneAt: blob.doneAt,
       actorRationale: blob.reasoningDoneAt,


### PR DESCRIPTION
## Description

Fixes the bug where TODOs kept changing text. We have now a stable text

When the project-todo merge re-extracts items from a takeaway, text changes are now ignored: the first version's wording is always preserved. Status, `doneAt`, and rationale changes still trigger a new version, but `updateWithVersion` is called with the original `todo.text`.

## Tests

Unit tests updated