### PR TITLE
Allow frame owners to view their own frames and the conversation URL

### DIFF
--- a/front/pages/api/v1/public/frames/[token]/index.test.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.test.ts
@@ -8,7 +8,6 @@ import {
 } from "@app/lib/resources/storage/models/files";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -519,74 +518,6 @@ describe("GET /api/v1/public/frames/[token]", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
-    });
-  });
-
-  describe("conversation URL", () => {
-    const createFrameLinkedToConversation = async (scope: FileShareScope) => {
-      const conversation = await ConversationFactory.createEmpty(auth);
-
-      const file = await FileFactory.create(auth, user, {
-        contentType: frameContentType,
-        fileName: "test-frame.html",
-        fileSize: 100,
-        status: "ready",
-        useCase: "conversation",
-        useCaseMetadata: { conversationId: conversation.sId },
-      });
-      await file.setShareScope(auth, scope);
-
-      const shareInfo = await file.getShareInfo();
-      expect(shareInfo).not.toBeNull();
-      const token = shareInfo!.shareUrl.split("/").at(-1)!;
-
-      return { file, token };
-    };
-
-    it("returns conversationUrl for the file owner even when not a participant", async () => {
-      // Owner is `user`. No participant row is created for `user` on this conversation.
-      const { token } = await createFrameLinkedToConversation(
-        "workspace_and_emails"
-      );
-      vi.mocked(getAuthForSharedEndpointWorkspaceMembersOnly).mockResolvedValue(
-        auth
-      );
-
-      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
-        method: "GET",
-        query: { token },
-      });
-
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(200);
-      expect(res._getJSONData().conversationUrl).toEqual(expect.any(String));
-    });
-
-    it("returns null conversationUrl for a non-owner workspace member who isn't a participant", async () => {
-      const { token } = await createFrameLinkedToConversation(
-        "workspace_and_emails"
-      );
-
-      const otherUser = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
-      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        otherUser.sId,
-        workspace.sId
-      );
-      vi.mocked(getAuthForSharedEndpointWorkspaceMembersOnly).mockResolvedValue(
-        otherAuth
-      );
-
-      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
-        method: "GET",
-        query: { token },
-      });
-
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(200);
-      expect(res._getJSONData().conversationUrl).toBeNull();
     });
   });
 });

--- a/front/pages/api/v1/public/frames/[token]/index.test.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.test.ts
@@ -1,15 +1,19 @@
 import { getAuthForSharedEndpointWorkspaceMembersOnly } from "@app/lib/api/auth_wrappers";
 import { createFrameSession } from "@app/lib/api/share/frame_session";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import {
   ExternalViewerSessionModel,
   SharingGrantModel,
 } from "@app/lib/resources/storage/models/files";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { FileShareScope } from "@app/types/files";
 import { frameContentType } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -175,9 +179,33 @@ describe("GET /api/v1/public/frames/[token]", () => {
       expect(res._getStatusCode()).toBe(200);
     });
 
