### PR TITLE
feat(sbx): inject workspace env vars at sandbox boot

### DIFF
--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -238,6 +238,17 @@ export function EnvironmentSection() {
           after saving, only overwritten or deleted.
         </ContentMessage>
 
+        <ContentMessage
+          variant="info"
+          icon={InformationCircleIcon}
+          size="lg"
+          title="Changes apply to new sandboxes only"
+        >
+          Env vars are snapshotted at sandbox boot. Running sandboxes keep
+          their original values; new sandboxes (new conversations, restarts)
+          pick up the latest.
+        </ContentMessage>
+
         <div className="flex justify-end">
           <Button
             label="Add variable"

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -244,9 +244,9 @@ export function EnvironmentSection() {
           size="lg"
           title="Changes apply to new sandboxes only"
         >
-          Env vars are snapshotted at sandbox boot. Running sandboxes keep
-          their original values; new sandboxes (new conversations, restarts)
-          pick up the latest.
+          Env vars are snapshotted at sandbox boot. Running sandboxes keep their
+          original values; new sandboxes (new conversations, restarts) pick up
+          the latest.
         </ContentMessage>
 
         <div className="flex justify-end">

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -4,15 +4,21 @@ const {
   mockDeleteSandboxPolicy,
   mockDistribution,
   mockExecuteWithLock,
+  mockGetSandboxImage,
   mockGetSandboxProvider,
+  mockProviderCreate,
   mockProviderDestroy,
+  mockProviderExec,
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
   mockDeleteSandboxPolicy: vi.fn(),
   mockDistribution: vi.fn(),
   mockExecuteWithLock: vi.fn(),
+  mockGetSandboxImage: vi.fn(),
   mockGetSandboxProvider: vi.fn(),
+  mockProviderCreate: vi.fn(),
   mockProviderDestroy: vi.fn(),
+  mockProviderExec: vi.fn(),
   mockRevokeAllExecTokensForSandbox: vi.fn(),
 }));
 
@@ -35,18 +41,25 @@ vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
   deleteSandboxPolicy: mockDeleteSandboxPolicy,
 }));
 
+vi.mock("@app/lib/api/sandbox/image", () => ({
+  getSandboxImage: mockGetSandboxImage,
+}));
+
 vi.mock("@app/lib/lock", () => ({
   executeWithLock: mockExecuteWithLock,
 }));
 
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Ok } from "@app/types/shared/result";
+import { encrypt } from "@app/types/shared/utils/encryption";
 
 describe("SandboxResource.updateStatus", () => {
   let authenticator: Authenticator;
@@ -205,5 +218,112 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
       conversation.sId
     );
     expect(reloaded?.status).toBe("deleted");
+  });
+});
+
+describe("SandboxResource.ensureActive", () => {
+  let authenticator: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      create: mockProviderCreate,
+      destroy: mockProviderDestroy,
+      exec: mockProviderExec,
+    });
+    mockGetSandboxImage.mockReturnValue(
+      new Ok({
+        toCreateConfig: () => ({
+          imageId: { name: "test-image", tag: "latest" },
+          envVars: {
+            DST_API_TOKEN: "image-token",
+            DD_API_KEY: "image-dd-token",
+            WORKSPACE_ID: "image-workspace-id",
+          },
+          network: { egress: "restricted" },
+          resources: { cpu: 1, memoryMB: 512 },
+        }),
+      })
+    );
+    mockProviderCreate.mockResolvedValue(new Ok({ providerId: "provider-id" }));
+    mockProviderExec.mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+    );
+
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+  });
+
+  it("passes workspace env vars to provider.create with image and system precedence", async () => {
+    const workspace = authenticator.getNonNullableWorkspace();
+    const user = authenticator.getNonNullableUser();
+
+    // Bypass DST_ prefix validation via direct bulkCreate to verify
+    // defense-in-depth: image and system layers must win even if a row
+    // somehow lands in the table without the DST_ prefix.
+    await WorkspaceSandboxEnvVarModel.bulkCreate([
+      {
+        workspaceId: workspace.id,
+        name: "DST_API_TOKEN",
+        encryptedValue: encrypt({
+          text: "workspace-token",
+          key: workspace.sId,
+          useCase: "developer_secret",
+        }),
+        createdByUserId: user.id,
+        lastUpdatedByUserId: user.id,
+      },
+      {
+        workspaceId: workspace.id,
+        name: "DD_API_KEY",
+        encryptedValue: encrypt({
+          text: "workspace-dd-token",
+          key: workspace.sId,
+          useCase: "developer_secret",
+        }),
+        createdByUserId: user.id,
+        lastUpdatedByUserId: user.id,
+      },
+      {
+        workspaceId: workspace.id,
+        name: "WORKSPACE_ID",
+        encryptedValue: encrypt({
+          text: "workspace-overridden-id",
+          key: workspace.sId,
+          useCase: "developer_secret",
+        }),
+        createdByUserId: user.id,
+        lastUpdatedByUserId: user.id,
+      },
+    ]);
+
+    const result = await SandboxResource.ensureActive(
+      authenticator,
+      conversation
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockProviderCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envVars: expect.objectContaining({
+          DST_API_TOKEN: "image-token",
+          DD_API_KEY: config.getDatadogApiKey() ?? "",
+          CONVERSATION_ID: conversation.sId,
+          WORKSPACE_ID: workspace.sId,
+        }),
+      }),
+      { workspaceId: workspace.sId }
+    );
   });
 });

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -25,6 +25,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -324,6 +325,31 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     );
   }
 
