### PR TITLE
feat(project-todos): add creation rationale to takeaway extraction and propagate to actorRationale

### DIFF
--- a/front/lib/project_todo/analyze_document/action_items.test.ts
+++ b/front/lib/project_todo/analyze_document/action_items.test.ts
@@ -17,6 +17,7 @@ function makePrev(
     status: "open",
     detectedDoneAt: null,
     detectedDoneRationale: null,
+    detectedCreationRationale: null,
     ...overrides,
   };
 }
@@ -30,6 +31,7 @@ describe("buildActionItems — new items", () => {
             short_description: "Review PR",
             assignee_name: "Alice",
             assignee_user_id: "user-abc",
+            detected_creation_rationale: "Alice committed to reviewing the PR",
           },
         ],
         updatedItems: [],
@@ -47,6 +49,9 @@ describe("buildActionItems — new items", () => {
     expect(result[0].status).toBe("open");
     expect(result[0].detectedDoneAt).toBeNull();
     expect(result[0].detectedDoneRationale).toBeNull();
+    expect(result[0].detectedCreationRationale).toBe(
+      "Alice committed to reviewing the PR"
+    );
   });
 
   it("drops new items whose assignee is not a project member", () => {
@@ -57,6 +62,7 @@ describe("buildActionItems — new items", () => {
             short_description: "Call client",
             assignee_name: "Stranger",
             assignee_user_id: "unknown-id",
+            detected_creation_rationale: "Stranger said they would call",
           },
         ],
         updatedItems: [],
@@ -241,6 +247,7 @@ describe("buildPromptActionItems", () => {
         status: "open",
         detectedDoneAt: null,
         detectedDoneRationale: null,
+        detectedCreationRationale: null,
       },
       {
         sId: "def",
@@ -250,6 +257,7 @@ describe("buildPromptActionItems", () => {
         status: "done",
         detectedDoneAt: "2024-01-01T00:00:00.000Z",
         detectedDoneRationale: null,
+        detectedCreationRationale: null,
       },
     ];
     const prompt = buildPromptActionItems(items);

--- a/front/lib/project_todo/analyze_document/action_items.ts
+++ b/front/lib/project_todo/analyze_document/action_items.ts
@@ -56,6 +56,7 @@ export function buildActionItems(
       detectedDoneAt: transitioningToDone ? now : prev.detectedDoneAt,
       detectedDoneRationale:
         update.done?.detected_done_rationale ?? prev.detectedDoneRationale,
+      detectedCreationRationale: prev.detectedCreationRationale,
     };
   });
 
@@ -79,6 +80,7 @@ export function buildActionItems(
       status: "open",
       detectedDoneAt: null,
       detectedDoneRationale: null,
+      detectedCreationRationale: item.detected_creation_rationale,
     });
   }
 

--- a/front/lib/project_todo/analyze_document/types.ts
+++ b/front/lib/project_todo/analyze_document/types.ts
@@ -19,6 +19,11 @@ const NewActionItemSchema = z.object({
     .describe(
       "The participant id of the assigned person. Must be one of the participant ids listed in the prompt."
     ),
+  detected_creation_rationale: z
+    .string()
+    .describe(
+      "Brief explanation of why this item qualifies as a TODO — what commitment or request makes it worth tracking."
+    ),
 });
 
 export type NewActionItem = z.infer<typeof NewActionItemSchema>;

--- a/front/lib/project_todo/merge_into_project.test.ts
+++ b/front/lib/project_todo/merge_into_project.test.ts
@@ -24,6 +24,7 @@ function makeActionItem(
     status: "open",
     detectedDoneAt: null,
     detectedDoneRationale: null,
+    detectedCreationRationale: null,
     ...overrides,
   };
 }
