### PR TITLE
[front] refactor: simplify slash dropdown scroll fade tracking

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -175,22 +175,6 @@ export const SlashCommandDropdown = forwardRef<
       }
 
       updateScrollFadeState();
-      const animationFrame = window.requestAnimationFrame(
-        updateScrollFadeState
-      );
-
-      const list = listRef.current;
-      if (!list || typeof ResizeObserver === "undefined") {
-        return () => window.cancelAnimationFrame(animationFrame);
-      }
-
-      const resizeObserver = new ResizeObserver(updateScrollFadeState);
-      resizeObserver.observe(list);
-
-      return () => {
-        window.cancelAnimationFrame(animationFrame);
-        resizeObserver.disconnect();
-      };
     }, [itemCount, showScrollFade, updateScrollFadeState]);
 
     // Update virtual trigger position.

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -86,6 +86,8 @@ export const SlashCommandDropdown = forwardRef<
     );
     const itemCount = items.length;
     const listRef = useRef<HTMLDivElement>(null);
+    const topScrollSentinelRef = useRef<HTMLDivElement>(null);
+    const bottomScrollSentinelRef = useRef<HTMLDivElement>(null);
     const [virtualTriggerStyle, setVirtualTriggerStyle] =
       useState<React.CSSProperties>({});
 
@@ -136,36 +138,18 @@ export const SlashCommandDropdown = forwardRef<
       [selectItem, selectedIndex, items.length]
     );
 
-    const updateScrollFadeState = useCallback(() => {
+    useEffect(() => {
       const list = listRef.current;
+      const topScrollSentinel = topScrollSentinelRef.current;
+      const bottomScrollSentinel = bottomScrollSentinelRef.current;
 
-      if (!list) {
-        setScrollFadeState(EMPTY_SCROLL_FADE_STATE);
-        return;
-      }
-
-      const nextState = {
-        hasContentAbove: list.scrollTop > 1,
-        hasContentBelow:
-          list.scrollTop + list.clientHeight < list.scrollHeight - 1,
-      };
-
-      setScrollFadeState((previousState) =>
-        previousState.hasContentAbove === nextState.hasContentAbove &&
-        previousState.hasContentBelow === nextState.hasContentBelow
-          ? previousState
-          : nextState
-      );
-    }, []);
-
-    // Reset selected index when items change.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-    useEffect(() => {
-      setSelectedIndex(0);
-    }, [items]);
-
-    useEffect(() => {
-      if (!showScrollFade || itemCount === 0) {
+      if (
+        !showScrollFade ||
+        itemCount === 0 ||
+        !list ||
+        !topScrollSentinel ||
+        !bottomScrollSentinel
+      ) {
         setScrollFadeState((previousState) =>
           previousState.hasContentAbove || previousState.hasContentBelow
             ? EMPTY_SCROLL_FADE_STATE
@@ -174,8 +158,40 @@ export const SlashCommandDropdown = forwardRef<
         return;
       }
 
-      updateScrollFadeState();
-    }, [itemCount, showScrollFade, updateScrollFadeState]);
+      const observer = new IntersectionObserver(
+        (entries) => {
+          setScrollFadeState((previousState) => {
+            const nextState = { ...previousState };
+
+            for (const entry of entries) {
+              if (entry.target === topScrollSentinel) {
+                nextState.hasContentAbove = !entry.isIntersecting;
+              } else if (entry.target === bottomScrollSentinel) {
+                nextState.hasContentBelow = !entry.isIntersecting;
+              }
+            }
+
+            return previousState.hasContentAbove ===
+              nextState.hasContentAbove &&
+              previousState.hasContentBelow === nextState.hasContentBelow
+              ? previousState
+              : nextState;
+          });
+        },
+        { root: list }
+      );
+
+      observer.observe(topScrollSentinel);
+      observer.observe(bottomScrollSentinel);
+
+      return () => observer.disconnect();
+    }, [itemCount, showScrollFade]);
+
+    // Reset selected index when items change.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
+    useEffect(() => {
+      setSelectedIndex(0);
+    }, [items]);
 
     // Update virtual trigger position.
     const updateTriggerPosition = useCallback(() => {
@@ -239,44 +255,55 @@ export const SlashCommandDropdown = forwardRef<
               <div
                 ref={listRef}
                 className={cn("overflow-y-auto", listMaxHeightClassName)}
-                onScroll={showScrollFade ? updateScrollFadeState : undefined}
               >
-                {items.map((item, index) => {
-                  const menuItem = (
-                    <DropdownMenuItem
-                      key={item.id}
-                      icon={item.icon}
-                      itemId={item.id}
-                      label={item.label}
-                      description={item.description}
-                      truncateText
-                      onClick={() => selectItem(index)}
-                      onMouseEnter={() => setSelectedIndex(index)}
-                      className={
-                        index === selectedIndex
-                          ? "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
-                          : ""
-                      }
-                    />
-                  );
-
-                  // Wrap with DropdownTooltipTrigger if command has tooltip property.
-                  if (item.tooltip) {
-                    return (
-                      <DropdownTooltipTrigger
+                <div className="relative">
+                  <div
+                    ref={topScrollSentinelRef}
+                    className="pointer-events-none absolute left-0 top-0 h-px w-px"
+                    aria-hidden
+                  />
+                  <div
+                    ref={bottomScrollSentinelRef}
+                    className="pointer-events-none absolute bottom-0 left-0 h-px w-px"
+                    aria-hidden
+                  />
+                  {items.map((item, index) => {
+                    const menuItem = (
+                      <DropdownMenuItem
                         key={item.id}
-                        description={item.tooltip.description}
-                        media={item.tooltip.media}
-                        side="right"
-                        sideOffset={8}
-                      >
-                        {menuItem}
-                      </DropdownTooltipTrigger>
+                        icon={item.icon}
+                        itemId={item.id}
+                        label={item.label}
+                        description={item.description}
+                        truncateText
+                        onClick={() => selectItem(index)}
+                        onMouseEnter={() => setSelectedIndex(index)}
+                        className={
+                          index === selectedIndex
+                            ? "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
+                            : ""
+                        }
+                      />
                     );
-                  }
 
-                  return menuItem;
-                })}
+                    // Wrap with DropdownTooltipTrigger if command has tooltip property.
+                    if (item.tooltip) {
+                      return (
+                        <DropdownTooltipTrigger
+                          key={item.id}
+                          description={item.tooltip.description}
+                          media={item.tooltip.media}
+                          side="right"
+                          sideOffset={8}
+                        >
+                          {menuItem}
+                        </DropdownTooltipTrigger>
+                      );
+                    }
+
+                    return menuItem;
+                  })}
+                </div>
               </div>
               <div
                 className={cn(

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -148,7 +148,8 @@ export const SlashCommandDropdown = forwardRef<
         itemCount === 0 ||
         !list ||
         !topScrollSentinel ||
-        !bottomScrollSentinel
+        !bottomScrollSentinel ||
+        typeof IntersectionObserver === "undefined"
       ) {
         setScrollFadeState((previousState) =>
           previousState.hasContentAbove || previousState.hasContentBelow


### PR DESCRIPTION
## Description

This PR simplifies how the slash command dropdown decides when to show its top and bottom scroll fades.

It replaces manual scroll measurements, scroll handlers, `requestAnimationFrame`, and `ResizeObserver` wiring with two observed sentinels inside the scroll container. The fade state now follows whether the top and bottom sentinels are visible, which keeps the behavior tied to the browser’s intersection tracking and removes custom scroll math.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
