### PR TITLE
[front] chore: fix N+1 query in email webhook

### DIFF
--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -1,5 +1,4 @@
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import {
   createConversation,
   postNewContentFragment,
@@ -507,31 +506,24 @@ export async function userAndWorkspaceFromEmail({
   });
 }
 
-export async function emailAssistantMatcher({
-  auth,
+export function emailAssistantMatcher({
   targetEmail,
+  allAgentConfigurations,
 }: {
-  auth: Authenticator;
   targetEmail: string;
-}): Promise<
-  Result<
-    {
-      agentConfiguration: LightAgentConfigurationType;
-    },
-    EmailTriggerError
-  >
+  allAgentConfigurations: LightAgentConfigurationType[];
+}): Result<
+  {
+    agentConfiguration: LightAgentConfigurationType;
+  },
+  EmailTriggerError
 > {
-  const agentConfigurations = await getAgentConfigurationsForView({
-    auth,
-    agentsGetView: "list",
-    variant: "light",
-    limit: undefined,
-    sort: undefined,
-  });
-
   const agentPrefix = targetEmail.split("@")[0];
 
-  const matchingAgents = filterAndSortAgents(agentConfigurations, agentPrefix);
+  const matchingAgents = filterAndSortAgents(
+    allAgentConfigurations,
+    agentPrefix
+  );
   if (matchingAgents.length === 0) {
     return new Err({
       type: "assistant_not_found",
@@ -582,15 +574,16 @@ export async function splitThreadContent(content: string) {
  * Stores email context in Redis and the reply is sent by the agent loop
  * finalization activity when the message completes.
  */
-export async function triggerFromEmail({
-  auth,
-  agentConfigurations,
-  email,
-}: {
-  auth: Authenticator;
-  agentConfigurations: LightAgentConfigurationType[];
-  email: InboundEmail;
-}): Promise<
+export async function triggerFromEmail(
+  auth: Authenticator,
+  {
+    agentConfigurations,
+    email,
+  }: {
+    agentConfigurations: LightAgentConfigurationType[];
+    email: InboundEmail;
+  }
+): Promise<
   Result<
     {
       conversation: ConversationType;

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import type {
   EmailAttachment,
   EmailTriggerError,
@@ -35,13 +36,14 @@ import { config as regionsConfig } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isSupportedFileContentType } from "@app/types/files";
 import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isString, removeNulls } from "@app/types/shared/utils/general";
+import { isString } from "@app/types/shared/utils/general";
 import { IncomingForm } from "formidable";
 import { readFile } from "fs/promises";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -512,30 +514,34 @@ async function handler(
         return;
       }
 
-      const agentConfigurations = removeNulls(
-        await Promise.all(
-          targetEmails.map(async (targetEmail) => {
-            const matchRes = await emailAssistantMatcher({
-              auth,
-              targetEmail,
-            });
-            if (matchRes.isErr()) {
-              await replyToError(email, matchRes.error);
-              return null;
-            }
+      const allAgentConfigurations = await getAgentConfigurationsForView({
+        auth,
+        agentsGetView: "list",
+        variant: "light",
+        limit: undefined,
+        sort: undefined,
+      });
 
-            return matchRes.value.agentConfiguration;
-          })
-        )
-      );
+      let agentConfigurations: LightAgentConfigurationType[] = [];
+      for (const targetEmail of targetEmails) {
+        const matchResult = await emailAssistantMatcher({
+          allAgentConfigurations,
+          targetEmail,
+        });
+        if (matchResult.isErr()) {
+          await replyToError(email, matchResult.error);
+          continue;
+        }
+
+        agentConfigurations.push(matchResult.value.agentConfiguration);
+      }
 
       if (agentConfigurations.length === 0) {
         return;
       }
 
       // Trigger async processing - reply will be sent by finalization activity.
-      const triggerRes = await triggerFromEmail({
-        auth,
+      const triggerRes = await triggerFromEmail(auth, {
         agentConfigurations,
         email,
       });

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -524,7 +524,7 @@ async function handler(
 
       let agentConfigurations: LightAgentConfigurationType[] = [];
       for (const targetEmail of targetEmails) {
-        const matchResult = await emailAssistantMatcher({
+        const matchResult = emailAssistantMatcher({
           allAgentConfigurations,
           targetEmail,
         });


### PR DESCRIPTION
## Description

- This PR fixes a N+1 query in the email webhook trigger, where we loop over target emails to send and fetch the same agent configurations for each one of them in an unbounded `Promise.all`.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
