### PR TITLE
[sessions] auto-scroll on compaction 

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -721,10 +721,25 @@ export const ConversationViewer = ({
                   currentData,
                   compactionMessage
                 );
+                // Scroll to the bottom when the user compacts so the
+                // compaction message is in view.
+                const scrollToCompaction = () =>
+                  ({
+                    index: "LAST",
+                    align: "end",
+                    behavior: "smooth",
+                  }) as const;
                 if (offset < currentData.length) {
-                  ref.current.data.insert([compactionMessage], offset);
+                  ref.current.data.insert(
+                    [compactionMessage],
+                    offset,
+                    scrollToCompaction
+                  );
                 } else {
-                  ref.current.data.append([compactionMessage]);
+                  ref.current.data.append(
+                    [compactionMessage],
+                    scrollToCompaction
+                  );
                 }
               }
             }


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/7604#issuecomment-4337396562
## Description
When a compaction message arrives via SSE, scroll the user to it if they're already at the bottom of the conversation (otherwise leave their position alone). Mirrors the bottomOffset guard used by handleSubmit and uses the same smooth easing as user_message_new.

Also bumps the last-compaction-message bottom margin from mb-10 to mb-16 so the single-line component doesn't visually hug the input bar.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
