### PR TITLE
feat(sbx): admin API for sandbox env vars + audit

### DIFF
--- a/front/admin/audit_log_schemas/sandbox_env_var.created.json
+++ b/front/admin/audit_log_schemas/sandbox_env_var.created.json
@@ -1,0 +1,8 @@
+{
+  "action": "sandbox_env_var.created",
+  "targets": [{ "type": "workspace" }, { "type": "sandbox_env_var" }],
+  "metadata": {
+    "name": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/sandbox_env_var.deleted.json
+++ b/front/admin/audit_log_schemas/sandbox_env_var.deleted.json
@@ -1,0 +1,8 @@
+{
+  "action": "sandbox_env_var.deleted",
+  "targets": [{ "type": "workspace" }, { "type": "sandbox_env_var" }],
+  "metadata": {
+    "name": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/sandbox_env_var.updated.json
+++ b/front/admin/audit_log_schemas/sandbox_env_var.updated.json
@@ -1,0 +1,9 @@
+{
+  "action": "sandbox_env_var.updated",
+  "targets": [{ "type": "workspace" }, { "type": "sandbox_env_var" }],
+  "metadata": {
+    "name": "string",
+    "previously_existed": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -60,6 +60,9 @@ type AuditAction =
   | "sandbox_egress_policy.agent_requests_setting_updated"
   | "sandbox_egress_policy.sandbox_updated"
   | "sandbox_egress_policy.updated"
+  | "sandbox_env_var.created"
+  | "sandbox_env_var.deleted"
+  | "sandbox_env_var.updated"
   // SCIM / Directory Sync.
   | "scim.user_provisioned"
   | "scim.user_updated"
@@ -308,7 +311,8 @@ type AuditTargetType =
   | "invitation"
   | "group"
   | "credential"
-  | "mcp_connection";
+  | "mcp_connection"
+  | "sandbox_env_var";
 
 /**
  * Resource shape required for each audit target type.

--- a/front/pages/api/w/[wId]/sandbox/env-vars/[name].ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/[name].ts
@@ -1,0 +1,119 @@
+/** @ignoreswagger */
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { validateEnvVarName } from "@app/lib/api/sandbox/env_vars";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type DeleteWorkspaceSandboxEnvVarResponseBody = {
+  success: true;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<DeleteWorkspaceSandboxEnvVarResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only workspace admins can manage sandbox environment variables.",
+      },
+    });
+  }
+
+  if (!(await hasFeatureFlag(auth, "sandbox_tools"))) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message: "Sandbox tools are not enabled for this workspace.",
+      },
+    });
+  }
+
+  if (!isString(req.query.name)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Expected a string environment variable name.",
+      },
+    });
+  }
+
+  const { name } = req.query;
+  const nameValidation = validateEnvVarName(name);
+  if (nameValidation.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: nameValidation.error,
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "DELETE": {
+      const result = await WorkspaceSandboxEnvVarResource.deleteByName(
+        auth,
+        name
+      );
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      void emitAuditLogEvent({
+        auth,
+        action: "sandbox_env_var.deleted",
+        targets: [
+          buildAuditLogTarget("workspace", owner),
+          buildAuditLogTarget("sandbox_env_var", {
+            sId: `${owner.sId}:${name}`,
+            name,
+          }),
+        ],
+        context: getAuditLogContext(auth, req),
+        metadata: {
+          name,
+        },
+      });
+
+      return res.status(200).json({ success: true });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/sandbox/env-vars/[name].ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/[name].ts
@@ -48,7 +48,9 @@ async function handler(
     });
   }
 
-  if (!isString(req.query.name)) {
+  const { name } = req.query;
+
+  if (!isString(name)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -58,7 +60,6 @@ async function handler(
     });
   }
 
-  const { name } = req.query;
   const nameValidation = validateEnvVarName(name);
   if (nameValidation.isErr()) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/sandbox/env-vars/delete.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/delete.test.ts
