### PR TITLE
[front] feat: Metronome Enterprise upgrade flow via package + scheduled start

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -127,7 +127,6 @@ export function WorkspacePage() {
 
   const {
     activeSubscription,
-    hasMetronomeBilling,
     hasDummyFeature,
     membersCount,
     metronomeCustomerId,
@@ -228,7 +227,6 @@ export function WorkspacePage() {
                   subscription={activeSubscription}
                   subscriptions={subscriptions}
                   programmaticUsageConfig={programmaticUsageConfig}
-                  hasMetronomeBilling={hasMetronomeBilling}
                 />
               </TabsContent>
               <TabsContent value="planlimitations">

--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -79,12 +79,18 @@ export function InputField<T extends FieldValues>({
   title,
   type,
   placeholder,
+  min,
+  step,
 }: {
   control: Control<T>;
   name: Path<T>;
   title?: string;
-  type?: "text" | "number";
+  type?: "text" | "number" | "datetime-local";
   placeholder?: string;
+  /** Native `min` attribute, useful for `number` and `datetime-local`. */
+  min?: string;
+  /** Native `step` attribute, useful for `number` and `datetime-local`. */
+  step?: number | string;
 }) {
   return (
     <PokeFormField
@@ -97,6 +103,8 @@ export function InputField<T extends FieldValues>({
             <Input
               placeholder={placeholder ?? name}
               type={type}
+              min={min}
+              step={step}
               {...field}
               value={field.value}
               onChange={

--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -81,6 +81,7 @@ export function InputField<T extends FieldValues>({
   placeholder,
   min,
   step,
+  transformValue,
 }: {
   control: Control<T>;
   name: Path<T>;
@@ -91,6 +92,8 @@ export function InputField<T extends FieldValues>({
   min?: string;
   /** Native `step` attribute, useful for `number` and `datetime-local`. */
   step?: number | string;
+  /** Optional transform applied to the raw string value before updating the form. */
+  transformValue?: (value: string) => string | number;
 }) {
   return (
     <PokeFormField
@@ -107,16 +110,22 @@ export function InputField<T extends FieldValues>({
               step={step}
               {...field}
               value={field.value}
-              onChange={
-                type === "number"
-                  ? (e) => {
-                      const parsed = Number(e.target.value);
-                      if (isFinite(parsed)) {
-                        field.onChange(parsed);
-                      }
-                    }
-                  : field.onChange
-              }
+              onChange={(e) => {
+                if (transformValue) {
+                  field.onChange(transformValue(e.target.value));
+                  return;
+                }
+
+                if (type === "number") {
+                  const parsed = Number(e.target.value);
+                  if (isFinite(parsed)) {
+                    field.onChange(parsed);
+                  }
+                  return;
+                }
+
+                field.onChange(e.target.value);
+              }}
             />
           </PokeFormControl>
           <PokeFormMessage />

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -33,11 +33,21 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { ioTsResolver } from "@hookform/resolvers/io-ts";
-import { NonEmptyString } from "io-ts-types/lib/NonEmptyString";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 
 const MICRO_USD_PER_DOLLAR = 1_000_000;
+
+function snapDatetimeLocalToHour(value: string): string {
+  if (
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value) &&
+    value.slice(14, 16) !== "00"
+  ) {
+    return value.slice(0, 14) + "00";
+  }
+
+  return value;
+}
 
 interface EnterpriseUpgradeDialogProps {
   owner: WorkspaceType;
@@ -133,22 +143,6 @@ export default function EnterpriseUpgradeDialog({
 
   const freeCreditsOverrideEnabled = form.watch("freeCreditsOverrideEnabled");
   const paygEnabled = form.watch("paygEnabled");
-
-  // Snap startingAt minutes to :00. The native datetime-local picker shows a
-  // minute spinner regardless of `step`, so we enforce hour alignment here.
-  const startingAt = form.watch("startingAt");
-  useEffect(() => {
-    if (
-      typeof startingAt === "string" &&
-      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(startingAt) &&
-      startingAt.slice(14, 16) !== "00"
-    ) {
-      const snapped = startingAt.slice(0, 14) + "00";
-      if (NonEmptyString.is(snapped)) {
-        form.setValue("startingAt", snapped, { shouldValidate: false });
-      }
-    }
-  }, [startingAt, form]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const onSubmit = useCallback(
@@ -296,6 +290,7 @@ export default function EnterpriseUpgradeDialog({
                           type="datetime-local"
                           min={minStartingAtLocal}
                           step={3600}
+                          transformValue={snapDatetimeLocalToHour}
                         />
                       </div>
                     </>

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -305,70 +305,66 @@ export default function EnterpriseUpgradeDialog({
                     </div>
                   )}
 
-                  {!isMetronomeBilled && (
-                    <div className="border-t pt-4">
-                      <h4 className="mb-4 font-medium">
-                        Programmatic Usage Configuration
-                      </h4>
+                  <div className="border-t pt-4">
+                    <h4 className="mb-4 font-medium">
+                      Programmatic Usage Configuration
+                    </h4>
 
-                      <div className="mb-4 flex items-center gap-2">
-                        <SliderToggle
-                          selected={freeCreditsOverrideEnabled}
-                          onClick={() =>
-                            form.setValue(
-                              "freeCreditsOverrideEnabled",
-                              !freeCreditsOverrideEnabled
-                            )
-                          }
-                        />
-                        <Label className="text-sm">
-                          Negotiated Free Credits
-                        </Label>
-                      </div>
-                      {freeCreditsOverrideEnabled && (
-                        <div className="mb-4 ml-6">
-                          <InputField
-                            control={form.control}
-                            name="freeCreditsDollars"
-                            title="Free Credits (USD)"
-                            type="number"
-                            placeholder="e.g., 100"
-                          />
-                        </div>
-                      )}
-
-                      <div className="mb-4">
+                    <div className="mb-4 flex items-center gap-2">
+                      <SliderToggle
+                        selected={freeCreditsOverrideEnabled}
+                        onClick={() =>
+                          form.setValue(
+                            "freeCreditsOverrideEnabled",
+                            !freeCreditsOverrideEnabled
+                          )
+                        }
+                      />
+                      <Label className="text-sm">Negotiated Free Credits</Label>
+                    </div>
+                    {freeCreditsOverrideEnabled && (
+                      <div className="mb-4 ml-6">
                         <InputField
                           control={form.control}
-                          name="defaultDiscountPercent"
-                          title="Default Discount (%)"
+                          name="freeCreditsDollars"
+                          title="Free Credits (USD)"
                           type="number"
-                          placeholder="0"
+                          placeholder="e.g., 100"
                         />
                       </div>
+                    )}
 
-                      <div className="mb-4 flex items-center gap-2">
-                        <SliderToggle
-                          selected={paygEnabled}
-                          onClick={() =>
-                            form.setValue("paygEnabled", !paygEnabled)
-                          }
-                        />
-                        <Label className="text-sm">Pay-as-you-go</Label>
-                      </div>
-                      {paygEnabled && (
-                        <div className="ml-6">
-                          <InputField
-                            control={form.control}
-                            name="paygCapDollars"
-                            title="PAYG Spending Cap (USD)"
-                            type="number"
-                            placeholder="e.g., 1000"
-                          />
-                        </div>
-                      )}
+                    <div className="mb-4">
+                      <InputField
+                        control={form.control}
+                        name="defaultDiscountPercent"
+                        title="Default Discount (%)"
+                        type="number"
+                        placeholder="0"
+                      />
                     </div>
-                  )}
+
+                    <div className="mb-4 flex items-center gap-2">
+                      <SliderToggle
+                        selected={paygEnabled}
+                        onClick={() =>
+                          form.setValue("paygEnabled", !paygEnabled)
+                        }
+                      />
+                      <Label className="text-sm">Pay-as-you-go</Label>
+                    </div>
+                    {paygEnabled && (
+                      <div className="ml-6">
+                        <InputField
+                          control={form.control}
+                          name="paygCapDollars"
+                          title="PAYG Spending Cap (USD)"
+                          type="number"
+                          placeholder="e.g., 1000"
+                        />
+                      </div>
+                    )}
+                  </div>
                 </div>
                 <DialogFooter>
                   <Button

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -6,7 +6,7 @@ import {
 import { clientFetch } from "@app/lib/egress/client";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
-import { usePokePlans } from "@app/lib/swr/poke";
+import { usePokeMetronomePackages, usePokePlans } from "@app/lib/swr/poke";
 import type {
   EnterpriseUpgradeFormType,
   SubscriptionType,
@@ -30,7 +30,8 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { ioTsResolver } from "@hookform/resolvers/io-ts";
-import { useCallback, useEffect, useState } from "react";
+import { NonEmptyString } from "io-ts-types/lib/NonEmptyString";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 
 const MICRO_USD_PER_DOLLAR = 1_000_000;
@@ -62,7 +63,43 @@ export default function EnterpriseUpgradeDialog({
   }, []);
 
   const { plans } = usePokePlans();
+  const {
+    packages: metronomePackages,
+    isPackagesLoading,
+    packagesError,
+  } = usePokeMetronomePackages({
+    disabled: !hasMetronomeBilling || !open,
+  });
   const router = useAppRouter();
+
+  // Min datetime for the startingAt picker — at least one hour in the future
+  // and rounded up to the next local hour boundary, since Metronome contracts
+  // must start on the hour and the picker is restricted to whole hours.
+  const minStartingAtLocal = useMemo(() => {
+    const d = new Date(Date.now() + 60 * 60 * 1000);
+    if (d.getMinutes() > 0 || d.getSeconds() > 0 || d.getMilliseconds() > 0) {
+      d.setHours(d.getHours() + 1);
+    }
+    d.setMinutes(0, 0, 0);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return (
+      `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+      `T${pad(d.getHours())}:00`
+    );
+  }, []);
+
+  const enterprisePackageOptions = useMemo(
+    () =>
+      metronomePackages
+        .filter((p) => p.name.toLowerCase().includes("enterprise"))
+        .map((p) => ({ value: p.id, display: p.name })),
+    [metronomePackages]
+  );
+  const isEnterprisePackageSelectionDisabled =
+    hasMetronomeBilling &&
+    (isPackagesLoading ||
+      !!packagesError ||
+      enterprisePackageOptions.length === 0);
 
   const freeCreditMicroUsd =
     programmaticUsageConfig?.freeCreditMicroUsd ?? null;
@@ -74,7 +111,8 @@ export default function EnterpriseUpgradeDialog({
       stripeSubscriptionId: !hasMetronomeBilling
         ? (subscription.stripeSubscriptionId ?? "")
         : undefined,
-      metronomeContractId: hasMetronomeBilling ? "" : undefined,
+      metronomePackageId: hasMetronomeBilling ? "" : undefined,
+      startingAt: hasMetronomeBilling ? minStartingAtLocal : undefined,
       planCode: "",
       freeCreditsOverrideEnabled: freeCreditMicroUsd !== null,
       freeCreditsDollars:
@@ -94,6 +132,22 @@ export default function EnterpriseUpgradeDialog({
   const freeCreditsOverrideEnabled = form.watch("freeCreditsOverrideEnabled");
   const paygEnabled = form.watch("paygEnabled");
 
+  // Snap startingAt minutes to :00. The native datetime-local picker shows a
+  // minute spinner regardless of `step`, so we enforce hour alignment here.
+  const startingAt = form.watch("startingAt");
+  useEffect(() => {
+    if (
+      typeof startingAt === "string" &&
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(startingAt) &&
+      startingAt.slice(14, 16) !== "00"
+    ) {
+      const snapped = startingAt.slice(0, 14) + "00";
+      if (NonEmptyString.is(snapped)) {
+        form.setValue("startingAt", snapped, { shouldValidate: false });
+      }
+    }
+  }, [startingAt, form]);
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const onSubmit = useCallback(
     (values: EnterpriseUpgradeFormType) => {
@@ -111,6 +165,14 @@ export default function EnterpriseUpgradeDialog({
           })
         )
       );
+
+      // datetime-local inputs return a local-time string with no timezone.
+      // Convert to ISO so the server's Date.parse is unambiguous.
+      if (typeof cleanedValues.startingAt === "string") {
+        cleanedValues.startingAt = new Date(
+          cleanedValues.startingAt
+        ).toISOString();
+      }
 
       const submit = async () => {
         setIsSubmitting(true);
@@ -159,7 +221,7 @@ export default function EnterpriseUpgradeDialog({
           <DialogDescription>
             Select the enterprise plan and provide the{" "}
             {hasMetronomeBilling
-              ? "Metronome contract ID"
+              ? "Metronome package and contract start time"
               : "Stripe subscription Id"}{" "}
             of the customer.
           </DialogDescription>
@@ -192,87 +254,132 @@ export default function EnterpriseUpgradeDialog({
                         }))}
                     />
                   </div>
-                  <div className="grid-cols grid items-center gap-4">
-                    {hasMetronomeBilling ? (
-                      <InputField
-                        control={form.control}
-                        name="metronomeContractId"
-                        title="Metronome Contract ID"
-                        placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                      />
-                    ) : (
+                  {hasMetronomeBilling ? (
+                    <>
+                      {isPackagesLoading && (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <Spinner size="sm" />
+                          <span>Loading Metronome packages...</span>
+                        </div>
+                      )}
+                      {!isPackagesLoading && packagesError && (
+                        <div className="text-warning text-sm">
+                          Failed to load Metronome packages:{" "}
+                          {packagesError.message}
+                        </div>
+                      )}
+                      {!isPackagesLoading &&
+                        !packagesError &&
+                        enterprisePackageOptions.length === 0 && (
+                          <div className="text-warning text-sm">
+                            No enterprise Metronome package is available.
+                          </div>
+                        )}
+                      {!isPackagesLoading && !packagesError && (
+                        <div className="grid-cols grid items-center gap-4">
+                          <SelectField
+                            control={form.control}
+                            name="metronomePackageId"
+                            title="Metronome Enterprise Package"
+                            mountPortalContainer={portalContainer}
+                            options={enterprisePackageOptions}
+                          />
+                        </div>
+                      )}
+                      <div className="grid-cols grid items-center gap-4">
+                        <InputField
+                          control={form.control}
+                          name="startingAt"
+                          title="Starts At (local time, ≥ 1h from now, on the hour)"
+                          type="datetime-local"
+                          min={minStartingAtLocal}
+                          step={3600}
+                        />
+                      </div>
+                    </>
+                  ) : (
+                    <div className="grid-cols grid items-center gap-4">
                       <InputField
                         control={form.control}
                         name="stripeSubscriptionId"
                         title="Stripe Subscription id"
                         placeholder="sub_1234567890"
                       />
-                    )}
-                  </div>
-
-                  <div className="border-t pt-4">
-                    <h4 className="mb-4 font-medium">
-                      Programmatic Usage Configuration
-                    </h4>
-
-                    <div className="mb-4 flex items-center gap-2">
-                      <SliderToggle
-                        selected={freeCreditsOverrideEnabled}
-                        onClick={() =>
-                          form.setValue(
-                            "freeCreditsOverrideEnabled",
-                            !freeCreditsOverrideEnabled
-                          )
-                        }
-                      />
-                      <Label className="text-sm">Negotiated Free Credits</Label>
                     </div>
-                    {freeCreditsOverrideEnabled && (
-                      <div className="mb-4 ml-6">
+                  )}
+
+                  {!hasMetronomeBilling && (
+                    <div className="border-t pt-4">
+                      <h4 className="mb-4 font-medium">
+                        Programmatic Usage Configuration
+                      </h4>
+
+                      <div className="mb-4 flex items-center gap-2">
+                        <SliderToggle
+                          selected={freeCreditsOverrideEnabled}
+                          onClick={() =>
+                            form.setValue(
+                              "freeCreditsOverrideEnabled",
+                              !freeCreditsOverrideEnabled
+                            )
+                          }
+                        />
+                        <Label className="text-sm">
+                          Negotiated Free Credits
+                        </Label>
+                      </div>
+                      {freeCreditsOverrideEnabled && (
+                        <div className="mb-4 ml-6">
+                          <InputField
+                            control={form.control}
+                            name="freeCreditsDollars"
+                            title="Free Credits (USD)"
+                            type="number"
+                            placeholder="e.g., 100"
+                          />
+                        </div>
+                      )}
+
+                      <div className="mb-4">
                         <InputField
                           control={form.control}
-                          name="freeCreditsDollars"
-                          title="Free Credits (USD)"
+                          name="defaultDiscountPercent"
+                          title="Default Discount (%)"
                           type="number"
-                          placeholder="e.g., 100"
+                          placeholder="0"
                         />
                       </div>
-                    )}
 
-                    <div className="mb-4">
-                      <InputField
-                        control={form.control}
-                        name="defaultDiscountPercent"
-                        title="Default Discount (%)"
-                        type="number"
-                        placeholder="0"
-                      />
-                    </div>
-
-                    <div className="mb-4 flex items-center gap-2">
-                      <SliderToggle
-                        selected={paygEnabled}
-                        onClick={() =>
-                          form.setValue("paygEnabled", !paygEnabled)
-                        }
-                      />
-                      <Label className="text-sm">Pay-as-you-go</Label>
-                    </div>
-                    {paygEnabled && (
-                      <div className="ml-6">
-                        <InputField
-                          control={form.control}
-                          name="paygCapDollars"
-                          title="PAYG Spending Cap (USD)"
-                          type="number"
-                          placeholder="e.g., 1000"
+                      <div className="mb-4 flex items-center gap-2">
+                        <SliderToggle
+                          selected={paygEnabled}
+                          onClick={() =>
+                            form.setValue("paygEnabled", !paygEnabled)
+                          }
                         />
+                        <Label className="text-sm">Pay-as-you-go</Label>
                       </div>
-                    )}
-                  </div>
+                      {paygEnabled && (
+                        <div className="ml-6">
+                          <InputField
+                            control={form.control}
+                            name="paygCapDollars"
+                            title="PAYG Spending Cap (USD)"
+                            type="number"
+                            placeholder="e.g., 1000"
+                          />
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </div>
                 <DialogFooter>
-                  <Button type="submit" variant="warning" label="Upgrade" />
+                  <Button
+                    type="submit"
+                    variant="warning"
+                    label="Upgrade"
+                    disabled={isEnterprisePackageSelectionDisabled}
+                  />
                 </DialogFooter>
               </form>
             </PokeForm>

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -11,7 +11,10 @@ import type {
   EnterpriseUpgradeFormType,
   SubscriptionType,
 } from "@app/types/plan";
-import { EnterpriseUpgradeFormSchema } from "@app/types/plan";
+import {
+  EnterpriseUpgradeFormSchema,
+  isSubscriptionMetronomeBilled,
+} from "@app/types/plan";
 import type { ProgrammaticUsageConfigurationType } from "@app/types/programmatic_usage";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { WorkspaceType } from "@app/types/user";
@@ -38,14 +41,12 @@ const MICRO_USD_PER_DOLLAR = 1_000_000;
 
 interface EnterpriseUpgradeDialogProps {
   owner: WorkspaceType;
-  hasMetronomeBilling: boolean;
   subscription: SubscriptionType;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
 }
 
 export default function EnterpriseUpgradeDialog({
   owner,
-  hasMetronomeBilling,
   subscription,
   programmaticUsageConfig,
 }: EnterpriseUpgradeDialogProps) {
@@ -62,13 +63,14 @@ export default function EnterpriseUpgradeDialog({
     }
   }, []);
 
+  const isMetronomeBilled = isSubscriptionMetronomeBilled(subscription);
   const { plans } = usePokePlans();
   const {
     packages: metronomePackages,
     isPackagesLoading,
     packagesError,
   } = usePokeMetronomePackages({
-    disabled: !hasMetronomeBilling || !open,
+    disabled: !isMetronomeBilled || !open,
   });
   const router = useAppRouter();
 
@@ -96,7 +98,7 @@ export default function EnterpriseUpgradeDialog({
     [metronomePackages]
   );
   const isEnterprisePackageSelectionDisabled =
-    hasMetronomeBilling &&
+    isMetronomeBilled &&
     (isPackagesLoading ||
       !!packagesError ||
       enterprisePackageOptions.length === 0);
@@ -108,11 +110,11 @@ export default function EnterpriseUpgradeDialog({
   const form = useForm<EnterpriseUpgradeFormType>({
     resolver: ioTsResolver(EnterpriseUpgradeFormSchema),
     defaultValues: {
-      stripeSubscriptionId: !hasMetronomeBilling
+      stripeSubscriptionId: !isMetronomeBilled
         ? (subscription.stripeSubscriptionId ?? "")
         : undefined,
-      metronomePackageId: hasMetronomeBilling ? "" : undefined,
-      startingAt: hasMetronomeBilling ? minStartingAtLocal : undefined,
+      metronomePackageId: isMetronomeBilled ? "" : undefined,
+      startingAt: isMetronomeBilled ? minStartingAtLocal : undefined,
       planCode: "",
       freeCreditsOverrideEnabled: freeCreditMicroUsd !== null,
       freeCreditsDollars:
@@ -220,7 +222,7 @@ export default function EnterpriseUpgradeDialog({
           <DialogTitle>Upgrade {owner.name} to Enterprise.</DialogTitle>
           <DialogDescription>
             Select the enterprise plan and provide the{" "}
-            {hasMetronomeBilling
+            {isMetronomeBilled
               ? "Metronome package and contract start time"
               : "Stripe subscription Id"}{" "}
             of the customer.
@@ -254,7 +256,7 @@ export default function EnterpriseUpgradeDialog({
                         }))}
                     />
                   </div>
-                  {hasMetronomeBilling ? (
+                  {isMetronomeBilled ? (
                     <>
                       {isPackagesLoading && (
                         <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -308,7 +310,7 @@ export default function EnterpriseUpgradeDialog({
                     </div>
                   )}
 
-                  {!hasMetronomeBilling && (
+                  {!isMetronomeBilled && (
                     <div className="border-t pt-4">
                       <h4 className="mb-4 font-medium">
                         Programmatic Usage Configuration

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -165,7 +165,6 @@ export function SubscriptionsDataTable({
 
 interface ActiveSubscriptionTableProps {
   owner: WorkspaceType;
-  hasMetronomeBilling: boolean;
   metronomeCustomerId: string | null;
   subscription: SubscriptionType;
   subscriptions: SubscriptionType[];
@@ -174,7 +173,6 @@ interface ActiveSubscriptionTableProps {
 
 export function ActiveSubscriptionTable({
   owner,
-  hasMetronomeBilling,
   metronomeCustomerId,
   subscription,
   subscriptions,
@@ -200,7 +198,6 @@ export function ActiveSubscriptionTable({
             />
             <UpgradeDowngradeModal
               owner={owner}
-              hasMetronomeBilling={hasMetronomeBilling}
               subscription={subscription}
               programmaticUsageConfig={programmaticUsageConfig}
             />
@@ -435,14 +432,12 @@ export function PlanLimitationsTable({
 
 interface UpgradeDowngradeModalProps {
   owner: WorkspaceType;
-  hasMetronomeBilling: boolean;
   subscription: SubscriptionType;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
 }
 
 function UpgradeDowngradeModal({
   owner,
-  hasMetronomeBilling,
   subscription,
   programmaticUsageConfig,
 }: UpgradeDowngradeModalProps) {
@@ -564,7 +559,6 @@ function UpgradeDowngradeModal({
                 owner={owner}
                 subscription={subscription}
                 programmaticUsageConfig={programmaticUsageConfig}
-                hasMetronomeBilling={hasMetronomeBilling}
               />
             </div>
             {isProPlanPrefix(subscription.plan.code) && (

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -572,16 +572,18 @@ export async function getMetronomeRateCardById({
 }
 
 /**
- * List all contracts for a Metronome customer (active, future-scheduled,
- * archived). Used when we need to reason about overlaps rather than just
- * "the most recent" contract.
+ * List contracts for a Metronome customer. Archived contracts are excluded
+ * by default (Metronome API default). Pass `coveringDate` to restrict the
+ * response to contracts active at that point in time.
  */
 export async function listMetronomeContracts(
-  metronomeCustomerId: string
+  metronomeCustomerId: string,
+  { coveringDate }: { coveringDate?: Date } = {}
 ): Promise<Result<ContractV2[], Error>> {
   try {
     const response = await getMetronomeClient().v2.contracts.list({
       customer_id: metronomeCustomerId,
+      ...(coveringDate ? { covering_date: coveringDate.toISOString() } : {}),
     });
     return new Ok(response.data);
   } catch (err) {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -359,6 +359,79 @@ export async function addStripeMetronomeBillingConfig({
 }
 
 // ---------------------------------------------------------------------------
+// Package management
+// ---------------------------------------------------------------------------
+
+/**
+ * Compact summary of a Metronome package, used by Poke to let an operator
+ * pick which package to put a customer on.
+ */
+export interface MetronomePackageSummary {
+  id: string;
+  name: string;
+  aliases: string[];
+}
+
+// Cache the package list for a few minutes as the catalog rarely changes and
+// the dialog may open many times.
+const PACKAGE_LIST_CACHE_TTL_MS = 5 * 60 * 1000;
+let packageListCache: {
+  expiresAtMs: number;
+  packages: MetronomePackageSummary[];
+} | null = null;
+
+/**
+ * List all Metronome packages on the account. Cached for 5 minutes.
+ */
+export async function listMetronomePackages(): Promise<
+  Result<MetronomePackageSummary[], Error>
+> {
+  if (packageListCache && packageListCache.expiresAtMs > Date.now()) {
+    return new Ok(packageListCache.packages);
+  }
+
+  try {
+    const packages: MetronomePackageSummary[] = [];
+    for await (const pkg of getMetronomeClient().v1.packages.list()) {
+      packages.push({
+        id: pkg.id,
+        name: pkg.name ?? "",
+        aliases: pkg.aliases?.map((a) => a.name) ?? [],
+      });
+    }
+    packageListCache = {
+      expiresAtMs: Date.now() + PACKAGE_LIST_CACHE_TTL_MS,
+      packages,
+    };
+    return new Ok(packages);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error({ error }, "[Metronome] Failed to list packages");
+    return new Err(error);
+  }
+}
+
+/** Set custom field values on a Metronome contract. */
+export async function setMetronomeContractCustomFields({
+  contractId,
+  customFields,
+}: {
+  contractId: string;
+  customFields: Record<string, string>;
+}): Promise<Result<void, Error>> {
+  try {
+    await getMetronomeClient().v1.customFields.setValues({
+      entity: "contract",
+      entity_id: contractId,
+      custom_fields: customFields,
+    });
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Contract management
 // ---------------------------------------------------------------------------
 
@@ -371,23 +444,36 @@ export async function addStripeMetronomeBillingConfig({
 export async function createMetronomeContract({
   metronomeCustomerId,
   packageAlias,
+  packageId,
   uniquenessKey,
   startingAt,
   enableStripeBilling,
 }: {
   metronomeCustomerId: string;
-  packageAlias: string;
+  /** Mutually exclusive with `packageId`. */
+  packageAlias?: string;
+  /** Mutually exclusive with `packageAlias` */
+  packageId?: string;
   uniquenessKey?: string;
   // Must already be on an hour boundary (Metronome requirement).
   startingAt: Date;
   enableStripeBilling: boolean;
 }): Promise<Result<{ contractId: string }, Error>> {
+  if (!packageAlias === !packageId) {
+    return new Err(
+      new Error(
+        "createMetronomeContract requires exactly one of packageAlias or packageId."
+      )
+    );
+  }
   const startingAtISO = startingAt.toISOString();
+  const packageLabel = packageAlias ?? packageId!;
 
   try {
     const response = await getMetronomeClient().v1.contracts.create({
       customer_id: metronomeCustomerId,
-      package_alias: packageAlias,
+      ...(packageAlias ? { package_alias: packageAlias } : {}),
+      ...(packageId ? { package_id: packageId } : {}),
       starting_at: startingAtISO,
       ...(uniquenessKey ? { uniqueness_key: uniquenessKey } : {}),
     });
@@ -402,14 +488,16 @@ export async function createMetronomeContract({
     logger.info(
       {
         metronomeCustomerId,
-        packageAlias,
+        package: packageLabel,
         metronomeContractId: response.data.id,
       },
       "[Metronome] Contract created"
     );
     return new Ok({ contractId: response.data.id });
   } catch (err) {
-    if (err instanceof ConflictError) {
+    // Conflict-by-uniqueness-key recovery only applies when creating by alias.
+    // When creating by package_id we surface the error.
+    if (err instanceof ConflictError && packageAlias) {
       const existingContract =
         await getMetronomeActiveContract(metronomeCustomerId);
       if (existingContract.isOk() && existingContract.value) {
@@ -419,7 +507,7 @@ export async function createMetronomeContract({
 
     const error = normalizeError(err);
     logger.error(
-      { error, metronomeCustomerId, packageAlias },
+      { error, metronomeCustomerId, package: packageLabel },
       "[Metronome] Failed to create contract"
     );
     return new Err(error);
@@ -480,6 +568,29 @@ export async function getMetronomeRateCardById({
     return new Ok(response.data);
   } catch (err) {
     return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * List all contracts for a Metronome customer (active, future-scheduled,
+ * archived). Used when we need to reason about overlaps rather than just
+ * "the most recent" contract.
+ */
+export async function listMetronomeContracts(
+  metronomeCustomerId: string
+): Promise<Result<ContractV2[], Error>> {
+  try {
+    const response = await getMetronomeClient().v2.contracts.list({
+      customer_id: metronomeCustomerId,
+    });
+    return new Ok(response.data);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId },
+      "[Metronome] Failed to list contracts"
+    );
+    return new Err(error);
   }
 }
 

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -79,6 +79,8 @@ const PROD_PRODUCT_SEAT_SUBSCRIPTION_CREDITS =
 export const CREDIT_TYPE_USD_ID = "2714e483-4ff1-48e4-9e25-ac732e8f24f2";
 export const CREDIT_TYPE_EUR_ID = "58f0be15-cc47-4220-bdaf-072ab0e44f96";
 
+export const PLAN_CODE_CUSTOM_FIELD_KEY = "PLAN_CODE";
+
 // AWU (Agentic Work Units) differs per environment.
 export const DEV_CREDIT_TYPE_AWU_ID = "1ad632f0-4e5a-44d6-a1bf-aa6f6bc550d8";
 export const PROD_CREDIT_TYPE_AWU_ID = "e53a841e-b741-4bc3-8148-f377c1fb2501";

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -79,7 +79,7 @@ const PROD_PRODUCT_SEAT_SUBSCRIPTION_CREDITS =
 export const CREDIT_TYPE_USD_ID = "2714e483-4ff1-48e4-9e25-ac732e8f24f2";
 export const CREDIT_TYPE_EUR_ID = "58f0be15-cc47-4220-bdaf-072ab0e44f96";
 
-export const PLAN_CODE_CUSTOM_FIELD_KEY = "PLAN_CODE";
+export const PLAN_CODE_CUSTOM_FIELD_KEY = "DUST_PLAN_CODE";
 
 // AWU (Agentic Work Units) differs per environment.
 export const DEV_CREDIT_TYPE_AWU_ID = "1ad632f0-4e5a-44d6-a1bf-aa6f6bc550d8";

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -150,6 +150,12 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     );
   }
 
+  get isMetronomeOnlyBilled(): boolean {
+    return (
+      this.metronomeContractId !== null && this.stripeSubscriptionId === null
+    );
+  }
+
   static async makeNew(
     blob: CreationAttributes<SubscriptionModel>,
     plan: PlanType,

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -135,9 +135,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       return false;
     }
 
-    return (
-      this.stripeSubscriptionId !== null || this.metronomeContractId !== null
-    );
+    return !!this.stripeSubscriptionId || !!this.metronomeContractId;
   }
 
   /**
@@ -145,15 +143,11 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
    * Both stripeSubscriptionId and metronomeContractId are set.
    */
   get isMetronomeShadowBilled(): boolean {
-    return (
-      this.stripeSubscriptionId !== null && this.metronomeContractId !== null
-    );
+    return !!this.stripeSubscriptionId && !!this.metronomeContractId;
   }
 
   get isMetronomeOnlyBilled(): boolean {
-    return (
-      this.metronomeContractId !== null && this.stripeSubscriptionId === null
-    );
+    return !!this.metronomeContractId && !this.stripeSubscriptionId;
   }
 
   static async makeNew(

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1208,6 +1208,45 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     await invalidateContractCache(subscription.workspace.sId);
   }
 
+  /**
+   * End the current subscription as `ended_backend_only` and create a new
+   * active subscription on a different Metronome contract and plan code.
+   * Used by the contract.start webhook when an admin-scheduled Enterprise
+   * upgrade activates — preserves the plan-change history rather than
+   * mutating the existing subscription in place. The `ended_backend_only`
+   * status ensures the contract.end webhook for the old contract finds the
+   * old subscription in that state and does not scrub the workspace.
+   */
+  async swapMetronomeContract({
+    metronomeContractId,
+    planCode,
+  }: {
+    metronomeContractId: string;
+    planCode: string;
+  }): Promise<void> {
+    const newPlan = await SubscriptionResource.findPlanOrThrow(planCode);
+
+    await withTransaction(async (t) => {
+      await this.markAsEnded("ended_backend_only", t);
+
+      await SubscriptionResource.makeNew(
+        {
+          sId: generateRandomModelSId(),
+          workspaceId: this.workspaceId,
+          planId: newPlan.id,
+          status: "active",
+          trialing: false,
+          startDate: new Date(),
+          endDate: null,
+          stripeSubscriptionId: this.stripeSubscriptionId,
+          metronomeContractId,
+        },
+        renderPlanFromModel({ plan: newPlan }),
+        t
+      );
+    });
+  }
+
   async getPerSeatPricing(): Promise<SubscriptionPerSeatPricing | null> {
     if (!this.stripeSubscriptionId) {
       return null;

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -6,6 +6,7 @@ import { isRegionRedirect } from "@app/lib/swr/workspaces";
 import type { GetPokeNoWorkspaceAuthContextResponseType } from "@app/pages/api/poke/auth-context";
 import type { GetPokeCouponRedemptionsResponseBody } from "@app/pages/api/poke/coupons/[couponId]/redemptions";
 import type { GetPokeCouponsResponseBody } from "@app/pages/api/poke/coupons/index";
+import type { GetPokeMetronomePackagesResponseBody } from "@app/pages/api/poke/metronome/packages";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetRegionResponseType } from "@app/pages/api/poke/region";
 import type { GetPokeWorkspaceAuthContextResponseType } from "@app/pages/api/poke/workspaces/[wId]/auth-context";
@@ -145,6 +146,29 @@ export function usePokeArchiveCoupon() {
     }
     await mutate("/api/poke/coupons");
     sendNotification({ title: "Coupon archived", type: "success" });
+  };
+}
+
+export function usePokeMetronomePackages({
+  disabled,
+}: {
+  disabled?: boolean;
+} = {}) {
+  const { fetcher } = useFetcher();
+  const packagesFetcher: Fetcher<GetPokeMetronomePackagesResponseBody> =
+    fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    "/api/poke/metronome/packages",
+    packagesFetcher,
+    { disabled }
+  );
+
+  return {
+    packages: data?.packages ?? emptyArray(),
+    isPackagesLoading: !error && !data && !disabled,
+    isPackagesError: error,
+    packagesError: isAPIErrorResponse(error) ? error.error : null,
   };
 }
 

--- a/front/pages/api/metronome/webhook.test.ts
+++ b/front/pages/api/metronome/webhook.test.ts
@@ -4,6 +4,7 @@ import {
   getMetronomeContractById,
   listMetronomeContracts,
 } from "@app/lib/metronome/client";
+import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import { PlanModel } from "@app/lib/models/plan";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -209,7 +210,9 @@ describe("Metronome webhook — contract.start", () => {
         id: NEW_CONTRACT_ID,
         customer_id: METRONOME_CUSTOMER_ID,
         starting_at: new Date().toISOString(),
-        custom_fields: { PLAN_CODE: NON_ENTERPRISE_PLAN_CODE },
+        custom_fields: {
+          [PLAN_CODE_CUSTOM_FIELD_KEY]: NON_ENTERPRISE_PLAN_CODE,
+        },
       } as never)
     );
 
@@ -235,7 +238,7 @@ describe("Metronome webhook — contract.start", () => {
         id: NEW_CONTRACT_ID,
         customer_id: METRONOME_CUSTOMER_ID,
         starting_at: new Date().toISOString(),
-        custom_fields: { PLAN_CODE: "ENT_PLAN_UNKNOWN" },
+        custom_fields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: "ENT_PLAN_UNKNOWN" },
       } as never)
     );
 
@@ -262,7 +265,7 @@ describe("Metronome webhook — contract.start", () => {
         id: NEW_CONTRACT_ID,
         customer_id: METRONOME_CUSTOMER_ID,
         starting_at: new Date().toISOString(),
-        custom_fields: { PLAN_CODE: ENT_PLAN_CODE },
+        custom_fields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
       } as never)
     );
 
@@ -302,7 +305,7 @@ describe("Metronome webhook — contract.start", () => {
         id: NEW_CONTRACT_ID,
         customer_id: METRONOME_CUSTOMER_ID,
         starting_at: new Date().toISOString(),
-        custom_fields: { PLAN_CODE: ENT_PLAN_CODE },
+        custom_fields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
       } as never)
     );
 

--- a/front/pages/api/metronome/webhook.test.ts
+++ b/front/pages/api/metronome/webhook.test.ts
@@ -4,6 +4,7 @@ import {
   getMetronomeContractById,
   listMetronomeContracts,
 } from "@app/lib/metronome/client";
+import { PlanModel } from "@app/lib/models/plan";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -53,7 +54,39 @@ vi.mock("@app/lib/api/subscription", () => ({
 const METRONOME_CUSTOMER_ID = "cust_test_xxx";
 const OLD_CONTRACT_ID = "contract_old_xxx";
 const NEW_CONTRACT_ID = "contract_new_yyy";
-const ENT_PLAN_CODE = "PRO_PLAN_SEAT_29"; // pre-seeded; we just need a valid plan code
+const ENT_PLAN_CODE = "ENT_TEST_PLAN";
+const NON_ENTERPRISE_PLAN_CODE = "PRO_PLAN_SEAT_29";
+
+async function ensureEnterprisePlan(): Promise<void> {
+  await PlanModel.upsert({
+    code: ENT_PLAN_CODE,
+    name: "Test Enterprise",
+    maxMessages: -1,
+    maxMessagesTimeframe: "lifetime",
+    isDeepDiveAllowed: true,
+    maxImagesPerWeek: 1000,
+    maxUsersInWorkspace: 1000,
+    maxVaultsInWorkspace: 100,
+    isSlackbotAllowed: true,
+    isManagedSlackAllowed: true,
+    isManagedConfluenceAllowed: true,
+    isManagedNotionAllowed: true,
+    isManagedGoogleDriveAllowed: true,
+    isManagedGithubAllowed: true,
+    isManagedIntercomAllowed: true,
+    isManagedWebCrawlerAllowed: true,
+    isManagedSalesforceAllowed: true,
+    isSSOAllowed: true,
+    isSCIMAllowed: true,
+    isAuditLogsAllowed: true,
+    maxDataSourcesCount: -1,
+    maxDataSourcesDocumentsCount: -1,
+    maxDataSourcesDocumentsSizeMb: 100,
+    trialPeriodDays: 0,
+    canUseProduct: true,
+    isByok: false,
+  });
+}
 
 /** Build a contract event payload that matches the centralized webhook schema. */
 function contractEvent(
@@ -167,7 +200,60 @@ describe("Metronome webhook — contract.start", () => {
     expect(restoreWorkspaceAfterSubscription).not.toHaveBeenCalled();
   });
 
+  it("does nothing when PLAN_CODE refers to a non-enterprise plan", async () => {
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: NEW_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        custom_fields: { PLAN_CODE: NON_ENTERPRISE_PLAN_CODE },
+      } as never)
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(sub!.metronomeContractId).toBe(OLD_CONTRACT_ID);
+    expect(restoreWorkspaceAfterSubscription).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when PLAN_CODE does not resolve to a Dust plan", async () => {
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: NEW_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        custom_fields: { PLAN_CODE: "ENT_PLAN_UNKNOWN" },
+      } as never)
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(sub!.metronomeContractId).toBe(OLD_CONTRACT_ID);
+    expect(restoreWorkspaceAfterSubscription).not.toHaveBeenCalled();
+  });
+
   it("ends the current subscription and creates a new active one with the target plan code on a successful swap", async () => {
+    await ensureEnterprisePlan();
     const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
     const event = contractEvent("contract.start", NEW_CONTRACT_ID);
     mockUnwrap(event);
@@ -207,6 +293,7 @@ describe("Metronome webhook — contract.start", () => {
   });
 
   it("is idempotent — re-firing after the swap does nothing", async () => {
+    await ensureEnterprisePlan();
     const workspace = await setupMetronomeWorkspace(NEW_CONTRACT_ID);
     const event = contractEvent("contract.start", NEW_CONTRACT_ID);
     mockUnwrap(event);

--- a/front/pages/api/metronome/webhook.test.ts
+++ b/front/pages/api/metronome/webhook.test.ts
@@ -1,0 +1,314 @@
+import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
+import {
+  getMetronomeClient,
+  getMetronomeContractById,
+  listMetronomeContracts,
+} from "@app/lib/metronome/client";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  launchScheduleWorkspaceScrubWorkflow,
+  terminateScheduleWorkspaceScrubWorkflow,
+} from "@app/temporal/scrub_workspace/client";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { createResponse } from "node-mocks-http";
+import { Readable } from "stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./webhook";
+
+vi.mock(import("@app/lib/api/config"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    default: {
+      ...mod.default,
+      getMetronomeWebhookSecret: vi.fn().mockReturnValue("test-secret"),
+    },
+  };
+});
+
+vi.mock(import("@app/lib/metronome/client"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getMetronomeClient: vi.fn(),
+    getMetronomeContractById: vi.fn(),
+    listMetronomeContracts: vi.fn(),
+  };
+});
+
+vi.mock("@app/temporal/scrub_workspace/client", () => ({
+  launchScheduleWorkspaceScrubWorkflow: vi.fn(),
+  terminateScheduleWorkspaceScrubWorkflow: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/subscription", () => ({
+  restoreWorkspaceAfterSubscription: vi.fn(),
+}));
+
+const METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const OLD_CONTRACT_ID = "contract_old_xxx";
+const NEW_CONTRACT_ID = "contract_new_yyy";
+const ENT_PLAN_CODE = "PRO_PLAN_SEAT_29"; // pre-seeded; we just need a valid plan code
+
+/** Build a contract event payload that matches the centralized webhook schema. */
+function contractEvent(
+  type: "contract.start" | "contract.end",
+  contractId: string,
+  customerId: string = METRONOME_CUSTOMER_ID
+) {
+  return {
+    type,
+    id: `evt_${type}_${contractId}`,
+    timestamp: new Date().toISOString(),
+    contract_id: contractId,
+    customer_id: customerId,
+  };
+}
+
+/**
+ * Build a request-like Readable carrying the JSON body, plus a response mock.
+ * The webhook handler reads the raw body via `pipeline(req, collector)`, so
+ * the request needs to be a real stream — node-mocks-http's request isn't.
+ */
+function makeWebhookRequest(eventBody: Record<string, unknown>) {
+  const rawBody = Buffer.from(JSON.stringify(eventBody));
+  const stream = Readable.from([rawBody]) as Readable & {
+    method: string;
+    headers: Record<string, string>;
+    query: Record<string, string>;
+    cookies: Record<string, string>;
+    socket: { remoteAddress: string };
+  };
+  stream.method = "POST";
+  stream.headers = { "x-metronome-signature": "fake" };
+  stream.query = {};
+  stream.cookies = {};
+  stream.socket = { remoteAddress: "127.0.0.1" };
+  const res = createResponse();
+  return { req: stream as never, res };
+}
+
+async function setupMetronomeWorkspace(
+  contractId: string
+): Promise<WorkspaceType> {
+  const workspace = await WorkspaceFactory.basic();
+  const workspaceModelId = (await WorkspaceResource.fetchById(workspace.sId))!
+    .id;
+  await WorkspaceResource.updateMetronomeCustomerId(
+    workspaceModelId,
+    METRONOME_CUSTOMER_ID
+  );
+  const sub =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspaceModelId);
+  await sub!.markAsEnded("ended");
+  await SubscriptionResource.makeNew(
+    {
+      sId: generateRandomModelSId(),
+      workspaceId: workspaceModelId,
+      planId: sub!.planId,
+      status: "active",
+      startDate: new Date(),
+      endDate: null,
+      stripeSubscriptionId: null,
+      metronomeContractId: contractId,
+    },
+    sub!.getPlan()
+  );
+  return workspace;
+}
+
+beforeEach(() => {
+  vi.mocked(launchScheduleWorkspaceScrubWorkflow).mockResolvedValue(
+    new Ok(undefined as never)
+  );
+  vi.mocked(terminateScheduleWorkspaceScrubWorkflow).mockResolvedValue(
+    new Ok({} as never)
+  );
+  vi.mocked(restoreWorkspaceAfterSubscription).mockResolvedValue(undefined);
+});
+
+/** Stub `getMetronomeClient().webhooks.unwrap` to bypass signature verification. */
+function mockUnwrap(event: Record<string, unknown>) {
+  vi.mocked(getMetronomeClient).mockReturnValue({
+    webhooks: { unwrap: vi.fn().mockReturnValue(event) },
+  } as never);
+}
+
+describe("Metronome webhook — contract.start", () => {
+  it("does nothing when the new contract has no PLAN_CODE custom field", async () => {
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: NEW_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        // no custom_fields
+      } as never)
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    // Subscription is unchanged.
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(sub!.metronomeContractId).toBe(OLD_CONTRACT_ID);
+    expect(restoreWorkspaceAfterSubscription).not.toHaveBeenCalled();
+  });
+
+  it("ends the current subscription and creates a new active one with the target plan code on a successful swap", async () => {
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: NEW_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        custom_fields: { PLAN_CODE: ENT_PLAN_CODE },
+      } as never)
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    // Active subscription now points at the new contract id.
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const newSub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(newSub!.metronomeContractId).toBe(NEW_CONTRACT_ID);
+    expect(newSub!.status).toBe("active");
+
+    // Old subscription was preserved as `ended_backend_only` so the eventual
+    // contract.end webhook for the old contract finds it in that state and
+    // does not scrub.
+    const oldSub = await SubscriptionResource.fetchByMetronomeContractId(
+      refreshed!,
+      OLD_CONTRACT_ID
+    );
+    expect(oldSub).not.toBeNull();
+    expect(oldSub!.status).toBe("ended_backend_only");
+
+    expect(restoreWorkspaceAfterSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it("is idempotent — re-firing after the swap does nothing", async () => {
+    const workspace = await setupMetronomeWorkspace(NEW_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: NEW_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        custom_fields: { PLAN_CODE: ENT_PLAN_CODE },
+      } as never)
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(restoreWorkspaceAfterSubscription).not.toHaveBeenCalled();
+
+    // Subscription still points at the same contract — no swap performed.
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(sub!.metronomeContractId).toBe(NEW_CONTRACT_ID);
+  });
+});
+
+describe("Metronome webhook — contract.end", () => {
+  it("skips scrub when an active successor contract exists on the customer", async () => {
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.end", OLD_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(listMetronomeContracts).mockResolvedValue(
+      new Ok([
+        {
+          id: OLD_CONTRACT_ID,
+          starting_at: new Date(Date.now() - 10_000).toISOString(),
+          ending_before: new Date().toISOString(),
+        },
+        {
+          id: NEW_CONTRACT_ID,
+          starting_at: new Date(Date.now() - 5_000).toISOString(),
+          // open-ended → currently active
+        },
+      ] as never)
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(launchScheduleWorkspaceScrubWorkflow).not.toHaveBeenCalled();
+
+    // Subscription left untouched — contract.start will swap it.
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(sub!.status).toBe("active");
+    expect(sub!.metronomeContractId).toBe(OLD_CONTRACT_ID);
+  });
+
+  it("returns 500 and leaves the subscription untouched when the successor check fails", async () => {
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.end", OLD_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(listMetronomeContracts).mockResolvedValue(
+      new Err(new Error("Metronome unavailable"))
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(launchScheduleWorkspaceScrubWorkflow).not.toHaveBeenCalled();
+
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(sub!.status).toBe("active");
+    expect(sub!.metronomeContractId).toBe(OLD_CONTRACT_ID);
+  });
+
+  it("scrubs the workspace when no successor contract exists", async () => {
+    await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.end", OLD_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(listMetronomeContracts).mockResolvedValue(
+      new Ok([
+        {
+          id: OLD_CONTRACT_ID,
+          starting_at: new Date(Date.now() - 10_000).toISOString(),
+          ending_before: new Date().toISOString(),
+        },
+      ] as never)
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(launchScheduleWorkspaceScrubWorkflow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -1,5 +1,6 @@
 /** @ignoreswagger */
 import apiConfig from "@app/lib/api/config";
+import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import {
   calculateFreeCreditAmountMicroUsd,
@@ -10,11 +11,13 @@ import {
 import {
   getMetronomeClient,
   getMetronomeContractById,
+  listMetronomeContracts,
   updateMetronomeCreditSegmentAmount,
 } from "@app/lib/metronome/client";
 import {
   getCreditTypeProgrammaticUsdId,
   getProductFreeMonthlyCreditId,
+  PLAN_CODE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import {
@@ -157,7 +160,6 @@ async function handler(
         case "contract.archive":
         case "contract.create":
         case "contract.edit":
-        case "contract.start":
         case "credit.archive":
         case "credit.create":
         case "credit.edit":
@@ -380,6 +382,95 @@ async function handler(
           break;
         }
 
+        case "contract.start": {
+          const { contract_id: contractId, customer_id: customerId } = event;
+
+          // Read PLAN_CODE custom field to determine whether this is a
+          // Poke-scheduled Enterprise upgrade. Absence of PLAN_CODE means
+          // this contract.start is for some other flow (e.g., Pro signup) —
+          // leave the subscription alone.
+          const contractResult = await getMetronomeContractById({
+            metronomeCustomerId: customerId,
+            metronomeContractId: contractId,
+          });
+          if (contractResult.isErr()) {
+            logger.error(
+              {
+                contractId,
+                customerId,
+                error: contractResult.error,
+                workspaceId: workspace.sId,
+              },
+              "[Metronome Webhook] contract.start: failed to fetch contract"
+            );
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: `Error fetching contract: ${contractResult.error.message}`,
+              },
+            });
+          }
+
+          const targetPlanCode =
+            contractResult.value.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];
+          if (!targetPlanCode) {
+            logger.info(
+              { contractId, workspaceId: workspace.sId },
+              "[Metronome Webhook] contract.start: no PLAN_CODE custom field, leaving subscription alone"
+            );
+            break;
+          }
+
+          const activeSubscription =
+            await SubscriptionResource.fetchActiveByWorkspaceModelId(
+              workspace.id
+            );
+          if (!activeSubscription) {
+            logger.warn(
+              { contractId, customerId, workspaceId: workspace.sId },
+              "[Metronome Webhook] contract.start: no active subscription"
+            );
+            break;
+          }
+
+          // Idempotency: re-deliveries land here with the subscription
+          // already pointing at the new contract.
+          if (activeSubscription.metronomeContractId === contractId) {
+            logger.info(
+              { contractId, workspaceId: workspace.sId },
+              "[Metronome Webhook] contract.start: subscription already swapped, skipping"
+            );
+            break;
+          }
+
+          // End the current subscription as `ended_backend_only` and create
+          // a new active subscription on the target plan + new contract.
+          await activeSubscription.swapMetronomeContract({
+            metronomeContractId: contractId,
+            planCode: targetPlanCode,
+          });
+
+          await invalidateContractCache(workspace.sId);
+
+          // Cancel any scheduled scrub workflow, unpause connectors, re-enable
+          // triggers. Idempotent — safe to call regardless of prior state.
+          const auth = await Authenticator.internalAdminForWorkspace(
+            workspace.sId
+          );
+          await restoreWorkspaceAfterSubscription(auth);
+
+          logger.info(
+            {
+              contractId,
+              planCode: targetPlanCode,
+              workspaceId: workspace.sId,
+            },
+            "[Metronome Webhook] contract.start: subscription upgraded"
+          );
+          break;
+        }
+
         case "contract.end": {
           const { contract_id: contractId, customer_id: customerId } = event;
 
@@ -428,7 +519,48 @@ async function handler(
               await subscription.markAsEnded("ended");
               break;
 
-            case "active":
+            case "active": {
+              // Race-safety: an Enterprise upgrade scheduled this end as part
+              // of a transition. If a successor contract is already running
+              // on this customer, contract.start (whether already processed
+              // or arriving shortly) will swap the subscription — leave the
+              // subscription alone here and skip the scrub.
+              const successorsResult = await listMetronomeContracts(customerId);
+              if (successorsResult.isErr()) {
+                logger.error(
+                  {
+                    contractId,
+                    error: successorsResult.error,
+                    workspaceId: workspace.sId,
+                  },
+                  "[Metronome Webhook] contract.end: failed to list contracts for successor check"
+                );
+                return apiError(req, res, {
+                  status_code: 500,
+                  api_error: {
+                    type: "internal_server_error",
+                    message: "Error listing contracts for successor check.",
+                  },
+                });
+              }
+
+              const nowMs = Date.now();
+              const hasActiveSuccessor = successorsResult.value.some(
+                (c) =>
+                  c.id !== contractId &&
+                  !c.archived_at &&
+                  new Date(c.starting_at).getTime() <= nowMs &&
+                  (!c.ending_before ||
+                    new Date(c.ending_before).getTime() > nowMs)
+              );
+              if (hasActiveSuccessor) {
+                logger.info(
+                  { contractId, workspaceId: workspace.sId },
+                  "[Metronome Webhook] contract.end: successor contract active, skipping scrub (contract.start will swap subscription)"
+                );
+                break;
+              }
+
               await subscription.markAsEnded("ended");
               logger.info(
                 { contractId, workspaceId: workspace.sId },
@@ -455,6 +587,7 @@ async function handler(
                 });
               }
               break;
+            }
 
             default:
               assertNever(subscription.status);

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -546,7 +546,10 @@ async function handler(
               // on this customer, contract.start (whether already processed
               // or arriving shortly) will swap the subscription — leave the
               // subscription alone here and skip the scrub.
-              const successorsResult = await listMetronomeContracts(customerId);
+              const successorsResult = await listMetronomeContracts(
+                customerId,
+                { coveringDate: new Date() }
+              );
               if (successorsResult.isErr()) {
                 logger.error(
                   {
@@ -565,14 +568,8 @@ async function handler(
                 });
               }
 
-              const nowMs = Date.now();
               const hasActiveSuccessor = successorsResult.value.some(
-                (c) =>
-                  c.id !== contractId &&
-                  !c.archived_at &&
-                  new Date(c.starting_at).getTime() <= nowMs &&
-                  (!c.ending_before ||
-                    new Date(c.ending_before).getTime() > nowMs)
+                (c) => c.id !== contractId
               );
               if (hasActiveSuccessor) {
                 logger.info(

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -24,6 +24,8 @@ import {
   getCustomerIdFromEvent,
   MetronomeWebhookEventSchema,
 } from "@app/lib/metronome/webhook_events";
+import { PlanModel } from "@app/lib/models/plan";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -386,9 +388,9 @@ async function handler(
           const { contract_id: contractId, customer_id: customerId } = event;
 
           // Read PLAN_CODE custom field to determine whether this is a
-          // Poke-scheduled Enterprise upgrade. Absence of PLAN_CODE means
-          // this contract.start is for some other flow (e.g., Pro signup) —
-          // leave the subscription alone.
+          // Poke-scheduled Enterprise upgrade. Only Enterprise plan codes
+          // should trigger a subscription swap; other plan contract starts
+          // are handled by their own creation/update flows.
           const contractResult = await getMetronomeContractById({
             metronomeCustomerId: customerId,
             metronomeContractId: contractId,
@@ -422,6 +424,25 @@ async function handler(
             break;
           }
 
+          const targetPlan = await PlanModel.findOne({
+            where: { code: targetPlanCode },
+          });
+          if (!targetPlan) {
+            logger.info(
+              { contractId, targetPlanCode, workspaceId: workspace.sId },
+              "[Metronome Webhook] contract.start: PLAN_CODE not found, leaving subscription alone"
+            );
+            break;
+          }
+
+          if (!isEntreprisePlanPrefix(targetPlan.code)) {
+            logger.info(
+              { contractId, targetPlanCode, workspaceId: workspace.sId },
+              "[Metronome Webhook] contract.start: non-enterprise PLAN_CODE, leaving subscription alone"
+            );
+            break;
+          }
+
           const activeSubscription =
             await SubscriptionResource.fetchActiveByWorkspaceModelId(
               workspace.id
@@ -448,7 +469,7 @@ async function handler(
           // a new active subscription on the target plan + new contract.
           await activeSubscription.swapMetronomeContract({
             metronomeContractId: contractId,
-            planCode: targetPlanCode,
+            planCode: targetPlan.code,
           });
 
           await invalidateContractCache(workspace.sId);
@@ -463,7 +484,7 @@ async function handler(
           logger.info(
             {
               contractId,
-              planCode: targetPlanCode,
+              planCode: targetPlan.code,
               workspaceId: workspace.sId,
             },
             "[Metronome Webhook] contract.start: subscription upgraded"

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -387,7 +387,7 @@ async function handler(
         case "contract.start": {
           const { contract_id: contractId, customer_id: customerId } = event;
 
-          // Read PLAN_CODE custom field to determine whether this is a
+          // Read the PLAN_CODE custom field to determine whether this is a
           // Poke-scheduled Enterprise upgrade. Only Enterprise plan codes
           // should trigger a subscription swap; other plan contract starts
           // are handled by their own creation/update flows.
@@ -419,7 +419,7 @@ async function handler(
           if (!targetPlanCode) {
             logger.info(
               { contractId, workspaceId: workspace.sId },
-              "[Metronome Webhook] contract.start: no PLAN_CODE custom field, leaving subscription alone"
+              `[Metronome Webhook] contract.start: no ${PLAN_CODE_CUSTOM_FIELD_KEY} custom field, leaving subscription alone`
             );
             break;
           }
@@ -430,7 +430,7 @@ async function handler(
           if (!targetPlan) {
             logger.info(
               { contractId, targetPlanCode, workspaceId: workspace.sId },
-              "[Metronome Webhook] contract.start: PLAN_CODE not found, leaving subscription alone"
+              `[Metronome Webhook] contract.start: ${PLAN_CODE_CUSTOM_FIELD_KEY} not found, leaving subscription alone`
             );
             break;
           }
@@ -438,7 +438,7 @@ async function handler(
           if (!isEntreprisePlanPrefix(targetPlan.code)) {
             logger.info(
               { contractId, targetPlanCode, workspaceId: workspace.sId },
-              "[Metronome Webhook] contract.start: non-enterprise PLAN_CODE, leaving subscription alone"
+              `[Metronome Webhook] contract.start: non-enterprise ${PLAN_CODE_CUSTOM_FIELD_KEY}, leaving subscription alone`
             );
             break;
           }

--- a/front/pages/api/poke/metronome/packages.test.ts
+++ b/front/pages/api/poke/metronome/packages.test.ts
@@ -1,0 +1,107 @@
+import { listMetronomePackages } from "@app/lib/metronome/client";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./packages";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/client")
+  >("@app/lib/metronome/client");
+  return {
+    ...actual,
+    listMetronomePackages: vi.fn(),
+  };
+});
+
+describe("GET /api/poke/metronome/packages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns packages for a super user", async () => {
+    vi.mocked(listMetronomePackages).mockResolvedValue(
+      new Ok([
+        {
+          id: "pkg_ent_usd",
+          name: "Enterprise USD",
+          aliases: ["enterprise-usd"],
+        },
+      ])
+    );
+
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: true,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      packages: [
+        {
+          id: "pkg_ent_usd",
+          name: "Enterprise USD",
+          aliases: ["enterprise-usd"],
+        },
+      ],
+    });
+  });
+
+  it("returns 401 when the user is not a super user", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: false,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "not_authenticated",
+        message: "The user does not have permission",
+      },
+    });
+  });
+
+  it("only supports GET", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  });
+
+  it("returns 502 when listing packages fails", async () => {
+    vi.mocked(listMetronomePackages).mockResolvedValue(
+      new Err(new Error("Metronome unavailable"))
+    );
+
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: true,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(502);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "internal_server_error",
+        message: "Failed to list Metronome packages: Metronome unavailable",
+      },
+    });
+  });
+});

--- a/front/pages/api/poke/metronome/packages.ts
+++ b/front/pages/api/poke/metronome/packages.ts
@@ -1,0 +1,58 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import type { MetronomePackageSummary } from "@app/lib/metronome/client";
+import { listMetronomePackages } from "@app/lib/metronome/client";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetPokeMetronomePackagesResponseBody = {
+  packages: MetronomePackageSummary[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetPokeMetronomePackagesResponseBody>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const result = await listMetronomePackages();
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 502,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to list Metronome packages: ${result.error.message}`,
+      },
+    });
+  }
+
+  res.status(200).json({ packages: result.value });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
@@ -11,7 +11,6 @@ import { PlanModel } from "@app/lib/models/plan";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
@@ -158,13 +157,12 @@ beforeEach(() => {
 describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path", () => {
   it("rejects when the current subscription is not Metronome-only billed", async () => {
     await ensureEnterprisePlan();
-    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+    const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });
     // Don't make the subscription Metronome-billed — leave the WorkspaceFactory
     // default (Pro plan, no metronomeContractId).
-    await FeatureFlagFactory.basic(auth, "metronome_billing");
 
     req.body = defaultBody();
     req.query.wId = workspace.sId;
@@ -180,12 +178,11 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
 
   it("rejects when startingAt is in the past", async () => {
     await ensureEnterprisePlan();
-    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+    const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
-    await FeatureFlagFactory.basic(auth, "metronome_billing");
 
     req.body = defaultBody({ startingAt: futureIso(-1) });
     req.query.wId = workspace.sId;
@@ -201,12 +198,11 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
 
   it("rejects when planCode is not an enterprise plan", async () => {
     await ensureEnterprisePlan();
-    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+    const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
-    await FeatureFlagFactory.basic(auth, "metronome_billing");
 
     req.body = defaultBody({ planCode: "PRO_PLAN_SEAT_29" });
     req.query.wId = workspace.sId;
@@ -222,12 +218,11 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
 
   it("rejects when packageId is unknown", async () => {
     await ensureEnterprisePlan();
-    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+    const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
-    await FeatureFlagFactory.basic(auth, "metronome_billing");
 
     req.body = defaultBody({ metronomePackageId: "pkg_does_not_exist" });
     req.query.wId = workspace.sId;
@@ -243,12 +238,11 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
 
   it("creates a new contract, stamps PLAN_CODE, sunsets the overlapping contract, and leaves the subscription untouched", async () => {
     await ensureEnterprisePlan();
-    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+    const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
-    await FeatureFlagFactory.basic(auth, "metronome_billing");
 
     req.body = defaultBody();
     req.query.wId = workspace.sId;

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
@@ -237,6 +237,26 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
     expect(createMetronomeContract).not.toHaveBeenCalled();
   });
 
+  it("rejects when paygEnabled is true (PAYG on Metronome is not yet supported)", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = defaultBody({ paygEnabled: true, paygCapDollars: 1000 });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "Pay-as-you-go is not yet supported"
+    );
+    expect(createMetronomeContract).not.toHaveBeenCalled();
+  });
+
   it("rejects when packageId is unknown", async () => {
     await ensureEnterprisePlan();
     const { req, res, workspace } = await createPrivateApiMockRequest({

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
@@ -77,7 +77,8 @@ async function ensureEnterprisePlan(): Promise<void> {
  */
 async function makeSubscriptionMetronomeBilled(
   workspace: WorkspaceType,
-  contractId: string
+  contractId: string,
+  { stripeSubscriptionId = null }: { stripeSubscriptionId?: string | null } = {}
 ): Promise<void> {
   await WorkspaceResource.updateMetronomeCustomerId(
     (await WorkspaceResource.fetchById(workspace.sId))!.id,
@@ -99,7 +100,7 @@ async function makeSubscriptionMetronomeBilled(
       status: "active",
       startDate: new Date(),
       endDate: null,
-      stripeSubscriptionId: null,
+      stripeSubscriptionId,
       metronomeContractId: contractId,
     },
     sub.getPlan()
@@ -174,6 +175,25 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
       "not Metronome-only billed"
     );
     expect(createMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("accepts a metronome-billed subscription when stripeSubscriptionId is an empty string", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID, {
+      stripeSubscriptionId: "",
+    });
+
+    req.body = defaultBody();
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(createMetronomeContract).toHaveBeenCalled();
   });
 
   it("rejects when startingAt is in the past", async () => {

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
@@ -1,0 +1,293 @@
+import { Authenticator } from "@app/lib/auth";
+import {
+  createMetronomeContract,
+  findMetronomeCustomerByAlias,
+  listMetronomeContracts,
+  listMetronomePackages,
+  scheduleMetronomeContractEnd,
+  setMetronomeContractCustomFields,
+} from "@app/lib/metronome/client";
+import { PlanModel } from "@app/lib/models/plan";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./upgrade_enterprise";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/client")
+  >("@app/lib/metronome/client");
+  return {
+    ...actual,
+    findMetronomeCustomerByAlias: vi.fn(),
+    listMetronomePackages: vi.fn(),
+    createMetronomeContract: vi.fn(),
+    setMetronomeContractCustomFields: vi.fn(),
+    listMetronomeContracts: vi.fn(),
+    scheduleMetronomeContractEnd: vi.fn(),
+  };
+});
+
+const METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const EXISTING_CONTRACT_ID = "contract_existing_xxx";
+const NEW_CONTRACT_ID = "contract_new_yyy";
+const PACKAGE_ID = "pkg_ent_usd";
+const ENT_PLAN_CODE = "ENT_TEST_PLAN";
+
+async function ensureEnterprisePlan(): Promise<void> {
+  await PlanModel.upsert({
+    code: ENT_PLAN_CODE,
+    name: "Test Enterprise",
+    maxMessages: -1,
+    maxMessagesTimeframe: "lifetime",
+    isDeepDiveAllowed: true,
+    maxImagesPerWeek: 1000,
+    maxUsersInWorkspace: 1000,
+    maxVaultsInWorkspace: 100,
+    isSlackbotAllowed: true,
+    isManagedSlackAllowed: true,
+    isManagedConfluenceAllowed: true,
+    isManagedNotionAllowed: true,
+    isManagedGoogleDriveAllowed: true,
+    isManagedGithubAllowed: true,
+    isManagedIntercomAllowed: true,
+    isManagedWebCrawlerAllowed: true,
+    isManagedSalesforceAllowed: true,
+    isSSOAllowed: true,
+    isSCIMAllowed: true,
+    isAuditLogsAllowed: true,
+    maxDataSourcesCount: -1,
+    maxDataSourcesDocumentsCount: -1,
+    maxDataSourcesDocumentsSizeMb: 100,
+    trialPeriodDays: 0,
+    canUseProduct: true,
+    isByok: false,
+  });
+}
+
+/**
+ * Patch the workspace's subscription to be Metronome-only billed (set
+ * `metronomeContractId`, no `stripeSubscriptionId`) so the handler's gate
+ * passes.
+ */
+async function makeSubscriptionMetronomeBilled(
+  workspace: WorkspaceType,
+  contractId: string
+): Promise<void> {
+  await WorkspaceResource.updateMetronomeCustomerId(
+    (await WorkspaceResource.fetchById(workspace.sId))!.id,
+    METRONOME_CUSTOMER_ID
+  );
+  const workspaceModelId = (await WorkspaceResource.fetchById(workspace.sId))!
+    .id;
+  const sub =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspaceModelId);
+  if (!sub) {
+    throw new Error("Test setup: workspace has no active subscription");
+  }
+  await sub.markAsEnded("ended");
+  await SubscriptionResource.makeNew(
+    {
+      sId: generateRandomModelSId(),
+      workspaceId: workspaceModelId,
+      planId: sub.planId,
+      status: "active",
+      startDate: new Date(),
+      endDate: null,
+      stripeSubscriptionId: null,
+      metronomeContractId: contractId,
+    },
+    sub.getPlan()
+  );
+}
+
+function futureIso(hoursFromNow: number): string {
+  return new Date(Date.now() + hoursFromNow * 60 * 60 * 1000).toISOString();
+}
+
+function defaultBody(overrides: Record<string, unknown> = {}) {
+  return {
+    planCode: ENT_PLAN_CODE,
+    metronomePackageId: PACKAGE_ID,
+    startingAt: futureIso(2),
+    freeCreditsOverrideEnabled: false,
+    paygEnabled: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  // Default-happy mocks; individual tests override as needed.
+  vi.mocked(findMetronomeCustomerByAlias).mockResolvedValue(
+    new Ok(METRONOME_CUSTOMER_ID)
+  );
+  vi.mocked(listMetronomePackages).mockResolvedValue(
+    new Ok([{ id: PACKAGE_ID, name: "Enterprise USD", aliases: [] }])
+  );
+  vi.mocked(createMetronomeContract).mockResolvedValue(
+    new Ok({ contractId: NEW_CONTRACT_ID })
+  );
+  vi.mocked(setMetronomeContractCustomFields).mockResolvedValue(
+    new Ok(undefined)
+  );
+  // After creation, both contracts coexist on the customer.
+  vi.mocked(listMetronomeContracts).mockResolvedValue(
+    new Ok([
+      {
+        id: EXISTING_CONTRACT_ID,
+        starting_at: new Date(
+          Date.now() - 30 * 24 * 60 * 60 * 1000
+        ).toISOString(),
+        // Open-ended → should be sunset.
+      },
+      {
+        id: NEW_CONTRACT_ID,
+        starting_at: futureIso(2),
+      },
+    ] as never)
+  );
+  vi.mocked(scheduleMetronomeContractEnd).mockResolvedValue(new Ok(undefined));
+});
+
+describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path", () => {
+  it("rejects when the current subscription is not Metronome-only billed", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    // Don't make the subscription Metronome-billed — leave the WorkspaceFactory
+    // default (Pro plan, no metronomeContractId).
+    await FeatureFlagFactory.basic(auth, "metronome_billing");
+
+    req.body = defaultBody();
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "not Metronome-only billed"
+    );
+    expect(createMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("rejects when startingAt is in the past", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+    await FeatureFlagFactory.basic(auth, "metronome_billing");
+
+    req.body = defaultBody({ startingAt: futureIso(-1) });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "at least one hour in the future"
+    );
+    expect(createMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("rejects when planCode is not an enterprise plan", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+    await FeatureFlagFactory.basic(auth, "metronome_billing");
+
+    req.body = defaultBody({ planCode: "PRO_PLAN_SEAT_29" });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "is not an enterprise plan"
+    );
+    expect(createMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("rejects when packageId is unknown", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+    await FeatureFlagFactory.basic(auth, "metronome_billing");
+
+    req.body = defaultBody({ metronomePackageId: "pkg_does_not_exist" });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "Metronome package not found"
+    );
+    expect(createMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("creates a new contract, stamps PLAN_CODE, sunsets the overlapping contract, and leaves the subscription untouched", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+    await FeatureFlagFactory.basic(auth, "metronome_billing");
+
+    req.body = defaultBody();
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+
+    expect(createMetronomeContract).toHaveBeenCalledTimes(1);
+    expect(createMetronomeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: METRONOME_CUSTOMER_ID,
+        packageId: PACKAGE_ID,
+      })
+    );
+
+    expect(setMetronomeContractCustomFields).toHaveBeenCalledWith({
+      contractId: NEW_CONTRACT_ID,
+      customFields: { PLAN_CODE: ENT_PLAN_CODE },
+    });
+
+    // Old contract is sunset, new one is skipped by id.
+    expect(scheduleMetronomeContractEnd).toHaveBeenCalledTimes(1);
+    expect(scheduleMetronomeContractEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: METRONOME_CUSTOMER_ID,
+        contractId: EXISTING_CONTRACT_ID,
+      })
+    );
+
+    // Subscription DB record is unchanged: still active, still on the old
+    // contract id. The contract.start webhook is what flips it.
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const sub = adminAuth.subscriptionResource();
+    expect(sub).not.toBeNull();
+    expect(sub!.metronomeContractId).toBe(EXISTING_CONTRACT_ID);
+    expect(sub!.status).toBe("active");
+  });
+});

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
@@ -7,6 +7,7 @@ import {
   scheduleMetronomeContractEnd,
   setMetronomeContractCustomFields,
 } from "@app/lib/metronome/client";
+import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import { PlanModel } from "@app/lib/models/plan";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -282,7 +283,7 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
 
     expect(setMetronomeContractCustomFields).toHaveBeenCalledWith({
       contractId: NEW_CONTRACT_ID,
-      customFields: { PLAN_CODE: ENT_PLAN_CODE },
+      customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
     });
 
     // Old contract is sunset, new one is skipped by id.

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -289,6 +289,7 @@ async function handler(
           metronomeCustomerId,
           packageId: pkg.id,
           startingAt: startingAtDate,
+          enableStripeBilling: true,
         });
         if (createResult.isErr()) {
           const errorMessage = `Failed to create Metronome contract: ${createResult.error.message}`;

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -10,9 +10,16 @@ import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { startOrResumeEnterprisePAYG } from "@app/lib/credits/payg";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import {
+  ceilToHourISO,
+  createMetronomeContract,
   findMetronomeCustomerByAlias,
-  getMetronomeContractById,
+  listMetronomeContracts,
+  listMetronomePackages,
+  scheduleMetronomeContractEnd,
+  setMetronomeContractCustomFields,
 } from "@app/lib/metronome/client";
+import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import {
   assertStripeSubscriptionIsValid,
   getStripeSubscription,
@@ -100,23 +107,82 @@ async function handler(
       }
       const body = bodyValidation.right;
 
-      let metronome:
-        | {
-            metronomeCustomerId: string;
-            metronomeContractId: string;
-            startingAt: string;
-          }
-        | undefined = undefined;
+      const programmaticConfigValidation =
+        ProgrammaticUsageConfigurationSchema.safeParse(body);
+      if (!programmaticConfigValidation.success) {
+        const errorMessage = programmaticConfigValidation.error.errors
+          .map((e) => `${e.path.join(".")}: ${e.message}`)
+          .join(", ");
+        await pluginRun.recordError(errorMessage);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: errorMessage,
+          },
+        });
+      }
+
+      const {
+        freeCreditsOverrideEnabled,
+        freeCreditsDollars,
+        defaultDiscountPercent,
+        paygEnabled,
+        paygCapDollars,
+      } = programmaticConfigValidation.data;
+
+      const freeCreditMicroUsd =
+        freeCreditsOverrideEnabled && freeCreditsDollars
+          ? Math.round(freeCreditsDollars * 1_000_000)
+          : null;
+
+      const paygCapMicroUsd =
+        paygEnabled && paygCapDollars
+          ? Math.round(paygCapDollars * 1_000_000)
+          : null;
+
+      // Metronome path: schedule the upgrade in Metronome. The subscription
+      // DB record is updated later by the contract.start webhook.
 
       if (useMetronomeBilling) {
-        if (!body.metronomeContractId) {
+        if (!body.metronomePackageId || !body.startingAt) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
               message:
-                "metronomeContractId is required when metronome_billing is enabled.",
+                "metronomePackageId and startingAt are required when metronome_billing is enabled.",
             },
+          });
+        }
+
+        if (!isEntreprisePlanPrefix(body.planCode)) {
+          const errorMessage = `Plan ${body.planCode} is not an enterprise plan.`;
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: { type: "invalid_request_error", message: errorMessage },
+          });
+        }
+
+        // Gate: only allow this flow for workspaces whose current subscription
+        // is Metronome-only billed. Running it on a free or Stripe-billed
+        // subscription would leave the workspace in a shadow-billed or
+        // orphaned state when the contract.start webhook swaps the subscription.
+        // TODO(remy): Use isSubscriptionMetronomeBilled that has to be merged from another PR
+        const currentSubscription = auth.subscriptionResource();
+        const currentIsMetronomeOnlyBilled =
+          currentSubscription !== null &&
+          currentSubscription.metronomeContractId !== null &&
+          !currentSubscription.isMetronomeShadowBilled;
+        if (!currentIsMetronomeOnlyBilled) {
+          const errorMessage =
+            "Workspace's current subscription is not Metronome-only billed. " +
+            "Migrate the workspace to Metronome billing before scheduling an Enterprise upgrade.";
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: { type: "invalid_request_error", message: errorMessage },
           });
         }
 
@@ -133,83 +199,180 @@ async function handler(
 
         const metronomeCustomerId = customerResult.value;
 
-        const contractResult = await getMetronomeContractById({
+        const ONE_HOUR_MS = 60 * 60 * 1000;
+        const requestedStartMs = Date.parse(body.startingAt);
+        if (Number.isNaN(requestedStartMs)) {
+          const errorMessage = "startingAt is not a valid ISO timestamp.";
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: errorMessage,
+            },
+          });
+        }
+
+        if (requestedStartMs < Date.now() + ONE_HOUR_MS) {
+          const errorMessage =
+            "startingAt must be at least one hour in the future.";
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: errorMessage,
+            },
+          });
+        }
+
+        // Metronome requires hour-aligned timestamps.
+        const startingAtDate = new Date(
+          ceilToHourISO(new Date(requestedStartMs))
+        );
+
+        const packagesResult = await listMetronomePackages();
+        if (packagesResult.isErr()) {
+          const errorMessage = `Failed to list Metronome packages: ${packagesResult.error.message}`;
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 502,
+            api_error: { type: "internal_server_error", message: errorMessage },
+          });
+        }
+
+        const pkg = packagesResult.value.find(
+          (p) => p.id === body.metronomePackageId
+        );
+        if (!pkg) {
+          const errorMessage = `Metronome package not found: ${body.metronomePackageId}`;
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: errorMessage,
+            },
+          });
+        }
+
+        const createResult = await createMetronomeContract({
           metronomeCustomerId,
-          metronomeContractId: body.metronomeContractId,
+          packageId: pkg.id,
+          startingAt: startingAtDate,
+        });
+        if (createResult.isErr()) {
+          const errorMessage = `Failed to create Metronome contract: ${createResult.error.message}`;
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 502,
+            api_error: {
+              type: "internal_server_error",
+              message: errorMessage,
+            },
+          });
+        }
+
+        const newMetronomeContractId = createResult.value.contractId;
+
+        // Stamp the target plan code on the new contract so the contract.start
+        // webhook can determine which plan to put the subscription on.
+        const customFieldsResult = await setMetronomeContractCustomFields({
+          contractId: newMetronomeContractId,
+          customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: body.planCode },
+        });
+        if (customFieldsResult.isErr()) {
+          const errorMessage =
+            `Created contract ${newMetronomeContractId} but failed to set ` +
+            `${PLAN_CODE_CUSTOM_FIELD_KEY}: ${customFieldsResult.error.message}. Manual cleanup required in Metronome.`;
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 502,
+            api_error: {
+              type: "internal_server_error",
+              message: errorMessage,
+            },
+          });
+        }
+
+        // Sunset any other non-archived contract on this customer that
+        // overlaps with our new contract's window. We list all contracts
+        // because `getMetronomeActiveContract` returns "the most recent",
+        // which is usually our just-created contract — masking the running
+        // one.
+        const contractsResult =
+          await listMetronomeContracts(metronomeCustomerId);
+        if (contractsResult.isErr()) {
+          const errorMessage =
+            `Created new contract ${newMetronomeContractId} but failed to list ` +
+            `existing contracts to sunset: ${contractsResult.error.message}. ` +
+            `Manual cleanup may be required.`;
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 502,
+            api_error: { type: "internal_server_error", message: errorMessage },
+          });
+        }
+
+        const newStartMs = startingAtDate.getTime();
+        for (const existing of contractsResult.value) {
+          if (existing.id === newMetronomeContractId) {
+            continue;
+          }
+          if (existing.archived_at) {
+            continue;
+          }
+          // Future-scheduled contracts that start after ours: leave them alone
+          // (sunsetting a contract to before it starts would be invalid).
+          const existingStartMs = new Date(existing.starting_at).getTime();
+          if (existingStartMs > newStartMs) {
+            continue;
+          }
+          // Already ends in time — nothing to do.
+          const existingEndsBeforeMs = existing.ending_before
+            ? new Date(existing.ending_before).getTime()
+            : null;
+          if (
+            existingEndsBeforeMs !== null &&
+            existingEndsBeforeMs <= newStartMs
+          ) {
+            continue;
+          }
+          const sunsetResult = await scheduleMetronomeContractEnd({
+            metronomeCustomerId,
+            contractId: existing.id,
+            endingBefore: startingAtDate,
+          });
+          if (sunsetResult.isErr()) {
+            const errorMessage =
+              `Created new contract ${newMetronomeContractId} but failed to sunset ` +
+              `existing contract ${existing.id}: ${sunsetResult.error.message}. ` +
+              `Manual cleanup may be required.`;
+            await pluginRun.recordError(errorMessage);
+            return apiError(req, res, {
+              status_code: 502,
+              api_error: {
+                type: "internal_server_error",
+                message: errorMessage,
+              },
+            });
+          }
+        }
+
+        // Programmatic-usage configuration is intentionally not touched on
+        // the Metronome path: the dialog hides the section, so unrendered
+        // form defaults could otherwise overwrite an existing config.
+
+        await pluginRun.recordResult({
+          display: "text",
+          value:
+            `Workspace ${owner.name} scheduled to upgrade to enterprise plan ${body.planCode} ` +
+            `at ${startingAtDate.toISOString()} (Metronome contract ${newMetronomeContractId}). ` +
+            `Subscription will flip when the contract.start webhook fires.`,
         });
 
-        if (contractResult.isErr()) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: `Failed to retrieve Metronome contract: ${contractResult.error.message}`,
-            },
-          });
-        }
-
-        const contract = contractResult.value;
-
-        if (contract.archived_at) {
-          const errorMessage = "The Metronome contract is archived.";
-          await pluginRun.recordError(errorMessage);
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: errorMessage,
-            },
-          });
-        }
-
-        if (
-          contract.ending_before &&
-          new Date(contract.ending_before) <= new Date()
-        ) {
-          const errorMessage = "The Metronome contract has already ended.";
-          await pluginRun.recordError(errorMessage);
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: errorMessage,
-            },
-          });
-        }
-
-        if (!contract.customer_billing_provider_configuration) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "No billing provider configured on the Metronome contract. Configure billing before upgrading.",
-            },
-          });
-        }
-
-        const isContractAlreadyUsed =
-          await SubscriptionResource.isMetronomeContractIdAlreadyUsed(
-            body.metronomeContractId
-          );
-        if (isContractAlreadyUsed) {
-          const errorMessage =
-            "The Metronome contract ID is already used by an existing subscription.";
-          await pluginRun.recordError(errorMessage);
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: errorMessage,
-            },
-          });
-        }
-
-        metronome = {
-          metronomeCustomerId,
-          metronomeContractId: body.metronomeContractId,
-          startingAt: contract.starting_at,
-        };
+        res.status(200).json({ success: true });
+        return;
       }
 
       let stripeSubscription = null;
