### PR TITLE
fix(project-todos): allow marking any project member's todo as done

### DIFF
--- a/front/lib/api/actions/servers/project_todos/metadata.ts
+++ b/front/lib/api/actions/servers/project_todos/metadata.ts
@@ -94,7 +94,7 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
     },
   },
   mark_todo_done: {
-    description: "Mark one or more of the current user's TODOs as done.",
+    description: "Mark one or more TODOs as done.",
     schema: {
       actorType: z
         .enum(["user", "agent"])
@@ -190,7 +190,7 @@ export const PROJECT_TODOS_SERVER = {
     name: PROJECT_TODOS_SERVER_NAME,
     version: "1.0.0",
     description:
-      "Manage the current user's project TODOs: list, create, and complete personal action items.",
+      "Manage project TODOs: list, create, and complete action items.",
     icon: "ActionListCheckIcon",
     authorization: null,
     documentationUrl: null,

--- a/front/lib/api/actions/servers/project_todos/tools/index.ts
+++ b/front/lib/api/actions/servers/project_todos/tools/index.ts
@@ -219,17 +219,11 @@ export function createProjectTodosTools(
         const marked: string[] = [];
         const alreadyDone: string[] = [];
         const notFound: string[] = [];
-        const forbidden: string[] = [];
 
         for (const todoId of todoIds) {
           const todo = await ProjectTodoResource.fetchBySId(auth, todoId);
           if (!todo) {
             notFound.push(todoId);
-            continue;
-          }
-
-          if (todo.userId !== currentUser.id) {
-            forbidden.push(todoId);
             continue;
           }
 
@@ -266,11 +260,6 @@ export function createProjectTodosTools(
         }
         if (notFound.length > 0) {
           lines.push(`Not found (${notFound.length}): ${notFound.join(", ")}`);
-        }
-        if (forbidden.length > 0) {
-          lines.push(
-            `Not owned by current user (${forbidden.length}): ${forbidden.join(", ")}`
-          );
         }
         if (lines.length === 0) {
           lines.push("No TODOs were updated.");


### PR DESCRIPTION
## Problem

The `mark_todo_done` tool had an ownership check that silently blocked marking a todo as done if it belonged to a different user:

```typescript
if (todo.userId !== currentUser.id) {
  forbidden.push(todoId);
  continue;
}
```

When an agent (butler or any agent with `project_todos` tools) tried to mark another project member's todo as done, it returned `Not owned by current user` instead of completing the action. This broke any agent workflow spanning the whole team's todos.

Note: `update_todo` had **no such restriction** — making the inconsistency clear.

## Fix

- **Remove the ownership check** from `mark_todo_done`. Any project member (and agents acting on their behalf) can mark any todo in the project as done.
- **Update the tool description** in `metadata.ts`: `"Mark one or more of the current user's TODOs as done."` → `"Mark one or more TODOs as done."`
- **Update the server description** to drop "personal" / "current user's" scoping.

## Files changed

- `front/lib/api/actions/servers/project_todos/tools/index.ts`
- `front/lib/api/actions/servers/project_todos/metadata.ts`

Closes #7884