### PR TITLE
feat(sbx): sandbox env vars resource, validation, types

### DIFF
--- a/front/lib/api/sandbox/env_vars.test.ts
+++ b/front/lib/api/sandbox/env_vars.test.ts
@@ -1,0 +1,54 @@
+import {
+  isReservedEnvVarName,
+  validateEnvVarName,
+  validateEnvVarValue,
+} from "@app/lib/api/sandbox/env_vars";
+import { describe, expect, it } from "vitest";
+
+describe("sandbox env var validation", () => {
+  it("accepts valid POSIX-style names", () => {
+    expect(validateEnvVarName("API_TOKEN").isOk()).toBe(true);
+    expect(validateEnvVarName("A").isOk()).toBe(true);
+    expect(validateEnvVarName("A_123").isOk()).toBe(true);
+  });
+
+  it("rejects names outside the allowed pattern", () => {
+    expect(validateEnvVarName("api_token").isErr()).toBe(true);
+    expect(validateEnvVarName("1_API_TOKEN").isErr()).toBe(true);
+    expect(validateEnvVarName("API-TOKEN").isErr()).toBe(true);
+    expect(validateEnvVarName("A".repeat(65)).isErr()).toBe(true);
+  });
+
+  it("rejects exact reserved names, prefixes, and leading underscores", () => {
+    for (const name of [
+      "PATH",
+      "HOME",
+      "USER",
+      "SHELL",
+      "PWD",
+      "TERM",
+      "LANG",
+      "LC_ALL",
+      "HOSTNAME",
+      "TMPDIR",
+      "_PRIVATE",
+      "LD_PRELOAD",
+      "DUST_API_KEY",
+      "SANDBOX_TOKEN",
+      "E2B_API_KEY",
+      "DD_API_KEY",
+      "CONVERSATION_ID",
+      "WORKSPACE_ID",
+    ]) {
+      expect(validateEnvVarName(name).isErr()).toBe(true);
+      expect(isReservedEnvVarName(name)).toBe(true);
+    }
+  });
+
+  it("validates value constraints while allowing multiline values", () => {
+    expect(validateEnvVarValue("").isErr()).toBe(true);
+    expect(validateEnvVarValue("abc\u0000def").isErr()).toBe(true);
+    expect(validateEnvVarValue("line 1\nline 2").isOk()).toBe(true);
+    expect(validateEnvVarValue("a".repeat(32 * 1024 + 1)).isErr()).toBe(true);
+  });
+});

