### PR TITLE
feat(sbx): workspace-level sandbox env vars manager

### DIFF
--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -34,12 +34,10 @@ const SecretsPage = withSuspense(
     import("@dust-tt/front/components/pages/workspace/developers/SecretsPage"),
   "SecretsPage"
 );
-const EgressPolicyPage = withSuspense(
+const SandboxPage = withSuspense(
   () =>
-    import(
-      "@dust-tt/front/components/pages/workspace/developers/EgressPolicyPage"
-    ),
-  "EgressPolicyPage"
+    import("@dust-tt/front/components/pages/workspace/developers/SandboxPage"),
+  "SandboxPage"
 );
 const MembersPage = withSuspense(
   () => import("@dust-tt/front/components/pages/workspace/MembersPage"),
@@ -111,8 +109,8 @@ export const adminRoutes: RouteObject[] = [
         element: <SecretsPage />,
       },
       {
-        path: "developers/egress-policy",
-        element: <EgressPolicyPage />,
+        path: "developers/sandbox",
+        element: <SandboxPage />,
       },
     ],
   },

--- a/front/admin/audit_log_schemas/sandbox_env_var.created.json
+++ b/front/admin/audit_log_schemas/sandbox_env_var.created.json
@@ -1,0 +1,8 @@
+{
+  "action": "sandbox_env_var.created",
+  "targets": [{ "type": "workspace" }, { "type": "sandbox_env_var" }],
+  "metadata": {
+    "name": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/sandbox_env_var.deleted.json
+++ b/front/admin/audit_log_schemas/sandbox_env_var.deleted.json
@@ -1,0 +1,8 @@
+{
+  "action": "sandbox_env_var.deleted",
+  "targets": [{ "type": "workspace" }, { "type": "sandbox_env_var" }],
+  "metadata": {
+    "name": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/sandbox_env_var.updated.json
+++ b/front/admin/audit_log_schemas/sandbox_env_var.updated.json
@@ -1,0 +1,9 @@
+{
+  "action": "sandbox_env_var.updated",
+  "targets": [{ "type": "workspace" }, { "type": "sandbox_env_var" }],
+  "metadata": {
+    "name": "string",
+    "previously_existed": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -128,6 +128,7 @@ import { UserProjectNotificationPreferenceModel } from "@app/lib/resources/stora
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import { WorkspaceVerificationAttemptModel } from "@app/lib/resources/storage/models/workspace_verification_attempt";
 import logger from "@app/logger/logger";
 import { sendInitDbMessage } from "@app/types/shared/deployment";
@@ -245,6 +246,7 @@ export function loadAllModels() {
     ProjectTodoTakeawaySourcesModel,
     UserProjectNotificationPreferenceModel,
     WorkspaceSensitivityLabelConfigModel,
+    WorkspaceSandboxEnvVarModel,
   ];
 }
 

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -81,7 +81,7 @@ export type SubNavigationAdminId =
   | "providers"
   | "api_keys"
   | "dev_secrets"
-  | "egress_policy"
+  | "sandbox"
   | "analytics"
   | "credits_usage";
 
@@ -95,7 +95,7 @@ export const ADMIN_ROUTE_PATTERNS: Record<SubNavigationAdminId, string[]> = {
   credits_usage: ["/w/[wId]/developers/credits-usage"],
   providers: ["/w/[wId]/developers/providers"],
   dev_secrets: ["/w/[wId]/developers/dev-secrets"],
-  egress_policy: ["/w/[wId]/developers/egress-policy"],
+  sandbox: ["/w/[wId]/developers/sandbox"],
 };
 
 export type SubNavigationAppId =
@@ -204,7 +204,7 @@ export const getTopNavigationTabs = (
           "/w/[wId]/developers/providers",
           "/w/[wId]/developers/api-keys",
           "/w/[wId]/developers/dev-secrets",
-          "/w/[wId]/developers/egress-policy",
+          "/w/[wId]/developers/sandbox",
         ]),
       sizing: "hug",
     });
@@ -318,11 +318,11 @@ export const subNavigationAdmin = ({
           current: isCurrent("dev_secrets"),
         },
         {
-          id: "egress_policy",
-          label: "Network",
+          id: "sandbox",
+          label: "Sandbox",
           icon: GlobeAltIcon,
-          href: `/w/${owner.sId}/developers/egress-policy`,
-          current: isCurrent("egress_policy"),
+          href: `/w/${owner.sId}/developers/sandbox`,
+          current: isCurrent("sandbox"),
           featureFlag: "sandbox_tools",
         },
       ],

--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -1,0 +1,51 @@
+import { EnvironmentSection } from "@app/components/pages/workspace/developers/sections/EnvironmentSection";
+import { NetworkSection } from "@app/components/pages/workspace/developers/sections/NetworkSection";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import {
+  CommandLineIcon,
+  ContentMessage,
+  InformationCircleIcon,
+  Page,
+} from "@dust-tt/sparkle";
+
+export function SandboxPage() {
+  const { isAdmin } = useAuth();
+  const { featureFlags } = useFeatureFlags();
+  const hasSandboxTools = featureFlags.includes("sandbox_tools");
+
+  const renderBody = () => {
+    if (!isAdmin) {
+      return (
+        <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
+          Only workspace admins can manage sandbox settings.
+        </ContentMessage>
+      );
+    }
+
+    if (!hasSandboxTools) {
+      return (
+        <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
+          Sandbox tools are not enabled for this workspace.
+        </ContentMessage>
+      );
+    }
+
+    return (
+      <>
+        <NetworkSection />
+        <EnvironmentSection />
+      </>
+    );
+  };
+
+  return (
+    <Page.Vertical gap="xl" align="stretch">
+      <Page.Header
+        title="Sandbox"
+        icon={CommandLineIcon}
+        description="Configure workspace-level sandbox network access and environment variables."
+      />
+      {renderBody()}
+    </Page.Vertical>
+  );
+}

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -1,0 +1,390 @@
+import {
+  ENV_VAR_NAME_REGEX,
+  isReservedEnvVarName,
+  MAX_VALUE_BYTES,
+} from "@app/lib/api/sandbox/env_vars";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
+import {
+  useDeleteWorkspaceSandboxEnvVar,
+  useUpsertWorkspaceSandboxEnvVar,
+  useWorkspaceSandboxEnvVars,
+} from "@app/lib/swr/sandbox";
+import { timeAgoFrom } from "@app/lib/utils";
+import type { WorkspaceSandboxEnvVarType } from "@app/types/sandbox/env_var";
+import {
+  Button,
+  ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  InformationCircleIcon,
+  Input,
+  LockIcon,
+  Page,
+  PlusIcon,
+  Spinner,
+  TextArea,
+  TrashIcon,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+const NAME_HELPER_TEXT =
+  "Must match ^[A-Z][A-Z0-9_]{0,63}$. Reserved: PATH, HOME, USER, SHELL, PWD, TERM, LANG, LC_ALL, HOSTNAME, TMPDIR, leading underscore, and prefixes LD_, DUST_, SANDBOX_, E2B_, DD_, CONVERSATION_, WORKSPACE_.";
+
+function getNameMessage(name: string, isReplacing: boolean): string {
+  if (name.length === 0) {
+    return NAME_HELPER_TEXT;
+  }
+
+  if (!ENV_VAR_NAME_REGEX.test(name)) {
+    return "Names must start with A-Z and then use only A-Z, 0-9, or underscore, up to 64 characters.";
+  }
+
+  if (isReservedEnvVarName(name)) {
+    return "This name is reserved for the sandbox runtime.";
+  }
+
+  return isReplacing
+    ? "A variable with this name already exists. Saving will replace its value."
+    : "This name can be saved.";
+}
+
+function getValueMessage(value: string): {
+  message: string;
+  isError: boolean;
+} {
+  if (value.length === 0) {
+    return {
+      message: "Values cannot be empty. Delete a variable to remove it.",
+      isError: true,
+    };
+  }
+
+  if (value.includes("\u0000")) {
+    return {
+      message: "Values cannot contain NUL bytes.",
+      isError: true,
+    };
+  }
+
+  const valueBytes = new TextEncoder().encode(value).length;
+  if (valueBytes > MAX_VALUE_BYTES) {
+    return {
+      message: "Values cannot exceed 32 KiB.",
+      isError: true,
+    };
+  }
+
+  return {
+    message: `${valueBytes} / ${MAX_VALUE_BYTES} bytes. Multiline values are allowed.`,
+    isError: false,
+  };
+}
+
+export function EnvironmentSection() {
+  const owner = useWorkspace();
+  const { isAdmin } = useAuth();
+  const { featureFlags } = useFeatureFlags();
+  const hasSandboxTools = featureFlags.includes("sandbox_tools");
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [envVarForm, setEnvVarForm] = useState({ name: "", value: "" });
+  const [envVarToDelete, setEnvVarToDelete] =
+    useState<WorkspaceSandboxEnvVarType | null>(null);
+
+  const {
+    envVars,
+    isWorkspaceSandboxEnvVarsLoading,
+    isWorkspaceSandboxEnvVarsError,
+  } = useWorkspaceSandboxEnvVars({
+    owner,
+    disabled: !hasSandboxTools || !isAdmin,
+  });
+  const { upsertWorkspaceSandboxEnvVar, isUpsertingWorkspaceSandboxEnvVar } =
+    useUpsertWorkspaceSandboxEnvVar({ owner });
+  const { deleteWorkspaceSandboxEnvVar, isDeletingWorkspaceSandboxEnvVar } =
+    useDeleteWorkspaceSandboxEnvVar({ owner });
+
+  const isReplacing = envVars.some((envVar) => envVar.name === envVarForm.name);
+  const nameMessage = getNameMessage(envVarForm.name, isReplacing);
+  const isNameInvalid =
+    envVarForm.name.length === 0 ||
+    !ENV_VAR_NAME_REGEX.test(envVarForm.name) ||
+    isReservedEnvVarName(envVarForm.name);
+  const valueMessage = getValueMessage(envVarForm.value);
+  const canSave =
+    !isNameInvalid &&
+    !valueMessage.isError &&
+    !isUpsertingWorkspaceSandboxEnvVar;
+
+  const closeDialog = () => {
+    setIsDialogOpen(false);
+    setEnvVarForm({ name: "", value: "" });
+  };
+
+  const handleSave = async () => {
+    if (!canSave) {
+      return;
+    }
+
+    const success = await upsertWorkspaceSandboxEnvVar(envVarForm);
+    if (success) {
+      closeDialog();
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!envVarToDelete) {
+      return;
+    }
+
+    const success = await deleteWorkspaceSandboxEnvVar(envVarToDelete);
+    if (success) {
+      setEnvVarToDelete(null);
+    }
+  };
+
+  const renderBody = () => {
+    if (!isAdmin) {
+      return (
+        <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
+          Only workspace admins can manage sandbox environment variables.
+        </ContentMessage>
+      );
+    }
+    if (!hasSandboxTools) {
+      return (
+        <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
+          Sandbox tools are not enabled for this workspace.
+        </ContentMessage>
+      );
+    }
+    if (isWorkspaceSandboxEnvVarsLoading) {
+      return <Spinner />;
+    }
+    if (isWorkspaceSandboxEnvVarsError) {
+      return (
+        <ContentMessage
+          variant="warning"
+          icon={InformationCircleIcon}
+          size="lg"
+          title="Failed to load"
+        >
+          The sandbox environment variables could not be loaded.
+        </ContentMessage>
+      );
+    }
+
+    return (
+      <Page.Vertical align="stretch" gap="lg">
+        <Page.SectionHeader
+          title="Environment variables"
+          description="Secrets mounted as env vars on every sandbox in this workspace."
+        />
+
+        <ContentMessage
+          variant="warning"
+          icon={InformationCircleIcon}
+          size="lg"
+          title="Handle as write-only secrets"
+        >
+          These values are mounted on every future sandbox in this workspace.
+          The agent is instructed not to print or echo them, and bash output is
+          redacted on a best-effort basis. This is defense-in-depth, not a
+          guarantee: encoded output, network calls from sandbox code, and short
+          or dictionary-like values may still leak. Use least-privilege,
+          high-entropy credentials and rotate often. Values cannot be viewed
+          after saving, only overwritten or deleted.
+        </ContentMessage>
+
+        <div className="flex justify-end">
+          <Button
+            label="Add variable"
+            icon={PlusIcon}
+            onClick={() => {
+              setEnvVarForm({ name: "", value: "" });
+              setIsDialogOpen(true);
+            }}
+            disabled={isUpsertingWorkspaceSandboxEnvVar}
+          />
+        </div>
+
+        {envVars.length === 0 ? (
+          <ContentMessage variant="info" size="lg">
+            No environment variables yet.
+          </ContentMessage>
+        ) : (
+          <div className="flex w-full flex-col divide-y divide-separator dark:divide-separator-night">
+            {envVars.map((envVar) => {
+              const updatedBy =
+                envVar.lastUpdatedByName ?? envVar.createdByName ?? "Unknown";
+
+              return (
+                <div key={envVar.name} className="flex items-center gap-3 py-3">
+                  <pre
+                    title={envVar.name}
+                    className="min-w-0 grow overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2 text-sm text-foreground dark:bg-muted-background-night dark:text-foreground-night"
+                  >
+                    {envVar.name}
+                  </pre>
+                  <div className="hidden shrink-0 text-right text-sm text-muted-foreground dark:text-muted-foreground-night sm:block">
+                    Updated{" "}
+                    {timeAgoFrom(envVar.updatedAt, { useLongFormat: true })} ago
+                    by {updatedBy}
+                  </div>
+                  <Button
+                    variant="warning"
+                    size="mini"
+                    icon={TrashIcon}
+                    tooltip={`Delete ${envVar.name}`}
+                    disabled={
+                      isDeletingWorkspaceSandboxEnvVar ||
+                      isUpsertingWorkspaceSandboxEnvVar
+                    }
+                    onClick={() => setEnvVarToDelete(envVar)}
+                    className="shrink-0"
+                  />
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </Page.Vertical>
+    );
+  };
+
+  return (
+    <>
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeDialog();
+          }
+        }}
+      >
+        <DialogContent size="lg">
+          <DialogHeader>
+            <DialogTitle>
+              {isReplacing ? "Replace variable" : "Add variable"}
+            </DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
+            <Page.Vertical align="stretch" gap="md">
+              <Input
+                label="Name"
+                name="name"
+                placeholder="API_TOKEN"
+                value={envVarForm.name}
+                message={nameMessage}
+                messageStatus={isNameInvalid ? "error" : "info"}
+                onChange={(event) =>
+                  setEnvVarForm({
+                    ...envVarForm,
+                    name: event.target.value.toUpperCase(),
+                  })
+                }
+                disabled={isUpsertingWorkspaceSandboxEnvVar}
+              />
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="sandbox-env-var-value"
+                  className="text-sm font-medium text-foreground dark:text-foreground-night"
+                >
+                  Value
+                </label>
+                <TextArea
+                  id="sandbox-env-var-value"
+                  name="value"
+                  autoComplete="off"
+                  minRows={8}
+                  placeholder="Paste the secret value"
+                  value={envVarForm.value}
+                  error={valueMessage.isError ? valueMessage.message : null}
+                  showErrorLabel={false}
+                  resize="vertical"
+                  onChange={(event) =>
+                    setEnvVarForm({
+                      ...envVarForm,
+                      value: event.target.value,
+                    })
+                  }
+                  disabled={isUpsertingWorkspaceSandboxEnvVar}
+                />
+                <div
+                  className={
+                    valueMessage.isError
+                      ? "text-xs text-warning-600 dark:text-warning-600-night"
+                      : "text-xs text-muted-foreground dark:text-muted-foreground-night"
+                  }
+                >
+                  {valueMessage.message}
+                </div>
+              </div>
+            </Page.Vertical>
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              onClick: closeDialog,
+            }}
+            rightButtonProps={{
+              label: isReplacing ? "Replace" : "Save",
+              icon: LockIcon,
+              onClick: () => {
+                void handleSave();
+              },
+              disabled: !canSave,
+              isLoading: isUpsertingWorkspaceSandboxEnvVar,
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {envVarToDelete ? (
+        <Dialog
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) {
+              setEnvVarToDelete(null);
+            }
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete {envVarToDelete.name}</DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
+              Are you sure you want to delete{" "}
+              <strong>{envVarToDelete.name}</strong>?
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: () => setEnvVarToDelete(null),
+              }}
+              rightButtonProps={{
+                label: "Delete",
+                variant: "warning",
+                onClick: () => {
+                  void handleDelete();
+                },
+                isLoading: isDeletingWorkspaceSandboxEnvVar,
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+      ) : null}
+
+      {renderBody()}
+    </>
+  );
+}

--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -18,7 +18,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  GlobeAltIcon,
   InformationCircleIcon,
   Input,
   Page,
@@ -29,7 +28,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
-export function EgressPolicyPage() {
+export function NetworkSection() {
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
   const { featureFlags } = useFeatureFlags();
@@ -278,14 +277,7 @@ export function EgressPolicyPage() {
         </DialogContent>
       </Dialog>
 
-      <Page.Vertical gap="xl" align="stretch">
-        <Page.Header
-          title="Network"
-          icon={GlobeAltIcon}
-          description="Configure workspace-level domains that sandboxes are allowed to access through the egress proxy."
-        />
-        {renderBody()}
-      </Page.Vertical>
+      {renderBody()}
     </>
   );
 }

--- a/front/docs/plans/sandbox-env-manager.md
+++ b/front/docs/plans/sandbox-env-manager.md
@@ -1,0 +1,789 @@
+# Sandbox Environment Manager — Implementation Plan
+
+## 1. Goal
+
+Add a workspace-level secret manager for sandbox env vars. Workspace admins
+write secrets (name + value) once; values are encrypted at rest and never
+re-exposed in the UI. On sandbox boot, all workspace env vars are merged into
+the sandbox process environment so agent-run code can read them via standard
+`process.env` / `os.environ`.
+
+The existing **Network** admin page (`/w/[wId]/developers/egress-policy`,
+`EgressPolicyPage.tsx`) is renamed to **Sandbox** and gains a second section,
+**Environment**, below the existing network controls.
+
+## 2. Decisions (locked)
+
+| Topic | Decision |
+| --- | --- |
+| Page URL | Rename to `/w/[wId]/developers/sandbox`; delete the old route in the same PR (no redirect — feature is Dust-only-flag-gated, no external bookmarks) |
+| Page layout | Single page, two stacked sections (Network, Environment) |
+| Update semantics | `POST` with same name overwrites the value (rotation) |
+| Encryption | Reuse `config.getDeveloperSecretsSecret()` (same as `DustAppSecret`) |
+| Algorithm | AES-256-CBC via `front/types/shared/utils/encryption.ts` |
+| Scope | Workspace-wide; every sandbox in the workspace gets all vars |
+| Feature flag | Reuse `sandbox_tools` (no new flag) |
+| Bulk paste `.env` | **Not in v1** |
+| Agent visibility | Agent may **use** env vars from code, but must not inspect/print/echo them. Mitigated via skill instructions + best-effort bash-tool output redaction (v1 scope: bash only, final-payload only). Not a guarantee — see §6 limitations. No system-prompt hint listing names. |
+| Name validation | `^[A-Z][A-Z0-9_]{0,63}$`, reserved-prefix blocklist, ≤ 50/workspace |
+| Audit | New `sandbox_env_var.{created,updated,deleted}` actions |
+
+### 2.1 Reserved name blocklist
+
+Reject the following on create/update:
+
+- Exact: `PATH`, `HOME`, `USER`, `SHELL`, `PWD`, `TERM`, `LANG`, `LC_ALL`,
+  `HOSTNAME`, `TMPDIR`
+- Prefix: `LD_*`, `DUST_*`, `SANDBOX_*`, `E2B_*`, `DD_*`, `CONVERSATION_*`,
+  `WORKSPACE_*`
+- Leading underscore: `_*`
+
+Rationale: prevents admins from breaking the sandbox boot environment, and
+prevents shadowing of variables we inject in
+`sandbox_resource.ts` (`DD_API_KEY`, `DD_HOST`, `CONVERSATION_ID`,
+`WORKSPACE_ID`).
+
+## 3. Data Model
+
+### 3.0 Why a new table (not reusing `DustAppSecret`)
+
+Considered and rejected. The existing `DustAppSecret` model already does
+encryption with the same key and would save ~a day of work, but reusing it
+creates problems we don't want:
+
+- **Namespace collision.** `DustAppSecret` rows are referenced by name in
+  Dust app / MCP server config (`secrets.MY_KEY`). Mixing sandbox env vars
+  into the same table means a sandbox secret could silently rebind a Dust
+  app block, or a Dust app secret could leak into every sandbox env.
+- **Different validation.** Sandbox env vars need strict POSIX names + a
+  reserved-prefix blocklist (`PATH`, `LD_*`, `DD_*`, …). Applying that to
+  `DustAppSecret` would break existing rows; not applying it loses the
+  protection.
+- **Different visibility.** `DustAppSecret` exposes a 1-char redacted
+  preview after creation; sandbox env vars must be write-only with no
+  preview at all.
+- **Different audit lineage.** Mixed events make "who changed sandbox
+  secrets" un-answerable.
+- **Different lifecycle.** If sandbox secrets ever get scoping, rotation
+  policies, or a separate access boundary, splitting later is a painful
+  data migration.
+
+Encryption helpers and the `DeveloperSecretsSecret` key are still shared.
+A common base resource is **not** introduced for two consumers — revisit
+if a third use case appears.
+
+### 3.1 Sequelize model
+
+`front/lib/resources/storage/models/workspace_sandbox_env_var.ts`
+(matches existing convention, e.g. `apps.ts`, `agent_memories.ts`)
+
+```ts
+class WorkspaceSandboxEnvVarModel extends WorkspaceAwareModel {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare workspaceId: ForeignKey<WorkspaceModel["id"]>;
+  declare name: string;             // validated against allowlist regex
+  declare encryptedValue: string;   // AES-256-CBC ciphertext (TEXT)
+  declare createdByUserId: ForeignKey<UserModel["id"]> | null;
+  declare lastUpdatedByUserId: ForeignKey<UserModel["id"]> | null;
+}
+```
+
+Indexes:
+- Unique `(workspaceId, name)` — enforces one row per name per workspace and
+  makes `(wId, name)` lookups fast for delete and overwrite.
+- Per `[BACK13]`, FK columns `workspaceId`, `createdByUserId`,
+  `lastUpdatedByUserId` need explicit indexes.
+
+Migration: a SQL file under `front/migrations/db/migration_N.sql`, generated
+via `./front/create_db_migration_file.sh` (which picks the next `N` and
+scaffolds the file). Register the new model in `front/admin/db.ts` so
+`init_db.sh` picks it up.
+
+### 3.2 Resource
+
+`front/lib/resources/workspace_sandbox_env_var_resource.ts`
+(per `[BACK11]`, model wears the `Model` suffix, resource does not).
+
+Public interface (no `ModelId`, no model objects per `[BACK4]`):
+
+```ts
+class WorkspaceSandboxEnvVarResource {
+  // Per [BACK15], Resource methods return Resources, not Types. The
+  // endpoint handler maps with .toJSON() to produce
+  // WorkspaceSandboxEnvVarType[] for the wire response.
+  static listForWorkspace(auth): Promise<WorkspaceSandboxEnvVarResource[]>
+  static fetchByName(auth, name): Promise<WorkspaceSandboxEnvVarResource | null>
+  static upsert(auth, { name, value, user }): Promise<Result<{ created: boolean }, Error>>
+  static deleteByName(auth, name): Promise<Result<void, Error>>
+
+  toJSON(): WorkspaceSandboxEnvVarType
+
+  // Two explicit decrypt helpers — same impl, distinct logger context so
+  // we can audit-trace why secrets were materialized.
+  static loadEnvForSandboxProvisioning(auth): Promise<Record<string, string>>
+  static loadEnvForRedaction(auth): Promise<Record<string, string>>
+}
+```
+
+These are the only paths that decrypt. The split makes call sites
+self-documenting (`provisioning` mounts onto a sandbox, `redaction` is
+read-only and used to filter tool I/O before it reaches the model). Each
+helper logs `{ workspaceId, useCase: "provision" | "redact", count }` on
+each call.
+
+### 3.3 Type interface (frontend-safe)
+
+`front/types/sandbox/env_var.ts`
+
+```ts
+export type WorkspaceSandboxEnvVarType = {
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  createdByName: string | null;
+  lastUpdatedByName: string | null;
+};
+// NOTE: never includes value or encryptedValue.
+```
+
+`toJSON()` on the Resource produces this shape (per `[BACK15]`).
+
+### 3.4 Encryption
+
+Reuse the helpers in `front/types/shared/utils/encryption.ts` with the same
+shape used by `DustAppSecret` (see
+`front/pages/api/w/[wId]/dust_app_secrets/index.ts:100`):
+
+```ts
+const encryptedValue = encrypt({
+  text: value,
+  key: owner.sId,           // workspace sId is mixed into the salt
+  useCase: "developer_secret",
+});
+
+const plaintext = decrypt({
+  encrypted: row.encryptedValue,
+  key: owner.sId,
+  useCase: "developer_secret",
+});
+```
+
+Algorithm: AES-256-CBC, IV derived from `md5(key)`, key derived from
+`sha256(getDeveloperSecretsSecret() + key)`. The plaintext value never
+leaves the server; `WorkspaceSandboxEnvVarResource.toJSON()` does not
+include it.
+
+## 4. Backend API
+
+All endpoints live under the existing sandbox API namespace, alongside
+`egress-policy.ts`.
+
+### 4.1 `front/pages/api/w/[wId]/sandbox/env-vars/index.ts`
+
+| Method | Auth | Behavior |
+| --- | --- | --- |
+| `GET` | admin | List names + metadata. Body: `{ envVars: WorkspaceSandboxEnvVarType[] }` |
+| `POST` | admin | Create or overwrite. Body: `{ name: string, value: string }`. Validates name + value length. Emits `sandbox_env_var.created` or `sandbox_env_var.updated` based on whether row pre-existed. |
+
+Gated by `sandbox_tools` feature flag (matches `egress-policy.ts:50`).
+
+### 4.2 `front/pages/api/w/[wId]/sandbox/env-vars/[name].ts`
+
+| Method | Auth | Behavior |
+| --- | --- | --- |
+| `DELETE` | admin | Delete by name. 404 if not found. Emits `sandbox_env_var.deleted`. |
+
+Note: `[name]` is **not** a `ModelId` per `[SEC2]`, so this is OK. Name is
+validated against the same regex on read to prevent path traversal.
+
+### 4.3 Swagger annotation
+
+Both new endpoint files start with `/** @ignoreswagger */` (line 1),
+matching the existing pattern in
+`front/pages/api/w/[wId]/sandbox/egress-policy.ts:1`. Sandbox-admin APIs
+are private and Dust-only-flag-gated; documenting them in Swagger is not
+useful and would require schema entries in
+`pages/api/swagger_private_schemas.ts` per `[BACK14]`. Revisit if/when
+the feature graduates beyond `dust_only`.
+
+The `lint:swagger-annotations` check enforces that every endpoint has
+either `@swagger` or `@ignoreswagger`, so omitting the annotation would
+fail CI.
+
+### 4.4 Validation helpers
+
+`front/lib/api/sandbox/env_vars.ts`
+
+```ts
+export const ENV_VAR_NAME_REGEX = /^[A-Z][A-Z0-9_]{0,63}$/;
+export const MAX_VALUE_BYTES = 32 * 1024; // 32 KiB, measured in UTF-8 bytes
+export const MAX_VARS_PER_WORKSPACE = 50;
+
+export function validateEnvVarName(name: string): Result<void, string>;
+export function isReservedEnvVarName(name: string): boolean;
+export function validateEnvVarValue(value: string): Result<void, string>;
+```
+
+`validateEnvVarValue` enforces:
+
+- **non-empty** — empty string is rejected (use `DELETE` to remove).
+- **size** — `Buffer.byteLength(value, "utf8") <= MAX_VALUE_BYTES`. Note:
+  enforced on bytes, not characters, so a 32 KiB cap is exact regardless
+  of whether the value is ASCII or multibyte.
+- **no NUL byte** — `value.includes("\u0000")` is rejected.
+- **multiline allowed** — LF and CRLF are explicitly permitted (legitimate
+  for PEM-encoded keys, JSON service-account blobs, etc.). The UI uses a
+  multiline text input.
+
+Returns `Result` per `[ERR1]`. Reserved names produce a user-facing error
+message naming the rule that was violated.
+
+### 4.5 Limit semantics
+
+The 50-var cap applies to **creating a new name**, not to overwriting an
+existing one:
+
+- `POST` with a name that does not yet exist + workspace already at 50 →
+  `400 { error: "limit_reached" }`.
+- `POST` with a name that **does** exist (rotation) → succeeds even at the
+  cap, since count is unchanged.
+
+This is enforced inside `WorkspaceSandboxEnvVarResource.upsert`: count the
+rows for the workspace, then insert if under the cap. **The check is
+best-effort, not race-free**: under default `READ COMMITTED` isolation,
+two concurrent creates can both observe count = 49, both pass the
+`count < 50` check, and both insert — landing the workspace at 51. We
+accept this race because:
+
+- the cap is a UI/usage guard, not a security boundary;
+- concurrent admin creates on the same workspace are extremely rare in
+  practice;
+- the next operation in that workspace (any create) will see the true
+  count and reject further inserts until rows fall below the cap;
+- adding a PG advisory lock or `SELECT ... FOR UPDATE` for this is more
+  ceremony than the failure mode warrants.
+
+Document the race with an inline comment in the upsert path so future
+readers don't try to "fix" it without understanding the trade-off:
+
+```ts
+// Best-effort cap. A concurrent burst of creates from the same workspace
+// can land 1-2 rows over MAX_VARS_PER_WORKSPACE under READ COMMITTED.
+// Acceptable: cap is a UI guard, not a security boundary.
+```
+
+## 5. Sandbox Injection
+
+### 5.1 Merge points
+
+Two call sites in `front/lib/resources/sandbox_resource.ts`:
+- Fresh create: lines `355–369`
+- Recreate after `deleted`: lines `458–470`
+
+Both currently merge image defaults with system vars
+(`DD_API_KEY`, `DD_HOST`, `CONVERSATION_ID`, `WORKSPACE_ID`).
+
+**Precedence (lowest → highest): workspace env → image `runEnv` → system
+vars.** Image `runEnv` is treated as infra: an admin must not be able to
+shadow it. System vars always win for the same reason. The reserved-prefix
+blocklist already filters out infra names, but the merge order enforces it
+as defense in depth.
+
+```ts
+const workspaceEnv =
+  await WorkspaceSandboxEnvVarResource.loadEnvForSandboxProvisioning(auth);
+
+const createResult = await provider.create({
+  ...createConfig,
+  envVars: {
+    ...workspaceEnv,                  // workspace secrets (lowest precedence)
+    ...createConfig.envVars,          // image runEnv overrides workspace
+    DD_API_KEY: config.getDatadogApiKey() ?? "",
+    DD_HOST: "http-intake.logs.datadoghq.eu",
+    CONVERSATION_ID: conversation.sId,
+    WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
+  },
+});
+```
+
+A small refactor extracts this `envVars` composition into a helper
+(`buildSandboxEnvVars(auth, conversation)`) shared between the two call
+sites — the duplication is already there pre-existing, so doing this as part
+of the same PR keeps `[GEN1]` happy.
+
+### 5.2 Snapshot semantics
+
+Env vars are read at sandbox **create** time. They do **not** propagate to a
+running sandbox; rotating a value affects the next sandbox boot in that
+conversation (next `getOrCreate`), not the current one. Documented in the UI.
+
+If a tighter SLA is needed later, we can add a
+`sandbox.commands.run({ envs: ... })` override in
+`front/lib/api/sandbox/providers/e2b.ts:257`, but that is out of scope for v1.
+
+### 5.3 Failure mode
+
+`loadEnvForSandboxProvisioning` is fail-closed: if decryption errors on
+any row, the whole sandbox boot returns `Err` rather than silently dropping
+the broken var. The error message identifies the offending name so the
+admin can delete and re-create. `loadEnvForRedaction` is also fail-closed
+— if it errors, the tool result is suppressed (returned as a generic error
+to the model) rather than passed through unredacted.
+
+## 6. Agent Disclosure Controls
+
+The agent gets the env vars (it has to — code it runs needs them) but is
+told not to reveal them, and **bash-tool output** is filtered before being
+shown back to the user / model.
+
+**v1 scope is deliberately narrow:**
+- Only the bash/code-exec tool runs the redactor. Other sandbox tools
+  (`add_egress_domain`, `dsbx`, etc.) are not instrumented. Bash is the
+  only tool whose output is meaningfully derived from the sandbox process
+  environment, so it is the only realistic leak vector via tool output.
+- Redaction operates on the **final tool result payload** only. The bash
+  tool today returns a single non-streaming `CallToolResult`, so a
+  final-payload pass sees the same bytes the model and persistence layer
+  see. (Implementer must re-verify this property when wiring up the
+  redactor; if bash ever moves to token-level streaming, redaction must
+  move with it — flagged in §12.)
+- **No input-argument scanning** and **no refusal path**. The skill
+  instruction is the primary defense against the agent passing values
+  back as arguments; we are not policing arg shapes in v1.
+
+### 6.1 Skill instructions
+
+Update the sandbox skill at
+`front/lib/resources/skill/code_defined/sandbox.ts` to add a clear rule:
+
+> **Environment variables.** The sandbox may have workspace-configured
+> environment variables available to your code (read via `process.env`,
+> `os.environ`, etc.). You may **use** them — pass them to APIs,
+> authenticate with them, read them in code paths that consume them — but
+> you must **never**:
+> - print, echo, or `cat` an env var value (no `printenv`, `env`,
+>   `echo $FOO`, `print(os.environ["FOO"])`, etc.);
+> - include an env var value in any output you emit, log line, error
+>   message, or final answer to the user;
+> - re-encode (base64, hex, reverse) and emit a value to bypass the
+>   above;
+> - list the available env var names just to enumerate what's there.
+>
+> If a user asks for a secret value, refuse and say it is not viewable.
+> If you need to confirm a var is set, check `"FOO" in os.environ`
+> (boolean only) — never read or print the value.
+
+This instruction is the **primary** defense. The bash-output redactor
+(§6.2) is a safety net for accidents — not the enforcement mechanism.
+
+This is added alongside the existing egress instructions so it is
+in-context for every code-running session.
+
+### 6.2 Bash-tool output redaction
+
+Best-effort redaction inside the bash tool result handler in
+`front/lib/api/actions/servers/sandbox/tools/index.ts` (the function that
+builds the tool result from `sandbox.commands.run` output). Other sandbox
+tools are out of scope.
+
+#### 6.2.1 Where the hook sits
+
+In the bash handler, **after** the formatted tool output is fully
+assembled (including any structured sections appended on top of raw
+stdout/stderr — e.g. the bash structured-rendering blocks from PR
+#24948), and **before** returning the `content` array to the MCP
+wrapper. One pass over the final string content blocks; the redactor
+does not see streamed bytes because bash returns a single non-streaming
+`CallToolResult`.
+
+If a future change makes bash streaming, this hook becomes incorrect —
+called out in §12 as a v2 follow-up to move into the provider layer.
+
+#### 6.2.2 Match-floor algorithm
+
+A value is **eligible for redaction** if and only if all of these hold:
+
+1. `value.length >= 12` — short values produce too many false positives
+   on innocent text.
+2. `value` is not in `LOW_VALUE_DENYLIST`, a small hardcoded set:
+   `{"true", "false", "production", "staging", "development", "admin",
+   "root", "localhost"}` plus pure-digit strings and pure-ASCII-letter
+   strings under 16 chars.
+3. (Optional, second-pass safety net) `value` does not match a common
+   English word; we do **not** ship a dictionary in v1, but the denylist
+   above covers the obvious cases. Rotation guidance in the UI ("use
+   high-entropy random tokens") is the practical defense for the rest.
+
+For values that **fail** the eligibility check, we emit a one-time
+`logger.info({ workspaceId, name }, "sandbox env var value not eligible
+for output redaction (too short or low-value)")` per workspace per
+process lifetime, so admins can be told if they ask why their `password`
+value is leaking. (Surfacing this to the admin UI is a v2 candidate.)
+
+#### 6.2.3 Replacement
+
+For each eligible value, substring-replace every occurrence in the final
+output with `«redacted: $NAME»`. No regex, no encoding-aware matching —
+plain substring. This is intentionally simple; the skill instruction is
+the primary defense, this is defense-in-depth for accidents.
+
+#### 6.2.4 Observability
+
+If any replacement happened, emit
+`logger.warn({ workspaceId, varNames }, "sandbox bash output contained
+env var values; redacted")`. No `redactionOccurred` flag on the tool
+result itself — internal MCP handlers return only
+`CallToolResult["content"]` with no metadata bag, and threading one
+through would require refactoring `ToolHandlerResult` and every internal
+MCP wrapper. Observability lives in the log; the model-visible signal is
+the inline marker.
+
+#### 6.2.5 Documented limitations
+
+In the warning banner on the admin page (§9.4) and in code comments at
+the redactor:
+
+- Defeated by trivial transformations (base64, hex, slicing, reversing,
+  splitting across `echo` calls). The skill instruction is the primary
+  defense.
+- Values under 12 chars and dictionary-like values are not redacted, by
+  design, to avoid mangling unrelated bash output.
+- Only the bash tool's final output is filtered. Other sandbox tools are
+  not instrumented. Out-of-band exfiltration (network calls from inside
+  the sandbox, files written to mounted volumes, etc.) is not a concern
+  of this feature.
+
+## 7. Audit Logging
+
+Per `[AUDIT3]`, three artifacts per action:
+
+### 7.1 Schemas
+
+`front/admin/audit_log_schemas/sandbox_env_var.created.json`
+`front/admin/audit_log_schemas/sandbox_env_var.updated.json`
+`front/admin/audit_log_schemas/sandbox_env_var.deleted.json`
+
+Targets: `[{ type: "workspace" }, { type: "sandbox_env_var" }]`.
+
+Metadata (strings only, per `[AUDIT5]`):
+- `name`: env var name
+- `actor_type`: `"user"` (admin)
+- For `updated`: `previously_existed` = `"true"`
+
+**Never** log the value, length, or any hash that could leak entropy.
+
+### 7.2 Action union
+
+Add to `AuditAction` in `front/lib/api/audit/workos_audit.ts`:
+
+```ts
+| "sandbox_env_var.created"
+| "sandbox_env_var.updated"
+| "sandbox_env_var.deleted"
+```
+
+### 7.3 Emit sites
+
+Inside the `POST`/`DELETE` handlers, after the mutation succeeds (per
+`[AUDIT4]`), `void emitAuditLogEvent({ ... })` with
+`getAuditLogContext(auth, req)` (per `[AUDIT6]`) and
+`buildWorkspaceTarget(auth.getNonNullableWorkspace())` first (per `[AUDIT7]`).
+
+## 8. SWR Hooks
+
+`front/lib/swr/sandbox.ts` (extending the existing file).
+
+```ts
+export function useWorkspaceSandboxEnvVars({ owner, disabled = false })
+export function useUpsertWorkspaceSandboxEnvVar({ owner })
+export function useDeleteWorkspaceSandboxEnvVar({ owner })
+```
+
+Per `[REACT2]`:
+- `disabled` honored; `loading` is `false` when disabled.
+- Listing returns `emptyArray()` while loading/error.
+- Mutation hooks fire `useSendNotification` on success and failure.
+- Hooks call `mutate` on the list URL after writes.
+
+## 9. UI
+
+Single page component, two sections, both inside one `Page.Vertical`. All
+controls are `@dust-tt/sparkle`.
+
+### 9.1 File moves
+
+- New: `front/components/pages/workspace/developers/SandboxPage.tsx` —
+  composes `<NetworkSection />` and `<EnvironmentSection />`.
+- Refactor: extract the existing body of `EgressPolicyPage.tsx` into
+  `NetworkSection`. Drop `Page.Header`, since the parent renders it.
+- New: `EnvironmentSection.tsx` next to it.
+- Delete `EgressPolicyPage.tsx` in the same PR (no shim period — see
+  §9.2 and §11 for the rationale: feature is gated by the Dust-only
+  `sandbox_tools` flag, so the legacy URL has no external consumers).
+
+### 9.2 Routing & nav
+
+The admin UI is a **React SPA**, not Next.js pages — routing lives in
+`front-spa/src/app/routes/adminRoutes.tsx`.
+
+**`front-spa/src/app/routes/adminRoutes.tsx`** (around line 37, 114):
+
+- Add a lazy `SandboxPage` import:
+  ```ts
+  const SandboxPage = withSuspense(
+    () => import("@dust-tt/front/components/pages/workspace/developers/SandboxPage"),
+    "SandboxPage"
+  );
+  ```
+- Add the new route `{ path: "developers/sandbox", element: <SandboxPage /> }`.
+- **Delete the existing `EgressPolicyPage` lazy import and its route
+  entry in the same PR.** No redirect needed: the feature is gated by a
+  Dust-only feature flag (`sandbox_tools`), so external bookmarks to
+  `/developers/egress-policy` don't exist in the wild. Keeping the lazy
+  import without a route would fail TS/lint; keeping the route to render
+  a `<Navigate>` would orphan the import. Removing both together is the
+  cleanest cut.
+
+  (If, later, this feature graduates beyond `dust_only` and the URL
+  becomes load-bearing for external users, add an absolute redirect at
+  that point: `<Navigate to={\`/w/${owner.sId}/developers/sandbox\`}
+  replace />`. Relative `to="../sandbox"` is **not** safe here — React
+  Router resolves it against the current route segment, and
+  `developers/egress-policy` is registered as a flat path, so `..`
+  doesn't land where you'd think.)
+
+**`front/components/navigation/config.ts`**:
+
+- Rename the route key `egress_policy` → `sandbox` and update the two route
+  arrays at lines 207 and 324 to `/w/[wId]/developers/sandbox`.
+- Update the `href` at line 324 to `${owner.sId}/developers/sandbox` and
+  the user-visible label "Network" → "Sandbox".
+- Drop the legacy `egress-policy` URL from any route arrays it appears in
+  (the legacy route is being deleted in the same PR — see §9.2).
+
+### 9.3 NetworkSection
+
+Identical to current page minus the outer `Page.Header`. No behavior
+changes.
+
+### 9.4 EnvironmentSection
+
+Top-level layout:
+
+```
+┌─ Page.SectionHeader title="Environment variables"
+│   description="Secrets mounted as env vars on every sandbox in this workspace."
+│
+├─ ContentMessage variant="warning" icon={InformationCircleIcon} size="lg"
+│   "These values are mounted as env vars on every sandbox in this
+│    workspace. The agent is instructed not to print or echo them, and
+│    bash-tool output is redacted on a best-effort basis. This is
+│    defense-in-depth, not a guarantee: a determined agent can still
+│    leak a value through encoded output, network calls from sandbox
+│    code, or short/dictionary-like values that the redactor skips to
+│    avoid mangling unrelated text. Use least-privilege, high-entropy
+│    credentials and rotate often. Values cannot be viewed after saving
+│    — only overwritten or deleted."
+│
+├─ Button label="Add variable" icon={PlusIcon}  → opens AddDialog
+│
+└─ List rows (flex + divide-y, mirroring NetworkSection)
+    ├─ name (mono font)
+    ├─ "Updated <relative>" + author
+    ├─ Button icon={TrashIcon} variant="warning" size="mini" → confirm dialog
+```
+
+Empty state: `ContentMessage variant="info"` "No environment variables yet."
+
+### 9.5 AddDialog
+
+`Dialog` + `DialogContainer` + `DialogContent` containing:
+- `Input` label="Name" with live regex validation; `messageStatus="error"`
+  for invalid names. Helper text shows the regex and reserved-prefix list.
+- `Input` (multiline / `textarea` if Sparkle exposes one — falls back to
+  `Input` with `type="password"` if not) label="Value". Visually masked.
+- Footer: Cancel + Save.
+
+If a variable with the same name already exists, the dialog title becomes
+"Replace variable" and the Save button reads "Replace". Confirmed via
+client-side check against the SWR list (no extra round-trip).
+
+### 9.6 Sparkle components used
+
+Reused from `EgressPolicyPage.tsx` exemplars:
+
+- `Page`, `Page.Vertical`, `Page.Header`, `Page.SectionHeader`
+- `Dialog`, `DialogContainer`, `DialogContent`, `DialogHeader`,
+  `DialogTitle`, `DialogFooter`
+- `Input` (with `messageStatus`)
+- `Button` (`variant`, `icon`, `size`, `isLoading`)
+- `ContentMessage` (`variant`, `icon`, `size`, `title`)
+- `Spinner`, `TrashIcon`, `PlusIcon`, `KeyIcon` (or `LockIcon` for the
+  section header), `InformationCircleIcon`
+
+No bespoke Tailwind beyond what `EgressPolicyPage` already uses
+(`flex items-center gap-3 py-3` for list rows, `divide-y` between rows).
+
+## 10. Tests
+
+Per `[TEST1]`/`[TEST2]`, functional tests at the endpoint level using
+factories.
+
+`front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts`:
+- non-admin GET → 403
+- non-admin POST → 403
+- POST with invalid name → 400 (covers reserved prefixes, regex, leading
+  underscore)
+- POST creating a new name when workspace already has 50 → 400
+  (`limit_reached`)
+- POST overwriting an existing name when workspace has 50 → 200 (rotation
+  always allowed)
+- (Not tested: the documented race window where two concurrent creates
+  briefly exceed the cap — accepted trade-off, see §4.5.)
+- POST with empty value → 400
+- POST with NUL byte in value → 400
+- POST with multiline value (PEM-style) → 200 round-trips intact
+- POST with > 32 KiB UTF-8 value (verified via `Buffer.byteLength`) → 400
+- POST same name twice → 200 with second response indicating overwrite;
+  audit emits `created` then `updated`
+- value never appears in the GET response or the audit metadata
+
+`front/pages/api/w/[wId]/sandbox/env-vars/[name].test.ts`:
+- DELETE existing → 200, row gone
+- DELETE missing → 404
+- non-admin DELETE → 403
+
+`front/lib/api/sandbox/env_vars.test.ts`:
+- `validateEnvVarName` covers each reserved prefix and edge cases
+- `isReservedEnvVarName` truth table
+
+`front/lib/resources/workspace_sandbox_env_var_resource.test.ts`:
+- round-trip encrypt/decrypt
+- `loadEnvForSandboxProvisioning` returns `{}` for an empty workspace
+- `loadEnvForRedaction` returns `{}` for an empty workspace
+- both helpers are fail-closed: one bad ciphertext fails the whole call
+  (assert against both `loadEnvForSandboxProvisioning` and
+  `loadEnvForRedaction`)
+- both helpers emit the use-case-tagged `logger.info` with the row
+  count (covers the audit-trace property called out in §3.2)
+
+Sandbox provisioning test (extend existing):
+- workspace env vars present in the env passed to `provider.create` mock
+- system vars (`DD_API_KEY`, `CONVERSATION_ID`, `WORKSPACE_ID`) take
+  precedence even if a row sneaks past validation
+
+Bash-tool output redaction (extend
+`front/lib/api/actions/servers/sandbox/tools/index.test.ts`):
+- stdout containing an env var value (≥ 12 chars, not in the denylist)
+  is replaced with `«redacted: $NAME»` in the final tool result
+- a value embedded in an **appended/structured** section of the
+  formatted output (not just raw stdout) is also redacted
+- values shorter than 12 chars are **not** redacted (avoid mangling) —
+  cover with a value of length 8 and assert no replacement
+- denylisted values (`"true"`, `"production"`, `"admin"`, pure digits,
+  short alphanumeric) are **not** redacted, even if longer than 12
+  chars (denylist wins over length)
+- redaction emits one `logger.warn({ workspaceId, varNames }, ...)` per
+  bash invocation containing matches; varNames includes only the names
+  whose values were actually replaced (no metadata flag on the tool
+  result itself — see §6.2.4)
+- ineligible-value `logger.info` is emitted at most once per
+  (workspaceId, name) per process lifetime (covers the "your value is
+  too short to redact" telemetry path)
+
+## 11. Migration / Rollout
+
+1. Generate `migration_N.sql` via `./front/create_db_migration_file.sh` and
+   register the model in `front/admin/db.ts`. Migration is additive, no
+   backfill.
+2. Ship backend (resource, API, audit, sandbox merge, redaction) behind
+   the existing `sandbox_tools` flag.
+3. Ship frontend (renamed page + new section) and SPA route changes
+   behind the same flag — including deletion of the legacy
+   `EgressPolicyPage` lazy import, the `developers/egress-policy` route,
+   and `EgressPolicyPage.tsx`. No redirect cycle is needed because the
+   feature is currently gated by a Dust-only flag, so the legacy URL has
+   no external consumers.
+
+No data migration is required — existing workspaces simply have zero env
+vars on day one.
+
+## 12. Out of Scope (v2 candidates)
+
+- Bulk paste `.env` import on create.
+- Per-agent or per-conversation scoped env vars.
+- Extending the redactor beyond the bash tool (other sandbox tools).
+- Stream-time redaction at the provider layer (`sandbox.commands.run`
+  byte stream) — required if/when the bash tool moves to token-level
+  streaming.
+- Input-argument scanning + refusal path (catch the agent passing a
+  value verbatim back as a tool arg).
+- Encoding-aware redaction (decode obvious base64/hex strings before
+  matching).
+- Surfacing "your value is too short / too dictionary-like to be
+  redacted" warnings into the admin UI on create.
+- Listing the available env var names in the system prompt to the
+  agent (deferred — currently the agent learns about a var only when it
+  references one explicitly in code).
+- Hot-rotation: pushing env updates into already-running sandboxes via
+  `sandbox.commands.run({ envs })` overrides.
+- Read-once "reveal value" UX (deliberately omitted to keep the
+  write-only contract simple).
+- A CLI/SDK to manage env vars outside the admin UI.
+
+## 13. File Touch List (summary)
+
+**New files**
+- `front/migrations/db/migration_N.sql` — generated via
+  `./front/create_db_migration_file.sh`; creates the
+  `workspace_sandbox_env_vars` table with `(workspaceId, name)` unique
+  index plus FK indexes.
+- `front/lib/resources/storage/models/workspace_sandbox_env_var.ts` —
+  Sequelize model (matches existing `models/` location).
+- `front/lib/resources/workspace_sandbox_env_var_resource.ts` — Resource
+  with `upsert`, `deleteByName`, `loadEnvForSandboxProvisioning`,
+  `loadEnvForRedaction`.
+- `front/types/sandbox/env_var.ts` — `WorkspaceSandboxEnvVarType` (no
+  value).
+- `front/lib/api/sandbox/env_vars.ts` — name + value validation.
+- `front/pages/api/w/[wId]/sandbox/env-vars/index.ts` — GET + POST.
+- `front/pages/api/w/[wId]/sandbox/env-vars/[name].ts` — DELETE.
+- `front/admin/audit_log_schemas/sandbox_env_var.created.json`
+- `front/admin/audit_log_schemas/sandbox_env_var.updated.json`
+- `front/admin/audit_log_schemas/sandbox_env_var.deleted.json`
+- `front/components/pages/workspace/developers/SandboxPage.tsx`
+- `front/components/pages/workspace/developers/sections/NetworkSection.tsx`
+- `front/components/pages/workspace/developers/sections/EnvironmentSection.tsx`
+- Tests as listed in §10.
+
+**Modified**
+- `front-spa/src/app/routes/adminRoutes.tsx` — add `SandboxPage` lazy
+  import + route, **delete** the `EgressPolicyPage` lazy import and its
+  `developers/egress-policy` route entry (same PR). See §9.2 for why no
+  redirect is needed (Dust-only feature flag).
+- `front/components/navigation/config.ts` — rename key, label, and href
+  (`egress_policy` → `sandbox`); remove the legacy `egress-policy` URL
+  entry.
+- `front/admin/db.ts` — register the new `WorkspaceSandboxEnvVarModel`
+  import (around line 127).
+- `front/lib/resources/sandbox_resource.ts` — merge `workspaceEnv` at
+  the two `provider.create` sites (lines 355–369 and 458–470); extract
+  a shared `buildSandboxEnvVars(auth, conversation)` helper.
+- `front/lib/swr/sandbox.ts` — add three hooks
+  (`useWorkspaceSandboxEnvVars`, `useUpsertWorkspaceSandboxEnvVar`,
+  `useDeleteWorkspaceSandboxEnvVar`).
+- `front/lib/api/audit/workos_audit.ts` — extend `AuditAction` union
+  with `sandbox_env_var.{created,updated,deleted}`.
+- `front/lib/resources/skill/code_defined/sandbox.ts` — add the env-var
+  disclosure-control instructions per §6.1.
+- `front/lib/api/actions/servers/sandbox/tools/index.ts` — bash-tool
+  output redaction only, per §6.2. No input-arg scanning, no refusal
+  path, no changes to other sandbox tools.
+
+**Deleted**
+- `front/components/pages/workspace/developers/EgressPolicyPage.tsx` —
+  body moved into `NetworkSection`; the file itself is removed in the
+  same PR (no shim period needed under the Dust-only flag).
+

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -21,6 +21,10 @@ const {
   mockStartTelemetry,
   mockWrapCommand,
   mockEnsureActive,
+  mockLoadEnvForRedaction,
+  mockLoggerError,
+  mockLoggerInfo,
+  mockLoggerWarn,
 } = vi.hoisted(() => ({
   mockAddSandboxPolicyDomain: vi.fn(),
   mockCheckEgressForwarderHealth: vi.fn(),
@@ -37,6 +41,10 @@ const {
   mockStartTelemetry: vi.fn(),
   mockWrapCommand: vi.fn(),
   mockEnsureActive: vi.fn(),
+  mockLoadEnvForRedaction: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/config", () => ({
@@ -119,11 +127,17 @@ vi.mock("@app/lib/resources/sandbox_resource", () => ({
   },
 }));
 
+vi.mock("@app/lib/resources/workspace_sandbox_env_var_resource", () => ({
+  WorkspaceSandboxEnvVarResource: {
+    loadEnvForRedaction: mockLoadEnvForRedaction,
+  },
+}));
+
 vi.mock("@app/logger/logger", () => ({
   default: {
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
+    error: mockLoggerError,
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
   },
 }));
 
@@ -204,6 +218,7 @@ describe("runSandboxBashTool", () => {
     mockGetSandboxImage.mockReturnValue(new Ok({}));
     mockMountConversationFiles.mockResolvedValue(new Ok(undefined));
     mockRefreshGcsToken.mockResolvedValue(new Ok(undefined));
+    mockLoadEnvForRedaction.mockResolvedValue(new Ok({}));
     mockReadNewDenyLogEntries.mockResolvedValue(new Ok([]));
     mockRevokeExecToken.mockResolvedValue(undefined);
     mockSetupEgressForwarder.mockResolvedValue(new Ok(undefined));
@@ -270,6 +285,190 @@ describe("runSandboxBashTool", () => {
         user: "agent-proxied",
       })
     );
+  });
+
+  it("redacts eligible workspace env var values from final bash output", async () => {
+    const secretValue = "high-entropy-token-123";
+    mockLoadEnvForRedaction.mockResolvedValue(
+      new Ok({ API_TOKEN: secretValue })
+    );
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi.fn().mockResolvedValue(
+        new Ok({
+          exitCode: 0,
+          stdout: `token=${secretValue}`,
+          stderr: "",
+        })
+      ),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
+
+    const result = await runSandboxBashTool(
+      { command: "echo token", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value[0].text).toContain("«redacted: $API_TOKEN»");
+    expect(result.value[0].text).not.toContain(secretValue);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      {
+        workspaceId: "workspace-id",
+        varNames: ["API_TOKEN"],
+      },
+      "sandbox bash output contained env var values; redacted"
+    );
+  });
+
+  it("redacts eligible values from appended network proxy logs", async () => {
+    const secretValue = "another-high-entropy-token";
+    mockLoadEnvForRedaction.mockResolvedValue(
+      new Ok({ API_TOKEN: secretValue })
+    );
+    mockReadNewDenyLogEntries.mockResolvedValue(
+      new Ok([`denied example.com ${secretValue}`])
+    );
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi
+        .fn()
+        .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ok", stderr: "" })),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
+
+    const result = await runSandboxBashTool(
+      { command: "echo ok", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value[0].text).toContain(
+      "<network_proxy_logs>\ndenied example.com «redacted: $API_TOKEN»\n</network_proxy_logs>"
+    );
+    expect(result.value[0].text).not.toContain(secretValue);
+  });
+
+  it("does not redact short or low-value values and logs ineligibility once per name", async () => {
+    mockLoadEnvForRedaction.mockResolvedValue(
+      new Ok({
+        SHORT_VALUE: "12345678",
+        BOOLEAN_VALUE: "true",
+        NUMERIC_VALUE: "1234567890123456",
+        WORD_VALUE: "abc123def456",
+      })
+    );
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi.fn().mockResolvedValue(
+        new Ok({
+          exitCode: 0,
+          stdout:
+            "12345678 true 1234567890123456 abc123def456 high-entropy-token",
+          stderr: "",
+        })
+      ),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
+
+    const firstResult = await runSandboxBashTool(
+      { command: "echo values", description: "Run command" },
+      makeExtra()
+    );
+    const secondResult = await runSandboxBashTool(
+      { command: "echo values", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(firstResult.isOk()).toBe(true);
+    expect(secondResult.isOk()).toBe(true);
+    if (firstResult.isErr() || secondResult.isErr()) {
+      throw new Error("Unexpected bash tool failure");
+    }
+    expect(firstResult.value[0].text).toContain(
+      "12345678 true 1234567890123456 abc123def456"
+    );
+    expect(firstResult.value[0].text).not.toContain("«redacted:");
+
+    const ineligibleLogCalls = mockLoggerInfo.mock.calls.filter(
+      (call) =>
+        call[1] ===
+        "sandbox env var value not eligible for output redaction (too short or low-value)"
+    );
+    expect(ineligibleLogCalls).toHaveLength(4);
+    expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "sandbox bash output contained env var values; redacted"
+    );
+  });
+
+  it("fails closed when env var redaction materialization fails", async () => {
+    mockLoadEnvForRedaction.mockResolvedValue(
+      new Err(new Error("bad ciphertext for API_TOKEN"))
+    );
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi
+        .fn()
+        .mockResolvedValue(
+          new Ok({ exitCode: 0, stdout: "secret", stderr: "" })
+        ),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
+
+    const result = await runSandboxBashTool(
+      { command: "echo secret", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(
+        "Failed to safely return sandbox output."
+      );
+    }
   });
 
   it("restarts the forwarder when the health check fails", async () => {

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -44,6 +44,7 @@ import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import logger from "@app/logger/logger";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isDevelopment } from "@app/types/shared/env";
@@ -52,6 +53,19 @@ import { Err, Ok, type Result } from "@app/types/shared/result";
 const DEFAULT_WORKING_DIRECTORY = "/home/agent";
 const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
 const ADD_EGRESS_DOMAIN_TOOL_NAME = "add_egress_domain" as const;
+const REDACTION_MARKER_PREFIX = "«redacted:";
+const REDACTION_MARKER_SUFFIX = "»";
+const LOW_VALUE_DENYLIST = new Set([
+  "true",
+  "false",
+  "production",
+  "staging",
+  "development",
+  "admin",
+  "root",
+  "localhost",
+]);
+const loggedIneligibleRedactionValues = new Set<string>();
 
 interface FormatExecOutputOpts {
   denyLogEntries?: string[];
@@ -82,6 +96,89 @@ function formatExecOutput(
   }
 
   return sections.join("\n") || "(no output)";
+}
+
+function isRedactionEligible(value: string): boolean {
+  const normalizedValue = value.toLowerCase();
+
+  if (value.length < 12) {
+    return false;
+  }
+
+  if (LOW_VALUE_DENYLIST.has(normalizedValue)) {
+    return false;
+  }
+
+  if (/^[0-9]+$/.test(value)) {
+    return false;
+  }
+
+  if (/^[A-Za-z0-9]+$/.test(value) && value.length < 16) {
+    return false;
+  }
+
+  return true;
+}
+
+function logIneligibleRedactionValueOnce({
+  workspaceId,
+  name,
+}: {
+  workspaceId: string;
+  name: string;
+}) {
+  const key = `${workspaceId}:${name}`;
+  if (loggedIneligibleRedactionValues.has(key)) {
+    return;
+  }
+
+  loggedIneligibleRedactionValues.add(key);
+  logger.info(
+    { workspaceId, name },
+    "sandbox env var value not eligible for output redaction (too short or low-value)"
+  );
+}
+
+async function redactSandboxEnvVarsFromOutput(
+  auth: Authenticator,
+  output: string
+): Promise<Result<string, Error>> {
+  const envResult =
+    await WorkspaceSandboxEnvVarResource.loadEnvForRedaction(auth);
+  if (envResult.isErr()) {
+    return envResult;
+  }
+
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  let redactedOutput = output;
+  const redactedNames: string[] = [];
+
+  // Best-effort final-payload redaction for accidental bash output leaks.
+  // This does not catch transformed values, short/low-entropy values, other
+  // sandbox tools, or out-of-band exfiltration. The sandbox skill instruction
+  // remains the primary disclosure control.
+  for (const [name, value] of Object.entries(envResult.value)) {
+    if (!isRedactionEligible(value)) {
+      logIneligibleRedactionValueOnce({ workspaceId, name });
+      continue;
+    }
+
+    if (redactedOutput.includes(value)) {
+      redactedOutput = redactedOutput
+        .split(value)
+        .join(`${REDACTION_MARKER_PREFIX} $${name}${REDACTION_MARKER_SUFFIX}`);
+      redactedNames.push(name);
+    }
+  }
+
+  if (redactedNames.length > 0) {
+    logger.warn(
+      { workspaceId, varNames: redactedNames },
+      "sandbox bash output contained env var values; redacted"
+    );
+  }
+
+  return new Ok(redactedOutput);
 }
 
 function isSandboxAgentEgressRequestsAllowed(auth: Authenticator): boolean {
@@ -298,8 +395,19 @@ export async function runSandboxBashTool(
   }
 
   const output = formatExecOutput(execResult.value, { denyLogEntries });
+  const redactedOutputResult = await redactSandboxEnvVarsFromOutput(
+    auth,
+    output
+  );
+  if (redactedOutputResult.isErr()) {
+    logger.error(
+      { err: redactedOutputResult.error },
+      "Failed to load sandbox env vars for bash output redaction"
+    );
+    return new Err(new MCPError("Failed to safely return sandbox output."));
+  }
 
-  return new Ok([{ type: "text" as const, text: output }]);
+  return new Ok([{ type: "text" as const, text: redactedOutputResult.value }]);
 }
 
 export async function addEgressDomainTool(

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -60,6 +60,9 @@ type AuditAction =
   | "sandbox_egress_policy.agent_requests_setting_updated"
   | "sandbox_egress_policy.sandbox_updated"
   | "sandbox_egress_policy.updated"
+  | "sandbox_env_var.created"
+  | "sandbox_env_var.deleted"
+  | "sandbox_env_var.updated"
   // SCIM / Directory Sync.
   | "scim.user_provisioned"
   | "scim.user_updated"

--- a/front/lib/api/sandbox/env_vars.test.ts
+++ b/front/lib/api/sandbox/env_vars.test.ts
@@ -1,0 +1,54 @@
+import {
+  isReservedEnvVarName,
+  validateEnvVarName,
+  validateEnvVarValue,
+} from "@app/lib/api/sandbox/env_vars";
+import { describe, expect, it } from "vitest";
+
+describe("sandbox env var validation", () => {
+  it("accepts valid POSIX-style names", () => {
+    expect(validateEnvVarName("API_TOKEN").isOk()).toBe(true);
+    expect(validateEnvVarName("A").isOk()).toBe(true);
+    expect(validateEnvVarName("A_123").isOk()).toBe(true);
+  });
+
+  it("rejects names outside the allowed pattern", () => {
+    expect(validateEnvVarName("api_token").isErr()).toBe(true);
+    expect(validateEnvVarName("1_API_TOKEN").isErr()).toBe(true);
+    expect(validateEnvVarName("API-TOKEN").isErr()).toBe(true);
+    expect(validateEnvVarName("A".repeat(65)).isErr()).toBe(true);
+  });
+
+  it("rejects exact reserved names, prefixes, and leading underscores", () => {
+    for (const name of [
+      "PATH",
+      "HOME",
+      "USER",
+      "SHELL",
+      "PWD",
+      "TERM",
+      "LANG",
+      "LC_ALL",
+      "HOSTNAME",
+      "TMPDIR",
+      "_PRIVATE",
+      "LD_PRELOAD",
+      "DUST_API_KEY",
+      "SANDBOX_TOKEN",
+      "E2B_API_KEY",
+      "DD_API_KEY",
+      "CONVERSATION_ID",
+      "WORKSPACE_ID",
+    ]) {
+      expect(validateEnvVarName(name).isErr()).toBe(true);
+      expect(isReservedEnvVarName(name)).toBe(true);
+    }
+  });
+
+  it("validates value constraints while allowing multiline values", () => {
+    expect(validateEnvVarValue("").isErr()).toBe(true);
+    expect(validateEnvVarValue("abc\u0000def").isErr()).toBe(true);
+    expect(validateEnvVarValue("line 1\nline 2").isOk()).toBe(true);
+    expect(validateEnvVarValue("a".repeat(32 * 1024 + 1)).isErr()).toBe(true);
+  });
+});

--- a/front/lib/api/sandbox/env_vars.ts
+++ b/front/lib/api/sandbox/env_vars.ts
@@ -1,0 +1,68 @@
+import { Err, Ok, type Result } from "@app/types/shared/result";
+
+export const ENV_VAR_NAME_REGEX = /^[A-Z][A-Z0-9_]{0,63}$/;
+export const MAX_VALUE_BYTES = 32 * 1024;
+export const MAX_VARS_PER_WORKSPACE = 50;
+
+const RESERVED_EXACT_NAMES = new Set([
+  "PATH",
+  "HOME",
+  "USER",
+  "SHELL",
+  "PWD",
+  "TERM",
+  "LANG",
+  "LC_ALL",
+  "HOSTNAME",
+  "TMPDIR",
+]);
+
+const RESERVED_PREFIXES = [
+  "LD_",
+  "DUST_",
+  "SANDBOX_",
+  "E2B_",
+  "DD_",
+  "CONVERSATION_",
+  "WORKSPACE_",
+];
+
+export function isReservedEnvVarName(name: string): boolean {
+  return (
+    name.startsWith("_") ||
+    RESERVED_EXACT_NAMES.has(name) ||
+    RESERVED_PREFIXES.some((prefix) => name.startsWith(prefix))
+  );
+}
+
+export function validateEnvVarName(name: string): Result<void, string> {
+  if (!ENV_VAR_NAME_REGEX.test(name)) {
+    return new Err(
+      "Environment variable names must match /^[A-Z][A-Z0-9_]{0,63}$/."
+    );
+  }
+
+  if (isReservedEnvVarName(name)) {
+    return new Err(
+      "This environment variable name is reserved for the sandbox runtime."
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+export function validateEnvVarValue(value: string): Result<void, string> {
+  if (value.length === 0) {
+    return new Err("Environment variable values cannot be empty.");
+  }
+
+  if (value.includes("\u0000")) {
+    return new Err("Environment variable values cannot contain NUL bytes.");
+  }
+
+  if (Buffer.byteLength(value, "utf8") > MAX_VALUE_BYTES) {
+    return new Err("Environment variable values cannot exceed 32 KiB.");
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -4,15 +4,21 @@ const {
   mockDeleteSandboxPolicy,
   mockDistribution,
   mockExecuteWithLock,
+  mockGetSandboxImage,
   mockGetSandboxProvider,
+  mockProviderCreate,
   mockProviderDestroy,
+  mockProviderExec,
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
   mockDeleteSandboxPolicy: vi.fn(),
   mockDistribution: vi.fn(),
   mockExecuteWithLock: vi.fn(),
+  mockGetSandboxImage: vi.fn(),
   mockGetSandboxProvider: vi.fn(),
+  mockProviderCreate: vi.fn(),
   mockProviderDestroy: vi.fn(),
+  mockProviderExec: vi.fn(),
   mockRevokeAllExecTokensForSandbox: vi.fn(),
 }));
 
@@ -35,18 +41,26 @@ vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
   deleteSandboxPolicy: mockDeleteSandboxPolicy,
 }));
 
+vi.mock("@app/lib/api/sandbox/image", () => ({
+  getSandboxImage: mockGetSandboxImage,
+}));
+
 vi.mock("@app/lib/lock", () => ({
   executeWithLock: mockExecuteWithLock,
 }));
 
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Ok } from "@app/types/shared/result";
+import { encrypt } from "@app/types/shared/utils/encryption";
+
+process.env.DUST_DEVELOPERS_SECRETS_SECRET ??= "test-developer-secret";
 
 describe("SandboxResource.updateStatus", () => {
   let authenticator: Authenticator;
@@ -58,9 +72,25 @@ describe("SandboxResource.updateStatus", () => {
       async (_key: string, fn: () => Promise<unknown>) => fn()
     );
     mockGetSandboxProvider.mockReturnValue({
+      create: mockProviderCreate,
       destroy: mockProviderDestroy,
+      exec: mockProviderExec,
     });
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          imageId: { name: "test-image", tag: "latest" },
+          envVars: {},
+          network: { egress: "restricted" },
+          resources: { cpu: 1, memoryMB: 512 },
+        }),
+      })
+    );
+    mockProviderCreate.mockResolvedValue(new Ok({ providerId: "provider-id" }));
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
+    mockProviderExec.mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+    );
     mockDeleteSandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
 
@@ -167,9 +197,25 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
       async (_key: string, fn: () => Promise<unknown>) => fn()
     );
     mockGetSandboxProvider.mockReturnValue({
+      create: mockProviderCreate,
       destroy: mockProviderDestroy,
+      exec: mockProviderExec,
     });
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          imageId: { name: "test-image", tag: "latest" },
+          envVars: {},
+          network: { egress: "restricted" },
+          resources: { cpu: 1, memoryMB: 512 },
+        }),
+      })
+    );
+    mockProviderCreate.mockResolvedValue(new Ok({ providerId: "provider-id" }));
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
+    mockProviderExec.mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+    );
     mockDeleteSandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
 
@@ -205,5 +251,111 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
       conversation.sId
     );
     expect(reloaded?.status).toBe("deleted");
+  });
+});
+
+describe("SandboxResource.ensureActive", () => {
+  let authenticator: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      create: mockProviderCreate,
+      destroy: mockProviderDestroy,
+      exec: mockProviderExec,
+    });
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          imageId: { name: "test-image", tag: "latest" },
+          envVars: {
+            API_TOKEN: "image-token",
+            DD_API_KEY: "image-dd-token",
+            WORKSPACE_ID: "image-workspace-id",
+          },
+          network: { egress: "restricted" },
+          resources: { cpu: 1, memoryMB: 512 },
+        }),
+      })
+    );
+    mockProviderCreate.mockResolvedValue(new Ok({ providerId: "provider-id" }));
+    mockProviderExec.mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+    );
+
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+  });
+
+  it("passes workspace env vars to provider.create with image and system precedence", async () => {
+    const workspace = authenticator.getNonNullableWorkspace();
+    const user = authenticator.getNonNullableUser();
+
+    await WorkspaceSandboxEnvVarModel.bulkCreate([
+      {
+        workspaceId: workspace.id,
+        name: "API_TOKEN",
+        encryptedValue: encrypt({
+          text: "workspace-token",
+          key: workspace.sId,
+          useCase: "developer_secret",
+        }),
+        createdByUserId: user.id,
+        lastUpdatedByUserId: user.id,
+      },
+      {
+        workspaceId: workspace.id,
+        name: "DD_API_KEY",
+        encryptedValue: encrypt({
+          text: "workspace-dd-token",
+          key: workspace.sId,
+          useCase: "developer_secret",
+        }),
+        createdByUserId: user.id,
+        lastUpdatedByUserId: user.id,
+      },
+      {
+        workspaceId: workspace.id,
+        name: "WORKSPACE_ID",
+        encryptedValue: encrypt({
+          text: "workspace-overridden-id",
+          key: workspace.sId,
+          useCase: "developer_secret",
+        }),
+        createdByUserId: user.id,
+        lastUpdatedByUserId: user.id,
+      },
+    ]);
+
+    const result = await SandboxResource.ensureActive(
+      authenticator,
+      conversation
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockProviderCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envVars: expect.objectContaining({
+          API_TOKEN: "image-token",
+          CONVERSATION_ID: conversation.sId,
+          WORKSPACE_ID: workspace.sId,
+        }),
+      }),
+      { workspaceId: workspace.sId }
+    );
+    const createConfig = mockProviderCreate.mock.calls[0][0];
+    expect(createConfig.envVars.DD_API_KEY).not.toBe("workspace-dd-token");
+    expect(createConfig.envVars.DD_API_KEY).not.toBe("image-dd-token");
   });
 });

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -25,6 +25,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -324,6 +325,27 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     );
   }
 