@@ -93,6 +94,7 @@ function makeBlob(
     status: "todo" | "done";
     doneAt: Date | null;
     reasoningDoneAt: string | null;
+    reasoningCreatedAt: string | null;
   }> = {}
 ) {
   return {
@@ -100,6 +102,7 @@ function makeBlob(
     status: "todo" as const,
     doneAt: null,
     reasoningDoneAt: null,
+    reasoningCreatedAt: null,
     ...overrides,
   };
 }

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -67,6 +67,7 @@ type TodoBlob = {
   status: "todo" | "done";
   doneAt: Date | null;
   reasoningDoneAt: string | null;
+  reasoningCreatedAt: string | null;
 };
 
 // A candidate todo that has no existing source link yet and therefore needs to
@@ -437,6 +438,7 @@ async function createOrLinkTodos(
           text: primary.blob.text,
           status: primary.blob.status,
           doneAt: primary.blob.doneAt,
+          actorRationale: primary.blob.reasoningCreatedAt,
         },
         itemId: primary.itemId,
         source: primary.source,
@@ -533,5 +535,6 @@ export function actionItemBlob(item: TodoVersionedActionItem): TodoBlob {
       isDone && item.detectedDoneAt ? new Date(item.detectedDoneAt) : null,
     reasoningDoneAt:
       isDone && item.detectedDoneRationale ? item.detectedDoneRationale : null,
+    reasoningCreatedAt: item.detectedCreationRationale,
   };
 }

