### PR TITLE
Handle Slack bot message_not_in_streaming_state gracefully

### DIFF
--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -96,6 +96,7 @@ export class SlackStreamHandler {
       return;
     }
 
+    this.stopped = true;
     try {
       const res = await this.streamer.stop();
 

--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -54,6 +54,18 @@ export class SlackStreamHandler {
     });
   }
 
+  private handleStreamExpiredError(e: unknown, logMessage: string): void {
+    if (
+      isSlackWebAPIPlatformError(e) &&
+      e.data?.error === "message_not_in_streaming_state"
+    ) {
+      this.stopped = true;
+      logger.warn({ connectorId: this.connectorId }, logMessage);
+      return;
+    }
+    throw e;
+  }
+
   async appendText(text: string) {
     if (this.stopped) {
       return;
@@ -72,19 +84,10 @@ export class SlackStreamHandler {
         this.messageTs = res.ts;
       }
     } catch (e) {
-      if (
-        isSlackWebAPIPlatformError(e) &&
-        e.data?.error === "message_not_in_streaming_state"
-      ) {
-        this.stopped = true;
-        logger.warn(
-          { connectorId: this.connectorId },
-          "Slack stream expired mid-answer, falling back to chat.update on agent_message_success"
-        );
-        return;
-      }
-
-      throw e;
+      this.handleStreamExpiredError(
+        e,
+        "Slack stream expired mid-answer, falling back to chat.update on agent_message_success"
+      );
     }
   }
 
@@ -93,11 +96,17 @@ export class SlackStreamHandler {
       return;
     }
 
-    this.stopped = true;
-    const res = await this.streamer.stop();
+    try {
+      const res = await this.streamer.stop();
 
-    if (!this.messageTs && res?.ts) {
-      this.messageTs = res.ts;
+      if (!this.messageTs && res?.ts) {
+        this.messageTs = res.ts;
+      }
+    } catch (e) {
+      this.handleStreamExpiredError(
+        e,
+        "Slack stream already expired when stopping — no action needed"
+      );
     }
   }
 }


### PR DESCRIPTION
## Description

Extracts the `message_not_in_streaming_state` error handling into a reusable `handleStreamExpiredError` method and applies it to both `appendText` and `stop` calls. Previously, only `appendText` caught this Slack streaming expiration error (fixed in #24049); `stop()` could still throw when called after the 5-minute streaming window expired. This ensures both code paths gracefully mark the stream as stopped and fall back to `chat.update` on `agent_message_success`.

## Risk

Low. This is a refactoring that consolidates existing error handling logic and extends it to the `stop()` method. The behavior for `appendText` is unchanged.

## Deploy Plan

Deploy connectors.