### PR TITLE
fix(mentions): auto-scroll to validation card when mention requires approval

### DIFF
--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -1,5 +1,7 @@
-import type { VirtuosoMessageListContext } from "@app/components/assistant/conversation/types";
-import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
+import type {
+  VirtuosoMessage,
+  VirtuosoMessageListContext,
+} from "@app/components/assistant/conversation/types";
 import { isAgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useMentionValidation } from "@app/lib/swr/mentions";

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -1,3 +1,4 @@
+import type { VirtuosoMessageListContext } from "@app/components/assistant/conversation/types";
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
 import { isAgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
 import { useAuth } from "@app/lib/auth/AuthContext";
@@ -13,7 +14,8 @@ import {
   Button,
   ChatBubbleLeftRightIcon,
 } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
+import { useEffect, useMemo, useState } from "react";
 
 interface MentionValidationRequiredProps {
   triggeringUser: UserType | null;
@@ -39,6 +41,11 @@ export function MentionValidationRequired({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isProjectMembership = mention.status === "pending_project_membership";
 
+  const methods = useVirtuosoMethods<
+    VirtuosoMessage,
+    VirtuosoMessageListContext
+  >();
+
   const { validateMention } = useMentionValidation({
     workspaceId: owner.sId,
     conversationId: conversation.sId,
@@ -50,6 +57,25 @@ export function MentionValidationRequired({
     () => !triggeringUser || triggeringUser.sId === user?.sId,
     [triggeringUser, user?.sId]
   );
+
+  // Auto-scroll to make the validation card visible when it first appears.
+  // The card is rendered below the message content, so without this the user
+  // would have to manually scroll down to find it.
+  useEffect(() => {
+    if (!isTriggeredByCurrentUser) {
+      return;
+    }
+    const currentData = methods.data.get();
+    const messageIndex = currentData.findIndex((m) => m.sId === message.sId);
+    if (messageIndex !== -1) {
+      methods.scrollToItem({
+        index: messageIndex,
+        align: "end",
+        behavior: "smooth",
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleReject = async () => {
     setIsSubmitting(true);

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -63,6 +63,7 @@ export function MentionValidationRequired({
   // Auto-scroll to make the validation card visible when it first appears.
   // The card is rendered below the message content, so without this the user
   // would have to manually scroll down to find it.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll runs only on mount
   useEffect(() => {
     if (!isTriggeredByCurrentUser) {
       return;
@@ -76,7 +77,6 @@ export function MentionValidationRequired({
         behavior: "smooth",
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleReject = async () => {


### PR DESCRIPTION
## Problem

When an agent mentions a user who needs approval (`pending_conversation_access` or `pending_project_membership`), the `MentionValidationRequired` card is rendered below the message content. The viewport doesn't scroll to it, so the triggering user may not notice it and has to manually scroll down to find it.

## Fix

Added a `useEffect` in `MentionValidationRequired` that fires on mount (only for the triggering user) and calls `methods.scrollToItem` from Virtuoso to smooth-scroll the parent message to the bottom of the viewport, making the card immediately visible.

```tsx
useEffect(() => {
  if (!isTriggeredByCurrentUser) return;
  const currentData = methods.data.get();
  const messageIndex = currentData.findIndex((m) => m.sId === message.sId);
  if (messageIndex !== -1) {
    methods.scrollToItem({ index: messageIndex, align: "end", behavior: "smooth" });
  }
}, []);
```

## Testing

- Trigger a mention of a user who doesn't have conversation/project access
- Verify the viewport auto-scrolls smoothly so the approve/decline card is visible without manual scrolling
- Verify no scroll happens for users who are *not* the triggering user
