### PR TITLE
feat(sbx): add workspace sandbox env vars table

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -130,6 +130,7 @@ import { UserProjectNotificationPreferenceModel } from "@app/lib/resources/stora
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import { WorkspaceVerificationAttemptModel } from "@app/lib/resources/storage/models/workspace_verification_attempt";
 import logger from "@app/logger/logger";
 import { sendInitDbMessage } from "@app/types/shared/deployment";
@@ -249,6 +250,7 @@ export function loadAllModels() {
     ProjectTodoTakeawaySourcesModel,
     UserProjectNotificationPreferenceModel,
     WorkspaceSensitivityLabelConfigModel,
+    WorkspaceSandboxEnvVarModel,
   ];
 }
 

--- a/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
+++ b/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
@@ -1,0 +1,93 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export class WorkspaceSandboxEnvVarModel extends WorkspaceAwareModel<WorkspaceSandboxEnvVarModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare name: string;
+  declare encryptedValue: string;
+  declare createdByUserId: ForeignKey<UserModel["id"]> | null;
+  declare lastUpdatedByUserId: ForeignKey<UserModel["id"]> | null;
+
+  declare createdByUser: NonAttribute<UserModel | null>;
+  declare lastUpdatedByUser: NonAttribute<UserModel | null>;
+}
+
+WorkspaceSandboxEnvVarModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    encryptedValue: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    createdByUserId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      references: {
+        model: UserModel,
+        key: "id",
+      },
+    },
+    lastUpdatedByUserId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      references: {
+        model: UserModel,
+        key: "id",
+      },
+    },
+  },
+  {
+    modelName: "workspace_sandbox_env_var",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "workspace_sandbox_env_vars_workspace_name_idx",
+        unique: true,
+        fields: ["workspaceId", "name"],
+      },
+      {
+        name: "workspace_sandbox_env_vars_workspace_id_idx",
+        fields: ["workspaceId"],
+      },
+      {
+        name: "workspace_sandbox_env_vars_created_by_user_id_idx",
+        fields: ["createdByUserId"],
+      },
+      {
+        name: "workspace_sandbox_env_vars_last_updated_by_user_id_idx",
+        fields: ["lastUpdatedByUserId"],
+      },
+    ],
+  }
+);
+
+WorkspaceSandboxEnvVarModel.belongsTo(UserModel, {
+  as: "createdByUser",
+  foreignKey: { name: "createdByUserId", allowNull: true },
+  onDelete: "SET NULL",
+});
+
+WorkspaceSandboxEnvVarModel.belongsTo(UserModel, {
+  as: "lastUpdatedByUser",
+  foreignKey: { name: "lastUpdatedByUserId", allowNull: true },
+  onDelete: "SET NULL",
+});

--- a/front/lib/resources/workspace_sandbox_env_var_resource.ts
+++ b/front/lib/resources/workspace_sandbox_env_var_resource.ts
@@ -1,0 +1,46 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface WorkspaceSandboxEnvVarResource
+  extends ReadonlyAttributesType<WorkspaceSandboxEnvVarModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandboxEnvVarModel> {
+  static model: ModelStaticWorkspaceAware<WorkspaceSandboxEnvVarModel> =
+    WorkspaceSandboxEnvVarModel;
+
+  constructor(
+    model: ModelStatic<WorkspaceSandboxEnvVarModel>,
+    blob: Attributes<WorkspaceSandboxEnvVarModel>
+  ) {
+    super(WorkspaceSandboxEnvVarModel, blob);
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    await WorkspaceSandboxEnvVarModel.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+    return new Ok(undefined);
+  }
+
+  static async deleteAllForWorkspace(auth: Authenticator): Promise<undefined> {
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
+}

--- a/front/migrations/db/migration_613.sql
+++ b/front/migrations/db/migration_613.sql
@@ -1,0 +1,24 @@
+-- Migration created on Apr 29, 2026
+
+CREATE TABLE IF NOT EXISTS "workspace_sandbox_env_vars" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "name" VARCHAR(255) NOT NULL,
+  "encryptedValue" TEXT NOT NULL,
+  "createdByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  "lastUpdatedByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sandbox_env_vars_workspace_name_idx"
+  ON "workspace_sandbox_env_vars" ("workspaceId", "name");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sandbox_env_vars_workspace_id_idx"
+  ON "workspace_sandbox_env_vars" ("workspaceId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sandbox_env_vars_created_by_user_id_idx"
+  ON "workspace_sandbox_env_vars" ("createdByUserId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "workspace_sandbox_env_vars_last_updated_by_user_id_idx"
+  ON "workspace_sandbox_env_vars" ("lastUpdatedByUserId");

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -34,6 +34,7 @@ import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -133,6 +134,7 @@ export async function scrubWorkspaceData({
   await deleteSkills(auth);
   await deleteOnboardingTasks(auth);
   await deleteTags(auth);
+  await deleteSandboxEnvVars(auth);
   await deleteDatasources(auth);
   await deleteSpaces(auth);
   await cleanupCustomerio(auth);
@@ -245,6 +247,10 @@ async function deleteTags(auth: Authenticator) {
   for (const tag of tags) {
     await tag.delete(auth);
   }
+}
+
+async function deleteSandboxEnvVars(auth: Authenticator) {
+  await WorkspaceSandboxEnvVarResource.deleteAllForWorkspace(auth);
 }
 
 async function deleteDatasources(auth: Authenticator) {


### PR DESCRIPTION
## Description

First PR of a series adding a workspace-level secret manager for sandbox env vars (full plan #25013, kept as reference and will be closed).

This one is the storage layer only: a new `workspace_sandbox_env_vars` table and the matching Sequelize model. Nothing reads or writes it yet. The Resource, API, audit, sandbox boot wiring and admin UI come in follow-up PRs.

The table holds `(workspaceId, name, encryptedValue)` plus author tracking. Values will be AES-256-CBC encrypted with the same `developer_secret` key used by `DustAppSecret`. A unique index on `(workspaceId, name)` enforces one row per name per workspace and makes lookups fast for delete and overwrite. FK columns are explicitly indexed per BACK13.

Not reusing `DustAppSecret` because of namespace collision (Dust app blocks reference secrets by name), different validation (POSIX names + reserved blocklist), different visibility (sandbox vars are write-only with no preview), and different audit lineage.

## Tests

Model registration is exercised by `init_db.sh` running clean. No behavioral tests at this stage since there is no read/write path yet.

## Risk

Low. Migration is additive, no backfill, no code path uses the table yet. Safe to roll back by reverting the model registration; the empty table can stay.

## Deploy Plan

Lock front, apply migration in both environments, unlock & deploy front