### PR TITLE
Avoid Zod 400 on mention-only messages from Zapier

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1181,6 +1181,13 @@ async function answerMessage(
 
   const origin = slackBotId ? "slack_workflow" : "slack";
 
+  // Mention-only messages (e.g. Zapier sending `<@bot> +AgentName`) end up empty after stripping
+  // the bot mention and extracting the agent mention. The public API rejects empty content via
+  // Zod (`z.string().min(1)`), so substitute a minimal placeholder.
+  if (message.trim() === "") {
+    message = " ";
+  }
+
   const messageReqBody: PublicPostMessagesRequestBody = {
     content: message,
     mentions: [{ configurationId: mention.agentId }],


### PR DESCRIPTION
## Description

- Zapier-style messages like <@bot> +AgentName end up with empty content after the bot mention is stripped and the agent mention is extracted by processMentions().
- The public API's PublicPostMessagesRequestBodySchema validates content with z.string().min(1), so the request fails with 400 before the handler (which already tolerates empty content when mentions exist) is reached.
- Spike of ~400+ daily errors observed since Apr 21; connector 27411 alone accounts for ~half of the last 7 days.
- Fix: in connectors/src/connectors/slack/bot.ts, when message.trim() is empty right before building messageReqBody, substitute a single space so the request passes Zod validation. The mention is already attached, so the agent receives the same effective input.

Fixes https://github.com/dust-tt/tasks/issues/7894

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Connectors