### PR TITLE
fix: avoid double loader on inline activity items during pending tool calls

### DIFF
--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -154,9 +154,6 @@ export function InlineActivitySteps({
   const showActiveThinking = !isDone && isThinking;
   const showActiveWriting = !isDone && isWriting;
   const activePendingToolCalls = showPendingToolCalls ? pendingToolCalls : [];
-  const showTrailingLoader =
-    (showActiveThinking && !chainOfThought) ||
-    (showActiveWriting && !agentMessage.content);
   const completedActionIds = new Set(
     completedSteps.filter((s) => s.type === "action").map((s) => s.id)
   );
@@ -164,6 +161,13 @@ export function InlineActivitySteps({
     !isDone && isActing && isAgentMessageWithActions
       ? actions.filter((a) => !completedActionIds.has(`action-${a.id}`))
       : [];
+  const isStreamingWithoutContent =
+    (showActiveThinking && !chainOfThought) ||
+    (showActiveWriting && !agentMessage.content);
+  const hasActiveSpinnerRow =
+    activeActions.length > 0 || activePendingToolCalls.length > 0;
+  // Only show the trailing loader when nothing else already renders one.
+  const showTrailingLoader = isStreamingWithoutContent && !hasActiveSpinnerRow;
 
   const hasContent =
     completedSteps.length > 0 ||


### PR DESCRIPTION
## Description

In InlineActivitySteps, the showTrailingLoader condition didn't consider that a pending-tool-call row (e.g. "Creating new Frame") already renders its own spinner. When the agent state was thinking with empty chainOfThought AND a pending tool call was being streamed in (the brief window before a tool starts executing), both spinners rendered, producing two loaders at once.

Gated showTrailingLoader on !hasActiveSpinnerRow so it only shows when no active action / pending tool call row is already displaying a spinner.

Fixes https://github.com/dust-tt/tasks/issues/7895

## Tests

Locally. Before: 

<kbd>
<img width="543" height="372" alt="Screenshot 2026-04-29 at 15 12 35" src="https://github.com/user-attachments/assets/67afc3a3-4b72-44ef-8b80-97f619cb3687" />
</kbd>


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 