### PR TITLE
[front] fix: clear input bar drafts when content is emptied

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -670,15 +670,14 @@ const InputBarContainer = ({
   // Update the editor ref when the editor is created and listen for updates to the editor.
   useEffect(() => {
     const handleUpdate = () => {
-      setIsEmpty(editorService.isEmpty());
+      const editorIsEmpty = editorService.isEmpty();
+      setIsEmpty(editorIsEmpty);
 
       // Auto-save draft when content changes and track user mentions.
       // Include the selected single agent so the debounced save doesn't
       // overwrite the agent mention saved by the single-agent effect.
       const { markdown, mentions } = editorService.getMarkdownAndMentions();
-      if (!editorService.isEmpty()) {
-        saveDraft(markdown, selectedSingleAgentRef.current);
-      }
+      saveDraft(editorIsEmpty ? "" : markdown, selectedSingleAgentRef.current);
       const userMentioned = mentions.some((m) => m.type === "user");
       setHasUserMention(userMentioned);
       onEditorMentionsChangedRef.current(userMentioned);

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -36,7 +36,6 @@ export function useConversationDrafts({
   draftKey: string;
   shouldUseDraft?: boolean;
 }) {
-  // Get all drafts from localStorage.
   const getDraftsFromStorage = useCallback((): DraftStorage => {
     try {
       if (!shouldUseDraft) {
@@ -71,7 +70,6 @@ export function useConversationDrafts({
     }
   }, [shouldUseDraft]);
 
-  // Save drafts to localStorage.
   const saveDraftsToStorage = useCallback((drafts: DraftStorage) => {
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(drafts));
@@ -83,7 +81,6 @@ export function useConversationDrafts({
     }
   }, []);
 
-  // Create a ref to hold the debounced save function
   const debouncedSaveRef =
     useRef<
       ReturnType<
@@ -100,12 +97,9 @@ export function useConversationDrafts({
       >
     >();
 
-  // Update the debounced function when dependencies change
   useEffect(() => {
-    // Cancel any pending debounced calls from the old function
     debouncedSaveRef.current?.cancel();
 
-    // Create new debounced function with current closures
     debouncedSaveRef.current = debounce(
       ({
         workspaceId,
@@ -138,7 +132,6 @@ export function useConversationDrafts({
     );
   }, [getDraftsFromStorage, saveDraftsToStorage]);
 
-  // Clear draft for the current conversation.
   const clearDraft = useCallback(() => {
     if (!shouldUseDraft || !userId) {
       return;
@@ -148,9 +141,7 @@ export function useConversationDrafts({
 
     delete drafts[getKeyId(workspaceId, userId, draftKey)];
 
-    // Also, cancel any pending debounced save.
     debouncedSaveRef.current?.cancel();
-
     saveDraftsToStorage(drafts);
   }, [
     getDraftsFromStorage,
@@ -161,7 +152,6 @@ export function useConversationDrafts({
     saveDraftsToStorage,
   ]);
 
-  // Save draft for current conversation (debounced).
   const saveDraft = useCallback(
     (text: string, agentMention?: RichAgentMention | null) => {
       if (!shouldUseDraft || !userId) {
@@ -185,7 +175,6 @@ export function useConversationDrafts({
     [workspaceId, userId, shouldUseDraft, draftKey, clearDraft]
   );
 
-  // Get draft for current conversation.
   const getDraft = useCallback((): ConversationDraft | null => {
     const drafts = getDraftsFromStorage();
 

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -36,39 +36,42 @@ export function useConversationDrafts({
   draftKey: string;
   shouldUseDraft?: boolean;
 }) {
-  const getDraftsFromStorage = useCallback((): DraftStorage => {
-    try {
-      if (!shouldUseDraft) {
-        return {};
-      }
-
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (!stored) {
-        return {};
-      }
-
-      const parsed = JSON.parse(stored) as DraftStorage;
-
-      // Clean up expired drafts (older than DRAFT_EXPIRY_DAYS).
-      const now = Date.now();
-      const cleaned: DraftStorage = {};
-
-      Object.entries(parsed).forEach(([id, draft]) => {
-        if (now - draft.timestamp < DRAFT_EXPIRY_MS) {
-          cleaned[id] = draft;
+  const getDraftsFromStorage = useCallback(
+    ({ ignoreShouldUseDraft = false } = {}): DraftStorage => {
+      try {
+        if (!ignoreShouldUseDraft && !shouldUseDraft) {
+          return {};
         }
-      });
 
-      return cleaned;
-    } catch (error) {
-      logger.error(
-        "Failed to read conversation drafts from localStorage, cleaning localStorage:",
-        error
-      );
-      delete localStorage[STORAGE_KEY];
-      return {};
-    }
-  }, [shouldUseDraft]);
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (!stored) {
+          return {};
+        }
+
+        const parsed = JSON.parse(stored) as DraftStorage;
+
+        // Clean up expired drafts (older than DRAFT_EXPIRY_DAYS).
+        const now = Date.now();
+        const cleaned: DraftStorage = {};
+
+        Object.entries(parsed).forEach(([id, draft]) => {
+          if (now - draft.timestamp < DRAFT_EXPIRY_MS) {
+            cleaned[id] = draft;
+          }
+        });
+
+        return cleaned;
+      } catch (error) {
+        logger.error(
+          "Failed to read conversation drafts from localStorage, cleaning localStorage:",
+          error
+        );
+        delete localStorage[STORAGE_KEY];
+        return {};
+      }
+    },
+    [shouldUseDraft]
+  );
 
   const saveDraftsToStorage = useCallback((drafts: DraftStorage) => {
     try {
@@ -186,18 +189,18 @@ export function useConversationDrafts({
   }, [getDraftsFromStorage, workspaceId, userId, draftKey]);
 
   const clearAllDraftsFromUser = useCallback(() => {
-    if (!shouldUseDraft || !userId) {
+    if (!userId) {
       return;
     }
 
-    const drafts = getDraftsFromStorage();
+    const drafts = getDraftsFromStorage({ ignoreShouldUseDraft: true });
     Object.keys(drafts).forEach((key) => {
       if (key.startsWith(`${userId}::`)) {
         delete drafts[key];
       }
     });
     saveDraftsToStorage(drafts);
-  }, [getDraftsFromStorage, userId, shouldUseDraft, saveDraftsToStorage]);
+  }, [getDraftsFromStorage, userId, saveDraftsToStorage]);
 
   return { saveDraft, getDraft, clearDraft, clearAllDraftsFromUser };
 }

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -138,39 +138,9 @@ export function useConversationDrafts({
     );
   }, [getDraftsFromStorage, saveDraftsToStorage]);
 
-  // Save draft for current conversation (debounced).
-  const saveDraft = useCallback(
-    (text: string, agentMention?: RichAgentMention | null) => {
-      if (!shouldUseDraft || !userId) {
-        return;
-      }
-
-      debouncedSaveRef.current?.({
-        workspaceId,
-        userId,
-        draftKey,
-        text,
-        timestamp: Date.now(),
-        agentMention,
-      });
-    },
-    [workspaceId, userId, shouldUseDraft, draftKey]
-  );
-
-  // Get draft for current conversation.
-  const getDraft = useCallback((): ConversationDraft | null => {
-    const drafts = getDraftsFromStorage();
-
-    if (!userId) {
-      return null;
-    }
-
-    return drafts[getKeyId(workspaceId, userId, draftKey)] ?? null;
-  }, [getDraftsFromStorage, workspaceId, userId, draftKey]);
-
   // Clear draft for the current conversation.
   const clearDraft = useCallback(() => {
-    if (!userId) {
+    if (!shouldUseDraft || !userId) {
       return;
     }
 
@@ -187,10 +157,50 @@ export function useConversationDrafts({
     workspaceId,
     userId,
     draftKey,
+    shouldUseDraft,
     saveDraftsToStorage,
   ]);
 
+  // Save draft for current conversation (debounced).
+  const saveDraft = useCallback(
+    (text: string, agentMention?: RichAgentMention | null) => {
+      if (!shouldUseDraft || !userId) {
+        return;
+      }
+
+      if (text.trim().length === 0) {
+        clearDraft();
+        return;
+      }
+
+      debouncedSaveRef.current?.({
+        workspaceId,
+        userId,
+        draftKey,
+        text,
+        timestamp: Date.now(),
+        agentMention,
+      });
+    },
+    [workspaceId, userId, shouldUseDraft, draftKey, clearDraft]
+  );
+
+  // Get draft for current conversation.
+  const getDraft = useCallback((): ConversationDraft | null => {
+    const drafts = getDraftsFromStorage();
+
+    if (!userId) {
+      return null;
+    }
+
+    return drafts[getKeyId(workspaceId, userId, draftKey)] ?? null;
+  }, [getDraftsFromStorage, workspaceId, userId, draftKey]);
+
   const clearAllDraftsFromUser = useCallback(() => {
+    if (!shouldUseDraft || !userId) {
+      return;
+    }
+
     const drafts = getDraftsFromStorage();
     Object.keys(drafts).forEach((key) => {
       if (key.startsWith(`${userId}::`)) {
@@ -198,7 +208,7 @@ export function useConversationDrafts({
       }
     });
     saveDraftsToStorage(drafts);
-  }, [getDraftsFromStorage, userId, saveDraftsToStorage]);
+  }, [getDraftsFromStorage, userId, shouldUseDraft, saveDraftsToStorage]);
 
   return { saveDraft, getDraft, clearDraft, clearAllDraftsFromUser };
 }


### PR DESCRIPTION
## Description

This PR fixes an input bar draft persistence edge case where deleting the last character did not update localStorage, causing that character to come back after a reload.

The input bar now delegates empty editor content to the draft hook, and the draft hook treats empty text as a request to clear the current draft immediately. This keeps the previous fixes around empty drafts and default-agent restoration intact: we do not persist blank drafts with an agent mention.

## Tests

- Tested locally.
- Tested against the cases fixed by https://github.com/dust-tt/dust/pull/24267 and https://github.com/dust-tt/dust/pull/24124

## Risk

- Low.

## Deploy Plan

- Deploy front.
