### PR TITLE
feat(sbx): structured rendering of bash tool output sections

### DIFF
--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -3,8 +3,6 @@ import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/deta
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
-  ActionDocumentTextIcon,
-  Button,
   CodeBlock,
   Collapsible,
   CollapsibleContent,
@@ -13,7 +11,7 @@ import {
   cn,
   Markdown,
 } from "@dust-tt/sparkle";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 type SandboxSectionType =
   | "stdout"
@@ -68,54 +66,6 @@ function sectionLabel(type: SandboxSectionType): string {
   }
 }
 
-const STORAGE_KEY = "dust:sandbox:rawMode";
-
-function getStoredRawMode(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  return localStorage.getItem(STORAGE_KEY) === "true";
-}
-
-function setStoredRawMode(value: boolean): void {
-  if (typeof window !== "undefined") {
-    localStorage.setItem(STORAGE_KEY, String(value));
-  }
-}
-
-/**
- * Extract a clean, short command name from a potentially complex command string.
- * Strips heredocs, pipes, semicolons, and env vars to find the core binary/script.
- */
-function extractCommandName(command: string): string {
-  const firstLine = command.trim().split("\n")[0];
-
-  // Strip heredoc markers (e.g. `python3 << 'EOF'` → `python3`)
-  const beforeHeredoc = firstLine.split("<<")[0].trim();
-
-  // Strip pipes and take the first command
-  const firstCmd = beforeHeredoc.split("|")[0].trim();
-
-  // Strip leading env vars (e.g. `FOO=bar python3` → `python3`)
-  const tokens = firstCmd.split(/\s+/);
-  const cmdToken = tokens.find((t) => !t.includes("=")) ?? tokens[0];
-
-  // Strip path (e.g. `/usr/bin/python3` → `python3`)
-  const basename = cmdToken.split("/").pop() ?? cmdToken;
-
-  return basename;
-}
-
-function deriveSummary(command: string, exitCode: number | null): string {
-  const name = extractCommandName(command);
-
-  if (exitCode !== null && exitCode !== 0) {
-    return `\`${name}\` failed with exit code ${exitCode}.`;
-  }
-
-  return `Ran \`${name}\` successfully.`;
-}
-
 function parseExitCode(sections: SandboxSection[]): number | null {
   const section = sections.find((s) => s.type === "exit_code");
   if (!section) {
@@ -130,8 +80,6 @@ export function MCPSandboxActionDetails({
   toolParams,
   toolOutput,
 }: ToolExecutionDetailsProps) {
-  const [isRawMode, setIsRawMode] = useState(getStoredRawMode);
-
   const command =
     typeof toolParams.command === "string" ? toolParams.command : null;
 
@@ -154,31 +102,13 @@ export function MCPSandboxActionDetails({
 
   const isRunning = toolOutput === null;
 
-  const summary = useMemo(() => {
-    if (!command) {
-      return "Executed command in sandbox";
-    }
-    return deriveSummary(command, exitCode);
-  }, [command, exitCode]);
-
-  const toggleRawMode = useCallback(() => {
-    setIsRawMode((prev) => {
-      const next = !prev;
-      setStoredRawMode(next);
-      return next;
-    });
-  }, []);
-
   const actionName = isRunning
     ? "Executing command in sandbox"
     : "Executed command in sandbox";
 
   const viewProps: SandboxViewProps = {
     command,
-    summary,
-    rawOutputText,
     parsedSections,
-    isRawMode,
     isRunning,
     exitCode,
   };
@@ -188,11 +118,6 @@ export function MCPSandboxActionDetails({
       displayContext={displayContext}
       actionName={actionName}
       visual={CommandLineIcon}
-      headerAction={
-        !isRunning ? (
-          <ToggleButton isRawMode={isRawMode} onToggle={toggleRawMode} />
-        ) : undefined
-      }
     >
       {displayContext === "conversation" ? (
         <ConversationView {...viewProps} />
@@ -205,41 +130,9 @@ export function MCPSandboxActionDetails({
 
 interface SandboxViewProps {
   command: string | null;
-  summary: string;
-  rawOutputText: string | null;
   parsedSections: SandboxSection[];
-  isRawMode: boolean;
   isRunning: boolean;
   exitCode: number | null;
-}
-
-interface ToggleButtonProps {
-  isRawMode: boolean;
-  onToggle: () => void;
-}
-
-function ToggleButton({ isRawMode, onToggle }: ToggleButtonProps) {
-  return (
-    <Button
-      size="xs"
-      variant="ghost"
-      label={isRawMode ? "Show summary" : "Show code"}
-      icon={isRawMode ? ActionDocumentTextIcon : CommandLineIcon}
-      onClick={onToggle}
-    />
-  );
-}
-
-interface CommandPreviewProps {
-  command: string;
-}
-
-function CommandPreview({ command }: CommandPreviewProps) {
-  return (
-    <code className="rounded bg-muted px-1 py-0.5 text-xs dark:bg-muted-night">
-      {extractCommandName(command)}
-    </code>
-  );
 }
 
 interface ExitCodeBadgeProps {
@@ -353,35 +246,19 @@ function SandboxOutput({
 
 function ConversationView({
   command,
-  summary,
   parsedSections,
-  isRawMode,
   isRunning,
   exitCode,
 }: SandboxViewProps) {
   return (
-    <div className="flex flex-col gap-2 pl-6">
-      {isRunning && command && (
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Running <CommandPreview command={command} />
-        </p>
-      )}
-
-      {!isRunning && !isRawMode && (
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {summary}
-        </p>
-      )}
-
-      {!isRunning && isRawMode && (
-        <div className="flex flex-col gap-3">
-          {command && <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />}
-          <SandboxOutput
-            sections={parsedSections}
-            exitCode={exitCode}
-            isRunning={isRunning}
-          />
-        </div>
+    <div className="flex flex-col gap-3 pl-6">
+      {command && <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />}
+      {!isRunning && (
+        <SandboxOutput
+          sections={parsedSections}
+          exitCode={exitCode}
+          isRunning={isRunning}
+        />
       )}
     </div>
   );
@@ -389,51 +266,35 @@ function ConversationView({
 
 function SidebarView({
   command,
-  summary,
   parsedSections,
-  isRawMode,
   isRunning,
   exitCode,
 }: SandboxViewProps) {
   return (
     <div className="flex flex-col gap-4 py-4 pl-6">
-      {!isRawMode && (
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {isRunning && command
-            ? `Running \`${command}\``
-            : isRunning
-              ? "Running command…"
-              : summary}
-        </p>
-      )}
-
-      {isRawMode && (
-        <>
-          {command && (
-            <div>
-              <span className="font-medium text-foreground dark:text-foreground-night">
-                Command
-              </span>
-              <div className="py-2">
-                <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />
-              </div>
-            </div>
-          )}
-
-          <div>
-            <span className="font-medium text-foreground dark:text-foreground-night">
-              Output
-            </span>
-            <div className="py-2">
-              <SandboxOutput
-                sections={parsedSections}
-                exitCode={exitCode}
-                isRunning={isRunning}
-              />
-            </div>
+      {command && (
+        <div>
+          <span className="font-medium text-foreground dark:text-foreground-night">
+            Command
+          </span>
+          <div className="py-2">
+            <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />
           </div>
-        </>
+        </div>
       )}
+
+      <div>
+        <span className="font-medium text-foreground dark:text-foreground-night">
+          Output
+        </span>
+        <div className="py-2">
+          <SandboxOutput
+            sections={parsedSections}
+            exitCode={exitCode}
+            isRunning={isRunning}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -1,14 +1,72 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   ActionDocumentTextIcon,
   Button,
+  CodeBlock,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
   CommandLineIcon,
   cn,
   Markdown,
 } from "@dust-tt/sparkle";
 import { useCallback, useMemo, useState } from "react";
+
+type SandboxSectionType =
+  | "stdout"
+  | "stderr"
+  | "exit_code"
+  | "network_proxy_logs";
+
+interface SandboxSection {
+  type: SandboxSectionType;
+  content: string;
+}
+
+const SECTION_REGEX =
+  /<(stdout|stderr|exit_code|network_proxy_logs)>([\s\S]*?)<\/\1>/g;
+
+const COLLAPSE_LINE_THRESHOLD = 20;
+const COLLAPSE_CHAR_THRESHOLD = 1500;
+
+function parseSandboxOutput(rawText: string): SandboxSection[] {
+  const sections: SandboxSection[] = [];
+  for (const match of rawText.matchAll(SECTION_REGEX)) {
+    const [, type, content] = match;
+    sections.push({
+      type: type as SandboxSectionType,
+      content: content.replace(/^\n|\n$/g, ""),
+    });
+  }
+  return sections;
+}
+
+function isLongContent(content: string): boolean {
+  if (content.length > COLLAPSE_CHAR_THRESHOLD) {
+    return true;
+  }
+  const lines = content.split("\n").length;
+  return lines > COLLAPSE_LINE_THRESHOLD;
+}
+
+function sectionLabel(type: SandboxSectionType): string {
+  switch (type) {
+    case "stdout":
+      return "stdout";
+    case "stderr":
+      return "stderr";
+    case "exit_code":
+      return "exit code";
+    case "network_proxy_logs":
+      return "network proxy logs";
+    default:
+      assertNeverAndIgnore(type);
+      return "";
+  }
+}
 
 const STORAGE_KEY = "dust:sandbox:rawMode";
 
@@ -55,20 +113,16 @@ function deriveSummary(command: string, exitCode: number | null): string {
     return `\`${name}\` failed with exit code ${exitCode}.`;
   }
 
-  if (exitCode === 0) {
-    return `Ran \`${name}\` successfully.`;
-  }
-
-  return `Ran \`${name}\`.`;
+  return `Ran \`${name}\` successfully.`;
 }
 
-/**
- * Parse the raw text output to extract the exit code if present.
- * The sandbox tool formats output as: stdout + [stderr]\n... + [exit code: N]
- */
-function parseExitCode(rawText: string): number | null {
-  const match = rawText.match(/\[exit code: (\d+)\]\s*$/);
-  return match ? parseInt(match[1], 10) : null;
+function parseExitCode(sections: SandboxSection[]): number | null {
+  const section = sections.find((s) => s.type === "exit_code");
+  if (!section) {
+    return null;
+  }
+  const parsed = parseInt(section.content.trim(), 10);
+  return Number.isNaN(parsed) ? null : parsed;
 }
 
 export function MCPSandboxActionDetails({
@@ -89,9 +143,14 @@ export function MCPSandboxActionDetails({
     return textBlocks.map((b) => b.text).join("\n") || null;
   }, [toolOutput]);
 
-  const exitCode = useMemo(() => {
-    return rawOutputText ? parseExitCode(rawOutputText) : null;
+  const parsedSections = useMemo(() => {
+    return rawOutputText ? parseSandboxOutput(rawOutputText) : [];
   }, [rawOutputText]);
+
+  const exitCode = useMemo(
+    () => parseExitCode(parsedSections),
+    [parsedSections]
+  );
 
   const isRunning = toolOutput === null;
 
@@ -118,6 +177,7 @@ export function MCPSandboxActionDetails({
     command,
     summary,
     rawOutputText,
+    parsedSections,
     isRawMode,
     isRunning,
     exitCode,
@@ -147,6 +207,7 @@ interface SandboxViewProps {
   command: string | null;
   summary: string;
   rawOutputText: string | null;
+  parsedSections: SandboxSection[];
   isRawMode: boolean;
   isRunning: boolean;
   exitCode: number | null;
@@ -204,10 +265,96 @@ function ExitCodeBadge({ exitCode }: ExitCodeBadgeProps) {
   );
 }
 
+interface SectionBlockProps {
+  type: SandboxSectionType;
+  content: string;
+  defaultOpen: boolean;
+}
+
+function SectionBlock({ type, content, defaultOpen }: SectionBlockProps) {
+  const isStderr = type === "stderr";
+  const isExitCode = type === "exit_code";
+
+  if (isExitCode) {
+    return null;
+  }
+
+  const labelClass = cn(
+    "font-mono text-xs uppercase tracking-wide",
+    isStderr
+      ? "text-warning dark:text-warning-night"
+      : "text-muted-foreground dark:text-muted-foreground-night"
+  );
+
+  if (!isLongContent(content)) {
+    return (
+      <div className="flex flex-col gap-1">
+        <span className={labelClass}>{sectionLabel(type)}</span>
+        <CodeBlock wrapLongLines>{content}</CodeBlock>
+      </div>
+    );
+  }
+
+  const lineCount = content.split("\n").length;
+
+  return (
+    <Collapsible defaultOpen={defaultOpen}>
+      <CollapsibleTrigger>
+        <span className={labelClass}>
+          {sectionLabel(type)} · {lineCount} lines
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="pt-1">
+          <CodeBlock wrapLongLines>{content}</CodeBlock>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+interface SandboxOutputProps {
+  sections: SandboxSection[];
+  exitCode: number | null;
+  isRunning: boolean;
+}
+
+function SandboxOutput({
+  sections,
+  exitCode,
+  isRunning,
+}: SandboxOutputProps) {
+  const renderable = sections.filter((s) => s.type !== "exit_code");
+
+  if (renderable.length === 0) {
+    return (
+      <p className="text-sm italic text-muted-foreground dark:text-muted-foreground-night">
+        {isRunning ? "Waiting for output…" : "No output"}
+      </p>
+    );
+  }
+
+  const failed = exitCode !== null && exitCode !== 0;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {renderable.map((section, idx) => (
+        <SectionBlock
+          key={`${section.type}-${idx}`}
+          type={section.type}
+          content={section.content}
+          defaultOpen={!(failed && section.type === "stdout")}
+        />
+      ))}
+      <ExitCodeBadge exitCode={exitCode} />
+    </div>
+  );
+}
+
 function ConversationView({
   command,
   summary,
-  rawOutputText,
+  parsedSections,
   isRawMode,
   isRunning,
   exitCode,
@@ -227,12 +374,13 @@ function ConversationView({
       )}
 
       {!isRunning && isRawMode && (
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-3">
           {command && <Markdown content={`\`\`\`bash\n${command}\n\`\`\``} />}
-          {rawOutputText && (
-            <Markdown content={`\`\`\`\n${rawOutputText}\n\`\`\``} />
-          )}
-          <ExitCodeBadge exitCode={exitCode} />
+          <SandboxOutput
+            sections={parsedSections}
+            exitCode={exitCode}
+            isRunning={isRunning}
+          />
         </div>
       )}
     </div>
@@ -242,7 +390,7 @@ function ConversationView({
 function SidebarView({
   command,
   summary,
-  rawOutputText,
+  parsedSections,
   isRawMode,
   isRunning,
   exitCode,
@@ -277,17 +425,13 @@ function SidebarView({
               Output
             </span>
             <div className="py-2">
-              {rawOutputText ? (
-                <Markdown content={`\`\`\`\n${rawOutputText}\n\`\`\``} />
-              ) : (
-                <p className="text-sm italic text-muted-foreground dark:text-muted-foreground-night">
-                  {isRunning ? "Waiting for output…" : "(no output)"}
-                </p>
-              )}
+              <SandboxOutput
+                sections={parsedSections}
+                exitCode={exitCode}
+                isRunning={isRunning}
+              />
             </div>
           </div>
-
-          <ExitCodeBadge exitCode={exitCode} />
         </>
       )}
     </div>

--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -13,11 +13,18 @@ import {
 } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
-type SandboxSectionType =
-  | "stdout"
-  | "stderr"
-  | "exit_code"
-  | "network_proxy_logs";
+const SANDBOX_SECTION_TYPES = [
+  "stdout",
+  "stderr",
+  "exit_code",
+  "network_proxy_logs",
+] as const;
+
+type SandboxSectionType = (typeof SANDBOX_SECTION_TYPES)[number];
+
+function isSandboxSectionType(value: string): value is SandboxSectionType {
+  return (SANDBOX_SECTION_TYPES as readonly string[]).includes(value);
+}
 
 interface SandboxSection {
   type: SandboxSectionType;
@@ -34,8 +41,11 @@ function parseSandboxOutput(rawText: string): SandboxSection[] {
   const sections: SandboxSection[] = [];
   for (const match of rawText.matchAll(SECTION_REGEX)) {
     const [, type, content] = match;
+    if (!isSandboxSectionType(type)) {
+      continue;
+    }
     sections.push({
-      type: type as SandboxSectionType,
+      type,
       content: content.replace(/^\n|\n$/g, ""),
     });
   }

--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -212,11 +212,7 @@ interface SandboxOutputProps {
   isRunning: boolean;
 }
 
-function SandboxOutput({
-  sections,
-  exitCode,
-  isRunning,
-}: SandboxOutputProps) {
+function SandboxOutput({ sections, exitCode, isRunning }: SandboxOutputProps) {
   const renderable = sections.filter((s) => s.type !== "exit_code");
 
   if (renderable.length === 0) {


### PR DESCRIPTION
## Description

The sandbox bash tool returns output as XML-tagged sections (`<stdout>`, `<stderr>`, `<exit_code>`, `<network_proxy_logs>`). The tool-result inspect panel was rendering the raw XML inside a `Markdown` code block, which is hard to scan when stderr matters.

This PR parses the sections and renders each one as a labeled `CodeBlock`:
- `stderr` is highlighted with the warning color so failures are visible at a glance.
- Long sections (>20 lines or >1500 chars) are wrapped in a `Collapsible` with a line count in the trigger.
- When the command exited non-zero, `stdout` starts collapsed so `stderr` surfaces first.
- `exit_code` is rendered as the existing colored badge under the sections.
- Empty output falls back to a "No output" / "Waiting for output…" message instead of the literal `(no output)` string.

Also fixes `parseExitCode`, which was still scanning for the obsolete `[exit code: N]` format and therefore never matched against the current XML output. The summary line now correctly reflects "Ran X successfully." vs "X failed with exit code N."
<img width="593" height="226" alt="Screenshot 2026-04-28 at 16 21 49" src="https://github.com/user-attachments/assets/cb0a6a35-ad9e-477b-ab78-8f0562d6caae" />
<img width="605" height="390" alt="Screenshot 2026-04-28 at 16 21 41" src="https://github.com/user-attachments/assets/c1deca90-a2dd-44d6-9ff0-49cd970d8e2d" />
<img width="597" height="821" alt="Screenshot 2026-04-28 at 16 21 33" src="https://github.com/user-attachments/assets/760cc18d-b4cd-4003-855e-680781c1be72" />
<img width="594" height="376" alt="Screenshot 2026-04-28 at 16 21 25" src="https://github.com/user-attachments/assets/54cea1f6-8477-4511-a304-187adc5384c9" />
<img width="597" height="330" alt="Screenshot 2026-04-28 at 16 21 20" src="https://github.com/user-attachments/assets/a9cb1424-8b24-4227-a6b1-3abe86e2e1c6" />




## Tests

Manual: load a sandbox tool execution in the inspect panel, toggle raw mode, and check rendering for:
- Successful command with stdout only.
- Failing command with both stdout and stderr.
- Long stdout (>20 lines) — collapsible with line count.
- Empty output — "No output" fallback.
- Network-denied command — `network_proxy_logs` section appears.

`npx tsc --noEmit` passes in `front`.

## Risk

Low. UI-only change scoped to the sandbox bash tool inspect panel. The parser is forgiving (regex over a fully controlled server-side format) and falls back to the empty state if no sections match. No backend or schema changes.

## Deploy Plan

Standard front deploy.