@@ -1,0 +1,68 @@
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { describe, expect, it } from "vitest";
+
+process.env.DUST_DEVELOPERS_SECRETS_SECRET ??= "test-developer-secret";
+
+import handler from "./[name]";
+
+async function createDeleteRequest({
+  role = "admin",
+  name,
+}: {
+  role?: "admin" | "builder" | "user";
+  name: string;
+}) {
+  const request = await createPrivateApiMockRequest({
+    method: "DELETE",
+    role,
+  });
+  await FeatureFlagFactory.basic(request.auth, "sandbox_tools");
+  request.req.query.name = name;
+  return request;
+}
+
+describe("DELETE /api/w/[wId]/sandbox/env-vars/[name]", () => {
+  it("deletes an existing sandbox environment variable", async () => {
+    const { req, res, auth } = await createDeleteRequest({
+      name: "API_TOKEN",
+    });
+
+    const upsertResult = await WorkspaceSandboxEnvVarResource.upsert(auth, {
+      name: "API_TOKEN",
+      value: "super-secret-token",
+      user: auth.getNonNullableUser(),
+    });
+    expect(upsertResult.isOk()).toBe(true);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData())).toEqual({ success: true });
+    expect(
+      await WorkspaceSandboxEnvVarResource.fetchByName(auth, "API_TOKEN")
+    ).toBeNull();
+  });
+
+  it("returns 404 for a missing sandbox environment variable", async () => {
+    const { req, res } = await createDeleteRequest({
+      name: "API_TOKEN",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it("rejects non-admin deletes", async () => {
+    const { req, res } = await createDeleteRequest({
+      role: "user",
+      name: "API_TOKEN",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+  });
+});

--- a/front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts
@@ -1,0 +1,224 @@
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { encrypt } from "@app/types/shared/utils/encryption";
+import type { WorkspaceType } from "@app/types/user";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+process.env.DUST_DEVELOPERS_SECRETS_SECRET ??= "test-developer-secret";
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return {
+    ...actual,
+    emitAuditLogEvent: mockEmitAuditLogEvent,
+  };
+});
+
+import handler from "./index";
+
+async function createEnvVarRequest({
+  method,
+  role = "admin",
+  body,
+}: {
+  method: "GET" | "POST";
+  role?: "admin" | "builder" | "user";
+  body?: unknown;
+}) {
+  const request = await createPrivateApiMockRequest({ method, role });
+  await FeatureFlagFactory.basic(request.auth, "sandbox_tools");
+  request.req.body = body;
+  return request;
+}
+
+function createEnvVarHttpRequest({
+  method,
+  workspace,
+  body,
+}: {
+  method: "GET" | "POST";
+  workspace: WorkspaceType;
+  body?: unknown;
+}) {
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method,
+    query: { wId: workspace.sId },
+    headers: {},
+  });
+  req.body = body;
+
+  return { req, res };
+}
+
+describe("GET/POST /api/w/[wId]/sandbox/env-vars", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects non-admin GET and POST requests", async () => {
+    const getRequest = await createEnvVarRequest({
+      method: "GET",
+      role: "user",
+    });
+    await handler(getRequest.req, getRequest.res);
+    expect(getRequest.res._getStatusCode()).toBe(403);
+
+    const postRequest = await createEnvVarRequest({
+      method: "POST",
+      role: "builder",
+      body: { name: "API_TOKEN", value: "super-secret-token" },
+    });
+    await handler(postRequest.req, postRequest.res);
+    expect(postRequest.res._getStatusCode()).toBe(403);
+  });
+
+  it("rejects invalid names and invalid values", async () => {
+    for (const body of [
+      { name: "api_token", value: "super-secret-token" },
+      { name: "_API_TOKEN", value: "super-secret-token" },
+      { name: "DUST_API_KEY", value: "super-secret-token" },
+      { name: "API_TOKEN", value: "" },
+      { name: "API_TOKEN", value: "abc\u0000def" },
+      { name: "API_TOKEN", value: "a".repeat(32 * 1024 + 1) },
+    ]) {
+      const { req, res } = await createEnvVarRequest({
+        method: "POST",
+        body,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+    }
+  });
+
+  it("enforces the create cap while allowing overwrite at the cap", async () => {
+    const { req, res, auth, user, workspace } = await createEnvVarRequest({
+      method: "POST",
+      body: { name: "NEW_TOKEN", value: "super-secret-token" },
+    });
+
+    await WorkspaceSandboxEnvVarModel.bulkCreate(
+      Array.from({ length: 50 }, (_unused, index) => ({
+        workspaceId: workspace.id,
+        name: `VAR_${index}`,
+        encryptedValue: encrypt({
+          text: `value-${index}`,
+          key: workspace.sId,
+          useCase: "developer_secret",
+        }),
+        createdByUserId: user.id,
+        lastUpdatedByUserId: user.id,
+      }))
+    );
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(JSON.parse(res._getData())).toMatchObject({
+      error: {
+        type: "invalid_request_error",
+      },
+    });
+
+    const overwriteRequest = createEnvVarHttpRequest({
+      method: "POST",
+      workspace,
+      body: { name: "VAR_0", value: "rotated-secret-token" },
+    });
+
+    await handler(overwriteRequest.req, overwriteRequest.res);
+    expect(overwriteRequest.res._getStatusCode()).toBe(200);
+    expect(JSON.parse(overwriteRequest.res._getData())).toEqual({
+      created: false,
+    });
+
+    const envResult =
+      await WorkspaceSandboxEnvVarResource.loadEnv(auth);
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value.VAR_0).toBe("rotated-secret-token");
+  });
+
+  it("creates multiline values, overwrites by name, audits without values, and never lists values", async () => {
+    const first = await createEnvVarRequest({
+      method: "POST",
+      body: {
+        name: "API_TOKEN",
+        value: "-----BEGIN KEY-----\nline two\n-----END KEY-----",
+      },
+    });
+    await handler(first.req, first.res);
+    expect(first.res._getStatusCode()).toBe(200);
+    expect(JSON.parse(first.res._getData())).toEqual({ created: true });
+
+    const second = createEnvVarHttpRequest({
+      method: "POST",
+      workspace: first.workspace,
+      body: {
+        name: "API_TOKEN",
+        value: "rotated-secret-token",
+      },
+    });
+    await handler(second.req, second.res);
+    expect(second.res._getStatusCode()).toBe(200);
+    expect(JSON.parse(second.res._getData())).toEqual({ created: false });
+
+    const envResult =
+      await WorkspaceSandboxEnvVarResource.loadEnv(
+        first.auth
+      );
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value.API_TOKEN).toBe("rotated-secret-token");
+
+    const listRequest = createEnvVarHttpRequest({
+      method: "GET",
+      workspace: first.workspace,
+    });
+    await handler(listRequest.req, listRequest.res);
+    expect(listRequest.res._getStatusCode()).toBe(200);
+    const responseBody = JSON.parse(listRequest.res._getData());
+    expect(responseBody).toEqual({
+      envVars: [
+        expect.objectContaining({
+          name: "API_TOKEN",
+        }),
+      ],
+    });
+    expect(JSON.stringify(responseBody)).not.toContain("rotated-secret-token");
+
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sandbox_env_var.created",
+        metadata: { name: "API_TOKEN" },
+      })
+    );
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sandbox_env_var.updated",
+        metadata: {
+          name: "API_TOKEN",
+          previously_existed: "true",
+        },
+      })
+    );
+    expect(JSON.stringify(mockEmitAuditLogEvent.mock.calls)).not.toContain(
+      "rotated-secret-token"
+    );
+  });
+});

