### PR TITLE
fix(snowflake): use static-IP proxy for OAuth token exchange

### DIFF
--- a/core/src/oauth/providers/snowflake.rs
+++ b/core/src/oauth/providers/snowflake.rs
@@ -1,5 +1,4 @@
 use crate::{
-    http::proxy_client::create_untrusted_egress_client_builder,
     oauth::{
         connection::{
             Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
@@ -12,7 +11,7 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use tracing::{error, info};
+use tracing::info;
 
 use super::utils::ProviderHttpRequestError;
 
@@ -123,16 +122,9 @@ impl Provider for SnowflakeConnectionProvider {
         ConnectionProvider::Snowflake
     }
 
-    fn reqwest_client(&self) -> reqwest::Client {
-        // Snowflake provider makes requests to user-provided account URLs, so we use the untrusted egress proxy.
-        match create_untrusted_egress_client_builder().build() {
-            Ok(client) => client,
-            Err(e) => {
-                error!(error = ?e, "Failed to create client with untrusted egress proxy");
-                reqwest::Client::new()
-            }
-        }
-    }
+    // Snowflake OAuth requests must use the static-IP proxy (default trait impl) — customers
+    // with network policies like NETWORK_POLICY = DUST_ONLY allowlist Dust's documented static
+    // egress IPs and reject requests coming from the untrusted egress proxy.
 
     async fn finalize(
         &self,


### PR DESCRIPTION
## Description

Removed the reqwest_client() override that was using create_untrusted_egress_client_builder (non-static IP). The provider now inherits the default Provider::reqwest_client() from core/src/oauth/connection.rs:194-220, which routes through the static-IP proxy via PROXY_HOST/PROXY_PORT/PROXY_USER_NAME/PROXY_USER_PASSWORD — the same proxy the Snowflake data sync connector at core/src/databases/remote_databases/snowflake/snowflake.rs:266-285 already uses (PR #20111).

This means token-exchange requests (finalize, refresh) will now egress from Dust's documented static IPs, so customers with NETWORK_POLICY = DUST_ONLY will pass Snowflake's allowlist check.

Fixes https://github.com/dust-tt/tasks/issues/7899

## Tests

Not set up to test

## Risk

Need to evaluate

## Deploy Plan

Core