### PR TITLE
feat(poke): add project TODO details plugin

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -18,6 +18,7 @@ export * from "./manage_authorized_domains";
 export * from "./manage_conversation_kill_switch";
 export * from "./manage_programmatic_usage_configuration";
 export * from "./manage_workspace_kill_switch";
+export * from "./project_todo_details";
 export * from "./reinforcement_workflow";
 export * from "./rename_workspace";
 export * from "./reset_message_rate_limit";

--- a/front/lib/api/poke/plugins/workspaces/project_todo_details.ts
+++ b/front/lib/api/poke/plugins/workspaces/project_todo_details.ts
@@ -1,0 +1,156 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { ProjectTodoTakeawaySourcesModel } from "@app/lib/resources/storage/models/project_todo_takeaway_sources";
+import {
+  TakeawaySourcesModel,
+  TakeawaysModel,
+} from "@app/lib/resources/storage/models/takeaways";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const projectTodoDetailsPlugin = createPlugin({
+  manifest: {
+    id: "project-todo-details",
+    name: "Project TODO Details",
+    description:
+      "Display all related objects for a Project TODO (sources, conversations, etc.)",
+    resourceTypes: ["workspaces"],
+    readonly: true,
+    args: {
+      todoId: {
+        type: "string",
+        label: "Project TODO sId or ModelId",
+        description:
+          "The sId or numeric ModelId of the Project TODO to inspect",
+      },
+    },
+  },
+  execute: async (auth, workspace, args) => {
+    if (!workspace) {
+      return new Err(new Error("Workspace not found."));
+    }
+
+    const numericId = Number(args.todoId);
+    const todo =
+      Number.isInteger(numericId) && numericId > 0
+        ? await ProjectTodoResource.fetchByModelIdWithDeleted(auth, numericId)
+        : await ProjectTodoResource.fetchBySIdWithDeleted(auth, args.todoId);
+
+    if (!todo) {
+      return new Err(new Error(`Project TODO not found: ${args.todoId}`));
+    }
+
+    const todoSId = todo.sId;
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const [sourcesMap, conversationsMap, takeawayLinks] = await Promise.all([
+      ProjectTodoResource.fetchSourcesForTodoIds(auth, { sIds: [todoSId] }),
+      ProjectTodoResource.fetchConversationIdsForTodoIds(auth, {
+        sIds: [todoSId],
+      }),
+      ProjectTodoTakeawaySourcesModel.findAll({
+        where: { workspaceId, projectTodoId: todo.id },
+        include: [
+          {
+            model: TakeawaySourcesModel,
+            as: "takeawaySource",
+            required: true,
+          },
+        ],
+      }),
+    ]);
+
+    const sources = sourcesMap.get(todoSId) ?? [];
+    const conversationId = conversationsMap.get(todoSId) ?? null;
+
+    // Fetch the parent TakeawaysModel rows to retrieve actionItems.
+    const takeawaysIds = [
+      ...new Set(
+        takeawayLinks
+          .map((l) => l.takeawaySource?.takeawaysId)
+          .filter((id): id is number => id != null)
+      ),
+    ];
+    const takeawaysById = new Map(
+      takeawaysIds.length > 0
+        ? (
+            await TakeawaysModel.findAll({
+              where: { workspaceId, id: takeawaysIds },
+            })
+          ).map((t) => [t.id, t])
+        : []
+    );
+
+    const statusEmoji: Record<string, string> = {
+      todo: "⬜",
+      in_progress: "🔄",
+      done: "✅",
+    };
+
+    const sourcesSection =
+      sources.length === 0
+        ? "_No sources._"
+        : sources
+            .map((s) => {
+              const link = s.sourceUrl ? ` ([link](${s.sourceUrl}))` : "";
+              return `- **${s.sourceType}** — ${s.sourceTitle ?? s.sourceId}${link}`;
+            })
+            .join("\n");
+
+    const conversationSection = conversationId
+      ? `\`${conversationId}\``
+      : "_No linked conversation._";
+
+    const takeawaysSection =
+      takeawayLinks.length === 0
+        ? "_No takeaway sources._"
+        : takeawayLinks
+            .map((link) => {
+              const src = link.takeawaySource;
+              const takeaway = src ? takeawaysById.get(src.takeawaysId) : null;
+              const srcLink = src?.sourceUrl
+                ? ` ([link](${src.sourceUrl}))`
+                : "";
+              const label = `**${src?.sourceType}** — ${src?.sourceTitle ?? src?.sourceId}${srcLink}`;
+
+              const matchingItem = takeaway?.actionItems?.find(
+                (item: { sId: string }) => item.sId === todoSId
+              );
+              const itemDetail = matchingItem
+                ? `\n  - _"${matchingItem.shortDescription}"_ (status: \`${matchingItem.status}\`)`
+                : "";
+
+              return `- ${label}${itemDetail}`;
+            })
+            .join("\n");
+
+    const doneAt = todo.doneAt ? new Date(todo.doneAt).toISOString() : "—";
+    const createdAt = new Date(todo.createdAt).toISOString();
+
+    return new Ok({
+      display: "markdown",
+      value: `## ${statusEmoji[todo.status] ?? "❓"} Project TODO \`${todo.sId}\`
+
+**Text:** ${todo.text}
+
+| Field | Value |
+|---|---|
+| Status | \`${todo.status}\` |
+| Created by | \`${todo.createdByType}\` |
+| Created at | ${createdAt} |
+| Done at | ${doneAt} |
+
+## Sources (${sources.length})
+
+${sourcesSection}
+
+## Takeaway Sources (${takeawayLinks.length})
+
+${takeawaysSection}
+
+## Linked Conversation
+
+${conversationSection}
+`,
+    });
+  },
+});

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -256,7 +256,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
   }
 
