### PR TITLE
[front] enh(skills): fetch inherited skill data source views once

### DIFF
--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -30,14 +30,13 @@ export async function getSkillServers(
   }
 ): Promise<MCPServerConfigurationType[]> {
   let inheritedDataSourceViews: DataSourceViewResource[] = [];
-  if (skills.some(
-    (skill) => skill.inheritsAgentConfigurationDataSources
-  )) {
+  if (skills.some((skill) => skill.inheritsAgentConfigurationDataSources)) {
     inheritedDataSourceViews = await DataSourceViewResource.listBySpaceIds(
-        auth,
-        agentConfiguration.requestedSpaceIds,
-        { includeGlobalSpace: true }
-      )}
+      auth,
+      agentConfiguration.requestedSpaceIds,
+      { includeGlobalSpace: true }
+    );
+  }
 
   const remoteDbViews = inheritedDataSourceViews.filter((v) =>
     isRemoteDatabase(v.dataSource)

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -8,7 +8,6 @@ import { isRemoteDatabase } from "@app/lib/data_sources";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   AgentConfigurationType,
   LightAgentConfigurationType,
@@ -30,14 +29,15 @@ export async function getSkillServers(
     skills: (SkillResource & { extendedSkill?: SkillResource | null })[];
   }
 ): Promise<MCPServerConfigurationType[]> {
-  const rawInheritedDataSourceViews = await concurrentExecutor(
-    skills,
-    (skill) => skill.listInheritedDataSourceViews(auth, agentConfiguration),
-    { concurrency: 5 }
-  );
-  const inheritedDataSourceViews = removeNulls(
-    rawInheritedDataSourceViews.flat()
-  );
+  let inheritedDataSourceViews: DataSourceViewResource[] = [];
+  if (skills.some(
+    (skill) => skill.inheritsAgentConfigurationDataSources
+  )) {
+    inheritedDataSourceViews = await DataSourceViewResource.listBySpaceIds(
+        auth,
+        agentConfiguration.requestedSpaceIds,
+        { includeGlobalSpace: true }
+      )}
 
   const remoteDbViews = inheritedDataSourceViews.filter((v) =>
     isRemoteDatabase(v.dataSource)

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -328,6 +328,21 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return SystemSkillsRegistry.isSystemSkill(this.sId);
   }
 
+  get inheritsAgentConfigurationDataSources(): boolean {
+    if (!this.globalSId) {
+      return false;
+    }
+
+    return (
+      GlobalSkillsRegistry.doesSkillInheritAgentConfigurationDataSources(
+        this.globalSId
+      ) ||
+      SystemSkillsRegistry.doesSkillInheritAgentConfigurationDataSources(
+        this.globalSId
+      )
+    );
+  }
+
   get isExtendable(): boolean {
     // System skills are baseline capabilities: they are not meant to be extended.
     return this.globalSId !== null && !this.isSystemSkill;
@@ -1831,32 +1846,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     return shouldReturnEditedByUser ? editedByUser : null;
-  }
-
-  async listInheritedDataSourceViews(
-    auth: Authenticator,
-    agentConfiguration: LightAgentConfigurationType
-  ): Promise<DataSourceViewResource[] | null> {
-    if (!this.globalSId) {
-      return null;
-    }
-
-    if (
-      !GlobalSkillsRegistry.doesSkillInheritAgentConfigurationDataSources(
-        this.globalSId
-      ) &&
-      !SystemSkillsRegistry.doesSkillInheritAgentConfigurationDataSources(
-        this.globalSId
-      )
-    ) {
-      return null;
-    }
-
-    return DataSourceViewResource.listBySpaceIds(
-      auth,
-      agentConfiguration.requestedSpaceIds,
-      { includeGlobalSpace: true }
-    );
   }
 
   async archive(auth: Authenticator): Promise<{ affectedCount: number }> {


### PR DESCRIPTION
## Description

When we resolve skill MCP servers, we currently may fetch the same data source views more than once via `listInheritedDataSourceViews`.
In practice not a major issue but still a bad pattern we do not want to see repeated.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