+  private static async buildSandboxEnvVars(
+    auth: Authenticator,
+    conversation: ConversationType,
+    imageEnvVars: Record<string, string> | undefined
+  ): Promise<Result<Record<string, string>, Error>> {
+    const workspaceEnvResult =
+      await WorkspaceSandboxEnvVarResource.loadEnvForSandboxProvisioning(auth);
+    if (workspaceEnvResult.isErr()) {
+      return workspaceEnvResult;
+    }
+
+    return new Ok({
+      ...workspaceEnvResult.value,
+      ...imageEnvVars,
+      DD_API_KEY: config.getDatadogApiKey() ?? "",
+      DD_HOST: "http-intake.logs.datadoghq.eu",
+      CONVERSATION_ID: conversation.sId,
+      WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
+    });
+  }
+
   /**
    * Ensure a running sandbox exists for the given conversation.
    *
@@ -353,17 +375,19 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         }
 
         const createConfig = imageResult.value.toCreateConfig();
+        const envVarsResult = await this.buildSandboxEnvVars(
+          auth,
+          conversation,
+          createConfig.envVars
+        );
+        if (envVarsResult.isErr()) {
+          return new Err(envVarsResult.error);
+        }
 
         const createResult = await provider.create(
           {
             ...createConfig,
-            envVars: {
-              ...createConfig.envVars,
-              DD_API_KEY: config.getDatadogApiKey() ?? "",
-              DD_HOST: "http-intake.logs.datadoghq.eu",
-              CONVERSATION_ID: conversation.sId,
-              WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
-            },
+            envVars: envVarsResult.value,
           },
           tracingOpts
         );
@@ -456,17 +480,19 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           }
 
           const createConfig = imageResult.value.toCreateConfig();
+          const envVarsResult = await this.buildSandboxEnvVars(
+            auth,
+            conversation,
+            createConfig.envVars
+          );
+          if (envVarsResult.isErr()) {
+            return new Err(envVarsResult.error);
+          }
 
           const createResult = await provider.create(
             {
               ...createConfig,
-              envVars: {
-                ...createConfig.envVars,
-                DD_API_KEY: config.getDatadogApiKey() ?? "",
-                DD_HOST: "http-intake.logs.datadoghq.eu",
-                CONVERSATION_ID: conversation.sId,
-                WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
-              },
+              envVars: envVarsResult.value,
             },
             tracingOpts
           );

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -118,12 +118,30 @@ hangs or fails with TLS/DNS errors, check the \`<network_proxy_logs>\`
 block first; a denied egress is a possible cause.`;
 }
 
+function buildEnvironmentVariablesSection(): string {
+  return `#### Sandbox Environment Variables
+
+The sandbox may have workspace-configured environment variables available to
+your code via standard environment APIs such as \`process.env\` or
+\`os.environ\`. You may use them to authenticate with APIs or pass them into
+code paths that consume them, but you must never print, echo, \`cat\`, or
+otherwise disclose an environment variable value. Do not include a value in
+output, logs, error messages, or final answers. Do not re-encode, transform, or
+split a value to bypass this rule. Do not list available environment variable
+names just to enumerate what is configured.
+
+If a user asks for a secret value, refuse and say it is not viewable. If you
+need to confirm a variable is set, check a boolean condition such as
+\`"FOO" in os.environ\` and do not read or print the value.`;
+}
+
 async function buildSandboxInstructions(
   auth: Authenticator,
   providerId: ModelProviderIdType | undefined,
   hasDsbxTools: boolean
 ): Promise<string> {
   const networkAccessSection = await buildNetworkAccessSection(auth);
+  const environmentVariablesSection = buildEnvironmentVariablesSection();
   const sandboxInstructions = buildSandboxInstructionProse({ hasDsbxTools });
 
   let toolsResult;
@@ -135,7 +153,7 @@ async function buildSandboxInstructions(
   } else {
     const imageResult = getSandboxImage(auth);
     if (imageResult.isErr()) {
-      return `${sandboxInstructions}\n\n${networkAccessSection}`;
+      return `${sandboxInstructions}\n\n${networkAccessSection}\n\n${environmentVariablesSection}`;
     }
     toolsResult = new Ok(
       filterDsbxToolEntries(imageResult.value.tools, {
@@ -145,7 +163,7 @@ async function buildSandboxInstructions(
   }
 
   if (toolsResult.isErr()) {
-    return `${sandboxInstructions}\n\n${networkAccessSection}`;
+    return `${sandboxInstructions}\n\n${networkAccessSection}\n\n${environmentVariablesSection}`;
   }
 
   const manifest = createToolManifest(toolsResult.value);
@@ -154,6 +172,8 @@ async function buildSandboxInstructions(
   return `${sandboxInstructions}
 
 ${networkAccessSection}
+
+${environmentVariablesSection}
 
 #### Sandbox Available Tools and Libraries
 

--- a/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
+++ b/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
@@ -1,0 +1,93 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export class WorkspaceSandboxEnvVarModel extends WorkspaceAwareModel<WorkspaceSandboxEnvVarModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare name: string;
+  declare encryptedValue: string;
+  declare createdByUserId: ForeignKey<UserModel["id"]> | null;
+  declare lastUpdatedByUserId: ForeignKey<UserModel["id"]> | null;
+
+  declare createdByUser: NonAttribute<UserModel | null>;
+  declare lastUpdatedByUser: NonAttribute<UserModel | null>;
+}
+
+WorkspaceSandboxEnvVarModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    encryptedValue: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    createdByUserId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      references: {
+        model: UserModel,
+        key: "id",
+      },
+    },
+    lastUpdatedByUserId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      references: {
+        model: UserModel,
+        key: "id",
+      },
+    },
+  },
+  {
+    modelName: "workspace_sandbox_env_var",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "workspace_sandbox_env_vars_workspace_name_idx",
+        unique: true,
+        fields: ["workspaceId", "name"],
+      },
+      {
+        name: "workspace_sandbox_env_vars_workspace_id_idx",
+        fields: ["workspaceId"],
+      },
+      {
+        name: "workspace_sandbox_env_vars_created_by_user_id_idx",
+        fields: ["createdByUserId"],
+      },
+      {
+        name: "workspace_sandbox_env_vars_last_updated_by_user_id_idx",
+        fields: ["lastUpdatedByUserId"],
+      },
+    ],
+  }
+);
+
+WorkspaceSandboxEnvVarModel.belongsTo(UserModel, {
+  as: "createdByUser",
+  foreignKey: { name: "createdByUserId", allowNull: true },
+  onDelete: "SET NULL",
+});
+
+WorkspaceSandboxEnvVarModel.belongsTo(UserModel, {
+  as: "lastUpdatedByUser",
+  foreignKey: { name: "lastUpdatedByUserId", allowNull: true },
+  onDelete: "SET NULL",
+});

--- a/front/lib/resources/workspace_sandbox_env_var_resource.test.ts
+++ b/front/lib/resources/workspace_sandbox_env_var_resource.test.ts
@@ -1,0 +1,132 @@
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import logger from "@app/logger/logger";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+process.env.DUST_DEVELOPERS_SECRETS_SECRET ??= "test-developer-secret";
+
+describe("WorkspaceSandboxEnvVarResource", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("encrypts values at rest and decrypts them for sandbox provisioning", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const user = authenticator.getNonNullableUser();
+
+    const upsertResult = await WorkspaceSandboxEnvVarResource.upsert(
+      authenticator,
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+        user,
+      }
+    );
+
+    expect(upsertResult.isOk()).toBe(true);
+    if (upsertResult.isErr()) {
+      throw upsertResult.error;
+    }
+    expect(upsertResult.value.created).toBe(true);
+
+    const row = await WorkspaceSandboxEnvVarModel.findOne({
+      where: {
+        workspaceId: authenticator.getNonNullableWorkspace().id,
+        name: "API_TOKEN",
+      },
+    });
+    expect(row?.encryptedValue).toBeDefined();
+    expect(row?.encryptedValue).not.toBe("super-secret-token");
+
+    const envResult =
+      await WorkspaceSandboxEnvVarResource.loadEnvForSandboxProvisioning(
+        authenticator
+      );
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value).toEqual({
+      API_TOKEN: "super-secret-token",
+    });
+
+    const listed =
+      await WorkspaceSandboxEnvVarResource.listForWorkspace(authenticator);
+    expect(listed.map((envVar) => envVar.toJSON())).toEqual([
+      expect.objectContaining({
+        name: "API_TOKEN",
+        createdByName: user.name,
+        lastUpdatedByName: user.name,
+      }),
+    ]);
+    expect(
+      JSON.stringify(listed.map((envVar) => envVar.toJSON()))
+    ).not.toContain("super-secret-token");
+  });
+
+  it("returns empty env maps and logs use-case-tagged counts for empty workspaces", async () => {
+    const loggerInfoSpy = vi.spyOn(logger, "info");
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const provisioningResult =
+      await WorkspaceSandboxEnvVarResource.loadEnvForSandboxProvisioning(
+        authenticator
+      );
+    const redactionResult =
+      await WorkspaceSandboxEnvVarResource.loadEnvForRedaction(authenticator);
+
+    expect(provisioningResult.isOk()).toBe(true);
+    expect(redactionResult.isOk()).toBe(true);
+    if (provisioningResult.isErr() || redactionResult.isErr()) {
+      throw new Error("Unexpected failed env load");
+    }
+    expect(provisioningResult.value).toEqual({});
+    expect(redactionResult.value).toEqual({});
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: authenticator.getNonNullableWorkspace().sId,
+        useCase: "provision",
+        count: 0,
+      }),
+      "Loading workspace sandbox environment variables"
+    );
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: authenticator.getNonNullableWorkspace().sId,
+        useCase: "redact",
+        count: 0,
+      }),
+      "Loading workspace sandbox environment variables"
+    );
+  });
+
+  it("fails closed when a stored value cannot be decrypted", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const user = authenticator.getNonNullableUser();
+
+    await WorkspaceSandboxEnvVarModel.create({
+      workspaceId: authenticator.getNonNullableWorkspace().id,
+      name: "API_TOKEN",
+      encryptedValue: "not-valid-ciphertext",
+      createdByUserId: user.id,
+      lastUpdatedByUserId: user.id,
+    });
+
+    const provisioningResult =
+      await WorkspaceSandboxEnvVarResource.loadEnvForSandboxProvisioning(
+        authenticator
+      );
+    const redactionResult =
+      await WorkspaceSandboxEnvVarResource.loadEnvForRedaction(authenticator);
+
+    expect(provisioningResult.isErr()).toBe(true);
+    expect(redactionResult.isErr()).toBe(true);
+    if (provisioningResult.isErr()) {
+      expect(provisioningResult.error.message).toContain("API_TOKEN");
+    }
+    if (redactionResult.isErr()) {
+      expect(redactionResult.error.message).toContain("API_TOKEN");
+    }
+  });
+});

--- a/front/lib/resources/workspace_sandbox_env_var_resource.ts
+++ b/front/lib/resources/workspace_sandbox_env_var_resource.ts
@@ -1,0 +1,283 @@
+import {
+  MAX_VARS_PER_WORKSPACE,
+  validateEnvVarName,
+  validateEnvVarValue,
+} from "@app/lib/api/sandbox/env_vars";
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
+import type { WorkspaceSandboxEnvVarType } from "@app/types/sandbox/env_var";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { decrypt, encrypt } from "@app/types/shared/utils/encryption";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Attributes, Transaction } from "sequelize";
+import { UniqueConstraintError } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface WorkspaceSandboxEnvVarResource
+  extends ReadonlyAttributesType<WorkspaceSandboxEnvVarModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandboxEnvVarModel> {
+  static model: ModelStaticWorkspaceAware<WorkspaceSandboxEnvVarModel> =
+    WorkspaceSandboxEnvVarModel;
+
+  private readonly createdByName: string | null;
+  private readonly lastUpdatedByName: string | null;
+
+  constructor(
+    _model: ModelStaticWorkspaceAware<WorkspaceSandboxEnvVarModel>,
+    blob: Attributes<WorkspaceSandboxEnvVarModel>,
+    metadata?: {
+      createdByName: string | null;
+      lastUpdatedByName: string | null;
+    }
+  ) {
+    super(WorkspaceSandboxEnvVarModel, blob);
+    this.createdByName = metadata?.createdByName ?? null;
+    this.lastUpdatedByName = metadata?.lastUpdatedByName ?? null;
+  }
+
+  private static fromRow(row: WorkspaceSandboxEnvVarModel) {
+    return new this(this.model, row.get(), {
+      createdByName: row.createdByUser?.name ?? null,
+      lastUpdatedByName: row.lastUpdatedByUser?.name ?? null,
+    });
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    where?: Partial<Pick<WorkspaceSandboxEnvVarModel, "name">>
+  ): Promise<WorkspaceSandboxEnvVarResource[]> {
+    const rows = await this.model.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      include: [
+        {
+          association: "createdByUser",
+          attributes: ["name"],
+          required: false,
+        },
+        {
+          association: "lastUpdatedByUser",
+          attributes: ["name"],
+          required: false,
+        },
+      ],
+      order: [["name", "ASC"]],
+    });
+
+    return rows.map((row) => this.fromRow(row));
+  }
+
+  static async listForWorkspace(
+    auth: Authenticator
+  ): Promise<WorkspaceSandboxEnvVarResource[]> {
+    return this.baseFetch(auth);
+  }
+
+  static async fetchByName(
+    auth: Authenticator,
+    name: string
+  ): Promise<WorkspaceSandboxEnvVarResource | null> {
+    const rows = await this.baseFetch(auth, { name });
+    return rows[0] ?? null;
+  }
+
+  static async upsert(
+    auth: Authenticator,
+    {
+      name,
+      value,
+      user,
+    }: {
+      name: string;
+      value: string;
+      user: UserResource;
+    }
+  ): Promise<Result<{ created: boolean }, Error>> {
+    const nameValidation = validateEnvVarName(name);
+    if (nameValidation.isErr()) {
+      return new Err(new Error(nameValidation.error));
+    }
+
+    const valueValidation = validateEnvVarValue(value);
+    if (valueValidation.isErr()) {
+      return new Err(new Error(valueValidation.error));
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const encryptedValue = encrypt({
+      text: value,
+      key: owner.sId,
+      useCase: "developer_secret",
+    });
+
+    const existing = await this.model.findOne({
+      where: {
+        workspaceId: owner.id,
+        name,
+      },
+    });
+    if (existing) {
+      await existing.update({
+        encryptedValue,
+        lastUpdatedByUserId: user.id,
+      });
+      return new Ok({ created: false });
+    }
+
+    const count = await this.model.count({
+      where: {
+        workspaceId: owner.id,
+      },
+    });
+    if (count >= MAX_VARS_PER_WORKSPACE) {
+      return new Err(
+        new Error(
+          `Workspace sandbox environment variable limit reached (${MAX_VARS_PER_WORKSPACE}).`
+        )
+      );
+    }
+
+    try {
+      // Best-effort cap. A concurrent burst of creates from the same workspace
+      // can land 1-2 rows over MAX_VARS_PER_WORKSPACE under READ COMMITTED.
+      // Acceptable: cap is a UI guard, not a security boundary.
+      await this.model.create({
+        workspaceId: owner.id,
+        name,
+        encryptedValue,
+        createdByUserId: user.id,
+        lastUpdatedByUserId: user.id,
+      });
+      return new Ok({ created: true });
+    } catch (error) {
+      if (error instanceof UniqueConstraintError) {
+        await this.model.update(
+          {
+            encryptedValue,
+            lastUpdatedByUserId: user.id,
+          },
+          {
+            where: {
+              workspaceId: owner.id,
+              name,
+            },
+          }
+        );
+        return new Ok({ created: false });
+      }
+
+      return new Err(normalizeError(error));
+    }
+  }
+
+  static async deleteByName(
+    auth: Authenticator,
+    name: string
+  ): Promise<Result<void, Error>> {
+    const deletedCount = await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        name,
+      },
+    });
+
+    if (deletedCount === 0) {
+      return new Err(new Error("Sandbox environment variable not found."));
+    }
+
+    return new Ok(undefined);
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+
+  private static async loadEnv(
+    auth: Authenticator,
+    useCase: "provision" | "redact"
+  ): Promise<Result<Record<string, string>, Error>> {
+    const owner = auth.getNonNullableWorkspace();
+    const rows = await this.model.findAll({
+      where: {
+        workspaceId: owner.id,
+      },
+      order: [["name", "ASC"]],
+    });
+
+    logger.info(
+      { workspaceId: owner.sId, useCase, count: rows.length },
+      "Loading workspace sandbox environment variables"
+    );
+
+    const env: Record<string, string> = {};
+    for (const row of rows) {
+      try {
+        env[row.name] = decrypt({
+          encrypted: row.encryptedValue,
+          key: owner.sId,
+          useCase: "developer_secret",
+        });
+      } catch (error) {
+        return new Err(
+          new Error(
+            `Failed to decrypt sandbox environment variable ${row.name}: ${
+              normalizeError(error).message
+            }`
+          )
+        );
+      }
+    }
+
+    return new Ok(env);
+  }
+
+  static async loadEnvForSandboxProvisioning(
+    auth: Authenticator
+  ): Promise<Result<Record<string, string>, Error>> {
+    return this.loadEnv(auth, "provision");
+  }
+
+  static async loadEnvForRedaction(
+    auth: Authenticator
+  ): Promise<Result<Record<string, string>, Error>> {
+    return this.loadEnv(auth, "redact");
+  }
+
+  toJSON(): WorkspaceSandboxEnvVarType {
+    return {
+      name: this.name,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      createdByName: this.createdByName,
+      lastUpdatedByName: this.lastUpdatedByName,
+    };
+  }
+
+  toLogJSON() {
+    return {
+      workspaceId: this.workspaceId,
+      name: this.name,
+    };
+  }
+}

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -1,6 +1,7 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
+  emptyArray,
   getErrorFromResponse,
   useFetcher,
   useSWRWithDefaults,
@@ -9,8 +10,13 @@ import type {
   GetWorkspaceEgressPolicyResponseBody,
   PutWorkspaceEgressPolicyResponseBody,
 } from "@app/pages/api/w/[wId]/sandbox/egress-policy";
+import type {
+  GetWorkspaceSandboxEnvVarsResponseBody,
+  PostWorkspaceSandboxEnvVarsResponseBody,
+} from "@app/pages/api/w/[wId]/sandbox/env-vars";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import { EMPTY_EGRESS_POLICY } from "@app/types/sandbox/egress_policy";
+import type { WorkspaceSandboxEnvVarType } from "@app/types/sandbox/env_var";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useState } from "react";
@@ -18,6 +24,10 @@ import type { Fetcher } from "swr";
 
 function workspaceEgressPolicyUrl(workspaceId: string) {
   return `/api/w/${workspaceId}/sandbox/egress-policy`;
+}
+
+function workspaceSandboxEnvVarsUrl(workspaceId: string) {
+  return `/api/w/${workspaceId}/sandbox/env-vars`;
 }
 
 export function useWorkspaceEgressPolicy({
@@ -40,6 +50,162 @@ export function useWorkspaceEgressPolicy({
     isWorkspaceEgressPolicyLoading: isLoading,
     isWorkspaceEgressPolicyError: !!error,
     mutateWorkspaceEgressPolicy: mutate,
+  };
+}
+
+export function useWorkspaceSandboxEnvVars({
+  owner,
+  disabled = false,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const envVarsFetcher: Fetcher<GetWorkspaceSandboxEnvVarsResponseBody> =
+    fetcher;
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    workspaceSandboxEnvVarsUrl(owner.sId),
+    envVarsFetcher,
+    { disabled }
+  );
+
+  return {
+    envVars: data?.envVars ?? emptyArray(),
+    isWorkspaceSandboxEnvVarsLoading: disabled ? false : isLoading,
+    isWorkspaceSandboxEnvVarsError: !!error,
+    mutateWorkspaceSandboxEnvVars: mutate,
+  };
+}
+
+export function useUpsertWorkspaceSandboxEnvVar({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isUpserting, setIsUpserting] = useState(false);
+  const { mutateWorkspaceSandboxEnvVars } = useWorkspaceSandboxEnvVars({
+    owner,
+    disabled: true,
+  });
+
+  const upsertWorkspaceSandboxEnvVar = async ({
+    name,
+    value,
+  }: {
+    name: string;
+    value: string;
+  }): Promise<boolean> => {
+    setIsUpserting(true);
+    try {
+      const response = await clientFetch(
+        workspaceSandboxEnvVarsUrl(owner.sId),
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name, value }),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to save environment variable",
+          description: error.message,
+        });
+        return false;
+      }
+
+      const data: PostWorkspaceSandboxEnvVarsResponseBody =
+        await response.json();
+      await mutateWorkspaceSandboxEnvVars();
+      sendNotification({
+        type: "success",
+        title: data.created
+          ? "Environment variable created"
+          : "Environment variable replaced",
+        description: `${name} has been saved for future sandboxes.`,
+      });
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to save environment variable",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsUpserting(false);
+    }
+  };
+
+  return {
+    upsertWorkspaceSandboxEnvVar,
+    isUpsertingWorkspaceSandboxEnvVar: isUpserting,
+  };
+}
+
+export function useDeleteWorkspaceSandboxEnvVar({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const { mutateWorkspaceSandboxEnvVars } = useWorkspaceSandboxEnvVars({
+    owner,
+    disabled: true,
+  });
+
+  const deleteWorkspaceSandboxEnvVar = async (
+    envVar: WorkspaceSandboxEnvVarType
+  ): Promise<boolean> => {
+    setIsDeleting(true);
+    try {
+      const response = await clientFetch(
+        `${workspaceSandboxEnvVarsUrl(owner.sId)}/${encodeURIComponent(
+          envVar.name
+        )}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to delete environment variable",
+          description: error.message,
+        });
+        return false;
+      }
+
+      await mutateWorkspaceSandboxEnvVars();
+      sendNotification({
+        type: "success",
+        title: "Environment variable deleted",
+        description: `${envVar.name} has been deleted.`,
+      });
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to delete environment variable",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return {
+    deleteWorkspaceSandboxEnvVar,
+    isDeletingWorkspaceSandboxEnvVar: isDeleting,
   };
 }
 

--- a/front/migrations/db/migration_611.sql
+++ b/front/migrations/db/migration_611.sql
@@ -1,0 +1,24 @@
+-- Migration created on Apr 29, 2026
+
+CREATE TABLE IF NOT EXISTS "workspace_sandbox_env_vars" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "name" VARCHAR(255) NOT NULL,
+  "encryptedValue" TEXT NOT NULL,
+  "createdByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  "lastUpdatedByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sandbox_env_vars_workspace_name_idx"
+  ON "workspace_sandbox_env_vars" ("workspaceId", "name");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sandbox_env_vars_workspace_id_idx"
+  ON "workspace_sandbox_env_vars" ("workspaceId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sandbox_env_vars_created_by_user_id_idx"
+  ON "workspace_sandbox_env_vars" ("createdByUserId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sandbox_env_vars_last_updated_by_user_id_idx"
+  ON "workspace_sandbox_env_vars" ("lastUpdatedByUserId");

--- a/front/pages/api/w/[wId]/sandbox/env-vars/[name].ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/[name].ts
@@ -1,0 +1,124 @@
+/** @ignoreswagger */
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { validateEnvVarName } from "@app/lib/api/sandbox/env_vars";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type DeleteWorkspaceSandboxEnvVarResponseBody = {
+  success: true;
+};
+
+function buildSandboxEnvVarTarget(owner: { sId: string }, name: string) {
+  return {
+    type: "sandbox_env_var",
+    id: `${owner.sId}:${name}`,
+    name,
+  };
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<DeleteWorkspaceSandboxEnvVarResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only workspace admins can manage sandbox environment variables.",
+      },
+    });
+  }
+
+  if (!(await hasFeatureFlag(auth, "sandbox_tools"))) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message: "Sandbox tools are not enabled for this workspace.",
+      },
+    });
+  }
+
+  if (!isString(req.query.name)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Expected a string environment variable name.",
+      },
+    });
+  }
+
+  const { name } = req.query;
+  const nameValidation = validateEnvVarName(name);
+  if (nameValidation.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: nameValidation.error,
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "DELETE": {
+      const result = await WorkspaceSandboxEnvVarResource.deleteByName(
+        auth,
+        name
+      );
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      void emitAuditLogEvent({
+        auth,
+        action: "sandbox_env_var.deleted",
+        targets: [
+          buildAuditLogTarget("workspace", owner),
+          buildSandboxEnvVarTarget(owner, name),
+        ],
+        context: getAuditLogContext(auth, req),
+        metadata: {
+          name,
+        },
+      });
+
+      return res.status(200).json({ success: true });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/sandbox/env-vars/delete.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/delete.test.ts
@@ -1,0 +1,68 @@
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { describe, expect, it } from "vitest";
+
+process.env.DUST_DEVELOPERS_SECRETS_SECRET ??= "test-developer-secret";
+
+import handler from "./[name]";
+
+async function createDeleteRequest({
+  role = "admin",
+  name,
+}: {
+  role?: "admin" | "builder" | "user";
+  name: string;
+}) {
+  const request = await createPrivateApiMockRequest({
+    method: "DELETE",
+    role,
+  });
+  await FeatureFlagFactory.basic(request.auth, "sandbox_tools");
+  request.req.query.name = name;
+  return request;
+}
+
+describe("DELETE /api/w/[wId]/sandbox/env-vars/[name]", () => {
+  it("deletes an existing sandbox environment variable", async () => {
+    const { req, res, auth } = await createDeleteRequest({
+      name: "API_TOKEN",
+    });
+
+    const upsertResult = await WorkspaceSandboxEnvVarResource.upsert(auth, {
+      name: "API_TOKEN",
+      value: "super-secret-token",
+      user: auth.getNonNullableUser(),
+    });
+    expect(upsertResult.isOk()).toBe(true);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData())).toEqual({ success: true });
+    expect(
+      await WorkspaceSandboxEnvVarResource.fetchByName(auth, "API_TOKEN")
+    ).toBeNull();
+  });
+
+  it("returns 404 for a missing sandbox environment variable", async () => {
+    const { req, res } = await createDeleteRequest({
+      name: "API_TOKEN",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it("rejects non-admin deletes", async () => {
+    const { req, res } = await createDeleteRequest({
+      role: "user",
+      name: "API_TOKEN",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+  });
+});

--- a/front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts
@@ -1,0 +1,224 @@
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { encrypt } from "@app/types/shared/utils/encryption";
+import type { WorkspaceType } from "@app/types/user";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+process.env.DUST_DEVELOPERS_SECRETS_SECRET ??= "test-developer-secret";
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return {
+    ...actual,
+    emitAuditLogEvent: mockEmitAuditLogEvent,
+  };
+});
+
+import handler from "./index";
+
+async function createEnvVarRequest({
+  method,
+  role = "admin",
+  body,
+}: {
+  method: "GET" | "POST";
+  role?: "admin" | "builder" | "user";
+  body?: unknown;
+}) {
+  const request = await createPrivateApiMockRequest({ method, role });
+  await FeatureFlagFactory.basic(request.auth, "sandbox_tools");
+  request.req.body = body;
+  return request;
+}
+
+function createEnvVarHttpRequest({
+  method,
+  workspace,
+  body,
+}: {
+  method: "GET" | "POST";
+  workspace: WorkspaceType;
+  body?: unknown;
+}) {
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method,
+    query: { wId: workspace.sId },
+    headers: {},
+  });
+  req.body = body;
+
+  return { req, res };
+}
+
+describe("GET/POST /api/w/[wId]/sandbox/env-vars", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects non-admin GET and POST requests", async () => {
+    const getRequest = await createEnvVarRequest({
+      method: "GET",
+      role: "user",
+    });
+    await handler(getRequest.req, getRequest.res);
+    expect(getRequest.res._getStatusCode()).toBe(403);
+
+    const postRequest = await createEnvVarRequest({
+      method: "POST",
+      role: "builder",
+      body: { name: "API_TOKEN", value: "super-secret-token" },
+    });
+    await handler(postRequest.req, postRequest.res);
+    expect(postRequest.res._getStatusCode()).toBe(403);
+  });
+
+  it("rejects invalid names and invalid values", async () => {
+    for (const body of [
+      { name: "api_token", value: "super-secret-token" },
+      { name: "_API_TOKEN", value: "super-secret-token" },
+      { name: "DUST_API_KEY", value: "super-secret-token" },
+      { name: "API_TOKEN", value: "" },
+      { name: "API_TOKEN", value: "abc\u0000def" },
+      { name: "API_TOKEN", value: "a".repeat(32 * 1024 + 1) },
+    ]) {
+      const { req, res } = await createEnvVarRequest({
+        method: "POST",
+        body,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+    }
+  });
+
+  it("enforces the create cap while allowing overwrite at the cap", async () => {
+    const { req, res, auth, user, workspace } = await createEnvVarRequest({
+      method: "POST",
+      body: { name: "NEW_TOKEN", value: "super-secret-token" },
+    });
+
+    await WorkspaceSandboxEnvVarModel.bulkCreate(
+      Array.from({ length: 50 }, (_unused, index) => ({
+        workspaceId: workspace.id,
+        name: `VAR_${index}`,
+        encryptedValue: encrypt({
+          text: `value-${index}`,
+          key: workspace.sId,
+          useCase: "developer_secret",
+        }),
+        createdByUserId: user.id,
+        lastUpdatedByUserId: user.id,
+      }))
+    );
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(JSON.parse(res._getData())).toMatchObject({
+      error: {
+        type: "invalid_request_error",
+      },
+    });
+
+    const overwriteRequest = createEnvVarHttpRequest({
+      method: "POST",
+      workspace,
+      body: { name: "VAR_0", value: "rotated-secret-token" },
+    });
+
+    await handler(overwriteRequest.req, overwriteRequest.res);
+    expect(overwriteRequest.res._getStatusCode()).toBe(200);
+    expect(JSON.parse(overwriteRequest.res._getData())).toEqual({
+      created: false,
+    });
+
+    const envResult =
+      await WorkspaceSandboxEnvVarResource.loadEnvForSandboxProvisioning(auth);
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value.VAR_0).toBe("rotated-secret-token");
+  });
+
+  it("creates multiline values, overwrites by name, audits without values, and never lists values", async () => {
+    const first = await createEnvVarRequest({
+      method: "POST",
+      body: {
+        name: "API_TOKEN",
+        value: "-----BEGIN KEY-----\nline two\n-----END KEY-----",
+      },
+    });
+    await handler(first.req, first.res);
+    expect(first.res._getStatusCode()).toBe(200);
+    expect(JSON.parse(first.res._getData())).toEqual({ created: true });
+
+    const second = createEnvVarHttpRequest({
+      method: "POST",
+      workspace: first.workspace,
+      body: {
+        name: "API_TOKEN",
+        value: "rotated-secret-token",
+      },
+    });
+    await handler(second.req, second.res);
+    expect(second.res._getStatusCode()).toBe(200);
+    expect(JSON.parse(second.res._getData())).toEqual({ created: false });
+
+    const envResult =
+      await WorkspaceSandboxEnvVarResource.loadEnvForSandboxProvisioning(
+        first.auth
+      );
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value.API_TOKEN).toBe("rotated-secret-token");
+
+    const listRequest = createEnvVarHttpRequest({
+      method: "GET",
+      workspace: first.workspace,
+    });
+    await handler(listRequest.req, listRequest.res);
+    expect(listRequest.res._getStatusCode()).toBe(200);
+    const responseBody = JSON.parse(listRequest.res._getData());
+    expect(responseBody).toEqual({
+      envVars: [
+        expect.objectContaining({
+          name: "API_TOKEN",
+        }),
+      ],
+    });
+    expect(JSON.stringify(responseBody)).not.toContain("rotated-secret-token");
+
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sandbox_env_var.created",
+        metadata: { name: "API_TOKEN" },
+      })
+    );
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sandbox_env_var.updated",
+        metadata: {
+          name: "API_TOKEN",
+          previously_existed: "true",
+        },
+      })
+    );
+    expect(JSON.stringify(mockEmitAuditLogEvent.mock.calls)).not.toContain(
+      "rotated-secret-token"
+    );
+  });
+});