+  // Compose the env vars passed to provider.create. Precedence (lowest →
+  // highest): workspace env vars → image runEnv → system vars. The image and
+  // system layers always win, so even if a row slips past the DST_ prefix
+  // validation it cannot shadow a system var like CONVERSATION_ID.
+  private static async buildSandboxEnvVars(
+    auth: Authenticator,
+    conversation: ConversationType,
+    imageEnvVars: Record<string, string> | undefined
+  ): Promise<Result<Record<string, string>, Error>> {
+    const workspaceEnvResult =
+      await WorkspaceSandboxEnvVarResource.loadEnv(auth);
+    if (workspaceEnvResult.isErr()) {
+      return workspaceEnvResult;
+    }
+
+    return new Ok({
+      ...workspaceEnvResult.value,
+      ...imageEnvVars,
+      DD_API_KEY: config.getDatadogApiKey() ?? "",
+      DD_HOST: "http-intake.logs.datadoghq.eu",
+      CONVERSATION_ID: conversation.sId,
+      WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
+    });
+  }
+
   /**
    * Ensure a running sandbox exists for the given conversation.
    *
@@ -353,17 +379,19 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         }
 
         const createConfig = imageResult.value.toCreateConfig();
+        const envVarsResult = await this.buildSandboxEnvVars(
+          auth,
+          conversation,
+          createConfig.envVars
+        );
+        if (envVarsResult.isErr()) {
+          return new Err(envVarsResult.error);
+        }
 
         const createResult = await provider.create(
           {
             ...createConfig,
-            envVars: {
-              ...createConfig.envVars,
-              DD_API_KEY: config.getDatadogApiKey() ?? "",
-              DD_HOST: "http-intake.logs.datadoghq.eu",
-              CONVERSATION_ID: conversation.sId,
-              WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
-            },
+            envVars: envVarsResult.value,
           },
           tracingOpts
         );
@@ -456,17 +484,19 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           }
 
           const createConfig = imageResult.value.toCreateConfig();
+          const envVarsResult = await this.buildSandboxEnvVars(
+            auth,
+            conversation,
+            createConfig.envVars
+          );
+          if (envVarsResult.isErr()) {
+            return new Err(envVarsResult.error);
+          }
 
           const createResult = await provider.create(
             {
               ...createConfig,
-              envVars: {
-                ...createConfig.envVars,
-                DD_API_KEY: config.getDatadogApiKey() ?? "",
-                DD_HOST: "http-intake.logs.datadoghq.eu",
-                CONVERSATION_ID: conversation.sId,
-                WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
-              },
+              envVars: envVarsResult.value,
             },
             tracingOpts
           );


### PR DESCRIPTION
## Description

Wires workspace sandbox env vars into the sandbox process environment at create / recreate time. Until now, admins could create / rotate / delete env vars via the existing `/developers/sandbox` admin UI — but those values had no effect at runtime. This PR closes that loop.

### Implementation

- New private static helper `SandboxResource.buildSandboxEnvVars(auth, conversation, imageEnvVars)` returning `Result<Record<string, string>, Error>`.
- Composition order (lowest → highest precedence):
  1. workspace env vars (decrypted via `WorkspaceSandboxEnvVarResource.loadEnv`)
  2. image `runEnv`
  3. system vars: `DD_API_KEY`, `DD_HOST`, `CONVERSATION_ID`, `WORKSPACE_ID`
- Replaces the two duplicated inline `envVars: { ...createConfig.envVars, DD_API_KEY, DD_HOST, CONVERSATION_ID, WORKSPACE_ID }` literals at the two `provider.create` sites in `ensureActive` (the no-existing-sandbox branch and the deleted-recreate branch) with a single call to the helper.
- Snapshot at create time. Rotation hits the next boot — there's no live update of running sandbox env.
- Fail-closed: any `Err` from `loadEnv` (decrypt failure) bubbles up and aborts the whole sandbox boot.

The image and system layers always win, so even if a row somehow lands in the table without the `DST_` prefix it cannot shadow a system var like `CONVERSATION_ID`. This is defense-in-depth — the validation at write time is the primary defense.

## Tests

- New `describe("SandboxResource.ensureActive")` block in `front/lib/resources/sandbox_resource.test.ts`. Seeds three workspace env vars via `WorkspaceSandboxEnvVarModel.bulkCreate` (deliberately bypassing `DST_` validation): one image-clobbered (`DST_API_TOKEN`), two system-clobbered (`DD_API_KEY`, `WORKSPACE_ID`). Asserts the merged envVars passed to `provider.create` reflect the documented precedence (image wins over workspace; system wins over both).
## Risk

Low. The feature remains gated by the existing `sandbox_tools` Dust-only flag (the admin UI is the only way to create env vars; until that's enabled for a workspace, `loadEnv` returns an empty object and the merge is a no-op).

If `loadEnv` fails (e.g. corrupt ciphertext from a key rotation gone wrong), sandbox boot fails for the affected workspace. Acceptable: failing closed is the right call for a credentials store, and the workspace can recover by rotating the offending var.

Rollback: revert. No migrations, no schema change, no flag change.

## Deploy Plan

1. Merge.
2. Deploy `front`.
3. Smoke-test on a Dust workspace with `sandbox_tools` enabled: create a `DST_FOO` env var via `/developers/sandbox`, trigger a fresh sandbox in a new conversation, confirm via `python -c "import os; print('DST_FOO' in os.environ)"` that it returns `True`.