### PR TITLE
[GitHub] fix: migrate openapi command to GitHub action version used

### DIFF
--- a/.github/workflows/deploy-docs-openapi.yml
+++ b/.github/workflows/deploy-docs-openapi.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Run `openapi` command 🚀
         uses: readmeio/rdme@51a80867c45de15e2b41af0c4bd5bbc61b932804 # v10.6.2
         with:
-          rdme: openapi front/public/swagger.json --version=v1.1 --key=${{ secrets.README_API_KEY }} --id=66cee36af1922700458e4678
+          rdme: openapi upload front/public/swagger.json --version=v1.1 --key=${{ secrets.README_API_KEY }} --slug=dust-api-documentation.json


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/dust/pull/24206 bumped the version of the readmeio GitHub action from v8 to v10.6.2
- The syntax changed since, followed their migration guide https://github.com/readmeio/rdme/blob/next/documentation/migration-guide.md
- This PR updates the syntax to the version currently on main

## Tests

- Tested using their CLI

## Risk

- Low.

## Deploy Plan

- No deploy.
