### PR TITLE
[front] - refactor(InputBar): remove pasted URL no-match notification logic

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -782,11 +782,6 @@ const InputBarContainer = ({
       }
     }
 
-    sendNotification({
-      title: "No match for URL",
-      description: `Pasted URL does not match any content in knowledge. ${nodeOrUrlCandidate?.provider === "microsoft" ? "(Microsoft URLs are not supported)" : ""}`,
-      type: "info",
-    });
     setNodeOrUrlCandidate(null);
   }, [
     searchResultNodes,
@@ -795,7 +790,6 @@ const InputBarContainer = ({
     editorService,
     spacesMap,
     nodeOrUrlCandidate,
-    sendNotification,
     isSpacesLoading,
   ]);
 


### PR DESCRIPTION
## Description

This PR removes the notification that informed users when a pasted URL does not match knowledge content

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front