### PR TITLE
Handle "column not found" gracefully

### DIFF
--- a/connectors/src/connectors/microsoft/lib/utils.ts
+++ b/connectors/src/connectors/microsoft/lib/utils.ts
@@ -1,5 +1,6 @@
 // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 import { clientApiGet } from "@connectors/connectors/microsoft/lib/graph_api";
+import { isItemNotFoundError } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
 import { MicrosoftNodeResource } from "@connectors/resources/microsoft_resource";
 import { cacheWithRedis } from "@connectors/types";
 import type { LoggerInterface } from "@dust-tt/client";
@@ -116,8 +117,19 @@ export async function _getListColumns({
   listId: string;
 }): Promise<ColumnDefinition[]> {
   const endpoint = `/sites/${siteId}/lists/${listId}/columns`;
-  const res = await clientApiGet(logger, client, endpoint);
-  return res.value.filter(isCustomColumn);
+  try {
+    const res = await clientApiGet(logger, client, endpoint);
+    return res.value.filter(isCustomColumn);
+  } catch (e) {
+    if (isItemNotFoundError(e)) {
+      logger.warn(
+        { siteId, listId },
+        "List not found (deleted?), skipping columns."
+      );
+      return [];
+    }
+    throw e;
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

When a SharePoint list is deleted on the Microsoft side, the Graph API returns a 404 `itemNotFound` error when the connector calls `/sites/${siteId}/lists/${listId}/columns` in `_getListColumns`. Because the error was previously thrown rather than handled, `cacheWithRedis` never cached the result — meaning every file referencing the same deleted list would make a fresh Graph API call on each sync cycle, generating a new 404 each time.

This was causing ~2,000+ error logs per day for a single affected connector.

**Changes:**
- In `_getListColumns`: catch `GraphError` with `statusCode === 404` (`itemNotFound`), log a `warn`, and return `[]`. This lets `cacheWithRedis` cache the empty result, so subsequent files sharing the same `siteId`/`listId` skip the API call for the duration of the TTL.
- In `getColumnsFromListItem`: downgrade the catch block log from `error` to `warn`, since a deleted list is an expected external state.

All other error codes continue to throw and propagate normally.

## Risk

Low. Only adds error handling for a known Graph API error type (`itemNotFound`). Lists that are genuinely deleted will skip column extraction but won't block the sync workflow.

## Deploy Plan

Deploy connectors.