--- a/front/lib/api/sandbox/env_vars.ts
+++ b/front/lib/api/sandbox/env_vars.ts
@@ -1,0 +1,68 @@
+import { Err, Ok, type Result } from "@app/types/shared/result";
+
+export const ENV_VAR_NAME_REGEX = /^[A-Z][A-Z0-9_]{0,63}$/;
+export const MAX_VALUE_BYTES = 32 * 1024;
+export const MAX_VARS_PER_WORKSPACE = 50;
+
+const RESERVED_EXACT_NAMES = new Set([
+  "PATH",
+  "HOME",
+  "USER",
+  "SHELL",
+  "PWD",
+  "TERM",
+  "LANG",
+  "LC_ALL",
+  "HOSTNAME",
+  "TMPDIR",
+]);
+
+const RESERVED_PREFIXES = [
+  "LD_",
+  "DUST_",
+  "SANDBOX_",
+  "E2B_",
+  "DD_",
+  "CONVERSATION_",
+  "WORKSPACE_",
+];
+
+export function isReservedEnvVarName(name: string): boolean {
+  return (
+    name.startsWith("_") ||
+    RESERVED_EXACT_NAMES.has(name) ||
+    RESERVED_PREFIXES.some((prefix) => name.startsWith(prefix))
+  );
+}
+
+export function validateEnvVarName(name: string): Result<void, string> {
+  if (!ENV_VAR_NAME_REGEX.test(name)) {
+    return new Err(
+      "Environment variable names must match /^[A-Z][A-Z0-9_]{0,63}$/."
+    );
+  }
+
+  if (isReservedEnvVarName(name)) {
+    return new Err(
+      "This environment variable name is reserved for the sandbox runtime."
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+export function validateEnvVarValue(value: string): Result<void, string> {
+  if (value.length === 0) {
+    return new Err("Environment variable values cannot be empty.");
+  }
+
+  if (value.includes("\u0000")) {
+    return new Err("Environment variable values cannot contain NUL bytes.");
+  }
+
+  if (Buffer.byteLength(value, "utf8") > MAX_VALUE_BYTES) {
+    return new Err("Environment variable values cannot exceed 32 KiB.");
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/resources/workspace_sandbox_env_var_resource.test.ts
+++ b/front/lib/resources/workspace_sandbox_env_var_resource.test.ts
@@ -1,0 +1,90 @@
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+describe("WorkspaceSandboxEnvVarResource", () => {
+  it("encrypts values at rest and decrypts them via loadEnv", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const user = authenticator.getNonNullableUser();
+
+    const upsertResult = await WorkspaceSandboxEnvVarResource.upsert(
+      authenticator,
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+        user,
+      }
+    );
+
+    expect(upsertResult.isOk()).toBe(true);
+    if (upsertResult.isErr()) {
+      throw upsertResult.error;
+    }
+    expect(upsertResult.value.created).toBe(true);
+
+    const row = await WorkspaceSandboxEnvVarModel.findOne({
+      where: {
+        workspaceId: authenticator.getNonNullableWorkspace().id,
+        name: "API_TOKEN",
+      },
+    });
+    expect(row?.encryptedValue).toBeDefined();
+    expect(row?.encryptedValue).not.toBe("super-secret-token");
+
+    const envResult =
+      await WorkspaceSandboxEnvVarResource.loadEnv(authenticator);
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value).toEqual({
+      API_TOKEN: "super-secret-token",
+    });
+
+    const listed =
+      await WorkspaceSandboxEnvVarResource.listForWorkspace(authenticator);
+    expect(listed.map((envVar) => envVar.toJSON())).toEqual([
+      expect.objectContaining({
+        name: "API_TOKEN",
+        createdByName: user.name,
+        lastUpdatedByName: user.name,
+      }),
+    ]);
+    expect(
+      JSON.stringify(listed.map((envVar) => envVar.toJSON()))
+    ).not.toContain("super-secret-token");
+  });
+
+  it("returns an empty env map for a workspace with no vars", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const envResult =
+      await WorkspaceSandboxEnvVarResource.loadEnv(authenticator);
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value).toEqual({});
+  });
+
+  it("fails closed when a stored value cannot be decrypted", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const user = authenticator.getNonNullableUser();
+
+    await WorkspaceSandboxEnvVarModel.create({
+      workspaceId: authenticator.getNonNullableWorkspace().id,
+      name: "API_TOKEN",
+      encryptedValue: "not-valid-ciphertext",
+      createdByUserId: user.id,
+      lastUpdatedByUserId: user.id,
+    });
+
+    const envResult =
+      await WorkspaceSandboxEnvVarResource.loadEnv(authenticator);
+    expect(envResult.isErr()).toBe(true);
+    if (envResult.isErr()) {
+      expect(envResult.error.message).toContain("API_TOKEN");
+    }
+  });
+});

