### PR TITLE
Add files MCP server

### DIFF
--- a/front/components/assistant/conversation/files_panel/FileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorer.tsx
@@ -17,7 +17,10 @@ import { useConversationSandboxStatus } from "@app/hooks/conversations/useConver
 import { useSendNotification } from "@app/hooks/useNotification";
 import { downloadSandboxFile } from "@app/lib/swr/files";
 import logger from "@app/logger/logger";
-import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
+import type {
+  GCSMountEntry,
+  GCSMountFileEntry,
+} from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isInteractiveContentType } from "@app/types/files";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -90,7 +93,7 @@ function FileExplorerViewToggle({
 
 interface NewFileExplorerProps {
   conversation: ConversationWithoutContentType;
-  files: GCSMountFileEntry[];
+  files: GCSMountEntry[];
   isLoading: boolean;
   onClose: () => void;
   owner: LightWorkspaceType;
@@ -123,9 +126,13 @@ export function NewFileExplorer({
 
   // Map from tree-relative path → original GCSMountFileEntry (for metadata).
   // Tree-relative path = entry.path with the use-case prefix (first segment) stripped.
+  // Only file entries are indexed; directory entries are inferred from paths by buildSandboxTree.
   const entryByRelativePath = useMemo(() => {
     const map = new Map<string, GCSMountFileEntry>();
     for (const f of files) {
+      if (f.isDirectory) {
+        continue;
+      }
       const slashIdx = f.path.indexOf("/");
       const relativePath = slashIdx >= 0 ? f.path.slice(slashIdx + 1) : f.path;
       map.set(relativePath, f);
@@ -148,7 +155,7 @@ export function NewFileExplorer({
       if (node.name.startsWith(".")) {
         continue;
       }
-      if (node.contentType === "inode/directory") {
+      if (node.isDirectory) {
         folders.push(node);
       } else {
         const entry = entryByRelativePath.get(node.path);

--- a/front/components/assistant/conversation/files_panel/SandboxTab.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxTab.tsx
@@ -140,8 +140,8 @@ export function SandboxTab({
   const files = useMemo(
     () =>
       sandboxFiles.filter(
-        (f) =>
-          !f.fileName.startsWith(".") && f.contentType !== "inode/directory"
+        (f): f is GCSMountFileEntry =>
+          !f.isDirectory && !f.fileName.startsWith(".")
       ),
     [sandboxFiles]
   );

--- a/front/components/assistant/conversation/files_panel/types.ts
+++ b/front/components/assistant/conversation/files_panel/types.ts
@@ -30,7 +30,8 @@ export type ConversationAttachmentRow = {
 export type SandboxTreeNode = {
   name: string;
   path: string;
-  contentType: string;
+  isDirectory: boolean;
+  contentType: string | null;
   fileId: string | null;
   children: SandboxTreeNode[];
 };

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -166,9 +166,7 @@ export function conversationAttachmentToRow(
  * use-case prefix (first segment) is stripped so tree paths start at the
  * sandbox working directory root.
  */
-export function buildSandboxTree(
-  entries: GCSMountEntry[]
-): SandboxTreeNode[] {
+export function buildSandboxTree(entries: GCSMountEntry[]): SandboxTreeNode[] {
   const root: SandboxTreeNode[] = [];
   const nodeMap = new Map<string, SandboxTreeNode>();
 

--- a/front/components/assistant/conversation/files_panel/utils.ts
+++ b/front/components/assistant/conversation/files_panel/utils.ts
@@ -6,7 +6,7 @@ import {
   isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
-import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
+import type { GCSMountEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import {
   frameSlideshowContentType,
   isInteractiveContentType,
@@ -167,12 +167,12 @@ export function conversationAttachmentToRow(
  * sandbox working directory root.
  */
 export function buildSandboxTree(
-  entries: GCSMountFileEntry[]
+  entries: GCSMountEntry[]
 ): SandboxTreeNode[] {
   const root: SandboxTreeNode[] = [];
   const nodeMap = new Map<string, SandboxTreeNode>();
 
-  for (const entry of entries) {
+  for (const entry of entries.filter((e) => !e.isDirectory)) {
     const slashIdx = entry.path.indexOf("/");
     const relativePath =
       slashIdx >= 0 ? entry.path.slice(slashIdx + 1) : entry.path;
@@ -191,7 +191,8 @@ export function buildSandboxTree(
         const dirNode: SandboxTreeNode = {
           name: parts[i],
           path: currentPath,
-          contentType: "inode/directory",
+          isDirectory: true,
+          contentType: null,
           fileId: null,
           children: [],
         };
@@ -214,6 +215,7 @@ export function buildSandboxTree(
     const fileNode: SandboxTreeNode = {
       name: parts[parts.length - 1],
       path: relativePath,
+      isDirectory: false,
       contentType: entry.contentType,
       fileId: entry.fileId,
       children: [],

--- a/front/hooks/conversations/useConversationSandboxFiles.ts
+++ b/front/hooks/conversations/useConversationSandboxFiles.ts
@@ -1,6 +1,6 @@
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
-  GCSMountFileEntry,
+  GCSMountEntry,
   GetConversationFilesResponseBody,
 } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -30,7 +30,7 @@ export function useConversationSandboxFiles({
   const disabled = options?.disabled;
 
   return {
-    sandboxFiles: data?.files ?? emptyArray<GCSMountFileEntry>(),
+    sandboxFiles: data?.files ?? emptyArray<GCSMountEntry>(),
     isSandboxFilesLoading: !disabled && !error && !data,
     isSandboxFilesError: error,
     mutateSandboxFiles: mutate,

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -109,6 +109,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "generate_file": "never_ask",
     "get_supported_source_formats_for_output_format": "never_ask",
   },
+  "files": {
+    "list": "never_ask",
+  },
   "freshservice": {
     "add_ticket_note": "low",
     "add_ticket_reply": "low",

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -71,6 +71,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "ask_user_question", id: 1028 },
       { name: "wakeups", id: 1031 },
       { name: "plan_mode", id: 1032 },
+      { name: "files", id: 1033 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -18,6 +18,7 @@ import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot
 import { COMMON_UTILITIES_SERVER } from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
+import { FILES_SERVER } from "@app/lib/api/actions/servers/files/metadata";
 import { DATA_SOURCES_FILE_SYSTEM_SERVER } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
 import { DATABRICKS_SERVER } from "@app/lib/api/actions/servers/databricks/metadata";
@@ -149,6 +150,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "clari_copilot",
   "confluence",
   "conversation_files",
+  "files",
   "databricks",
   "data_sources_file_system",
   DATA_WAREHOUSE_SERVER_NAME,
@@ -1134,6 +1136,18 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: PLAN_MODE_SERVER,
+  },
+  files: {
+    id: 1033,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) =>
+      !featureFlags.includes("new_file_explorer"),
+    isPreview: false,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: FILES_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -18,13 +18,13 @@ import { CLARI_COPILOT_SERVER } from "@app/lib/api/actions/servers/clari_copilot
 import { COMMON_UTILITIES_SERVER } from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { CONFLUENCE_SERVER } from "@app/lib/api/actions/servers/confluence/metadata";
 import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversation_files/metadata";
-import { FILES_SERVER } from "@app/lib/api/actions/servers/files/metadata";
 import { DATA_SOURCES_FILE_SYSTEM_SERVER } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
 import { DATABRICKS_SERVER } from "@app/lib/api/actions/servers/databricks/metadata";
 import { EXTRACT_DATA_SERVER } from "@app/lib/api/actions/servers/extract_data/metadata";
 import { FATHOM_SERVER } from "@app/lib/api/actions/servers/fathom/metadata";
 import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_generation/metadata";
+import { FILES_SERVER } from "@app/lib/api/actions/servers/files/metadata";
 import { FRESHSERVICE_SERVER } from "@app/lib/api/actions/servers/freshservice/metadata";
 import { FRONT_SERVER } from "@app/lib/api/actions/servers/front/metadata";
 import { GITHUB_SERVER } from "@app/lib/api/actions/servers/github/metadata";

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -22,6 +22,7 @@ import { default as databricksServer } from "@app/lib/api/actions/servers/databr
 import { default as extractDataServer } from "@app/lib/api/actions/servers/extract_data";
 import { default as fathomServer } from "@app/lib/api/actions/servers/fathom";
 import { default as fileGenerationServer } from "@app/lib/api/actions/servers/file_generation";
+import { default as filesServer } from "@app/lib/api/actions/servers/files";
 import { default as freshserviceServer } from "@app/lib/api/actions/servers/freshservice";
 import { default as frontServer } from "@app/lib/api/actions/servers/front";
 import { default as githubServer } from "@app/lib/api/actions/servers/github";
@@ -90,7 +91,7 @@ function isAdvancedSearchMode(agentLoopContext?: AgentLoopContextType) {
   return (
     (agentLoopContext?.runContext &&
       isLightServerSideMCPToolConfiguration(
-        agentLoopContext.runContext.toolConfiguration
+        agentLoopContext.runContext.toolConfiguration,
       ) &&
       agentLoopContext.runContext.toolConfiguration.additionalConfiguration[
         ADVANCED_SEARCH_SWITCH
@@ -98,7 +99,7 @@ function isAdvancedSearchMode(agentLoopContext?: AgentLoopContextType) {
       ] === true) ||
     (agentLoopContext?.listToolsContext &&
       isServerSideMCPServerConfiguration(
-        agentLoopContext.listToolsContext.agentActionConfiguration
+        agentLoopContext.listToolsContext.agentActionConfiguration,
       ) &&
       agentLoopContext.listToolsContext.agentActionConfiguration
         .additionalConfiguration[ADVANCED_SEARCH_SWITCH] === true)
@@ -114,7 +115,7 @@ export async function getInternalMCPServer(
     internalMCPServerName: InternalMCPServerNameType;
     mcpServerId: string;
   },
-  agentLoopContext?: AgentLoopContextType
+  agentLoopContext?: AgentLoopContextType,
 ): Promise<McpServer> {
   switch (internalMCPServerName) {
     case "github":
@@ -191,6 +192,8 @@ export async function getInternalMCPServer(
       return dataSourcesFileSystemServer(auth, agentLoopContext);
     case "conversation_files":
       return conversationFilesServer(auth, agentLoopContext);
+    case "files":
+      return filesServer(auth, agentLoopContext);
     case "databricks":
       return databricksServer(auth, agentLoopContext);
     case "jira":

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -91,7 +91,7 @@ function isAdvancedSearchMode(agentLoopContext?: AgentLoopContextType) {
   return (
     (agentLoopContext?.runContext &&
       isLightServerSideMCPToolConfiguration(
-        agentLoopContext.runContext.toolConfiguration,
+        agentLoopContext.runContext.toolConfiguration
       ) &&
       agentLoopContext.runContext.toolConfiguration.additionalConfiguration[
         ADVANCED_SEARCH_SWITCH
@@ -99,7 +99,7 @@ function isAdvancedSearchMode(agentLoopContext?: AgentLoopContextType) {
       ] === true) ||
     (agentLoopContext?.listToolsContext &&
       isServerSideMCPServerConfiguration(
-        agentLoopContext.listToolsContext.agentActionConfiguration,
+        agentLoopContext.listToolsContext.agentActionConfiguration
       ) &&
       agentLoopContext.listToolsContext.agentActionConfiguration
         .additionalConfiguration[ADVANCED_SEARCH_SWITCH] === true)
@@ -115,7 +115,7 @@ export async function getInternalMCPServer(
     internalMCPServerName: InternalMCPServerNameType;
     mcpServerId: string;
   },
-  agentLoopContext?: AgentLoopContextType,
+  agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> {
   switch (internalMCPServerName) {
     case "github":

--- a/front/lib/api/actions/servers/files/index.ts
+++ b/front/lib/api/actions/servers/files/index.ts
@@ -8,7 +8,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
   auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType,
+  agentLoopContext?: AgentLoopContextType
 ): McpServer {
   const server = makeInternalMCPServer(FILES_SERVER_NAME);
 

--- a/front/lib/api/actions/servers/files/index.ts
+++ b/front/lib/api/actions/servers/files/index.ts
@@ -1,0 +1,23 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/files/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType,
+): McpServer {
+  const server = makeInternalMCPServer(FILES_SERVER_NAME);
+
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: FILES_SERVER_NAME,
+    });
+  }
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -1,0 +1,53 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const FILES_SERVER_NAME = "files" as const;
+export const FILES_LIST_ACTION_NAME = "list" as const;
+
+export const FILES_TOOLS_METADATA = createToolsRecord({
+  [FILES_LIST_ACTION_NAME]: {
+    description:
+      "List all files in the conversation file system. " +
+      "Returns one entry per file with its scoped path (e.g. `conversation/chart.png`), " +
+      "content type, and size in KB. " +
+      "Scoped paths can be used to reference or display a file in a response, " +
+      "or passed to other tools that accept a file path.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing available files",
+      done: "Listed available files",
+    },
+  },
+});
+
+export const FILES_SERVER = {
+  serverInfo: {
+    name: FILES_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "File system interface scoped to the current conversation. " +
+      "Gives the agent visibility into all files present in the conversation: " +
+      "files uploaded by the user, files generated during execution (e.g. charts, " +
+      "exports, processed data produced by code run in the sandbox), and files produced " +
+      "as results of tool use. " +
+      "Files are identified by scoped paths such as `conversation/chart.png` that can " +
+      "be used to reference, display, or link files in agent responses.",
+    authorization: null,
+    icon: "ActionDocumentTextIcon" as const,
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(FILES_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(FILES_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -1,0 +1,10 @@
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  FILES_LIST_ACTION_NAME,
+  FILES_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/files/metadata";
+import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
+
+export const TOOLS = buildTools(FILES_TOOLS_METADATA, {
+  [FILES_LIST_ACTION_NAME]: listHandler,
+});

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -29,7 +29,7 @@ export async function listHandler(
   }
 
   // Build the set of all ancestor dir paths that contain at least one file.
-  // O(m × depth) — depth is bounded in practice (< 10 levels).
+  // O(m × depth). Deph is typically small.
   const nonEmptyDirPaths = new Set<string>();
   for (const file of files) {
     const parts = file.path.split("/");

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -4,16 +4,18 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { listGCSMountFiles } from "@app/lib/api/files/gcs_mount/files";
+import { stripMimeParameters } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 
 export async function listHandler(
   _params: Record<string, never>,
-  { auth, agentLoopContext }: ToolHandlerExtra,
+  { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const conversation = agentLoopContext?.runContext?.conversation;
   if (!conversation) {
     return new Err(new MCPError("No conversation context available."));
   }
+
   const entries = await listGCSMountFiles(auth, {
     useCase: "conversation",
     conversationId: conversation.sId,
@@ -22,10 +24,12 @@ export async function listHandler(
   if (files.length === 0) {
     return new Ok([{ type: "text", text: "No files available." }]);
   }
+
   const lines = files.map((f) => {
-    const mimeType = f.contentType.split(";")[0].trim();
+    const mimeType = stripMimeParameters(f.contentType);
     const kb = Math.ceil(f.sizeBytes / 1024);
     return `${f.path} (${mimeType}, ${kb} KB)`;
   });
+
   return new Ok([{ type: "text", text: lines.join("\n") }]);
 }

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -6,6 +6,7 @@ import type {
 import { listGCSMountFiles } from "@app/lib/api/files/gcs_mount/files";
 import { stripMimeParameters } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
+import partition from "lodash/partition";
 
 export async function listHandler(
   _params: Record<string, never>,
@@ -21,16 +22,26 @@ export async function listHandler(
     conversationId: conversation.sId,
   });
 
-  const files = entries.filter((f) => !f.isDirectory);
-  if (files.length === 0) {
+  const [dirs, files] = partition(entries, (e) => e.isDirectory);
+
+  if (dirs.length === 0 && files.length === 0) {
     return new Ok([{ type: "text", text: "No files available." }]);
   }
 
-  const lines = files.map((f) => {
-    const mimeType = stripMimeParameters(f.contentType);
-    const kb = Math.ceil(f.sizeBytes / 1024);
-    return `${f.path} (${mimeType}, ${kb} KB)`;
-  });
+  const lines: string[] = [];
+
+  for (const dir of dirs) {
+    const hasChildren = files.some((f) => f.path.startsWith(`${dir.path}/`));
+    if (!hasChildren) {
+      lines.push(`${dir.path}/ [empty directory]`);
+    }
+  }
+
+  for (const file of files) {
+    const mimeType = stripMimeParameters(file.contentType);
+    const kb = Math.ceil(file.sizeBytes / 1024);
+    lines.push(`${file.path} (${mimeType}, ${kb} KB)`);
+  }
 
   return new Ok([{ type: "text", text: lines.join("\n") }]);
 }

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -20,7 +20,8 @@ export async function listHandler(
     useCase: "conversation",
     conversationId: conversation.sId,
   });
-  const files = entries.filter((f) => f.contentType !== "inode/directory");
+
+  const files = entries.filter((f) => !f.isDirectory);
   if (files.length === 0) {
     return new Ok([{ type: "text", text: "No files available." }]);
   }

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -1,0 +1,31 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { listGCSMountFiles } from "@app/lib/api/files/gcs_mount/files";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function listHandler(
+  _params: Record<string, never>,
+  { auth, agentLoopContext }: ToolHandlerExtra,
+): Promise<ToolHandlerResult> {
+  const conversation = agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(new MCPError("No conversation context available."));
+  }
+  const entries = await listGCSMountFiles(auth, {
+    useCase: "conversation",
+    conversationId: conversation.sId,
+  });
+  const files = entries.filter((f) => f.contentType !== "inode/directory");
+  if (files.length === 0) {
+    return new Ok([{ type: "text", text: "No files available." }]);
+  }
+  const lines = files.map((f) => {
+    const mimeType = f.contentType.split(";")[0].trim();
+    const kb = Math.ceil(f.sizeBytes / 1024);
+    return `${f.path} (${mimeType}, ${kb} KB)`;
+  });
+  return new Ok([{ type: "text", text: lines.join("\n") }]);
+}

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -28,11 +28,20 @@ export async function listHandler(
     return new Ok([{ type: "text", text: "No files available." }]);
   }
 
+  // Build the set of all ancestor dir paths that contain at least one file.
+  // O(m × depth) — depth is bounded in practice (< 10 levels).
+  const nonEmptyDirPaths = new Set<string>();
+  for (const file of files) {
+    const parts = file.path.split("/");
+    for (let i = 1; i < parts.length - 1; i++) {
+      nonEmptyDirPaths.add(parts.slice(0, i + 1).join("/"));
+    }
+  }
+
   const lines: string[] = [];
 
   for (const dir of dirs) {
-    const hasChildren = files.some((f) => f.path.startsWith(`${dir.path}/`));
-    if (!hasChildren) {
+    if (!nonEmptyDirPaths.has(dir.path)) {
       lines.push(`${dir.path}/ [empty directory]`);
     }
   }

--- a/front/lib/api/assistant/jit/files.ts
+++ b/front/lib/api/assistant/jit/files.ts
@@ -1,40 +1,28 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 
 /**
- * Get the skill_management MCP server if the agent has skills that can be enabled.
+ * Get the files MCP server for conversation file system access.
  */
-export async function getSkillManagementServer(
-  auth: Authenticator,
-  agentConfiguration: AgentConfigurationType,
+export function getFilesServer(
+  agentConfiguration: LightAgentConfigurationType,
   conversation: ConversationWithoutContentType,
   autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
-): Promise<ServerSideMCPServerConfigurationType | null> {
-  const { equippedSkills } = await SkillResource.listForAgentLoop(auth, {
-    agentConfiguration,
-    conversation,
-  });
+): ServerSideMCPServerConfigurationType | null {
+  const filesView = autoInternalViews.get("files") ?? null;
 
-  if (equippedSkills.length === 0) {
-    return null;
-  }
-
-  const skillManagementView = autoInternalViews.get("skill_management") ?? null;
-
-  if (!skillManagementView) {
+  if (!filesView) {
     logger.warn(
       {
         agentConfigurationId: agentConfiguration.sId,
         conversationId: conversation.sId,
       },
-      "MCP server view not found for skill_management. Ensure auto tools are created."
+      "MCP server view not found for files. Ensure auto tools are created."
     );
     return null;
   }
@@ -43,9 +31,10 @@ export async function getSkillManagementServer(
     id: -1,
     sId: generateRandomModelSId(),
     type: "mcp_server_configuration",
-    name: "skill_management",
+    name: filesView.name ?? "files",
     description:
-      skillManagementView.description ?? "Enable skills for the conversation.",
+      filesView.description ??
+      "File system interface scoped to the current conversation.",
     dataSources: null,
     tables: null,
     childAgentId: null,
@@ -54,8 +43,8 @@ export async function getSkillManagementServer(
     secretName: null,
     dustProject: null,
     additionalConfiguration: {},
-    mcpServerViewId: skillManagementView.sId,
+    mcpServerViewId: filesView.sId,
     dustAppConfiguration: null,
-    internalMCPServerId: skillManagementView.mcpServerId,
+    internalMCPServerId: filesView.mcpServerId,
   };
 }

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -7,6 +7,7 @@ import {
   getConversationFilesServer,
   getConversationMCPServers,
 } from "@app/lib/api/assistant/jit/conversation";
+import { getFilesServer } from "@app/lib/api/assistant/jit/files";
 import { getFolderSearchServers } from "@app/lib/api/assistant/jit/folder";
 import { getQueryTablesServer } from "@app/lib/api/assistant/jit/query_tables_v2";
 import { getSchedulesManagementServer } from "@app/lib/api/assistant/jit/schedules_management";
@@ -17,6 +18,13 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
+
+const ALWAYS_PREFETCHED_MCP_SERVERS: AutoInternalMCPServerNameType[] = [
+  "common_utilities",
+  "files",
+  "schedules_management",
+  "skill_management",
+];
 
 /**
  * Servers whose tool specifications are mostly always added or never added.
@@ -53,6 +61,13 @@ async function getUnconditionalJITServers(
     autoInternalViews
   );
   servers.push(skillManagementServer);
+
+  const filesServer = getFilesServer(
+    agentConfiguration,
+    conversation,
+    autoInternalViews
+  );
+  servers.push(filesServer);
 
   return removeNulls(servers);
 }
@@ -142,29 +157,28 @@ export async function getJITServers(
   servers: ServerSideMCPServerConfigurationType[];
   hasConditionalJITTools: boolean;
 }> {
-  const namesToFetch: AutoInternalMCPServerNameType[] = [
-    "common_utilities",
-    "skill_management",
-    "schedules_management",
-  ];
+  const mcpServersToFetch = new Set<AutoInternalMCPServerNameType>(
+    ALWAYS_PREFETCHED_MCP_SERVERS
+  );
+
   if (attachments.length > 0) {
-    namesToFetch.push("conversation_files");
+    mcpServersToFetch.add("conversation_files");
     if (attachments.some((a) => a.isQueryable)) {
-      namesToFetch.push("query_tables_v2");
+      mcpServersToFetch.add("query_tables_v2");
     }
     if (
       attachments.some(
         (a) => isContentNodeAttachmentType(a) && isSearchableFolder(a)
       )
     ) {
-      namesToFetch.push("search");
+      mcpServersToFetch.add("search");
     }
   }
 
   const autoInternalViews =
     await MCPServerViewResource.getMCPServerViewsForAutoInternalToolsAsMap(
       auth,
-      namesToFetch
+      Array.from(mcpServersToFetch)
     );
 
   const [baseServers, conditionalServers] = await Promise.all([

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -7,20 +7,53 @@ import { isSupportedImageContentType } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 
-export type GCSMountFileEntry = {
+type GCSMountEntryBase = {
   fileName: string;
   path: string;
   sizeBytes: number;
-  contentType: string;
   lastModifiedMs: number;
+};
+
+export type GCSMountDirectoryEntry = GCSMountEntryBase & {
+  isDirectory: true;
+};
+
+export type GCSMountFileEntry = GCSMountEntryBase & {
+  isDirectory: false;
+  contentType: string;
   fileId: string | null;
   thumbnailUrl: string | null;
 };
+
+export type GCSMountEntry = GCSMountDirectoryEntry | GCSMountFileEntry;
 
 type GCSMountPoint = {
   useCase: "conversation";
   conversationId: string;
 };
+
+function makeDirectoryEntry(
+  {
+    fileName,
+    relativeFilePath,
+    sizeBytes,
+    lastModifiedMs,
+  }: {
+    fileName: string;
+    relativeFilePath: string;
+    sizeBytes: number;
+    lastModifiedMs: number;
+  },
+  scope: GCSMountPoint
+): GCSMountDirectoryEntry {
+  return {
+    isDirectory: true,
+    fileName,
+    path: `${scope.useCase}/${relativeFilePath}`,
+    sizeBytes,
+    lastModifiedMs,
+  };
+}
 
 function makeFileEntry(
   {
@@ -42,6 +75,7 @@ function makeFileEntry(
   workspaceId: string
 ): GCSMountFileEntry {
   return {
+    isDirectory: false,
     fileName,
     path: `${scope.useCase}/${relativeFilePath}`,
     sizeBytes,
@@ -60,7 +94,7 @@ function makeFileEntry(
 export async function listGCSMountFiles(
   auth: Authenticator,
   scope: GCSMountPoint
-): Promise<GCSMountFileEntry[]> {
+): Promise<GCSMountEntry[]> {
   const owner = auth.getNonNullableWorkspace();
 
   let prefix: string;
@@ -79,8 +113,6 @@ export async function listGCSMountFiles(
   const gcsFiles = await bucket.getFiles({ prefix, maxResults: 200 });
 
   // GCS folder placeholders are zero-byte objects whose path ends with "/".
-  // Split them out early so we can represent them as inode/directory entries
-  // without fetching FileResources for them.
   const folderPlaceholders = gcsFiles.filter((f) => f.name.endsWith("/"));
   const regularFiles = gcsFiles.filter((f) => {
     if (f.name.endsWith("/")) {
@@ -102,30 +134,30 @@ export async function listGCSMountFiles(
     }
   }
 
-  const folderEntries: GCSMountFileEntry[] = folderPlaceholders.flatMap((f) => {
-    const trimmed = f.name.replace(/\/$/, "");
-    const name = trimmed.split("/").pop() ?? "";
-    // Skip hidden folders (name starting with ".").
-    if (!name || name.startsWith(".")) {
-      return [];
+  const folderEntries: GCSMountDirectoryEntry[] = folderPlaceholders.flatMap(
+    (f) => {
+      const trimmed = f.name.replace(/\/$/, "");
+      const name = trimmed.split("/").pop() ?? "";
+      // Skip hidden folders (name starting with ".").
+      if (!name || name.startsWith(".")) {
+        return [];
+      }
+
+      return [
+        makeDirectoryEntry(
+          {
+            fileName: name,
+            relativeFilePath: trimmed.slice(prefix.length),
+            sizeBytes: 0,
+            lastModifiedMs: isString(f.metadata.updated)
+              ? new Date(f.metadata.updated).getTime()
+              : 0,
+          },
+          scope
+        ),
+      ];
     }
-    return [
-      makeFileEntry(
-        {
-          fileName: name,
-          relativeFilePath: trimmed.slice(prefix.length),
-          sizeBytes: 0,
-          contentType: "inode/directory",
-          lastModifiedMs: isString(f.metadata.updated)
-            ? new Date(f.metadata.updated).getTime()
-            : 0,
-          fileId: null,
-        },
-        scope,
-        owner.sId
-      ),
-    ];
-  });
+  );
 
   const fileEntries: GCSMountFileEntry[] = regularFiles.map((gcsFile) => {
     const metadata = gcsFile.metadata;

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -63,6 +63,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   data_sources_file_system: "retrieval",
   include_data: "retrieval",
   conversation_files: "retrieval",
+  files: "retrieval",
 
   // Deep research — web search, browsing, HTTP.
   "web_search_&_browse": "deep_research",
@@ -143,7 +144,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
 };
 
 export function getToolCategory(
-  internalMCPServerName: string | null
+  internalMCPServerName: string | null,
 ): ToolCategory {
   if (
     !internalMCPServerName ||
@@ -340,7 +341,7 @@ export function buildToolUseEvents({
 
   return [...groups.values()].map(({ action, count, totalDurationMs }) => ({
     transaction_id: truncateTransactionId(
-      `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`
+      `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`,
     ),
     customer_id: workspaceId,
     event_type: "tool_use_v3",
@@ -357,7 +358,7 @@ export function buildToolUseEvents({
       tool_name: truncatePropertyValue(action.toolName),
       mcp_server_id: truncatePropertyValue(action.mcpServerId ?? ""),
       internal_mcp_server_name: truncatePropertyValue(
-        action.internalMCPServerName ?? ""
+        action.internalMCPServerName ?? "",
       ),
       tool_category: getToolCategory(action.internalMCPServerName),
       // Constant grouping key — used as presentation_group_key in Metronome to

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -144,7 +144,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
 };
 
 export function getToolCategory(
-  internalMCPServerName: string | null,
+  internalMCPServerName: string | null
 ): ToolCategory {
   if (
     !internalMCPServerName ||
@@ -341,7 +341,7 @@ export function buildToolUseEvents({
 
   return [...groups.values()].map(({ action, count, totalDurationMs }) => ({
     transaction_id: truncateTransactionId(
-      `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`,
+      `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`
     ),
     customer_id: workspaceId,
     event_type: "tool_use_v3",
@@ -358,7 +358,7 @@ export function buildToolUseEvents({
       tool_name: truncatePropertyValue(action.toolName),
       mcp_server_id: truncatePropertyValue(action.mcpServerId ?? ""),
       internal_mcp_server_name: truncatePropertyValue(
-        action.internalMCPServerName ?? "",
+        action.internalMCPServerName ?? ""
       ),
       tool_category: getToolCategory(action.internalMCPServerName),
       // Constant grouping key — used as presentation_group_key in Metronome to

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/index.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
+  type GCSMountEntry,
   type GCSMountFileEntry,
   listGCSMountFiles,
 } from "@app/lib/api/files/gcs_mount/files";
@@ -11,10 +12,10 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type { GCSMountFileEntry };
+export type { GCSMountEntry, GCSMountFileEntry };
 
 export type GetConversationFilesResponseBody = {
-  files: GCSMountFileEntry[];
+  files: GCSMountEntry[];
 };
 
 async function handler(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Making progress towards only leveraging the more recent representation of files system. This PR introduces the files internal MCP server, scoped to the current conversation (and project tomorrow).

It exposes a single list tool that returns the files available to the agent as a flat list of scoped paths.

Example:
```
onversation/empty_folder/ [empty directory]
conversation/random_data.csv (text/csv, 1 KB)
conversation/random_folder/config.yaml (application/yaml, 1 KB)
conversation/random_folder/readme.md (text/markdown, 1 KB)
conversation/random_folder/script.py (text/x-python, 1 KB)
conversation/random_notes.txt (text/plain, 1 KB)
conversation/random_users.json (application/json, 1 KB)
```

The representation is deliberately flat rather than a tree. The alternative would have the model receive a nested structure and reconstruct full paths by traversing parent nodes, which introduces unnecessary reasoning overhead and room for error. A pre-computed scoped path is immediately usable: the model can reference, cat, or pass it to another tool without any path
construction. The folder structure is still readable from the paths themselves when the agent needs to reason about it.

The server is registered with auto_hidden_builder availability, gated behind the `new_file_explorer` FF. If FF is on the server is always available.

The current `conversation_files` is not retired in this PR. The files server runs alongside it. Retirement, along with read/cat tool equivalents, is a follow-up once the FF is on by default.

Gave some love to `GCSMountEntry` is to have a proper discriminated union and stop leaking GCS implementation or emulating with high fidelity a Linux system.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
