### PR TITLE
Slack bot: Tool approval state

### DIFF
--- a/connectors/src/connectors/slack/chat/action_utils.ts
+++ b/connectors/src/connectors/slack/chat/action_utils.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 // tool type system (ServerSideMCPToolType doesn't carry displayLabels).
 // Fall back to the label defined in the run_agent server metadata.
 const RUN_AGENT_RUNNING_LABEL = "Running agent";
+export const AWAITING_USER_PERMISSION_LABEL = "Awaiting user permission";
 
 export function getActionRunningLabel(action: AgentActionPublicType): string {
   if (action.displayLabels?.running) {

--- a/connectors/src/connectors/slack/chat/action_utils.ts
+++ b/connectors/src/connectors/slack/chat/action_utils.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 // tool type system (ServerSideMCPToolType doesn't carry displayLabels).
 // Fall back to the label defined in the run_agent server metadata.
 const RUN_AGENT_RUNNING_LABEL = "Running agent";
-export const AWAITING_USER_PERMISSION_LABEL = "Awaiting user permission";
+export const AWAITING_TOOL_APPROVAL_LABEL = "Awaiting tool approval";
 
 export function getActionRunningLabel(action: AgentActionPublicType): string {
   if (action.displayLabels?.running) {

--- a/connectors/src/connectors/slack/chat/plan_message_handler.ts
+++ b/connectors/src/connectors/slack/chat/plan_message_handler.ts
@@ -1,4 +1,5 @@
 import {
+  AWAITING_USER_PERMISSION_LABEL,
   getActionDetails,
   getActionDoneLabel,
   getActionRunningLabel,
@@ -111,6 +112,14 @@ export class PlanMessageHandler {
     });
   }
 
+  setTaskAwaitingUserPermission(taskId: string = "default"): void {
+    this.taskCards.set(taskId, {
+      taskId,
+      title: AWAITING_USER_PERMISSION_LABEL,
+      status: "pending",
+    });
+  }
+
   private async handleChildStreamEvent(
     taskId: string,
     event: AgentEvent
@@ -138,6 +147,11 @@ export class PlanMessageHandler {
           sources: getActionSources(event.action),
         });
         await this.upsertPlanMessage(label);
+        return "continue";
+      }
+      case "tool_approve_execution": {
+        this.setTaskAwaitingUserPermission(taskId);
+        await this.upsertPlanMessage(AWAITING_USER_PERMISSION_LABEL);
         return "continue";
       }
       case "agent_message_success":

--- a/connectors/src/connectors/slack/chat/plan_message_handler.ts
+++ b/connectors/src/connectors/slack/chat/plan_message_handler.ts
@@ -1,5 +1,5 @@
 import {
-  AWAITING_USER_PERMISSION_LABEL,
+  AWAITING_TOOL_APPROVAL_LABEL,
   getActionDetails,
   getActionDoneLabel,
   getActionRunningLabel,
@@ -112,10 +112,10 @@ export class PlanMessageHandler {
     });
   }
 
-  setTaskAwaitingUserPermission(taskId: string = "default"): void {
+  setTaskAwaitingToolApproval(taskId: string = "default"): void {
     this.taskCards.set(taskId, {
       taskId,
-      title: AWAITING_USER_PERMISSION_LABEL,
+      title: AWAITING_TOOL_APPROVAL_LABEL,
       status: "pending",
     });
   }
@@ -150,8 +150,8 @@ export class PlanMessageHandler {
         return "continue";
       }
       case "tool_approve_execution": {
-        this.setTaskAwaitingUserPermission(taskId);
-        await this.upsertPlanMessage(AWAITING_USER_PERMISSION_LABEL);
+        this.setTaskAwaitingToolApproval(taskId);
+        await this.upsertPlanMessage(AWAITING_TOOL_APPROVAL_LABEL);
         return "continue";
       }
       case "agent_message_success":

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -1,4 +1,5 @@
 import {
+  AWAITING_USER_PERMISSION_LABEL,
   getActionDoneLabel,
   getActionRunningLabel,
   getRunAgentNotificationOutput,
@@ -279,6 +280,10 @@ async function streamAgentAnswerToSlack(
           botId: undefined,
           slackChatBotMessageId: slackChatBotMessage.id,
         });
+
+        planHandler.setTaskAwaitingUserPermission();
+        await planHandler.upsertPlanMessage(AWAITING_USER_PERMISSION_LABEL);
+        await streamHandler.setThinking(AWAITING_USER_PERMISSION_LABEL);
 
         if (slackUserId && !slackUserInfo.is_bot) {
           await slackClient.chat.postEphemeral({

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -1,5 +1,5 @@
 import {
-  AWAITING_USER_PERMISSION_LABEL,
+  AWAITING_TOOL_APPROVAL_LABEL,
   getActionDoneLabel,
   getActionRunningLabel,
   getRunAgentNotificationOutput,
@@ -281,9 +281,9 @@ async function streamAgentAnswerToSlack(
           slackChatBotMessageId: slackChatBotMessage.id,
         });
 
-        planHandler.setTaskAwaitingUserPermission();
-        await planHandler.upsertPlanMessage(AWAITING_USER_PERMISSION_LABEL);
-        await streamHandler.setThinking(AWAITING_USER_PERMISSION_LABEL);
+        planHandler.setTaskAwaitingToolApproval();
+        await planHandler.upsertPlanMessage(AWAITING_TOOL_APPROVAL_LABEL);
+        await streamHandler.setThinking(AWAITING_TOOL_APPROVAL_LABEL);
 
         if (slackUserId && !slackUserInfo.is_bot) {
           await slackClient.chat.postEphemeral({


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/7921

Before (during tool approval):

<img width="414" height="146" alt="Screenshot 2026-04-30 at 13 49 54" src="https://github.com/user-attachments/assets/0e3d70ae-5b30-4e07-801a-6e148174fb6c" />

After (during tool approval):

<img width="471" height="162" alt="Screenshot 2026-04-30 at 13 49 11" src="https://github.com/user-attachments/assets/d62fb348-8408-4456-bbfa-a8cd5a6622cc" />

## Tests

Tested locally e2e

## Risk

Low

## Deploy Plan

- deploy `connectors`