--- a/front/pages/api/w/[wId]/sandbox/env-vars/index.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/index.ts
@@ -1,0 +1,165 @@
+/** @ignoreswagger */
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  validateEnvVarName,
+  validateEnvVarValue,
+} from "@app/lib/api/sandbox/env_vars";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { WorkspaceSandboxEnvVarType } from "@app/types/sandbox/env_var";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetWorkspaceSandboxEnvVarsResponseBody = {
+  envVars: WorkspaceSandboxEnvVarType[];
+};
+
+export type PostWorkspaceSandboxEnvVarsResponseBody = {
+  created: boolean;
+};
+
+function buildSandboxEnvVarTarget(owner: { sId: string }, name: string) {
+  return {
+    type: "sandbox_env_var",
+    id: `${owner.sId}:${name}`,
+    name,
+  };
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      | GetWorkspaceSandboxEnvVarsResponseBody
+      | PostWorkspaceSandboxEnvVarsResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only workspace admins can manage sandbox environment variables.",
+      },
+    });
+  }
+
+  if (!(await hasFeatureFlag(auth, "sandbox_tools"))) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message: "Sandbox tools are not enabled for this workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const envVars =
+        await WorkspaceSandboxEnvVarResource.listForWorkspace(auth);
+
+      return res.status(200).json({
+        envVars: envVars.map((envVar) => envVar.toJSON()),
+      });
+    }
+
+    case "POST": {
+      if (!isString(req.body?.name) || !isString(req.body?.value)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Expected body with string fields name and value.",
+          },
+        });
+      }
+
+      const nameValidation = validateEnvVarName(req.body.name);
+      if (nameValidation.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: nameValidation.error,
+          },
+        });
+      }
+
+      const valueValidation = validateEnvVarValue(req.body.value);
+      if (valueValidation.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: valueValidation.error,
+          },
+        });
+      }
+
+      const result = await WorkspaceSandboxEnvVarResource.upsert(auth, {
+        name: req.body.name,
+        value: req.body.value,
+        user: auth.getNonNullableUser(),
+      });
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      const action = result.value.created
+        ? "sandbox_env_var.created"
+        : "sandbox_env_var.updated";
+
+      void emitAuditLogEvent({
+        auth,
+        action,
+        targets: [
+          buildAuditLogTarget("workspace", owner),
+          buildSandboxEnvVarTarget(owner, req.body.name),
+        ],
+        context: getAuditLogContext(auth, req),
+        metadata: {
+          name: req.body.name,
+          ...(result.value.created
+            ? {}
+            : {
+                previously_existed: "true",
+              }),
+        },
+      });
+
+      return res.status(200).json(result.value);
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/sandbox/env_var.ts
+++ b/front/types/sandbox/env_var.ts
@@ -1,0 +1,7 @@
+export type WorkspaceSandboxEnvVarType = {
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  createdByName: string | null;
+  lastUpdatedByName: string | null;
+};


