### PR TITLE
[front] fix: show only skills the user edits in "Editable by me" tab

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -162,7 +162,7 @@ export function ManageSkillsPage() {
           )
         ),
     };
-  }, [activeSkills, archivedSkills, skillSearch]);
+  }, [activeSkills, archivedSkills, skillSearch, user]);
 
   const isLoading = isActiveLoading || isArchivedLoading || isSuggestedLoading;
 

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -134,7 +134,9 @@ export function ManageSkillsPage() {
 
     return {
       active: sortedActiveSkills,
-      editable_by_me: sortedActiveSkills.filter((s) => s.canWrite),
+      editable_by_me: sortedActiveSkills.filter((s) =>
+        s.relations.editors?.some((e) => e.sId === user?.sId)
+      ),
       default: sortedActiveSkills
         .filter((s) => s.isDefault || s.relations.editors === null)
         .sort((a, b) => {


### PR DESCRIPTION
## Description

- This PR changes the rule for filtering the content of the tab "Editable by me" of the Manage Skills page.
- Previously checked the `canWrite`, which is a no-op for admins (always true).
- Now checks whether the authentified user is an editor.
- This is less true semantically but makes it actually useful for admins.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
