### PR TITLE
Fix multiple stake approvals for same tool

### DIFF
--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -101,14 +101,11 @@ export function MCPToolValidationRequired({
     setErrorMessage(null);
 
     const isAlwaysApproved = approved === "approved" && neverAskAgain;
-    const finalApproval: MCPValidationOutputType = isAlwaysApproved
-      ? "always_approved"
-      : approved;
 
     const result = await validateAction({
       validationRequest: blockedAction,
       messageId,
-      approved: finalApproval,
+      approved: isAlwaysApproved ? "always_approved" : approved,
     });
 
     if (!result.success) {

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -100,25 +100,23 @@ export function MCPToolValidationRequired({
 
     setErrorMessage(null);
 
-    const isAlwaysApproved = approved === "approved" && neverAskAgain;
-
     const result = await validateAction({
       validationRequest: blockedAction,
       messageId,
-      approved: isAlwaysApproved ? "always_approved" : approved,
+      approved:
+        approved === "approved" && neverAskAgain ? "always_approved" : approved,
     });
 
     if (!result.success) {
       setErrorMessage("Failed to assess action approval. Please try again.");
       return;
     }
-
     removeCompletedAction(blockedAction.actionId);
     setNeverAskAgain(false);
 
     // When the user grants always-allow, cascade to other queued
     // confirmations of the same tool so they don't have to click each one.
-    if (isAlwaysApproved && user) {
+    if (approved === "approved" && neverAskAgain && user) {
       const cascadable = getBlockedActions(user.sId).filter(
         (c) =>
           c.actionId !== blockedAction.actionId &&

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -169,11 +169,6 @@ export function MCPToolValidationRequired({
       ? "always_approved"
       : approved;
 
-    console.log("======= Validating action with approval:", {
-      actionId: blockedAction.actionId,
-      finalApproval,
-      isAlwaysApproved, });
-
     const result = await validateAction({
       validationRequest: blockedAction,
       messageId,
@@ -197,8 +192,6 @@ export function MCPToolValidationRequired({
             candidates: getBlockedActions(user.sId),
           })
         : [];
-
-    console.log("======= Cascadable actions:", cascadableActions.map((a) => a.actionId));
 
     removeCompletedAction(blockedAction.actionId);
     setNeverAskAgain(false);

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -113,32 +113,29 @@ export function MCPToolValidationRequired({
       return;
     }
 
-    // When the user grants always-allow, cascade to other queued
-    // confirmations of the same tool so they don't have to click each one.
-    // Capture matches before removing self so the candidate list is stable.
-    const cascadable =
-      isAlwaysApproved && user
-        ? getBlockedActions(user.sId).filter(
-            (c) =>
-              c.actionId !== blockedAction.actionId &&
-              c.status === "blocked_validation_required" &&
-              c.metadata.mcpServerName ===
-                blockedAction.metadata.mcpServerName &&
-              c.metadata.toolName === blockedAction.metadata.toolName
-          )
-        : [];
-
     removeCompletedAction(blockedAction.actionId);
     setNeverAskAgain(false);
 
-    for (const cascadeAction of cascadable) {
-      const cascadeResult = await validateAction({
-        validationRequest: cascadeAction,
-        messageId,
-        approved: "approved",
-      });
-      if (cascadeResult.success) {
-        removeCompletedAction(cascadeAction.actionId);
+    // When the user grants always-allow, cascade to other queued
+    // confirmations of the same tool so they don't have to click each one.
+    if (isAlwaysApproved && user) {
+      const cascadable = getBlockedActions(user.sId).filter(
+        (c) =>
+          c.actionId !== blockedAction.actionId &&
+          c.status === "blocked_validation_required" &&
+          c.metadata.mcpServerName === blockedAction.metadata.mcpServerName &&
+          c.metadata.toolName === blockedAction.metadata.toolName
+      );
+
+      for (const cascadeAction of cascadable) {
+        const cascadeResult = await validateAction({
+          validationRequest: cascadeAction,
+          messageId,
+          approved: "approved",
+        });
+        if (cascadeResult.success) {
+          removeCompletedAction(cascadeAction.actionId);
+        }
       }
     }
   };

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -4,9 +4,7 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import { extractArgRequiringApprovalValues } from "@app/lib/actions/tool_status";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
@@ -53,68 +51,6 @@ const MCP_TOOL_OVERRIDES: Partial<
     },
   },
 };
-
-// Returns the queued blocked actions that should be auto-approved alongside
-// `current` when the user grants always-allow. Low-stake persistence covers
-// the tool across agents and arg values; medium-stake persistence is keyed
-// on (agent, approval-relevant args), so the cascade is restricted to
-// candidates that share both.
-function findCascadableBlockedActions({
-  current,
-  candidates,
-}: {
-  current: BlockedToolExecution;
-  candidates: BlockedToolExecution[];
-}): BlockedToolExecution[] {
-  return candidates.filter((candidate) => {
-    if (candidate.actionId === current.actionId) {
-      return false;
-    }
-    if (candidate.status !== "blocked_validation_required") {
-      return false;
-    }
-    if (candidate.userId !== current.userId) {
-      return false;
-    }
-    if (candidate.metadata.mcpServerName !== current.metadata.mcpServerName) {
-      return false;
-    }
-    if (candidate.metadata.toolName !== current.metadata.toolName) {
-      return false;
-    }
-
-    if (current.stake === "medium") {
-      if (candidate.metadata.agentName !== current.metadata.agentName) {
-        return false;
-      }
-      const currentArgs = extractArgRequiringApprovalValues(
-        current.argumentsRequiringApproval ?? [],
-        current.inputs
-      );
-      const candidateArgs = extractArgRequiringApprovalValues(
-        candidate.argumentsRequiringApproval ?? [],
-        candidate.inputs
-      );
-      if (!areArgRecordsEqual(currentArgs, candidateArgs)) {
-        return false;
-      }
-    }
-
-    return true;
-  });
-}
-
-function areArgRecordsEqual(
-  a: Record<string, string>,
-  b: Record<string, string>
-): boolean {
-  const aKeys = Object.keys(a);
-  const bKeys = Object.keys(b);
-  if (aKeys.length !== bKeys.length) {
-    return false;
-  }
-  return aKeys.every((key) => a[key] === b[key]);
-}
 
 interface MCPToolValidationRequiredProps {
   triggeringUser: UserType | null;
@@ -181,36 +117,32 @@ export function MCPToolValidationRequired({
     }
 
     // When the user grants always-allow, cascade to other queued
-    // confirmations that the newly persisted preference would cover, so the
-    // user does not have to click through every pending call of the same
-    // tool individually. Capture matches before removing self from the
-    // queue so the candidate list is stable.
-    const cascadableActions =
+    // confirmations of the same tool so they don't have to click each one.
+    // Capture matches before removing self so the candidate list is stable.
+    const cascadable =
       isAlwaysApproved && user
-        ? findCascadableBlockedActions({
-            current: blockedAction,
-            candidates: getBlockedActions(user.sId),
-          })
+        ? getBlockedActions(user.sId).filter(
+            (c) =>
+              c.actionId !== blockedAction.actionId &&
+              c.status === "blocked_validation_required" &&
+              c.metadata.mcpServerName ===
+                blockedAction.metadata.mcpServerName &&
+              c.metadata.toolName === blockedAction.metadata.toolName
+          )
         : [];
 
     removeCompletedAction(blockedAction.actionId);
     setNeverAskAgain(false);
 
-    if (cascadableActions.length > 0) {
-      await concurrentExecutor(
-        cascadableActions,
-        async (matchingAction) => {
-          const cascadeResult = await validateAction({
-            validationRequest: matchingAction,
-            messageId,
-            approved: "approved",
-          });
-          if (cascadeResult.success) {
-            removeCompletedAction(matchingAction.actionId);
-          }
-        },
-        { concurrency: 4 }
-      );
+    for (const cascadeAction of cascadable) {
+      const cascadeResult = await validateAction({
+        validationRequest: cascadeAction,
+        messageId,
+        approved: "approved",
+      });
+      if (cascadeResult.success) {
+        removeCompletedAction(cascadeAction.actionId);
+      }
     }
   };
 

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -4,7 +4,9 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { extractArgRequiringApprovalValues } from "@app/lib/actions/tool_status";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
@@ -52,6 +54,68 @@ const MCP_TOOL_OVERRIDES: Partial<
   },
 };
 
+// Returns the queued blocked actions that should be auto-approved alongside
+// `current` when the user grants always-allow. Low-stake persistence covers
+// the tool across agents and arg values; medium-stake persistence is keyed
+// on (agent, approval-relevant args), so the cascade is restricted to
+// candidates that share both.
+function findCascadableBlockedActions({
+  current,
+  candidates,
+}: {
+  current: BlockedToolExecution;
+  candidates: BlockedToolExecution[];
+}): BlockedToolExecution[] {
+  return candidates.filter((candidate) => {
+    if (candidate.actionId === current.actionId) {
+      return false;
+    }
+    if (candidate.status !== "blocked_validation_required") {
+      return false;
+    }
+    if (candidate.userId !== current.userId) {
+      return false;
+    }
+    if (candidate.metadata.mcpServerName !== current.metadata.mcpServerName) {
+      return false;
+    }
+    if (candidate.metadata.toolName !== current.metadata.toolName) {
+      return false;
+    }
+
+    if (current.stake === "medium") {
+      if (candidate.metadata.agentName !== current.metadata.agentName) {
+        return false;
+      }
+      const currentArgs = extractArgRequiringApprovalValues(
+        current.argumentsRequiringApproval ?? [],
+        current.inputs
+      );
+      const candidateArgs = extractArgRequiringApprovalValues(
+        candidate.argumentsRequiringApproval ?? [],
+        candidate.inputs
+      );
+      if (!areArgRecordsEqual(currentArgs, candidateArgs)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+function areArgRecordsEqual(
+  a: Record<string, string>,
+  b: Record<string, string>
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  return aKeys.every((key) => a[key] === b[key]);
+}
+
 interface MCPToolValidationRequiredProps {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
@@ -71,8 +135,12 @@ export function MCPToolValidationRequired({
   const [neverAskAgain, setNeverAskAgain] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const { removeCompletedAction, isActionPulsing, stopPulsingAction } =
-    useBlockedActionsContext();
+  const {
+    getBlockedActions,
+    removeCompletedAction,
+    isActionPulsing,
+    stopPulsingAction,
+  } = useBlockedActionsContext();
   const { validateAction, isValidating } = useValidateAction({
     owner,
     conversationId,
@@ -96,19 +164,61 @@ export function MCPToolValidationRequired({
 
     setErrorMessage(null);
 
+    const isAlwaysApproved = approved === "approved" && neverAskAgain;
+    const finalApproval: MCPValidationOutputType = isAlwaysApproved
+      ? "always_approved"
+      : approved;
+
+    console.log("======= Validating action with approval:", {
+      actionId: blockedAction.actionId,
+      finalApproval,
+      isAlwaysApproved, });
+
     const result = await validateAction({
       validationRequest: blockedAction,
       messageId,
-      approved:
-        approved === "approved" && neverAskAgain ? "always_approved" : approved,
+      approved: finalApproval,
     });
 
     if (!result.success) {
       setErrorMessage("Failed to assess action approval. Please try again.");
       return;
     }
+
+    // When the user grants always-allow, cascade to other queued
+    // confirmations that the newly persisted preference would cover, so the
+    // user does not have to click through every pending call of the same
+    // tool individually. Capture matches before removing self from the
+    // queue so the candidate list is stable.
+    const cascadableActions =
+      isAlwaysApproved && user
+        ? findCascadableBlockedActions({
+            current: blockedAction,
+            candidates: getBlockedActions(user.sId),
+          })
+        : [];
+
+    console.log("======= Cascadable actions:", cascadableActions.map((a) => a.actionId));
+
     removeCompletedAction(blockedAction.actionId);
     setNeverAskAgain(false);
+
+    if (cascadableActions.length > 0) {
+      await concurrentExecutor(
+        cascadableActions,
+        async (matchingAction) => {
+          const cascadeResult = await validateAction({
+            validationRequest: matchingAction,
+            messageId,
+            approved: "approved",
+          });
+          if (cascadeResult.success) {
+            removeCompletedAction(matchingAction.actionId);
+          }
+        },
+        { concurrency: 4 }
+      );
+    }
   };
 
   const toolOverride =


### PR DESCRIPTION
## Description

When the agent fires multiple tool calls in parallel (or several blocked actions land before any are approved), each call is stored as `blocked_validation_required`. Clicking "Always allow" on one only flipped that single row — the other pending confirmations stayed blocked, forcing the user to click through every duplicate.

This change adds a client-side cascade in `MCPToolValidationRequired` after the always-approved call succeeds, the component scans the queue for other pending blocked actions of the same tool (`mcpServerName + toolName`) and approves them sequentially before removing them from the queue. The user's `user_tool_approvals` row is already persisted by the first call, so future calls remain auto-approved through the normal `getExecutionStatusFromConfig` path; this only resolves the duplicates that were already queued at the moment of the click.

Fixes https://github.com/dust-tt/tasks/issues/7904

## Tests

Several E2E manual tests

## Risk

Approving too much is there is a bug

## Deploy Plan

Front