--- a/front/lib/resources/workspace_sandbox_env_var_resource.ts
+++ b/front/lib/resources/workspace_sandbox_env_var_resource.ts
@@ -1,38 +1,189 @@
+import {
+  MAX_VARS_PER_WORKSPACE,
+  validateEnvVarName,
+  validateEnvVarValue,
+} from "@app/lib/api/sandbox/env_vars";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { WorkspaceSandboxEnvVarType } from "@app/types/sandbox/env_var";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
-import type { Attributes, ModelStatic, Transaction } from "sequelize";
+import { Err, Ok } from "@app/types/shared/result";
+import { decrypt, encrypt } from "@app/types/shared/utils/encryption";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Attributes, Transaction } from "sequelize";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface WorkspaceSandboxEnvVarResource
   extends ReadonlyAttributesType<WorkspaceSandboxEnvVarModel> {}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandboxEnvVarModel> {
   static model: ModelStaticWorkspaceAware<WorkspaceSandboxEnvVarModel> =
     WorkspaceSandboxEnvVarModel;
 
+  private readonly createdByName: string | null;
+  private readonly lastUpdatedByName: string | null;
+
   constructor(
-    model: ModelStatic<WorkspaceSandboxEnvVarModel>,
-    blob: Attributes<WorkspaceSandboxEnvVarModel>
+    _model: ModelStaticWorkspaceAware<WorkspaceSandboxEnvVarModel>,
+    blob: Attributes<WorkspaceSandboxEnvVarModel>,
+    metadata?: {
+      createdByName: string | null;
+      lastUpdatedByName: string | null;
+    }
   ) {
     super(WorkspaceSandboxEnvVarModel, blob);
+    this.createdByName = metadata?.createdByName ?? null;
+    this.lastUpdatedByName = metadata?.lastUpdatedByName ?? null;
+  }
+
+  private static fromRow(row: WorkspaceSandboxEnvVarModel) {
+    return new this(this.model, row.get(), {
+      createdByName: row.createdByUser?.name ?? null,
+      lastUpdatedByName: row.lastUpdatedByUser?.name ?? null,
+    });
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    where?: Partial<Pick<WorkspaceSandboxEnvVarModel, "name">>
+  ): Promise<WorkspaceSandboxEnvVarResource[]> {
+    const rows = await this.model.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      include: [
+        {
+          association: "createdByUser",
+          attributes: ["name"],
+          required: false,
+        },
+        {
+          association: "lastUpdatedByUser",
+          attributes: ["name"],
+          required: false,
+        },
+      ],
+      order: [["name", "ASC"]],
+    });
+
+    return rows.map((row) => this.fromRow(row));
+  }
+
+  static async listForWorkspace(
+    auth: Authenticator
+  ): Promise<WorkspaceSandboxEnvVarResource[]> {
+    return this.baseFetch(auth);
+  }
+
+  static async fetchByName(
+    auth: Authenticator,
+    name: string
+  ): Promise<WorkspaceSandboxEnvVarResource | null> {
+    const rows = await this.baseFetch(auth, { name });
+    return rows[0] ?? null;
+  }
+
+  static async upsert(
+    auth: Authenticator,
+    {
+      name,
+      value,
+      user,
+    }: {
+      name: string;
+      value: string;
+      user: UserResource;
+    }
+  ): Promise<Result<{ created: boolean }, Error>> {
+    const nameValidation = validateEnvVarName(name);
+    if (nameValidation.isErr()) {
+      return new Err(new Error(nameValidation.error));
+    }
+
+    const valueValidation = validateEnvVarValue(value);
+    if (valueValidation.isErr()) {
+      return new Err(new Error(valueValidation.error));
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const encryptedValue = encrypt({
+      text: value,
+      key: owner.sId,
+      useCase: "developer_secret",
+    });
+
+    const existing = await this.model.findOne({
+      where: {
+        workspaceId: owner.id,
+        name,
+      },
+    });
+
+    if (!existing) {
+      const count = await this.model.count({
+        where: {
+          workspaceId: owner.id,
+        },
+      });
+      // Best-effort cap. A concurrent burst of creates from the same workspace
+      // can land 1-2 rows over MAX_VARS_PER_WORKSPACE under READ COMMITTED.
+      // Acceptable: cap is a UI guard, not a security boundary.
+      if (count >= MAX_VARS_PER_WORKSPACE) {
+        return new Err(
+          new Error(
+            `Workspace sandbox environment variable limit reached (${MAX_VARS_PER_WORKSPACE}).`
+          )
+        );
+      }
+    }
+
+    await this.model.upsert({
+      workspaceId: owner.id,
+      name,
+      encryptedValue,
+      createdByUserId: existing?.createdByUserId ?? user.id,
+      lastUpdatedByUserId: user.id,
+    });
+
+    return new Ok({ created: existing === null });
+  }
+
+  static async deleteByName(
+    auth: Authenticator,
+    name: string
+  ): Promise<Result<void, Error>> {
+    const deletedCount = await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        name,
+      },
+    });
+
+    if (deletedCount === 0) {
+      return new Err(new Error("Sandbox environment variable not found."));
+    }
+
+    return new Ok(undefined);
   }
 
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
-    await WorkspaceSandboxEnvVarModel.destroy({
+    await this.model.destroy({
       where: {
         id: this.id,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
       transaction,
     });
+
     return new Ok(undefined);
   }
 
@@ -42,5 +193,55 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
         workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
+  }
+
+  static async loadEnv(
+    auth: Authenticator
+  ): Promise<Result<Record<string, string>, Error>> {
+    const owner = auth.getNonNullableWorkspace();
+    const rows = await this.model.findAll({
+      where: {
+        workspaceId: owner.id,
+      },
+      order: [["name", "ASC"]],
+    });
+
+    const env: Record<string, string> = {};
+    for (const row of rows) {
+      try {
+        env[row.name] = decrypt({
+          encrypted: row.encryptedValue,
+          key: owner.sId,
+          useCase: "developer_secret",
+        });
+      } catch (error) {
+        return new Err(
+          new Error(
+            `Failed to decrypt sandbox environment variable ${row.name}: ${
+              normalizeError(error).message
+            }`
+          )
+        );
+      }
+    }
+
+    return new Ok(env);
+  }
+
+  toJSON(): WorkspaceSandboxEnvVarType {
+    return {
+      name: this.name,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      createdByName: this.createdByName,
+      lastUpdatedByName: this.lastUpdatedByName,
+    };
+  }
+
+  toLogJSON() {
+    return {
+      workspaceId: this.workspaceId,
+      name: this.name,
+    };
   }
 }

