### PR TITLE
fix: uniq index on project_todo_source

### DIFF
--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -447,8 +447,8 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
   // ── Source links (* => todo) ─────────────────────────────────────────────
 
   // Links the given takeaway item + source document to this todo. Idempotent
-  // by (workspaceId, itemId, userId): if a row already exists for this
-  // (item, user) pair, its fields are updated to point at this todo and
+  // by (workspaceId, sourceType, sourceId, userId, projectTodoId): if a row already exists for this,\
+  // its fields are updated to point at this todo and
   // source — so a Temporal activity retry after a partial success converges
   // to the same state instead of creating a duplicate.
   async upsertSource(
@@ -463,17 +463,18 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     transaction?: Transaction
   ): Promise<void> {
     const workspaceId = auth.getNonNullableWorkspace().id;
+    // we want one link between one given TODO (that belongs to a user) for a given source
     const identity = {
       workspaceId,
       sourceType: source.sourceType,
       sourceId: source.sourceId,
       userId: this.userId,
+      projectTodoId: this.id,
     };
     const payload = {
-      projectTodoId: this.id,
-      itemId,
-      sourceTitle: source.sourceTitle,
-      sourceUrl: source.sourceUrl,
+      itemId, // we can have multiple items from the same source
+      sourceTitle: source.sourceTitle, // we update to the latest title
+      sourceUrl: source.sourceUrl, // same here
     };
 
     const [sourceInstance, created] = await ProjectTodoSourceModel.findOrCreate(

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -446,8 +446,14 @@ ProjectTodoSourceModel.init(
         concurrently: true,
       },
       {
-        name: "project_todo_sources_ws_item_user_unique_idx",
-        fields: ["workspaceId", "itemId", "userId"],
+        name: "project_todo_sources_ws_todo_source_user_unique_idx",
+        fields: [
+          "workspaceId",
+          "projectTodoId",
+          "sourceType",
+          "sourceId",
+          "userId",
+        ],
         unique: true,
         concurrently: true,
       },

--- a/front/migrations/db/migration_609.sql
+++ b/front/migrations/db/migration_609.sql
@@ -1,0 +1,5 @@
+-- Migration created on Apr 28, 2026
+DROP INDEX IF EXISTS "project_todo_sources_ws_item_user_unique_idx";
+
+CREATE UNIQUE INDEX CONCURRENTLY "project_todo_sources_ws_todo_source_user_unique_idx" ON
+    "project_todo_sources" ("workspaceId", "projectTodoId", "sourceType", "sourceId", "userId");


### PR DESCRIPTION
## Description

This fixes the `duplicate key value violates unique constraint "project_todo_sources_ws_item_user_unique_idx"` we have in production.

We had a discrepancy between the code and the index in the DB. 

When we link a todo and a source we used a uniq index, and different uniqueness in the code. 

This aligns both.

⚠️ we currently have [98](https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo0LCJsaWIvdHlwZSI6Im1icWwvcXVlcnkiLCJzdGFnZXMiOlt7ImxpYi90eXBlIjoibWJxbC5zdGFnZS9uYXRpdmUiLCJuYXRpdmUiOiJTRUxFQ1QgXG4gIFwid29ya3NwYWNlSWRcIiwgXG4gIFwicHJvamVjdFRvZG9JZFwiLCBcbiAgXCJzb3VyY2VUeXBlXCIsIFxuICBcInNvdXJjZUlkXCIsIFxuICBcInVzZXJJZFwiLCBcbiAgQ09VTlQoKikgYXMgY250XG5GUk9NIFwicHJvamVjdF90b2RvX3NvdXJjZXNcIlxuR1JPVVAgQlkgXG4gIFwid29ya3NwYWNlSWRcIiwgXG4gIFwicHJvamVjdFRvZG9JZFwiLCBcbiAgXCJzb3VyY2VUeXBlXCIsIFxuICBcInNvdXJjZUlkXCIsIFxuICBcInVzZXJJZFwiXG5IQVZJTkcgQ09VTlQoKikgPiAxIiwidGVtcGxhdGUtdGFncyI6e319XX0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=) duplicates considering the new index, I'll clean them before running the migration.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
