### PR TITLE
Add: custom chip for to-dos in messages.

### DIFF
--- a/front/components/actions/mcp/details/MCPDeepDiveActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDeepDiveActionDetails.tsx
@@ -4,6 +4,10 @@ import {
   CiteBlock,
   getCiteDirective,
 } from "@app/components/markdown/CiteBlock";
+import {
+  TodoDirectiveBlock,
+  todoDirective,
+} from "@app/components/markdown/TodoDirectiveBlock";
 import { isAgentPauseOutputResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   agentMentionDirective,
@@ -28,7 +32,7 @@ export function MCPDeepDiveActionDetails({
   }, [handoffResource]);
 
   const additionalMarkdownPlugins: PluggableList = useMemo(
-    () => [getCiteDirective(), agentMentionDirective],
+    () => [getCiteDirective(), agentMentionDirective, todoDirective],
     []
   );
 
@@ -37,6 +41,7 @@ export function MCPDeepDiveActionDetails({
       sup: CiteBlock,
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: getAgentMentionPlugin(owner),
+      todo: TodoDirectiveBlock,
     }),
     [owner]
   );

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -12,6 +12,10 @@ import {
   getCiteDirective,
 } from "@app/components/markdown/CiteBlock";
 import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
+import {
+  TodoDirectiveBlock,
+  todoDirective,
+} from "@app/components/markdown/TodoDirectiveBlock";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { useChildAgentStream } from "@app/hooks/useChildAgentStream";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
@@ -249,7 +253,7 @@ function MCPRunAgentActionDetailsDisplay({
   };
 
   const additionalMarkdownPlugins: PluggableList = useMemo(
-    () => [getCiteDirective(), agentMentionDirective],
+    () => [getCiteDirective(), agentMentionDirective, todoDirective],
     []
   );
 
@@ -258,6 +262,7 @@ function MCPRunAgentActionDetailsDisplay({
       sup: CiteBlock,
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: getAgentMentionPlugin(owner),
+      todo: TodoDirectiveBlock,
     }),
     [owner]
   );

--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -9,6 +9,10 @@ import {
   preprocessInstructionBlocks,
 } from "@app/components/markdown/InstructionBlock";
 import { quickReplyDirective } from "@app/components/markdown/QuickReplyBlock";
