### PR TITLE
feat(sbx): dedicated action details for add_egress_domain

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -27,6 +27,7 @@ import { MCPImageGenerationActionDetails } from "@app/components/actions/mcp/det
 import { MCPListToolsActionDetails } from "@app/components/actions/mcp/details/MCPListToolsActionDetails";
 import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
 import { MCPSandboxActionDetails } from "@app/components/actions/mcp/details/MCPSandboxActionDetails";
+import { MCPSandboxAddEgressDomainDetails } from "@app/components/actions/mcp/details/MCPSandboxAddEgressDomainDetails";
 import { MCPSkillEnableActionDetails } from "@app/components/actions/mcp/details/MCPSkillEnableActionDetails";
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
 import {
@@ -382,6 +383,9 @@ export function MCPActionDetails({
   }
 
   if (internalMCPServerName === "sandbox") {
+    if (toolName === "add_egress_domain") {
+      return <MCPSandboxAddEgressDomainDetails {...toolOutputDetailsProps} />;
+    }
     return <MCPSandboxActionDetails {...toolOutputDetailsProps} />;
   }
 

--- a/front/components/actions/mcp/details/MCPSandboxAddEgressDomainDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxAddEgressDomainDetails.tsx
@@ -42,12 +42,8 @@ export function MCPSandboxAddEgressDomainDetails({
   const status = useMemo(() => parseStatus(rawOutputText), [rawOutputText]);
 
   const actionName = isRunning
-    ? domain
-      ? `Requesting access to ${domain}`
-      : "Requesting sandbox network access"
-    : domain
-      ? `Request access to ${domain}`
-      : "Allow domain in sandbox";
+    ? `Requesting access to ${domain ?? "domain"}`
+    : `Request access to ${domain ?? "domain"}`;
 
   return (
     <ActionDetailsWrapper

--- a/front/components/actions/mcp/details/MCPSandboxAddEgressDomainDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxAddEgressDomainDetails.tsx
@@ -1,0 +1,154 @@
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { GlobeAltIcon } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+type EgressStatus = "added" | "already_allowed" | "unknown";
+
+function parseStatus(rawText: string | null): EgressStatus {
+  if (!rawText) {
+    return "unknown";
+  }
+  if (/^Allowed:/m.test(rawText)) {
+    return "added";
+  }
+  if (/^Already allowed:/m.test(rawText)) {
+    return "already_allowed";
+  }
+  return "unknown";
+}
+
+export function MCPSandboxAddEgressDomainDetails({
+  displayContext,
+  toolParams,
+  toolOutput,
+}: ToolExecutionDetailsProps) {
+  const domain =
+    typeof toolParams.domain === "string" ? toolParams.domain : null;
+  const reason =
+    typeof toolParams.reason === "string" ? toolParams.reason : null;
+
+  const rawOutputText = useMemo(() => {
+    if (!toolOutput) {
+      return null;
+    }
+    const textBlocks = toolOutput.filter(isTextContent);
+    return textBlocks.map((b) => b.text).join("\n") || null;
+  }, [toolOutput]);
+
+  const isRunning = toolOutput === null;
+  const status = useMemo(() => parseStatus(rawOutputText), [rawOutputText]);
+
+  const actionName = isRunning
+    ? domain
+      ? `Requesting access to ${domain}`
+      : "Requesting sandbox network access"
+    : domain
+      ? `Request access to ${domain}`
+      : "Allow domain in sandbox";
+
+  return (
+    <ActionDetailsWrapper
+      displayContext={displayContext}
+      actionName={actionName}
+      visual={GlobeAltIcon}
+    >
+      {displayContext === "conversation" ? (
+        <ConversationView
+          domain={domain}
+          reason={reason}
+          status={status}
+          isRunning={isRunning}
+        />
+      ) : (
+        <SidebarView
+          domain={domain}
+          reason={reason}
+          status={status}
+          isRunning={isRunning}
+        />
+      )}
+    </ActionDetailsWrapper>
+  );
+}
+
+interface EgressViewProps {
+  domain: string | null;
+  reason: string | null;
+  status: EgressStatus;
+  isRunning: boolean;
+}
+
+function statusLabel(status: EgressStatus, isRunning: boolean): string {
+  if (isRunning) {
+    return "Pending user approval…";
+  }
+  switch (status) {
+    case "added":
+      return "Added to sandbox allowlist";
+    case "already_allowed":
+      return "Already allowed";
+    case "unknown":
+      return "Not added";
+  }
+}
+
+function ConversationView({
+  domain,
+  reason,
+  status,
+  isRunning,
+}: EgressViewProps) {
+  return (
+    <div className="flex flex-col gap-1 pl-6 text-sm">
+      {domain && (
+        <div>
+          <span className="text-muted-foreground dark:text-muted-foreground-night">
+            Domain:{" "}
+          </span>
+          <span className="font-mono">{domain}</span>
+        </div>
+      )}
+      {reason && (
+        <div>
+          <span className="text-muted-foreground dark:text-muted-foreground-night">
+            Reason:{" "}
+          </span>
+          <span>{reason}</span>
+        </div>
+      )}
+      <div>
+        <span className="text-muted-foreground dark:text-muted-foreground-night">
+          Status:{" "}
+        </span>
+        <span>{statusLabel(status, isRunning)}</span>
+      </div>
+    </div>
+  );
+}
+
+function SidebarView({ domain, reason, status, isRunning }: EgressViewProps) {
+  return (
+    <div className="flex flex-col gap-4 py-4 pl-6 text-sm">
+      <div className="flex flex-col gap-1">
+        <span className="font-medium text-foreground dark:text-foreground-night">
+          Domain
+        </span>
+        <span className="font-mono">{domain ?? "—"}</span>
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="font-medium text-foreground dark:text-foreground-night">
+          Reason
+        </span>
+        <span>{reason ?? "—"}</span>
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="font-medium text-foreground dark:text-foreground-night">
+          Status
+        </span>
+        <span>{statusLabel(status, isRunning)}</span>
+      </div>
+    </div>
+  );
+}

--- a/front/components/actions/mcp/details/MCPSandboxAddEgressDomainDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxAddEgressDomainDetails.tsx
@@ -1,6 +1,7 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { GlobeAltIcon } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
@@ -90,6 +91,9 @@ function statusLabel(status: EgressStatus, isRunning: boolean): string {
     case "already_allowed":
       return "Already allowed";
     case "unknown":
+      return "Not added";
+    default:
+      assertNeverAndIgnore(status);
       return "Not added";
   }
 }

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -27,6 +27,7 @@ import {
   CheckIcon,
   ChevronRightIcon,
   cn,
+  GlobeAltIcon,
   Icon,
   ToolsIcon,
   XCircleIcon,
@@ -274,13 +275,17 @@ export function InlineActivitySteps({
                     </div>
                   );
                 case "action": {
-                  const actionIcon = step.internalMCPServerName
-                    ? InternalActionIcons[
-                        getInternalMCPServerIconByName(
-                          step.internalMCPServerName
-                        )
-                      ]
-                    : ToolsIcon;
+                  const actionIcon =
+                    step.internalMCPServerName === "sandbox" &&
+                    step.toolName === "add_egress_domain"
+                      ? GlobeAltIcon
+                      : step.internalMCPServerName
+                        ? InternalActionIcons[
+                            getInternalMCPServerIconByName(
+                              step.internalMCPServerName
+                            )
+                          ]
+                        : ToolsIcon;
 
                   return (
                     <div

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -246,6 +246,7 @@ describe("appendThinkingStep", () => {
         id: "action-1",
         actionId: "act_1",
         internalMCPServerName: null,
+        toolName: null,
       },
     ];
 

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -468,6 +468,7 @@ describe("useAgentMessageStream", () => {
         id: `action-${action.id}`,
         actionId: action.sId,
         internalMCPServerName: action.internalMCPServerName,
+        toolName: action.toolName ?? null,
       },
     ]);
     expect(currentMessage.chainOfThought).toBe("");

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -476,6 +476,7 @@ export function useAgentMessageStream({
                     id: `action-${action.id}`,
                     actionId: action.sId,
                     internalMCPServerName: action.internalMCPServerName,
+                    toolName: action.toolName ?? null,
                   },
                 ];
             return {

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -23,7 +23,7 @@ export function getActionOneLineLabel(
 ): string {
   if (
     action.internalMCPServerName === "sandbox" &&
-    action.functionCallName === "add_egress_domain" &&
+    action.toolName === "add_egress_domain" &&
     typeof action.params?.domain === "string"
   ) {
     return context === "running"
@@ -118,6 +118,7 @@ export async function contentsToActivitySteps(
           id: `action-${matchingAction.id}`,
           actionId: matchingAction.sId,
           internalMCPServerName: matchingAction.internalMCPServerName,
+          toolName: matchingAction.toolName ?? null,
         });
       }
     }

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -21,6 +21,16 @@ export function getActionOneLineLabel(
   action: AgentMCPActionWithOutputType,
   context: "running" | "done" = "done"
 ): string {
+  if (
+    action.internalMCPServerName === "sandbox" &&
+    action.functionCallName === "add_egress_domain" &&
+    typeof action.params?.domain === "string"
+  ) {
+    return context === "running"
+      ? `Requesting access to ${action.params.domain}`
+      : `Request access to ${action.params.domain}`;
+  }
+
   return (
     action.displayLabels?.[context] ??
     (action.functionCallName ? asDisplayName(action.functionCallName) : "Tool")

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -265,6 +265,7 @@ export type InlineActivityStep =
       id: string;
       actionId: string;
       internalMCPServerName: InternalMCPServerNameType | null;
+      toolName: string | null;
     };
 
 export type ParsedContentItem =


### PR DESCRIPTION
## Description

The shared `MCPSandboxActionDetails` component was hard-coded for the `bash` tool: fixed `"Executed command in sandbox"` label, `CommandLineIcon`, and an output parser that only extracts `<stdout>` / `<stderr>` / `<exit_code>` / `<network_proxy_logs>` sections. The new `add_egress_domain` tool returns plain text without those tags, which surfaced as an empty `"No output"` panel and a misleading inline label.

This adds a dedicated `MCPSandboxAddEgressDomainDetails` renderer:
- `GlobeAltIcon` instead of the command-line icon.
- Dynamic inline label: `"Requesting access to <domain>"` while running, `"Request access to <domain>"` once done.
- Body shows Domain / Reason (from tool params) and a Status parsed cheaply from the tool output (`Allowed:` → "Added to sandbox allowlist", `Already allowed:` → "Already allowed").

Routing in `MCPActionDetails.tsx` dispatches to the new component when `internalMCPServerName === "sandbox"` and `toolName === "add_egress_domain"`, and falls through to the existing bash renderer otherwise.

## Tests

Manual: triggered `add_egress_domain` from an agent in a sandbox-enabled workspace and confirmed the new icon, dynamic label, and Domain/Reason/Status panel render in both conversation and sidebar contexts. Verified the bash tool details still render unchanged.


## Risk

Low — purely a frontend rendering change, scoped to the sandbox MCP server. No backend, schema, or contract changes. Bash tool rendering is untouched. Safe to roll back.

## Deploy Plan

Standard front deploy.