### PR TITLE
fix(project): add instrumention for langfus

### DIFF
--- a/front/lib/api/instrumentation/init.ts
+++ b/front/lib/api/instrumentation/init.ts
@@ -17,7 +17,11 @@ export let resource: Resource | undefined;
 export function initializeOpenTelemetryInstrumentation({
   serviceName,
 }: {
-  serviceName: "dust-agent-loop" | "dust-front" | "dust-reinforcement";
+  serviceName:
+    | "dust-agent-loop"
+    | "dust-front"
+    | "dust-reinforcement"
+    | "dust-project-todo";
 }): void {
   if (!config.isLangfuseEnabled() || sdk) {
     return;

--- a/front/temporal/project_todo/worker.ts
+++ b/front/temporal/project_todo/worker.ts
@@ -1,3 +1,4 @@
+import { initializeOpenTelemetryInstrumentation } from "@app/lib/api/instrumentation/init";
 import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
@@ -13,6 +14,10 @@ import { QUEUE_NAME } from "./config";
 
 export async function runProjectTodoWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
+
+  initializeOpenTelemetryInstrumentation({
+    serviceName: "dust-project-todo",
+  });
 
   const worker = await Worker.create({
     ...getWorkflowConfig({


### PR DESCRIPTION
## Description

We still don't have traces in langfuse. Following @fabiencelier's advice it's probably because we were missing the `initializeOpenTelemetryInstrumentation` that configures things for langfuse.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
