### PR TITLE
feat(sbx): drop e2b hard ceiling in prod, bump reaper destroy to 4 days

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -182,6 +182,10 @@ const config = {
         EnvironmentConfig.getOptionalEnvVariable("NODE_ENV") || "development",
     };
   },
+  getNodeEnv: (): string => {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    return EnvironmentConfig.getOptionalEnvVariable("NODE_ENV") || "development";
+  },
   getVizJwtSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("VIZ_JWT_SECRET");
   },

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -177,14 +177,14 @@ const config = {
       url:
         EnvironmentConfig.getOptionalEnvVariable("DUST_PROD_API") ??
         PRODUCTION_DUST_API,
-      nodeEnv:
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        EnvironmentConfig.getOptionalEnvVariable("NODE_ENV") || "development",
+      nodeEnv: config.getNodeEnv(),
     };
   },
   getNodeEnv: (): string => {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    return EnvironmentConfig.getOptionalEnvVariable("NODE_ENV") || "development";
+    return (
+      EnvironmentConfig.getOptionalEnvVariable("NODE_ENV") || "development"
+    );
   },
   getVizJwtSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("VIZ_JWT_SECRET");

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -177,14 +177,10 @@ const config = {
       url:
         EnvironmentConfig.getOptionalEnvVariable("DUST_PROD_API") ??
         PRODUCTION_DUST_API,
-      nodeEnv: config.getNodeEnv(),
+      nodeEnv:
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        EnvironmentConfig.getOptionalEnvVariable("NODE_ENV") || "development",
     };
