### PR TITLE
Auth: avoid dependency on OAuth in simple load

### DIFF
--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -2,6 +2,7 @@ import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const inMemoryCache = vi.hoisted(() => new Map<string, string>());
+const mockOpenAIModelsList = vi.hoisted(() => vi.fn());
 
 vi.mock("@app/lib/api/redis", () => ({
   getRedisCacheClient: vi.fn().mockImplementation(() =>
@@ -55,6 +56,24 @@ vi.mock("@app/lib/utils/cache", async (importOriginal) => {
 });
 
 const mockGetCredentials = vi.fn();
+const mockPostCredentials = vi.fn();
+const mockDeleteCredentials = vi.fn();
+
+vi.mock("openai", () => {
+  class MockAuthenticationError extends Error {}
+
+  class MockOpenAI {
+    static AuthenticationError = MockAuthenticationError;
+
+    models = {
+      list: mockOpenAIModelsList,
+    };
+  }
+
+  return {
+    default: MockOpenAI,
+  };
+});
 
 vi.mock("@app/types/oauth/oauth_api", async (importOriginal) => {
   const actual = (await importOriginal()) as object;
@@ -63,7 +82,8 @@ vi.mock("@app/types/oauth/oauth_api", async (importOriginal) => {
     OAuthAPI: vi.fn().mockImplementation(function () {
       return {
         getCredentials: mockGetCredentials,
-        deleteCredentials: vi.fn().mockResolvedValue(new Ok(undefined)),
+        postCredentials: mockPostCredentials,
+        deleteCredentials: mockDeleteCredentials,
       };
     }),
   };
@@ -88,9 +108,17 @@ function getHealthCacheKey(workspaceId: number): string {
 describe("ProviderCredentialResource", () => {
   beforeEach(() => {
     mockGetCredentials.mockClear();
+    mockPostCredentials.mockClear();
+    mockDeleteCredentials.mockClear();
+    mockOpenAIModelsList.mockClear();
     mockGetCredentials.mockResolvedValue(
       new Ok({ credential: { content: { api_key: "sk-test" } } })
     );
+    mockPostCredentials.mockResolvedValue(
+      new Ok({ credential: { credential_id: "cred-openai-updated" } })
+    );
+    mockDeleteCredentials.mockResolvedValue(new Ok(undefined));
+    mockOpenAIModelsList.mockResolvedValue([]);
     inMemoryCache.clear();
   });
 
@@ -320,6 +348,42 @@ describe("ProviderCredentialResource", () => {
 
       expect(inMemoryCache.has(cacheKey)).toBe(false);
       expect(inMemoryCache.has(healthCacheKey)).toBe(false);
+    });
+
+    it("invalidates cache after updateApiKey", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
+      const cacheKey = getCacheKey(workspace.id);
+      const healthCacheKey = getHealthCacheKey(workspace.id);
+      inMemoryCache.clear();
+
+      await ProviderCredentialFactory.basic(workspace, "openai");
+
+      const [credential] =
+        await ProviderCredentialResource.listByWorkspace(authenticator);
+      await ProviderCredentialResource.fetchProvidersHealthByWorkspaceId(
+        workspace.id
+      );
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+      expect(inMemoryCache.has(healthCacheKey)).toBe(true);
+
+      await credential.updateApiKey(authenticator, { apiKey: "sk-updated" });
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+      expect(inMemoryCache.has(healthCacheKey)).toBe(false);
+      expect(mockOpenAIModelsList).toHaveBeenCalledOnce();
+      expect(mockPostCredentials).toHaveBeenCalledWith({
+        provider: "openai",
+        workspaceId: workspace.sId,
+        userId: authenticator.getNonNullableUser().sId,
+        credentials: { api_key: "sk-updated" },
+      });
+      expect(mockDeleteCredentials).toHaveBeenCalledWith({
+        credentialsId: "cred-openai",
+      });
     });
 
     it("returns fresh data after cache invalidation", async () => {

--- a/front/lib/resources/provider_credential_resource.test.ts
+++ b/front/lib/resources/provider_credential_resource.test.ts
@@ -78,6 +78,13 @@ function getCacheKey(workspaceId: number): string {
   return `cacheWithRedis-_baseFetchUncached-provider_credentials:workspaceId:${workspaceId}`;
 }
 
+function getHealthCacheKey(workspaceId: number): string {
+  return (
+    "cacheWithRedis-_fetchProvidersHealthUncached-" +
+    `provider_credentials_health:workspaceId:${workspaceId}`
+  );
+}
+
 describe("ProviderCredentialResource", () => {
   beforeEach(() => {
     mockGetCredentials.mockClear();
@@ -114,8 +121,6 @@ describe("ProviderCredentialResource", () => {
         isByok: true,
       });
       const workspace = authenticator.getNonNullableWorkspace();
-      // Authenticator init populates the cache (empty) via fetchByokProvidersHealth; clear it so
-      // credentials created below are visible on first listByWorkspace call.
       inMemoryCache.clear();
 
       await ProviderCredentialFactory.basic(workspace, "openai");
@@ -129,6 +134,38 @@ describe("ProviderCredentialResource", () => {
         "anthropic",
         "openai",
       ]);
+    });
+  });
+
+  describe("fetchProvidersHealthByWorkspaceId", () => {
+    it("returns persisted provider health without fetching credentials from OAuth", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+        isByok: true,
+      });
+      const workspace = authenticator.getNonNullableWorkspace();
+      inMemoryCache.clear();
+
+      await ProviderCredentialFactory.basic(workspace, "openai", {
+        isHealthy: true,
+      });
+      await ProviderCredentialFactory.basic(workspace, "anthropic", {
+        isHealthy: false,
+      });
+      mockGetCredentials.mockRejectedValue(
+        new Error("OAuth should not be called when fetching provider health.")
+      );
+
+      const result =
+        await ProviderCredentialResource.fetchProvidersHealthByWorkspaceId(
+          workspace.id
+        );
+
+      expect(result).toEqual({
+        anthropic: false,
+        openai: true,
+      });
+      expect(mockGetCredentials).not.toHaveBeenCalled();
     });
   });
 
@@ -268,15 +305,21 @@ describe("ProviderCredentialResource", () => {
       });
       const workspace = authenticator.getNonNullableWorkspace();
       const cacheKey = getCacheKey(workspace.id);
+      const healthCacheKey = getHealthCacheKey(workspace.id);
 
       await ProviderCredentialFactory.basic(workspace, "openai");
 
       await ProviderCredentialResource.listByWorkspace(authenticator);
+      await ProviderCredentialResource.fetchProvidersHealthByWorkspaceId(
+        workspace.id
+      );
       expect(inMemoryCache.has(cacheKey)).toBe(true);
+      expect(inMemoryCache.has(healthCacheKey)).toBe(true);
 
       await ProviderCredentialResource.deleteAllForWorkspace(authenticator);
 
       expect(inMemoryCache.has(cacheKey)).toBe(false);
+      expect(inMemoryCache.has(healthCacheKey)).toBe(false);
     });
 
     it("returns fresh data after cache invalidation", async () => {

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -48,6 +48,8 @@ type CachedProviderCredential = {
   credentials: ApiKeyCredentialsType;
 };
 
+type CachedProvidersHealth = Partial<Record<ByokModelProviderIdType, boolean>>;
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 export interface ProviderCredentialResource
@@ -116,6 +118,10 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     workspaceModelId: ModelId
   ) => `provider_credentials:workspaceId:${workspaceModelId}`;
 
+  private static readonly providerCredentialHealthCacheKeyResolver = (
+    workspaceModelId: ModelId
+  ) => `provider_credentials_health:workspaceId:${workspaceModelId}`;
+
   private static async _baseFetchUncached(
     workspaceModelId: ModelId,
     transaction?: Transaction
@@ -145,6 +151,19 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     }));
   }
 
+  private static async _fetchProvidersHealthUncached(
+    workspaceModelId: ModelId,
+    transaction?: Transaction
+  ): Promise<CachedProvidersHealth> {
+    const models = await ProviderCredentialResource.model.findAll({
+      attributes: ["providerId", "isHealthy"],
+      where: { workspaceId: workspaceModelId },
+      transaction,
+    });
+
+    return Object.fromEntries(models.map((m) => [m.providerId, m.isHealthy]));
+  }
+
   // Cache eviction is handled by Redis's allkeys-lfu eviction policy.
   private static baseFetchCached = cacheWithRedis(
     ProviderCredentialResource._baseFetchUncached,
@@ -152,10 +171,30 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     { cacheNullValues: false, ttlMs: PROVIDER_CREDENTIALS_CACHE_TTL_MS }
   );
 
+  private static fetchProvidersHealthCached = cacheWithRedis(
+    ProviderCredentialResource._fetchProvidersHealthUncached,
+    ProviderCredentialResource.providerCredentialHealthCacheKeyResolver,
+    { cacheNullValues: false, ttlMs: PROVIDER_CREDENTIALS_CACHE_TTL_MS }
+  );
+
   private static invalidateProviderCredentialCache = invalidateCacheWithRedis(
     ProviderCredentialResource._baseFetchUncached,
     ProviderCredentialResource.providerCredentialCacheKeyResolver
   );
+
+  private static invalidateProvidersHealthCache = invalidateCacheWithRedis(
+    ProviderCredentialResource._fetchProvidersHealthUncached,
+    ProviderCredentialResource.providerCredentialHealthCacheKeyResolver
+  );
+
+  private static async invalidateProviderCredentialCaches(
+    workspaceId: ModelId
+  ): Promise<void> {
+    await Promise.all([
+      this.invalidateProviderCredentialCache(workspaceId),
+      this.invalidateProvidersHealthCache(workspaceId),
+    ]);
+  }
 
   private static fromCachedData(
     data: CachedProviderCredential
@@ -278,7 +317,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       editedByUserId: user.id,
     });
 
-    await this.invalidateProviderCredentialCache(workspace.id);
+    await this.invalidateProviderCredentialCaches(workspace.id);
 
     notifyProviderCredentialsHealthUpdated(auth);
 
@@ -356,7 +395,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       credentialsId: oldCredentialId,
     });
 
-    await ProviderCredentialResource.invalidateProviderCredentialCache(
+    await ProviderCredentialResource.invalidateProviderCredentialCaches(
       workspace.id
     );
 
@@ -379,11 +418,9 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
     workspaceId: ModelId,
     transaction?: Transaction
   ): Promise<Partial<Record<ByokModelProviderIdType, boolean>>> {
-    const cached = transaction
-      ? await this._baseFetchUncached(workspaceId, transaction)
-      : await this.baseFetchCached(workspaceId);
-
-    return Object.fromEntries(cached.map((c) => [c.providerId, c.isHealthy]));
+    return transaction
+      ? this._fetchProvidersHealthUncached(workspaceId, transaction)
+      : this.fetchProvidersHealthCached(workspaceId);
   }
 
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
@@ -393,7 +430,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       where: { workspaceId: workspace.id },
     });
 
