### PR TITLE
Add cat and grep tools to files MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -110,6 +110,8 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_supported_source_formats_for_output_format": "never_ask",
   },
   "files": {
+    "cat": "never_ask",
+    "grep": "never_ask",
     "list": "never_ask",
   },
   "freshservice": {

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -1,6 +1,6 @@
-import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -1,3 +1,4 @@
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -6,6 +7,12 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const FILES_SERVER_NAME = "files" as const;
 export const FILES_LIST_ACTION_NAME = "list" as const;
+export const FILES_CAT_ACTION_NAME = "cat" as const;
+export const FILES_GREP_ACTION_NAME = "grep" as const;
+
+export const CAT_LINES_DEFAULT = 200;
+export const CAT_LINES_MAX = 500;
+export const GREP_MATCHES_MAX = 50;
 
 export const FILES_TOOLS_METADATA = createToolsRecord({
   [FILES_LIST_ACTION_NAME]: {
@@ -20,6 +27,64 @@ export const FILES_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Listing available files",
       done: "Listed available files",
+    },
+  },
+  [FILES_CAT_ACTION_NAME]: {
+    description:
+      "Read the content of a text file by line range. " +
+      "Returns lines with their line numbers. " +
+      "Use `offset` to start at a specific line and `limit` to control how many lines to return. " +
+      "When the output is truncated, a footer indicates the next offset to use.",
+    schema: {
+      path: z
+        .string()
+        .describe(
+          `Scoped file path as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` (e.g. \`conversation/data.csv\`)`
+        ),
+      offset: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe("Line number to start reading from (1-indexed, default 1)"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(CAT_LINES_MAX)
+        .optional()
+        .describe(
+          `Maximum number of lines to return (default ${CAT_LINES_DEFAULT}, max ${CAT_LINES_MAX})`
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Reading file",
+      done: "Read file",
+    },
+  },
+  [FILES_GREP_ACTION_NAME]: {
+    description:
+      "Search a text file for lines matching a regular expression. " +
+      "Returns matching lines with their line numbers. " +
+      "Use the line numbers with `files__cat` to read surrounding context. " +
+      `Results are capped at ${GREP_MATCHES_MAX} matches.`,
+    schema: {
+      path: z
+        .string()
+        .describe(
+          `Scoped file path as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` (e.g. \`conversation/data.csv\`)`
+        ),
+      pattern: z
+        .string()
+        .describe(
+          "Regular expression to search for (case-sensitive; use `(?i)` prefix for case-insensitive)"
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Searching file",
+      done: "Searched file",
     },
   },
 });

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -1,0 +1,115 @@
+import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { CAT_LINES_DEFAULT } from "@app/lib/api/actions/servers/files/metadata";
+import {
+  isReadableAsText,
+  resolveConversationFile,
+} from "@app/lib/api/actions/servers/files/tools/utils";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { File as GCSFile } from "@google-cloud/storage";
+import * as readline from "readline";
+
+async function catText(
+  file: GCSFile,
+  path: string,
+  startLine: number,
+  maxLines: number
+): Promise<ToolHandlerResult> {
+  const lines: string[] = [];
+  let lineNumber = 0;
+  let byteCount = 0;
+  let byteCapped = false;
+  let totalLines = 0;
+
+  try {
+    const stream = file.createReadStream();
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    for await (const line of rl) {
+      lineNumber++;
+
+      if (lineNumber < startLine) {
+        continue;
+      }
+
+      totalLines++;
+
+      const lineWithNumber = `${lineNumber}: ${line}`;
+      const lineBytes = Buffer.byteLength(lineWithNumber + "\n", "utf8");
+
+      if (byteCount + lineBytes > FILE_OFFLOAD_TEXT_SIZE_BYTES) {
+        byteCapped = true;
+        break;
+      }
+
+      lines.push(lineWithNumber);
+      byteCount += lineBytes;
+
+      if (totalLines >= maxLines) {
+        break;
+      }
+    }
+
+    rl.close();
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `Failed to read file \`${path}\`: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  if (lines.length === 0) {
+    if (startLine > 1) {
+      return new Ok([
+        {
+          type: "text",
+          text: `No lines found at offset ${startLine} in \`${path}\`.`,
+        },
+      ]);
+    }
+    return new Ok([{ type: "text", text: `\`${path}\` is empty.` }]);
+  }
+
+  const endLine = startLine + lines.length - 1;
+
+  let text = lines.join("\n");
+  if (byteCapped) {
+    const kb = FILE_OFFLOAD_TEXT_SIZE_BYTES / 1024;
+    text +=
+      `\n\n[Truncated at ${kb}KB. Showing lines ${startLine}-${endLine}.` +
+      ` Use offset=${endLine + 1} to read more.]`;
+  } else if (totalLines >= maxLines) {
+    text += `\n\n[Showing lines ${startLine}-${endLine}. Use offset=${endLine + 1} to read more.]`;
+  }
+
+  return new Ok([{ type: "text", text }]);
+}
+
+export async function catHandler(
+  { path, offset, limit }: { path: string; offset?: number; limit?: number },
+  extra: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const resolvedRes = await resolveConversationFile(path, extra);
+  if (resolvedRes.isErr()) {
+    return resolvedRes;
+  }
+  // TODO(20260429 FILE SYSTEM) Add image support to cat (return vision content block).
+  const { file, mimeType } = resolvedRes.value;
+
+  if (!isReadableAsText(mimeType)) {
+    return new Ok([
+      {
+        type: "text",
+        text: `\`${path}\` is a binary file (${mimeType}) and cannot be read as text.`,
+      },
+    ]);
+  }
+
+  return catText(file, path, offset ?? 1, limit ?? CAT_LINES_DEFAULT);
+}

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -26,10 +26,10 @@ async function catText(
   let byteCapped = false;
   let totalLines = 0;
 
-  try {
-    const stream = file.createReadStream();
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  const stream = file.createReadStream();
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
+  try {
     for await (const line of rl) {
       lineNumber++;
 
@@ -54,8 +54,6 @@ async function catText(
         break;
       }
     }
-
-    rl.close();
   } catch (err) {
     return new Err(
       new MCPError(
@@ -63,6 +61,8 @@ async function catText(
       )
     );
   }
+
+  rl.close();
 
   if (lines.length === 0) {
     if (startLine > 1) {

--- a/front/lib/api/actions/servers/files/tools/grep.ts
+++ b/front/lib/api/actions/servers/files/tools/grep.ts
@@ -1,0 +1,101 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  FILES_CAT_ACTION_NAME,
+  FILES_SERVER_NAME,
+  GREP_MATCHES_MAX,
+} from "@app/lib/api/actions/servers/files/metadata";
+import {
+  isReadableAsText,
+  resolveConversationFile,
+} from "@app/lib/api/actions/servers/files/tools/utils";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import * as readline from "readline";
+
+export async function grepHandler(
+  { path, pattern }: { path: string; pattern: string },
+  extra: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const resolvedRes = await resolveConversationFile(path, extra);
+  if (resolvedRes.isErr()) {
+    return resolvedRes;
+  }
+  const { file, mimeType } = resolvedRes.value;
+
+  if (!isReadableAsText(mimeType)) {
+    return new Ok([
+      {
+        type: "text",
+        text:
+          `\`${path}\` is not a text file (${mimeType}) ` +
+          `and cannot be searched with grep.`,
+      },
+    ]);
+  }
+
+  let regex: RegExp;
+  try {
+    regex = new RegExp(pattern, "m");
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `Invalid regular expression: \`${pattern}\`. Error: ${normalizeError(err).message}`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const stream = file.createReadStream();
+
+  const matches: string[] = [];
+  let lineNumber = 0;
+  let capped = false;
+
+  try {
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    for await (const line of rl) {
+      lineNumber++;
+
+      if (regex.test(line)) {
+        matches.push(`${lineNumber}: ${line}`);
+
+        if (matches.length >= GREP_MATCHES_MAX) {
+          capped = true;
+          rl.close();
+          stream.destroy();
+          break;
+        }
+      }
+    }
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `Failed to read file \`${path}\`: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  if (matches.length === 0) {
+    return new Ok([
+      {
+        type: "text",
+        text: `No lines matched \`${pattern}\` in \`${path}\`.`,
+      },
+    ]);
+  }
+
+  let text = matches.join("\n");
+  if (capped) {
+    text += `\n\n[Showing first ${GREP_MATCHES_MAX} matches. Refine your pattern or use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` with a line offset to read a specific section.]`;
+  } else {
+    text += `\n\n[${matches.length} match${matches.length === 1 ? "" : "es"} found]`;
+  }
+
+  return new Ok([{ type: "text", text }]);
+}

--- a/front/lib/api/actions/servers/files/tools/grep.ts
+++ b/front/lib/api/actions/servers/files/tools/grep.ts
@@ -56,9 +56,9 @@ export async function grepHandler(
   let lineNumber = 0;
   let capped = false;
 
-  try {
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
+  try {
     for await (const line of rl) {
       lineNumber++;
 

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -1,10 +1,16 @@
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  FILES_CAT_ACTION_NAME,
+  FILES_GREP_ACTION_NAME,
   FILES_LIST_ACTION_NAME,
   FILES_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/files/metadata";
+import { catHandler } from "@app/lib/api/actions/servers/files/tools/cat";
+import { grepHandler } from "@app/lib/api/actions/servers/files/tools/grep";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 
 export const TOOLS = buildTools(FILES_TOOLS_METADATA, {
   [FILES_LIST_ACTION_NAME]: listHandler,
+  [FILES_CAT_ACTION_NAME]: catHandler,
+  [FILES_GREP_ACTION_NAME]: grepHandler,
 });

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -1,0 +1,82 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
+import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { stripMimeParameters } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
+import type { File as GCSFile } from "@google-cloud/storage";
+
+type ResolvedFile = { file: GCSFile; mimeType: string; sizeBytes: number };
+
+export async function resolveConversationFile(
+  path: string,
+  {
+    auth,
+    agentLoopContext,
+  }: Pick<ToolHandlerExtra, "auth" | "agentLoopContext">
+): Promise<Ok<ResolvedFile> | Err<MCPError>> {
+  const conversation = agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(new MCPError("No conversation context available."));
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const prefix = getConversationFilesBasePath({
+    workspaceId: owner.sId,
+    conversationId: conversation.sId,
+  });
+  const gcsPath = getGCSPathFromScopedPath({
+    prefix,
+    scopedPath: path,
+    useCase: "conversation",
+  });
+  if (!gcsPath) {
+    return new Err(
+      new MCPError(
+        `Invalid path: \`${path}\` does not belong to the conversation file system.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const bucket = getPrivateUploadBucket();
+  const file = bucket.file(gcsPath);
+
+  try {
+    const [metadata] = await file.getMetadata();
+    const rawContentType = isString(metadata.contentType)
+      ? metadata.contentType
+      : "application/octet-stream";
+    return new Ok({
+      file,
+      mimeType: stripMimeParameters(rawContentType),
+      sizeBytes: Number(metadata.size ?? 0),
+    });
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `File not found: \`${path}\`. Error: ${normalizeError(err).message}`,
+        { tracked: false }
+      )
+    );
+  }
+}
+
+// TODO(20260429 FILE SYSTEM): Find a more exhaustive approach to cover more files.
+export function isReadableAsText(contentType: string): boolean {
+  const mime = stripMimeParameters(contentType);
+  return (
+    mime.startsWith("text/") ||
+    [
+      "application/json",
+      "application/yaml",
+      "application/xml",
+      "application/x-ndjson",
+      "application/javascript",
+      "application/typescript",
+    ].includes(mime)
+  );
+}

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -1,5 +1,5 @@
-import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
 import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -6,6 +6,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { isSupportedImageContentType } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