--- a/front/lib/resources/takeaways_resource.test.ts
+++ b/front/lib/resources/takeaways_resource.test.ts
@@ -50,6 +50,7 @@ describe("TakeawaysResource", () => {
         status: "open" as const,
         detectedDoneAt: null,
         detectedDoneRationale: null,
+        detectedCreationRationale: null,
       };
       const updated = await takeaway.updateWithVersion(auth, {
         actionItems: [actionItem],
@@ -77,6 +78,7 @@ describe("TakeawaysResource", () => {
               status: "open",
               detectedDoneAt: null,
               detectedDoneRationale: null,
+              detectedCreationRationale: null,
             },
           ],
         })
@@ -94,6 +96,7 @@ describe("TakeawaysResource", () => {
         status: "open" as const,
         detectedDoneAt: null,
         detectedDoneRationale: null,
+        detectedCreationRationale: null,
       };
       const actionItem2 = {
         sId: "ai_002",
@@ -103,6 +106,7 @@ describe("TakeawaysResource", () => {
         status: "done" as const,
         detectedDoneAt: "2026-04-24T00:00:00.000Z",
         detectedDoneRationale: "Mentioned as completed in summary",
+        detectedCreationRationale: null,
       };
 
       const v1 = await takeaway.updateWithVersion(auth, {
@@ -141,6 +145,7 @@ describe("TakeawaysResource", () => {
         status: "open" as const,
         detectedDoneAt: null,
         detectedDoneRationale: null,
+        detectedCreationRationale: null,
       };
 
       const first = await TakeawaysResource.makeNewForConversation(auth, {
@@ -242,6 +247,7 @@ describe("TakeawaysResource", () => {
         status: "open" as const,
         detectedDoneAt: null,
         detectedDoneRationale: null,
+        detectedCreationRationale: null,
       };
 
       const takeaway = await TakeawaysResource.makeNewForConversation(auth, {

--- a/front/tests/takeaway-evals/test-suites/action-items.ts
+++ b/front/tests/takeaway-evals/test-suites/action-items.ts
@@ -122,6 +122,7 @@ Score 3 if only Alice's action item is extracted, agent responses correctly igno
             status: "open",
             detectedDoneAt: null,
             detectedDoneRationale: null,
+            detectedCreationRationale: null,
           },
           {
             sId: "prev-action-2",
@@ -131,6 +132,7 @@ Score 3 if only Alice's action item is extracted, agent responses correctly igno
             status: "open",
             detectedDoneAt: null,
             detectedDoneRationale: null,
+            detectedCreationRationale: null,
           },
         ],
       },
@@ -221,6 +223,90 @@ Score 0 if vague items are extracted as action items.
 Score 1 if the hotfix is missing.
 Score 2 if the hotfix is extracted but vague items also appear.
 Score 3 if only the hotfix is extracted as an action item.`,
+    },
+
+    // ── Ownership from context + multiple parallel tracks ────────────────────
+
+    {
+      scenarioId: "ownership-and-parallel-tracks",
+      document: {
+        id: "doc-7",
+        title: "Ship requirements discussion",
+        type: "slack",
+        text: [
+          "$title: Thread in #initiative-projects: @matteo @rcs @ed Looking at the ship requirements from last meeting, we are getting dangerously close to have everything covered. @rcs is owning the opt-in part while polishing the todo autogeneration workflow.",
+          ">> @seb [10:21]",
+          "@matteo @rcs @ed Looking at the ship requirements from last meeting, we are getting dangerously close to have everything covered. @rcs is owning the opt-in part while polishing the todo autogeneration workflow.",
+          "",
+          "Now that we have the TODOs, having played a bit with them, personally, I will iterate on the humans UX / UI for them, notably:",
+          "",
+          "Ability to manually add a TODO",
+          "Ability to manually edit any TODO (including re-assignment)",
+          "Always show the button to start working on todo | the button to see the conversation",
+          "Allow to add a custom message and pick a custom agent when starting to work on a todo",
+          "Show the TODO with a custom UI in the conversation (instead of todo ID: ptr_X134YT34)",
+          "",
+          ">> @rcs  [10:42 AM]",
+          "Aligned on 1), 2) to have the symmetric between human/agents from collaboration",
+          "For 3) This could add a lot of visual burden in the UI, so unless we manage to find a clean way, I would not do it. I believe the current on hover is enough to be self-discoverable",
+          "Aligned on 4), and 5)",
+          "",
+          ">> @seb  [10:48 AM]",
+          "I believe the current on hover is enough to be self-discoverableDoesnt' work on mobile, and actually I wanted to do this because jd said it didn't discover via hover.",
+          "",
+          ">> @rcs  [10:51 AM]",
+          "As you seem to already have an idea to make this not-cluttered, let's do it!",
+          "",
+          ">> @seb  [12:45 PM]",
+          "After some discussions with @ed, I'll wait a bit on some item for more brainstorming.",
+          "",
+          "I'll do 3, 4 and 5 while we think more about 1 and 2.",
+          "",
+          ">> @rcs  [1:26 PM]",
+          "Could you share the tldr; on why not 1 and 2 now? :pray:",
+        ].join("\n"),
+        uri: "https://example.com/doc-7",
+      },
+      members: [
+        {
+          sId: "zxcvb",
+          fullName: "Rémy-Christophe Schermesser",
+          email: "rcs@dust.tt",
+        },
+        {
+          sId: "abcdef",
+          fullName: "Sebastien Flory",
+          email: "seb@dust.tt",
+        },
+        {
+          sId: "qwert",
+          fullName: "Edouard Wautier",
+          email: "ed@dust.tt",
+        },
+      ],
+      expectedAssertions: [
+        shouldExtractActionItem("show", {
+          assigneeUserId: "abcdef",
+          status: "open",
+        }),
+        shouldExtractActionItem("opt-in", {
+          assigneeUserId: "zxcvb",
+          status: "open",
+        }),
+        shouldNotExtractActionItem("1 and 2"),
+        maxActionItems(4),
+      ],
+      judgeCriteria: `Seb commits to working on items 3, 4, and 5 of the TODO UX improvements, and defers 1 and 2 to further brainstorming.
+Rcs is described as owning the opt-in part.
+
+- Rcs's opt-in ownership → action item assigned to user-rcs (open)
+- Seb's commitment to items 3, 4 and 5 → action items assigned to user-seb (open); these can be grouped or individual
+- Items 1 and 2 (manually add / edit TODO) are explicitly deferred — NOT action items
+
+Score 0 if deferred items 1 and 2 are extracted as action items.
+Score 1 if Rcs's opt-in ownership is missing.
+Score 2 if Seb's items are extracted but Rcs's item is missing or wrongly assigned.
+Score 3 if Rcs's opt-in item and Seb's items 3/4/5 are correctly extracted, items 1 and 2 are not.`,
     },
 
     // ── No inline completion should be registered ──────────────────────────────

--- a/front/types/takeaways.ts
+++ b/front/types/takeaways.ts
@@ -8,4 +8,5 @@ export type TodoVersionedActionItem = {
   status: TodoVersionedActionItemStatus;
   detectedDoneAt: string | null;
   detectedDoneRationale: string | null;
+  detectedCreationRationale: string | null;
 };


### PR DESCRIPTION
## Description

Adds creation rationale to takeaway extraction and prevents the system from reopening completed todos.

- `detected_creation_rationale` is now extracted from documents and propagated through `TodoVersionedActionItem` → `actionItemBlob` → `actorRationale` on new project todos.


## Tests


