### PR TITLE
[front] enh: pre-warm mcp action output items gcs

### DIFF
--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -26,10 +26,15 @@ export interface RedisClientOptions {
 const DEFAULT_ISOLATION_POOL_OPTIONS = {
   acquireTimeoutMillis: 10000,
   min: 1,
-  max: 8000,
+  max: 128,
   evictionRunIntervalMillis: 15000,
   idleTimeoutMillis: 30000,
 };
+
+// Default concurrency for batched Redis cache operations (e.g. warming N keys
+// in parallel). Per-URI client is shared and pooled (isolation pool max=128),
+// Meant to be used along concurrentExecutor
+export const REDIS_CACHE_CONCURRENCY = 32;
 
 export type RedisUsageTagsType =
   | "agent_recent_authors"

--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -1,8 +1,9 @@
+import { REDIS_CACHE_CONCURRENCY } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { cacheWithRedis } from "@app/lib/utils/cache";
+import { cacheWithRedis, warmCacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -75,28 +76,62 @@ export async function batchWriteContentsToGcs(
 }
 
 /**
- * Fetches raw JSON content from GCS. Throws on failure (cacheWithRedis propagates the error).
+ * Fetches content from GCS. Throws on failure (cacheWithRedis propagates the error).
  */
 // itemId is unused in the fetch logic but passed to populate the cache key.
 async function fetchGcsContent(
   auth: Authenticator,
   gcsPath: string,
   _itemId: ModelId
-): Promise<string> {
+): Promise<OutputContent> {
   const bucket = getPrivateUploadBucket();
   const file = bucket.file(gcsPath);
 
   const [buffer] = await file.download();
 
-  return buffer.toString("utf-8");
+  return JSON.parse(buffer.toString("utf-8"));
 }
+
+const gcsContentCacheKey = (
+  auth: Authenticator,
+  _gcsPath: string,
+  itemId: ModelId
+) => `w:${auth.getNonNullableWorkspace().sId}:mcp_output:${itemId}`;
 
 const fetchGcsContentCached = cacheWithRedis(
   fetchGcsContent,
-  (auth, _gcsPath, itemId) =>
-    `w:${auth.getNonNullableWorkspace().sId}:mcp_output:${itemId}`,
-  { cacheNullValues: false, ttlMs: GCS_CONTENT_CACHE_TTL_MS }
+  gcsContentCacheKey,
+  {
+    cacheNullValues: false,
+    ttlMs: GCS_CONTENT_CACHE_TTL_MS,
+  }
 );
+
+const warmOneGcsContent = warmCacheWithRedis(
+  fetchGcsContent,
+  gcsContentCacheKey,
+  { ttlMs: GCS_CONTENT_CACHE_TTL_MS }
+);
+
+export async function warmGcsContentCache(
+  auth: Authenticator,
+  items: Array<{
+    itemId: ModelId;
+    gcsPath: string;
+    content: OutputContent;
+  }>
+): Promise<void> {
+  if (items.length === 0) {
+    return;
+  }
+  await concurrentExecutor(
+    items,
+    async ({ itemId, gcsPath, content }) => {
+      await warmOneGcsContent(content, auth, gcsPath, itemId);
+    },
+    { concurrency: REDIS_CACHE_CONCURRENCY }
+  );
+}
 
 /**
  * Fetches content for a single item from cache (LRU) or GCS.
@@ -109,8 +144,8 @@ async function fetchContentFromGcs(
   itemId: ModelId
 ): Promise<Result<OutputContent, Error>> {
   try {
-    const raw = await fetchGcsContentCached(auth, gcsPath, itemId);
-    return new Ok(JSON.parse(raw) as OutputContent);
+    const content = await fetchGcsContentCached(auth, gcsPath, itemId);
+    return new Ok(content);
   } catch (err) {
     logger.error(
       { err: normalizeError(err), gcsPath },

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -3,12 +3,14 @@ import type {
   LightServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPActionModel,
   AgentMCPActionOutputItemModel,
 } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { warmGcsContentCache } from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -379,6 +381,9 @@ describe("Output items with GCS storage", () => {
     workspace = setup.workspace;
     auth = setup.authenticator;
 
+    const redis = await getRedisCacheClient({ origin: "cache_with_redis" });
+    vi.mocked(redis.set).mockClear();
+
     agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent",
     });
@@ -451,6 +456,26 @@ describe("Output items with GCS storage", () => {
 
     // Content should match the GCS version, proving it was read from GCS.
     expect(items![0].content).toEqual({ type: "text", text: "from GCS" });
+  });
+
+  it("warms Redis cache for each item after createOutputItems succeeds", async () => {
+    const { outputItems } = await createActionWithOutputItems([
+      { type: "text", text: "first" },
+      { type: "text", text: "second" },
+    ]);
+
+    const redis = await getRedisCacheClient({ origin: "cache_with_redis" });
+    const setCalls = vi.mocked(redis.set).mock.calls;
+
+    expect(outputItems).toHaveLength(2);
+
+    for (const item of outputItems) {
+      expect(setCalls).toContainEqual([
+        `cacheWithRedis-fetchGcsContent-w:${workspace.sId}:mcp_output:${item.id}`,
+        JSON.stringify(item.content),
+        { PX: 15 * 60 * 1000 },
+      ]);
+    }
   });
 
   it("should destroy output items from both DB and GCS", async () => {
@@ -643,5 +668,71 @@ describe("Output items with GCS storage", () => {
       .map((i) => (i.content as { type: "text"; text: string }).text)
       .sort();
     expect(texts).toEqual(["first", "second"]);
+  });
+});
+
+describe("warmGcsContentCache", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    const redis = await getRedisCacheClient({ origin: "cache_with_redis" });
+    vi.mocked(redis.set).mockClear();
+  });
+
+  it("is a no-op for empty items", async () => {
+    await warmGcsContentCache(auth, []);
+
+    const redis = await getRedisCacheClient({ origin: "cache_with_redis" });
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it("warms each item with the correct key, value, and TTL", async () => {
+    const items = [
+      {
+        itemId: 42,
+        gcsPath: "mcp_output_items/w/x/a/42.json",
+        content: { type: "text" as const, text: "hello" },
+      },
+      {
+        itemId: 43,
+        gcsPath: "mcp_output_items/w/x/a/43.json",
+        content: { type: "text" as const, text: "world" },
+      },
+    ];
+
+    await warmGcsContentCache(auth, items);
+
+    const redis = await getRedisCacheClient({ origin: "cache_with_redis" });
+    const setCalls = vi.mocked(redis.set).mock.calls;
+
+    expect(setCalls).toHaveLength(2);
+
+    for (const item of items) {
+      expect(setCalls).toContainEqual([
+        `cacheWithRedis-fetchGcsContent-w:${workspace.sId}:mcp_output:${item.itemId}`,
+        JSON.stringify(item.content),
+        { PX: 15 * 60 * 1000 },
+      ]);
+    }
+  });
+
+  it("propagates Redis errors", async () => {
+    const redis = await getRedisCacheClient({ origin: "cache_with_redis" });
+    vi.mocked(redis.set).mockRejectedValueOnce(new Error("redis down"));
+
+    await expect(
+      warmGcsContentCache(auth, [
+        {
+          itemId: 1,
+          gcsPath: "mcp_output_items/w/x/a/1.json",
+          content: { type: "text", text: "anything" },
+        },
+      ])
+    ).rejects.toThrow("redis down");
   });
 });

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -38,6 +38,7 @@ import {
   batchFetchContentsFromGcs,
   batchWriteContentsToGcs,
   deleteContentsFromGcs,
+  warmGcsContentCache,
 } from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -698,6 +699,18 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     if (gcsResult.isErr()) {
       return outputItems;
     }
+
+    await warmGcsContentCache(
+      auth,
+      removeNulls(
+        outputItems.map((item) => {
+          const gcsPath = gcsResult.value.get(item.id);
+          return gcsPath
+            ? { itemId: item.id, gcsPath, content: item.content }
+            : null;
+        })
+      )
+    );
 
     // Update DB rows with their GCS paths.
     // TODO(2026-02-25 PERF): Optimize by writing items only once.

--- a/front/lib/utils/cache.test.ts
+++ b/front/lib/utils/cache.test.ts
@@ -36,6 +36,7 @@ import {
   cacheWithRedis,
   invalidateCacheAfterCommit,
   invalidateCacheWithRedis,
+  warmCacheWithRedis,
 } from "@app/lib/utils/cache";
 
 describe("invalidateCacheAfterCommit", () => {
@@ -471,6 +472,80 @@ describe("invalidateCacheWithRedis", () => {
     expect(mockRedisClient.del).toHaveBeenCalledWith(
       "cacheWithRedis-myFunc-foo-42"
     );
+  });
+});
+
+describe("warmCacheWithRedis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedisClient.get.mockReset();
+    mockRedisClient.set.mockReset();
+  });
+
+  it("writes JSON-stringified value at the same key cacheWithRedis would read", async () => {
+    const fn = vi.fn().mockResolvedValue("data");
+    Object.defineProperty(fn, "name", { value: "testFn" });
+    mockRedisClient.set.mockResolvedValue("OK");
+
+    const warm = warmCacheWithRedis(fn, (arg: string) => arg, {
+      ttlMs: 60000,
+    });
+    await warm("data", "key1");
+
+    expect(mockRedisClient.set).toHaveBeenCalledWith(
+      "cacheWithRedis-testFn-key1",
+      JSON.stringify("data"),
+      { PX: 60000 }
+    );
+  });
+
+  it("omits TTL when ttlMs is not provided", async () => {
+    const fn = vi.fn().mockResolvedValue("data");
+    Object.defineProperty(fn, "name", { value: "testFn" });
+    mockRedisClient.set.mockResolvedValue("OK");
+
+    const warm = warmCacheWithRedis(fn, (arg: string) => arg);
+    await warm("data", "key1");
+
+    expect(mockRedisClient.set).toHaveBeenCalledWith(
+      "cacheWithRedis-testFn-key1",
+      JSON.stringify("data")
+    );
+  });
+
+  it("warmed value is then served by cacheWithRedis without invoking fn", async () => {
+    const fn = vi.fn().mockResolvedValue("fresh");
+    Object.defineProperty(fn, "name", { value: "testFn" });
+
+    const cache = new Map<string, string>();
+    mockRedisClient.get.mockImplementation(
+      async (key: string) => cache.get(key) ?? null
+    );
+    mockRedisClient.set.mockImplementation(
+      async (key: string, value: string) => {
+        cache.set(key, value);
+        return "OK";
+      }
+    );
+
+    const resolver = (arg: string) => arg;
+    const warm = warmCacheWithRedis(fn, resolver, { ttlMs: 60000 });
+    const cached = cacheWithRedis(fn, resolver, { ttlMs: 60000 });
+
+    await warm("warmed", "key1");
+    const result = await cached("key1");
+
+    expect(result).toBe("warmed");
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("throws when ttlMs > 24 hours", () => {
+    const fn = vi.fn();
+    expect(() =>
+      warmCacheWithRedis(fn, (arg: string) => arg, {
+        ttlMs: 25 * 60 * 60 * 1000,
+      })
+    ).toThrow("ttlMs should be less than 24 hours");
   });
 });
 

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -163,6 +163,28 @@ export function cacheWithRedis<T, Args extends unknown[]>(
   };
 }
 
+export function warmCacheWithRedis<T, Args extends unknown[]>(
+  fn: CacheableFunction<JsonSerializable<T>, Args>,
+  resolver: KeyResolver<Args>,
+  { ttlMs }: { ttlMs?: number } = {}
+): (value: JsonSerializable<T>, ...args: Args) => Promise<void> {
+  if (ttlMs !== undefined && ttlMs > 60 * 60 * 24 * 1000) {
+    throw new Error("ttlMs should be less than 24 hours");
+  }
+  return async function (
+    value: JsonSerializable<T>,
+    ...args: Args
+  ): Promise<void> {
+    const key = getCacheKey(fn, resolver, args);
+    const redisCli = await getRedisCacheClient({ origin: "cache_with_redis" });
+    if (ttlMs !== undefined) {
+      await redisCli.set(key, JSON.stringify(value), { PX: ttlMs });
+    } else {
+      await redisCli.set(key, JSON.stringify(value));
+    }
+  };
+}
+
 export function invalidateCacheWithRedis<T, Args extends unknown[]>(
   fn: CacheableFunction<JsonSerializable<T>, Args>,
   resolver: KeyResolver<Args>,

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -124,6 +124,7 @@ vi.mock("@app/lib/api/redis", () => ({
   runOnRedis: vi.fn().mockImplementation(mockRunOnRedisImpl),
   runOnRedisCache: vi.fn().mockImplementation(mockRunOnRedisCacheImpl),
   closeRedisClients: vi.fn().mockResolvedValue(undefined),
+  REDIS_CACHE_CONCURRENCY: 32,
 }));
 
 vi.mock("@app/lib/utils/cache", () => ({
@@ -139,6 +140,9 @@ vi.mock("@app/lib/utils/cache", () => ({
         };
       }
     ),
+  warmCacheWithRedis: vi.fn().mockImplementation(() => {
+    return async () => {};
+  }),
   invalidateCacheWithRedis: vi.fn().mockImplementation(() => {
     return async () => {};
   }),


### PR DESCRIPTION
## Description

Full context here: https://app.datadoghq.eu/notebook/306234/1s-avg-ttpc-30-04-2026?refresh_mode=sliding&from_ts=1777369777743&to_ts=1777542577743

We store mcp output items on GCS, and have a redis cache to avoid the ~50ms latency per read (with a low concurrency).
These output items are re-used immediately after we stored them, in the next loop turn, and as of today, we will be guaranteed a cache miss.

This PR puts the content on redis right after it did on GCS, to maximise cache hits.

## Tests

- [x] Tested locally
- [x] Front edge

## Risk

Low - Main risk is busting our cache instance's RAM, but given how small it is we can afford to grow it.


## Deploy Plan

- [ ] Deploy front once confident on the tests.