### PR TITLE
[front] coupons: add page on poke

### DIFF
--- a/front-spa/src/poke/routes.tsx
+++ b/front-spa/src/poke/routes.tsx
@@ -4,6 +4,7 @@ import { AssistantInstructionsPage } from "@dust-tt/front/components/poke/pages/
 import { CacheLookupPage } from "@dust-tt/front/components/poke/pages/CacheLookupPage";
 import { ConnectorRedirectPage } from "@dust-tt/front/components/poke/pages/ConnectorRedirectPage";
 import { ConversationPage } from "@dust-tt/front/components/poke/pages/ConversationPage";
+import { CouponsPage } from "@dust-tt/front/components/poke/pages/CouponsPage";
 import { DashboardPage } from "@dust-tt/front/components/poke/pages/DashboardPage";
 import { DataSourcePage } from "@dust-tt/front/components/poke/pages/DataSourcePage";
 import { DataSourceQueryPage } from "@dust-tt/front/components/poke/pages/DataSourceQueryPage";
@@ -71,6 +72,7 @@ export const routes: RouteObject[] = [
           { index: true, element: <DashboardPage /> },
           { path: "kill", element: <KillPage /> },
           { path: "plans", element: <PlansPage /> },
+          { path: "coupons", element: <CouponsPage /> },
           { path: "pokefy", element: <PokefyPage /> },
           { path: "production-checks", element: <ProductionChecksPage /> },
           { path: "email-templates", element: <EmailTemplatesPage /> },

--- a/front/components/poke/coupons/CreateCouponForm.tsx
+++ b/front/components/poke/coupons/CreateCouponForm.tsx
@@ -1,0 +1,254 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type { CreatePokeCouponResponseBody } from "@app/pages/api/poke/coupons/index";
+import type { CouponDiscountType } from "@app/types/coupon";
+import { CreateCouponBodySchema } from "@app/types/coupon";
+import { Button, Input, XMarkIcon } from "@dust-tt/sparkle";
+import type React from "react";
+import { useState } from "react";
+
+interface CreateCouponFormProps {
+  onCreated: () => void;
+  onCancel: () => void;
+}
+
+interface FormState {
+  code: string;
+  description: string;
+  discountType: CouponDiscountType;
+  amountUsdStr: string;
+  creditTypeId: string;
+  durationMonths: string;
+  maxRedemptions: string;
+  redeemBy: string;
+}
+
+const EMPTY_FORM: FormState = {
+  code: "",
+  description: "",
+  discountType: "fixed",
+  amountUsdStr: "",
+  creditTypeId: "",
+  durationMonths: "",
+  maxRedemptions: "",
+  redeemBy: "",
+};
+
+export function CreateCouponForm({
+  onCreated,
+  onCancel,
+}: CreateCouponFormProps) {
+  const sendNotification = useSendNotification();
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [errors, setErrors] = useState<
+    Partial<Record<keyof FormState, string>>
+  >({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function set<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    setErrors((prev) => ({ ...prev, [key]: undefined }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    const body = {
+      code: form.code.trim(),
+      description: form.description.trim() || null,
+      discountType: form.discountType,
+      amountMicroUsd: form.amountUsdStr
+        ? Math.round(parseFloat(form.amountUsdStr) * 1_000_000)
+        : 0,
+      creditTypeId: form.creditTypeId.trim(),
+      durationMonths: form.durationMonths
+        ? parseInt(form.durationMonths, 10)
+        : null,
+      maxRedemptions: form.maxRedemptions
+        ? parseInt(form.maxRedemptions, 10)
+        : null,
+      redeemBy: form.redeemBy || null,
+    };
+
+    const result = CreateCouponBodySchema.safeParse(body);
+    if (!result.success) {
+      const fieldErrors: Partial<Record<keyof FormState, string>> = {};
+      for (const issue of result.error.issues) {
+        const zodField = issue.path[0] as string;
+        // Map amountMicroUsd back to the form field name.
+        const field = (
+          zodField === "amountMicroUsd" ? "amountUsdStr" : zodField
+        ) as keyof FormState;
+        if (field) {
+          fieldErrors[field] = issue.message;
+        }
+      }
+      setErrors(fieldErrors);
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const r = await clientFetch("/api/poke/coupons", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(result.data),
+      });
+
+      if (!r.ok) {
+        const text = await r.text();
+        if (r.status === 400 && text.includes("already exists")) {
+          setErrors({ code: "A coupon with this code already exists." });
+        } else {
+          sendNotification({
+            title: "Error creating coupon",
+            type: "error",
+            description: `Something went wrong: ${r.status} ${text}`,
+          });
+        }
+        return;
+      }
+
+      const data = (await r.json()) as CreatePokeCouponResponseBody;
+      sendNotification({
+        title: "Coupon created",
+        type: "success",
+        description: `Coupon "${data.coupon.code}" created successfully.`,
+      });
+      setForm(EMPTY_FORM);
+      onCreated();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border bg-muted/40 p-6 dark:bg-muted-night/40">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Create coupon</h2>
+        <Button icon={XMarkIcon} variant="ghost" size="sm" onClick={onCancel} />
+      </div>
+
+      <form onSubmit={handleSubmit} className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium">
+            Code <span className="text-red-500">*</span>
+          </label>
+          <Input
+            value={form.code}
+            onChange={(e) => set("code", e.target.value)}
+            placeholder="PROMO2025"
+          />
+          {errors.code && (
+            <span className="text-xs text-red-500">{errors.code}</span>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium">Description</label>
+          <Input
+            value={form.description}
+            onChange={(e) => set("description", e.target.value)}
+            placeholder="Optional description"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium">
+            Discount type <span className="text-red-500">*</span>
+          </label>
+          <select
+            value={form.discountType}
+            onChange={(e) =>
+              set("discountType", e.target.value as CouponDiscountType)
+            }
+            className="h-9 rounded-md border bg-background px-3 text-sm dark:bg-background-night"
+          >
+            <option value="fixed">fixed</option>
+            <option value="usage_credit">usage_credit</option>
+          </select>
+          {errors.discountType && (
+            <span className="text-xs text-red-500">{errors.discountType}</span>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium">
+            Amount (USD) <span className="text-red-500">*</span>
+          </label>
+          <Input
+            type="number"
+            value={form.amountUsdStr}
+            onChange={(e) => set("amountUsdStr", e.target.value)}
+            placeholder="e.g. 10.00"
+            min={0.01}
+            step={0.01}
+          />
+          {errors.amountUsdStr && (
+            <span className="text-xs text-red-500">{errors.amountUsdStr}</span>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1 col-span-2">
+          <label className="text-sm font-medium">
+            Credit type ID (Metronome) <span className="text-red-500">*</span>
+          </label>
+          <Input
+            value={form.creditTypeId}
+            onChange={(e) => set("creditTypeId", e.target.value)}
+            placeholder="Metronome credit type ID"
+          />
+          {errors.creditTypeId && (
+            <span className="text-xs text-red-500">{errors.creditTypeId}</span>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium">Duration (months)</label>
+          <Input
+            type="number"
+            value={form.durationMonths}
+            onChange={(e) => set("durationMonths", e.target.value)}
+            placeholder="Leave blank for unlimited"
+            min={1}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium">Max redemptions</label>
+          <Input
+            type="number"
+            value={form.maxRedemptions}
+            onChange={(e) => set("maxRedemptions", e.target.value)}
+            placeholder="Leave blank for unlimited"
+            min={1}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium">Redeem by</label>
+          <Input
+            type="date"
+            value={form.redeemBy}
+            onChange={(e) => set("redeemBy", e.target.value)}
+          />
+        </div>
+
+        <div className="col-span-2 flex justify-end gap-2 pt-2">
+          <Button
+            label="Cancel"
+            variant="outline"
+            onClick={onCancel}
+            disabled={isSubmitting}
+          />
+          <Button
+            label={isSubmitting ? "Creating…" : "Create coupon"}
+            variant="primary"
+            type="submit"
+            disabled={isSubmitting}
+          />
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/front/components/poke/coupons/CreateCouponForm.tsx
+++ b/front/components/poke/coupons/CreateCouponForm.tsx
@@ -3,6 +3,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import type { CreatePokeCouponResponseBody } from "@app/pages/api/poke/coupons/index";
 import type { CouponDiscountType } from "@app/types/coupon";
 import { CreateCouponBodySchema } from "@app/types/coupon";
+import { isString } from "@app/types/shared/utils/general";
 import { Button, Input, XMarkIcon } from "@dust-tt/sparkle";
 import type React from "react";
 import { useState } from "react";
@@ -21,6 +22,21 @@ interface FormState {
   durationMonths: string;
   maxRedemptions: string;
   redeemBy: string;
+}
+
+const FORM_STATE_KEYS: ReadonlyArray<keyof FormState> = [
+  "code",
+  "description",
+  "discountType",
+  "amountUsdStr",
+  "creditTypeId",
+  "durationMonths",
+  "maxRedemptions",
+  "redeemBy",
+];
+
+function isFormStateKey(key: string): key is keyof FormState {
+  return (FORM_STATE_KEYS as readonly string[]).includes(key);
 }
 
 const EMPTY_FORM: FormState = {
@@ -74,12 +90,14 @@ export function CreateCouponForm({
     if (!result.success) {
       const fieldErrors: Partial<Record<keyof FormState, string>> = {};
       for (const issue of result.error.issues) {
-        const zodField = issue.path[0] as string;
+        const pathElement = issue.path[0];
+        if (!isString(pathElement)) {
+          continue;
+        }
         // Map amountMicroUsd back to the form field name.
-        const field = (
-          zodField === "amountMicroUsd" ? "amountUsdStr" : zodField
-        ) as keyof FormState;
-        if (field) {
+        const field =
+          pathElement === "amountMicroUsd" ? "amountUsdStr" : pathElement;
+        if (isFormStateKey(field)) {
           fieldErrors[field] = issue.message;
         }
       }

--- a/front/components/poke/coupons/CreateCouponForm.tsx
+++ b/front/components/poke/coupons/CreateCouponForm.tsx
@@ -2,16 +2,20 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import type { CreatePokeCouponResponseBody } from "@app/pages/api/poke/coupons/index";
 import type { CouponDiscountType } from "@app/types/coupon";
-import { CreateCouponBodySchema } from "@app/types/coupon";
+import {
+  CouponDiscountTypeSchema,
+  CreateCouponBodySchema,
+} from "@app/types/coupon";
 import { isString } from "@app/types/shared/utils/general";
-import { Button, Input, XMarkIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  Input,
+  RadioGroup,
+  RadioGroupItem,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
 import type React from "react";
 import { useState } from "react";
-
-interface CreateCouponFormProps {
-  onCreated: () => void;
-  onCancel: () => void;
-}
 
 interface FormState {
   code: string;
@@ -24,21 +28,6 @@ interface FormState {
   redeemBy: string;
 }
 
-const FORM_STATE_KEYS: ReadonlyArray<keyof FormState> = [
-  "code",
-  "description",
-  "discountType",
-  "amountUsdStr",
-  "creditTypeId",
-  "durationMonths",
-  "maxRedemptions",
-  "redeemBy",
-];
-
-function isFormStateKey(key: string): key is keyof FormState {
-  return (FORM_STATE_KEYS as readonly string[]).includes(key);
-}
-
 const EMPTY_FORM: FormState = {
   code: "",
   description: "",
@@ -49,6 +38,19 @@ const EMPTY_FORM: FormState = {
   maxRedemptions: "",
   redeemBy: "",
 };
+
+const FORM_STATE_KEYS = Object.keys(EMPTY_FORM) as ReadonlyArray<
+  keyof FormState
+>;
+
+function isFormStateKey(key: string): key is keyof FormState {
+  return (FORM_STATE_KEYS as readonly string[]).includes(key);
+}
+
+interface CreateCouponFormProps {
+  onCreated: () => void;
+  onCancel: () => void;
+}
 
 export function CreateCouponForm({
   onCreated,
@@ -175,16 +177,19 @@ export function CreateCouponForm({
           <label className="text-sm font-medium">
             Discount type <span className="text-red-500">*</span>
           </label>
-          <select
+          <RadioGroup
+            name="discountType"
             value={form.discountType}
-            onChange={(e) =>
-              set("discountType", e.target.value as CouponDiscountType)
-            }
-            className="h-9 rounded-md border bg-background px-3 text-sm dark:bg-background-night"
+            onValueChange={(value: string) => {
+              const parsed = CouponDiscountTypeSchema.safeParse(value);
+              if (parsed.success) {
+                set("discountType", parsed.data);
+              }
+            }}
           >
-            <option value="fixed">fixed</option>
-            <option value="usage_credit">usage_credit</option>
-          </select>
+            <RadioGroupItem value="fixed" label="Fixed" />
+            <RadioGroupItem value="usage_credit" label="Usage credit" />
+          </RadioGroup>
           {errors.discountType && (
             <span className="text-xs text-red-500">{errors.discountType}</span>
           )}

--- a/front/components/poke/pages/CouponsPage.tsx
+++ b/front/components/poke/pages/CouponsPage.tsx
@@ -1,0 +1,258 @@
+import { CreateCouponForm } from "@app/components/poke/coupons/CreateCouponForm";
+import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
+import {
+  usePokeArchiveCoupon,
+  usePokeCouponRedemptions,
+  usePokeCoupons,
+} from "@app/lib/swr/poke";
+import type { CouponRedemptionType, CouponType } from "@app/types/coupon";
+import {
+  ArchiveIcon,
+  Button,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  IconButton,
+  PlusIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+function formatUsd(microUsd: number): string {
+  return `$${(microUsd / 1_000_000).toFixed(2)}`;
+}
+
+function formatDate(date: Date | string | null): string {
+  if (!date) {
+    return "—";
+  }
+  return new Date(date).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+interface CouponRedemptionsRowProps {
+  couponId: string;
+}
+
+function CouponRedemptionsRow({ couponId }: CouponRedemptionsRowProps) {
+  const { redemptions, isRedemptionsLoading } = usePokeCouponRedemptions({
+    couponId,
+    disabled: false,
+  });
+
+  if (isRedemptionsLoading) {
+    return (
+      <tr>
+        <td colSpan={9} className="px-4 py-2 text-center">
+          <Spinner size="xs" />
+        </td>
+      </tr>
+    );
+  }
+
+  if (redemptions.length === 0) {
+    return (
+      <tr>
+        <td
+          colSpan={9}
+          className="px-6 py-2 text-sm text-muted-foreground dark:text-muted-foreground-night"
+        >
+          No redemptions yet.
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <>
+      {redemptions.map((r: CouponRedemptionType) => (
+        <tr
+          key={r.sId}
+          className="bg-muted/30 dark:bg-muted-night/30 text-xs text-muted-foreground dark:text-muted-foreground-night"
+        >
+          <td className="w-8" />
+          <td className="border px-3 py-1 font-mono">↳ {r.workspaceId}</td>
+          <td className="border px-3 py-1 font-mono">
+            {r.redeemedByUserId ?? "—"}
+          </td>
+          <td className="border px-3 py-1">{formatDate(r.redeemedAt)}</td>
+          <td colSpan={5} />
+        </tr>
+      ))}
+    </>
+  );
+}
+
+interface CouponRowProps {
+  coupon: CouponType;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onArchive: () => void;
+}
+
+function CouponRow({
+  coupon,
+  isExpanded,
+  onToggleExpand,
+  onArchive,
+}: CouponRowProps) {
+  const isArchived = coupon.archivedAt !== null;
+
+  return (
+    <>
+      <tr
+        className={
+          isArchived
+            ? "cursor-pointer opacity-50"
+            : "cursor-pointer hover:bg-muted/20 dark:hover:bg-muted-night/20"
+        }
+        onClick={onToggleExpand}
+      >
+        <td className="w-8 px-2 py-2 text-center">
+          {isExpanded ? (
+            <ChevronDownIcon className="h-4 w-4" />
+          ) : (
+            <ChevronRightIcon className="h-4 w-4" />
+          )}
+        </td>
+        <td className="border px-4 py-2 font-semibold">
+          <div className="flex items-center gap-2">
+            {coupon.code}
+            {isArchived && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-xs dark:bg-muted-night">
+                archived
+              </span>
+            )}
+          </div>
+        </td>
+        <td className="border px-4 py-2 text-sm">
+          {coupon.description ?? "—"}
+        </td>
+        <td className="border px-4 py-2 text-sm">{coupon.discountType}</td>
+        <td className="border px-4 py-2 text-sm font-mono">
+          {formatUsd(coupon.amountMicroUsd)}
+        </td>
+        <td className="border px-4 py-2 text-sm text-center">
+          {coupon.durationMonths ?? "—"}
+        </td>
+        <td className="border px-4 py-2 text-sm text-center font-mono">
+          {coupon.redemptionCount}
+          {coupon.maxRedemptions !== null ? ` / ${coupon.maxRedemptions}` : ""}
+        </td>
+        <td className="border px-4 py-2 text-sm">
+          {formatDate(coupon.redeemBy)}
+        </td>
+        <td
+          className="border px-4 py-2 text-sm"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <IconButton
+            icon={ArchiveIcon}
+            size="xs"
+            variant="ghost"
+            disabled={isArchived}
+            tooltip={isArchived ? "Already archived" : "Archive coupon"}
+            onClick={onArchive}
+          />
+        </td>
+      </tr>
+      {isExpanded && <CouponRedemptionsRow couponId={coupon.sId} />}
+    </>
+  );
+}
+
+export function CouponsPage() {
+  useDocumentTitle("Poke - Coupons");
+
+  const { coupons, isCouponsLoading, mutate } = usePokeCoupons();
+  const archiveCoupon = usePokeArchiveCoupon();
+
+  const [expandedCouponId, setExpandedCouponId] = useState<string | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  function toggleExpand(couponId: string) {
+    setExpandedCouponId((prev) => (prev === couponId ? null : couponId));
+  }
+
+  async function handleArchive(couponId: string) {
+    await archiveCoupon(couponId);
+  }
+
+  if (isCouponsLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col items-center">
+      <div className="py-8 text-2xl font-bold">Coupons</div>
+
+      {showCreateForm && (
+        <div className="mb-6 w-full max-w-3xl">
+          <CreateCouponForm
+            onCreated={async () => {
+              await mutate();
+              setShowCreateForm(false);
+            }}
+            onCancel={() => setShowCreateForm(false)}
+          />
+        </div>
+      )}
+
+      <div className="mb-4 flex w-full justify-end">
+        <Button
+          icon={PlusIcon}
+          label="Create coupon"
+          variant="outline"
+          disabled={showCreateForm}
+          onClick={() => setShowCreateForm(true)}
+        />
+      </div>
+
+      <div className="w-full overflow-x-auto pb-24">
+        <table className="w-full table-auto rounded-lg text-left">
+          <thead className="bg-muted dark:bg-muted-night">
+            <tr>
+              <th className="w-8" />
+              <th className="border px-4 py-2 text-sm">Code</th>
+              <th className="border px-4 py-2 text-sm">Description</th>
+              <th className="border px-4 py-2 text-sm">Type</th>
+              <th className="border px-4 py-2 text-sm">Amount (USD)</th>
+              <th className="border px-4 py-2 text-sm">Duration (mo)</th>
+              <th className="border px-4 py-2 text-sm">Uses</th>
+              <th className="border px-4 py-2 text-sm">Redeem by</th>
+              <th className="border px-4 py-2 text-sm">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {coupons.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={9}
+                  className="px-4 py-8 text-center text-muted-foreground dark:text-muted-foreground-night"
+                >
+                  No coupons yet.
+                </td>
+              </tr>
+            ) : (
+              coupons.map((coupon: CouponType) => (
+                <CouponRow
+                  key={coupon.sId}
+                  coupon={coupon}
+                  isExpanded={expandedCouponId === coupon.sId}
+                  onToggleExpand={() => toggleExpand(coupon.sId)}
+                  onArchive={() => handleArchive(coupon.sId)}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/front/components/poke/pages/CouponsPage.tsx
+++ b/front/components/poke/pages/CouponsPage.tsx
@@ -5,167 +5,237 @@ import {
   usePokeCouponRedemptions,
   usePokeCoupons,
 } from "@app/lib/swr/poke";
-import type { CouponRedemptionType, CouponType } from "@app/types/coupon";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type {
+  CouponDiscountType,
+  CouponRedemptionType,
+  CouponType,
+} from "@app/types/coupon";
+import type { MenuItem } from "@dust-tt/sparkle";
 import {
   ArchiveIcon,
   Button,
   ChevronDownIcon,
   ChevronRightIcon,
-  IconButton,
+  DataTable,
   PlusIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { MouseEvent } from "react";
+import { useMemo, useState } from "react";
 
 function formatUsd(microUsd: number): string {
   return `$${(microUsd / 1_000_000).toFixed(2)}`;
 }
 
-function formatDate(date: Date | string | null): string {
-  if (!date) {
-    return "—";
-  }
-  return new Date(date).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
+interface CouponRowData {
+  sId: string;
+  code: string;
+  description: string | null;
+  discountType: CouponDiscountType;
+  amountMicroUsd: number;
+  durationMonths: number | null;
+  maxRedemptions: number | null;
+  redemptionCount: number;
+  redeemBy: Date | null;
+  archivedAt: Date | null;
+  isExpanded: boolean;
+  onClick?: () => void;
+  menuItems?: MenuItem[];
 }
 
-interface CouponRedemptionsRowProps {
-  couponId: string;
-  disabled: boolean;
+interface CouponRedemptionRowData {
+  sId: string;
+  workspaceId: string;
+  redeemedByUserId: string | null;
+  redeemedAt: Date;
+  onClick?: () => void;
+  menuItems?: MenuItem[];
 }
 
-function CouponRedemptionsRow({
-  couponId,
-  disabled,
-}: CouponRedemptionsRowProps) {
+const couponColumns: ColumnDef<CouponRowData>[] = [
+  {
+    id: "expand",
+    header: "",
+    cell: ({ row }) =>
+      row.original.isExpanded ? (
+        <ChevronDownIcon className="h-4 w-4" />
+      ) : (
+        <ChevronRightIcon className="h-4 w-4" />
+      ),
+    meta: { className: "w-8" },
+  },
+  {
+    accessorKey: "code",
+    header: "Code",
+    cell: ({ row }) => (
+      <DataTable.CellContent disabled={!!row.original.archivedAt}>
+        <div className="flex items-center gap-2">
+          <span>{row.original.code}</span>
+          {row.original.archivedAt && (
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs dark:bg-muted-night">
+              archived
+            </span>
+          )}
+        </div>
+      </DataTable.CellContent>
+    ),
+  },
+  {
+    accessorKey: "description",
+    header: "Description",
+    cell: ({ row }) => (
+      <DataTable.BasicCellContent
+        label={row.original.description ?? "—"}
+        disabled={!!row.original.archivedAt}
+      />
+    ),
+  },
+  {
+    accessorKey: "discountType",
+    header: "Type",
+    cell: ({ row }) => (
+      <DataTable.BasicCellContent
+        label={row.original.discountType}
+        disabled={!!row.original.archivedAt}
+      />
+    ),
+  },
+  {
+    accessorKey: "amountMicroUsd",
+    header: "Amount (USD)",
+    cell: ({ row }) => (
+      <DataTable.BasicCellContent
+        label={formatUsd(row.original.amountMicroUsd)}
+        disabled={!!row.original.archivedAt}
+      />
+    ),
+  },
+  {
+    accessorKey: "durationMonths",
+    header: "Duration (mo)",
+    cell: ({ row }) => (
+      <DataTable.BasicCellContent
+        label={row.original.durationMonths ?? "—"}
+        disabled={!!row.original.archivedAt}
+      />
+    ),
+  },
+  {
+    id: "uses",
+    header: "Uses",
+    cell: ({ row }) => (
+      <DataTable.BasicCellContent
+        label={`${row.original.redemptionCount}${row.original.maxRedemptions !== null ? ` / ${row.original.maxRedemptions}` : ""}`}
+        disabled={!!row.original.archivedAt}
+      />
+    ),
+  },
+  {
+    accessorKey: "redeemBy",
+    header: "Redeem by",
+    cell: ({ row }) => (
+      <DataTable.BasicCellContent
+        label={
+          row.original.redeemBy
+            ? formatTimestampToFriendlyDate(
+                new Date(row.original.redeemBy).getTime(),
+                "compactWithDay"
+              )
+            : "—"
+        }
+        disabled={!!row.original.archivedAt}
+      />
+    ),
+  },
+  {
+    id: "actions",
+    header: "",
+    cell: ({ row }) => (
+      <DataTable.MoreButton menuItems={row.original.menuItems} />
+    ),
+    meta: { className: "w-14" },
+  },
+];
+
+const redemptionColumns: ColumnDef<CouponRedemptionRowData>[] = [
+  {
+    accessorKey: "workspaceId",
+    header: "Workspace",
+    cell: ({ row }) => (
+      <DataTable.BasicCellContent label={row.original.workspaceId} />
+    ),
+  },
+  {
+    accessorKey: "redeemedByUserId",
+    header: "Redeemed by",
+    cell: ({ row }) => (
+      <DataTable.BasicCellContent
+        label={row.original.redeemedByUserId ?? "—"}
+      />
+    ),
+  },
+  {
+    accessorKey: "redeemedAt",
+    header: "Redeemed at",
+    cell: ({ row }) => (
+      <DataTable.BasicCellContent
+        label={formatTimestampToFriendlyDate(
+          new Date(row.original.redeemedAt).getTime(),
+          "compactWithDay"
+        )}
+      />
+    ),
+  },
+];
+
+interface CouponRedemptionsPanelProps {
+  coupon: CouponType;
+}
+
+function CouponRedemptionsPanel({ coupon }: CouponRedemptionsPanelProps) {
   const { redemptions, isRedemptionsLoading } = usePokeCouponRedemptions({
-    couponId,
-    disabled,
+    couponId: coupon.sId,
+    disabled: false,
   });
+
+  const data: CouponRedemptionRowData[] = useMemo(
+    () =>
+      redemptions.map((r: CouponRedemptionType) => ({
+        sId: r.sId,
+        workspaceId: r.workspaceId,
+        redeemedByUserId: r.redeemedByUserId,
+        redeemedAt: r.redeemedAt,
+      })),
+    [redemptions]
+  );
 
   if (isRedemptionsLoading) {
     return (
-      <tr>
-        <td colSpan={9} className="px-4 py-2 text-center">
-          <Spinner size="xs" />
-        </td>
-      </tr>
+      <div className="flex justify-center py-4">
+        <Spinner size="sm" />
+      </div>
     );
   }
 
-  if (redemptions.length === 0) {
-    return (
-      <tr>
-        <td
-          colSpan={9}
-          className="px-6 py-2 text-sm text-muted-foreground dark:text-muted-foreground-night"
-        >
+  return (
+    <div className="mt-2 rounded-lg border p-4">
+      <p className="mb-2 text-sm font-semibold">
+        Redemptions for <span className="font-mono">{coupon.code}</span>
+      </p>
+      {redemptions.length === 0 ? (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
           No redemptions yet.
-        </td>
-      </tr>
-    );
-  }
-
-  return (
-    <>
-      {redemptions.map((r: CouponRedemptionType) => (
-        <tr
-          key={r.sId}
-          className="bg-muted/30 dark:bg-muted-night/30 text-xs text-muted-foreground dark:text-muted-foreground-night"
-        >
-          <td className="w-8" />
-          <td className="border px-3 py-1 font-mono">↳ {r.workspaceId}</td>
-          <td className="border px-3 py-1 font-mono">
-            {r.redeemedByUserId ?? "—"}
-          </td>
-          <td className="border px-3 py-1">{formatDate(r.redeemedAt)}</td>
-          <td colSpan={5} />
-        </tr>
-      ))}
-    </>
-  );
-}
-
-interface CouponRowProps {
-  coupon: CouponType;
-  isExpanded: boolean;
-  onToggleExpand: () => void;
-  onArchive: () => void;
-}
-
-function CouponRow({
-  coupon,
-  isExpanded,
-  onToggleExpand,
-  onArchive,
-}: CouponRowProps) {
-  const isArchived = coupon.archivedAt !== null;
-
-  return (
-    <>
-      <tr
-        className={
-          isArchived
-            ? "cursor-pointer opacity-50"
-            : "cursor-pointer hover:bg-muted/20 dark:hover:bg-muted-night/20"
-        }
-        onClick={onToggleExpand}
-      >
-        <td className="w-8 px-2 py-2 text-center">
-          {isExpanded ? (
-            <ChevronDownIcon className="h-4 w-4" />
-          ) : (
-            <ChevronRightIcon className="h-4 w-4" />
-          )}
-        </td>
-        <td className="border px-4 py-2 font-semibold">
-          <div className="flex items-center gap-2">
-            {coupon.code}
-            {isArchived && (
-              <span className="rounded bg-muted px-1.5 py-0.5 text-xs dark:bg-muted-night">
-                archived
-              </span>
-            )}
-          </div>
-        </td>
-        <td className="border px-4 py-2 text-sm">
-          {coupon.description ?? "—"}
-        </td>
-        <td className="border px-4 py-2 text-sm">{coupon.discountType}</td>
-        <td className="border px-4 py-2 text-sm font-mono">
-          {formatUsd(coupon.amountMicroUsd)}
-        </td>
-        <td className="border px-4 py-2 text-sm text-center">
-          {coupon.durationMonths ?? "—"}
-        </td>
-        <td className="border px-4 py-2 text-sm text-center font-mono">
-          {coupon.redemptionCount}
-          {coupon.maxRedemptions !== null ? ` / ${coupon.maxRedemptions}` : ""}
-        </td>
-        <td className="border px-4 py-2 text-sm">
-          {formatDate(coupon.redeemBy)}
-        </td>
-        <td
-          className="border px-4 py-2 text-sm"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <IconButton
-            icon={ArchiveIcon}
-            size="xs"
-            variant="ghost"
-            disabled={isArchived}
-            tooltip={isArchived ? "Already archived" : "Archive coupon"}
-            onClick={onArchive}
-          />
-        </td>
-      </tr>
-      {isExpanded && (
-        <CouponRedemptionsRow couponId={coupon.sId} disabled={!isExpanded} />
+        </p>
+      ) : (
+        <DataTable
+          data={data}
+          columns={redemptionColumns}
+          getRowId={(row) => row.sId}
+        />
       )}
-    </>
+    </div>
   );
 }
 
@@ -178,13 +248,36 @@ export function CouponsPage() {
   const [expandedCouponId, setExpandedCouponId] = useState<string | null>(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
 
-  function toggleExpand(couponId: string) {
-    setExpandedCouponId((prev) => (prev === couponId ? null : couponId));
-  }
+  const data: CouponRowData[] = useMemo(
+    () =>
+      coupons.map((coupon: CouponType) => ({
+        ...coupon,
+        isExpanded: expandedCouponId === coupon.sId,
+        onClick: () =>
+          setExpandedCouponId((prev) =>
+            prev === coupon.sId ? null : coupon.sId
+          ),
+        menuItems: coupon.archivedAt
+          ? []
+          : [
+              {
+                kind: "item" as const,
+                label: "Archive",
+                icon: ArchiveIcon,
+                onClick: (e: MouseEvent) => {
+                  e.stopPropagation();
+                  void archiveCoupon(coupon.sId);
+                },
+              },
+            ],
+      })),
+    [coupons, expandedCouponId, archiveCoupon]
+  );
 
-  async function handleArchive(couponId: string) {
-    await archiveCoupon(couponId);
-  }
+  const expandedCoupon = useMemo(
+    () => coupons.find((c) => c.sId === expandedCouponId) ?? null,
+    [coupons, expandedCouponId]
+  );
 
   if (isCouponsLoading) {
     return (
@@ -220,44 +313,13 @@ export function CouponsPage() {
         />
       </div>
 
-      <div className="w-full overflow-x-auto pb-24">
-        <table className="w-full table-auto rounded-lg text-left">
-          <thead className="bg-muted dark:bg-muted-night">
-            <tr>
-              <th className="w-8" />
-              <th className="border px-4 py-2 text-sm">Code</th>
-              <th className="border px-4 py-2 text-sm">Description</th>
-              <th className="border px-4 py-2 text-sm">Type</th>
-              <th className="border px-4 py-2 text-sm">Amount (USD)</th>
-              <th className="border px-4 py-2 text-sm">Duration (mo)</th>
-              <th className="border px-4 py-2 text-sm">Uses</th>
-              <th className="border px-4 py-2 text-sm">Redeem by</th>
-              <th className="border px-4 py-2 text-sm">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {coupons.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={9}
-                  className="px-4 py-8 text-center text-muted-foreground dark:text-muted-foreground-night"
-                >
-                  No coupons yet.
-                </td>
-              </tr>
-            ) : (
-              coupons.map((coupon: CouponType) => (
-                <CouponRow
-                  key={coupon.sId}
-                  coupon={coupon}
-                  isExpanded={expandedCouponId === coupon.sId}
-                  onToggleExpand={() => toggleExpand(coupon.sId)}
-                  onArchive={() => handleArchive(coupon.sId)}
-                />
-              ))
-            )}
-          </tbody>
-        </table>
+      <div className="w-full pb-24">
+        <DataTable
+          data={data}
+          columns={couponColumns}
+          getRowId={(row) => row.sId}
+        />
+        {expandedCoupon && <CouponRedemptionsPanel coupon={expandedCoupon} />}
       </div>
     </div>
   );

--- a/front/components/poke/pages/CouponsPage.tsx
+++ b/front/components/poke/pages/CouponsPage.tsx
@@ -34,12 +34,16 @@ function formatDate(date: Date | string | null): string {
 
 interface CouponRedemptionsRowProps {
   couponId: string;
+  disabled: boolean;
 }
 
-function CouponRedemptionsRow({ couponId }: CouponRedemptionsRowProps) {
+function CouponRedemptionsRow({
+  couponId,
+  disabled,
+}: CouponRedemptionsRowProps) {
   const { redemptions, isRedemptionsLoading } = usePokeCouponRedemptions({
     couponId,
-    disabled: false,
+    disabled,
   });
 
   if (isRedemptionsLoading) {
@@ -158,7 +162,9 @@ function CouponRow({
           />
         </td>
       </tr>
-      {isExpanded && <CouponRedemptionsRow couponId={coupon.sId} />}
+      {isExpanded && (
+        <CouponRedemptionsRow couponId={coupon.sId} disabled={!isExpanded} />
+      )}
     </>
   );
 }

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -1,7 +1,11 @@
+import { useSendNotification } from "@app/hooks/useNotification";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
+import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { isRegionRedirect } from "@app/lib/swr/workspaces";
 import type { GetPokeNoWorkspaceAuthContextResponseType } from "@app/pages/api/poke/auth-context";
+import type { GetPokeCouponRedemptionsResponseBody } from "@app/pages/api/poke/coupons/[couponId]/redemptions";
+import type { GetPokeCouponsResponseBody } from "@app/pages/api/poke/coupons/index";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetRegionResponseType } from "@app/pages/api/poke/region";
 import type { GetPokeWorkspaceAuthContextResponseType } from "@app/pages/api/poke/workspaces/[wId]/auth-context";
@@ -17,6 +21,7 @@ import {
 import type { LightWorkspaceType } from "@app/types/user";
 import { useEffect } from "react";
 import type { Fetcher } from "swr";
+import { useSWRConfig } from "swr";
 
 export function usePokeRegion() {
   const { fetcher } = useFetcher();
@@ -78,6 +83,68 @@ export function usePokePlans() {
     plans: data?.plans ?? emptyArray(),
     isPlansLoading: !error && !data,
     isPlansError: error,
+  };
+}
+
+export function usePokeCoupons() {
+  const { fetcher } = useFetcher();
+  const couponsFetcher: Fetcher<GetPokeCouponsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    "/api/poke/coupons",
+    couponsFetcher
+  );
+
+  return {
+    coupons: data?.coupons ?? emptyArray(),
+    isCouponsLoading: !error && !data,
+    isCouponsError: error,
+    mutate,
+  };
+}
+
+export function usePokeCouponRedemptions({
+  couponId,
+  disabled,
+}: {
+  couponId: string;
+  disabled: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const redemptionsFetcher: Fetcher<GetPokeCouponRedemptionsResponseBody> =
+    fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/poke/coupons/${couponId}/redemptions`,
+    redemptionsFetcher,
+    { disabled }
+  );
+
+  return {
+    redemptions: data?.redemptions ?? emptyArray(),
+    isRedemptionsLoading: !error && !data && !disabled,
+    isRedemptionsError: error,
+  };
+}
+
+export function usePokeArchiveCoupon() {
+  const { mutate } = useSWRConfig();
+  const sendNotification = useSendNotification();
+
+  return async (couponId: string) => {
+    const r = await clientFetch(`/api/poke/coupons/${couponId}/archive`, {
+      method: "POST",
+    });
+    if (!r.ok) {
+      sendNotification({
+        title: "Error archiving coupon",
+        type: "error",
+        description: `Something went wrong: ${r.status} ${await r.text()}`,
+      });
+      return;
+    }
+    await mutate("/api/poke/coupons");
+    sendNotification({ title: "Coupon archived", type: "success" });
   };
 }
 

--- a/front/pages/api/poke/coupons/[couponId]/archive.ts
+++ b/front/pages/api/poke/coupons/[couponId]/archive.ts
@@ -1,0 +1,89 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { CouponType } from "@app/types/coupon";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type ArchivePokeCouponResponseBody = {
+  coupon: CouponType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<ArchivePokeCouponResponseBody>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  const { couponId } = req.query;
+  if (!isString(couponId)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "coupon_not_found",
+        message: "Could not find the coupon.",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const coupon = await CouponResource.fetchByCouponId(couponId);
+  if (!coupon) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "coupon_not_found",
+        message: "Could not find the coupon.",
+      },
+    });
+  }
+
+  if (coupon.archivedAt !== null) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Coupon is already archived.",
+      },
+    });
+  }
+
+  const result = await coupon.archive(auth);
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to archive coupon: ${result.error.message}`,
+      },
+    });
+  }
+
+  res.status(200).json({ coupon: coupon.toJSON() });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/coupons/[couponId]/redemptions.ts
+++ b/front/pages/api/poke/coupons/[couponId]/redemptions.ts
@@ -1,0 +1,72 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { CouponRedemptionType } from "@app/types/coupon";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetPokeCouponRedemptionsResponseBody = {
+  redemptions: CouponRedemptionType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetPokeCouponRedemptionsResponseBody>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  const { couponId } = req.query;
+  if (!isString(couponId)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "coupon_not_found",
+        message: "Could not find the coupon.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const coupon = await CouponResource.fetchByCouponId(couponId);
+  if (!coupon) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "coupon_not_found",
+        message: "Could not find the coupon.",
+      },
+    });
+  }
+
+  const redemptions = await CouponRedemptionResource.listAllByCoupon(coupon);
+  res.status(200).json({ redemptions: redemptions.map((r) => r.toJSON()) });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/coupons/index.ts
+++ b/front/pages/api/poke/coupons/index.ts
@@ -1,0 +1,97 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { CouponType } from "@app/types/coupon";
+import { CreateCouponBodySchema } from "@app/types/coupon";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetPokeCouponsResponseBody = {
+  coupons: CouponType[];
+};
+
+export type CreatePokeCouponResponseBody = {
+  coupon: CouponType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      GetPokeCouponsResponseBody | CreatePokeCouponResponseBody
+    >
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const coupons = await CouponResource.listAll({ includeArchived: true });
+      res.status(200).json({ coupons: coupons.map((c) => c.toJSON()) });
+      return;
+    }
+
+    case "POST": {
+      const bodyResult = CreateCouponBodySchema.safeParse(req.body);
+      if (!bodyResult.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${bodyResult.error.message}`,
+          },
+        });
+      }
+
+      const existing = await CouponResource.findByCode(bodyResult.data.code);
+      if (existing) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "A coupon with this code already exists.",
+          },
+        });
+      }
+
+      const result = await CouponResource.makeNew(auth, bodyResult.data);
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to create coupon: ${result.error.message}`,
+          },
+        });
+      }
+
+      res.status(201).json({ coupon: result.value.toJSON() });
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET or POST expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -121,6 +121,8 @@ const API_ERROR_TYPES = [
   "project_todo_not_found",
   // Groups:
   "group_not_found",
+  // Coupons:
+  "coupon_not_found",
   // Plugins:
   "plugin_not_found",
   "plugin_execution_failed",


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/7870
Add a page in poke to list coupons and redemptions + form to add a new coupon
Page is not visible, only accessible via url for the moment

## Tests

Tested locally

## Risk

None, coupons are not used yet and isolated

## Deploy Plan

Deploy front