### PR TITLE
Reduce storage on Microsoft connector Delta items

### DIFF
--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -246,8 +246,9 @@ export async function getFullDeltaResults({
   heartbeatFunction: () => void;
 }): Promise<{ results: DriveItem[]; deltaLink: string }> {
   let nextLink: string | undefined = initialDeltaLink;
-  let allItems: DriveItem[] = [];
+  const itemMap = new Map<string, DriveItem>();
   let deltaLink: string | undefined = undefined;
+  let pageCount = 0;
 
   do {
     const {
@@ -255,7 +256,16 @@ export async function getFullDeltaResults({
       nextLink: newNextLink,
       deltaLink: finalDeltaLink,
     } = await getDeltaResults({ logger, client, parentInternalId, nextLink });
-    allItems = allItems.concat(results);
+    for (const item of results) {
+      if (item.id) {
+        itemMap.set(item.id, item); // last write wins = correct dedup
+      }
+    }
+    pageCount++;
+    logger.info(
+      { pageCount, pageItems: results.length, totalItems: itemMap.size },
+      "Delta pagination progress"
+    );
     nextLink = newNextLink;
     deltaLink = finalDeltaLink;
     heartbeatFunction();
@@ -265,7 +275,7 @@ export async function getFullDeltaResults({
     throw new Error("Delta link not found");
   }
 
-  return { results: allItems, deltaLink };
+  return { results: Array.from(itemMap.values()), deltaLink };
 }
 
 export async function getWorksheets(


### PR DESCRIPTION
## Description

Reduce storage of duplicate items in Microsoft connector delta synchronization. 
"Microsoft connectors workers" get OOM.

The Graph API delta endpoint can return the same item multiple times across pagination, and Microsoft's documentation states that consumers should keep only the last occurrence. 

Previously, we concatenated all pages into an array, which could result in processing the same item multiple times with stale data. This change uses a `Map<itemId, DriveItem>` to deduplicate items during pagination, ensuring "last write wins" semantics. Also adds logging to track pagination progress (page count, items per page, total unique items).

## Tests

Manually tested delta sync behavior. No new automated tests added as this is a data processing fix that doesn't change the external API.

## Risk

Low. The deduplication logic is self-contained within `getFullDeltaResults()` and matches Microsoft's recommended approach. The change only affects how we store intermediate results during pagination—the final output signature (`results` array + `deltaLink`) remains unchanged.

## Deploy Plan

Deploy connectors.