### PR TITLE
[front] fix source citations opening empty file previews

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -158,19 +158,21 @@ export function MCPRunAgentActionDetails({
     if (!resultResource?.resource.refs) {
       return {};
     }
-    const mcpReferenceCitations: { [ref: string]: MCPReferenceCitation } = {};
-    Object.entries(resultResource.resource.refs).forEach(([ref, citation]) => {
-      mcpReferenceCitations[ref] = {
-        provider: citation.provider,
-        contentType:
-          citation.contentType as AllSupportedWithDustSpecificFileContentType,
-        title: citation.title,
-        href: citation.href,
-        description: citation.description,
+
+    return Object.fromEntries(
+      Object.entries(resultResource.resource.refs).map(([ref, citation]) => [
         ref,
-      };
-    });
-    return mcpReferenceCitations;
+        {
+          ref,
+          provider: citation.provider,
+          contentType:
+            citation.contentType as AllSupportedWithDustSpecificFileContentType,
+          title: citation.title,
+          href: citation.href,
+          description: citation.description,
+        },
+      ])
+    ) satisfies Record<string, MCPReferenceCitation>;
   }, [resultResource]);
 
   if (!childAgent) {

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -158,16 +158,16 @@ export function MCPRunAgentActionDetails({
     if (!resultResource?.resource.refs) {
       return {};
     }
-    const mcpReferenceCitations: { [key: string]: MCPReferenceCitation } = {};
-    Object.entries(resultResource.resource.refs).forEach(([key, citation]) => {
-      mcpReferenceCitations[key] = {
+    const mcpReferenceCitations: { [ref: string]: MCPReferenceCitation } = {};
+    Object.entries(resultResource.resource.refs).forEach(([ref, citation]) => {
+      mcpReferenceCitations[ref] = {
         provider: citation.provider,
         contentType:
           citation.contentType as AllSupportedWithDustSpecificFileContentType,
         title: citation.title,
         href: citation.href,
         description: citation.description,
-        fileId: key,
+        ref,
       };
     });
     return mcpReferenceCitations;

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -435,17 +435,17 @@ export function AgentMessage({
     () =>
       Object.entries(agentMessage.citations ?? {}).reduce<
         Record<string, MCPReferenceCitation>
-      >((acc, [key, citation]) => {
+      >((acc, [ref, citation]) => {
         if (citation) {
           return {
             ...acc,
-            [key]: {
+            [ref]: {
               provider: citation.provider,
               href: citation.href,
               title: citation.title,
               description: citation.description,
               contentType: citation.contentType,
-              fileId: key,
+              ref,
             },
           };
         }

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -71,22 +71,28 @@ export function AttachmentCitation({
   const isLoading =
     attachmentCitation.type === "file" && attachmentCitation.isUploading;
 
+  const fileResourceId =
+    attachmentCitation.type === "file" && attachmentCitation.fileId
+      ? attachmentCitation.fileId
+      : null;
+
   const canOpenInDialog =
     attachmentCitation.type === "file" &&
+    fileResourceId !== null &&
     getFileFormat(attachmentCitation.contentType)?.isSafeToDisplay &&
     (isTextualContentType(attachmentCitation) ||
       isAudioContentType(attachmentCitation));
 
   const canOpenInteractivePanel =
     attachmentCitation.type === "file" &&
-    Boolean(attachmentCitation.fileId) &&
+    fileResourceId !== null &&
     !attachmentCitation.isUploading &&
     isInteractiveContentType(attachmentCitation.contentType) &&
     sidePanel != null;
 
   const canOpenInSheet =
     attachmentCitation.type === "file" &&
-    Boolean(attachmentCitation.fileId) &&
+    fileResourceId !== null &&
     !attachmentCitation.isUploading &&
     !canOpenInteractivePanel &&
     !canOpenInDialog &&
@@ -98,7 +104,7 @@ export function AttachmentCitation({
           e.preventDefault();
           sidePanel.openPanel({
             type: "interactive_content",
-            fileId: attachmentCitation.fileId as string,
+            fileId: fileResourceId,
           });
         },
       }
@@ -115,11 +121,11 @@ export function AttachmentCitation({
           ? {
               onClick: (e: React.MouseEvent<HTMLDivElement>) => {
                 e.preventDefault();
-                if (!attachmentCitation.fileId) {
+                if (!fileResourceId) {
                   return;
                 }
                 setPreviewFile({
-                  sId: attachmentCitation.fileId,
+                  sId: fileResourceId,
                   fileName: attachmentCitation.title,
                   contentType: attachmentCitation.contentType,
                 });

--- a/front/components/assistant/conversation/attachment/types.ts
+++ b/front/components/assistant/conversation/attachment/types.ts
@@ -50,7 +50,6 @@ interface BaseAttachmentCitation {
 
 export interface FileAttachmentCitation extends BaseAttachmentCitation {
   type: "file";
-
   contentType: SupportedContentFragmentType;
   description: string | null;
   fileId: string | null;
@@ -59,7 +58,6 @@ export interface FileAttachmentCitation extends BaseAttachmentCitation {
 
 export interface NodeAttachmentCitation extends BaseAttachmentCitation {
   type: "node";
-
   path?: string;
   spaceIcon?: React.ComponentType;
   spaceName: string;
@@ -68,10 +66,9 @@ export interface NodeAttachmentCitation extends BaseAttachmentCitation {
 export interface MCPAttachmentCitation extends BaseAttachmentCitation {
   type: "file";
   attachmentCitationType: "mcp";
-  fileId: string;
+  fileId: string | null;
   isUploading: false;
   description?: string;
-
   contentType: AllSupportedWithDustSpecificFileContentType;
 }
 

--- a/front/components/assistant/conversation/attachment/utils.tsx
+++ b/front/components/assistant/conversation/attachment/utils.tsx
@@ -275,8 +275,8 @@ export function markdownCitationToAttachmentCitation(
   citation: MCPReferenceCitation
 ): MCPAttachmentCitation {
   return {
-    id: citation.fileId,
-    fileId: citation.fileId,
+    id: citation.fileId ?? citation.ref ?? citation.title,
+    fileId: citation.fileId ?? null,
     attachmentCitationType: "mcp",
     contentType: citation.contentType,
     sourceUrl: citation.href ?? null,

--- a/front/components/markdown/MCPReferenceCitation.tsx
+++ b/front/components/markdown/MCPReferenceCitation.tsx
@@ -7,5 +7,6 @@ export interface MCPReferenceCitation {
   href?: string;
   title: string;
   contentType: AllSupportedWithDustSpecificFileContentType;
-  fileId: string;
+  fileId?: string;
+  ref?: string;
 }


### PR DESCRIPTION
## Description

- Clicking on a citation block at the bottom of an agent message currently opens a sheet on some empty content.
- This behavior was introduced in https://github.com/dust-tt/dust/pull/24514, which relies on `fileId` being defined on an `attachmentCitation` to consider the file as being relevant to open in a sheet.
- https://github.com/dust-tt/dust/pull/16760 introduced the behavior of passing a ref as a file ID, creating the confusion: a file ID being present does not mean that there is a file to display nor that the file ID is a valid file ID.
- This PR fixes this by not defining a file ID when there isn't one.

## Tests

- Tested locally.
- Checked the behavior for generated files was kept.

## Risk

- Low.

## Deploy Plan

- Deploy front.
