### PR TITLE
Show clean button if anyone's todos is marked as done.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -913,9 +913,7 @@ function EditableProjectTodosPanel({
         );
     }
   }, [assigneeScope, selectedUserSIds, todos, viewerUserId]);
-  const hasDoneItems = filteredTodos.some(
-    (todo) => todo.status === "done" && todo.userId === viewerUserId
-  );
+  const hasDoneItems = filteredTodos.some((todo) => todo.status === "done");
   const shouldGroupByAssignee =
     assigneeScope === "all" ||
     (assigneeScope === "users" && selectedUserSIds.size > 1);


### PR DESCRIPTION
## Description

The "Clean done items" button was only visible when the viewer had their own completed todos, so it was hidden when viewing another team member's done todos or when using the "all" filter. Since the button operates on the filtered list, it should appear whenever any visible todo is marked as done.

- Remove `todo.userId === viewerUserId` guard from `hasDoneItems` — the clean button now shows whenever any todo in the current filtered view has `status === "done"`

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`