@@ -286,40 +449,6 @@ async function handler(
         }
       }
 
-      const programmaticConfigValidation =
-        ProgrammaticUsageConfigurationSchema.safeParse(body);
-      if (!programmaticConfigValidation.success) {
-        const errorMessage = programmaticConfigValidation.error.errors
-          .map((e) => `${e.path.join(".")}: ${e.message}`)
-          .join(", ");
-        await pluginRun.recordError(errorMessage);
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: errorMessage,
-          },
-        });
-      }
-
-      const {
-        freeCreditsOverrideEnabled,
-        freeCreditsDollars,
-        defaultDiscountPercent,
-        paygEnabled,
-        paygCapDollars,
-      } = programmaticConfigValidation.data;
-
-      const freeCreditMicroUsd =
-        freeCreditsOverrideEnabled && freeCreditsDollars
-          ? Math.round(freeCreditsDollars * 1_000_000)
-          : null;
-
-      const paygCapMicroUsd =
-        paygEnabled && paygCapDollars
-          ? Math.round(paygCapDollars * 1_000_000)
-          : null;
-
       const upsertResult = await upsertProgrammaticUsageConfiguration(auth, {
         freeCreditMicroUsd,
         defaultDiscountPercent: defaultDiscountPercent ?? 0,
@@ -341,8 +470,7 @@ async function handler(
         await SubscriptionResource.pokeUpgradeWorkspaceToEnterprise(
           auth,
           body,
-          stripeSubscription,
-          metronome
+          stripeSubscription
         );
         // Restore workspace functionality after subscription upgrade
         await restoreWorkspaceAfterSubscription(auth);

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -6,7 +6,7 @@ import {
   upsertProgrammaticUsageConfiguration,
 } from "@app/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { startOrResumeEnterprisePAYG } from "@app/lib/credits/payg";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import {
@@ -87,11 +87,6 @@ async function handler(
         }
       );
 
-      const useMetronomeBilling = await hasFeatureFlag(
-        auth,
-        "metronome_billing"
-      );
-
       const bodyValidation = EnterpriseUpgradeFormSchema.decode(req.body);
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);
@@ -141,17 +136,22 @@ async function handler(
           ? Math.round(paygCapDollars * 1_000_000)
           : null;
 
+      const currentSubscription = auth.subscriptionResource();
+      const isCurrentSubscriptionMetronomeBilled =
+        currentSubscription?.isMetronomeOnlyBilled ?? false;
+      const requestedMetronomeUpgrade =
+        body.metronomePackageId !== undefined || body.startingAt !== undefined;
+
       // Metronome path: schedule the upgrade in Metronome. The subscription
       // DB record is updated later by the contract.start webhook.
-
-      if (useMetronomeBilling) {
+      if (requestedMetronomeUpgrade || isCurrentSubscriptionMetronomeBilled) {
         if (!body.metronomePackageId || !body.startingAt) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
               message:
-                "metronomePackageId and startingAt are required when metronome_billing is enabled.",
+                "metronomePackageId and startingAt are required for Metronome-billed subscriptions.",
             },
           });
         }
