### PR TITLE
Don't raise panic log on CancelFailure("NOT_FOUND")

### DIFF
--- a/connectors/src/types/shared/utils/global_error_handler.ts
+++ b/connectors/src/types/shared/utils/global_error_handler.ts
@@ -10,6 +10,21 @@ export function setupGlobalErrorHandler(logger: LoggerInterface) {
   }
   once = true;
   process.on("unhandledRejection", (reason, promise) => {
+    // CancelledFailure: NOT_FOUND from Temporal SDK is expected when workflows
+    // are terminated while activities are still pending on the worker.
+    // This is not actionable — downgrade from panic to warn.
+    if (
+      reason instanceof Error &&
+      reason.name === "CancelledFailure" &&
+      reason.message === "NOT_FOUND"
+    ) {
+      logger.warn(
+        { error: reason },
+        "Temporal activity cancellation for terminated workflow (ignored)"
+      );
+      return;
+    }
+
     // uuid here serves as a correlation id for the console.error and the logger.error.
     const uuid = uuidv4();
     // console.log here is important because the promise.catch() below could fail.

--- a/connectors/src/types/shared/utils/global_error_handler.ts
+++ b/connectors/src/types/shared/utils/global_error_handler.ts
@@ -1,4 +1,5 @@
 import type { LoggerInterface } from "@dust-tt/client";
+import { CancelledFailure } from "@temporalio/common";
 import { v4 as uuidv4 } from "uuid";
 
 let once = false;
@@ -13,11 +14,7 @@ export function setupGlobalErrorHandler(logger: LoggerInterface) {
     // CancelledFailure: NOT_FOUND from Temporal SDK is expected when workflows
     // are terminated while activities are still pending on the worker.
     // This is not actionable — downgrade from panic to warn.
-    if (
-      reason instanceof Error &&
-      reason.name === "CancelledFailure" &&
-      reason.message === "NOT_FOUND"
-    ) {
+    if (reason instanceof CancelledFailure && reason.message === "NOT_FOUND") {
       logger.warn(
         { error: reason },
         "Temporal activity cancellation for terminated workflow (ignored)"


### PR DESCRIPTION
## Description

When Temporal workflows are terminated while activities are still pending on the worker, the Temporal SDK raises a `CancelledFailure` with message `"NOT_FOUND"`. This is expected behavior and not actionable. Previously, this error triggered a panic-level log via the global unhandled rejection handler, creating noise in our error monitoring. This PR downgrades these specific errors from panic to warn level.

## Risk

Low. This only affects logging level for a specific, expected error case. All other unhandled rejections continue to be logged as panic.

## Deploy Plan

Deploy connectors.