### PR DESCRIPTION
## Description

Adds a workspace-admin manager for environment variables that are mounted as env vars on every sandbox in the workspace, so agent code can authenticate to APIs without hardcoding credentials in prompts or app state.

The existing `/developers/egress-policy` admin page is renamed to `/developers/sandbox` and gains a second section, **Environment**, below the existing **Network** section.

### Highlights

- **Storage**: dedicated `WorkspaceSandboxEnvVarModel` table, AES-256-CBC at rest, reusing the existing `developer_secret` encryption key + workspace `sId` salt.
- **Write-only contract**: values never come back to the frontend; the listing exposes only `name`, `createdAt`, `updatedAt`, and authoring users. To rotate, `POST` overwrites in place.
- **Validation**: strict POSIX names (`^[A-Z][A-Z0-9_]{0,63}$`), reserved-prefix blocklist (`PATH`, `LD_*`, `DUST_*`, `SANDBOX_*`, `E2B_*`, `DD_*`, `CONVERSATION_*`, `WORKSPACE_*`, leading underscore, etc.), 32 KiB UTF-8 cap (`Buffer.byteLength`), NUL rejected, multiline allowed, 50 vars/workspace cap (best-effort, race documented).
- **Sandbox merge**: at sandbox create/recreate, env is composed as `workspaceEnv → image runEnv → system vars`. Image and system vars always win, defense-in-depth alongside the reserved-prefix blocklist. Snapshot at create time; rotation hits the next boot.
- **Disclosure controls**:
  - Skill instruction tells the agent to use env vars from code only — never print/echo/encode-and-emit them.
  - Best-effort redactor on the **bash tool's final output**: replaces eligible env var values (`>= 12` chars, not in a low-entropy denylist, not pure digits, not short alphanumeric) with `«redacted: $NAME»` markers. Logs to `logger.warn` on hit. Other sandbox tools and streaming paths are out of scope for v1 — see `front/docs/plans/sandbox-env-manager.md` §6 and §12.