@@ -169,13 +169,7 @@ async function handler(
         // is Metronome-only billed. Running it on a free or Stripe-billed
         // subscription would leave the workspace in a shadow-billed or
         // orphaned state when the contract.start webhook swaps the subscription.
-        // TODO(remy): Use isSubscriptionMetronomeBilled that has to be merged from another PR
-        const currentSubscription = auth.subscriptionResource();
-        const currentIsMetronomeOnlyBilled =
-          currentSubscription !== null &&
-          currentSubscription.metronomeContractId !== null &&
-          !currentSubscription.isMetronomeShadowBilled;
-        if (!currentIsMetronomeOnlyBilled) {
+        if (!isCurrentSubscriptionMetronomeBilled) {
           const errorMessage =
             "Workspace's current subscription is not Metronome-only billed. " +
             "Migrate the workspace to Metronome billing before scheduling an Enterprise upgrade.";
@@ -376,14 +370,14 @@ async function handler(
       }
 
       let stripeSubscription = null;
-      if (!useMetronomeBilling) {
+      if (!requestedMetronomeUpgrade) {
         if (!body.stripeSubscriptionId) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
               message:
-                "stripeSubscriptionId is required when metronome billing is not enabled.",
+                "stripeSubscriptionId is required for Stripe-billed subscriptions.",
             },
           });
         }
@@ -477,7 +471,7 @@ async function handler(
 
         // If PAYG is enabled, create the PAYG credit for the current billing period
         if (
-          !useMetronomeBilling &&
+          !requestedMetronomeUpgrade &&
           stripeSubscription &&
           paygEnabled &&
           paygCapMicroUsd !== null

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -139,12 +139,47 @@ async function handler(
       const currentSubscription = auth.subscriptionResource();
       const isCurrentSubscriptionMetronomeBilled =
         currentSubscription?.isMetronomeOnlyBilled ?? false;
-      const requestedMetronomeUpgrade =
-        body.metronomePackageId !== undefined || body.startingAt !== undefined;
+      const isMetronomeUpgrade =
+        body.metronomePackageId !== undefined ||
+        body.startingAt !== undefined ||
+        isCurrentSubscriptionMetronomeBilled;
+
+      // PAYG on the Metronome path is not yet wired up: there is no
+      // Metronome-side cycle-renewal or invoicing for PAYG credits, so
+      // turning the flag on would let usage exceed commit silently. Reject
+      // before persisting the config so paygCapMicroUsd never reaches the DB
+      // for a Metronome workspace. Will be lifted in a follow-up PR.
+      if (isMetronomeUpgrade && paygEnabled) {
+        const errorMessage =
+          "Pay-as-you-go is not yet supported for Metronome-billed " +
+          "subscriptions and will be added in a follow-up PR.";
+        await pluginRun.recordError(errorMessage);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: { type: "invalid_request_error", message: errorMessage },
+        });
+      }
+
+      const upsertResult = await upsertProgrammaticUsageConfiguration(auth, {
+        freeCreditMicroUsd,
+        defaultDiscountPercent: defaultDiscountPercent ?? 0,
+        paygCapMicroUsd,
+      });
+      if (upsertResult.isErr()) {
+        const errorMessage = upsertResult.error.message;
+        await pluginRun.recordError(errorMessage);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: errorMessage,
+          },
+        });
+      }
 
       // Metronome path: schedule the upgrade in Metronome. The subscription
       // DB record is updated later by the contract.start webhook.
