### PR TITLE
docs: add FAQ section for common questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,43 @@ Check out our [user guides and developer platform](https://docs.dust.tt)
 
 - [About Us](https://dust.tt/home/about)
 - [Open Positions](https://jobs.ashbyhq.com/dust)
+
+## FAQ
+
+### What is Dust?
+
+Dust is a custom AI agent platform designed to help teams build, deploy, and manage AI agents that automate workflows and accelerate work. It supports multiple LLM providers and integrates with existing tools and data sources.
+
+### How do I get started?
+
+The fastest way to explore Dust is through the [user guides](https://docs.dust.tt). For self-hosting, you can use the provided [Docker Compose](https://github.com/dust-tt/dust/blob/main/docker-compose.yml) configuration to run the platform locally.
+
+### What LLM providers are supported?
+
+Dust supports multiple large language model providers. You can configure your preferred provider through the platform settings. The platform is designed to be provider-agnostic, allowing you to choose the best model for your use case.
+
+### How do I deploy Dust?
+
+Dust can be deployed using:
+- **Docker Compose**: The repository includes a `docker-compose.yml` for easy local deployment
+- **Self-hosted**: The platform is designed to be self-hostable on your own infrastructure
+- **Managed**: Check [dust.tt](https://dust.tt) for managed deployment options
+
+### What technologies is Dust built with?
+
+Dust is built with **Rust** for performance-critical components and **TypeScript** for the application layer. This combination provides both speed and developer ergonomics.
+
+### How do I contribute?
+
+Dust is an open-source project. You can contribute by:
+1. Forking the repository
+2. Creating a feature or fix branch
+3. Submitting a pull request with a clear description of your changes
+
+For larger changes, consider opening an issue first to discuss your approach with the maintainers.
+
+### Where can I get help?
+
+- **Documentation**: [docs.dust.tt](https://docs.dust.tt)
+- **Issues**: [GitHub Issues](https://github.com/dust-tt/dust/issues)
+- **Website**: [dust.tt](https://dust.tt)


### PR DESCRIPTION
## Summary
Add a FAQ section to the README covering common questions about Dust for new users.

## Changes
- Added FAQ section with 7 questions covering:
  - What is Dust
  - How to get started
  - LLM provider support
  - Deployment options (Docker Compose/Self-hosted/Managed)
  - Technology stack (Rust + TypeScript)
  - Contribution guide
  - Help and support resources

## Motivation
The current README is very minimal with just a link to docs. New users often have basic questions about the platform, LLM support, deployment options, and how to contribute. A FAQ section provides quick answers without requiring users to navigate the full documentation.

## Checklist
- [x] Content is accurate and based on the project's repository and documentation
- [x] FAQ questions are relevant to new users
- [x] Links to official docs and website are preserved
- [x] Formatting follows the existing README style