### PR TITLE
Script to scrub conversations by workspace and conversation ID

### DIFF
--- a/front/scripts/scrub_conversation.ts
+++ b/front/scripts/scrub_conversation.ts
@@ -17,9 +17,7 @@ makeScript(
     },
   },
   async ({ workspaceId, conversationId, execute }, logger) => {
-    const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
-      dangerouslyRequestAllGroups: true,
-    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
     const conversation = await ConversationResource.fetchById(
       auth,

--- a/front/scripts/scrub_conversation.ts
+++ b/front/scripts/scrub_conversation.ts
@@ -1,0 +1,60 @@
+import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
+import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      describe: "The sId of the workspace owning the conversation.",
+      demandOption: true,
+    },
+    conversationId: {
+      type: "string",
+      describe: "The sId of the conversation to scrub.",
+      demandOption: true,
+    },
+  },
+  async ({ workspaceId, conversationId, execute }, logger) => {
+    const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
+      dangerouslyRequestAllGroups: true,
+    });
+
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationId,
+      { includeDeleted: true }
+    );
+    if (!conversation) {
+      logger.error(
+        { workspaceId, conversationId },
+        "Conversation not found in workspace."
+      );
+      return;
+    }
+
+    if (!execute) {
+      logger.info(
+        { workspaceId, conversationId, title: conversation.title },
+        "Would scrub conversation."
+      );
+      return;
+    }
+
+    logger.info(
+      { workspaceId, conversationId, title: conversation.title },
+      "Scrubbing conversation."
+    );
+
+    const result = await destroyConversation(auth, { conversation });
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    logger.info(
+      { workspaceId, conversationId },
+      "Conversation scrubbed successfully."
+    );
+  }
+);


### PR DESCRIPTION
## Description

One-off admin script that scrubs a single conversation given a workspace sId and conversation sId.

Needed for https://github.com/dust-tt/tasks/issues/7844

## Tests

Tested locally (had to comment out a sandbox related line due to missing key)

## Risk

Low

## Deploy Plan

None