### PR TITLE
feat(sbx): tell the agent not to redundantly request already-allowed domains

### DIFF
--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -18,12 +18,12 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .string()
         .describe(
           "The reason this command is being run and what it achieves, in a few words. Use infinitive verbs (e.g. " +
-            '"Set up environment", "Generate the chart").',
+            '"Set up environment", "Generate the chart").'
         ),
       command: z
         .string()
         .describe(
-          "The shell command to execute. Can be a single command or a script.",
+          "The shell command to execute. Can be a single command or a script."
         ),
       workingDirectory: z
         .string()
@@ -34,7 +34,7 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .max(120000)
         .optional()
         .describe(
-          "Timeout in milliseconds for command execution. Defaults to 60000, max 120000.",
+          "Timeout in milliseconds for command execution. Defaults to 60000, max 120000."
         ),
     },
     stake: "never_ask",
@@ -78,14 +78,14 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .min(1)
         .describe(
           'Exact domain to allow for this sandbox, e.g. "api.openai.com". ' +
-            "Wildcards are not supported.",
+            "Wildcards are not supported."
         ),
       reason: z
         .string()
         .min(1)
         .describe(
           "Why this domain is needed, in one short sentence the user will " +
-            "see in the approval prompt.",
+            "see in the approval prompt."
         ),
     },
     stake: "high",
@@ -116,6 +116,6 @@ export const SANDBOX_SERVER = {
     displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
-    Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake]),
+    Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake])
   ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -18,12 +18,12 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .string()
         .describe(
           "The reason this command is being run and what it achieves, in a few words. Use infinitive verbs (e.g. " +
-            '"Set up environment", "Generate the chart").'
+            '"Set up environment", "Generate the chart").',
         ),
       command: z
         .string()
         .describe(
-          "The shell command to execute. Can be a single command or a script."
+          "The shell command to execute. Can be a single command or a script.",
         ),
       workingDirectory: z
         .string()
@@ -34,7 +34,7 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .max(120000)
         .optional()
         .describe(
-          "Timeout in milliseconds for command execution. Defaults to 60000, max 120000."
+          "Timeout in milliseconds for command execution. Defaults to 60000, max 120000.",
         ),
     },
     stake: "never_ask",
@@ -63,7 +63,11 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       "Request user approval to add a single domain to the current " +
       "sandbox's network allowlist. Each call adds one exact domain " +
       "(wildcards are not accepted) and requires an explicit user " +
-      "approval. Outbound HTTPS connections that fall outside the " +
+      "approval. Only call this if the target domain is not already " +
+      "covered by the workspace or sandbox allowlist. The workspace " +
+      "allowlist is provided in the sandbox skill instructions; if the " +
+      "domain or a wildcard parent is listed there, use the domain " +
+      "directly. Outbound HTTPS connections that fall outside the " +
       "allowlist surface as denied entries in `<network_proxy_logs>` in " +
       "the bash tool output. Allowlist entries added through this tool " +
       "live for the lifetime of the current sandbox and are discarded " +
@@ -74,14 +78,14 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .min(1)
         .describe(
           'Exact domain to allow for this sandbox, e.g. "api.openai.com". ' +
-            "Wildcards are not supported."
+            "Wildcards are not supported.",
         ),
       reason: z
         .string()
         .min(1)
         .describe(
           "Why this domain is needed, in one short sentence the user will " +
-            "see in the approval prompt."
+            "see in the approval prompt.",
         ),
     },
     stake: "high",