-      if (requestedMetronomeUpgrade || isCurrentSubscriptionMetronomeBilled) {
+      if (isMetronomeUpgrade) {
         if (!body.metronomePackageId || !body.startingAt) {
           return apiError(req, res, {
             status_code: 400,
@@ -369,87 +404,67 @@ async function handler(
         return;
       }
 
-      let stripeSubscription = null;
-      if (!requestedMetronomeUpgrade) {
-        if (!body.stripeSubscriptionId) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "stripeSubscriptionId is required for Stripe-billed subscriptions.",
-            },
-          });
-        }
-
-        stripeSubscription = await getStripeSubscription(
-          body.stripeSubscriptionId
-        );
-        if (!stripeSubscription) {
-          const errorMessage = "The Stripe subscription does not exist.";
-          await pluginRun.recordError(errorMessage);
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: errorMessage,
-            },
-          });
-        }
-
-        // Ensure the stripe subscription ID has not been used before (same or different workspace).
-        const isAlreadyUsed = await SubscriptionResource.isStripeIdAlreadyUsed(
-          stripeSubscription.id
-        );
-
-        if (isAlreadyUsed) {
-          const errorMessage =
-            "The Stripe subscription ID is already used by an existing subscription.";
-          await pluginRun.recordError(errorMessage);
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: errorMessage,
-            },
-          });
-        }
-
-        if (!isEnterpriseSubscription(stripeSubscription)) {
-          const errorMessage =
-            "The subscription provided is not an enterprise subscription.";
-          await pluginRun.recordError(errorMessage);
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: errorMessage,
-            },
-          });
-        }
-
-        const assertValidSubscription =
-          assertStripeSubscriptionIsValid(stripeSubscription);
-        if (assertValidSubscription.isErr()) {
-          const errorMessage = assertValidSubscription.error.invalidity_message;
-          await pluginRun.recordError(errorMessage);
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: errorMessage,
-            },
-          });
-        }
+      if (!body.stripeSubscriptionId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "stripeSubscriptionId is required for Stripe-billed subscriptions.",
+          },
+        });
       }
 
