### PR TITLE
Fixed chunking for utf-16 files

### DIFF
--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -59,7 +59,7 @@ export function handleTextFile(
   if (data.byteLength > 4 * maxDocumentLen) {
     return new Err(new Error("file_too_big"));
   }
-  const content = Buffer.from(data).toString("utf-8").trim();
+  const content = decodeBuffer(data).trim();
   const digitCount = (content.match(/[\d\n\r]/g) || []).length;
   if (digitCount / content.length > MAX_NUMBER_CHAR_RATIO) {
     return new Err(new Error("too_many_digits"));


### PR DESCRIPTION
## Description

Use proper buffer decoding when parsing txt files. 
If handleTextFile receives an UTF-16 buffer, we receive invalid content leading to huge number of chunks. We already have a decodeBuffer method that detects UTF-16 based on boms - using this instead of hard-convert to utf-8 will create a proper string.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low


## Deploy Plan

deploy connectors, force reindex of guilty file