### PR TITLE
Release wakeups

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1107,8 +1107,7 @@ export const INTERNAL_MCP_SERVERS = {
     availability: "auto",
     allowMultipleInstances: false,
     isPreview: false,
-    isRestricted: ({ featureFlags }) =>
-      !featureFlags.includes("enable_wakeups"),
+    isRestricted: undefined,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -320,11 +320,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable ES-backed conversation listing in the sidebar (read path)",
     stage: "dust_only",
   },
-  enable_wakeups: {
-    description:
-      "Enable the wakeups MCP server, letting agents schedule wake-ups in a conversation.",
-    stage: "dust_only",
-  },
   new_file_explorer: {
     description:
       "Unified GCS-backed file explorer with folder hierarchy, replacing the two-tab files panel.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -757,7 +757,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "sensitivity_labels"
   | "conversation_search_indexing"
   | "conversation_search_read"
-  | "enable_wakeups"
   | "new_file_explorer"
 >();
 

--- a/x/spolu/wakeup/plan.md
+++ b/x/spolu/wakeup/plan.md
@@ -74,10 +74,10 @@ Done:
 
 ### [x] PR 6 — `wakeups` internal MCP server
 
-Adds the `wakeups` internal MCP server (id 1031, `availability: "auto"`, preview, gated
-behind the new `enable_wakeups` feature flag) exposing `schedule_wakeup`, `list_wakeups`,
-and `cancel_wakeup` to agents. `when` is parsed deterministically (relative duration, ISO
-8601, 5-field cron); cron timezone falls back to the last user message's timezone.
+Adds the `wakeups` internal MCP server (id 1031, `availability: "auto"`, preview) exposing
+`schedule_wakeup`, `list_wakeups`, and `cancel_wakeup` to agents. `when` is parsed
+deterministically (relative duration, ISO 8601, 5-field cron); cron timezone falls back to the
+last user message's timezone.
 Guardrails enforced at tool-call time: max 1 active wake-up per conversation, max 256 per
 workspace, max 31-day one-shot delay. Also updates `runWakeUpActivity` to post the
 wake-up message with `username: "dust_system"` / `fullName: "Dust System"` instead of

--- a/x/spolu/wakeup/wakeup.md
+++ b/x/spolu/wakeup/wakeup.md
@@ -187,8 +187,7 @@ fire via `cleanupTemporalAfterFire(...)`.
 ## Agent Skill Interface
 
 The wake-up capability is exposed through the `wakeups` internal MCP server (server id
-1031, `availability: "auto"`, gated behind the `enable_wakeups` feature flag while in
-preview). It registers three tools:
+1031, `availability: "auto"`). It registers three tools:
 
 ```
 schedule_wakeup({


### PR DESCRIPTION
## Description

Remove the `enable_wakeups` feature flag so the wakeups internal MCP server is available to all workspaces. Also removes the flag from whitelistable feature definitions and updates wakeups planning notes to reflect the release state.

## Tests

Focused internal MCP constants test passed locally.

## Risk

Low. This removes a release gate for an already implemented auto internal MCP server.

## Deploy Plan

- deploy `front`