### PR TITLE
fix: stop streaming replay duplication on conversation remount

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -58,6 +58,7 @@ import logger from "@app/logger/logger";
 import {
   type ConversationForkedChildType,
   type ConversationListItemType,
+  isTerminalAgentMessageStatus,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
@@ -311,6 +312,7 @@ export const ConversationViewer = ({
     isMessagesError,
     isValidating,
     messages,
+    mutateMessages,
     setSize,
     size,
   } = useConversationMessages({
@@ -653,7 +655,22 @@ export const ConversationViewer = ({
               const exists = ref.current.data.find(predicate);
 
               if (exists) {
-                ref.current.data.map((m) => (predicate(m) ? agentMessage : m));
+                // On replay (e.g. after navigating away and coming back), the
+                // existing message may already reflect the final state from
+                // the SWR snapshot. The replayed event always carries the
+                // initial "created" payload — replacing would downgrade the
+                // status (re-activating shouldStream and the message-events
+                // stream) and wipe inlineActivitySteps. Skip the replace
+                // when the existing message is already in a terminal state.
+                const isTerminal =
+                  isAgentMessageWithStreaming(exists) &&
+                  isTerminalAgentMessageStatus(exists.status);
+
+                if (!isTerminal) {
+                  ref.current.data.map((m) =>
+                    predicate(m) ? agentMessage : m
+                  );
+                }
               } else {
                 const currentData = ref.current.data.get();
                 const offset = getBranchedInsertIndex(
@@ -712,6 +729,12 @@ export const ConversationViewer = ({
 
             // Re-fetch context usage after the agent finishes so the indicator is up-to-date.
             void mutateContextUsage();
+
+            // Refresh the messages SWR cache so a future remount of this
+            // conversation (e.g. navigating away and back) sees the final
+            // status/activitySteps instead of the stale "created" snapshot,
+            // which would otherwise re-open an SSE replay.
+            void mutateMessages();
 
             // Update the conversation hasError state in the local cache without making a network request.
             void mutateConversations(
@@ -810,6 +833,7 @@ export const ConversationViewer = ({
       mutateConversationAttachments,
       mutateConversationParticipants,
       mutateConversations,
+      mutateMessages,
       openPanel,
       owner.sId,
       user.sId,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -658,15 +658,18 @@ export const ConversationViewer = ({
                 // On replay (e.g. after navigating away and coming back), the
                 // existing message may already reflect the final state from
                 // the SWR snapshot. The replayed event always carries the
-                // initial "created" payload — replacing would downgrade the
+                // initial "created" payload, so replacing would downgrade the
                 // status (re-activating shouldStream and the message-events
-                // stream) and wipe inlineActivitySteps. Skip the replace
-                // when the existing message is already in a terminal state.
-                const isTerminal =
+                // stream) and wipe inlineActivitySteps. Skip the replace only
+                // when the existing message is the same logical message (same
+                // sId) and already terminal. A retry creates a new sId at the
+                // same rank/branch, so it must still go through the replace.
+                const isReplayOfTerminalMessage =
                   isAgentMessageWithStreaming(exists) &&
+                  exists.sId === agentMessage.sId &&
                   isTerminalAgentMessageStatus(exists.status);
 
-                if (!isTerminal) {
+                if (!isReplayOfTerminalMessage) {
                   ref.current.data.map((m) =>
                     predicate(m) ? agentMessage : m
                   );

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -58,6 +58,7 @@ import logger from "@app/logger/logger";
 import {
   type ConversationForkedChildType,
   type ConversationListItemType,
+  isLightAgentMessageType,
   isTerminalAgentMessageStatus,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
@@ -733,11 +734,32 @@ export const ConversationViewer = ({
             // Re-fetch context usage after the agent finishes so the indicator is up-to-date.
             void mutateContextUsage();
 
-            // Refresh the messages SWR cache so a future remount of this
-            // conversation (e.g. navigating away and back) sees the final
-            // status/activitySteps instead of the stale "created" snapshot,
-            // which would otherwise re-open an SSE replay.
-            void mutateMessages();
+            // Update the messages SWR cache in place so a future remount
+            // of this conversation (e.g. navigating away and back) sees the
+            // message as terminal instead of the stale "created" snapshot
+            // (which would otherwise re-open an SSE replay). We only flip
+            // status here to avoid a network refetch on every termination,
+            // which on prod was slow enough to delay retry feedback. The
+            // richer final state (activitySteps, content, gracefully_stopped
+            // vs cancelled) is restored by the next real fetch when needed.
+            void mutateMessages(
+              (pages) =>
+                pages?.map((page) => ({
+                  ...page,
+                  messages: page.messages.map((m) =>
+                    isLightAgentMessageType(m) && m.sId === event.messageId
+                      ? {
+                          ...m,
+                          status:
+                            event.status === "error"
+                              ? ("failed" as const)
+                              : ("succeeded" as const),
+                        }
+                      : m
+                  ),
+                })),
+              { revalidate: false }
+            );
 
             // Update the conversation hasError state in the local cache without making a network request.
             void mutateConversations(

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -303,6 +303,12 @@ export function useAgentMessageStream({
     []
   );
 
+  // Short-circuit replays of events we've already processed in this hook
+  // instance. Without this, a within-mount EventSource reconnect can re-emit
+  // events whose handlers are not idempotent (inline activity step IDs are
+  // built from `Date.now()` and would collide on same-ms re-processing).
+  const seenEventIds = useRef<Set<string>>(new Set());
+
   useEffect(() => {
     return () => {
       updateMessageThrottled.cancel();
@@ -353,6 +359,12 @@ export function useAgentMessageStream({
         eventId: string;
         data: AgentMessageStateWithControlEvent;
       } = JSON.parse(eventStr);
+      if (eventPayload.eventId) {
+        if (seenEventIds.current.has(eventPayload.eventId)) {
+          return;
+        }
+        seenEventIds.current.add(eventPayload.eventId);
+      }
       const eventType = eventPayload.data.type;
       switch (eventType) {
         case "end-of-stream":

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -304,9 +304,14 @@ export function useAgentMessageStream({
   );
 
   // Short-circuit replays of events we've already processed in this hook
-  // instance. Without this, a within-mount EventSource reconnect can re-emit
-  // events whose handlers are not idempotent (inline activity step IDs are
-  // built from `Date.now()` and would collide on same-ms re-processing).
+  // instance. The hook is mounted per agent message (via AgentMessage.tsx),
+  // so the ref is scoped to a single message and resets on remount or when a
+  // retry creates a new agentMessage.sId. Within a single mount,
+  // `useEventSource` reconnects on every server-side "done" frame and on
+  // network errors using `lastEventId`; if the server replays an event we
+  // already saw (e.g. just past the cursor boundary), the handlers downstream
+  // are not idempotent — inline activity step IDs are built from `Date.now()`
+  // and same-millisecond re-processing produces duplicate React keys.
   const seenEventIds = useRef<Set<string>>(new Set());
 
   useEffect(() => {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -8,6 +8,7 @@ import moment from "moment";
 import type { ContentFragmentType } from "../content_fragment";
 import type { AllSupportedWithDustSpecificFileContentType } from "../files";
 import type { ModelId } from "../shared/model_id";
+import { assertNeverAndIgnore } from "../shared/utils/assert_never";
 import type { UserType, WorkspaceType } from "../user";
 import type {
   AgentConfigurationStatus,
@@ -219,6 +220,23 @@ export const AGENT_MESSAGE_STATUSES_TO_TRACK: AgentMessageStatus[] = [
   "cancelled",
   "gracefully_stopped",
 ];
+
+export function isTerminalAgentMessageStatus(
+  status: AgentMessageStatus
+): boolean {
+  switch (status) {
+    case "succeeded":
+    case "failed":
+    case "cancelled":
+    case "gracefully_stopped":
+      return true;
+    case "created":
+      return false;
+    default:
+      assertNeverAndIgnore(status);
+      return false;
+  }
+}
 
 export interface CitationType {
   description?: string;


### PR DESCRIPTION
## Description

Fixes the same issue as #24963 (https://github.com/dust-tt/tasks/issues/7893) but with a smaller, narrower diff after reviewing the original PR end to end.

## Why a separate PR

#24963 bundled four changes. After tracing the timelines and reproducing in a Playwright session, three of them are load bearing and one introduces a regression, so this PR re lands the three and drops the fourth.

What we kept. Calling mutateMessages() on agent_message_done invalidates the SWR cache so a future remount sees the final status and server computed activitySteps instead of the stale "created" snapshot that re opens an SSE replay. Guarding the agent_message_new replace branch on a terminal existing state prevents the replayed "created"
payload from downgrading a message that the SWR snapshot already reflects as finalized. Tracking seen event ids in useAgentMessageStream prevents within mount EventSource reconnects from re processing events whose handlers are not idempotent (inline activity step ids are built from Date.now() and collide on same millisecond re processing,
which manifested as React "Encountered two children with the same key" warnings during empirical testing).

What we dropped. The synchronous status flip inside the agent_message_done handler in #24963 unconditionally rewrote the message status to "succeeded" or "failed" based on the binary event.status. The conversation level done event collapses agent_message_gracefully_stopped and agent_generation_cancelled into "success", but the message
events stream had already set the richer terminal status ("cancelled" or "gracefully_stopped") via useAgentMessageStream. The synchronous flip therefore clobbers that fidelity and visibly affects rendering in AgentMessage, AgentMessageCompletionStatus, and InlineActivitySteps. With the terminal state guard in place this defense in depth no longer earns its keep.

## Cleanup on top

The terminal status check is reused enough that we extracted isTerminalAgentMessageStatus next to the AgentMessageStatus type definition rather than inlining the four cases at the call site.

## Tests

Reproduced the flow manually with Playwright. Sent a streaming message, navigated away mid stream via sidebar (SPA navigation so the SWR cache persists), waited for completion, navigated back. The message renders cleanly with the correct number of activity steps. Without the fix, console warnings about duplicate React keys for "thinking-toolparams-{ms}" appeared during the remount; with the fix applied, those warnings are gone.

  ## Risk

Limited to the conversation viewer and the agent message stream hook. Behavior change is gated on existing message status, so non terminal messages still get replaced as before. Server contract unchanged.

## Deploy Plan

Deploy front. 
