### PR TITLE
refactor(sbx): drop redundant model bits on workspace_sandbox_env_vars

### DIFF
--- a/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
+++ b/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
@@ -38,22 +38,6 @@ WorkspaceSandboxEnvVarModel.init(
       type: DataTypes.TEXT,
       allowNull: false,
     },
-    createdByUserId: {
-      type: DataTypes.BIGINT,
-      allowNull: true,
-      references: {
-        model: UserModel,
-        key: "id",
-      },
-    },
-    lastUpdatedByUserId: {
-      type: DataTypes.BIGINT,
-      allowNull: true,
-      references: {
-        model: UserModel,
-        key: "id",
-      },
-    },
   },
   {
     modelName: "workspace_sandbox_env_var",
@@ -63,18 +47,6 @@ WorkspaceSandboxEnvVarModel.init(
         name: "workspace_sandbox_env_vars_workspace_name_idx",
         unique: true,
         fields: ["workspaceId", "name"],
-      },
-      {
-        name: "workspace_sandbox_env_vars_workspace_id_idx",
-        fields: ["workspaceId"],
-      },
-      {
-        name: "workspace_sandbox_env_vars_created_by_user_id_idx",
-        fields: ["createdByUserId"],
-      },
-      {
-        name: "workspace_sandbox_env_vars_last_updated_by_user_id_idx",
-        fields: ["lastUpdatedByUserId"],
       },
     ],
   }

--- a/front/migrations/db/migration_615.sql
+++ b/front/migrations/db/migration_615.sql
@@ -1,0 +1,8 @@
+-- Migration created on Apr 30, 2026
+-- Drop redundant indexes on workspace_sandbox_env_vars: the workspaceId-only
+-- lookup is served by the leftmost prefix of the (workspaceId, name) unique
+-- index, and the createdByUserId / lastUpdatedByUserId columns are never
+-- queried directly (joins go through users.id).
+DROP INDEX CONCURRENTLY IF EXISTS "workspace_sandbox_env_vars_workspace_id_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "workspace_sandbox_env_vars_created_by_user_id_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "workspace_sandbox_env_vars_last_updated_by_user_id_idx";


### PR DESCRIPTION
## Description

Follow-up on Flav's review of #25015. Drops redundant declarations on `WorkspaceSandboxEnvVarModel`:

- Drops the explicit `references: { model: UserModel, key: "id" }` blocks on `createdByUserId` / `lastUpdatedByUserId`. The `belongsTo(UserModel)` calls at the bottom of the file already declare those FKs.
- Drops the single-column `workspaceId` index. Workspace-only lookups are already served by the leftmost prefix of the existing `(workspaceId, name)` unique index.
- Drops the `createdByUserId` / `lastUpdatedByUserId` indexes. We never query by these columns; joins via `belongsTo(UserModel)` go through `users.id`.

`migration_614.sql` drops the three indexes with `DROP INDEX CONCURRENTLY IF EXISTS`.

## Tests
NA
## Risk

Low. The dropped indexes are unused — workspace-scoped queries hit the composite index via leftmost prefix, and we never filter by `createdByUserId` / `lastUpdatedByUserId`. The `references` removal is purely declarative (Sequelize's `belongsTo` already emits the FK at create time).

Rollback: revert the commit and add the indexes back with `CREATE INDEX CONCURRENTLY` if needed.

## Deploy Plan

1. Merge.
2. Run `migration_614.sql` (uses `CONCURRENTLY` so no table lock).
3. Done — no app-side coordination needed.


migration is safe