@@ -112,6 +116,6 @@ export const SANDBOX_SERVER = {
     displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
-    Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake])
+    Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake]),
   ),
 } as const satisfies ServerMetadata;

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -30,12 +30,12 @@ function buildSandboxInstructionProse({
   if (hasDsbxTools) {
     instructions.push(
       "You can use the `dsbx` command line tool to list and run tools programmatically in the sandbox.",
-      "Use it with `dsbx tools [SERVER_NAME] [TOOL_NAME] [ARGS]...`. Run `dsbx tools --help` for more information.",
+      "Use it with `dsbx tools [SERVER_NAME] [TOOL_NAME] [ARGS]...`. Run `dsbx tools --help` for more information."
     );
   }
 
   instructions.push(
-    "Write output files (scripts, results, exports) to /files/conversation to make them available to the user.",
+    "Write output files (scripts, results, exports) to /files/conversation to make them available to the user."
   );
 
   return instructions.join(" ");
@@ -57,7 +57,7 @@ async function buildNetworkAccessSection(auth: Authenticator): Promise<string> {
   if (policyResult.isErr()) {
     logger.warn(
       { err: policyResult.error },
-      "Failed to read workspace egress policy for sandbox skill instructions",
+      "Failed to read workspace egress policy for sandbox skill instructions"
     );
   } else {
     workspaceDomains = policyResult.value.allowedDomains;
@@ -121,7 +121,7 @@ block first; a denied egress is a possible cause.`;
 async function buildSandboxInstructions(
   auth: Authenticator,
   providerId: ModelProviderIdType | undefined,
-  hasDsbxTools: boolean,
+  hasDsbxTools: boolean
 ): Promise<string> {
   const networkAccessSection = await buildNetworkAccessSection(auth);
   const sandboxInstructions = buildSandboxInstructionProse({ hasDsbxTools });
@@ -140,7 +140,7 @@ async function buildSandboxInstructions(
     toolsResult = new Ok(
       filterDsbxToolEntries(imageResult.value.tools, {
         includeDsbxTools: hasDsbxTools,
-      }),
+      })
     );
   }
 
@@ -180,7 +180,7 @@ export const sandboxSkill = {
     auth: Authenticator,
     {
       agentLoopData,
-    }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData },
+    }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
   ) => {
     const providerId = agentLoopData?.agentConfiguration?.model.providerId;
     const flags = await getFeatureFlags(auth);

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -30,12 +30,12 @@ function buildSandboxInstructionProse({
   if (hasDsbxTools) {
     instructions.push(
       "You can use the `dsbx` command line tool to list and run tools programmatically in the sandbox.",
-      "Use it with `dsbx tools [SERVER_NAME] [TOOL_NAME] [ARGS]...`. Run `dsbx tools --help` for more information."
+      "Use it with `dsbx tools [SERVER_NAME] [TOOL_NAME] [ARGS]...`. Run `dsbx tools --help` for more information.",
     );
   }
 
   instructions.push(
-    "Write output files (scripts, results, exports) to /files/conversation to make them available to the user."
+    "Write output files (scripts, results, exports) to /files/conversation to make them available to the user.",
   );
 
   return instructions.join(" ");
@@ -57,7 +57,7 @@ async function buildNetworkAccessSection(auth: Authenticator): Promise<string> {
   if (policyResult.isErr()) {
     logger.warn(
       { err: policyResult.error },
-      "Failed to read workspace egress policy for sandbox skill instructions"
+      "Failed to read workspace egress policy for sandbox skill instructions",
     );
   } else {
     workspaceDomains = policyResult.value.allowedDomains;
@@ -100,11 +100,14 @@ ${formatWorkspaceAllowlist(workspaceDomains)}
    \`add_egress_domain\` tool. These live for the lifetime of the current
    sandbox only and are discarded when the sandbox is reaped.
 
-When you plan to hit a domain that is not on the workspace allowlist, you
-should call \`add_egress_domain\` **before** running the command, with the
-**exact** domain (wildcards are not accepted) and a one-sentence reason
-the user will see in the approval prompt. This is preferable to running
-the command first and reacting to a denial.
+If the target domain — or a wildcard parent of it (for example,
+\`*.github.com\` matches \`api.github.com\` and \`a.b.github.com\`, but not
+\`github.com\` itself) — is already in the workspace allowlist shown above,
+do NOT call \`add_egress_domain\`; just use the domain. Only call
+\`add_egress_domain\` for domains that are not yet covered, and do so
+**before** running the command, with the **exact** domain (wildcards are not
+accepted) and a one-sentence reason the user will see in the approval prompt.
+This is preferable to running the command first and reacting to a denial.
 
 If a request does get blocked — for example because you missed a domain or
 a redirect chain hits an unexpected host — the bash tool output will
@@ -118,7 +121,7 @@ block first; a denied egress is a possible cause.`;
 async function buildSandboxInstructions(
   auth: Authenticator,
   providerId: ModelProviderIdType | undefined,
-  hasDsbxTools: boolean
+  hasDsbxTools: boolean,
 ): Promise<string> {
   const networkAccessSection = await buildNetworkAccessSection(auth);
   const sandboxInstructions = buildSandboxInstructionProse({ hasDsbxTools });
@@ -137,7 +140,7 @@ async function buildSandboxInstructions(
     toolsResult = new Ok(
       filterDsbxToolEntries(imageResult.value.tools, {
         includeDsbxTools: hasDsbxTools,
-      })
+      }),
     );
   }
 
@@ -177,7 +180,7 @@ export const sandboxSkill = {
     auth: Authenticator,
     {
       agentLoopData,
-    }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
+    }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData },
   ) => {
     const providerId = agentLoopData?.agentConfiguration?.model.providerId;
     const flags = await getFeatureFlags(auth);


### PR DESCRIPTION
## Description

The sandbox skill prompt already injects the live workspace egress allowlist into the agent's context, but the guidance for \`add_egress_domain\` didn't explicitly tell the agent to skip the tool when the target domain (or its wildcard parent) is already covered. As a result agents would sometimes ask for user approval for domains the workspace had already opted in to.

This PR tightens the wording in two places:

- **Sandbox skill prose** (\`front/lib/resources/skill/code_defined/sandbox.ts\`): the prompt the agent actually reads. Now says: if the target domain — or a wildcard parent of it — is in the workspace allowlist shown above, do NOT call \`add_egress_domain\`; just use the domain. Includes a concrete example clarifying that \`*.github.com\` matches \`api.github.com\` and \`a.b.github.com\` but not \`github.com\` itself, matching the egress proxy's wildcard semantics.

- **Tool description** (\`front/lib/api/actions/servers/sandbox/metadata.ts\`): static text, cannot reference the live list. Updated to point the agent at the skill instructions for the workspace allowlist and to skip the tool when the domain is already covered.

A follow-up PR will add corresponding server-side auto-approval so that even if the agent does call the tool with an already-covered domain, the request is fast-pathed without a user prompt.

## Tests

Prompt-only

## Risk

Low

## Deploy Plan

Standard rollout. Rollback by reverting the commit; no migration.