-    it("blocks logged-in workspace member whose email has no grant", async () => {
+    it("blocks logged-in non-owner workspace member whose email has no grant", async () => {
       const { token } = await createFrameWithScope("emails_only");
-      // User IS authenticated but has no grant.
+
+      // A different workspace member who is NOT the file owner.
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+      vi.mocked(getAuthForSharedEndpointWorkspaceMembersOnly).mockResolvedValue(
+        otherAuth
+      );
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { token },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+    });
+
+    it("allows the file owner without an email grant", async () => {
+      // File is created by `user` and `auth` is for `user`, so `user` is the owner.
+      const { token } = await createFrameWithScope("emails_only");
       vi.mocked(getAuthForSharedEndpointWorkspaceMembersOnly).mockResolvedValue(
         auth
       );
@@ -189,7 +217,7 @@ describe("GET /api/v1/public/frames/[token]", () => {
 
       await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(404);
+      expect(res._getStatusCode()).toBe(200);
     });
 
     it("allows external viewer with valid session and grant", async () => {
@@ -492,6 +520,79 @@ describe("GET /api/v1/public/frames/[token]", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
+    });
+  });
+
+  describe("conversation URL", () => {
+    const createFrameLinkedToConversation = async (scope: FileShareScope) => {
+      const conversation = await ConversationModel.create({
+        workspaceId: workspace.id,
+        sId: generateRandomModelSId(),
+        title: "Test conversation",
+        requestedSpaceIds: [],
+      });
+
+      const file = await FileFactory.create(auth, user, {
+        contentType: frameContentType,
+        fileName: "test-frame.html",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+      await file.setShareScope(auth, scope);
+
+      const shareInfo = await file.getShareInfo();
+      expect(shareInfo).not.toBeNull();
+      const token = shareInfo!.shareUrl.split("/").at(-1)!;
+
+      return { file, token };
+    };
+
+    it("returns conversationUrl for the file owner even when not a participant", async () => {
+      // Owner is `user`. No participant row is created for `user` on this conversation.
+      const { token } = await createFrameLinkedToConversation(
+        "workspace_and_emails"
+      );
+      vi.mocked(getAuthForSharedEndpointWorkspaceMembersOnly).mockResolvedValue(
+        auth
+      );
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { token },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData().conversationUrl).toEqual(expect.any(String));
+    });
+
+    it("returns null conversationUrl for a non-owner workspace member who isn't a participant", async () => {
+      const { token } = await createFrameLinkedToConversation(
+        "workspace_and_emails"
+      );
+
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+      vi.mocked(getAuthForSharedEndpointWorkspaceMembersOnly).mockResolvedValue(
+        otherAuth
+      );
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { token },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData().conversationUrl).toBeNull();
     });
   });
 });

--- a/front/pages/api/v1/public/frames/[token]/index.test.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.test.ts
@@ -1,15 +1,14 @@
 import { getAuthForSharedEndpointWorkspaceMembersOnly } from "@app/lib/api/auth_wrappers";
 import { createFrameSession } from "@app/lib/api/share/frame_session";
 import { Authenticator } from "@app/lib/auth";
-import { ConversationModel } from "@app/lib/models/agent/conversation";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import {
   ExternalViewerSessionModel,
   SharingGrantModel,
 } from "@app/lib/resources/storage/models/files";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -525,12 +524,7 @@ describe("GET /api/v1/public/frames/[token]", () => {
 
   describe("conversation URL", () => {
     const createFrameLinkedToConversation = async (scope: FileShareScope) => {
-      const conversation = await ConversationModel.create({
-        workspaceId: workspace.id,
-        sId: generateRandomModelSId(),
-        title: "Test conversation",
-        requestedSpaceIds: [],
-      });
+      const conversation = await ConversationFactory.createEmpty(auth);
 
       const file = await FileFactory.create(auth, user, {
         contentType: frameContentType,

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -128,8 +128,9 @@ async function handler(
   // The file's creator should always be able to access their own frame, regardless of share scope
   // or grant list. Without this bypass, an owner viewing their own `emails_only` frame would be
   // sent through the OTP flow even though they are logged in as the file's creator.
-  const authUserId = auth?.user()?.id ?? null;
-  const isFileOwner = authUserId !== null && file.userId === authUserId;
+  const authUserModelId = auth?.user()?.id ?? null;
+  const isFileOwner =
+    authUserModelId !== null && file.userId === authUserModelId;
 
   // If workspace policy restricts to members only, block all non-member access.
   if (workspace.sharingPolicy === "workspace_only" && !auth) {

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -125,13 +125,6 @@ async function handler(
     workspace.sId
   );
 
-  // The file's creator should always be able to access their own frame, regardless of share scope
-  // or grant list. Without this bypass, an owner viewing their own `emails_only` frame would be
-  // sent through the OTP flow even though they are logged in as the file's creator.
-  const authUserModelId = auth?.user()?.id ?? null;
-  const isFileOwner =
-    authUserModelId !== null && file.userId === authUserModelId;
-
   // If workspace policy restricts to members only, block all non-member access.
   if (workspace.sharingPolicy === "workspace_only" && !auth) {
     return apiError(req, res, {
@@ -149,14 +142,19 @@ async function handler(
     shareScope === "workspace_and_emails" ||
     shareScope === "workspace"
   ) {
-    // For workspace_and_emails (and legacy "workspace"): workspace members are authorized directly.
-    // The file's creator is always authorized regardless of scope.
-    const isWorkspaceMemberWithAccess =
-      isFileOwner ||
-      ((shareScope === "workspace_and_emails" || shareScope === "workspace") &&
-        auth);
+    // The file's creator always has access to their own frame, regardless of share scope or grant
+    // list. Without this bypass, an owner viewing their own `emails_only` frame would be sent
+    // through the OTP flow even though they are logged in as the file's creator.
+    const authUserModelId = auth?.user()?.id ?? null;
+    const isFileOwner =
+      authUserModelId !== null && file.userId === authUserModelId;
 
-    if (!isWorkspaceMemberWithAccess) {
+    // For workspace_and_emails (and legacy "workspace"): workspace members are authorized directly.
+    const isWorkspaceMemberWithAccess =
+      (shareScope === "workspace_and_emails" || shareScope === "workspace") &&
+      auth;
+
+    if (!isFileOwner && !isWorkspaceMemberWithAccess) {
       // Resolve the verified email: prefer Dust session, fall back to external viewer cookie.
       let verifiedEmail: string | null = auth?.user()?.email ?? null;
       if (!verifiedEmail) {

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -125,6 +125,12 @@ async function handler(
     workspace.sId
   );
 
+  // The file's creator should always be able to access their own frame, regardless of share scope
+  // or grant list. Without this bypass, an owner viewing their own `emails_only` frame would be
+  // sent through the OTP flow even though they are logged in as the file's creator.
+  const authUserId = auth?.user()?.id ?? null;
+  const isFileOwner = authUserId !== null && file.userId === authUserId;
+
   // If workspace policy restricts to members only, block all non-member access.
   if (workspace.sharingPolicy === "workspace_only" && !auth) {
     return apiError(req, res, {
@@ -143,9 +149,11 @@ async function handler(
     shareScope === "workspace"
   ) {
     // For workspace_and_emails (and legacy "workspace"): workspace members are authorized directly.
+    // The file's creator is always authorized regardless of scope.
     const isWorkspaceMemberWithAccess =
-      (shareScope === "workspace_and_emails" || shareScope === "workspace") &&
-      auth;
+      isFileOwner ||
+      ((shareScope === "workspace_and_emails" || shareScope === "workspace") &&
+        auth);
 
     if (!isWorkspaceMemberWithAccess) {
       // Resolve the verified email: prefer Dust session, fall back to external viewer cookie.
@@ -188,15 +196,23 @@ async function handler(
   const user = auth && auth.user();
   const conversation =
     conversationId && auth
-      ? await ConversationResource.fetchById(auth, conversationId)
+      ? await ConversationResource.fetchById(auth, conversationId, {
+          // The file's creator may not be a participant of the conversation (for example,
+          // conversations created via "run_agent" deliberately skip participation registration),
+          // but they should still be able to navigate to it.
+          dangerouslySkipPermissionFiltering: isFileOwner,
+        })
       : null;
 
+  // The file's creator is treated as a conversation participant for the purposes of returning
+  // the conversation URL on the share page.
   const isParticipant =
     user && conversation && auth
-      ? await ConversationResource.isConversationParticipant(auth, {
+      ? isFileOwner ||
+        (await ConversationResource.isConversationParticipant(auth, {
           conversation: conversation.toJSON(),
           user: user.toJSON(),
-        })
+        }))
       : false;
 
   const spaceId = file.useCaseMetadata?.spaceId;
@@ -216,7 +232,8 @@ async function handler(
   res.status(200).json({
     accessToken,
     file: file.toJSON(),
-    // Only return the conversation URL if the user is a participant of the conversation.
+    // Only return the conversation URL if the user is a conversation participant or the
+    // file's creator.
     conversationUrl: isParticipant
       ? getConversationRoute(
           workspace.sId,

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -197,23 +197,15 @@ async function handler(
   const user = auth && auth.user();
   const conversation =
     conversationId && auth
-      ? await ConversationResource.fetchById(auth, conversationId, {
-          // The file's creator may not be a participant of the conversation (for example,
-          // conversations created via "run_agent" deliberately skip participation registration),
-          // but they should still be able to navigate to it.
-          dangerouslySkipPermissionFiltering: isFileOwner,
-        })
+      ? await ConversationResource.fetchById(auth, conversationId)
       : null;
 
-  // The file's creator is treated as a conversation participant for the purposes of returning
-  // the conversation URL on the share page.
   const isParticipant =
     user && conversation && auth
-      ? isFileOwner ||
-        (await ConversationResource.isConversationParticipant(auth, {
+      ? await ConversationResource.isConversationParticipant(auth, {
           conversation: conversation.toJSON(),
           user: user.toJSON(),
-        }))
+        })
       : false;
 
   const spaceId = file.useCaseMetadata?.spaceId;
@@ -233,8 +225,7 @@ async function handler(
   res.status(200).json({
     accessToken,
     file: file.toJSON(),
-    // Only return the conversation URL if the user is a conversation participant or the
-    // file's creator.
+    // Only return the conversation URL if the user is a participant of the conversation.
     conversationUrl: isParticipant
       ? getConversationRoute(
           workspace.sId,

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -29,27 +29,6 @@ import type { WorkspaceType } from "@app/types/user";
 import type { Transaction } from "sequelize";
 
 export class ConversationFactory {
-  // Lightweight factory for tests that need a conversation reference but no messages or
-  // participants. Avoids the AgentConfiguration setup required by `create`.
-  static async createEmpty(
-    auth: Authenticator,
-    {
-      title = "Test Conversation",
-      visibility = "unlisted",
-      spaceId,
-    }: {
-      title?: string;
-      visibility?: ConversationVisibility;
-      spaceId?: ModelId;
-    } = {}
-  ): Promise<ConversationType> {
-    return createConversation(auth, {
-      title,
-      visibility,
-      spaceId: spaceId ?? null,
-    });
-  }
-
   static async create(
     auth: Authenticator,
     {

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -29,6 +29,27 @@ import type { WorkspaceType } from "@app/types/user";
 import type { Transaction } from "sequelize";
 
 export class ConversationFactory {
+  // Lightweight factory for tests that need a conversation reference but no messages or
+  // participants. Avoids the AgentConfiguration setup required by `create`.
+  static async createEmpty(
+    auth: Authenticator,
+    {
+      title = "Test Conversation",
+      visibility = "unlisted",
+      spaceId,
+    }: {
+      title?: string;
+      visibility?: ConversationVisibility;
+      spaceId?: ModelId;
+    } = {}
+  ): Promise<ConversationType> {
+    return createConversation(auth, {
+      title,
+      visibility,
+      spaceId: spaceId ?? null,
+    });
+  }
+
   static async create(
     auth: Authenticator,
     {


### PR DESCRIPTION
## Description

The public frame endpoint had no special handling for the file's creator, so the owner of an `emails_only` frame would be sent through the OTP flow on their own frame.

Treat `auth.user().id === file.userId` as an unconditional bypass: the owner always passes the access gate.

## Tests

Added

## Risk

Low

## Deploy Plan

Front