+import {
+  TodoDirectiveBlock,
+  todoDirective,
+} from "@app/components/markdown/TodoDirectiveBlock";
 import { toolDirective } from "@app/components/markdown/tool/tool";
 import { visualizationDirective } from "@app/components/markdown/VisualizationBlock";
 import {
@@ -59,6 +63,7 @@ export const AgentMessageMarkdown = ({
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: getAgentMentionPlugin(owner),
       mention_user: getUserMentionPlugin(owner),
+      todo: TodoDirectiveBlock,
       dustimg: getImgPlugin(owner),
       instruction_block: InstructionBlock,
       ...additionalMarkdownComponents,
@@ -70,6 +75,7 @@ export const AgentMessageMarkdown = ({
     const baseDirectives = [
       agentMentionDirective,
       userMentionDirective,
+      todoDirective,
       getCiteDirective(),
       visualizationDirective,
       imgDirective,

--- a/front/components/assistant/UserMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/UserMessageMarkdown.integration.test.tsx
@@ -223,6 +223,22 @@ Quote text
       expect(container).toBeInTheDocument();
     });
 
+    it("renders project todo directives", () => {
+      const content = ":todo[Review PR]{sId=ptodo_123}";
+      const message = { ...mockMessage, content };
+      const { container } = render(
+        <UserMessageMarkdown
+          owner={mockOwner}
+          message={message}
+          isLastMessage={false}
+        />
+      );
+      expect(
+        container.querySelector("[data-project-todo-sid]")
+      ).toHaveAttribute("data-project-todo-sid", "ptodo_123");
+      expect(container.textContent).toContain("Review PR");
+    });
+
     it("renders pasted attachments", () => {
       const content =
         ":pasted_attachment[File.pdf]{attachmentId=att-123 contentType=application/pdf}";

--- a/front/components/assistant/UserMessageMarkdown.tsx
+++ b/front/components/assistant/UserMessageMarkdown.tsx
@@ -11,6 +11,10 @@ import {
   pastedAttachmentDirective,
 } from "@app/components/markdown/PastedAttachmentBlock";
 import {
+  TodoDirectiveBlock,
+  todoDirective,
+} from "@app/components/markdown/TodoDirectiveBlock";
+import {
   agentMentionDirective,
   getAgentMentionPlugin,
   getUserMentionPlugin,
@@ -43,6 +47,7 @@ export const UserMessageMarkdown = ({
       mention_user: getUserMentionPlugin(owner),
       content_node_mention: ContentNodeMentionBlock,
       pasted_attachment: PastedAttachmentBlock,
+      todo: TodoDirectiveBlock,
     }),
     [owner]
   );
@@ -54,6 +59,7 @@ export const UserMessageMarkdown = ({
       userMentionDirective,
       contentNodeMentionDirective,
       pastedAttachmentDirective,
+      todoDirective,
     ],
     []
   );

--- a/front/components/markdown/TodoDirectiveBlock.test.tsx
+++ b/front/components/markdown/TodoDirectiveBlock.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TodoDirectiveBlock, todoDirective } from "./TodoDirectiveBlock";
+
+describe("todoDirective", () => {
+  it("transforms :todo textDirective nodes with hName and hProperties", () => {
+    const tree: any = {
+      type: "root",
+      children: [
+        {
+          type: "textDirective",
+          name: "todo",
+          attributes: { sId: "todo_abc" },
+          children: [{ type: "text", value: "Ship feature" }],
+        },
+        {
+          type: "textDirective",
+          name: "todo",
+          attributes: {},
+          children: [{ type: "text", value: "Missing sId" }],
+        },
+      ],
+    };
+
+    todoDirective()(tree);
+
+    const ok = tree.children[0];
+    expect(ok.data.hName).toBe("todo");
+    expect(ok.data.hProperties).toEqual({
+      label: "Ship feature",
+      sId: "todo_abc",
+    });
+
+    expect(tree.children[1].data).toBeUndefined();
+  });
+});
+
+describe("TodoDirectiveBlock", () => {
+  it("renders label and exposes sId on the wrapper", () => {
+    render(<TodoDirectiveBlock label="My task" sId="sid_1" />);
+
+    expect(screen.getByText("My task")).toBeInTheDocument();
+    const wrap = document.querySelector("[data-project-todo-sid]");
+    expect(wrap).toHaveAttribute("data-project-todo-sid", "sid_1");
+  });
+});

--- a/front/components/markdown/TodoDirectiveBlock.tsx
+++ b/front/components/markdown/TodoDirectiveBlock.tsx
@@ -1,0 +1,39 @@
+import { AttachmentChip, ListCheckIcon } from "@dust-tt/sparkle";
+import { visit } from "unist-util-visit";
+
+export function TodoDirectiveBlock({
+  label,
+  sId,
+}: {
+  label: string;
+  sId: string;
+}) {
+  return (
+    <span data-project-todo-sid={sId} className="inline-block">
+      <AttachmentChip
+        label={label}
+        icon={{ visual: ListCheckIcon }}
+        color="green"
+      />
+    </span>
+  );
+}
+
+/**
+ * Remark plugin: `:todo[label]{sId=…}` → custom element `todo` for react-markdown.
+ */
+export function todoDirective() {
+  return (tree: any) => {
+    visit(tree, ["textDirective"], (node) => {
+      if (node.name === "todo" && node.children[0] && node.attributes?.sId) {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        const data = node.data || (node.data = {});
+        data.hName = "todo";
+        data.hProperties = {
+          label: node.children[0].value,
+          sId: String(node.attributes.sId),
+        };
+      }
+    });
+  };
+}

--- a/front/lib/project_todo/format.test.ts
+++ b/front/lib/project_todo/format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractProjectTodoDirectivesFromString,
+  serializeProjectTodoDirective,
+} from "./format";
+
+describe("project_todo format", () => {
+  it("serializes and extracts round-trip", () => {
+    const s = serializeProjectTodoDirective({
+      label: "Fix bug",
+      sId: "pt_123",
+    });
+    expect(s).toBe(":todo[Fix bug]{sId=pt_123}");
+
+    const extracted = extractProjectTodoDirectivesFromString(
+      `Before ${s} after`
+    );
+    expect(extracted).toEqual([{ label: "Fix bug", sId: "pt_123" }]);
+  });
+
+  it("extracts multiple todos", () => {
+    const text = ":todo[One]{sId=a} and :todo[Two]{sId=b}";
+    expect(extractProjectTodoDirectivesFromString(text)).toEqual([
+      { label: "One", sId: "a" },
+      { label: "Two", sId: "b" },
+    ]);
+  });
+});

--- a/front/lib/project_todo/format.ts
+++ b/front/lib/project_todo/format.ts
@@ -1,0 +1,28 @@
+/**
+ * Serialization and parsing for project todo references in plain text / markdown.
+ *
+ * Format: `:todo[label]{sId=projectTodoSid}`
+ */
+
+export const PROJECT_TODO_DIRECTIVE_REGEX = /:todo\[([^\]]+)]\{sId=([^}]+?)}/g;
+
+export const PROJECT_TODO_DIRECTIVE_REGEX_BEGINNING = new RegExp(
+  "^" + PROJECT_TODO_DIRECTIVE_REGEX.source,
+  PROJECT_TODO_DIRECTIVE_REGEX.flags
+);
+
+export function serializeProjectTodoDirective(mention: {
+  label: string;
+  sId: string;
+}): string {
+  return `:todo[${mention.label}]{sId=${mention.sId}}`;
+}
+
+export function extractProjectTodoDirectivesFromString(
+  content: string
+): { label: string; sId: string }[] {
+  return [...content.matchAll(PROJECT_TODO_DIRECTIVE_REGEX)].map((match) => ({
+    label: match[1],
+    sId: match[2],
+  }));
+}

--- a/front/lib/project_todo/start_agent.ts
+++ b/front/lib/project_todo/start_agent.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { Authenticator } from "@app/lib/auth";
+import { serializeProjectTodoDirective } from "@app/lib/project_todo/format";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -38,10 +39,13 @@ function buildTodoKickoffPrompt({
     ? ["", "Additional instructions :", customMessage]
     : [];
 
+  const todoDirective = serializeProjectTodoDirective({
+    label: todoText,
+    sId: todoId,
+  });
+
   return [
-    `You are working on the todo (id: ${todoId}) from the current project.`,
-    "",
-    `Todo: ${todoText}`,
+    `You are working on ${todoDirective} from the current project.`,
     "",
     sourceLine,
     "",

--- a/front/lib/resources/skill/code_defined/projects.ts
+++ b/front/lib/resources/skill/code_defined/projects.ts
@@ -40,6 +40,14 @@ It is stored in the project data source and can be searched using the \`semantic
 To keep something for later project-wide use, add it with \`add_file\`.
 To reuse an existing project file in this conversation, use \`attach_to_conversation\`.
 
+## Referencing project TODOs in messages
+
+To show a **project TODO** as an interactive chip in the conversation, use this markdown directive with the todo's \`sId\`:
+
+\`:todo[Short readable label]{sId=<projectTodoSId>}\`
+
+Use the \`sId\` from \`project_todos\` tools (e.g. \`list_todos\`, \`create_todos\`) or from the kickoff message when you are working on a todo. The bracket text is display-only; keep it concise.
+
 ## Tool Usage Priority
 
 When you need to find information, uses this order (skip steps if the relevant tools are not in your tool list):
@@ -50,7 +58,7 @@ When you need to find information, uses this order (skip steps if the relevant t
 `,
 
   mcpServers: [{ name: "project_manager" }, { name: "project_todos" }],
-  version: 1,
+  version: 3,
   icon: "ActionFolderIcon",
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);


### PR DESCRIPTION
## Description

When agents reference a todo in a message (e.g. in the kickoff prompt or a summary), it appeared as raw text like `todo (id: ptodo_123)`. Rendering it as an interactive chip makes it visually distinct and linkable, consistent with how agent mentions and content node mentions work.

- Add `TodoDirectiveBlock` component — renders a green `AttachmentChip` with `ListCheckIcon` and exposes `data-project-todo-sid` for testing
- Add `todoDirective` remark plugin — transforms `:todo[label]{sId=…}` text directives into `{ hName: "todo", hProperties: { label, sId } }` (silently skips nodes missing `sId`)
- Register both in `AgentMessageMarkdown`, `UserMessageMarkdown`, `MCPDeepDiveActionDetails`, and `MCPRunAgentActionDetailsDisplay`
- Add `format.ts` with `serializeProjectTodoDirective` (`:todo[label]{sId=…}`) and `extractProjectTodoDirectivesFromString` (regex extractor); add round-trip and multi-todo tests
- In `buildTodoKickoffPrompt`: replace the raw `"You are working on the todo (id: …)"` line with the serialized directive so the kickoff message itself renders the chip
- Update `projects` skill instructions to document the `:todo[…]{sId=…}` syntax for agents; bump skill `version` to 3

We'll probably iterate on the design.

## Tests

Local + green (new tests for `TodoDirectiveBlock`, `todoDirective`, and `format.ts`)
<img width="685" height="288" alt="image" src="https://github.com/user-attachments/assets/83ff8757-d1f2-4f69-9359-16a03b4d54e0" />
<img width="820" height="685" alt="image" src="https://github.com/user-attachments/assets/c19f6e87-4bd5-46fc-a9ad-74f3240cc294" />


## Risk

Low — additive directive; existing messages without `:todo[…]` are unaffected

## Deploy Plan

Deploy `front`
