### PR TITLE
User spend threshold event

### DIFF
--- a/front/lib/metronome/webhook_events.ts
+++ b/front/lib/metronome/webhook_events.ts
@@ -43,6 +43,16 @@ const SpendThresholdReachedSchema = z.object({
   type: z.literal("alerts.spend_threshold_reached"),
   properties: baseAlertPropertiesSchema.extend({
     current_spend: z.number().nullish(),
+    credit_type_id: z.string().nullish(),
+    invoice_type: z.string().nullish(),
+    group_values: z
+      .array(
+        z.object({
+          key: z.string(),
+          value: z.string().nullish(),
+        })
+      )
+      .nullish(),
   }),
 });
 

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -156,7 +156,6 @@ async function handler(
         case "contract.start":
         case "credit.archive":
         case "credit.create":
-        case "credit.create":
         case "credit.edit":
         case "credit.segment.end":
         case "invoice.billing_provider_error":

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -109,7 +109,7 @@ async function handler(
         logger.warn(
           {
             eventType: rawType.success ? rawType.data.type : "unknown",
-            event: rawEvent,
+            rawEvent,
             error: parsedEvent.error.message,
           },
           "[Metronome Webhook] Unknown or malformed event"
@@ -118,6 +118,8 @@ async function handler(
       }
 
       const event = parsedEvent.data;
+
+      logger.info({ event, rawEvent }, "[Metronome Webhook] Event received");
 
       // Resolve the workspace once for any event that carries a customer_id
       // (every type except `integration.issue`). If the customer can't be
@@ -137,69 +139,28 @@ async function handler(
       }
 
       switch (event.type) {
-        case "alerts.low_remaining_credit_balance_reached":
-          logger.info({ event }, "[Metronome Webhook] Credits exhausted alert");
-          break;
-
-        case "alerts.low_remaining_seat_balance_reached":
-          logger.info(
-            { event },
-            "[Metronome Webhook] Per-seat credits exhausted alert"
-          );
-          break;
-
-        case "alerts.spend_threshold_reached":
-          logger.info({ event }, "[Metronome Webhook] Approaching spend limit");
-          break;
-
         case "alerts.invoice_total_reached":
-          logger.info({ event }, "[Metronome Webhook] Invoice total reached");
-          break;
-
         case "alerts.low_remaining_commit_balance_reached":
-          logger.info(
-            { event },
-            "[Metronome Webhook] Commit balance exhausted alert"
-          );
-          break;
-
+        case "alerts.low_remaining_credit_balance_reached":
+        case "alerts.low_remaining_seat_balance_reached":
+        case "alerts.spend_threshold_reached":
         case "alerts.usage_threshold_reached":
-          logger.info({ event }, "[Metronome Webhook] Usage threshold reached");
-          break;
-
         case "commit.archive":
-          logger.info({ event }, "[Metronome Webhook] Commit archived");
-          break;
-
         case "commit.create":
-          logger.info({ event }, "[Metronome Webhook] Commit created");
-          break;
-
         case "commit.edit":
-          logger.info({ event }, "[Metronome Webhook] Commit edited");
-          break;
-
-        case "commit.segment.start":
-          logger.info(
-            { event },
-            "[Metronome Webhook] New commit segment started (credits available)"
-          );
-          break;
-
         case "commit.segment.end":
-          logger.info({ event }, "[Metronome Webhook] Commit segment ended");
-          break;
-
+        case "commit.segment.start":
+        case "contract.archive":
+        case "contract.create":
+        case "contract.edit":
+        case "contract.start":
         case "credit.archive":
-          logger.info({ event }, "[Metronome Webhook] Credit archived");
-          break;
-
         case "credit.create":
-          logger.info({ event }, "[Metronome Webhook] Credit created");
-          break;
-
+        case "credit.create":
         case "credit.edit":
-          logger.info({ event }, "[Metronome Webhook] Credit edited");
+        case "credit.segment.end":
+        case "invoice.billing_provider_error":
+        case "invoice.finalized":
           break;
 
         case "credit.segment.start": {
@@ -322,29 +283,6 @@ async function handler(
           break;
         }
 
-        case "credit.segment.end":
-          logger.info({ event }, "[Metronome Webhook] Credit segment ended");
-          break;
-
-        case "credit.create":
-          logger.info(
-            { event },
-            "[Metronome Webhook] Credit created (credits available)"
-          );
-          break;
-
-        case "contract.create":
-          logger.info({ event }, "[Metronome Webhook] Contract created");
-          break;
-
-        case "contract.start":
-          logger.info({ event }, "[Metronome Webhook] Contract started");
-          break;
-
-        case "contract.edit":
-          logger.info({ event }, "[Metronome Webhook] Contract edited");
-          break;
-
         case "contract.end": {
           const { contract_id: contractId, customer_id: customerId } = event;
 
@@ -426,21 +364,6 @@ async function handler(
           }
           break;
         }
-
-        case "contract.archive":
-          logger.info({ event }, "[Metronome Webhook] Contract archived");
-          break;
-
-        case "invoice.finalized":
-          logger.info({ event }, "[Metronome Webhook] Invoice finalized");
-          break;
-
-        case "invoice.billing_provider_error":
-          logger.error(
-            { event },
-            "[Metronome Webhook] Billing provider error on invoice"
-          );
-          break;
 
         default:
           logger.info(


### PR DESCRIPTION
## Description

fixed again spend_threshold_reached event parsing. 
We actually get something like : 

```
{
  "id": "e49bd741-ad95-4b40-985a-c8c610b84f72",
  "type": "alerts.spend_threshold_reached",
  "properties": {
    "customer_id": "6a2b264c-e182-4ea6-be30-41a39835bc1b",
    "alert_id": "eeadba98-96b3-4988-bafa-36de23672920",
    "timestamp": "2026-04-29T12:08:18.420Z",
    "threshold": 0.02,
    "alert_name": "teet",
    "group_values": [
      {
        "key": "api_key_name",
        "value": "test"
      }
    ],
    "credit_type_id": "713dda3d-4e9c-456f-91cf-c79cf5b71412",
    "triggered_by": "usage"
  }
}
```

Always log the raw event, simplified the switch case

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
