### PR TITLE
Add ability to pick a custom agent and a custom message when starting work on a todo.

### DIFF
--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -1,7 +1,7 @@
 import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
 import { filterAndSortAgents } from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type { WorkspaceType } from "@app/types/user";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
   Button,
@@ -17,7 +17,7 @@ import {
 import { useState } from "react";
 
 interface AgentPickerProps {
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
   agents: LightAgentConfigurationType[];
   onItemClick: (agent: LightAgentConfigurationType) => void;
   onAgentDetailsClick?: (agentId: string) => void;

--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -1,9 +1,13 @@
+import { AgentPicker } from "@app/components/assistant/AgentPicker";
 import {
   useSpaceConversations,
   useSpaceConversationsSummary,
 } from "@app/hooks/conversations";
 import { useAppRouter } from "@app/lib/platform";
-import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import {
+  useAgentConfigurations,
+  useUnifiedAgentConfigurations,
+} from "@app/lib/swr/assistants";
 import {
   useBulkUpdateProjectTodoStatus,
   useCleanDoneProjectTodos,
@@ -16,6 +20,11 @@ import {
 import { timeAgoFrom } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetProjectTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import {
+  compareAgentsForSort,
+  GLOBAL_AGENTS_SID,
+} from "@app/types/assistant/assistant";
 import type {
   ProjectTodoActorType,
   ProjectTodoAssigneeType,
@@ -46,8 +55,10 @@ import {
   MicrosoftLogo,
   NotionLogo,
   PlayIcon,
+  RobotIcon,
   SlackLogo,
   Spinner,
+  TextArea,
   Tooltip,
   TrashIcon,
   TypingAnimation,
@@ -434,8 +445,13 @@ interface EditableTodoItemProps {
   viewerUserId: string | null;
   onToggleDone: (todo: ProjectTodoType) => void;
   onDelete: (todo: ProjectTodoType) => void;
-  onStartWorking: (todo: ProjectTodoType) => void;
+  onStartWorking: (
+    todo: ProjectTodoType,
+    options?: { customMessage?: string; agentConfigurationId?: string }
+  ) => Promise<void>;
   owner: LightWorkspaceType;
+  activeAgents: LightAgentConfigurationType[];
+  agentsLoading: boolean;
   agentNameById: Map<string, string>;
   isExiting: boolean;
   isAdded: boolean;
@@ -452,6 +468,8 @@ function EditableTodoItem({
   onDelete,
   onStartWorking,
   owner,
+  activeAgents,
+  agentsLoading,
   agentNameById,
   isExiting,
   isAdded,
@@ -461,6 +479,11 @@ function EditableTodoItem({
   isStarting,
 }: EditableTodoItemProps) {
   const router = useAppRouter();
+  const [startMenuOpen, setStartMenuOpen] = useState(false);
+  const [startCustomMessage, setStartCustomMessage] = useState("");
+  const [selectedStartAgent, setSelectedStartAgent] =
+    useState<LightAgentConfigurationType | null>(null);
+
   const isDone = todo.status === "done";
   const hasConversationLink =
     (todo.status === "in_progress" || todo.status === "done") &&
@@ -480,6 +503,30 @@ function EditableTodoItem({
 
   const handleToggle = () => {
     onToggleDone(todo);
+  };
+
+  const handleStartMenuOpenChange = (open: boolean) => {
+    setStartMenuOpen(open);
+    if (open) {
+      setStartCustomMessage("");
+      const defaultAgent =
+        activeAgents.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST) ??
+        activeAgents[0] ??
+        null;
+      setSelectedStartAgent(defaultAgent);
+    }
+  };
+
+  const handleConfirmStart = async () => {
+    setStartMenuOpen(false);
+    const agentConfigurationId =
+      selectedStartAgent && selectedStartAgent.sId !== GLOBAL_AGENTS_SID.DUST
+        ? selectedStartAgent.sId
+        : undefined;
+    await onStartWorking(todo, {
+      customMessage: startCustomMessage.trim() || undefined,
+      agentConfigurationId,
+    });
   };
 
   return (
@@ -560,25 +607,92 @@ function EditableTodoItem({
           />
         ) : (
           canEdit &&
-          !hasConversationLink && (
+          !hasConversationLink &&
+          (isDoneWithoutConversation ? (
             <Tooltip
-              label={
-                isDoneWithoutConversation
-                  ? "Reopen this to-do before starting work."
-                  : "Start working on to-do"
-              }
+              label="Reopen this to-do before starting work."
               trigger={
+                <Button icon={PlayIcon} size="xs" variant="outline" disabled />
+              }
+            />
+          ) : (
+            <DropdownMenu
+              modal={false}
+              open={startMenuOpen}
+              onOpenChange={handleStartMenuOpenChange}
+            >
+              <DropdownMenuTrigger asChild>
                 <Button
                   icon={PlayIcon}
                   size="xs"
                   variant="outline"
                   isLoading={isStarting}
-                  disabled={isStarting || isDoneWithoutConversation}
-                  onClick={() => onStartWorking(todo)}
+                  disabled={isStarting}
+                  tooltip="Start working on to-do"
                 />
-              }
-            />
-          )
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-96 p-3">
+                <div className="flex flex-col gap-3">
+                  <TextArea
+                    id={`todo-start-msg-${todo.sId}`}
+                    aria-label="Additional instructions for the agent"
+                    placeholder="(optional) Add a custom message for the agent..."
+                    value={startCustomMessage}
+                    rows={4}
+                    onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+                      setStartCustomMessage(event.target.value)
+                    }
+                  />
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="w-[200px] min-w-0 shrink-0">
+                      <AgentPicker
+                        owner={owner}
+                        agents={activeAgents}
+                        disabled={agentsLoading}
+                        isLoading={agentsLoading}
+                        mountPortal
+                        showDropdownArrow
+                        showFooterButtons={false}
+                        side="bottom"
+                        size="xs"
+                        onItemClick={(agent) => setSelectedStartAgent(agent)}
+                        pickerButton={
+                          <Button
+                            variant="ghost-secondary"
+                            size="xs"
+                            isSelect
+                            icon={
+                              selectedStartAgent
+                                ? () => (
+                                    <Avatar
+                                      size="xxs"
+                                      visual={selectedStartAgent.pictureUrl}
+                                    />
+                                  )
+                                : RobotIcon
+                            }
+                            label={selectedStartAgent?.name ?? "Agent"}
+                            className="max-w-full min-w-0"
+                          />
+                        }
+                      />
+                    </div>
+                    <div className="w-[92px] shrink-0">
+                      <Button
+                        label="Go!"
+                        variant="highlight"
+                        size="sm"
+                        className="w-full"
+                        isLoading={isStarting}
+                        disabled={isStarting || !selectedStartAgent}
+                        onClick={() => void handleConfirmStart()}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ))
         )}
         {canEdit && (
           <div className="opacity-0 transition-opacity group-hover/todo:opacity-100">
@@ -617,7 +731,7 @@ function formatTodoScopeLabel({
     return "Your to-dos";
   }
   if (scope === "all") {
-    return "Everyone's to-dos";
+    return "Project's to-dos";
   }
 
   if (selectedUserSIds.size === 0) {
@@ -676,7 +790,7 @@ function EditableProjectTodosPanel({
   owner: LightWorkspaceType;
   spaceId: string;
 }) {
-  const [assigneeScope, setAssigneeScope] = useState<TodoAssigneeScope>("mine");
+  const [assigneeScope, setAssigneeScope] = useState<TodoAssigneeScope>("all");
   const [selectedUserSIds, setSelectedUserSIds] = useState<Set<string>>(
     new Set()
   );
@@ -726,6 +840,16 @@ function EditableProjectTodosPanel({
   const [startingTodoIds, setStartingTodoIds] = useState<Set<string>>(
     new Set()
   );
+  const { agentConfigurations, isLoading: isAgentsLoading } =
+    useUnifiedAgentConfigurations({
+      workspaceId: owner.sId,
+      disabled: isTodosLoading,
+    });
+  const activeAgents = useMemo(() => {
+    const agents = agentConfigurations.filter((a) => a.status === "active");
+    agents.sort(compareAgentsForSort);
+    return agents;
+  }, [agentConfigurations]);
 
   // ── Diff animation state ────────────────────────────────────────────────────
 
@@ -893,29 +1017,7 @@ function EditableProjectTodosPanel({
     usersBySId,
     viewerUserId,
   });
-  const hideAssigneeMenu =
-    users.length === 0 ||
-    (users.length === 1 &&
-      viewerUserId !== null &&
-      users[0]?.sId === viewerUserId);
   const assigneeLabel = selectedAssigneeLabel;
-
-  useEffect(() => {
-    if (isTodosLoading) {
-      return;
-    }
-
-    // Preserve the previous UX default:
-    // - if only "you" exists, default to "Your todos"
-    // - otherwise default to "Everyone's todos"
-    if (!hideAssigneeMenu) {
-      setAssigneeScope("all");
-    } else {
-      setAssigneeScope("mine");
-      setSelectedUserSIds(new Set());
-      setIsAssigneeMenuOpen(false);
-    }
-  }, [hideAssigneeMenu, isTodosLoading]);
 
   const filteredTodos = useMemo(() => {
     switch (assigneeScope) {
@@ -1071,9 +1173,15 @@ function EditableProjectTodosPanel({
   );
 
   const handleStartWorking = useCallback(
-    async (todo: ProjectTodoType) => {
+    async (
+      todo: ProjectTodoType,
+      options?: { customMessage?: string; agentConfigurationId?: string }
+    ) => {
       setStartingTodoIds((prev) => new Set([...prev, todo.sId]));
-      const result = await doStartConversation(todo.sId);
+      const result = await doStartConversation(todo.sId, {
+        customMessage: options?.customMessage,
+        agentConfigurationId: options?.agentConfigurationId,
+      });
       if (result.isOk()) {
         const { conversationId } = result.value;
         // Reflect the new todo state (conversationId set) immediately.
@@ -1175,7 +1283,7 @@ function EditableProjectTodosPanel({
             />
             <DropdownMenuCheckboxItem
               icon={UserGroupIcon}
-              label="Everyone's to-dos"
+              label="Project's to-dos"
               checked={assigneeScope === "all"}
               onClick={() => {
                 setAssigneeScope("all");
@@ -1272,6 +1380,8 @@ function EditableProjectTodosPanel({
                       onDelete={handleDelete}
                       onStartWorking={handleStartWorking}
                       owner={owner}
+                      activeAgents={activeAgents}
+                      agentsLoading={isAgentsLoading}
                       agentNameById={agentNameById}
                       isExiting={pendingRemovalIds.has(todo.sId)}
                       isAdded={

--- a/front/lib/api/actions/servers/project_todos/metadata.ts
+++ b/front/lib/api/actions/servers/project_todos/metadata.ts
@@ -176,6 +176,12 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional agent name. If provided, the tool searches matching agent configurations and uses the best match. Defaults to Dust."
         ),
+      customMessage: z
+        .string()
+        .optional()
+        .describe(
+          "Optional additional instructions appended to the kickoff message sent to the selected agent."
+        ),
       dustProject: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
       ]

--- a/front/lib/api/actions/servers/project_todos/tools/index.ts
+++ b/front/lib/api/actions/servers/project_todos/tools/index.ts
@@ -346,7 +346,12 @@ export function createProjectTodosTools(
       }, "Failed to reopen TODO");
     },
 
-    start_todo_agent: async ({ todoId, agentName, dustProject }) => {
+    start_todo_agent: async ({
+      todoId,
+      agentName,
+      customMessage,
+      dustProject,
+    }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -377,6 +382,7 @@ export function createProjectTodosTools(
           space,
           todoId,
           agentConfigurationId,
+          customMessage,
         });
 
         if (startRes.isErr()) {

--- a/front/lib/project_todo/start_agent.ts
+++ b/front/lib/project_todo/start_agent.ts
@@ -23,15 +23,20 @@ function buildTodoKickoffPrompt({
   todoId,
   todoText,
   sourceUrls,
+  customMessage,
 }: {
   todoId: string;
   todoText: string;
   sourceUrls: string[];
+  customMessage?: string;
 }): string {
   const sourceLine =
     sourceUrls.length > 0
       ? `The item was sourced from ${sourceUrls.join(", ")}.`
       : "No explicit source was attached to this todo item.";
+  const customMessageLine = customMessage
+    ? ["", "Additional instructions :", customMessage]
+    : [];
 
   return [
     `You are working on the todo (id: ${todoId}) from the current project.`,
@@ -45,6 +50,7 @@ function buildTodoKickoffPrompt({
     "2. Use available project context and tools to complete the work.",
     "3. Share concrete outputs and next checks.",
     "4. Once the task is completed, mark this todo as done.",
+    ...customMessageLine,
   ].join("\n");
 }
 
@@ -54,10 +60,12 @@ export async function startAgentForProjectTodo(
     space,
     todoId,
     agentConfigurationId,
+    customMessage,
   }: {
     space: SpaceResource;
     todoId: string;
     agentConfigurationId?: string;
+    customMessage?: string;
   }
 ): Promise<
   Result<
@@ -111,6 +119,7 @@ export async function startAgentForProjectTodo(
     todoId: todo.sId,
     todoText: todo.text,
     sourceUrls,
+    customMessage: customMessage?.trim() || undefined,
   });
 
   let conversationId = await todo.getLatestConversationId(auth);

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -550,11 +550,21 @@ export function useStartProjectTodoConversation({
 }) {
   const sendNotification = useSendNotification();
 
-  return async (todoId: string): Promise<Result<ProjectTodoType, Error>> => {
+  return async (
+    todoId: string,
+    options?: { customMessage?: string; agentConfigurationId?: string }
+  ): Promise<Result<ProjectTodoType, Error>> => {
     try {
       const res = await clientFetch(
         `/api/w/${owner.sId}/spaces/${spaceId}/project_todos/${todoId}/start`,
-        { method: "POST" }
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            customMessage: options?.customMessage,
+            agentConfigurationId: options?.agentConfigurationId,
+          }),
+        }
       );
 
       if (!res.ok) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
@@ -12,6 +12,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { ProjectTodoFactory } from "@app/tests/utils/ProjectTodoFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { WorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { MockRequest, MockResponse } from "node-mocks-http";
@@ -72,6 +73,29 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start", () =
     expect(data.todo.status).toBe("in_progress");
     expect(data.todo.userId).toBe(otherUser.sId);
     expect(data.todo.conversationId).toBeTruthy();
+  });
+
+  it("accepts custom start options (message + agent)", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Draft migration checklist",
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.todoId = todo.sId;
+    req.body = {
+      customMessage: "Focus on safe rollout and rollback plan.",
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.todo.sId).toBe(todo.sId);
+    expect(data.todo.status).toBe("in_progress");
   });
 
   it("returns 405 for unsupported methods", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.ts
@@ -9,10 +9,16 @@ import type { APIErrorType, WithAPIErrorResponse } from "@app/types/error";
 import type { ProjectTodoType } from "@app/types/project_todo";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export interface PostStartProjectTodoResponseBody {
   todo: ProjectTodoType;
 }
+
+const PostStartProjectTodoBodySchema = z.object({
+  customMessage: z.string().optional(),
+  agentConfigurationId: z.string().optional(),
+});
 
 async function handler(
   req: NextApiRequest,
@@ -43,9 +49,25 @@ async function handler(
 
   switch (req.method) {
     case "POST": {
+      const parsedBody = PostStartProjectTodoBodySchema.safeParse(
+        req.body ?? {}
+      );
+      if (!parsedBody.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: parsedBody.error.message,
+          },
+        });
+      }
+
+      const { customMessage, agentConfigurationId } = parsedBody.data;
       const startRes = await startAgentForProjectTodo(auth, {
         space,
         todoId,
+        customMessage,
+        agentConfigurationId,
       });
       if (startRes.isErr()) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

Clicking the Play button was a one-click action that always used `@dust` with a fixed kickoff prompt. Users had no way to choose a different agent or add specific instructions for the task. A small dropdown on the Play button addresses this without adding UI friction.

- **Play button → dropdown** — opens a popover with a `TextArea` (optional custom message / additional instructions) and an `AgentPicker` (defaults to `@dust`, sorted by `compareAgentsForSort`, loaded via `useUnifiedAgentConfigurations`); confirmed with a "Go!" button
- **Pass `customMessage` + `agentConfigurationId` through the full stack**: `onStartWorking` props → `handleStartWorking` → `useStartProjectTodoConversation` (POST body) → `/start` API endpoint → `startAgentForProjectTodo` → `buildTodoKickoffPrompt` (appends "Additional instructions: …" section)
- **Add `customMessage` to `start_todo_agent` MCP tool** — same field wired through to `startAgentForProjectTodo` for agent-initiated starts
- **Default assignee scope to `"all"`** — remove the `useEffect` that toggled scope based on member count; always open in "Project's to-dos" view
- Rename "Everyone's to-dos" → "Project's to-dos" in dropdown label and filter item
- Update tests to cover `agentConfigurationId` forwarding

## Tests

Local + green (tests updated)
<img width="457" height="616" alt="image" src="https://github.com/user-attachments/assets/eaa505f2-a8cb-4a53-a14f-914526d4f207" />


## Risk

Low — Play button behavior is additive; single click now opens a dropdown before starting, but the confirm is one more click

## Deploy Plan

Deploy `front`