-  },
-  getNodeEnv: (): string => {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    return (
-      EnvironmentConfig.getOptionalEnvVariable("NODE_ENV") || "development"
-    );
   },
   getVizJwtSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("VIZ_JWT_SECRET");

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -1,4 +1,3 @@
-import appConfig from "@app/lib/api/config";
 import {
   formatSandboxImageId,
   type NetworkPolicy,
@@ -16,6 +15,7 @@ import {
   traceSandboxOperation,
 } from "@app/lib/api/sandbox/provider";
 import logger from "@app/logger/logger";
+import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -26,15 +26,16 @@ const ONE_HOUR_MS = 60 * 60 * 1_000;
 const ONE_DAY_MS = 24 * ONE_HOUR_MS;
 
 /**
- * Outside of production, cap sandbox lifetime at 24h (E2B Pro max) so
- * forgotten local sandboxes don't linger. In production, set a 30-day cap:
- * the reaper destroys after 4 days *inactive*, but an actively-used sandbox
- * can keep refreshing its inactivity timer for much longer than 4 days of
- * wall-clock time. 30 days gives any realistic active session plenty of
- * headroom while still keeping a hard E2B-side safety net.
+ * In development, cap sandbox lifetime at 24h (E2B Pro max) so forgotten
+ * local sandboxes don't linger. In production, set a 30-day cap: the reaper
+ * destroys after 4 days *inactive*, but an actively-used sandbox can keep
+ * refreshing its inactivity timer for much longer than 4 days of wall-clock
+ * time. 30 days gives any realistic active session plenty of headroom while
+ * still keeping a hard E2B-side safety net.
  */
-const SANDBOX_LIFETIME_MS =
-  appConfig.getNodeEnv() === "production" ? 30 * ONE_DAY_MS : 24 * ONE_HOUR_MS;
+const SANDBOX_LIFETIME_MS = isDevelopment()
+  ? 24 * ONE_HOUR_MS
+  : 30 * ONE_DAY_MS;
 
 /** Timeout for individual API calls to E2B (create, connect, etc.). */
 const REQUEST_TIMEOUT_MS = 30_000;

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -1,4 +1,4 @@
-import config from "@app/lib/api/config";
+import appConfig from "@app/lib/api/config";
 import {
   formatSandboxImageId,
   type NetworkPolicy,
@@ -22,13 +22,18 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { CommandExitError, NotFoundError, Sandbox } from "e2b";
 
+const ONE_HOUR_MS = 60 * 60 * 1_000;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+
 /**
  * Outside of production, cap sandbox lifetime at 24h (E2B Pro max) so
- * forgotten local sandboxes don't linger. In production, omit `timeoutMs` so
- * the reaper is the sole authority on sandbox lifecycle.
+ * forgotten local sandboxes don't linger. In production, set a generous 7-day
+ * cap so the reaper (which destroys after 4 days idle) is effectively the
+ * sole authority on sandbox lifecycle, while still keeping a hard E2B-side
+ * safety net well above the reaper threshold.
  */
-const SANDBOX_LIFETIME_MS: number | undefined =
-  config.getNodeEnv() !== "production" ? 86_400_000 : undefined;
+const SANDBOX_LIFETIME_MS =
+  appConfig.getNodeEnv() === "production" ? 7 * ONE_DAY_MS : 24 * ONE_HOUR_MS;
 
 /** Timeout for individual API calls to E2B (create, connect, etc.). */
 const REQUEST_TIMEOUT_MS = 30_000;

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import {
   formatSandboxImageId,
   type NetworkPolicy,
@@ -15,7 +16,6 @@ import {
   traceSandboxOperation,
 } from "@app/lib/api/sandbox/provider";
 import logger from "@app/logger/logger";
-import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -23,13 +23,12 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { CommandExitError, NotFoundError, Sandbox } from "e2b";
 
 /**
- * In dev, cap sandbox lifetime at 24h (E2B Pro max) so forgotten local
- * sandboxes don't linger. In prod, omit `timeoutMs` so the reaper is the sole
- * authority on sandbox lifecycle.
+ * Outside of production, cap sandbox lifetime at 24h (E2B Pro max) so
+ * forgotten local sandboxes don't linger. In production, omit `timeoutMs` so
+ * the reaper is the sole authority on sandbox lifecycle.
  */
-const SANDBOX_LIFETIME_MS: number | undefined = isDevelopment()
-  ? 86_400_000
-  : undefined;
+const SANDBOX_LIFETIME_MS: number | undefined =
+  config.getNodeEnv() !== "production" ? 86_400_000 : undefined;
 
 /** Timeout for individual API calls to E2B (create, connect, etc.). */
 const REQUEST_TIMEOUT_MS = 30_000;

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -27,13 +27,14 @@ const ONE_DAY_MS = 24 * ONE_HOUR_MS;
 
 /**
  * Outside of production, cap sandbox lifetime at 24h (E2B Pro max) so
- * forgotten local sandboxes don't linger. In production, set a generous 7-day
- * cap so the reaper (which destroys after 4 days idle) is effectively the
- * sole authority on sandbox lifecycle, while still keeping a hard E2B-side
- * safety net well above the reaper threshold.
+ * forgotten local sandboxes don't linger. In production, set a 30-day cap:
+ * the reaper destroys after 4 days *inactive*, but an actively-used sandbox
+ * can keep refreshing its inactivity timer for much longer than 4 days of
+ * wall-clock time. 30 days gives any realistic active session plenty of
+ * headroom while still keeping a hard E2B-side safety net.
  */
 const SANDBOX_LIFETIME_MS =
-  appConfig.getNodeEnv() === "production" ? 7 * ONE_DAY_MS : 24 * ONE_HOUR_MS;
+  appConfig.getNodeEnv() === "production" ? 30 * ONE_DAY_MS : 24 * ONE_HOUR_MS;
 
 /** Timeout for individual API calls to E2B (create, connect, etc.). */
 const REQUEST_TIMEOUT_MS = 30_000;

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -15,13 +15,21 @@ import {
   traceSandboxOperation,
 } from "@app/lib/api/sandbox/provider";
 import logger from "@app/logger/logger";
+import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { CommandExitError, NotFoundError, Sandbox } from "e2b";
 
-const SANDBOX_LIFETIME_MS = 86_400_000; // 24 hours (E2B Pro max; reaper manages lifecycle)
+/**
+ * In dev, cap sandbox lifetime at 24h (E2B Pro max) so forgotten local
+ * sandboxes don't linger. In prod, omit `timeoutMs` so the reaper is the sole
+ * authority on sandbox lifecycle.
+ */
+const SANDBOX_LIFETIME_MS: number | undefined = isDevelopment()
+  ? 86_400_000
+  : undefined;
 
 /** Timeout for individual API calls to E2B (create, connect, etc.). */
 const REQUEST_TIMEOUT_MS = 30_000;

--- a/front/temporal/sandbox_reaper/config.ts
+++ b/front/temporal/sandbox_reaper/config.ts
@@ -23,10 +23,10 @@ export const PENDING_APPROVAL_THRESHOLD_MS = pendingApprovalThresholdEnv
   ? Number(pendingApprovalThresholdEnv)
   : 30 * 60 * 1_000;
 
-/** Destroy sandboxes that have been inactive for this long. Default: 24 h. */
+/** Destroy sandboxes that have been inactive for this long. Default: 4 days. */
 const destroyThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(
   "SANDBOX_DESTROY_THRESHOLD_MS"
 );
 export const DESTROY_THRESHOLD_MS = destroyThresholdEnv
   ? Number(destroyThresholdEnv)
-  : 24 * 60 * 60 * 1_000;
+  : 4 * 24 * 60 * 60 * 1_000;

--- a/front/temporal/sandbox_reaper/config.ts
+++ b/front/temporal/sandbox_reaper/config.ts
@@ -7,13 +7,17 @@ export const SCHEDULE_ID = "sandbox-reaper-schedule";
 
 export const BATCH_SIZE = 128;
 
+const ONE_MINUTE_MS = 60 * 1_000;
+const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+
 /** Sleep sandboxes that have been inactive for this long. Default: 10 min. */
 const sleepThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(
   "SANDBOX_SLEEP_THRESHOLD_MS"
 );
 export const SLEEP_THRESHOLD_MS = sleepThresholdEnv
   ? Number(sleepThresholdEnv)
-  : 10 * 60 * 1_000;
+  : 10 * ONE_MINUTE_MS;
 
 /** Transition pending_approval sandboxes to sleeping after this long. Default: 30 min. */
 const pendingApprovalThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(
@@ -21,7 +25,7 @@ const pendingApprovalThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(
 );
 export const PENDING_APPROVAL_THRESHOLD_MS = pendingApprovalThresholdEnv
   ? Number(pendingApprovalThresholdEnv)
-  : 30 * 60 * 1_000;
+  : 30 * ONE_MINUTE_MS;
 
 /** Destroy sandboxes that have been inactive for this long. Default: 4 days. */
 const destroyThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(
@@ -29,4 +33,4 @@ const destroyThresholdEnv = EnvironmentConfig.getOptionalEnvVariable(
 );
 export const DESTROY_THRESHOLD_MS = destroyThresholdEnv
   ? Number(destroyThresholdEnv)
-  : 4 * 24 * 60 * 60 * 1_000;
+  : 4 * ONE_DAY_MS;


### PR DESCRIPTION
## Description

Two related sandbox lifecycle tweaks:

1. **E2B timeout decoupled from reaper.** `Sandbox.create` (and the `Sandbox.connect` calls in wake/exec/writeFile/listFiles) now pass an explicit `timeoutMs`:
   - **Prod:** 30 days. The reaper destroys after 4 days *inactive*, but an actively-used sandbox can keep refreshing its inactivity timer well beyond 4 days of wall-clock time, so the prod cap needs to sit comfortably above any realistic active-session length. E2B remains a hard safety net.
   - **Dev:** 24h (E2B Pro max) so forgotten local sandboxes still get cleaned up.
2. **Reaper destroy threshold bumped from 24h to 4 days.** `SANDBOX_DESTROY_THRESHOLD_MS` now defaults to 4 days. Sleep (10 min) and pending-approval (30 min) thresholds are unchanged. The destroy threshold applies to *sleeping* sandboxes — running ones go through the sleep path first.

Drive-by 🚗: extracted `ONE_MINUTE_MS` / `ONE_HOUR_MS` / `ONE_DAY_MS` constants in the reaper config and e2b provider for readability.

## Tests

- Typechecks clean (`tsc --noEmit`).
- Manual verification suggested before/after rollout: spin up a sandbox in prod, leave it idle past the previous 24h E2B ceiling, confirm it survives and that the reaper sleeps it on the normal 10-min cadence.

## Risk

- **Storage / cost:** longer destroy threshold means sleeping sandboxes can hang around up to 4 days. Sleep is the dominant state and is cheap, so cost impact should be small — worth watching the sandbox table size after rollout.
- **E2B safety net:** the 30-day prod cap sits well above the reaper's 4-day destroy horizon, so a stalled reaper can't keep sandboxes alive forever — E2B will reclaim them eventually.
- Rollback is a straightforward revert; no migrations. `SANDBOX_DESTROY_THRESHOLD_MS` env override is still respected if we want to tune without a deploy.

## Deploy Plan

- [ ] Merge → deploy front (web + temporal worker that runs the reaper)
- [ ] Confirm the reaper schedule is still firing every 5 min and reads the new 4-day default from `config.ts`
- [ ] Watch sandbox count / E2B errors for the first 24h