-  // Fetches a todo by its stable string sId.
+  // Fetches a todo by its stable string sId, excluding soft-deleted rows.
   static async fetchBySId(
     auth: Authenticator,
     sId: string
@@ -267,6 +267,35 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     }
     const results = await this.baseFetch(auth, { where: { id }, limit: 1 });
     return results[0] ?? null;
+  }
+
+  // Fetches a todo by its stable string sId, including soft-deleted rows.
+  static async fetchBySIdWithDeleted(
+    auth: Authenticator,
+    sId: string
+  ): Promise<ProjectTodoResource | null> {
+    const id = getResourceIdFromSId(sId);
+    if (id === null) {
+      return null;
+    }
+
+    const todo = await ProjectTodoModel.findOne({
+      where: { id, workspaceId: auth.getNonNullableWorkspace().id },
+    });
+
+    return todo ? new this(ProjectTodoModel, todo.get()) : null;
+  }
+
+  // Fetches a todo by its numeric ModelId, including soft-deleted rows.
+  static async fetchByModelIdWithDeleted(
+    auth: Authenticator,
+    id: ModelId
+  ): Promise<ProjectTodoResource | null> {
+    const todo = await ProjectTodoModel.findOne({
+      where: { id, workspaceId: auth.getNonNullableWorkspace().id },
+    });
+
+    return todo ? new this(ProjectTodoModel, todo.get()) : null;
   }
 
   static async fetchBySpace(

--- a/front/scripts/encode_sid.ts
+++ b/front/scripts/encode_sid.ts
@@ -22,6 +22,7 @@ const RESOURCE_TYPES = [
   "data_source_configuration",
   "table_configuration",
   "agent_configuration",
+  "project_todo",
 ] as const;
 
 makeScript(


### PR DESCRIPTION
## Description

Adds a new read-only poke plugin **"Project TODO Details"** under the `workspaces` resource type. Given a Project TODO `sId` or `id`, it fetches and displays:

- The todo's text, status, creation metadata, and timestamps
- All associated sources (type, title, URL)
- The linked conversation sId (if any)

Output is rendered as markdown in the existing `RunPluginDialog` UI — no new frontend or API routes needed.

<img width="425" height="496" alt="image" src="https://github.com/user-attachments/assets/e74ea4ae-0052-48e3-9d1e-e6ad813d9516" />


## Tests

Tested manually by running the plugin against an existing Project TODO sId in the poke admin UI.

## Risk



## Deploy Plan


