### PR TITLE
refacto: simplify space update methods

### DIFF
--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -722,7 +722,7 @@ describe("rebuildConversationRequirements", () => {
   const moveOutAndRebuild = async (conversationId: string) => {
     const conversationResource =
       await fetchConversationResource(conversationId);
-    await conversationResource.clearSpaceId(auth);
+    await conversationResource.updateSpaceId(auth, null);
     await rebuildConversationRequirements(auth, conversationResource);
   };
 

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -184,7 +184,7 @@ export async function moveConversationOutOfProject(
   const participants = await conversationResource.listParticipants(auth);
 
   // Remove the project association.
-  await conversationResource.clearSpaceId(auth);
+  await conversationResource.updateSpaceId(auth, null);
 
   // Rebuild requestedSpaceIds from all agents and content fragments in the conversation.
   // When a conversation is in a project, its requestedSpaceIds is set to [projectSpaceId] only.

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -3175,17 +3175,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   async updateSpaceId(
     auth: Authenticator,
-    space: SpaceResource,
+    space: SpaceResource | null,
     transaction?: Transaction
   ) {
-    await this.update({ spaceId: space.id }, transaction);
-
-    await ConversationResource.triggerEsIndexing(auth, this.sId);
-  }
-
-  async clearSpaceId(auth: Authenticator) {
-    await this.update({ spaceId: null });
-    this._space = null;
+    await this.update({ spaceId: space?.id ?? null }, transaction);
+    this._space = space;
 
     await ConversationResource.triggerEsIndexing(auth, this.sId);
   }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -3179,6 +3179,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     transaction?: Transaction
   ) {
     await this.update({ spaceId: space?.id ?? null }, transaction);
+    // TODO(2026-04-30): BaseResource.update does not reload joins, so we
+    // manually refresh the space here.
+    this._space = space;
 
     await ConversationResource.triggerEsIndexing(auth, this.sId);
   }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -3179,7 +3179,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     transaction?: Transaction
   ) {
     await this.update({ spaceId: space?.id ?? null }, transaction);
-    this._space = space;
 
     await ConversationResource.triggerEsIndexing(auth, this.sId);
   }


### PR DESCRIPTION
## Description

This PR simplifies the space update methods in ConversationResource by removing the redundant `clearSpaceId` method.

## Tests

Manually

## Risks

Low - This is a refactoring that consolidates two methods into one without changing functionality.

## Deploy Plan

Standard deployment
