### PR TITLE
[front] Plan mode UI: PlanCard + side panel

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContent.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContent.tsx
@@ -1,12 +1,14 @@
 import { AgentActionsPanel } from "@app/components/assistant/conversation/actions/AgentActionsPanel";
 import { ConversationFilesPanel } from "@app/components/assistant/conversation/files_panel/ConversationFilesPanel";
 import { InteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/InteractiveContentContainer";
+import { ConversationPlanModePanel } from "@app/components/assistant/conversation/plan_mode/ConversationPlanModePanel";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
+  PLAN_SIDE_PANEL_TYPE,
 } from "@app/types/conversation_side_panel";
 import type { LightWorkspaceType } from "@app/types/user";
 
@@ -36,6 +38,11 @@ export default function ConversationSidePanelContent({
     case FILES_SIDE_PANEL_TYPE:
       return (
         <ConversationFilesPanel conversation={conversation} owner={owner} />
+      );
+
+    case PLAN_SIDE_PANEL_TYPE:
+      return (
+        <ConversationPlanModePanel conversation={conversation} owner={owner} />
       );
 
     default:

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -5,6 +5,7 @@ import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
+  PLAN_SIDE_PANEL_TYPE,
   SIDE_PANEL_HASH_PARAM,
   SIDE_PANEL_TYPE_HASH_PARAM,
 } from "@app/types/conversation_side_panel";
@@ -25,12 +26,18 @@ type OpenPanelParams =
     }
   | {
       type: "files";
+    }
+  | {
+      type: "plan";
     };
 
 const isSupportedPanelType = (
   type: string | undefined
 ): type is ConversationSidePanelType =>