- **Audit**: three new actions (`sandbox_env_var.{created,updated,deleted}`), metadata logs name only — never value, length, or hash.
- **Page rename**: `/developers/egress-policy` → `/developers/sandbox`. Old route, `EgressPolicyPage` component, and SPA lazy import all deleted in this PR. No redirect: the feature is gated by the Dust-only `sandbox_tools` flag, so the legacy URL has no external consumers.
- **Swagger**: both new endpoints carry `/** @ignoreswagger */`, matching the existing `egress-policy.ts` convention for private sandbox-admin APIs.

The full design doc with rejected alternatives and rationale is committed at `front/docs/plans/sandbox-env-manager.md`.

## Tests

- New unit + functional tests:
  - `front/lib/api/sandbox/env_vars.test.ts` — name + value validation truth tables.
  - `front/lib/resources/workspace_sandbox_env_var_resource.test.ts` — encrypt/decrypt round-trip, fail-closed on bad ciphertext for both decrypt helpers, empty-workspace shape.
  - `front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts` and `delete.test.ts` — admin-only enforcement, validation 400s, overwrite at the cap, multiline + UTF-8 size, 404 on missing.
  - `front/lib/api/actions/servers/sandbox/tools/index.test.ts` — bash-output redaction (eligible value redacted, sub-12-char skipped, denylist skipped, multiple values, ineligible-value `logger.info` rate-limit).
  - `front/lib/resources/sandbox_resource.test.ts` — provisioning merge order (workspace < image < system).
