### PR TITLE
Bypass cache for expired access tokens in Front

### DIFF
--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -57,7 +57,8 @@ pub fn provider_timeout_seconds(provider: ConnectionProvider) -> u64 {
 }
 // Buffer of time in ms before the expiry of an access token within which we will attempt to
 // refresh it.
-// NOTE: connectors/src/types/oauth/client/access_token.ts mirrors this value as
+// NOTE: connectors/src/types/oauth/client/access_token.ts and lib/api/oauth_access_token.ts
+// mirror this value as ACCESS_TOKEN_EXPIRY_BUFFER_MS. If you change this constant, update those too.
 // ACCESS_TOKEN_EXPIRY_BUFFER_MS. If you change this constant, update that file too.
 pub static ACCESS_TOKEN_REFRESH_BUFFER_MILLIS: u64 = 5 * 60 * 1000;
 

--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -447,7 +447,7 @@ impl Provider for MCPConnectionProvider {
         match &error {
             ProviderHttpRequestError::RequestFailed {
                 status, message, ..
-            } if *status == 400 => {
+            } if *status == 400 || *status == 401 => {
                 // Detect both "invalid_grant" and "invalid_refresh_token" as revoked token indicators.
                 let is_revoked =
                     message.contains("invalid_grant") || message.contains("invalid_refresh_token");

--- a/front/lib/api/oauth_access_token.ts
+++ b/front/lib/api/oauth_access_token.ts
@@ -6,6 +6,8 @@ import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 
 const OAUTH_ACCESS_TOKEN_CACHE_TTL_MS = 1000 * 60 * 5;
+// Mirror the OAuth server's refresh buffer so we never serve a token the server would already refresh.
+const ACCESS_TOKEN_EXPIRY_BUFFER_MS = 1000 * 60 * 5;
 
 const CACHE = new Map<
   string,
@@ -46,7 +48,21 @@ export async function getOAuthConnectionAccessToken({
   const cached = CACHE.get(connectionId);
 
   if (cached && cached.localExpiryMs > Date.now()) {
-    return new Ok(cached);
+    const isValid =
+      cached.access_token_expiry === null ||
+      cached.access_token_expiry > Date.now() + ACCESS_TOKEN_EXPIRY_BUFFER_MS;
+
+    if (isValid) {
+      return new Ok(cached);
+    }
+
+    logger.warn(
+      {
+        access_token_expiry: cached.access_token_expiry,
+        connectionId,
+      },
+      "Local cache has expired tokens"
+    );
   }
 
   const res = await new OAuthAPI(config, logger).getAccessToken({


### PR DESCRIPTION
## Description

This is the same fix as https://github.com/dust-tt/dust/pull/24898, but in Front instead of Connector, to have them match.

Also, fixed a refresh token error check in core to include both 400 and 401, sice we see from the logs that some of these errors are 401.

These fixes relate to https://github.com/dust-tt/tasks/issues/7905, but are probably not enough to fix the underlying issue, so just some small steps.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Core,front