-  type === "actions" || type === "interactive_content" || type === "files";
+  type === "actions" ||
+  type === "interactive_content" ||
+  type === "files" ||
+  type === "plan";
 
 interface ConversationSidePanelContextType {
   currentPanel: ConversationSidePanelType;
@@ -150,6 +157,15 @@ export function ConversationSidePanelProvider({
             return;
           }
           setData("files");
+          break;
+
+        case PLAN_SIDE_PANEL_TYPE:
+          // Toggle: if already open, close it.
+          if (currentPanel === PLAN_SIDE_PANEL_TYPE) {
+            closePanel();
+            return;
+          }
+          setData("plan");
           break;
 
         default:

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -37,6 +37,7 @@ import {
   useConversations,
 } from "@app/hooks/conversations";
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
+import { planFileKey } from "@app/hooks/conversations/usePlanFile";
 import { useConversationEvents } from "@app/hooks/useConversationEvents";
 import { useEnableBrowserNotification } from "@app/hooks/useEnableBrowserNotification";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -88,6 +89,7 @@ import React, {
 } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
+import { mutate } from "swr";
 import { findFirstUnreadMessageIndex } from "./utils";
 
 const DEFAULT_PAGE_LIMIT = 50;
@@ -419,8 +421,10 @@ export const ConversationViewer = ({
 
   // Sync the virtuoso ref with the side panel context.
   const {
+    closePanel,
     data: panelData,
     currentPanel,
+    openPanel,
     setVirtuosoMsg,
   } = useConversationSidePanelContext();
 
@@ -545,6 +549,20 @@ export const ConversationViewer = ({
   );
 
   const eventIds = useRef<string[]>([]);
+
+  // Last-seen plan.md version for this conversation. Used to auto-open the plan panel on the
+  // skeleton-to-first-edit transition (v1 -> v2+). If the user lands on an already-populated
+  // plan, no auto-open. ConversationViewer is keyed on conversationId by its parent, so the
+  // ref is naturally reset on conversation switch via remount.
+  const lastPlanVersionRef = useRef<number | undefined>(undefined);
+
+  // `onEventCallback` is bound by `useConversationEvents` once at mount and does not re-subscribe
+  // on identity changes (see useEventSource intentional behavior). Any state read from the
+  // closure would go stale, so we mirror `currentPanel` into a ref.
+  const currentPanelRef = useRef(currentPanel);
+  useEffect(() => {
+    currentPanelRef.current = currentPanel;
+  }, [currentPanel]);
 
   // Only conversation related events are handled here.
   const onEventCallback = useCallback(
@@ -745,10 +763,22 @@ export const ConversationViewer = ({
             void mutateContextUsage();
             window.dispatchEvent(new CompactionCompletedEvent());
             break;
-          case "plan_updated":
-            // Handled by a dedicated plan-mode UI hook (to be added in the UI PR); the
-            // conversation viewer itself doesn't need to react.
+          case "plan_updated": {
+            const prevVersion = lastPlanVersionRef.current;
+            lastPlanVersionRef.current = event.version;
+            if (event.isClosed && currentPanelRef.current === "plan") {
+              closePanel();
+            } else if (prevVersion === 1 && event.version >= 2) {
+              openPanel({ type: "plan" });
+            }
+            void mutate(
+              planFileKey({
+                workspaceId: owner.sId,
+                conversationId: event.conversationId,
+              })
+            );
             break;
+          }
           default:
             ((t: never) => {
               logger.error({ event: t }, "Unknown event type");
@@ -757,6 +787,7 @@ export const ConversationViewer = ({
       }
     },
     [
+      closePanel,
       conversationId,
       debouncedMarkAsRead,
       mutateContextUsage,
@@ -764,6 +795,8 @@ export const ConversationViewer = ({
       mutateConversationAttachments,
       mutateConversationParticipants,
       mutateConversations,
+      openPanel,
+      owner.sId,
       user.sId,
     ]
   );

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -8,6 +8,7 @@ import InputBarContainer, {
 } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
+import { PlanCard } from "@app/components/assistant/conversation/plan_mode/PlanCard";
 import {
   useAddDeleteConversationSkill,
   useAddDeleteConversationTool,
@@ -450,6 +451,10 @@ export const InputBar = React.memo(function InputBar({
 
   return (
     <div className="flex w-full flex-col">
+      <PlanCard
+        conversationId={conversation?.sId ?? null}
+        workspaceId={owner.sId}
+      />
       <div
         onAnimationEnd={() => setIsShaking(false)}
         className={classNames(

--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -1,0 +1,65 @@
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import {
+  ApprovalStateChip,
+  extractPlanTitle,
+} from "@app/components/assistant/conversation/plan_mode/utils";
+import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Button, Markdown, Spinner, XMarkIcon } from "@dust-tt/sparkle";
+
+interface ConversationPlanModePanelProps {
+  conversation: ConversationWithoutContentType;
+  owner: LightWorkspaceType;
+}
+
+export function ConversationPlanModePanel({
+  conversation,
+  owner,
+}: ConversationPlanModePanelProps) {
+  const { closePanel } = useConversationSidePanelContext();
+  const { planFile, content, approvalState, isPlanLoading } = usePlanFile({
+    conversationId: conversation.sId,
+    workspaceId: owner.sId,
+  });
+
+  const title = extractPlanTitle(content);
+
+  return (
+    <div className="flex h-full flex-col">
+      <AppLayoutTitle>
+        <div className="flex h-full items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-sm font-semibold text-foreground dark:text-foreground-night">
+              Plan: {title}
+            </span>
+            <ApprovalStateChip state={approvalState} />
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={closePanel}
+            icon={XMarkIcon}
+          />
+        </div>
+      </AppLayoutTitle>
+      <div className="flex-1 overflow-y-auto px-5 py-4">
+        {isPlanLoading && !content ? (
+          <div className="flex h-full items-center justify-center">
+            <Spinner />
+          </div>
+        ) : !planFile ? (
+          <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            No active plan for this conversation.
+          </div>
+        ) : (
+          // Key by planFile.version so React remounts on each edit. Sparkle's `Markdown`
+          // memoizes AST nodes for streaming reveal, which can hold stale child nodes when the
+          // full content prop changes between edits. Remounting forces a clean render.
+          content && <Markdown key={planFile.version} content={content} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/plan_mode/PlanCard.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanCard.tsx
@@ -1,0 +1,81 @@
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import {
+  ApprovalStateChip,
+  extractPlanTitle,
+} from "@app/components/assistant/conversation/plan_mode/utils";
+import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { ChevronRightIcon, cn, DocumentTextIcon, Icon } from "@dust-tt/sparkle";
+import React, { useMemo } from "react";
+
+interface PlanCardProps {
+  conversationId: string | null;
+  workspaceId: string;
+}
+
+// Total counts every task marker (open, done, blocked); done counts only checked boxes.
+// `[!]` is "blocked" by convention and is intentionally excluded from the "done" set so the
+// progress chip surfaces unfinished work.
+const TASK_TOTAL_REGEX = /^\s*-\s*\[[ xX!]\]/gm;
+const TASK_DONE_REGEX = /^\s*-\s*\[[xX]\]/gm;
+
+function countProgress(content: string | null): {
+  done: number;
+  total: number;
+} {
+  if (!content) {
+    return { done: 0, total: 0 };
+  }
+  const total = (content.match(TASK_TOTAL_REGEX) ?? []).length;
+  const done = (content.match(TASK_DONE_REGEX) ?? []).length;
+  return { done, total };
+}
+
+export const PlanCard = React.memo(function PlanCard({
+  conversationId,
+  workspaceId,
+}: PlanCardProps) {
+  const { hasFeature } = useFeatureFlags();
+  const isPlanModeEnabled = hasFeature("plan_mode");
+  const { planFile, content, approvalState } = usePlanFile({
+    // Skip the fetch entirely for workspaces without the plan_mode feature flag.
+    conversationId: isPlanModeEnabled ? conversationId : null,
+    workspaceId,
+  });
+  const { openPanel } = useConversationSidePanelContext();
+
+  const title = useMemo(() => extractPlanTitle(content), [content]);
+  const progress = useMemo(() => countProgress(content), [content]);
+
+  // Hide the card until the plan has been edited at least once (version >= 2). The skeleton
+  // upload from `create_plan` produces version 1; the first `edit_plan` bumps it to 2. This
+  // matches the side-panel auto-open trigger so the card appears at the same moment the panel
+  // first opens. `findActivePlanFile` already filters closed plans server-side, so `!planFile`
+  // also covers the post-close_plan case.
+  if (!planFile || planFile.version < 2) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => openPanel({ type: "plan" })}
+      className={cn(
+        "mb-2 flex w-full items-center gap-2 rounded-2xl border px-4 py-3 text-left",
+        "border-border-dark/50 bg-muted-background",
+        "dark:border-border-dark-night/30 dark:bg-muted-background-night",
+        "hover:bg-primary-50 dark:hover:bg-primary-50-night"
+      )}
+    >
+      <Icon visual={DocumentTextIcon} size="sm" />
+      <span className="heading-sm grow truncate">Plan: {title}</span>
+      <ApprovalStateChip state={approvalState} />
+      {progress.total > 0 && (
+        <span className="copy-xs shrink-0 text-muted-foreground dark:text-muted-foreground-night">
+          {progress.done}/{progress.total} done
+        </span>
+      )}
+      <Icon visual={ChevronRightIcon} size="sm" />
+    </button>
+  );
+});

--- a/front/components/assistant/conversation/plan_mode/utils.tsx
+++ b/front/components/assistant/conversation/plan_mode/utils.tsx
@@ -1,0 +1,27 @@
+import type { PlanApprovalState } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/plan_mode";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { Chip } from "@dust-tt/sparkle";
+
+const TITLE_REGEX = /^#\s+(.+)$/m;
+
+export function extractPlanTitle(content: string | null): string {
+  if (!content) {
+    return "Untitled plan";
+  }
+  const match = content.match(TITLE_REGEX);
+  return match ? match[1].trim() : "Untitled plan";
+}
+
+export function ApprovalStateChip({ state }: { state: PlanApprovalState }) {
+  switch (state) {
+    case "approved":
+      return <Chip size="mini" color="success" label="Approved" />;
+    case "pending":
+      return <Chip size="mini" color="warning" label="Pending approval" />;
+    case "draft":
+      return null;
+    default:
+      assertNeverAndIgnore(state);
+      return null;
+  }
+}

--- a/front/hooks/conversations/usePlanFile.ts
+++ b/front/hooks/conversations/usePlanFile.ts
@@ -1,0 +1,38 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetConversationPlanModeResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/plan_mode";
+import type { Fetcher } from "swr";
+
+export function planFileKey({
+  workspaceId,
+  conversationId,
+}: {
+  workspaceId: string;
+  conversationId: string;
+}): string {
+  return `/api/w/${workspaceId}/assistant/conversations/${conversationId}/plan_mode`;
+}
+
+export function usePlanFile({
+  conversationId,
+  workspaceId,
+}: {
+  conversationId: string | null;
+  workspaceId: string;
+}) {
+  const { fetcher } = useFetcher();
+  const planFetcher: Fetcher<GetConversationPlanModeResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    conversationId ? planFileKey({ workspaceId, conversationId }) : null,
+    planFetcher
+  );
+
+  return {
+    planFile: data?.planFile ?? null,
+    content: data?.content ?? null,
+    approvalState: data?.approvalState ?? "draft",
+    isPlanLoading: conversationId != null && !error && !data,
+    isPlanError: error,
+    mutatePlan: mutate,
+  };
+}

--- a/front/lib/resources/skill/code_defined/plan_mode.ts
+++ b/front/lib/resources/skill/code_defined/plan_mode.ts
@@ -38,7 +38,13 @@ Your next step MUST be to call \`${ASK_USER_QUESTION_TOOL_NAME}\` to ask the use
 - If they say to proceed anyway, continue execution without re-requesting approval (keep updating plan.md via \`${EDIT_PLAN_TOOL_NAME}\` for transparency).
 - If they ask to drop the plan, call \`${CLOSE_PLAN_TOOL_NAME}\`.
 
-**Closing the plan (\`${CLOSE_PLAN_TOOL_NAME}\`)**: only if the user explicitly asks to drop it (e.g. "never mind", "forget about it"). Do NOT close to handle revisions; use \`${EDIT_PLAN_TOOL_NAME}\` to iterate instead.
+**Closing the plan (\`${CLOSE_PLAN_TOOL_NAME}\`)** in two cases:
+1. The user explicitly asks to drop it (e.g. "never mind", "forget about it").
+2. **All tasks are done (\`- [x]\`) AND the user's new turn moves past the plan's scope** — they thank you, wrap up, or pivot to a different topic that isn't extending the plan. Close it before continuing so the completed plan doesn't linger in the UI.
+
+**Bias toward keeping the plan alive** when the new user turn is ambiguous or could plausibly extend the current plan. If they say "also do Y" or "one more thing", that's an extension — call \`${EDIT_PLAN_TOOL_NAME}\` to add tasks, do NOT close. Premature close mid-thread is worse UX than a plan card lingering for one extra turn.
+
+Do NOT close to handle revisions; use \`${EDIT_PLAN_TOOL_NAME}\` to iterate instead.
 `;
 
 export const planModeSkill = {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
@@ -1,0 +1,102 @@
+/** @ignoreswagger
+ * Internal endpoint used by the UI to read the conversation's active plan file. Undocumented.
+ */
+import {
+  PLAN_MODE_SERVER_NAME,
+  REQUEST_PLAN_APPROVAL_TOOL_NAME,
+} from "@app/lib/api/actions/servers/plan_mode/metadata";
+import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { findActivePlanFile } from "@app/lib/api/assistant/plan_mode";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { getFileContent } from "@app/lib/api/files/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { FileType } from "@app/types/files";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type PlanApprovalState = "draft" | "pending" | "approved";
+
+export type GetConversationPlanModeResponseBody = {
+  planFile: FileType | null;
+  content: string | null;
+  approvalState: PlanApprovalState;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetConversationPlanModeResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { cId } = req.query;
+  if (!isString(cId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  // Ensure the caller has access to the conversation.
+  const conversationRes = await getLightConversation(auth, cId);
+  if (conversationRes.isErr()) {
+    return apiErrorForConversation(req, res, conversationRes.error);
+  }
+
+  const planFile = await findActivePlanFile(auth, cId);
+  if (!planFile) {
+    return res.status(200).json({
+      planFile: null,
+      content: null,
+      approvalState: "draft",
+    });
+  }
+
+  // Sequential fetches to avoid holding multiple DB connections from the pool simultaneously.
+  const content = await getFileContent(auth, planFile, "original");
+  const conversationResource = await ConversationResource.fetchById(auth, cId);
+  const blockedActions = conversationResource
+    ? await AgentMCPActionResource.listBlockedActionsForConversation(
+        auth,
+        conversationResource
+      )
+    : [];
+
+  const hasPendingApproval = blockedActions.some(
+    (a) =>
+      a.metadata.mcpServerName === PLAN_MODE_SERVER_NAME &&
+      a.metadata.toolName === REQUEST_PLAN_APPROVAL_TOOL_NAME
+  );
+
+  const approvalState: PlanApprovalState = hasPendingApproval
+    ? "pending"
+    : planFile.useCaseMetadata?.planModeLastApproval != null
+      ? "approved"
+      : "draft";
+
+  return res.status(200).json({
+    planFile: planFile.toJSON(auth),
+    content,
+    approvalState,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/conversation_side_panel.ts
+++ b/front/types/conversation_side_panel.ts
@@ -5,11 +5,13 @@ export const FULL_SCREEN_HASH_PARAM = "fullScreen";
 export const AGENT_ACTIONS_SIDE_PANEL_TYPE = "actions";
 export const INTERACTIVE_CONTENT_SIDE_PANEL_TYPE = "interactive_content";
 export const FILES_SIDE_PANEL_TYPE = "files";
+export const PLAN_SIDE_PANEL_TYPE = "plan";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SIDE_PANEL_TYPES = [
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
+  PLAN_SIDE_PANEL_TYPE,
 ] as const;
 
 export type ConversationSidePanelType =


### PR DESCRIPTION
## Description

Adds a v0 user-facing UI for plan mode. A compact PlanCard surfaces above the input composer once the agent has populated the plan (file version >= 2), showing the title, progress, and approval state. Clicking the card opens a dedicated side panel that renders the full plan.md as markdown with proper scroll. The side panel reuses the existing ConversationSidePanelContext, registered under a new "plan" panel type. Both views subscribe to the same SWR key via the new usePlanFile hook, backed by a GET /api/w/[wId]/assistant/conversations/[cId]/plan_mode endpoint that returns the file metadata, content, and derived approval state in one call.

ConversationViewer wires the plan_updated event so subscribers refetch on each agent edit, the panel auto-opens on the first real edit (v1 to v2 transition), and auto-closes when the plan is closed. Stale-closure issues are avoided by mirroring the current panel into a ref since useConversationEvents intentionally does not re-subscribe when the callback identity changes.

## Tests

Locally, tool still gated. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 