### PR TITLE
[front] Make conversation timestamps locale-aware

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -478,7 +478,7 @@ export function UserMessage({
 }
 
 function getChipDateFormat(date: Date) {
-  return date.toLocaleDateString("en-EN", {
+  return date.toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -31,8 +31,7 @@ export const cleanTimestamp = (
 
 export const formatTimestring = (timestamp: number): string => {
   const date = new Date(timestamp);
-  return date.toLocaleTimeString("en-US", {
-    hour12: false,
+  return date.toLocaleTimeString(undefined, {
     hour: "2-digit",
     minute: "2-digit",
   });

--- a/front/lib/utils/wakeup_description.test.ts
+++ b/front/lib/utils/wakeup_description.test.ts
@@ -1,7 +1,6 @@
 import {
   describeWakeUpSchedule,
   formatWakeUpSidebarLabel,
-  formatWakeUpTimeOfDay,
   getNextWakeUpFireAt,
 } from "@app/lib/utils/wakeup_description";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
@@ -43,46 +42,33 @@ function localTimestamp(hour: number, minute: number): number {
   return new Date(2026, 3, 27, hour, minute).getTime();
 }
 
-describe("formatWakeUpTimeOfDay", () => {
-  it("zero-pads single-digit hours", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(9, 5))).toBe("09:05");
-  });
-
-  it("renders afternoon hours in 24-hour form", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(14, 0))).toBe("14:00");
-  });
-
-  it("renders midnight as 00:00", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(0, 0))).toBe("00:00");
-  });
-
-  it("renders noon as 12:00", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(12, 0))).toBe("12:00");
-  });
-
-  it("renders 1 PM as 13:00", () => {
-    expect(formatWakeUpTimeOfDay(localTimestamp(13, 0))).toBe("13:00");
-  });
-});
-
 describe("describeWakeUpSchedule (one_shot)", () => {
   it("prefixes the time with 'at'", () => {
     const wakeUp = makeWakeUp({
       type: "one_shot",
       fireAt: localTimestamp(9, 30),
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:30");
+    expect(describeWakeUpSchedule(wakeUp)).toMatch(
+      /^at \d{1,2}:\d{2}(?:\s?[AP]M)?$/
+    );
   });
 });
 
 describe("describeWakeUpSchedule (cron)", () => {
+  // The time portion of a cron description is locale-dependent (12h vs.
+  // 24h). These assertions match either form so the suite is portable
+  // across test environments.
+  const TIME = String.raw`\d{1,2}:\d{2}(?:\s?[AP]M)?`;
+
   it("describes a single weekday at a fixed time", () => {
     const wakeUp = makeWakeUp({
       type: "cron",
       cron: "0 9 * * 1",
       timezone: "America/New_York",
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00, only on Monday");
+    expect(describeWakeUpSchedule(wakeUp)).toMatch(
+      new RegExp(`^at ${TIME}, only on Monday$`)
+    );
   });
 
   it("describes a weekday range", () => {
@@ -91,8 +77,8 @@ describe("describeWakeUpSchedule (cron)", () => {
       cron: "30 8 * * 1-5",
       timezone: "America/New_York",
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe(
-      "at 08:30, Monday through Friday"
+    expect(describeWakeUpSchedule(wakeUp)).toMatch(
+      new RegExp(`^at ${TIME}, Monday through Friday$`)
     );
   });
 
@@ -114,13 +100,15 @@ describe("describeWakeUpSchedule (cron)", () => {
     expect(describeWakeUpSchedule(wakeUp)).toBe("every hour");
   });
 
-  it("renders multi-time crons in 24-hour form", () => {
+  it("renders multi-time crons", () => {
     const wakeUp = makeWakeUp({
       type: "cron",
       cron: "0 9,17 * * *",
       timezone: "America/New_York",
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00 and 17:00");
+    expect(describeWakeUpSchedule(wakeUp)).toMatch(
+      new RegExp(`^at ${TIME} and ${TIME}$`)
+    );
   });
 
   it("rewords every-other-day DOM steps", () => {
@@ -129,7 +117,9 @@ describe("describeWakeUpSchedule (cron)", () => {
       cron: "0 9 */2 * *",
       timezone: "America/New_York",
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00, every other day");
+    expect(describeWakeUpSchedule(wakeUp)).toMatch(
+      new RegExp(`^at ${TIME}, every other day$`)
+    );
   });
 
   it("rewords larger DOM steps", () => {
@@ -138,7 +128,9 @@ describe("describeWakeUpSchedule (cron)", () => {
       cron: "0 9 */3 * *",
       timezone: "America/New_York",
     });
-    expect(describeWakeUpSchedule(wakeUp)).toBe("at 09:00, every 3 days");
+    expect(describeWakeUpSchedule(wakeUp)).toMatch(
+      new RegExp(`^at ${TIME}, every 3 days$`)
+    );
   });
 });
 
@@ -157,16 +149,6 @@ describe("formatWakeUpSidebarLabel", () => {
     vi.useRealTimers();
   });
 
-  it("renders the time of day when the wake-up is within 24h", () => {
-    const oneHourLaterMs = NOW_MS + 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(oneHourLaterMs)).toBe("13:00");
-  });
-
-  it("renders the time of day for a wake-up exactly 24h away", () => {
-    const exactlyOneDayMs = NOW_MS + 24 * 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(exactlyOneDayMs)).toBe("12:00");
-  });
-
   it("renders the abbreviated weekday when the wake-up is more than 24h away", () => {
     // 25h after Monday noon -> Tuesday afternoon.
     const justOverADayMs = NOW_MS + 25 * 60 * 60 * 1000;
@@ -176,11 +158,6 @@ describe("formatWakeUpSidebarLabel", () => {
   it("renders the abbreviated weekday for far-future wake-ups", () => {
     const fiveDaysMs = NOW_MS + 5 * 24 * 60 * 60 * 1000;
     expect(formatWakeUpSidebarLabel(fiveDaysMs)).toBe("Sat");
-  });
-
-  it("renders the time of day for past timestamps", () => {
-    const oneHourAgoMs = NOW_MS - 60 * 60 * 1000;
-    expect(formatWakeUpSidebarLabel(oneHourAgoMs)).toBe("11:00");
   });
 });
 

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -3,13 +3,25 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { CronExpressionParser } from "cron-parser";
 import cronstrue from "cronstrue";
 
-// Render an instant as "HH:mm" (24-hour) in the viewer's local timezone, to
-// match the rest of the platform.
+// Render an instant as a localized time of day in the viewer's local
+// timezone. The locale is resolved from the browser/OS so users in 24h
+// regions see "14:30" and users in 12h regions see "2:30 PM".
 export function formatWakeUpTimeOfDay(timestamp: number): string {
   const date = new Date(timestamp);
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-  return `${hours}:${minutes}`;
+  return date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// Whether the viewer's locale prefers 24-hour time. Used to keep cron
+// schedule descriptions (rendered by cronstrue) consistent with the
+// time-of-day strings produced by `formatWakeUpTimeOfDay` above.
+function prefers24HourTime(): boolean {
+  const { hourCycle } = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+  }).resolvedOptions();
+  return hourCycle === "h23" || hourCycle === "h24";
 }
 
 // Compute the millisecond timestamp of the next time a wake-up fires. For
@@ -63,7 +75,7 @@ export function describeWakeUpSchedule(wakeUp: WakeUpType): string {
     case "cron": {
       let description = cronstrue.toString(config.cron, {
         verbose: false,
-        use24HourTimeFormat: true,
+        use24HourTimeFormat: prefers24HourTime(),
       });
       // cronstrue renders DOM steps as ", every N days in a month", which
       // reads awkwardly. Reword to natural English; "every 2" becomes


### PR DESCRIPTION
## Description
Drop hardcoded "en-US"/"en-EN" and manual HH:mm padding so message headers, the trigger-run chip, the sidebar wakeup label, and the wakeup banner/input-bar schedule (one-shot and cron) follow the viewer's browser locale — 24h for EU users, AM/PM for US users.
Removed some now redundant tests

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually w chrome dev tools locale override:
<img width="1124" height="717" alt="Screenshot 2026-04-29 at 3 48 05 PM" src="https://github.com/user-attachments/assets/593eec34-ca36-495c-b85d-60971624a8b0" />
<img width="1112" height="725" alt="Screenshot 2026-04-29 at 3 49 40 PM" src="https://github.com/user-attachments/assets/9d243260-588b-4eb9-822b-00ee03d107ba" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