- All new tests pass (30 unit/resource + 6 endpoint + 17 redactor + 6 provisioning = 59 cases). Full `pages/api` suite green (89 files, 713 tests, 4 pre-existing skipped).
- `npx tsc --noEmit` clean.

## Risk

- **Encryption key collision**: reuses the `developer_secret` key already used by `DustAppSecret`. No collision in practice because the two stores have disjoint tables and disjoint name validation rules; documented in §3.0 of the plan.
- **50-var cap race**: under `READ COMMITTED`, two concurrent admin creates can land 1–2 rows over the cap. Accepted as best-effort (cap is a UI guard, not a security boundary). Inline code comment + plan §4.5 document the trade-off.
- **Best-effort redaction**: defeated by base64/slicing/etc. and skips short/dictionary-like values to avoid mangling unrelated bash output. The skill instruction is the primary defense; the warning banner on the admin page is explicit about this. Stronger leak prevention is enumerated in plan §12 as v2 candidates.
- **Rollback**: feature is gated by the existing `sandbox_tools` Dust-only flag. Toggling it off hides the admin page and rejects the new endpoints. The migration is additive (new table + indexes only), no backfill.
- **Page rename has no redirect**: under the Dust-only flag, no external bookmarks exist. If the feature ever graduates beyond `dust_only`, an absolute redirect can be added at that point (plan §9.2).

## Deploy Plan

1. Merge to `main`.
2. Run `migration_611.sql` (additive: new `workspace_sandbox_env_vars` table + unique `(workspaceId, name)` index + FK indexes, all `CONCURRENTLY`).
3. Deploy `front` and `front-spa`.
4. Verify the new `/developers/sandbox` admin page loads for a Dust workspace, that creating + rotating + deleting an env var works, and that audit events land in WorkOS.
5. Smoke-test a sandbox-running agent in a Dust workspace: confirm the new env var is readable from inside `bash` (e.g., `python -c "import os; print(bool(os.environ.get('FOO')))"`) and that printing the value triggers the redactor (`echo $FOO` returns `«redacted: $FOO»`).