### PR TITLE
feat: delete empty conversation on branch reject

### DIFF
--- a/front/components/assistant/conversation/ConversationBranchApprovalModal.tsx
+++ b/front/components/assistant/conversation/ConversationBranchApprovalModal.tsx
@@ -10,6 +10,8 @@ import {
   useCancelMessage,
   useConversationBranchActions,
 } from "@app/hooks/conversations";
+import { useAppRouter } from "@app/lib/platform";
+import { getProjectRoute } from "@app/lib/utils/router";
 import {
   ArrowLeftIcon,
   ScrollArea,
@@ -61,6 +63,8 @@ export function ConversationBranchApprovalModal({
   );
   const [selectedMessage, setSelectedMessage] =
     useState<AgentMessageWithStreaming | null>(null);
+
+  const router = useAppRouter();
 
   const { mergeBranch, closeBranch, isMerging, isClosing } =
     useConversationBranchActions({
@@ -178,9 +182,21 @@ export function ConversationBranchApprovalModal({
                 setActiveBranchAction("close");
                 try {
                   await cancelOngoingAgentGenerations();
-                  const ok = await closeBranch(branchId);
+                  const { ok, conversationDeleted } =
+                    await closeBranch(branchId);
                   if (ok) {
                     context.setBranchIdToApprove?.(null);
+                    // The conversation only existed to host this branch — it
+                    // was just soft-deleted server-side. Send the user back to
+                    // the project page rather than a stale conversation view.
+                    if (conversationDeleted && context.conversation?.spaceId) {
+                      void router.push(
+                        getProjectRoute(
+                          context.owner.sId,
+                          context.conversation.spaceId
+                        )
+                      );
+                    }
                   }
                 } finally {
                   setActiveBranchAction(null);

--- a/front/hooks/conversations/useConversationBranchActions.ts
+++ b/front/hooks/conversations/useConversationBranchActions.ts
@@ -1,6 +1,7 @@
 import { useOpenConversationBranch } from "@app/hooks/conversations/useOpenConversationBranch";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import type { CloseConversationBranchResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/branches/[bId]/close";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
 
@@ -49,9 +50,11 @@ export function useConversationBranchActions({
   );
 
   const closeBranch = useCallback(
-    async (branchId: string) => {
+    async (
+      branchId: string
+    ): Promise<{ ok: boolean; conversationDeleted: boolean }> => {
       if (!conversationId) {
-        return false;
+        return { ok: false, conversationDeleted: false };
       }
       setIsClosing(true);
       try {
@@ -63,10 +66,11 @@ export function useConversationBranchActions({
           throw new Error("Failed to close branch");
         }
         void mutateOpenBranch({ branch: null }, { revalidate: false });
-        return true;
+        const body: CloseConversationBranchResponse = await res.json();
+        return { ok: true, conversationDeleted: body.conversationDeleted };
       } catch {
         sendNotification({ type: "error", title: "Failed to reject branch" });
-        return false;
+        return { ok: false, conversationDeleted: false };
       } finally {
         setIsClosing(false);
       }

--- a/front/lib/api/assistant/conversation/branches.ts
+++ b/front/lib/api/assistant/conversation/branches.ts
@@ -380,13 +380,13 @@ export async function closeConversationBranch(
   }
 ): Promise<
   Result<
-    { closedBranchId: number },
+    { closedBranchId: number; conversationDeleted: boolean },
     DustError<CloseConversationBranchErrorCode>
   >
 > {
   const owner = auth.getNonNullableWorkspace();
 
-  return withTransaction(async (t) => {
+  const closeRes = await withTransaction(async (t) => {
     const effectiveTransaction = transaction ?? t;
 
     const conversation = await ConversationResource.fetchById(
@@ -430,8 +430,44 @@ export async function closeConversationBranch(
       }
     );
 
-    return new Ok({ closedBranchId: branch.id });
+    return new Ok({
+      branch,
+    });
   }, transaction);
+
+  if (closeRes.isErr()) {
+    return closeRes;
+  }
+
+  // If the branch sat on an internal anchor user message (origin
+  // "branch_anchor"), the conversation has nothing user-visible left, so
+  // delete it.
+  const previousOrigin =
+    await closeRes.value.branch.getPreviousUserMessageOrigin(auth);
+  const branchSitsOnAnchor = previousOrigin === "branch_anchor";
+
+  if (!branchSitsOnAnchor) {
+    return new Ok({
+      closedBranchId: closeRes.value.branch.id,
+      conversationDeleted: false,
+    });
+  }
+
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return new Err(
+      new DustError("conversation_not_found", "Conversation not found.")
+    );
+  }
+  await conversation.updateVisibilityToDeleted(auth);
+
+  return new Ok({
+    closedBranchId: closeRes.value.branch.id,
+    conversationDeleted: true,
+  });
 }
 
 export type RenderedOpenBranch = {

--- a/front/lib/resources/conversation_branch_resource.ts
+++ b/front/lib/resources/conversation_branch_resource.ts
@@ -116,6 +116,24 @@ export class ConversationBranchResource extends BaseResource<ConversationBranchM
     });
   }
 
+  async getPreviousUserMessageOrigin(
+    auth: Authenticator
+  ): Promise<string | null> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const previous = await MessageModel.findOne({
+      where: {
+        id: this.previousMessageId,
+        workspaceId: owner.id,
+      },
+      include: [
+        { model: UserMessageModel, as: "userMessage", required: false },
+      ],
+    });
+
+    return previous?.userMessage?.userContextOrigin ?? null;
+  }
+
   /**
    * Lists all branches for a given conversation within the authenticated workspace.
    */

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/branches/[bId]/close.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/branches/[bId]/close.ts
@@ -10,6 +10,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 export type CloseConversationBranchResponse = {
   closedBranchId: string;
+  conversationDeleted: boolean;
 };
 
 async function handler(
@@ -102,7 +103,10 @@ async function handler(
     }
   }
 
-  res.status(200).json({ closedBranchId: bId });
+  res.status(200).json({
+    closedBranchId: bId,
+    conversationDeleted: closeRes.value.conversationDeleted,
+  });
 }
 
 export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

This PR adds automatic deletion of empty conversations when rejecting a branch that sits on an anchor user message.

- When a branch is rejected/closed, the system checks if it sits on an anchor user message (origin `branch_anchor`)
- If the branch sits on an anchor, the conversation is soft-deleted since it has no user-visible content left
- The user is redirected to the project page after deletion to avoid staying on a stale conversation view

## Tests

Manually

## Risk

Low.

## Deploy Plan

Standard deployment.