-      const upsertResult = await upsertProgrammaticUsageConfiguration(auth, {
-        freeCreditMicroUsd,
-        defaultDiscountPercent: defaultDiscountPercent ?? 0,
-        paygCapMicroUsd,
-      });
-      if (upsertResult.isErr()) {
-        const errorMessage = upsertResult.error.message;
+      const stripeSubscription = await getStripeSubscription(
+        body.stripeSubscriptionId
+      );
+      if (!stripeSubscription) {
+        const errorMessage = "The Stripe subscription does not exist.";
+        await pluginRun.recordError(errorMessage);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: errorMessage,
+          },
+        });
+      }
+
+      // Ensure the stripe subscription ID has not been used before (same or different workspace).
+      const isAlreadyUsed = await SubscriptionResource.isStripeIdAlreadyUsed(
+        stripeSubscription.id
+      );
+
+      if (isAlreadyUsed) {
+        const errorMessage =
+          "The Stripe subscription ID is already used by an existing subscription.";
+        await pluginRun.recordError(errorMessage);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: errorMessage,
+          },
+        });
+      }
+
+      if (!isEnterpriseSubscription(stripeSubscription)) {
+        const errorMessage =
+          "The subscription provided is not an enterprise subscription.";
+        await pluginRun.recordError(errorMessage);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: errorMessage,
+          },
+        });
+      }
+
+      const assertValidSubscription =
+        assertStripeSubscriptionIsValid(stripeSubscription);
+      if (assertValidSubscription.isErr()) {
+        const errorMessage = assertValidSubscription.error.invalidity_message;
         await pluginRun.recordError(errorMessage);
         return apiError(req, res, {
           status_code: 400,
@@ -470,12 +485,7 @@ async function handler(
         await restoreWorkspaceAfterSubscription(auth);
 
         // If PAYG is enabled, create the PAYG credit for the current billing period
-        if (
-          !requestedMetronomeUpgrade &&
-          stripeSubscription &&
-          paygEnabled &&
-          paygCapMicroUsd !== null
-        ) {
+        if (paygEnabled && paygCapMicroUsd !== null) {
           const paygResult = await startOrResumeEnterprisePAYG({
             auth,
             stripeSubscription,

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -26,7 +26,6 @@ export type PokeGetWorkspaceInfo = {
   activeSubscription: SubscriptionType;
   baseUrl: string;
   extensionConfig: ExtensionConfigurationType | null;
-  hasMetronomeBilling: boolean;
   hasDummyFeature: boolean;
   membersCount: number;
   metronomeCustomerId: string | null;
@@ -97,10 +96,6 @@ async function handler(
       const programmaticUsageConfig =
         await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
 
-      const hasMetronomeBilling = await hasFeatureFlag(
-        auth,
-        "metronome_billing"
-      );
       const hasDummyFeature = await hasFeatureFlag(
         auth,
         "dummy_feature_for_flag_testing"
@@ -122,7 +117,6 @@ async function handler(
 
       return res.status(200).json({
         activeSubscription,
-        hasMetronomeBilling,
         hasDummyFeature,
         membersCount,
         metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -18,6 +18,7 @@ import {
   CREDIT_TYPE_USD_ID,
   DEV_CREDIT_TYPE_AWU_ID,
   DEV_CREDIT_TYPE_PROG_USD_ID,
+  PLAN_CODE_CUSTOM_FIELD_KEY,
   PROD_CREDIT_TYPE_AWU_ID,
   PROD_CREDIT_TYPE_PROG_USD_ID,
 } from "@app/lib/metronome/constants";
@@ -895,7 +896,7 @@ async function syncMetrics(): Promise<void> {
   for (const m of existing) {
     if (!desiredNames.has(m.name) && !isTestObject(m.name)) {
       console.log(
-        `  ⚠ ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale metric: ${m.name} (${m.id})`
+        `  ! ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale metric: ${m.name} (${m.id})`
       );
       if (EXECUTE) {
         await client.v1.billableMetrics.archive({ id: m.id });
@@ -1109,7 +1110,7 @@ async function syncProducts(): Promise<void> {
     const name = p.current?.name ?? "";
     if (!desiredNames.has(name) && !isTestObject(name)) {
       console.log(
-        `  ⚠ ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale product: ${name} (${p.id})`
+        `  ! ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale product: ${name} (${p.id})`
       );
       if (EXECUTE) {
         try {
@@ -1324,7 +1325,7 @@ async function syncRateCards(): Promise<void> {
   for (const r of existing) {
     if (!desiredNames.has(r.name) && !isTestObject(r.name)) {
       console.log(
-        `  ⚠ ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale rate card: ${r.name} (${r.id})`
+        `  ! ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale rate card: ${r.name} (${r.id})`
       );
       if (EXECUTE) {
         try {
@@ -1576,7 +1577,7 @@ async function syncPackages(): Promise<void> {
     const isDesired = aliases.some((a) => desiredAliases.has(a));
     if (!isDesired && !isTestObject(p.name)) {
       console.log(
-        `  ⚠ ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale package: ${p.name} (${p.id})`
+        `  ! ${EXECUTE ? "Archiving" : "[DRYRUN] Would archive"} stale package: ${p.name} (${p.id})`
       );
       if (EXECUTE) {
         try {
@@ -1723,6 +1724,7 @@ const CUSTOM_FIELD_KEYS: Array<{
 }> = [
   { entity: "contract", key: "MAU_TIERS" },
   { entity: "contract", key: "MAU_THRESHOLD" },
+  { entity: "contract", key: PLAN_CODE_CUSTOM_FIELD_KEY },
 ];
 
 async function syncCustomFields(): Promise<void> {

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -156,7 +156,11 @@ export const EnterpriseUpgradeFormSchema = t.intersection([
   }),
   t.partial({
     stripeSubscriptionId: NonEmptyString,
-    metronomeContractId: NonEmptyString,
+    // For the Metronome path: id of the Metronome package the customer will
+    // be placed on, plus a timestamp at least one hour in the future
+    // when the new contracts starts (and the existing contract sunsets).
+    metronomePackageId: NonEmptyString,
+    startingAt: NonEmptyString,
     freeCreditsDollars: t.number,
     defaultDiscountPercent: t.number,
     paygCapDollars: t.number,


### PR DESCRIPTION
## Description

Replaces the Poke Enterprise upgrade dialog's contract-id input with a package selector and a hour-aligned datetime picker. The POST handler creates a new Metronome contract stamped with the target plan code as a custom field, sunsets overlapping contracts, and leaves the subscription DB record untouched. The contract.start webhook later swaps the subscription onto the new contract + plan (preserving history via ended_backend_only). The contract.end handler is race-safe: it skips the workspace scrub when an active successor contract exists on the customer.

## Tests

functional + local env

## Risk

Only available on Metronome billed subscriptions

## Deploy Plan

Deploy front, run `npx tsx scripts/metronome_setup.ts --execute` in prod to create the `DUST_PLAN_CODE` custom field on Metronome contracts