-    await this.invalidateProviderCredentialCache(workspace.id);
+    await this.invalidateProviderCredentialCaches(workspace.id);
   }
 
   // Returns the invalidated credential so the caller can emit credentials.invalidated, or null if no change was made.
@@ -430,7 +467,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
       return null;
     }
 
-    await this.invalidateProviderCredentialCache(workspace.id);
+    await this.invalidateProviderCredentialCaches(workspace.id);
     notifyProviderCredentialsHealthUpdated(auth);
 
     return credential;
@@ -460,7 +497,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
           credentialsId: this.credentialId,
         });
 
-        await ProviderCredentialResource.invalidateProviderCredentialCache(
+        await ProviderCredentialResource.invalidateProviderCredentialCaches(
           workspace.id
         );
 

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -20,6 +20,7 @@ import {
   ApiKeyCredentialContentSchema,
   type ApiKeyCredentialsType,
   type ProviderCredentialType,
+  type ProvidersHealth,
 } from "@app/types/provider_credential";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -35,7 +36,7 @@ import type { Attributes, ModelStatic, Transaction } from "sequelize";
 const API_KEY_REVEAL_WINDOW_MINUTES = 2;
 const PROVIDER_CREDENTIALS_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
-type CachedProviderCredential = {
+type ProviderCredential = {
   id: ModelId;
   workspaceId: ModelId;
   providerId: ByokModelProviderIdType;
@@ -47,8 +48,6 @@ type CachedProviderCredential = {
   updatedAt: number;
   credentials: ApiKeyCredentialsType;
 };
-
-type CachedProvidersHealth = Partial<Record<ByokModelProviderIdType, boolean>>;
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -125,7 +124,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   private static async _baseFetchUncached(
     workspaceModelId: ModelId,
     transaction?: Transaction
-  ): Promise<CachedProviderCredential[]> {
+  ): Promise<ProviderCredential[]> {
     const models = await ProviderCredentialResource.model.findAll({
       where: { workspaceId: workspaceModelId },
       transaction,
@@ -154,7 +153,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   private static async _fetchProvidersHealthUncached(
     workspaceModelId: ModelId,
     transaction?: Transaction
-  ): Promise<CachedProvidersHealth> {
+  ): Promise<ProvidersHealth> {
     const models = await ProviderCredentialResource.model.findAll({
       attributes: ["providerId", "isHealthy"],
       where: { workspaceId: workspaceModelId },
@@ -197,7 +196,7 @@ export class ProviderCredentialResource extends BaseResource<ProviderCredentialM
   }
 
   private static fromCachedData(
-    data: CachedProviderCredential
+    data: ProviderCredential
   ): ProviderCredentialResource {
     const blob: Attributes<ProviderCredentialModel> = {
       id: data.id,


### PR DESCRIPTION
## Description

Remove OAuth retrieval from `fetchProvidersHealthByWorkspaceId` maintaining cacheability.

This will help us not go to OAuth when constructing `Authenticators` which creates failures in migrations in particular.

Problem to solve: ~impossible to go to the end of https://github.com/dust-tt/dust/blob/main/front/scripts/ensure_all_mcp_server_views_created.ts when needed as it basically DOS OAuth leading to timeouts.

## Tests

Covered by existing tests + new tests. Tested locally.
Successfully run the migration on prodbox from the branch.

## Risk

Medium

## Deploy Plan

- deploy `front`