### PR TITLE
Refactor files use scoped paths as the canonical file identifier 

### DIFF
--- a/front/components/assistant/conversation/files_panel/FileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorer.tsx
@@ -122,19 +122,13 @@ export function NewFileExplorer({
   const tree = useMemo(() => buildSandboxTree(files), [files]);
 
   // Map from tree-relative path → original GCSMountFileEntry (for metadata).
+  // Tree-relative path = entry.path with the use-case prefix (first segment) stripped.
   const entryByRelativePath = useMemo(() => {
-    if (files.length === 0) {
-      return new Map<string, GCSMountFileEntry>();
-    }
-    const commonPrefix = files[0].path.substring(
-      0,
-      files[0].path.indexOf("/files/") + "/files/".length
-    );
     const map = new Map<string, GCSMountFileEntry>();
     for (const f of files) {
-      const relativePath = f.path.startsWith(commonPrefix)
-        ? f.path.slice(commonPrefix.length)
-        : f.path;
+      const slashIdx = f.path.indexOf("/");
+      const relativePath =
+        slashIdx >= 0 ? f.path.slice(slashIdx + 1) : f.path;
       map.set(relativePath, f);
     }
     return map;

--- a/front/components/assistant/conversation/files_panel/FileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorer.tsx
@@ -127,8 +127,7 @@ export function NewFileExplorer({
     const map = new Map<string, GCSMountFileEntry>();
     for (const f of files) {
       const slashIdx = f.path.indexOf("/");
-      const relativePath =
-        slashIdx >= 0 ? f.path.slice(slashIdx + 1) : f.path;
+      const relativePath = slashIdx >= 0 ? f.path.slice(slashIdx + 1) : f.path;
       map.set(relativePath, f);
     }
     return map;

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -162,8 +162,9 @@ export function conversationAttachmentToRow(
 
 /**
  * Build a tree from flat GCS file entries by inferring directories from paths.
- * The GCS prefix (e.g. "w/{wId}/conversations/{cId}/files/") is stripped so
- * tree paths start at the sandbox working directory root.
+ * entry.path is a scoped path (e.g. "conversation/subdir/file.png"); the
+ * use-case prefix (first segment) is stripped so tree paths start at the
+ * sandbox working directory root.
  */
 export function buildSandboxTree(
   entries: GCSMountFileEntry[]
@@ -171,19 +172,10 @@ export function buildSandboxTree(
   const root: SandboxTreeNode[] = [];
   const nodeMap = new Map<string, SandboxTreeNode>();
 
-  // Find the common prefix to strip (everything up to and including "files/").
-  const commonPrefix =
-    entries.length > 0
-      ? entries[0].path.substring(
-          0,
-          entries[0].path.indexOf("/files/") + "/files/".length
-        )
-      : "";
-
   for (const entry of entries) {
-    const relativePath = entry.path.startsWith(commonPrefix)
-      ? entry.path.slice(commonPrefix.length)
-      : entry.path;
+    const slashIdx = entry.path.indexOf("/");
+    const relativePath =
+      slashIdx >= 0 ? entry.path.slice(slashIdx + 1) : entry.path;
 
     if (!relativePath) {
       continue;

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -56,7 +56,9 @@ describe("createGCSMountFile", () => {
       { fileName: "report.txt", content, contentType: "text/plain" }
     );
 
-    expect(saveMock).toHaveBeenCalledWith(content, { contentType: "text/plain" });
+    expect(saveMock).toHaveBeenCalledWith(content, {
+      contentType: "text/plain",
+    });
     const bucket = vi.mocked(getPrivateUploadBucket)();
     expect(bucket.file).toHaveBeenCalledWith(
       `w/${workspaceId}/conversations/${conversationId}/files/report.txt`
@@ -87,7 +89,11 @@ describe("createGCSMountFile", () => {
     const entry = await createGCSMountFile(
       auth,
       { useCase: "conversation", conversationId },
-      { fileName: "photo.png", content: Buffer.from("png data"), contentType: "image/png" }
+      {
+        fileName: "photo.png",
+        content: Buffer.from("png data"),
+        contentType: "image/png",
+      }
     );
 
     expect(entry.thumbnailUrl).toBe(
@@ -99,7 +105,11 @@ describe("createGCSMountFile", () => {
     const entry = await createGCSMountFile(
       auth,
       { useCase: "conversation", conversationId },
-      { fileName: "data.csv", content: Buffer.from("a,b"), contentType: "text/csv" }
+      {
+        fileName: "data.csv",
+        content: Buffer.from("a,b"),
+        contentType: "text/csv",
+      }
     );
 
     expect(entry.thumbnailUrl).toBeNull();

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -97,7 +97,7 @@ describe("createGCSMountFile", () => {
     );
 
     expect(entry.thumbnailUrl).toBe(
-      `https://dust.tt/api/w/${workspaceId}/assistant/conversations/${conversationId}/files/thumbnail?filePath=${encodeURIComponent("photo.png")}`
+      `https://dust.tt/api/w/${workspaceId}/assistant/conversations/${conversationId}/files/thumbnail?filePath=${encodeURIComponent("conversation/photo.png")}`
     );
   });
 

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -4,6 +4,9 @@ import {
 } from "@app/lib/api/files/gcs_mount/files";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/file_storage", () => ({
@@ -16,61 +19,62 @@ vi.mock("@app/lib/api/config", () => ({
   },
 }));
 
-function makeAuth(workspaceId: string): Authenticator {
-  return {
-    getNonNullableWorkspace: () => ({ sId: workspaceId }),
-  } as unknown as Authenticator;
-}
-
-const WORKSPACE_ID = "ws123";
-const CONVERSATION_ID = "conv456";
-
 describe("createGCSMountFile", () => {
+  let auth: Authenticator;
+  let conversationId: string;
+  let workspaceId: string;
   let saveMock: ReturnType<typeof vi.fn>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     saveMock = vi.fn().mockResolvedValue(undefined);
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
       file: vi.fn(() => ({ save: saveMock })),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator, conversationsSpace } = await createResourceTest({});
+    auth = authenticator;
+    workspaceId = auth.getNonNullableWorkspace().sId;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+    conversationId = conversation.sId;
   });
 
   it("writes to the correct GCS path", async () => {
-    const auth = makeAuth(WORKSPACE_ID);
     const content = Buffer.from("hello");
 
     await createGCSMountFile(
       auth,
-      { useCase: "conversation", conversationId: CONVERSATION_ID },
-      {
-        fileName: "report.txt",
-        content,
-        contentType: "text/plain",
-      }
+      { useCase: "conversation", conversationId },
+      { fileName: "report.txt", content, contentType: "text/plain" }
     );
 
-    expect(saveMock).toHaveBeenCalledWith(content, {
-      contentType: "text/plain",
-    });
+    expect(saveMock).toHaveBeenCalledWith(content, { contentType: "text/plain" });
     const bucket = vi.mocked(getPrivateUploadBucket)();
     expect(bucket.file).toHaveBeenCalledWith(
-      `w/${WORKSPACE_ID}/conversations/${CONVERSATION_ID}/files/report.txt`
+      `w/${workspaceId}/conversations/${conversationId}/files/report.txt`
     );
   });
 
   it("returns a correctly shaped GCSMountFileEntry", async () => {
-    const auth = makeAuth(WORKSPACE_ID);
     const content = Buffer.from("hello world");
 
     const entry = await createGCSMountFile(
       auth,
-      { useCase: "conversation", conversationId: CONVERSATION_ID },
+      { useCase: "conversation", conversationId },
       { fileName: "notes.txt", content, contentType: "text/plain" }
     );
 
     expect(entry).toMatchObject<Partial<GCSMountFileEntry>>({
       fileName: "notes.txt",
-      path: "conversation/notes.txt",
+      path: `conversation/notes.txt`,
       sizeBytes: content.length,
       contentType: "text/plain",
       fileId: null,
@@ -80,34 +84,22 @@ describe("createGCSMountFile", () => {
   });
 
   it("sets thumbnailUrl for image content types", async () => {
-    const auth = makeAuth(WORKSPACE_ID);
-
     const entry = await createGCSMountFile(
       auth,
-      { useCase: "conversation", conversationId: CONVERSATION_ID },
-      {
-        fileName: "photo.png",
-        content: Buffer.from("png data"),
-        contentType: "image/png",
-      }
+      { useCase: "conversation", conversationId },
+      { fileName: "photo.png", content: Buffer.from("png data"), contentType: "image/png" }
     );
 
     expect(entry.thumbnailUrl).toBe(
-      `https://dust.tt/api/w/${WORKSPACE_ID}/assistant/conversations/${CONVERSATION_ID}/files/thumbnail?filePath=${encodeURIComponent("photo.png")}`
+      `https://dust.tt/api/w/${workspaceId}/assistant/conversations/${conversationId}/files/thumbnail?filePath=${encodeURIComponent("photo.png")}`
     );
   });
 
   it("leaves thumbnailUrl null for non-image content types", async () => {
-    const auth = makeAuth(WORKSPACE_ID);
-
     const entry = await createGCSMountFile(
       auth,
-      { useCase: "conversation", conversationId: CONVERSATION_ID },
-      {
-        fileName: "data.csv",
-        content: Buffer.from("a,b"),
-        contentType: "text/csv",
-      }
+      { useCase: "conversation", conversationId },
+      { fileName: "data.csv", content: Buffer.from("a,b"), contentType: "text/csv" }
     );
 
     expect(entry.thumbnailUrl).toBeNull();

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -1,0 +1,115 @@
+import {
+  createGCSMountFile,
+  type GCSMountFileEntry,
+} from "@app/lib/api/files/gcs_mount/files";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/file_storage", () => ({
+  getPrivateUploadBucket: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getClientFacingUrl: vi.fn(() => "https://dust.tt"),
+  },
+}));
+
+function makeAuth(workspaceId: string): Authenticator {
+  return {
+    getNonNullableWorkspace: () => ({ sId: workspaceId }),
+  } as unknown as Authenticator;
+}
+
+const WORKSPACE_ID = "ws123";
+const CONVERSATION_ID = "conv456";
+
+describe("createGCSMountFile", () => {
+  let saveMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    saveMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({ save: saveMock })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("writes to the correct GCS path", async () => {
+    const auth = makeAuth(WORKSPACE_ID);
+    const content = Buffer.from("hello");
+
+    await createGCSMountFile(
+      auth,
+      { useCase: "conversation", conversationId: CONVERSATION_ID },
+      {
+        fileName: "report.txt",
+        content,
+        contentType: "text/plain",
+      }
+    );
+
+    expect(saveMock).toHaveBeenCalledWith(content, {
+      contentType: "text/plain",
+    });
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/conversations/${CONVERSATION_ID}/files/report.txt`
+    );
+  });
+
+  it("returns a correctly shaped GCSMountFileEntry", async () => {
+    const auth = makeAuth(WORKSPACE_ID);
+    const content = Buffer.from("hello world");
+
+    const entry = await createGCSMountFile(
+      auth,
+      { useCase: "conversation", conversationId: CONVERSATION_ID },
+      { fileName: "notes.txt", content, contentType: "text/plain" }
+    );
+
+    expect(entry).toMatchObject<Partial<GCSMountFileEntry>>({
+      fileName: "notes.txt",
+      path: "conversation/notes.txt",
+      sizeBytes: content.length,
+      contentType: "text/plain",
+      fileId: null,
+      thumbnailUrl: null,
+    });
+    expect(entry.lastModifiedMs).toBeGreaterThan(0);
+  });
+
+  it("sets thumbnailUrl for image content types", async () => {
+    const auth = makeAuth(WORKSPACE_ID);
+
+    const entry = await createGCSMountFile(
+      auth,
+      { useCase: "conversation", conversationId: CONVERSATION_ID },
+      {
+        fileName: "photo.png",
+        content: Buffer.from("png data"),
+        contentType: "image/png",
+      }
+    );
+
+    expect(entry.thumbnailUrl).toBe(
+      `https://dust.tt/api/w/${WORKSPACE_ID}/assistant/conversations/${CONVERSATION_ID}/files/thumbnail?filePath=${encodeURIComponent("photo.png")}`
+    );
+  });
+
+  it("leaves thumbnailUrl null for non-image content types", async () => {
+    const auth = makeAuth(WORKSPACE_ID);
+
+    const entry = await createGCSMountFile(
+      auth,
+      { useCase: "conversation", conversationId: CONVERSATION_ID },
+      {
+        fileName: "data.csv",
+        content: Buffer.from("a,b"),
+        contentType: "text/csv",
+      }
+    );
+
+    expect(entry.thumbnailUrl).toBeNull();
+  });
+});

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -49,7 +49,7 @@ function makeFileEntry(
     lastModifiedMs,
     fileId,
     thumbnailUrl: isSupportedImageContentType(contentType)
-      ? `${config.getClientFacingUrl()}/api/w/${workspaceId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(relativeFilePath)}`
+      ? `${config.getClientFacingUrl()}/api/w/${workspaceId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(`${scope.useCase}/${relativeFilePath}`)}`
       : null,
   };
 }

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -22,6 +22,38 @@ type GCSMountPoint = {
   conversationId: string;
 };
 
+function makeFileEntry(
+  {
+    fileName,
+    relativeFilePath,
+    sizeBytes,
+    contentType,
+    lastModifiedMs,
+    fileId,
+  }: {
+    fileName: string;
+    relativeFilePath: string;
+    sizeBytes: number;
+    contentType: string;
+    lastModifiedMs: number;
+    fileId: string | null;
+  },
+  scope: GCSMountPoint,
+  workspaceId: string
+): GCSMountFileEntry {
+  return {
+    fileName,
+    path: `${scope.useCase}/${relativeFilePath}`,
+    sizeBytes,
+    contentType,
+    lastModifiedMs,
+    fileId,
+    thumbnailUrl: isSupportedImageContentType(contentType)
+      ? `${config.getClientFacingUrl()}/api/w/${workspaceId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(relativeFilePath)}`
+      : null,
+  };
+}
+
 /**
  * List files from a GCS mount point (mounted bucket as source of truth).
  */
@@ -78,42 +110,94 @@ export async function listGCSMountFiles(
       return [];
     }
     return [
-      {
-        fileName: name,
-        path: trimmed,
-        sizeBytes: 0,
-        contentType: "inode/directory",
-        lastModifiedMs: isString(f.metadata.updated)
-          ? new Date(f.metadata.updated).getTime()
-          : 0,
-        fileId: null,
-        thumbnailUrl: null,
-      },
+      makeFileEntry(
+        {
+          fileName: name,
+          relativeFilePath: trimmed.slice(prefix.length),
+          sizeBytes: 0,
+          contentType: "inode/directory",
+          lastModifiedMs: isString(f.metadata.updated)
+            ? new Date(f.metadata.updated).getTime()
+            : 0,
+          fileId: null,
+        },
+        scope,
+        owner.sId
+      ),
     ];
   });
 
   const fileEntries: GCSMountFileEntry[] = regularFiles.map((gcsFile) => {
-    const fileName = gcsFile.name.split("/").pop() ?? gcsFile.name;
     const metadata = gcsFile.metadata;
     const contentType = isString(metadata.contentType)
       ? metadata.contentType
       : "application/octet-stream";
     const fileResource = fileResourceByMountPath.get(gcsFile.name) ?? null;
 
-    return {
-      fileName,
-      path: gcsFile.name,
-      sizeBytes: Number(metadata.size ?? 0),
-      contentType,
-      lastModifiedMs: isString(metadata.updated)
-        ? new Date(metadata.updated).getTime()
-        : 0,
-      fileId: fileResource?.sId ?? null,
-      thumbnailUrl: isSupportedImageContentType(contentType)
-        ? `${config.getClientFacingUrl()}/api/w/${owner.sId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(gcsFile.name.slice(prefix.length))}`
-        : null,
-    };
+    return makeFileEntry(
+      {
+        fileName: gcsFile.name.split("/").pop() ?? gcsFile.name,
+        relativeFilePath: gcsFile.name.slice(prefix.length),
+        sizeBytes: Number(metadata.size ?? 0),
+        contentType,
+        lastModifiedMs: isString(metadata.updated)
+          ? new Date(metadata.updated).getTime()
+          : 0,
+        fileId: fileResource?.sId ?? null,
+      },
+      scope,
+      owner.sId
+    );
   });
 
   return [...folderEntries, ...fileEntries];
+}
+
+/**
+ * Write a file into a GCS mount point.
+ * Returns the entry as it would appear in listGCSMountFiles.
+ */
+export async function createGCSMountFile(
+  auth: Authenticator,
+  scope: GCSMountPoint,
+  {
+    fileName,
+    content,
+    contentType,
+  }: {
+    fileName: string;
+    content: Buffer;
+    contentType: string;
+  }
+): Promise<GCSMountFileEntry> {
+  const owner = auth.getNonNullableWorkspace();
+
+  let prefix: string;
+  switch (scope.useCase) {
+    case "conversation":
+      prefix = getConversationFilesBasePath({
+        workspaceId: owner.sId,
+        conversationId: scope.conversationId,
+      });
+      break;
+    default:
+      assertNever(scope.useCase);
+  }
+
+  const gcsPath = `${prefix}${fileName}`;
+  const bucket = getPrivateUploadBucket();
+  await bucket.file(gcsPath).save(content, { contentType });
+
+  return makeFileEntry(
+    {
+      fileName,
+      relativeFilePath: fileName,
+      sizeBytes: content.length,
+      contentType,
+      lastModifiedMs: Date.now(),
+      fileId: null,
+    },
+    scope,
+    owner.sId
+  );
 }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.test.ts
@@ -78,35 +78,31 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/files/download", () =>
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
   });
 
+  it("should return 400 for a raw GCS path (not scoped)", async () => {
+    const { req, res } = await setupTest();
+    req.body = {
+      filePath: `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files/report.pdf`,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should return 400 for an unknown scope prefix", async () => {
+    const { req, res } = await setupTest();
+    req.body = { filePath: "project/report.pdf" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
   it("should return 403 for path traversal with '..'", async () => {
     const { req, res } = await setupTest();
-    req.body = {
-      filePath: `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files/../../other/secret.txt`,
-    };
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData().error.type).toBe("workspace_auth_error");
-  });
-
-  it("should return 403 for path outside conversation scope", async () => {
-    const { req, res } = await setupTest();
-    req.body = {
-      filePath: `w/${WORKSPACE_SID}/conversations/other_conv/files/secret.txt`,
-    };
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData().error.type).toBe("workspace_auth_error");
-  });
-
-  it("should return 403 for path targeting a different workspace", async () => {
-    const { req, res } = await setupTest();
-    req.body = {
-      filePath: `w/other_workspace/conversations/${CONVERSATION_SID}/files/file.txt`,
-    };
+    req.body = { filePath: "conversation/../../../etc/passwd" };
 
     await handler(req, res);
 
@@ -116,12 +112,19 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/files/download", () =>
 
   it("should normalize triple slashes before GCS access", async () => {
     const { req, res } = await setupTest();
-    // Triple slashes pass the old startsWith check and don't contain "..",
-    // but without normalization the raw path is sent to GCS as-is which could
-    // resolve to an unintended object.
-    req.body = {
-      filePath: `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files///report.pdf`,
-    };
+    req.body = { filePath: "conversation/%%%report.pdf" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockGetFileContentType).toHaveBeenCalledWith(
+      `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files/%%%report.pdf`
+    );
+  });
+
+  it("should succeed for a valid scoped file path", async () => {
+    const { req, res } = await setupTest();
+    req.body = { filePath: "conversation/report.pdf" };
 
     await handler(req, res);
 
@@ -129,17 +132,6 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/files/download", () =>
     expect(mockGetFileContentType).toHaveBeenCalledWith(
       `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files/report.pdf`
     );
-  });
-
-  it("should succeed for a valid file path", async () => {
-    const { req, res } = await setupTest();
-    req.body = {
-      filePath: `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files/report.pdf`,
-    };
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(200);
     expect(mockCreateReadStream).toHaveBeenCalled();
   });
 });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
@@ -57,7 +57,8 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid filePath: must be a scoped path (e.g. conversation/file.png).",
+        message:
+          "Invalid filePath: must be a scoped path (e.g. conversation/file.png).",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/download.ts
@@ -1,6 +1,9 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import {
+  getConversationFilesBasePath,
+  parseScopedFilePath,
+} from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -48,6 +51,17 @@ async function handler(
     });
   }
 
+  const scopedPath = parseScopedFilePath(filePath);
+  if (!scopedPath || scopedPath.prefix !== "conversation") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid filePath: must be a scoped path (e.g. conversation/file.png).",
+      },
+    });
+  }
+
   // Validate the conversation exists and user has access.
   const conversation = await ConversationResource.fetchById(auth, cId);
   if (!conversation) {
@@ -60,14 +74,13 @@ async function handler(
     });
   }
 
-  // Validate the requested path is within this conversation's files directory.
-  // Normalize first to collapse any ".." or "." segments, then verify the prefix.
+  // Resolve the scoped path to a full GCS path and guard against path traversal.
   const owner = auth.getNonNullableWorkspace();
   const expectedPrefix = getConversationFilesBasePath({
     workspaceId: owner.sId,
     conversationId: cId,
   });
-  const normalizedPath = path.posix.normalize(filePath);
+  const normalizedPath = path.posix.normalize(expectedPrefix + scopedPath.rel);
   if (!normalizedPath.startsWith(expectedPrefix)) {
     return apiError(req, res, {
       status_code: 403,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.test.ts
@@ -67,7 +67,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     req.query = {
       wId: workspace.sId,
       cId: conversation.sId,
-      filePath: "../../secret.txt",
+      filePath: "conversation/../../secret.txt",
     };
     await handler(req, res);
     expect(res._getStatusCode()).toBe(403);
@@ -93,7 +93,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     req.query = {
       wId: workspace.sId,
       cId: conversation.sId,
-      filePath: "generated.png",
+      filePath: "conversation/generated.png",
     };
     await handler(req, res);
 
@@ -112,7 +112,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     req.query = {
       wId: workspace.sId,
       cId: conversation.sId,
-      filePath: "sandbox_output.png",
+      filePath: "conversation/sandbox_output.png",
     };
     await handler(req, res);
 
@@ -139,7 +139,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     req.query = {
       wId: workspace.sId,
       cId: conversation.sId,
-      filePath: "report.txt",
+      filePath: "conversation/report.txt",
     };
     await handler(req, res);
 
@@ -158,7 +158,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     req.query = {
       wId: workspace.sId,
       cId: conversation.sId,
-      filePath: "report.txt",
+      filePath: "conversation/report.txt",
     };
     await handler(req, res);
 
@@ -179,7 +179,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/thumbnail", () =>
     req.query = {
       wId: workspace.sId,
       cId: conversation.sId,
-      filePath: "missing.png",
+      filePath: "conversation/missing.png",
     };
     await handler(req, res);
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
@@ -1,6 +1,9 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import {
+  getConversationFilesBasePath,
+  parseScopedFilePath,
+} from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -51,14 +54,25 @@ async function handler(
     });
   }
 
-  const owner = auth.getNonNullableWorkspace();
+  const scopedPath = parseScopedFilePath(filePath);
+  if (!scopedPath || scopedPath.prefix !== "conversation") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Invalid filePath: must be a scoped path (e.g. conversation/file.png).",
+      },
+    });
+  }
 
-  // filePath is relative to the conversation's files base. Reject any traversal attempt.
-  const normalizedRelative = path.posix.normalize(filePath);
-  if (
-    normalizedRelative.startsWith("..") ||
-    normalizedRelative.startsWith("/")
-  ) {
+  const owner = auth.getNonNullableWorkspace();
+  const basePath = getConversationFilesBasePath({
+    workspaceId: owner.sId,
+    conversationId: cId,
+  });
+  const normalizedPath = path.posix.normalize(`${basePath}${scopedPath.rel}`);
+  if (!normalizedPath.startsWith(basePath)) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
@@ -67,12 +81,6 @@ async function handler(
       },
     });
   }
-
-  const basePath = getConversationFilesBasePath({
-    workspaceId: owner.sId,
-    conversationId: cId,
-  });
-  const normalizedPath = `${basePath}${normalizedRelative}`;
 
   const [fileResource] = await FileResource.fetchByMountFilePaths(auth, [
     normalizedPath,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The `GCSMountFileEntry.path` previously held the raw GCS object path (`w/{wId}/conversations/{cId}/files/chart.png`). This was an internal storage detail leaking all the way to the client. UI components were manually stripping a GCS-specific prefix pattern to recover the human-readable relative path, and the download endpoint expected a full GCS path in the request body. This scoped approach, reduce the vector attack that could eventually target different conversations/workspaces.

This PR makes path a scoped identifier (`conversation/chart.png`) throughout the stack:

Add `createGCSMountFile` alongside. It takes a Buffer, writes it to the correct GCS prefix, and returns an entry consistent with what list would produce.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
