### PR TITLE
[front] - fix(yaml): fetch users 

### DIFF
--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -48,7 +48,10 @@ async function importAgentConfiguration(
   }
 
   const editorEmails = yamlConfig.editors;
-  const fetchedEditors = await UserResource.fetchByEmails(editorEmails);
+  const fetchedEditors = await UserResource.listUserWithExactEmails(
+    auth.getNonNullableWorkspace(),
+    editorEmails
+  );
 
   const uploadingUser = auth.user();
   const editorUsers =

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -341,7 +341,7 @@ export class UserResource extends BaseResource<UserModel> {
         },
       ],
       where: {
-        email: emails,
+        email: emails.map((e) => e.toLowerCase()),
       },
     });
 


### PR DESCRIPTION
## Description

Fixes editor email lookup during YAML agent configuration imports to be case-insensitive and workspace-scoped. Previously, `fetchByEmails` was used, which looked up users in the global user table without workspace filtering. This caused incorrect editor assignment when importing agents across workspaces. The fix switches to `listUserWithExactEmails` which filters by workspace membership.

Fixes https://github.com/dust-tt/tasks/issues/7897

## Tests

Manually tested YAML import flow.

## Risk

Low

## Deploy Plan

Deploy front