--- a/front/types/sandbox/env_var.ts
+++ b/front/types/sandbox/env_var.ts
@@ -1,0 +1,7 @@
+export type WorkspaceSandboxEnvVarType = {
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  createdByName: string | null;
+  lastUpdatedByName: string | null;
+};

--- a/front/vite.globalSetup.ts
+++ b/front/vite.globalSetup.ts
@@ -37,6 +37,7 @@ export default async function setup() {
     VIZ_JWT_SECRET: "viz-secret-for-tests",
     VIZ_PUBLIC_URL: "http://fake-viz-url",
     DUST_SANDBOX_JWT_SECRET: "sandbox-secret-for-tests",
+    DUST_DEVELOPERS_SECRETS_SECRET: "test-developer-secret",
     REGION: "us-central1",
     DUST_MCP_SERVER_CREDENTIALS_SECRET: "test-secret",
     OAUTH_API: process.env.OAUTH_API ?? "http://fake-oauth-api",


### PR DESCRIPTION
## Description

Second PR in the sandbox env vars series (full plan #25013, kept as reference). Builds on the bare model + minimal Resource shell from #25015.

This one adds the actual server-side logic:

- `WorkspaceSandboxEnvVarResource.upsert` (validates, encrypts, handles rotation, enforces the 50-vars-per-workspace cap as a UI guard).
- `listForWorkspace`, `fetchByName`, `deleteByName`.
- Two distinct decrypt paths: `loadEnvForSandboxProvisioning` (mounts onto a sandbox at boot) and `loadEnvForRedaction` (read-only, used to filter tool I/O before it reaches the model). Same impl, different `useCase` tag in the log line so we can audit-trace why values were materialized. Both fail-closed: one bad ciphertext fails the whole call rather than silently dropping a row.
- Validation helpers in `lib/api/sandbox/env_vars.ts`: POSIX name regex, reserved-prefix blocklist (`PATH`, `LD_*`, `DUST_*`, `SANDBOX_*`, `E2B_*`, `DD_*`, `CONVERSATION_*`, `WORKSPACE_*`, leading underscore), value rules (non-empty, no NUL, <= 32 KiB by `Buffer.byteLength`, multiline allowed for PEM/JSON blobs).
- `WorkspaceSandboxEnvVarType` for the wire (no value, ever).

Encryption reuses `encrypt`/`decrypt` from `types/shared/utils/encryption` with the `developer_secret` use case, same key as `DustAppSecret`. Workspace `sId` is mixed into the salt.

The 50-cap is best-effort: under READ COMMITTED two concurrent creates can both pass `count < 50` and land at 51. Documented inline. Cap is a UI guard, not a security boundary, so a `SELECT ... FOR UPDATE` would be more ceremony than the failure mode warrants.

No API endpoints, no sandbox boot wiring, no UI. Those land in PR3 / PR5 / PR4 respectively.

## Tests

- `lib/api/sandbox/env_vars.test.ts`: name regex, reserved exact + prefix + leading underscore, value constraints (empty, NUL, multiline, > 32 KiB).
- `lib/resources/workspace_sandbox_env_var_resource.test.ts`: round-trip encrypt/decrypt and value never appears in the JSON shape; both load helpers return `{}` and emit the use-case-tagged log line on empty workspaces; both fail-closed when a stored ciphertext is broken.

## Risk

Low. New code only, no call sites yet outside the temporal scrub flow already wired in PR1. Safe to revert.

## Deploy Plan

Standard.