### PR TITLE
Add create tool to files MCP

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -111,6 +111,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "files": {
     "cat": "never_ask",
+    "create": "never_ask",
     "grep": "never_ask",
     "list": "never_ask",
   },

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -112,7 +112,7 @@ export const FILES_TOOLS_METADATA = createToolsRecord({
     stake: "never_ask",
     displayLabels: {
       running: "Writing file",
-      done: "Wrote file",
+      done: "Write file",
     },
   },
 });

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -9,10 +9,12 @@ export const FILES_SERVER_NAME = "files" as const;
 export const FILES_LIST_ACTION_NAME = "list" as const;
 export const FILES_CAT_ACTION_NAME = "cat" as const;
 export const FILES_GREP_ACTION_NAME = "grep" as const;
+export const FILES_CREATE_ACTION_NAME = "create" as const;
 
 export const CAT_LINES_DEFAULT = 200;
 export const CAT_LINES_MAX = 500;
 export const GREP_MATCHES_MAX = 50;
+export const CREATE_CONTENT_MAX_BYTES = 50 * 1024; // 50 KB (~12K tokens).
 
 export const FILES_TOOLS_METADATA = createToolsRecord({
   [FILES_LIST_ACTION_NAME]: {
@@ -85,6 +87,32 @@ export const FILES_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Searching file",
       done: "Searched file",
+    },
+  },
+  [FILES_CREATE_ACTION_NAME]: {
+    description:
+      "Create or overwrite a file in the conversation file system. " +
+      "Accepts UTF-8 text content only. Binary files cannot be created via this tool. " +
+      `Content is capped at ${CREATE_CONTENT_MAX_BYTES / 1024} KB. ` +
+      "If the file already exists it is silently overwritten (shell \`>\` semantics). " +
+      "Returns whether the file was created or updated, along with its path and size.",
+    schema: {
+      path: z
+        .string()
+        .describe(
+          "Scoped file path for the new file (e.g. `conversation/output.json`, `conversation/reports/summary.txt`)"
+        ),
+      content: z.string().describe("UTF-8 text content to write"),
+      content_type: z
+        .string()
+        .describe(
+          "MIME content type (e.g. `text/plain`, `application/json`, `text/csv`, `text/markdown`)"
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Writing file",
+      done: "Wrote file",
     },
   },
 });

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -93,9 +93,13 @@ async function catText(
 
 export async function catHandler(
   { path, offset, limit }: { path: string; offset?: number; limit?: number },
-  extra: ToolHandlerExtra
+  { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const resolvedRes = await resolveConversationFile(path, extra);
+  const resolvedRes = await resolveConversationFile(
+    auth,
+    agentLoopContext?.runContext?.conversation,
+    path
+  );
   if (resolvedRes.isErr()) {
     return resolvedRes;
   }

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -1,0 +1,81 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
+import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
+import { createGCSMountFile, getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export async function createHandler(
+  {
+    path,
+    content,
+    content_type,
+  }: { path: string; content: string; content_type: string },
+  extra: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const mountRes = resolveMountPoint(
+    extra.auth,
+    extra.agentLoopContext?.runContext?.conversation
+  );
+  if (mountRes.isErr()) {
+    return mountRes;
+  }
+  const { scope, prefix } = mountRes.value;
+
+  const gcsPath = getGCSPathFromScopedPath({
+    prefix,
+    scopedPath: path,
+    useCase: scope.useCase,
+  });
+  if (!gcsPath) {
+    return new Err(
+      new MCPError(
+        `Invalid path: \`${path}\` does not belong to the conversation file system.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const contentBuffer = Buffer.from(content, "utf8");
+  if (contentBuffer.byteLength > CREATE_CONTENT_MAX_BYTES) {
+    return new Err(
+      new MCPError(
+        `Content exceeds the ${CREATE_CONTENT_MAX_BYTES / 1024} KB limit.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const bucket = getPrivateUploadBucket();
+  const [exists] = await bucket.file(gcsPath).exists();
+  const relativeFilePath = gcsPath.slice(prefix.length);
+
+  let entry;
+  try {
+    entry = await createGCSMountFile(extra.auth, scope, {
+      relativeFilePath,
+      content: contentBuffer,
+      contentType: content_type,
+    });
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `Failed to write file \`${path}\`: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  const kb = Math.ceil(entry.sizeBytes / 1024);
+  const verb = exists ? "Updated" : "Created";
+  return new Ok([
+    {
+      type: "text",
+      text: `${verb} \`${entry.path}\` (${entry.contentType}, ${kb} KB)`,
+    },
+  ]);
+}

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -73,12 +73,12 @@ export async function createHandler(
     );
   }
 
-  const kb = Math.ceil(entry.sizeBytes / 1024);
+  const sizeKb = Math.ceil(entry.sizeBytes / 1024);
   const verb = exists ? "Updated" : "Created";
   return new Ok([
     {
       type: "text",
-      text: `${verb} \`${entry.path}\` (${entry.contentType}, ${kb} KB)`,
+      text: `${verb} \`${entry.path}\` (${entry.contentType}, ${sizeKb} KB)`,
     },
   ]);
 }

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -5,7 +5,10 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
 import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
-import { createGCSMountFile, getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
+import {
+  createGCSMountFile,
+  getGCSPathFromScopedPath,
+} from "@app/lib/api/files/gcs_mount/files";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -16,11 +19,11 @@ export async function createHandler(
     content,
     content_type,
   }: { path: string; content: string; content_type: string },
-  extra: ToolHandlerExtra
+  { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const mountRes = resolveMountPoint(
-    extra.auth,
-    extra.agentLoopContext?.runContext?.conversation
+    auth,
+    agentLoopContext?.runContext?.conversation
   );
   if (mountRes.isErr()) {
     return mountRes;
@@ -57,7 +60,7 @@ export async function createHandler(
 
   let entry;
   try {
-    entry = await createGCSMountFile(extra.auth, scope, {
+    entry = await createGCSMountFile(auth, scope, {
       relativeFilePath,
       content: contentBuffer,
       contentType: content_type,

--- a/front/lib/api/actions/servers/files/tools/grep.ts
+++ b/front/lib/api/actions/servers/files/tools/grep.ts
@@ -19,9 +19,13 @@ import * as readline from "readline";
 
 export async function grepHandler(
   { path, pattern }: { path: string; pattern: string },
-  extra: ToolHandlerExtra
+  { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const resolvedRes = await resolveConversationFile(path, extra);
+  const resolvedRes = await resolveConversationFile(
+    auth,
+    agentLoopContext?.runContext?.conversation,
+    path
+  );
   if (resolvedRes.isErr()) {
     return resolvedRes;
   }

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -1,11 +1,13 @@
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   FILES_CAT_ACTION_NAME,
+  FILES_CREATE_ACTION_NAME,
   FILES_GREP_ACTION_NAME,
   FILES_LIST_ACTION_NAME,
   FILES_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/files/metadata";
 import { catHandler } from "@app/lib/api/actions/servers/files/tools/cat";
+import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { grepHandler } from "@app/lib/api/actions/servers/files/tools/grep";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 
@@ -13,4 +15,5 @@ export const TOOLS = buildTools(FILES_TOOLS_METADATA, {
   [FILES_LIST_ACTION_NAME]: listHandler,
   [FILES_CAT_ACTION_NAME]: catHandler,
   [FILES_GREP_ACTION_NAME]: grepHandler,
+  [FILES_CREATE_ACTION_NAME]: createHandler,
 });

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -1,26 +1,26 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
 import { listGCSMountFiles } from "@app/lib/api/files/gcs_mount/files";
 import { stripMimeParameters } from "@app/types/files";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import partition from "lodash/partition";
 
 export async function listHandler(
   _params: Record<string, never>,
-  { auth, agentLoopContext }: ToolHandlerExtra
+  extra: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversation = agentLoopContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(new MCPError("No conversation context available."));
+  const mountRes = resolveMountPoint(
+    extra.auth,
+    extra.agentLoopContext?.runContext?.conversation
+  );
+  if (mountRes.isErr()) {
+    return mountRes;
   }
 
-  const entries = await listGCSMountFiles(auth, {
-    useCase: "conversation",
-    conversationId: conversation.sId,
-  });
+  const entries = await listGCSMountFiles(extra.auth, mountRes.value.scope);
 
   const [dirs, files] = partition(entries, (e) => e.isDirectory);
 

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -8,6 +8,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { stripMimeParameters } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
@@ -20,7 +21,7 @@ type MountPoint = { scope: GCSMountPoint; prefix: string };
 export function resolveMountPoint(
   auth: Authenticator,
   conversation: ConversationType | null | undefined
-): Ok<MountPoint> | Err<MCPError> {
+): Result<MountPoint, MCPError> {
   if (!conversation) {
     return new Err(new MCPError("No conversation context available."));
   }
@@ -43,7 +44,7 @@ export async function resolveConversationFile(
   auth: Authenticator,
   conversation: ConversationType | undefined,
   path: string
-): Promise<Ok<ResolvedFile> | Err<MCPError>> {
+): Promise<Result<ResolvedFile, MCPError>> {
   const mountRes = resolveMountPoint(auth, conversation);
   if (mountRes.isErr()) {
     return mountRes;

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -1,5 +1,4 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   type GCSMountPoint,
   getGCSPathFromScopedPath,
@@ -41,16 +40,11 @@ export function resolveMountPoint(
 }
 
 export async function resolveConversationFile(
-  path: string,
-  {
-    auth,
-    agentLoopContext,
-  }: Pick<ToolHandlerExtra, "auth" | "agentLoopContext">
+  auth: Authenticator,
+  conversation: ConversationType | undefined,
+  path: string
 ): Promise<Ok<ResolvedFile> | Err<MCPError>> {
-  const mountRes = resolveMountPoint(
-    auth,
-    agentLoopContext?.runContext?.conversation
-  );
+  const mountRes = resolveMountPoint(auth, conversation);
   if (mountRes.isErr()) {
     return mountRes;
   }

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -1,8 +1,13 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
+import {
+  type GCSMountPoint,
+  getGCSPathFromScopedPath,
+} from "@app/lib/api/files/gcs_mount/files";
 import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import type { ConversationType } from "@app/types/assistant/conversation";
 import { stripMimeParameters } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -11,6 +16,30 @@ import type { File as GCSFile } from "@google-cloud/storage";
 
 type ResolvedFile = { file: GCSFile; mimeType: string; sizeBytes: number };
 
+type MountPoint = { scope: GCSMountPoint; prefix: string };
+
+export function resolveMountPoint(
+  auth: Authenticator,
+  conversation: ConversationType | null | undefined
+): Ok<MountPoint> | Err<MCPError> {
+  if (!conversation) {
+    return new Err(new MCPError("No conversation context available."));
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const scope: GCSMountPoint = {
+    useCase: "conversation",
+    conversationId: conversation.sId,
+  };
+
+  const prefix = getConversationFilesBasePath({
+    workspaceId: owner.sId,
+    conversationId: conversation.sId,
+  });
+
+  return new Ok({ scope, prefix });
+}
+
 export async function resolveConversationFile(
   path: string,
   {
@@ -18,20 +47,20 @@ export async function resolveConversationFile(
     agentLoopContext,
   }: Pick<ToolHandlerExtra, "auth" | "agentLoopContext">
 ): Promise<Ok<ResolvedFile> | Err<MCPError>> {
-  const conversation = agentLoopContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(new MCPError("No conversation context available."));
+  const mountRes = resolveMountPoint(
+    auth,
+    agentLoopContext?.runContext?.conversation
+  );
+  if (mountRes.isErr()) {
+    return mountRes;
   }
 
-  const owner = auth.getNonNullableWorkspace();
-  const prefix = getConversationFilesBasePath({
-    workspaceId: owner.sId,
-    conversationId: conversation.sId,
-  });
+  const { scope, prefix } = mountRes.value;
+
   const gcsPath = getGCSPathFromScopedPath({
     prefix,
     scopedPath: path,
-    useCase: "conversation",
+    useCase: scope.useCase,
   });
   if (!gcsPath) {
     return new Err(

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -53,7 +53,7 @@ describe("createGCSMountFile", () => {
     await createGCSMountFile(
       auth,
       { useCase: "conversation", conversationId },
-      { fileName: "report.txt", content, contentType: "text/plain" }
+      { relativeFilePath: "report.txt", content, contentType: "text/plain" }
     );
 
     expect(saveMock).toHaveBeenCalledWith(content, {
@@ -71,7 +71,7 @@ describe("createGCSMountFile", () => {
     const entry = await createGCSMountFile(
       auth,
       { useCase: "conversation", conversationId },
-      { fileName: "notes.txt", content, contentType: "text/plain" }
+      { relativeFilePath: "notes.txt", content, contentType: "text/plain" }
     );
 
     expect(entry).toMatchObject<Partial<GCSMountFileEntry>>({
@@ -90,7 +90,7 @@ describe("createGCSMountFile", () => {
       auth,
       { useCase: "conversation", conversationId },
       {
-        fileName: "photo.png",
+        relativeFilePath: "photo.png",
         content: Buffer.from("png data"),
         contentType: "image/png",
       }
@@ -106,7 +106,7 @@ describe("createGCSMountFile", () => {
       auth,
       { useCase: "conversation", conversationId },
       {
-        fileName: "data.csv",
+        relativeFilePath: "data.csv",
         content: Buffer.from("a,b"),
         contentType: "text/csv",
       }

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -28,7 +28,7 @@ export type GCSMountFileEntry = GCSMountEntryBase & {
 
 export type GCSMountEntry = GCSMountDirectoryEntry | GCSMountFileEntry;
 
-type GCSMountPoint = {
+export type GCSMountPoint = {
   useCase: "conversation";
   conversationId: string;
 };
@@ -220,11 +220,11 @@ export async function createGCSMountFile(
   auth: Authenticator,
   scope: GCSMountPoint,
   {
-    fileName,
+    relativeFilePath,
     content,
     contentType,
   }: {
-    fileName: string;
+    relativeFilePath: string;
     content: Buffer;
     contentType: string;
   }
@@ -232,14 +232,15 @@ export async function createGCSMountFile(
   const owner = auth.getNonNullableWorkspace();
   const prefix = resolvePrefix(owner, scope);
 
-  const gcsPath = `${prefix}${fileName}`;
+  const gcsPath = `${prefix}${relativeFilePath}`;
   const bucket = getPrivateUploadBucket();
   await bucket.file(gcsPath).save(content, { contentType });
 
+  const fileName = relativeFilePath.split("/").pop() ?? relativeFilePath;
   return makeFileEntry(
     {
       fileName,
-      relativeFilePath: fileName,
+      relativeFilePath,
       sizeBytes: content.length,
       contentType,
       lastModifiedMs: Date.now(),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a create tool to the files MCP server, completing the read-write loop for the conversation file system. The tool lets the agent write text files back into the conversation scope. Closing the gap where agents could read and search files produced by code execution but had no way to produce files of their own.

The interface is `create(path, content, content_type)`:
- The `path` follows the same scoped format as the existing tools (`conversation/output.json`).
- `content_type` is required and explicit: the agent knows what it's generating, and GCS stores it in object metadata where it drives downstream behavior like thumbnail detection.
- `content` is capped at 50 KB (~12K tokens), which comfortably covers any file an LLM would generate from scratch in a single tool call. Beyond that, the content would realistically come from processing existing files rather than pure generation.

Overwrite semantics are `shell >` silent, no flag, no confirmation. The file system is the agent's own scratch space within the conversation, so treating writes as dangerous would be friction without value. The response
distinguishes "Created" from "Updated" so the agent has signal about what happened, at no extra cost.

Took the opportunity to change a bit the code to easily add project scope in the neat future.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
We sadly have no way (yet!) to mock agent loop context, will build a generic brick so I can add tests in a follow up PR.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
