### PR TITLE
Fallback to cached tools when remote MCP rate limit hit

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -25,6 +25,7 @@ import type {
 } from "@app/lib/actions/mcp";
 import {
   MCPServerPersonalAuthenticationRequiredError,
+  MCPServerRateLimitedError,
   MCPServerRequiresAdminAuthenticationError,
 } from "@app/lib/actions/mcp_authentication";
 import {
@@ -1412,37 +1413,44 @@ async function listMCPServerToolsAndServerInstructions(
       agentLoopContext: { listToolsContext: agentLoopListToolsContext },
     });
     if (r.isErr()) {
-      // When the workspace connection is broken (admin token revoked/expired),
+      // When the workspace connection is broken (admin token revoked/expired) or hit the rate limit,
       // fall back to cached tools so users are not blocked.
       if (
-        MCPServerRequiresAdminAuthenticationError.is(r.error) &&
         isConnectViaMCPServerId(connectionParams) &&
         isServerSideMCPServerConfiguration(config)
       ) {
-        const remoteMCPServer = await RemoteMCPServerResource.fetchById(
-          auth,
-          connectionParams.mcpServerId
+        const isRateLimited = MCPServerRateLimitedError.is(r.error);
+        const isAuthError = MCPServerRequiresAdminAuthenticationError.is(
+          r.error
         );
-        if (remoteMCPServer?.cachedTools?.length) {
-          logger.warn(
-            {
-              workspaceId: owner.sId,
-              mcpServerId: connectionParams.mcpServerId,
-              cachedToolCount: remoteMCPServer.cachedTools.length,
-            },
-            "Workspace connection broken for remote MCP server, falling back to cached tools"
-          );
-          const cachedToolsRes = await buildToolConfigurationsFromRawTools(
+        if (isRateLimited || isAuthError) {
+          const remoteMCPServer = await RemoteMCPServerResource.fetchById(
             auth,
-            connectionParams.mcpServerId,
-            config,
-            remoteMCPServer.cachedTools
+            connectionParams.mcpServerId
           );
-          if (cachedToolsRes.isOk()) {
-            return new Ok({
-              instructions: undefined,
-              tools: cachedToolsRes.value,
-            });
+          if (remoteMCPServer?.cachedTools?.length) {
+            logger.warn(
+              {
+                workspaceId: owner.sId,
+                mcpServerId: connectionParams.mcpServerId,
+                cachedToolCount: remoteMCPServer.cachedTools.length,
+              },
+              isRateLimited
+                ? "Remote MCP server rate limited, falling back to cached tools"
+                : "Workspace connection broken for remote MCP server, falling back to cached tools"
+            );
+            const cachedToolsRes = await buildToolConfigurationsFromRawTools(
+              auth,
+              connectionParams.mcpServerId,
+              config,
+              remoteMCPServer.cachedTools
+            );
+            if (cachedToolsRes.isOk()) {
+              return new Ok({
+                instructions: undefined,
+                tools: cachedToolsRes.value,
+              });
+            }
           }
         }
       }

--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -154,6 +154,26 @@ export class MCPServerRequiresAdminAuthenticationError extends Error {
   }
 }
 
+const MCPServerRateLimitedErrorName = "MCPServerRateLimitedError";
+
+export class MCPServerRateLimitedError extends Error {
+  mcpServerId: string;
+
+  constructor(mcpServerId: string) {
+    super(`MCP server ${mcpServerId} is rate limited.`);
+    this.name = MCPServerRateLimitedErrorName;
+    this.mcpServerId = mcpServerId;
+  }
+
+  static is(error: unknown): error is MCPServerRateLimitedError {
+    return (
+      error instanceof Error &&
+      error.name === MCPServerRateLimitedErrorName &&
+      "mcpServerId" in error
+    );
+  }
+}
+
 export function getMCPServerAdminAuthenticationReason(
   error: DustError<"mcp_access_token_error" | "connection_not_found">
 ): MCPServerAdminAuthenticationReason {

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -10,6 +10,7 @@ import {
   getConnectionForMCPServer,
   getMCPServerAdminAuthenticationReason,
   MCPServerPersonalAuthenticationRequiredError,
+  MCPServerRateLimitedError,
   MCPServerRequiresAdminAuthenticationError,
 } from "@app/lib/actions/mcp_authentication";
 import {
@@ -616,6 +617,21 @@ export async function connectToMCPServer(
                   "reconnect"
                 )
               );
+            }
+
+            const isRateLimited =
+              e instanceof Error &&
+              "code" in e &&
+              (e as Error & { code: unknown }).code === 429;
+            if (isRateLimited) {
+              logger.warn(
+                {
+                  mcpServerId: params.mcpServerId,
+                  workspaceId: auth.getNonNullableWorkspace().sId,
+                },
+                "Remote MCP server rate limited"
+              );
+              return new Err(new MCPServerRateLimitedError(params.mcpServerId));
             }
 
             logger.error(


### PR DESCRIPTION
## Description

Extends the cached tools fallback mechanism to handle rate-limited remote MCP servers (HTTP 429). Previously, only broken workspace connections (admin token revoked/expired) would fall back to cached tools. Now, when a remote MCP server hits its rate limit, Dust will automatically use cached tools from the last successful sync instead of blocking users.

Datadog [logs](https://app.datadoghq.eu/logs?query=%40workspaceId%3A5494230b3c%20%22RESOURCE_EXHAUSTED%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ3PfUdN8L31UgAAABhBWjNQZlZlTEFBREUyQlJubTdpdU1nQU0AAAAkMDE5ZGNmOGMtMzE5Zi00MDBmLWIxMjktNjEyN2NhZTI1NTJkAAIYmQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1776792445151&to_ts=1777397245151&live=false)
<img width="796" height="296" alt="image" src="https://github.com/user-attachments/assets/42041bf4-76a5-4453-9b53-421505102a2a" />


## Risk

Low. This PR adds a new error case (`MCPServerRateLimitedError`) to the existing fallback pattern already used for authentication errors. 

## Deploy Plan

Deploy front.