--- a/front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts
@@ -1,14 +1,10 @@
-import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { encrypt } from "@app/types/shared/utils/encryption";
 import type { WorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-process.env.DUST_DEVELOPERS_SECRETS_SECRET ??= "test-developer-secret";
 
 const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
   mockEmitAuditLogEvent: vi.fn(),
@@ -109,19 +105,14 @@ describe("GET/POST /api/w/[wId]/sandbox/env-vars", () => {
       body: { name: "NEW_TOKEN", value: "super-secret-token" },
     });
 
-    await WorkspaceSandboxEnvVarModel.bulkCreate(
-      Array.from({ length: 50 }, (_unused, index) => ({
-        workspaceId: workspace.id,
-        name: `VAR_${index}`,
-        encryptedValue: encrypt({
-          text: `value-${index}`,
-          key: workspace.sId,
-          useCase: "developer_secret",
-        }),
-        createdByUserId: user.id,
-        lastUpdatedByUserId: user.id,
-      }))
-    );
+    for (let i = 0; i < 50; i++) {
+      const seedResult = await WorkspaceSandboxEnvVarResource.upsert(auth, {
+        name: `VAR_${i}`,
+        value: `value-${i}`,
+        user,
+      });
+      expect(seedResult.isOk()).toBe(true);
+    }
 
     await handler(req, res);
     expect(res._getStatusCode()).toBe(400);
@@ -143,8 +134,7 @@ describe("GET/POST /api/w/[wId]/sandbox/env-vars", () => {
       created: false,
     });
 
-    const envResult =
-      await WorkspaceSandboxEnvVarResource.loadEnv(auth);
+    const envResult = await WorkspaceSandboxEnvVarResource.loadEnv(auth);
     expect(envResult.isOk()).toBe(true);
     if (envResult.isErr()) {
       throw envResult.error;
@@ -176,10 +166,7 @@ describe("GET/POST /api/w/[wId]/sandbox/env-vars", () => {
     expect(second.res._getStatusCode()).toBe(200);
     expect(JSON.parse(second.res._getData())).toEqual({ created: false });
 
-    const envResult =
-      await WorkspaceSandboxEnvVarResource.loadEnv(
-        first.auth
-      );
+    const envResult = await WorkspaceSandboxEnvVarResource.loadEnv(first.auth);
     expect(envResult.isOk()).toBe(true);
     if (envResult.isErr()) {
       throw envResult.error;

--- a/front/pages/api/w/[wId]/sandbox/env-vars/index.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/index.ts
@@ -1,0 +1,160 @@
+/** @ignoreswagger */
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  validateEnvVarName,
+  validateEnvVarValue,
+} from "@app/lib/api/sandbox/env_vars";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { WorkspaceSandboxEnvVarType } from "@app/types/sandbox/env_var";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetWorkspaceSandboxEnvVarsResponseBody = {
+  envVars: WorkspaceSandboxEnvVarType[];
+};
+
+export type PostWorkspaceSandboxEnvVarsResponseBody = {
+  created: boolean;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      | GetWorkspaceSandboxEnvVarsResponseBody
+      | PostWorkspaceSandboxEnvVarsResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only workspace admins can manage sandbox environment variables.",
+      },
+    });
+  }
+
+  if (!(await hasFeatureFlag(auth, "sandbox_tools"))) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message: "Sandbox tools are not enabled for this workspace.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const envVars =
+        await WorkspaceSandboxEnvVarResource.listForWorkspace(auth);
+
+      return res.status(200).json({
+        envVars: envVars.map((envVar) => envVar.toJSON()),
+      });
+    }
+
+    case "POST": {
+      if (!isString(req.body?.name) || !isString(req.body?.value)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Expected body with string fields name and value.",
+          },
+        });
+      }
+
+      const nameValidation = validateEnvVarName(req.body.name);
+      if (nameValidation.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: nameValidation.error,
+          },
+        });
+      }
+
+      const valueValidation = validateEnvVarValue(req.body.value);
+      if (valueValidation.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: valueValidation.error,
+          },
+        });
+      }
+
+      const result = await WorkspaceSandboxEnvVarResource.upsert(auth, {
+        name: req.body.name,
+        value: req.body.value,
+        user: auth.getNonNullableUser(),
+      });
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      const action = result.value.created
+        ? "sandbox_env_var.created"
+        : "sandbox_env_var.updated";
+
+      void emitAuditLogEvent({
+        auth,
+        action,
+        targets: [
+          buildAuditLogTarget("workspace", owner),
+          buildAuditLogTarget("sandbox_env_var", {
+            sId: `${owner.sId}:${req.body.name}`,
+            name: req.body.name,
+          }),
+        ],
+        context: getAuditLogContext(auth, req),
+        metadata: {
+          name: req.body.name,
+          ...(result.value.created
+            ? {}
+            : {
+                previously_existed: "true",
+              }),
+        },
+      });
+
+      return res.status(200).json(result.value);
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Third PR in the sandbox env vars series (full plan #25013, kept as reference, will be closed). Builds on the Resource + validation from #25016.

Adds the admin REST API and the audit wiring:

- `GET /api/w/[wId]/sandbox/env-vars`: list names + metadata.
- `POST` same path: create or rotate (atomic upsert under the hood). 400 on regex, reserved name, value rules, or cap-reached. Emits `sandbox_env_var.created` or `sandbox_env_var.updated` based on whether the row pre-existed.
- `DELETE /api/w/[wId]/sandbox/env-vars/[name]`: 404 if missing. Emits `sandbox_env_var.deleted`. Name is validated against the regex on read to prevent path traversal.

Both endpoints are admin-only and gated by the `sandbox_tools` feature flag (matches `egress-policy.ts`). Marked `@ignoreswagger` since they're private and Dust-only-flag-gated; documenting them in Swagger would just add noise.

Audit:

- Three schema files (`sandbox_env_var.{created,updated,deleted}.json`). Metadata logs the var name only, never the value or any length / hash that could leak entropy. `previously_existed: "true"` on rotation.
- `sandbox_env_var.{created,updated,deleted}` added to the `AuditAction` union.
- `sandbox_env_var` added to the `AuditTargetType` union so `buildAuditLogTarget` is the typed path (drops a small inline helper that was duplicated across both endpoints).

The handler never sees the encrypted value or the plaintext beyond the immediate POST body, and the GET payload deliberately excludes both.

## Tests

- `index.test.ts`: 403s for non-admin GET / POST, 400s for invalid name (regex + reserved + leading underscore), 400 at the 50-cap on a new name, 200 on rotation even at the cap, value never appears in the GET response or audit metadata, multiline values round-trip, NUL byte rejected, > 32 KiB rejected, audit emits `created` then `updated` on the same name.
- `delete.test.ts`: 200 happy path, 404 on missing, 403 for non-admin.

## Risk

Low. Behind the `sandbox_tools` flag (Dust-only). No call sites outside the new endpoint files; sandbox boot still ignores these rows until PR5 lands. Safe to revert.

## Deploy Plan

Standard.