### PR TITLE
[sessions]: dedupe replayed agent message events to stop inline activity duplication

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -636,7 +636,25 @@ export const ConversationViewer = ({
               const exists = ref.current.data.find(predicate);
 
               if (exists) {
-                ref.current.data.map((m) => (predicate(m) ? agentMessage : m));
+                // On replay (e.g. after navigating away and coming back), the
+                // existing message may already reflect the final state from
+                // the SWR snapshot. The replayed event always carries the
+                // initial "created" payload — replacing would downgrade the
+                // status (re-activating shouldStream and the message-events
+                // stream) and wipe inlineActivitySteps. Skip the replace
+                // when the existing message is already in a terminal state.
+                const existsIsTerminal =
+                  isAgentMessageWithStreaming(exists) &&
+                  (exists.status === "succeeded" ||
+                    exists.status === "failed" ||
+                    exists.status === "cancelled" ||
+                    exists.status === "gracefully_stopped");
+
+                if (!existsIsTerminal) {
+                  ref.current.data.map((m) =>
+                    predicate(m) ? agentMessage : m
+                  );
+                }
               } else {
                 const currentData = ref.current.data.get();
                 const offset = getBranchedInsertIndex(
@@ -701,6 +719,37 @@ export const ConversationViewer = ({
             // status/activitySteps instead of the stale "created" snapshot,
             // which would otherwise re-open an SSE replay.
             void mutateMessages();
+
+            // Synchronously flip the message to a terminal state in Virtuoso.
+            // The agent_message_new replay (above) carries the initial
+            // "created" payload, so without this update an existing message
+            // could be downgraded (re-activating shouldStream and the
+            // message-events stream) before mutateMessages's async fetch
+            // returns. agent_message_done has no `event.message`, so we only
+            // flip status/agentState — inlineActivitySteps are preserved
+            // (either from the initial SWR snapshot via the smart-replace
+            // above, or from a still-streaming message-events replay).
+            if (ref.current) {
+              ref.current.data.map((m) => {
+                if (
+                  isAgentMessageWithStreaming(m) &&
+                  m.sId === event.messageId
+                ) {
+                  return {
+                    ...m,
+                    status:
+                      event.status === "error"
+                        ? ("failed" as const)
+                        : ("succeeded" as const),
+                    streaming: {
+                      ...m.streaming,
+                      agentState: "done" as const,
+                    },
+                  };
+                }
+                return m;
+              });
+            }
 
             // Update the conversation hasError state in the local cache without making a network request.
             void mutateConversations(

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -309,6 +309,7 @@ export const ConversationViewer = ({
     isMessagesError,
     isValidating,
     messages,
+    mutateMessages,
     setSize,
     size,
   } = useConversationMessages({
@@ -695,6 +696,12 @@ export const ConversationViewer = ({
             // Re-fetch context usage after the agent finishes so the indicator is up-to-date.
             void mutateContextUsage();
 
+            // Refresh the messages SWR cache so a future remount of this
+            // conversation (e.g. navigating away and back) sees the final
+            // status/activitySteps instead of the stale "created" snapshot,
+            // which would otherwise re-open an SSE replay.
+            void mutateMessages();
+
             // Update the conversation hasError state in the local cache without making a network request.
             void mutateConversations(
               (currentData: ConversationListItemType[] | undefined) =>
@@ -764,6 +771,7 @@ export const ConversationViewer = ({
       mutateConversationAttachments,
       mutateConversationParticipants,
       mutateConversations,
+      mutateMessages,
       user.sId,
     ]
   );

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -303,6 +303,12 @@ export function useAgentMessageStream({
     []
   );
 
+  // Track event ids already processed by this hook instance so that if the
+  // SSE stream replays history (e.g. on remount with a stale `lastEventId`)
+  // we don't re-append inline activity steps for events we've already seen.
+  // Mirrors the dedup pattern used for conversation events in ConversationViewer.
+  const seenEventIds = useRef<Set<string>>(new Set());
+
   useEffect(() => {
     return () => {
       updateMessageThrottled.cancel();
@@ -353,6 +359,12 @@ export function useAgentMessageStream({
         eventId: string;
         data: AgentMessageStateWithControlEvent;
       } = JSON.parse(eventStr);
+      if (eventPayload.eventId) {
+        if (seenEventIds.current.has(eventPayload.eventId)) {
+          return;
+        }
+        seenEventIds.current.add(eventPayload.eventId);
+      }
       const eventType = eventPayload.data.type;
       switch (eventType) {
         case "end-of-stream":


### PR DESCRIPTION
fix https://github.com/dust-tt/tasks/issues/7893

## Description
When the user navigates away from a conversation while an agent is streaming and comes back after it has finished, opening the conversation could show the same completed inline activity steps being re-appended in a loop until a hard refresh. Two gaps caused this:

- useAgentMessageStream had no event-id-level dedup, so any SSE replay (e.g. fresh hook mount with empty lastEventId) re-appended thinking/content steps whose dedup is partial-or-absent. Mirror the pattern from ConversationViewer by tracking seen eventIds in a ref-Set and short-circuiting replays.
- agent_message_done in ConversationViewer never invalidated the messages SWR cache, so a remount kept reading status:"created" and re-opening the stream. Call mutateMessages() so the next remount sees the final status and server-computed activitySteps.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
