### PR TITLE
[front] fix: Pass transaction to canAgentBeUsedInProjectConversation

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1713,6 +1713,38 @@ export async function retryAgentMessage(
     return limitResult;
   }
 
+  const retryAgentConfiguration = await getAgentConfiguration(auth, {
+    agentId: message.configuration.sId,
+    variant: "extra_light",
+  });
+  if (!retryAgentConfiguration || !canAccessAgent(retryAgentConfiguration)) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Invalid agent message retry request, the agent is no longer available to you.",
+      },
+    });
+  }
+
+  if (isProjectConversation(conversation)) {
+    const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
+      configuration: retryAgentConfiguration,
+      conversation,
+    });
+    if (!canAgentBeUsed) {
+      return new Err({
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Invalid agent message retry request, the agent is restricted by space usage.",
+        },
+      });
+    }
+  }
+
   let agentMessageResult: {
     agentMessage: AgentMessageType;
   } | null = null;
@@ -1763,30 +1795,6 @@ export async function retryAgentMessage(
         throw new AgentMessageError(
           "Invalid agent message retry request, this message was already retried."
         );
-      }
-
-      // Check if agent is still available to the user.
-      const agentConfiguration = await getAgentConfiguration(auth, {
-        agentId: message.configuration.sId,
-        variant: "extra_light",
-      });
-      if (!agentConfiguration || !canAccessAgent(agentConfiguration)) {
-        throw new AgentMessageError(
-          "Invalid agent message retry request, the agent is no longer available to you."
-        );
-      }
-
-      // Agent could be part of a conversation that was moved to a space OR the agent configuration could have changed to use a space that is not usable in a project.
-      if (isProjectConversation(conversation)) {
-        const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
-          configuration: agentConfiguration,
-          conversation,
-        });
-        if (!canAgentBeUsed) {
-          throw new AgentMessageError(
-            "Invalid agent message retry request, the agent is restricted by space usage."
-          );
-        }
       }
 
       const { agentMessages } = await createAgentMessages(auth, {

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -405,6 +405,7 @@ export const createAgentMessages = async (
                 {
                   configuration,
                   conversation,
+                  transaction,
                 }
               );
 

--- a/front/lib/api/assistant/conversation/permissions.ts
+++ b/front/lib/api/assistant/conversation/permissions.ts
@@ -88,9 +88,11 @@ export async function canAgentBeUsedInProjectConversation(
   {
     configuration,
     conversation,
+    transaction,
   }: {
     configuration: LightAgentConfigurationType;
     conversation: ConversationWithoutContentType;
+    transaction?: Transaction;
   }
 ): Promise<boolean> {
   if (!isProjectConversation(conversation)) {
@@ -114,7 +116,8 @@ export async function canAgentBeUsedInProjectConversation(
       auth,
       configuration.requestedSpaceIds.filter(
         (spaceId) => spaceId !== conversation.spaceId
-      )
+      ),
+      { transaction }
     );
     if (spaces.some((space) => !space.isOpen())) {
       return false;

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -453,18 +453,25 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async fetchByIds(
     auth: Authenticator,
     ids: string[],
-    { includeDeleted }: { includeDeleted?: boolean } = {}
+    {
+      includeDeleted,
+      transaction,
+    }: { includeDeleted?: boolean; transaction?: Transaction } = {}
   ): Promise<SpaceResource[]> {
     if (ids.length === 0) {
       return [];
     }
 
-    return this.baseFetch(auth, {
-      where: {
-        id: removeNulls(ids.map(getResourceIdFromSId)),
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          id: removeNulls(ids.map(getResourceIdFromSId)),
+        },
+        includeDeleted,
       },
-      includeDeleted,
-    });
+      transaction
+    );
   }
 
   static async fetchByModelIds(


### PR DESCRIPTION
## Description

`canAgentBeUsedInProjectConversation` is used in a transaction block, without using the transaction.
This induces idle in transaction time, which is never desirable, especially in our setup (high QPS OLTP workload). And it can also increase the risks of connection exhaustion - a lot of conditions are needed for that to happen but has been seen before.

Tried to remove getAgentConfiguration and canAgentBeUsedInProjectConversation from transaction blocks where I could, because they were not passing transaction anyway (🚓) and their results are not tied to any atomic workload that would justify a transaction (not the scope of this PR to deal with this)

## Tests

N/A

## Risk

Low

## Deploy Plan

- [ ] Deploy front