### PR TITLE
[front] fix: Source common.sh to be backward compatible

### DIFF
--- a/front/lib/api/sandbox/image/profile.exec.test.ts
+++ b/front/lib/api/sandbox/image/profile.exec.test.ts
@@ -21,7 +21,7 @@ function nextExecId(): string {
 }
 
 function stripProfileSource(wrapped: string): string {
-  const stripped = wrapped.replace(/^source \S+ && /m, "");
+  const stripped = wrapped.replace(/^DUST_PROFILE=\S+ source \S+ && /m, "");
 
   if (stripped === wrapped) {
     throw new Error("Expected wrapped command to contain a source prefix.");

--- a/front/lib/api/sandbox/image/profile.test.ts
+++ b/front/lib/api/sandbox/image/profile.test.ts
@@ -8,7 +8,7 @@ import { getSandboxImageFromRegistry } from "./registry";
 
 function expectedWrappedCommand(cmd: string, timeoutSec = 60): string {
   return [
-    `source /opt/dust/profile/anthropic.sh && shell "$(cat <<'DUST_CMD_EOF'`,
+    `DUST_PROFILE=anthropic source /opt/dust/profile/common.sh && shell "$(cat <<'DUST_CMD_EOF'`,
     cmd,
     "DUST_CMD_EOF",
     `)" ${timeoutSec}`,

--- a/front/lib/api/sandbox/image/profile.ts
+++ b/front/lib/api/sandbox/image/profile.ts
@@ -45,7 +45,7 @@ export function wrapCommand(
   }
 
   return [
-    `source ${PROFILE_DIR}/${profile}.sh && shell "$(cat <<'${COMMAND_HEREDOC_DELIMITER}'`,
+    `DUST_PROFILE=${profile} source ${PROFILE_DIR}/common.sh && shell "$(cat <<'${COMMAND_HEREDOC_DELIMITER}'`,
     cmd,
     COMMAND_HEREDOC_DELIMITER,
     `)" ${timeoutSec}`,

--- a/front/lib/api/sandbox/image/profile/anthropic.sh
+++ b/front/lib/api/sandbox/image/profile/anthropic.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
-
+# Sourced by common.sh when DUST_PROFILE=anthropic.
 # Dev override: DUST_TOOLS_CMD="bun run $SCRIPT_DIR/src/index.ts"
 
 read_file()   { run_dust_tool --profile anthropic read_file "$@"; }

--- a/front/lib/api/sandbox/image/profile/common.sh
+++ b/front/lib/api/sandbox/image/profile/common.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Dust Sandbox Profile - Shared Infrastructure
-# Sourced by each provider profile (anthropic.sh, openai.sh, gemini.sh).
+# Entry point sourced by the host wrapper. Sources the provider-specific
+# profile (anthropic.sh, openai.sh, gemini.sh) when DUST_PROFILE is set
+# and the matching file exists. Older images that ship only this file
+# define the tool functions inline and ignore DUST_PROFILE.
 
 set -o pipefail
 
@@ -22,3 +25,7 @@ ls() {
   command ls -al "$@"
 }
 export -f ls
+
+if [ -n "${DUST_PROFILE:-}" ] && [ -f "$SCRIPT_DIR/${DUST_PROFILE}.sh" ]; then
+  source "$SCRIPT_DIR/${DUST_PROFILE}.sh"
+fi

--- a/front/lib/api/sandbox/image/profile/gemini.sh
+++ b/front/lib/api/sandbox/image/profile/gemini.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
-
+# Sourced by common.sh when DUST_PROFILE=gemini.
 # Dev override: DUST_TOOLS_CMD="bun run $SCRIPT_DIR/src/index.ts"
 
 read_file()   { run_dust_tool --profile gemini read_file "$@"; }

--- a/front/lib/api/sandbox/image/profile/openai.sh
+++ b/front/lib/api/sandbox/image/profile/openai.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
-
+# Sourced by common.sh when DUST_PROFILE=openai.
 # Dev override: DUST_TOOLS_CMD="bun run $SCRIPT_DIR/src/index.ts"
 
 read_file()   { run_dust_tool --profile openai read_file "$@"; }

--- a/front/lib/api/sandbox/image/profile/tests/_test_utils.ts
+++ b/front/lib/api/sandbox/image/profile/tests/_test_utils.ts
@@ -21,7 +21,7 @@ export function runBashFunction(
   stderr: string;
   exitCode: number;
 } {
-  const profilePath = path.join(PROFILE_LOCAL_DIR, `${profile}.sh`);
+  const commonPath = path.join(PROFILE_LOCAL_DIR, "common.sh");
   const dustToolsCommand = `${process.execPath} ${tsxCliPath} ${path.join(
     PROFILE_LOCAL_DIR,
     "src",
@@ -29,12 +29,13 @@ export function runBashFunction(
   )}`;
   const result = spawnSync(
     "bash",
-    ["--norc", "-c", `source "${profilePath}" && ${funcCall}`],
+    ["--norc", "-c", `source "${commonPath}" && ${funcCall}`],
     {
       cwd,
       encoding: "utf-8",
       env: {
         ...process.env,
+        DUST_PROFILE: profile,
         DUST_TOOLS_CMD: dustToolsCommand,
         TSX_TSCONFIG_PATH: path.resolve(
           PROFILE_LOCAL_DIR,

--- a/front/lib/api/sandbox/image/profile/tests/wrap_command.test.ts
+++ b/front/lib/api/sandbox/image/profile/tests/wrap_command.test.ts
@@ -8,7 +8,7 @@ function expectedWrappedCommand(
   timeoutSec = 60
 ): string {
   return [
-    `source ${PROFILE_DIR}/${profile}.sh && shell "$(cat <<'DUST_CMD_EOF'`,
+    `DUST_PROFILE=${profile} source ${PROFILE_DIR}/common.sh && shell "$(cat <<'DUST_CMD_EOF'`,
     cmd,
     "DUST_CMD_EOF",
     `)" ${timeoutSec}`,

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -13,7 +13,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.1";
+const DUST_BASE_IMAGE_VERSION = "0.8.2";
 const DSBX_CLI_VERSION = "0.1.4";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).


### PR DESCRIPTION
## Description

WrapCommand currently emits commands that source /opt/dust/profile/<provider>.sh (e.g. anthropic.sh, openai.sh, gemini.sh). The provider-specific scripts in turn source common.sh.

This breaks backward compatibility with older sandbox images that ship only common.sh (and shell.sh) without the provider-specific files. When such an old image is reused with the latest front code, every MCP tool call fails because <provider>.sh doesn't exist on disk.

**Solution:** have wrapCommand always source common.sh and pass the provider via an env var (DUST_PROFILE). On new images, common.sh will source the matching provider script. On old images, common.sh already defines everything inline and simply ignores DUST_PROFILE. Either way, the host-side command works.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

Deploy Front