### PR TITLE
Make any todos editables by project members.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -466,7 +466,7 @@ function EditableTodoItem({
   const hasConversationLink =
     (todo.status === "in_progress" || todo.status === "done") &&
     !!todo.conversationId;
-  const canEdit = viewerUserId !== null && todo.userId === viewerUserId;
+  const canEdit = viewerUserId !== null;
   const showInProgressTextAnimation = todo.status === "in_progress";
   const [isFlashing, setIsFlashing] = useState(isNewlyDone);
 
@@ -884,13 +884,16 @@ function EditableProjectTodosPanel({
     (users.length === 1 &&
       viewerUserId !== null &&
       users[0]?.sId === viewerUserId);
-  const assigneeLabel = hideAssigneeMenu ? "Your todos" : selectedAssigneeLabel;
+  const assigneeLabel = selectedAssigneeLabel;
 
   useEffect(() => {
     if (isTodosLoading) {
       return;
     }
 
+    // Preserve the previous UX default:
+    // - if only "you" exists, default to "Your todos"
+    // - otherwise default to "Everyone's todos"
     if (!hideAssigneeMenu) {
       setAssigneeScope("all");
     } else {
@@ -898,7 +901,7 @@ function EditableProjectTodosPanel({
       setSelectedUserSIds(new Set());
       setIsAssigneeMenuOpen(false);
     }
-  }, [isTodosLoading, hideAssigneeMenu]);
+  }, [hideAssigneeMenu, isTodosLoading]);
 
   const filteredTodos = useMemo(() => {
     switch (assigneeScope) {
@@ -919,26 +922,20 @@ function EditableProjectTodosPanel({
     }
   }, [assigneeScope, selectedUserSIds, todos, viewerUserId]);
   const hasDoneItems = filteredTodos.some((todo) => todo.status === "done");
-  const shouldGroupByAssignee =
-    assigneeScope === "all" ||
-    (assigneeScope === "users" && selectedUserSIds.size > 1);
   const groupedTodosForAll = useMemo(() => {
-    if (!shouldGroupByAssignee) {
-      return [];
-    }
-
     const groups = new Map<
       string,
       { user: ProjectTodoAssigneeType | null; todos: ProjectTodoType[] }
     >();
 
     for (const todo of filteredTodos) {
-      const key = todo.user?.sId ?? `unknown-${todo.userId}`;
+      const user = todo.user ?? usersBySId.get(todo.userId) ?? null;
+      const key = user?.sId ?? `unknown-${todo.userId}`;
       const existing = groups.get(key);
       if (existing) {
         existing.todos.push(todo);
       } else {
-        groups.set(key, { user: todo.user, todos: [todo] });
+        groups.set(key, { user, todos: [todo] });
       }
     }
 
@@ -952,7 +949,7 @@ function EditableProjectTodosPanel({
       const bName = b.user?.fullName ?? "";
       return aName.localeCompare(bName, undefined, { sensitivity: "base" });
     });
-  }, [filteredTodos, shouldGroupByAssignee, viewerUserId]);
+  }, [filteredTodos, usersBySId, viewerUserId]);
 
   // Optimistically update a todo's status in the SWR cache and send the PATCH.
   // On failure the cache is revalidated from the server.
@@ -1112,119 +1109,113 @@ function EditableProjectTodosPanel({
     <div className="flex flex-col gap-3">
       {/* Header */}
       <div className="inline-flex items-center gap-2">
-        {hideAssigneeMenu ? (
-          <h3 className="heading-xl text-foreground dark:text-foreground-night">
-            {assigneeLabel}
-          </h3>
-        ) : (
-          <DropdownMenu
-            modal={false}
-            open={isAssigneeMenuOpen}
-            onOpenChange={(open) => {
-              setIsAssigneeMenuOpen(open);
-              if (open) {
-                setAssigneeSearch("");
-              }
-            }}
-          >
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 rounded-md px-1 py-0.5 hover:bg-muted/40 dark:hover:bg-muted-night/40"
-              >
-                <h3 className="heading-xl text-foreground dark:text-foreground-night">
-                  {assigneeLabel}
-                </h3>
-                <Icon
-                  visual={ChevronDownIcon}
-                  size="sm"
-                  className="text-muted-foreground dark:text-muted-foreground-night"
-                />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
-              align="start"
+        <DropdownMenu
+          modal={false}
+          open={isAssigneeMenuOpen}
+          onOpenChange={(open) => {
+            setIsAssigneeMenuOpen(open);
+            if (open) {
+              setAssigneeSearch("");
+            }
+          }}
+        >
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 rounded-md px-1 py-0.5 hover:bg-muted/40 dark:hover:bg-muted-night/40"
             >
-              <DropdownMenuSearchbar
-                autoFocus
-                name="assignee-filter"
-                placeholder="Search members"
-                value={assigneeSearch}
-                onChange={setAssigneeSearch}
+              <h3 className="heading-xl text-foreground dark:text-foreground-night">
+                {assigneeLabel}
+              </h3>
+              <Icon
+                visual={ChevronDownIcon}
+                size="sm"
+                className="text-muted-foreground dark:text-muted-foreground-night"
               />
-              <DropdownMenuSeparator />
-              <DropdownMenuCheckboxItem
-                icon={UserIcon}
-                label="Your todos"
-                checked={assigneeScope === "mine"}
-                onClick={() => {
-                  setAssigneeScope("mine");
-                  setSelectedUserSIds(new Set());
-                  setIsAssigneeMenuOpen(false);
-                }}
-                onSelect={(event) => {
-                  event.preventDefault();
-                }}
-              />
-              <DropdownMenuCheckboxItem
-                icon={UserGroupIcon}
-                label="Everyone's todos"
-                checked={assigneeScope === "all"}
-                onClick={() => {
-                  setAssigneeScope("all");
-                  setSelectedUserSIds(new Set());
-                  setIsAssigneeMenuOpen(false);
-                }}
-                onSelect={(event) => {
-                  event.preventDefault();
-                }}
-              />
-              <DropdownMenuSeparator />
-              <div className="max-h-64 overflow-auto">
-                {filteredUsers.length > 0 ? (
-                  filteredUsers.map((user) => (
-                    <DropdownMenuCheckboxItem
-                      key={`todo-assignee-filter-${user.sId}`}
-                      icon={() => (
-                        <Avatar
-                          size="xxs"
-                          visual={
-                            user.image ?? "/static/humanavatar/anonymous.png"
-                          }
-                        />
-                      )}
-                      label={`${user.fullName}${viewerUserId === user.sId ? " (you)" : ""}`}
-                      checked={
-                        assigneeScope === "users" &&
-                        selectedUserSIds.has(user.sId)
-                      }
-                      onClick={() => {
-                        setSelectedUserSIds((previous) => {
-                          const next = new Set(previous);
-                          if (next.has(user.sId)) {
-                            next.delete(user.sId);
-                          } else {
-                            next.add(user.sId);
-                          }
-                          setAssigneeScope(next.size === 0 ? "all" : "users");
-                          return next;
-                        });
-                      }}
-                      onSelect={(event) => {
-                        event.preventDefault();
-                      }}
-                    />
-                  ))
-                ) : (
-                  <div className="px-3 py-2 text-sm text-muted-foreground">
-                    No members found
-                  </div>
-                )}
-              </div>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
+            align="start"
+          >
+            <DropdownMenuSearchbar
+              autoFocus
+              name="assignee-filter"
+              placeholder="Search members"
+              value={assigneeSearch}
+              onChange={setAssigneeSearch}
+            />
+            <DropdownMenuSeparator />
+            <DropdownMenuCheckboxItem
+              icon={UserIcon}
+              label="Your todos"
+              checked={assigneeScope === "mine"}
+              onClick={() => {
+                setAssigneeScope("mine");
+                setSelectedUserSIds(new Set());
+                setIsAssigneeMenuOpen(false);
+              }}
+              onSelect={(event) => {
+                event.preventDefault();
+              }}
+            />
+            <DropdownMenuCheckboxItem
+              icon={UserGroupIcon}
+              label="Everyone's todos"
+              checked={assigneeScope === "all"}
+              onClick={() => {
+                setAssigneeScope("all");
+                setSelectedUserSIds(new Set());
+                setIsAssigneeMenuOpen(false);
+              }}
+              onSelect={(event) => {
+                event.preventDefault();
+              }}
+            />
+            <DropdownMenuSeparator />
+            <div className="max-h-64 overflow-auto">
+              {filteredUsers.length > 0 ? (
+                filteredUsers.map((user) => (
+                  <DropdownMenuCheckboxItem
+                    key={`todo-assignee-filter-${user.sId}`}
+                    icon={() => (
+                      <Avatar
+                        size="xxs"
+                        visual={
+                          user.image ?? "/static/humanavatar/anonymous.png"
+                        }
+                      />
+                    )}
+                    label={`${user.fullName}${viewerUserId === user.sId ? " (you)" : ""}`}
+                    checked={
+                      assigneeScope === "users" &&
+                      selectedUserSIds.has(user.sId)
+                    }
+                    onClick={() => {
+                      setSelectedUserSIds((previous) => {
+                        const next = new Set(previous);
+                        if (next.has(user.sId)) {
+                          next.delete(user.sId);
+                        } else {
+                          next.add(user.sId);
+                        }
+                        setAssigneeScope(next.size === 0 ? "all" : "users");
+                        return next;
+                      });
+                    }}
+                    onSelect={(event) => {
+                      event.preventDefault();
+                    }}
+                  />
+                ))
+              ) : (
+                <div className="px-3 py-2 text-sm text-muted-foreground">
+                  No members found
+                </div>
+              )}
+            </div>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <div className="flex-1" />
         {hasDoneItems && (
           <Button
@@ -1248,61 +1239,40 @@ function EditableProjectTodosPanel({
         <CollapsibleTodoList>
           {/* Todo items */}
           <div className="flex flex-col gap-2">
-            {shouldGroupByAssignee
-              ? groupedTodosForAll.map((group) => (
-                  <div
-                    key={group.user?.sId ?? `unknown-${group.todos[0]?.userId}`}
-                    className="mb-4 last:mb-0"
-                  >
-                    <TodoAssigneeHeader
-                      user={group.user}
+            {groupedTodosForAll.map((group) => (
+              <div
+                key={group.user?.sId ?? `unknown-${group.todos[0]?.userId}`}
+                className="mb-4 last:mb-0"
+              >
+                <TodoAssigneeHeader
+                  user={group.user}
+                  viewerUserId={viewerUserId}
+                />
+                <div className="ml-4 flex flex-col gap-2">
+                  {group.todos.map((todo) => (
+                    <EditableTodoItem
+                      key={todo.sId}
+                      todo={todo}
                       viewerUserId={viewerUserId}
+                      onToggleDone={handleToggleDone}
+                      onDelete={handleDelete}
+                      onStartWorking={handleStartWorking}
+                      owner={owner}
+                      agentNameById={agentNameById}
+                      isExiting={pendingRemovalIds.has(todo.sId)}
+                      isAdded={
+                        diffKeys.added.has(todo.sId) &&
+                        !enteredKeys.has(todo.sId)
+                      }
+                      isEntering={enteringKeys.has(todo.sId)}
+                      isTyping={typingKeys.has(todo.sId)}
+                      isNewlyDone={doneFlashKeys.has(todo.sId)}
+                      isStarting={startingTodoIds.has(todo.sId)}
                     />
-                    <div className="ml-4 flex flex-col gap-2">
-                      {group.todos.map((todo) => (
-                        <EditableTodoItem
-                          key={todo.sId}
-                          todo={todo}
-                          viewerUserId={viewerUserId}
-                          onToggleDone={handleToggleDone}
-                          onDelete={handleDelete}
-                          onStartWorking={handleStartWorking}
-                          owner={owner}
-                          agentNameById={agentNameById}
-                          isExiting={pendingRemovalIds.has(todo.sId)}
-                          isAdded={
-                            diffKeys.added.has(todo.sId) &&
-                            !enteredKeys.has(todo.sId)
-                          }
-                          isEntering={enteringKeys.has(todo.sId)}
-                          isTyping={typingKeys.has(todo.sId)}
-                          isNewlyDone={doneFlashKeys.has(todo.sId)}
-                          isStarting={startingTodoIds.has(todo.sId)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                ))
-              : filteredTodos.map((todo) => (
-                  <EditableTodoItem
-                    key={todo.sId}
-                    todo={todo}
-                    viewerUserId={viewerUserId}
-                    onToggleDone={handleToggleDone}
-                    onDelete={handleDelete}
-                    onStartWorking={handleStartWorking}
-                    owner={owner}
-                    agentNameById={agentNameById}
-                    isExiting={pendingRemovalIds.has(todo.sId)}
-                    isAdded={
-                      diffKeys.added.has(todo.sId) && !enteredKeys.has(todo.sId)
-                    }
-                    isEntering={enteringKeys.has(todo.sId)}
-                    isTyping={typingKeys.has(todo.sId)}
-                    isNewlyDone={doneFlashKeys.has(todo.sId)}
-                    isStarting={startingTodoIds.has(todo.sId)}
-                  />
-                ))}
+                  ))}
+                </div>
+              </div>
+            ))}
           </div>
 
           {/* Empty state */}
@@ -1322,15 +1292,15 @@ function EditableProjectTodosPanel({
 interface ProjectTodosPanelProps {
   owner: LightWorkspaceType;
   spaceId: string;
-  isArchived: boolean;
+  isReadOnly: boolean;
 }
 
 export function ProjectTodosPanel({
   owner,
   spaceId,
-  isArchived,
+  isReadOnly,
 }: ProjectTodosPanelProps) {
-  if (isArchived) {
+  if (isReadOnly) {
     return <ReadOnlyProjectTodosPanel owner={owner} spaceId={spaceId} />;
   }
 

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -180,7 +180,7 @@ export function SpaceConversationsTab({
             <ProjectTodosPanel
               owner={owner}
               spaceId={spaceInfo.sId}
-              isArchived={!!spaceInfo.archivedAt}
+              isReadOnly={!!spaceInfo.archivedAt || !spaceInfo.isMember}
             />
           )}
 

--- a/front/lib/project_todo/start_agent.ts
+++ b/front/lib/project_todo/start_agent.ts
@@ -88,13 +88,6 @@ export async function startAgentForProjectTodo(
   }
 
   const user = auth.getNonNullableUser();
-  if (todo.userId !== user.id) {
-    return new Err({
-      statusCode: 403,
-      type: "invalid_request_error",
-      message: "You can only modify your own todos.",
-    });
-  }
 
   if (todo.category !== "to_do") {
     return new Err({

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -570,8 +570,8 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
   }
 
   // Applies the same updates to a batch of todos in a single transaction.
-  // Scoped to the authenticated user + given space so unrelated or cross-user
-  // todos cannot be touched via this path.
+  // Scoped to the given space so unrelated or cross-space todos cannot be
+  // touched via this path.
   static async bulkUpdateWithVersionBySIds(
     auth: Authenticator,
     {
@@ -601,7 +601,6 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       where: {
         id: { [Op.in]: ids },
         spaceId,
-        userId: auth.getNonNullableUser().id,
       },
     });
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.test.ts
@@ -1,7 +1,9 @@
 import { Authenticator } from "@app/lib/auth";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { ProjectTodoFactory } from "@app/tests/utils/ProjectTodoFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { WorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { MockRequest, MockResponse } from "node-mocks-http";
@@ -120,6 +122,29 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]", () => {
 
     expect(res._getStatusCode()).toBe(404);
     expect(res._getJSONData().error.type).toBe("project_todo_not_found");
+  });
+
+  it("should allow updating a todo assigned to another project member", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherTodo = await ProjectTodoFactory.create(workspace, project, {
+      userId: otherUser.id,
+      text: "Other member todo",
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = otherTodo.sId;
+    req.body = { text: "Edited by project member", status: "done" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { todo: updated } = res._getJSONData();
+    expect(updated.text).toBe("Edited by project member");
+    expect(updated.status).toBe("done");
+    expect(updated.userId).toBe(otherUser.sId);
   });
 
   it("should return 400 when no update fields are provided", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.ts
@@ -73,15 +73,6 @@ async function handler(
   }
 
   const user = auth.getNonNullableUser();
-  if (todo.userId !== user.id) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "invalid_request_error",
-        message: "You can only modify your own todos.",
-      },
-    });
-  }
 
   switch (req.method) {
     case "PATCH": {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
@@ -8,8 +8,10 @@ vi.mock("@app/temporal/agent_loop/client", () => ({
 }));
 
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { ProjectTodoFactory } from "@app/tests/utils/ProjectTodoFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { WorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { MockRequest, MockResponse } from "node-mocks-http";
@@ -46,6 +48,29 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start", () =
     const data = res._getJSONData();
     expect(data.todo.sId).toBe(todo.sId);
     expect(data.todo.status).toBe("in_progress");
+    expect(data.todo.conversationId).toBeTruthy();
+  });
+
+  it("allows starting work on a todo assigned to another project member", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: otherUser.id,
+      text: "Prepare roadmap draft",
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = todo.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.todo.sId).toBe(todo.sId);
+    expect(data.todo.status).toBe("in_progress");
+    expect(data.todo.userId).toBe(otherUser.sId);
     expect(data.todo.conversationId).toBeTruthy();
   });
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/bulk-actions.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/bulk-actions.test.ts
@@ -2,8 +2,10 @@ import { Authenticator } from "@app/lib/auth";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { ProjectTodoFactory } from "@app/tests/utils/ProjectTodoFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { WorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { MockRequest, MockResponse } from "node-mocks-http";
@@ -105,6 +107,44 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos/bulk-actions", () => 
 
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should allow bulk status updates for todos assigned to other project members", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+
+    const myTodo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+    });
+    const otherTodo = await ProjectTodoFactory.create(workspace, project, {
+      userId: otherUser.id,
+    });
+
+    req.query.spaceId = project.sId;
+    req.body = {
+      action: "set_status",
+      todoIds: [myTodo.sId, otherTodo.sId],
+      status: "done",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const refreshedMyTodo = await ProjectTodoResource.fetchBySId(
+      auth,
+      myTodo.sId
+    );
+    const refreshedOtherTodo = await ProjectTodoResource.fetchBySId(
+      auth,
+      otherTodo.sId
+    );
+    expect(refreshedMyTodo?.status).toBe("done");
+    expect(refreshedOtherTodo?.status).toBe("done");
   });
 
   it("should clean done todos for the user in the space", async () => {


### PR DESCRIPTION
## Description

Todos were only editable by their assignee. In a collaborative project context, any member should be able to check off, delete, or start work on any todo — ownership shouldn't restrict editing.

- Remove `todo.userId === viewerUserId` guard from `canEdit` — all authenticated project members can edit any todo
- Always show the assignee filter dropdown, even in single-member projects (previously hidden via `hideAssigneeMenu`); default scope is still `"mine"` when solo, `"all"` when multiple members exist
- Remove `shouldGroupByAssignee` flag — `groupedTodosForAll` is always computed; grouping display is determined by scope at render time
- Fall back to `usersBySId.get(todo.userId)` when `todo.user` is null, so group headers resolve correctly for todos assigned to users not in the current page response

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`
