### PR TITLE
fix: tool approval in nested conversations

### DIFF
--- a/front/components/assistant/conversation/BlockedAction.tsx
+++ b/front/components/assistant/conversation/BlockedAction.tsx
@@ -33,8 +33,6 @@ export function BlockedAction({
           triggeringUser={triggeringUser}
           owner={owner}
           blockedAction={blockedAction}
-          conversationId={conversationId}
-          messageId={messageId}
         />
       );
 

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -90,17 +90,29 @@ export function BlockedActionsProvider({
 
   useEffect(() => {
     if (conversationId) {
-      setBlockedActionsQueue(
-        blockedActions.flatMap((action): BlockedActionQueueItem[] => {
+      // Sub-agent (run_agent) conversations can be nested arbitrarily deep:
+      // a `blocked_child_action_input_required` action can itself contain
+      // child actions in the same `blocked_child_action_input_required` state.
+      // Walk the tree to surface every leaf, anchored on the outermost
+      // message id so removal/lookup matches the rendered agent message.
+      const flattenBlockedActions = (
+        actions: BlockedToolExecution[],
+        outerMessageId: string
+      ): BlockedActionQueueItem[] =>
+        actions.flatMap((action) => {
           if (action.status === "blocked_child_action_input_required") {
-            return action.childBlockedActionsList.map((childAction) => ({
-              blockedAction: childAction,
-              messageId: action.messageId,
-            }));
-          } else {
-            return [{ blockedAction: action, messageId: action.messageId }];
+            return flattenBlockedActions(
+              action.childBlockedActionsList,
+              outerMessageId
+            );
           }
-        })
+          return [{ blockedAction: action, messageId: outerMessageId }];
+        });
+
+      setBlockedActionsQueue(
+        blockedActions.flatMap((action) =>
+          flattenBlockedActions([action], action.messageId)
+        )
       );
     } else {
       setBlockedActionsQueue(EMPTY_BLOCKED_ACTIONS_QUEUE);

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -56,16 +56,12 @@ interface MCPToolValidationRequiredProps {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
   blockedAction: BlockedToolExecution;
-  conversationId: string;
-  messageId: string;
 }
 
 export function MCPToolValidationRequired({
   triggeringUser,
   owner,
   blockedAction,
-  conversationId,
-  messageId,
 }: MCPToolValidationRequiredProps) {
   const { user } = useAuth();
   const [neverAskAgain, setNeverAskAgain] = useState(false);
@@ -79,7 +75,6 @@ export function MCPToolValidationRequired({
   } = useBlockedActionsContext();
   const { validateAction, isValidating } = useValidateAction({
     owner,
-    conversationId,
     onError: setErrorMessage,
   });
 
@@ -102,7 +97,6 @@ export function MCPToolValidationRequired({
 
     const result = await validateAction({
       validationRequest: blockedAction,
-      messageId,
       approved:
         approved === "approved" && neverAskAgain ? "always_approved" : approved,
     });

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -122,7 +122,6 @@ export function MCPToolValidationRequired({
       for (const cascadeAction of cascadable) {
         const cascadeResult = await validateAction({
           validationRequest: cascadeAction,
-          messageId,
           approved: "approved",
         });
         if (cascadeResult.success) {

--- a/front/hooks/useValidateAction.ts
+++ b/front/hooks/useValidateAction.ts
@@ -7,32 +7,26 @@ import { useCallback, useState } from "react";
 
 interface UseValidateActionParams {
   owner: LightWorkspaceType;
-  conversationId: string | null;
   onError: (errorMessage: string) => void;
 }
 
-export function useValidateAction({
-  owner,
-  conversationId,
-  onError,
-}: UseValidateActionParams) {
+export function useValidateAction({ owner, onError }: UseValidateActionParams) {
   const { fetcher } = useFetcher();
   const [isValidating, setIsValidating] = useState(false);
 
   const validateAction = useCallback(
     async ({
       validationRequest,
-      messageId,
       approved,
     }: {
       validationRequest: MCPActionValidationRequest;
-      messageId: string;
       approved: MCPValidationOutputType;
     }) => {
       setIsValidating(true);
 
       try {
-        // Validate the action.
+        // Validate the action. The backend resumes both the conversation that
+        // contains the action and any blocked ancestor conversations.
         await fetcher(
           `/api/w/${owner.sId}/assistant/conversations/${validationRequest.conversationId}/messages/${validationRequest.messageId}/validate-action`,
           {
@@ -43,31 +37,10 @@ export function useValidateAction({
             body: JSON.stringify({
               actionId: validationRequest.actionId,
               approved,
+              resumeAncestorConversations: true,
             }),
           }
         );
-
-        // Retry on blocked tools on the main conversation if there is one that is != from the event's.
-        if (
-          conversationId &&
-          messageId &&
-          conversationId !== validationRequest.conversationId
-        ) {
-          try {
-            await fetcher(
-              `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/retry?blocked_only=true`,
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                },
-              }
-            );
-          } catch {
-            onError("Failed to resume conversation. Please try again.");
-            return { success: false };
-          }
-        }
 
         return { success: true };
       } catch (e) {
@@ -82,7 +55,7 @@ export function useValidateAction({
         setIsValidating(false);
       }
     },
-    [owner.sId, conversationId, onError, fetcher]
+    [owner.sId, onError, fetcher]
   );
 
   return { validateAction, isValidating };

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
@@ -1,0 +1,63 @@
+import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import { MAX_CONVERSATION_DEPTH } from "@app/pages/api/v1/w/[wId]/assistant/conversations";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Walk up the agentic-parent chain from a freshly resumed agent message and
+ * relaunch every ancestor agent message that is still blocked waiting on its
+ * child to complete (run_agent scenario).
+ */
+export async function resumeAncestorConversations(
+  auth: Authenticator,
+  conversation: ConversationResource,
+  { agentMessageId }: { agentMessageId: string }
+): Promise<Result<void, DustError<"internal_error">>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  let cursor: {
+    conversation: ConversationResource;
+    agentMessageId: string;
+  } = { conversation, agentMessageId };
+
+  for (let depth = 0; depth < MAX_CONVERSATION_DEPTH; depth++) {
+    const parent = await cursor.conversation.findAgenticParent(auth, {
+      agentMessageSId: cursor.agentMessageId,
+    });
+    if (!parent) {
+      break;
+    }
+
+    const retryRes = await retryBlockedActions(
+      auth,
+      parent.conversation.toJSON(),
+      {
+        messageId: parent.agentMessageId,
+        waitForCompletion: true,
+      }
+    );
+
+    if (retryRes.isErr()) {
+      logger.error(
+        {
+          workspaceId: owner.sId,
+          parentConversationId: parent.conversation.sId,
+          parentAgentMessageId: parent.agentMessageId,
+          err: retryRes.error,
+        },
+        "Failed to retry blocked actions on parent conversation"
+      );
+      return new Err(
+        new DustError("internal_error", "Failed to resume parent conversation")
+      );
+    }
+
+    cursor = parent;
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
@@ -26,7 +26,7 @@ export async function resumeAncestorConversations(
 
   for (let depth = 0; depth < MAX_CONVERSATION_DEPTH; depth++) {
     const parent = await cursor.conversation.findAgenticParent(auth, {
-      agentMessageSId: cursor.agentMessageId,
+      agentMessageId: cursor.agentMessageId,
     });
     if (!parent) {
       break;

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
@@ -1,7 +1,7 @@
 import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_blocked_actions";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { MAX_CONVERSATION_DEPTH } from "@app/pages/api/v1/w/[wId]/assistant/conversations";
 import type { Result } from "@app/types/shared/result";
@@ -9,7 +9,7 @@ import { Err, Ok } from "@app/types/shared/result";
 
 /**
  * Walk up the agentic-parent chain from a freshly resumed agent message and
- * relaunch every ancestor agent message that is still blocked waiting on its
+ * relaunch every parentAgentMessage agent message that is still blocked waiting on its
  * child to complete (run_agent scenario).
  */
 export async function resumeAncestorConversations(
@@ -25,18 +25,29 @@ export async function resumeAncestorConversations(
   } = { conversation, agentMessageId };
 
   for (let depth = 0; depth < MAX_CONVERSATION_DEPTH; depth++) {
-    const parent = await cursor.conversation.findAgenticParent(auth, {
-      agentMessageId: cursor.agentMessageId,
-    });
-    if (!parent) {
+    const parentAgentMessage = await cursor.conversation.findAgenticParent(
+      auth,
+      {
+        agentMessageId: cursor.agentMessageId,
+      }
+    );
+    if (!parentAgentMessage) {
+      break;
+    }
+
+    const [parentConversation] = await ConversationResource.fetchByModelIds(
+      auth,
+      [parentAgentMessage.conversationId]
+    );
+    if (!parentConversation) {
       break;
     }
 
     const retryRes = await retryBlockedActions(
       auth,
-      parent.conversation.toJSON(),
+      parentConversation.toJSON(),
       {
-        messageId: parent.agentMessageId,
+        messageId: parentAgentMessage.sId,
         waitForCompletion: true,
       }
     );
@@ -45,8 +56,8 @@ export async function resumeAncestorConversations(
       logger.error(
         {
           workspaceId: owner.sId,
-          parentConversationId: parent.conversation.sId,
-          parentAgentMessageId: parent.agentMessageId,
+          parentConversationId: parentConversation.sId,
+          parentAgentMessageId: parentAgentMessage.sId,
           err: retryRes.error,
         },
         "Failed to retry blocked actions on parent conversation"
@@ -56,7 +67,10 @@ export async function resumeAncestorConversations(
       );
     }
 
-    cursor = parent;
+    cursor = {
+      conversation: parentConversation,
+      agentMessageId: parentAgentMessage.sId,
+    };
   }
 
   return new Ok(undefined);

--- a/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
+++ b/front/lib/api/assistant/conversation/resume_ancestor_conversations.ts
@@ -37,7 +37,8 @@ export async function resumeAncestorConversations(
 
     const [parentConversation] = await ConversationResource.fetchByModelIds(
       auth,
-      [parentAgentMessage.conversationId]
+      [parentAgentMessage.conversationId],
+      { loadSpaces: true }
     );
     if (!parentConversation) {
       break;

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -6,13 +6,13 @@ import type { DustError } from "@app/lib/error";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 async function findUserMessageForRetry(
   auth: Authenticator,
-  conversation: ConversationType,
+  conversation: ConversationWithoutContentType,
   { messageId }: { messageId: string }
 ): Promise<
   Result<
@@ -85,11 +85,13 @@ async function findUserMessageForRetry(
 
 export async function retryBlockedActions(
   auth: Authenticator,
-  conversation: ConversationType,
+  conversation: ConversationWithoutContentType,
   {
     messageId,
+    waitForCompletion,
   }: {
     messageId: string;
+    waitForCompletion?: boolean;
   }
 ): Promise<Result<void, Error | DustError<"agent_loop_already_running">>> {
   const {
@@ -130,5 +132,6 @@ export async function retryBlockedActions(
       userMessageVersion,
     },
     startStep: lastStep,
+    waitForCompletion,
   });
 }

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -8,6 +8,7 @@ import {
   setUserAlwaysApprovedTool,
 } from "@app/lib/actions/tool_status";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
+import { resumeAncestorConversations as resumeAncestorConversationsHelper } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
@@ -28,10 +29,12 @@ export async function validateAction(
     actionId,
     approvalState,
     messageId,
+    resumeAncestorConversations = false,
   }: {
     actionId: string;
     approvalState: ActionApprovalStateType;
     messageId: string;
+    resumeAncestorConversations?: boolean;
   }
 ): Promise<Result<void, DustError>> {
   const owner = auth.getNonNullableWorkspace();
@@ -219,5 +222,11 @@ export async function validateAction(
     `Action ${approvalState === "approved" ? "approved" : "rejected"} by user`
   );
 
-  return new Ok(undefined);
+  if (!resumeAncestorConversations) {
+    return new Ok(undefined);
+  }
+
+  return resumeAncestorConversationsHelper(auth, conversation, {
+    agentMessageId,
+  });
 }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2701,6 +2701,97 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   /**
+   * Resolve the parent conversation and parent agent message that spawned the
+   * given agent message in this conversation via run_agent / agent_handover.
+   *
+   * Walks the agent message → its parent user message (in the same conversation)
+   * → that user message's `agenticOriginMessageId` (the parent agent message,
+   * possibly in another conversation).
+   *
+   * Returns null when the agent message has no agentic origin (root
+   * conversation), when the parent message can no longer be found, or when the
+   * caller does not have access to the parent conversation.
+   */
+  async findAgenticParent(
+    auth: Authenticator,
+    { agentMessageSId }: { agentMessageSId: string }
+  ): Promise<{
+    conversation: ConversationResource;
+    agentMessageId: string;
+  } | null> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const agentMessage = await MessageModel.findOne({
+      where: {
+        workspaceId: owner.id,
+        conversationId: this.id,
+        sId: agentMessageSId,
+      },
+      attributes: ["parentId"],
+    });
+
+    if (!agentMessage?.parentId) {
+      return null;
+    }
+
+    const parentMessage = await MessageModel.findOne({
+      where: {
+        workspaceId: owner.id,
+        id: agentMessage.parentId,
+      },
+      attributes: [],
+      include: [
+        {
+          model: UserMessageModel,
+          as: "userMessage",
+          required: true,
+          attributes: ["agenticOriginMessageId"],
+        },
+      ],
+    });
+
+    const agenticOriginMessageId =
+      parentMessage?.userMessage?.agenticOriginMessageId;
+    if (!agenticOriginMessageId) {
+      return null;
+    }
+
+    const ancestorMessage = await MessageModel.findOne({
+      where: {
+        workspaceId: owner.id,
+        sId: agenticOriginMessageId,
+      },
+      attributes: [],
+      include: [
+        {
+          model: ConversationModel,
+          as: "conversation",
+          required: true,
+          attributes: ["sId"],
+        },
+      ],
+    });
+
+    if (!ancestorMessage?.conversation) {
+      return null;
+    }
+
+    const parentConversation = await ConversationResource.fetchById(
+      auth,
+      ancestorMessage.conversation.sId
+    );
+
+    if (!parentConversation) {
+      return null;
+    }
+
+    return {
+      conversation: parentConversation,
+      agentMessageId: agenticOriginMessageId,
+    };
+  }
+
+  /**
    * Get the latest agent message id by rank for a given conversation.
    * @returns The latest agent message id, version and rank.
    */

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2701,24 +2701,20 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   /**
-   * Resolve the parent conversation and parent agent message that spawned the
-   * given agent message in this conversation via run_agent / agent_handover.
+   * Resolve the parent agent message that spawned the given agent message in
+   * this conversation via run_agent / agent_handover.
    *
    * Walks the agent message → its parent user message (in the same conversation)
    * → that user message's `agenticOriginMessageId` (the parent agent message,
    * possibly in another conversation).
    *
    * Returns null when the agent message has no agentic origin (root
-   * conversation), when the parent message can no longer be found, or when the
-   * caller does not have access to the parent conversation.
+   * conversation) or when the parent message can no longer be found.
    */
   async findAgenticParent(
     auth: Authenticator,
     { agentMessageId }: { agentMessageId: string }
-  ): Promise<{
-    conversation: ConversationResource;
-    agentMessageId: string;
-  } | null> {
+  ): Promise<MessageModel | null> {
     const owner = auth.getNonNullableWorkspace();
 
     const agentMessage = await MessageModel.findOne({
@@ -2737,6 +2733,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const parentMessage = await MessageModel.findOne({
       where: {
         workspaceId: owner.id,
+        conversationId: this.id,
         id: agentMessage.parentId,
       },
       attributes: [],
@@ -2756,39 +2753,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return null;
     }
 
-    const ancestorMessage = await MessageModel.findOne({
+    const agenticOriginMessage = await MessageModel.findOne({
       where: {
         workspaceId: owner.id,
         sId: agenticOriginMessageId,
       },
-      attributes: [],
-      include: [
-        {
-          model: ConversationModel,
-          as: "conversation",
-          required: true,
-          attributes: ["sId"],
-        },
-      ],
     });
 
-    if (!ancestorMessage?.conversation) {
-      return null;
-    }
-
-    const parentConversation = await ConversationResource.fetchById(
-      auth,
-      ancestorMessage.conversation.sId
-    );
-
-    if (!parentConversation) {
-      return null;
-    }
-
-    return {
-      conversation: parentConversation,
-      agentMessageId: agenticOriginMessageId,
-    };
+    return agenticOriginMessage;
   }
 
   /**

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2714,7 +2714,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
    */
   async findAgenticParent(
     auth: Authenticator,
-    { agentMessageSId }: { agentMessageSId: string }
+    { agentMessageId }: { agentMessageId: string }
   ): Promise<{
     conversation: ConversationResource;
     agentMessageId: string;
@@ -2725,7 +2725,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       where: {
         workspaceId: owner.id,
         conversationId: this.id,
-        sId: agentMessageSId,
+        sId: agentMessageId,
       },
       attributes: ["parentId"],
     });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -60,6 +60,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type { UserType } from "@app/types/user";
 import assert from "assert";
 import isEqual from "lodash/isEqual";
@@ -279,8 +280,24 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       transaction,
     });
 
+    const uniqueSpaceIds = uniq(
+      removeNulls(conversations.map((c) => c.spaceId))
+    );
+    const spaces =
+      uniqueSpaceIds.length === 0
+        ? []
+        : await SpaceResource.fetchByModelIds(auth, uniqueSpaceIds, {
+            transaction,
+          });
+    const spaceIdToSpaceMap = new Map(spaces.map((s) => [s.id, s]));
+
     // Note: no permission filtering here. Callers must ensure the auth is allowed.
-    return conversations.map((c) => this.fromModel(c, null));
+    return conversations.map((c) =>
+      this.fromModel(
+        c,
+        c.spaceId ? (spaceIdToSpaceMap.get(c.spaceId) ?? null) : null
+      )
+    );
   }
 
   get forkingData(): ConversationForkingDataType | undefined {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -251,11 +251,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       excludeTest,
       updatedAfter,
       includeForkingData,
+      loadSpaces,
     }: {
       transaction?: Transaction;
       excludeTest?: boolean;
       updatedAfter?: Date;
       includeForkingData?: boolean;
+      loadSpaces?: boolean;
     } = {}
   ): Promise<ConversationResource[]> {
     if (ids.length === 0) {
@@ -280,22 +282,27 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       transaction,
     });
 
-    const uniqueSpaceIds = uniq(
-      removeNulls(conversations.map((c) => c.spaceId))
-    );
-    const spaces =
-      uniqueSpaceIds.length === 0
-        ? []
-        : await SpaceResource.fetchByModelIds(auth, uniqueSpaceIds, {
-            transaction,
-          });
-    const spaceIdToSpaceMap = new Map(spaces.map((s) => [s.id, s]));
+    let spaceIdToSpaceMap: Map<ModelId, SpaceResource> = new Map();
+    if (loadSpaces) {
+      const uniqueSpaceIds = uniq(
+        removeNulls(conversations.map((c) => c.spaceId))
+      );
+      const spaces =
+        uniqueSpaceIds.length === 0
+          ? []
+          : await SpaceResource.fetchByModelIds(auth, uniqueSpaceIds, {
+              transaction,
+            });
+      spaceIdToSpaceMap = new Map(spaces.map((s) => [s.id, s]));
+    }
 
     // Note: no permission filtering here. Callers must ensure the auth is allowed.
     return conversations.map((c) =>
       this.fromModel(
         c,
-        c.spaceId ? (spaceIdToSpaceMap.get(c.spaceId) ?? null) : null
+        loadSpaces && c.spaceId
+          ? (spaceIdToSpaceMap.get(c.spaceId) ?? null)
+          : null
       )
     );
   }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 export const ValidateActionSchema = z.object({
   actionId: z.string(),
   approved: z.enum(["approved", "rejected", "always_approved"]),
+  resumeAncestorConversations: z.boolean().optional(),
 });
 
 export type ValidateActionResponse = {
@@ -70,12 +71,13 @@ async function handler(
     });
   }
 
-  const { actionId, approved } = parseResult.data;
+  const { actionId, approved, resumeAncestorConversations } = parseResult.data;
 
   const result = await validateAction(auth, conversation, {
     actionId,
     approvalState: approved,
     messageId: mId,
+    resumeAncestorConversations,
   });
 
   if (result.isErr()) {


### PR DESCRIPTION
## Description

Fixes part of https://github.com/dust-tt/tasks/issues/7690

This PR fixes tool approval handling for nested (sub-agent) conversations. When a user approves/rejects a tool in a nested conversation, the system now correctly resumes all ancestor conversations that were blocked waiting for that approval.

`BlockedActionsProvider` previously only handled one level of nesting. It now correctly surfaces blocked actions at any depth.

- Introduced `resumeAncestorConversations` helper function that walks up the conversation chain and retries blocked actions on each ancestor conversation
- Added `findAgenticParent` method to `ConversationResource` to traverse the conversation hierarchy
- Modified `BlockedActionsProvider` to recursively flatten blocked actions in nested conversations, ensuring all leaf-level approvals are surfaced
- Removed frontend retry logic from `useValidateAction` hook as backend now handles resuming ancestor conversations when validating an action


Next steps:
Similar changes for
- blocked_authentication_required
- blocked_file_authorization_required
- blocked_user_answer_required

## Tests

Manually

## Risks

Low. The action validation for nested conversation currently does not work.

## Deploy Plan

Standard deployment
