### PR TITLE
Fix compaction error toast and split 409 messages by cause

### DIFF
--- a/front/hooks/conversations/useCompactConversation.ts
+++ b/front/hooks/conversations/useCompactConversation.ts
@@ -46,7 +46,7 @@ export function useCompactConversation({
           sendNotification({
             type: "error",
             title: "Failed to compact conversation",
-            description: body?.api_error?.message ?? "Unknown error.",
+            description: body?.error?.message ?? "Unknown error.",
           });
           setIsCompacting(false);
         }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2728,22 +2728,38 @@ export async function compactConversation(
     );
   const lastMessage = conversation.content.at(-1)?.at(-1);
 
-  if (
-    runningAgentMessage ||
-    runningCompaction ||
-    (lastMessage && isCompactionMessageType(lastMessage))
-  ) {
+  if (runningAgentMessage) {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Answer the pending agent message first.",
+      },
+    });
+  }
+
+  if (runningCompaction) {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message: "A compaction is already in progress. Please wait.",
+      },
+    });
+  }
+
+  if (lastMessage && isCompactionMessageType(lastMessage)) {
     return new Err({
       status_code: 409,
       api_error: {
         type: "invalid_request_error",
         message:
-          "Cannot compact while another compaction or an agent message is running, or when the last message is already a compaction message.",
+          "This conversation was just compacted. Send a new message before compacting again.",
       },
     });
   }
 
-  const { compactionMessage } = await withTransaction(async (t) => {
+  const { compactionMessage, conflict } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
     // Re-check the existence of a compaction message or running agent message inside the critical
@@ -2782,8 +2798,11 @@ export async function compactConversation(
       }),
     ]);
 
-    if (runningCompactionMessage || runningAgentMessage) {
-      return { compactionMessage: null };
+    if (runningAgentMessage) {
+      return { compactionMessage: null, conflict: "agent" as const };
+    }
+    if (runningCompactionMessage) {
+      return { compactionMessage: null, conflict: "compaction" as const };
     }
 
     const nextMessageRank = await getNextConversationMessageRank(auth, {
@@ -2802,7 +2821,7 @@ export async function compactConversation(
       transaction: t,
     });
 
-    return { compactionMessage };
+    return { compactionMessage, conflict: null };
   });
 
   if (!compactionMessage) {
@@ -2811,7 +2830,9 @@ export async function compactConversation(
       api_error: {
         type: "invalid_request_error",
         message:
-          "Cannot compact while another compaction or an agent message is running.",
+          conflict === "agent"
+            ? "Answer the pending agent message first."
+            : "A compaction is already in progress. Please wait.",
       },
     });
   }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2759,7 +2759,7 @@ export async function compactConversation(
     });
   }
 
-  const { compactionMessage, conflict } = await withTransaction(async (t) => {
+  const { compactionMessage } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
     // Re-check the existence of a compaction message or running agent message inside the critical
@@ -2798,11 +2798,8 @@ export async function compactConversation(
       }),
     ]);
 
-    if (runningAgentMessage) {
-      return { compactionMessage: null, conflict: "agent" as const };
-    }
-    if (runningCompactionMessage) {
-      return { compactionMessage: null, conflict: "compaction" as const };
+    if (runningCompactionMessage || runningAgentMessage) {
+      return { compactionMessage: null };
     }
 
     const nextMessageRank = await getNextConversationMessageRank(auth, {
@@ -2821,7 +2818,7 @@ export async function compactConversation(
       transaction: t,
     });
 
-    return { compactionMessage, conflict: null };
+    return { compactionMessage };
   });
 
   if (!compactionMessage) {
@@ -2830,9 +2827,7 @@ export async function compactConversation(
       api_error: {
         type: "invalid_request_error",
         message:
-          conflict === "agent"
-            ? "Answer the pending agent message first."
-            : "A compaction is already in progress. Please wait.",
+          "Cannot compact while another compaction or an agent message is running.",
       },
     });
   }


### PR DESCRIPTION
## Description

The compaction failure toast always showed "Unknown error" because the hook read `body.api_error.message`, but the API serializes errors as `{ error: { type, message } }`. Fixed the field name so the actual API message reaches the user.

While there, replaced the single catch-all 409 message ("Cannot compact while another compaction or an agent message is running, or when the last message is already a compaction message.") with three cause-specific messages, each naming the blocker and the next action:

1. Agent message in `created` status (includes the case where the agent is waiting on the user to answer a tool prompt) returns "Answer the pending agent message first."
2. Compaction in `created` status returns  "A compaction is already in progress. Please wait."
3. Last message is a compaction returns "This conversation was just compacted. Send a new message before compacting again."

The post-lock recheck inside the transaction now also distinguishes between the agent and compaction cases instead of returning a single generic message.


## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
