### PR TITLE
feat: branch creation in empty conversation

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -114,7 +114,7 @@ export const FEEDBACK_DISTRIBUTION_LEGEND = [
 
 export type AnalyticsVisibleOrigin = Exclude<
   UserMessageOrigin,
-  "reinforced_skill_notification" | "reinforcement"
+  "reinforced_skill_notification" | "reinforcement" | "branch_anchor"
 >;
 
 export const USER_MESSAGE_ORIGIN_LABELS: Record<

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -5,6 +5,7 @@ import {
   isCompactionMessageType,
   isLightAgentMessageType,
   isUserMessageTypeWithContentFragments,
+  isVisibleMessage,
   type LightConversationType,
 } from "@app/types/assistant/conversation";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -21,18 +22,6 @@ import { isMessageUnread } from "../../utils";
 interface SpaceConversationListItemProps {
   conversation: LightConversationType;
   owner: WorkspaceType;
-}
-
-function isVisibleMessage(
-  m: LightConversationType["content"][number]
-): boolean {
-  return (
-    m.visibility !== "deleted" &&
-    !(isUserMessageTypeWithContentFragments(m) && isHiddenMessage(m)) &&
-    // Compaction message will possibly be first messages of a conversation (forking) but they are
-    // not "visible" per se. `firstVisibleMessage` should null until a first user message is posted.
-    !isCompactionMessageType(m)
-  );
 }
 
 export function SpaceConversationListItem({

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -171,6 +171,7 @@ export const isHiddenMessage = (message: VirtuosoMessage): boolean => {
       (message.context.origin === "onboarding_conversation" ||
         message.context.origin === "project_kickoff" ||
         message.context.origin === "reinforced_skill_notification" ||
+        message.context.origin === "branch_anchor" ||
         isWakeUpOrigin(message.context.origin) ||
         isSidekickBootstrapMessage(message))) ||
     isHandoverUserMessage(message)

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -18,6 +18,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   isCompactionMessageType,
+  isHiddenMessageOrigin,
   isLightAgentMessageType,
   isLightAgentMessageWithActionsType,
   isUserMessageTypeWithContentFragments,
@@ -159,20 +160,12 @@ export const isTriggeredOrigin = (origin?: UserMessageOrigin | null) => {
   );
 };
 
-export const isWakeUpOrigin = (origin?: UserMessageOrigin | null) => {
-  return origin === "wakeup";
-};
-
 // Central helper to control which user message should be hidden in the UI.
 // Extend this list as we introduce more bootstrap/system user messages.
 export const isHiddenMessage = (message: VirtuosoMessage): boolean => {
   return (
     (isUserMessage(message) &&
-      (message.context.origin === "onboarding_conversation" ||
-        message.context.origin === "project_kickoff" ||
-        message.context.origin === "reinforced_skill_notification" ||
-        message.context.origin === "branch_anchor" ||
-        isWakeUpOrigin(message.context.origin) ||
+      (isHiddenMessageOrigin(message.context.origin) ||
         isSidekickBootstrapMessage(message))) ||
     isHandoverUserMessage(message)
   );

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -2456,7 +2456,11 @@ describe("postUserMessage", () => {
     let projectConversation: ConversationType;
     let agentWithDifferentSpace: LightAgentConfigurationType;
 
-    async function setupProjectWithRestrictedAgent() {
+    async function setupProjectWithRestrictedAgent({
+      messagesCreatedAt = [new Date()],
+    }: {
+      messagesCreatedAt?: Date[];
+    } = {}) {
       projectSpace = await SpaceFactory.project(workspace);
       anotherProjectSpace = await SpaceFactory.project(workspace);
 
@@ -2524,7 +2528,7 @@ describe("postUserMessage", () => {
         auth,
         {
           agentConfigurationId: agentWithDifferentSpace.sId,
-          messagesCreatedAt: [new Date()],
+          messagesCreatedAt,
           spaceId: projectSpace.id,
         }
       );
@@ -2696,6 +2700,110 @@ describe("postUserMessage", () => {
         );
         expect(branchRow).not.toBeNull();
         expect(secondUserMessageRow!.branchId).toBe(branchRow!.id);
+
+        rateLimiterSpy.mockRestore();
+      });
+    });
+
+    describe("with empty conversation and projects feature flag enabled", () => {
+      beforeEach(async () => {
+        await setupProjectWithRestrictedAgent({ messagesCreatedAt: [] });
+        await FeatureFlagFactory.basic(auth, "projects");
+      });
+
+      it("should create a branch with an anchor message when first message mentions a restricted agent", async () => {
+        const user = auth.getNonNullableUser();
+        const userJson = user.toJSON();
+
+        const rateLimiterSpy = vi
+          .spyOn(rateLimiterModule, "rateLimiter")
+          .mockResolvedValue(100);
+
+        expect(projectConversation.content.length).toBe(0);
+
+        const result = await postUserMessage(auth, {
+          conversation: projectConversation,
+          content: `Hello @${agentWithDifferentSpace.name}`,
+          mentions: [{ configurationId: agentWithDifferentSpace.sId }],
+          context: {
+            username: userJson.username,
+            timezone: "UTC",
+            fullName: userJson.fullName,
+            email: userJson.email,
+            profilePictureUrl: userJson.image,
+            origin: "web",
+          },
+          skipToolsValidation: false,
+        });
+
+        expect(result.isOk()).toBe(true);
+        if (!result.isOk()) {
+          return;
+        }
+
+        const branchesAfter =
+          await ConversationBranchResource.listForConversation(
+            auth,
+            projectConversation.id
+          );
+        expect(branchesAfter.length).toBe(1);
+        const branch = branchesAfter[0];
+        expect(projectConversation.branchId).toBe(branch.sId);
+
+        // Anchor message: rank 0, empty content, origin "branch_anchor".
+        const anchorMessageRow = await MessageModel.findOne({
+          where: {
+            conversationId: projectConversation.id,
+            workspaceId: workspace.id,
+            rank: 0,
+            branchId: null,
+          },
+          include: [
+            {
+              model: UserMessageModel,
+              as: "userMessage",
+              required: true,
+            },
+          ],
+        });
+        expect(anchorMessageRow).not.toBeNull();
+        expect(anchorMessageRow!.userMessage!.content).toBe("");
+        expect(anchorMessageRow!.userMessage!.userContextOrigin).toBe(
+          "branch_anchor"
+        );
+
+        // The actual user message lives on the branch at rank 1.
+        const newUserMessageRow = await MessageModel.findOne({
+          where: {
+            id: result.value.userMessage.id,
+            workspaceId: workspace.id,
+          },
+        });
+        expect(newUserMessageRow).not.toBeNull();
+        expect(newUserMessageRow!.branchId).toBe(branch.id);
+        expect(newUserMessageRow!.rank).toBe(1);
+
+        // Agent message also lives on the branch.
+        expect(result.value.agentMessages.length).toBe(1);
+        const agentMessageRow = await MessageModel.findOne({
+          where: {
+            id: result.value.agentMessages[0].id,
+            workspaceId: workspace.id,
+          },
+        });
+        expect(agentMessageRow).not.toBeNull();
+        expect(agentMessageRow!.branchId).toBe(branch.id);
+
+        // Mention is approved (not restricted) because it lives on a branch.
+        const mentionRow = await MentionModel.findOne({
+          where: {
+            messageId: result.value.userMessage.id,
+            workspaceId: workspace.id,
+            agentConfigurationId: agentWithDifferentSpace.sId,
+          },
+        });
+        expect(mentionRow).not.toBeNull();
+        expect(mentionRow!.status).toBe("approved");
 
         rateLimiterSpy.mockRestore();
       });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -552,6 +552,7 @@ export function isUserMessageContextValid(
     case "project_kickoff":
     case "reinforced_skill_notification":
     case "reinforcement":
+    case "branch_anchor":
     case "web":
       return false;
     default:
@@ -834,7 +835,6 @@ export async function postUserMessage(
     // We will do best effort to create a branch, but there a several conditions that we will not create a branch.
     // - User is null, cannot create branch without a user, should never happen, but we will log an error and continue.
     // - Message has user mentions, we don't support multiple users in a branch yet.
-    // - Conversation has no content, we cannot create a branch as the start of the conversation.
     // - Last message in conversation has no content should never happen, but we will log an error and continue.
     // If we do not create a branch, the user will receive a notification that the agent is not usable.
     if (shouldCreateBranch) {
@@ -846,9 +846,36 @@ export async function postUserMessage(
           "Message has user mentions, for now we do not support branching with user mentions."
         );
       } else if (conversation.content.length === 0) {
-        logger.info(
-          "Conversation has no content, cannot create branch as the start of the conversation."
+        // Create an invisible anchor message so the branch has a previousMessageId
+        // to reference.
+        const anchorMessage = await createUserMessage(auth, {
+          conversation,
+          content: "",
+          metadata: {
+            type: "create",
+            user: user.toJSON(),
+            rank: 0,
+            context: {
+              ...context,
+              origin: "branch_anchor",
+            },
+          },
+          transaction: t,
+        });
+
+        const branch = await ConversationBranchResource.makeNew(
+          auth,
+          {
+            conversationId: conversation.id,
+            previousMessageId: anchorMessage.id,
+            state: "open",
+            userId: user.id,
+          },
+          t
         );
+
+        conversation.branchId = branch.sId;
+        nextMessageRank = 1;
       } else {
         // Get the last message in the conversation.
         const previousMessage =

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -20,10 +20,7 @@ vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
 
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import {
-  createConversation,
-  postUserMessage,
-} from "@app/lib/api/assistant/conversation";
+import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   createUserMentions,
@@ -37,7 +34,6 @@ import {
 } from "@app/lib/api/assistant/streaming/events";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
   AgentMessageModel,
@@ -58,10 +54,7 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { AgentMention, MentionType } from "@app/types/assistant/mentions";
-import {
-  isRichAgentMention,
-  isRichUserMention,
-} from "@app/types/assistant/mentions";
+import { isRichUserMention } from "@app/types/assistant/mentions";
 import type { WorkspaceType } from "@app/types/user";
 
 describe("dismissMention", () => {
@@ -448,172 +441,6 @@ describe("dismissMention", () => {
       // Verify mention was NOT dismissed (only restricted mentions can be dismissed)
       await mentionInDb!.reload();
       expect(mentionInDb?.dismissed).toBe(false);
-    });
-  });
-
-  describe("agent mentions with agent_restricted_by_space_usage", () => {
-    it("should successfully dismiss an agent mention with restricted status", async () => {
-      // Create a restricted space
-      const restrictedSpace = await SpaceFactory.regular(workspace);
-      const adminAuth = await Authenticator.internalAdminForWorkspace(
-        workspace.sId
-      );
-      const refreshedRestrictedSpace = await SpaceResource.fetchById(
-        adminAuth,
-        restrictedSpace.sId
-      );
-      expect(refreshedRestrictedSpace).not.toBeNull();
-      expect(refreshedRestrictedSpace?.isOpen()).toBe(false);
-
-      // Add user to the restricted space so they can create conversations in it
-      await refreshedRestrictedSpace!.addMembers(adminAuth, {
-        userIds: [auth.getNonNullableUser().sId],
-      });
-
-      // Refresh authenticator to get updated permissions
-      const refreshedAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        auth.getNonNullableUser().sId,
-        workspace.sId
-      );
-
-      // Create a conversation in the restricted space
-      const restrictedSpaceModelId = getResourceIdFromSId(
-        refreshedRestrictedSpace!.sId
-      );
-      expect(restrictedSpaceModelId).not.toBeNull();
-
-      const spaceConversation = await createConversation(refreshedAuth, {
-        title: "Space Conversation",
-        visibility: "unlisted",
-        spaceId: restrictedSpaceModelId!,
-      });
-
-      // Create agent configuration that uses a different restricted space
-      const agentConfig = await AgentConfigurationFactory.createTestAgent(
-        refreshedAuth,
-        {
-          name: "Restricted Agent",
-        }
-      );
-
-      const otherRestrictedSpace = await SpaceFactory.regular(workspace);
-      const refreshedOtherRestrictedSpace = await SpaceResource.fetchById(
-        adminAuth,
-        otherRestrictedSpace.sId
-      );
-      expect(refreshedOtherRestrictedSpace).not.toBeNull();
-
-      // Add user to the other restricted space so they can mention the agent
-      // (but the agent will still be restricted because the conversation is in a different space)
-      await refreshedOtherRestrictedSpace!.addMembers(adminAuth, {
-        userIds: [auth.getNonNullableUser().sId],
-      });
-
-      // Refresh authenticator again to get updated permissions for the other restricted space
-      const refreshedAuthWithBothSpaces =
-        await Authenticator.fromUserIdAndWorkspaceId(
-          auth.getNonNullableUser().sId,
-          workspace.sId
-        );
-
-      const otherRestrictedSpaceModelId = getResourceIdFromSId(
-        otherRestrictedSpace.sId
-      );
-      expect(otherRestrictedSpaceModelId).not.toBeNull();
-
-      await AgentConfigurationModel.update(
-        {
-          requestedSpaceIds: [otherRestrictedSpaceModelId!],
-        },
-        {
-          where: {
-            workspaceId: workspace.id,
-            sId: agentConfig.sId,
-            version: agentConfig.version,
-          },
-        }
-      );
-
-      // Get conversation as ConversationType (needed for postUserMessage)
-      const conversationRes = await getConversation(
-        refreshedAuthWithBothSpaces,
-        spaceConversation.sId
-      );
-      expect(conversationRes.isOk()).toBe(true);
-      if (!conversationRes.isOk()) {
-        throw new Error("Failed to fetch conversation");
-      }
-      const conversation = conversationRes.value;
-
-      // Use postUserMessage to create the message with the full flow
-      const user = refreshedAuthWithBothSpaces.getNonNullableUser();
-      const userJson = user.toJSON();
-      const postResult = await postUserMessage(refreshedAuthWithBothSpaces, {
-        conversation,
-        content: `Hello @${agentConfig.name}`,
-        mentions: [
-          {
-            configurationId: agentConfig.sId,
-          } satisfies AgentMention,
-        ],
-        context: {
-          username: userJson.username,
-          timezone: "UTC",
-          fullName: userJson.fullName,
-          email: userJson.email,
-          profilePictureUrl: userJson.image,
-          origin: "web",
-        },
-        skipToolsValidation: false,
-      });
-
-      expect(postResult.isOk()).toBe(true);
-      if (!postResult.isOk()) {
-        throw new Error("Failed to post user message");
-      }
-      const { userMessage } = postResult.value;
-
-      // Verify mention was created with restricted status
-      const mentionInDb = await MentionModel.findOne({
-        where: {
-          workspaceId: workspace.id,
-          messageId: userMessage.id,
-          agentConfigurationId: agentConfig.sId,
-        },
-      });
-      expect(mentionInDb).not.toBeNull();
-      expect(mentionInDb?.status).toBe("agent_restricted_by_space_usage");
-      expect(mentionInDb?.dismissed).toBe(false);
-
-      // Verify the mention appears in the userMessage's richMentions
-      const agentMention = userMessage.richMentions.find(
-        (m) => isRichAgentMention(m) && m.id === agentConfig.sId
-      );
-      expect(agentMention).toBeDefined();
-      if (agentMention) {
-        expect(agentMention.status).toBe("agent_restricted_by_space_usage");
-      }
-
-      // Dismiss the mention
-      const result = await dismissMention(refreshedAuthWithBothSpaces, {
-        conversationId: spaceConversation.sId,
-        messageId: userMessage.sId,
-        type: "agent",
-        id: agentConfig.sId,
-      });
-
-      expect(result.isOk()).toBe(true);
-
-      // Verify mention was dismissed in database
-      await mentionInDb!.reload();
-      expect(mentionInDb?.dismissed).toBe(true);
-
-      // Verify events were published
-      // For restricted agent mentions, publishMessageEventsOnMessagePostOrEdit is called
-      // (postUserMessage calls it when creating the message, and dismissMention calls it when dismissing)
-      expect(
-        vi.mocked(publishMessageEventsOnMessagePostOrEdit)
-      ).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -38,6 +38,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   project_kickoff: "user",
   reinforced_skill_notification: "user",
   reinforcement: "user",
+  branch_anchor: "user",
 };
 
 export const USER_USAGE_ORIGINS = Object.keys(

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -94,6 +94,7 @@ describe("conversation-unread workflow business logic", () => {
     zendesk: false,
     reinforced_skill_notification: false,
     reinforcement: false,
+    branch_anchor: false,
   };
   describe("shouldSendNotificationForAgentAnswer", () => {
     it.each(

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -35,6 +35,7 @@ import {
   isLightAgentMessageType,
   isProjectConversation,
   isUserMessageType,
+  isVisibleMessage,
 } from "@app/types/assistant/conversation";
 import { isRichUserMention } from "@app/types/assistant/mentions";
 import { isContentFragmentType } from "@app/types/content_fragment";
@@ -226,13 +227,7 @@ const getConversationDetails = async ({
   // For new project conversations, use the first visible message
   const message = !payload.isNewProjectConversation
     ? conversation.content.find((msg) => msg.sId === payload.messageId)
-    : conversation.content.find(
-        (msg) =>
-          !(
-            msg.type === "user_message" &&
-            msg.context.origin === "branch_anchor"
-          )
-      );
+    : conversation.content.find(isVisibleMessage);
   if (!message) {
     // Message doesn't exist at all - could be true if it's in a branch.
     return new Err(new ConversationError("message_not_found"));

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -87,6 +87,7 @@ export const shouldSendNotificationForAgentAnswer = (
     case "agent_sidekick":
     case "reinforced_skill_notification":
     case "reinforcement":
+    case "branch_anchor":
       // Internal bootstrap conversations shouldn't trigger unread notifications.
       return false;
     case "api":
@@ -222,10 +223,16 @@ const getConversationDetails = async ({
   const isFromTrigger = !!conversation.triggerId;
 
   // Retrieve the message that triggered the notification.
-  // For new project conversations, use the first message
+  // For new project conversations, use the first visible message
   const message = !payload.isNewProjectConversation
     ? conversation.content.find((msg) => msg.sId === payload.messageId)
-    : conversation.content[0];
+    : conversation.content.find(
+        (msg) =>
+          !(
+            msg.type === "user_message" &&
+            msg.context.origin === "branch_anchor"
+          )
+      );
   if (!message) {
     // Message doesn't exist at all - could be true if it's in a branch.
     return new Err(new ConversationError("message_not_found"));

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -207,6 +207,29 @@ export function isUserMessageTypeWithContentFragments(
   return arg.type === "user_message" && "contentFragments" in arg;
 }
 
+export function isHiddenMessageOrigin(origin: UserMessageOrigin): boolean {
+  return (
+    origin === "onboarding_conversation" ||
+    origin === "project_kickoff" ||
+    origin === "reinforced_skill_notification" ||
+    origin === "branch_anchor" ||
+    origin === "wakeup"
+  );
+}
+
+export function isVisibleMessage(m: LightMessageType): boolean {
+  return (
+    m.visibility !== "deleted" &&
+    !(
+      isUserMessageTypeWithContentFragments(m) &&
+      isHiddenMessageOrigin(m.context.origin)
+    ) &&
+    // Compaction message will possibly be first messages of a conversation (forking) but they are
+    // not "visible" per se. `firstVisibleMessage` should null until a first user message is posted.
+    !isCompactionMessageType(m)
+  );
+}
+
 /**
  * Agent messages
  */

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -117,7 +117,10 @@ export type UserMessageOrigin =
   // (to be created).
   | "onboarding_conversation"
   // for internal use, for reinforced agent batch LLM operations
-  | "reinforcement";
+  | "reinforcement"
+  // Internal anchor user message inserted at the start of an empty conversation so
+  // a branch can be created before any user-visible message exists.
+  | "branch_anchor";
 
 /**
  * @swaggerschema Context (swagger_schemas.ts), PrivateUserMessageContext (swagger_private_schemas.ts)

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -348,6 +348,7 @@ const USER_MESSAGE_ORIGINS = [
   "project_kickoff",
   "reinforced_skill_notification",
   "reinforcement",
+  "branch_anchor",
 ] as const;
 
 const UserMessageOriginEnumSchema = z.enum(USER_MESSAGE_ORIGINS);


### PR DESCRIPTION
## Description

This PR enables branch creation in empty conversations by introducing an invisible anchor message mechanism.

- Adds a new `branch_anchor` user message origin type
- When creating a branch in an empty conversation, an invisible anchor message is inserted with empty content to serve as the `previousMessageId` reference
- The anchor message is hidden from the UI
- Updates all relevant type definitions to handle the new origin type

## Tests

Manually

## Risks

Low risk. 

## Deploy Plan

Standard deployment. No migrations or special deployment steps required.
