### PR TITLE
Suppress payment-failure banner/email for enterprise workspaces

### DIFF
--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -1,6 +1,9 @@
 import type { AppStatus } from "@app/lib/api/status";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { FREE_BYOK_TRANSITIONING_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import {
+  FREE_BYOK_TRANSITIONING_PLAN_CODE,
+  isEntreprisePlanPrefix,
+} from "@app/lib/plans/plan_codes";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
 import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
@@ -203,9 +206,11 @@ export function SidebarBanners() {
     <>
       <UnhealthyCredentialsBanner owner={owner} subscription={subscription} />
       {appStatus && <AppStatusBanner appStatus={appStatus} />}
-      {subscription.paymentFailingSince && isAdmin(owner) && (
-        <SubscriptionPastDueBanner />
-      )}
+      {subscription.paymentFailingSince &&
+        isAdmin(owner) &&
+        !isEntreprisePlanPrefix(subscription.plan.code) && (
+          <SubscriptionPastDueBanner />
+        )}
     </>
   );
 }

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -31,6 +31,7 @@ import {
 import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
   assertStripeSubscriptionIsValid,
@@ -704,6 +705,24 @@ async function handler(
                 "invoice.payment_failed",
                 "Couldn't get owner or subscription from `auth`."
               );
+            }
+
+            // Enterprise workspaces are paid by wire on 30-day invoice terms,
+            // so a Stripe payment_failed event does not reflect an actual
+            // billing problem. We also use the workspace's current active
+            // plan (not the plan attached to the failing invoice) so that a
+            // legacy non-enterprise subscription still tied to the same
+            // Stripe customer cannot trigger the past-due flow.
+            if (isEntreprisePlanPrefix(subscriptionType.plan.code)) {
+              logger.info(
+                {
+                  workspaceId: owner.sId,
+                  stripeSubscriptionId: invoice.subscription,
+                  planCode: subscriptionType.plan.code,
+                },
+                "[Stripe Webhook] Skipping payment_failed handling for enterprise workspace."
+              );
+              return res.status(200).json({ success: true });
             }
 
             if (subscription.paymentFailingSince === null) {


### PR DESCRIPTION
## Description

Enterprise customers were repeatedly receiving "Your payment has failed" banners and emails while their workspaces were healthy and contracts active. Two triggers, one root cause:

- The Stripe `invoice.payment_failed` webhook fires for enterprise invoices within their 30-day wire-payment window, marking the workspace past-due.
- For workspaces that transitioned from Pro to Enterprise, a legacy Pro subscription tied to the same Stripe customer can still fire `invoice.payment_failed`. The webhook resolved that event via `fetchByStripeId` back to the workspace and processed it without checking
  what the workspace's *current* plan was.

Both surfaces now key on the workspace's **current active plan** (`auth.subscription()` server-side, `useAuth().subscription` client-side), not the plan attached to the failing Stripe invoice:

- **Webhook** (`pages/api/stripe/webhook.ts`): early-return from the `invoice.payment_failed` handler when the workspace's current plan starts with `ENT_`. No `paymentFailingSince` set, no email sent.
- **Banner** (`components/navigation/AppStatusBanner.tsx`): hide `SubscriptionPastDueBanner` for enterprise workspaces. Belt-and-suspenders, and crucially this **retroactively hides the banner for the already-affected customers** without a DB cleanup — their
`paymentFailingSince` flag stays in the table but stops rendering on next page load.

Fixes https://github.com/dust-tt/tasks/issues/7896

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front