+import type { LightWorkspaceType } from "@app/types/user";
 
 type GCSMountEntryBase = {
   fileName: string;
@@ -31,6 +32,43 @@ type GCSMountPoint = {
   useCase: "conversation";
   conversationId: string;
 };
+
+function resolvePrefix(
+  owner: LightWorkspaceType,
+  scope: GCSMountPoint
+): string {
+  switch (scope.useCase) {
+    case "conversation":
+      return getConversationFilesBasePath({
+        workspaceId: owner.sId,
+        conversationId: scope.conversationId,
+      });
+
+    default:
+      assertNever(scope.useCase);
+  }
+}
+
+/**
+ * Resolve a scoped path (e.g. `conversation/folder/file.txt`) to a full GCS object path.
+ * Returns null if the scoped path does not belong to the given use case.
+ */
+export function getGCSPathFromScopedPath({
+  prefix,
+  scopedPath,
+  useCase,
+}: {
+  prefix: string;
+  scopedPath: string;
+  useCase: GCSMountPoint["useCase"];
+}): string | null {
+  const scopePrefix = `${useCase}/`;
+  if (!scopedPath.startsWith(scopePrefix)) {
+    return null;
+  }
+
+  return prefix + scopedPath.slice(scopePrefix.length);
+}
 
 function makeDirectoryEntry(
   {
@@ -96,18 +134,7 @@ export async function listGCSMountFiles(
   scope: GCSMountPoint
 ): Promise<GCSMountEntry[]> {
   const owner = auth.getNonNullableWorkspace();
-
-  let prefix: string;
-  switch (scope.useCase) {
-    case "conversation":
-      prefix = getConversationFilesBasePath({
-        workspaceId: owner.sId,
-        conversationId: scope.conversationId,
-      });
-      break;
-    default:
-      assertNever(scope.useCase);
-  }
+  const prefix = resolvePrefix(owner, scope);
 
   const bucket = getPrivateUploadBucket();
   const gcsFiles = await bucket.getFiles({ prefix, maxResults: 200 });
@@ -203,18 +230,7 @@ export async function createGCSMountFile(
   }
 ): Promise<GCSMountFileEntry> {
   const owner = auth.getNonNullableWorkspace();
-
-  let prefix: string;
-  switch (scope.useCase) {
-    case "conversation":
-      prefix = getConversationFilesBasePath({
-        workspaceId: owner.sId,
-        conversationId: scope.conversationId,
-      });
-      break;
-    default:
-      assertNever(scope.useCase);
-  }
+  const prefix = resolvePrefix(owner, scope);
 
   const gcsPath = `${prefix}${fileName}`;
   const bucket = getPrivateUploadBucket();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR extends the files MCP server introduced in #25000 with two new tools:
- cat
- grep

➡️  Goal: completing the basic read interface the agent needs to work with files in the new file system.

The intended workflow for the agent is sequential and purposeful:
- `list` to discover what is available
- `grep` to locate content within a specific file without reading all of it
- `cat` to read a section by liner ange.

**_This is the journey we optimized for at every design decision._**

The `cat` tool reads a file by line range and returns numbered lines. It supports an `offset` (start line) and `limit` (line count), with a byte cap as a secondary safety net (like done in `mcp_execution.ts`) to prevent token explosion on pathologically long lines (minified JS, CSV, etc.). When either cap is hit, the footer explicitly provides the next offset value so the agent can continue without having to compute it. The continuation path should never require reasoning, only
re-invoking. This tool only support a few selected plain text files (list to be improved) and we will add support for images in a next PR.

Example:
```
1: import random
2: import math
3: 
4: def compute(x):
5:     return x * 7 + 61
6: 
7: results = [compute(i) for i in range(10)]
8: print(results)
```

The `grep` tool takes a file path and a regex and returns matching lines with their numbers. It intentionally operates on the full file rather than on a piped stream (different from current `conversation_files` MCP server, which grep on the paginated content): the agent should not need to cat-then-grep, it should go directly to grep on any file it suspects contains relevant content.
The 50-match cap is paired with a footer that tells the agent to refine its pattern or switch to cat with a known offset. The two tools are meant to complement each other, not replace one another.

**Example** _(searching for **compute**)_
```
4: def compute(x):
7: results = [compute(i) for i in range(10)]

[2 matches found]
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
