### PR TITLE
[front] coupons: model fixes before Metronome integration (1.4)

### DIFF
--- a/front/components/poke/coupons/CreateCouponForm.tsx
+++ b/front/components/poke/coupons/CreateCouponForm.tsx
@@ -2,10 +2,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import type { CreatePokeCouponResponseBody } from "@app/pages/api/poke/coupons/index";
 import type { CouponDiscountType } from "@app/types/coupon";
-import {
-  CouponDiscountTypeSchema,
-  CreateCouponBodySchema,
-} from "@app/types/coupon";
+import { CreateCouponBodySchema } from "@app/types/coupon";
 import { isString } from "@app/types/shared/utils/general";
 import {
   Button,
@@ -21,31 +18,35 @@ interface FormState {
   code: string;
   description: string;
   discountType: CouponDiscountType;
-  amountUsdStr: string;
-  creditTypeId: string;
+  amountStr: string;
   durationMonths: string;
   maxRedemptions: string;
-  redeemBy: string;
+  expirationDate: string;
+}
+
+const FORM_STATE_KEYS: ReadonlyArray<keyof FormState> = [
+  "code",
+  "description",
+  "discountType",
+  "amountStr",
+  "durationMonths",
+  "maxRedemptions",
+  "expirationDate",
+];
+
+function isFormStateKey(key: string): key is keyof FormState {
+  return (FORM_STATE_KEYS as readonly string[]).includes(key);
 }
 
 const EMPTY_FORM: FormState = {
   code: "",
   description: "",
-  discountType: "fixed",
-  amountUsdStr: "",
-  creditTypeId: "",
+  discountType: "seat",
+  amountStr: "",
   durationMonths: "",
   maxRedemptions: "",
-  redeemBy: "",
+  expirationDate: "",
 };
-
-const FORM_STATE_KEYS = Object.keys(EMPTY_FORM) as ReadonlyArray<
-  keyof FormState
->;
-
-function isFormStateKey(key: string): key is keyof FormState {
-  return (FORM_STATE_KEYS as readonly string[]).includes(key);
-}
 
 interface CreateCouponFormProps {
   onCreated: () => void;
@@ -75,17 +76,14 @@ export function CreateCouponForm({
       code: form.code.trim(),
       description: form.description.trim() || null,
       discountType: form.discountType,
-      amountMicroUsd: form.amountUsdStr
-        ? Math.round(parseFloat(form.amountUsdStr) * 1_000_000)
-        : 0,
-      creditTypeId: form.creditTypeId.trim(),
+      amount: form.amountStr ? parseFloat(form.amountStr) : 0,
       durationMonths: form.durationMonths
         ? parseInt(form.durationMonths, 10)
         : null,
       maxRedemptions: form.maxRedemptions
         ? parseInt(form.maxRedemptions, 10)
         : null,
-      redeemBy: form.redeemBy || null,
+      expirationDate: form.expirationDate || null,
     };
 
     const result = CreateCouponBodySchema.safeParse(body);
@@ -96,9 +94,7 @@ export function CreateCouponForm({
         if (!isString(pathElement)) {
           continue;
         }
-        // Map amountMicroUsd back to the form field name.
-        const field =
-          pathElement === "amountMicroUsd" ? "amountUsdStr" : pathElement;
+        const field = pathElement === "amount" ? "amountStr" : pathElement;
         if (isFormStateKey(field)) {
           fieldErrors[field] = issue.message;
         }
@@ -180,49 +176,28 @@ export function CreateCouponForm({
           <RadioGroup
             name="discountType"
             value={form.discountType}
-            onValueChange={(value: string) => {
-              const parsed = CouponDiscountTypeSchema.safeParse(value);
-              if (parsed.success) {
-                set("discountType", parsed.data);
-              }
-            }}
+            onValueChange={(value) =>
+              set("discountType", value as CouponDiscountType)
+            }
           >
-            <RadioGroupItem value="fixed" label="Fixed" />
-            <RadioGroupItem value="usage_credit" label="Usage credit" />
+            <RadioGroupItem value="seat" label="Seat" />
           </RadioGroup>
-          {errors.discountType && (
-            <span className="text-xs text-red-500">{errors.discountType}</span>
-          )}
         </div>
 
         <div className="flex flex-col gap-1">
           <label className="text-sm font-medium">
-            Amount (USD) <span className="text-red-500">*</span>
+            Amount <span className="text-red-500">*</span>
           </label>
           <Input
             type="number"
-            value={form.amountUsdStr}
-            onChange={(e) => set("amountUsdStr", e.target.value)}
-            placeholder="e.g. 10.00"
-            min={0.01}
-            step={0.01}
+            value={form.amountStr}
+            onChange={(e) => set("amountStr", e.target.value)}
+            placeholder="e.g. 50"
+            min={0.5}
+            step={0.5}
           />
-          {errors.amountUsdStr && (
-            <span className="text-xs text-red-500">{errors.amountUsdStr}</span>
-          )}
-        </div>
-
-        <div className="flex flex-col gap-1 col-span-2">
-          <label className="text-sm font-medium">
-            Credit type ID (Metronome) <span className="text-red-500">*</span>
-          </label>
-          <Input
-            value={form.creditTypeId}
-            onChange={(e) => set("creditTypeId", e.target.value)}
-            placeholder="Metronome credit type ID"
-          />
-          {errors.creditTypeId && (
-            <span className="text-xs text-red-500">{errors.creditTypeId}</span>
+          {errors.amountStr && (
+            <span className="text-xs text-red-500">{errors.amountStr}</span>
           )}
         </div>
 
@@ -232,7 +207,7 @@ export function CreateCouponForm({
             type="number"
             value={form.durationMonths}
             onChange={(e) => set("durationMonths", e.target.value)}
-            placeholder="Leave blank for unlimited"
+            placeholder="Leave blank for once"
             min={1}
           />
         </div>
@@ -249,11 +224,11 @@ export function CreateCouponForm({
         </div>
 
         <div className="flex flex-col gap-1">
-          <label className="text-sm font-medium">Redeem by</label>
+          <label className="text-sm font-medium">Expiration date</label>
           <Input
             type="date"
-            value={form.redeemBy}
-            onChange={(e) => set("redeemBy", e.target.value)}
+            value={form.expirationDate}
+            onChange={(e) => set("expirationDate", e.target.value)}
           />
         </div>
 

--- a/front/components/poke/coupons/CreateCouponForm.tsx
+++ b/front/components/poke/coupons/CreateCouponForm.tsx
@@ -18,7 +18,7 @@ interface FormState {
   code: string;
   description: string;
   discountType: CouponDiscountType;
-  amountStr: string;
+  amount: string;
   durationMonths: string;
   maxRedemptions: string;
   expirationDate: string;
@@ -28,7 +28,7 @@ const FORM_STATE_KEYS: ReadonlyArray<keyof FormState> = [
   "code",
   "description",
   "discountType",
-  "amountStr",
+  "amount",
   "durationMonths",
   "maxRedemptions",
   "expirationDate",
@@ -42,7 +42,7 @@ const EMPTY_FORM: FormState = {
   code: "",
   description: "",
   discountType: "seat",
-  amountStr: "",
+  amount: "",
   durationMonths: "",
   maxRedemptions: "",
   expirationDate: "",
@@ -76,7 +76,7 @@ export function CreateCouponForm({
       code: form.code.trim(),
       description: form.description.trim() || null,
       discountType: form.discountType,
-      amount: form.amountStr ? parseFloat(form.amountStr) : 0,
+      amount: form.amount ? parseFloat(form.amount) : 0,
       durationMonths: form.durationMonths
         ? parseInt(form.durationMonths, 10)
         : null,
@@ -94,9 +94,8 @@ export function CreateCouponForm({
         if (!isString(pathElement)) {
           continue;
         }
-        const field = pathElement === "amount" ? "amountStr" : pathElement;
-        if (isFormStateKey(field)) {
-          fieldErrors[field] = issue.message;
+        if (isFormStateKey(pathElement)) {
+          fieldErrors[pathElement] = issue.message;
         }
       }
       setErrors(fieldErrors);
@@ -190,14 +189,14 @@ export function CreateCouponForm({
           </label>
           <Input
             type="number"
-            value={form.amountStr}
-            onChange={(e) => set("amountStr", e.target.value)}
+            value={form.amount}
+            onChange={(e) => set("amount", e.target.value)}
             placeholder="e.g. 50"
             min={0.5}
             step={0.5}
           />
-          {errors.amountStr && (
-            <span className="text-xs text-red-500">{errors.amountStr}</span>
+          {errors.amount && (
+            <span className="text-xs text-red-500">{errors.amount}</span>
           )}
         </div>
 

--- a/front/components/poke/pages/CouponsPage.tsx
+++ b/front/components/poke/pages/CouponsPage.tsx
@@ -8,15 +8,18 @@ import {
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type {
   CouponDiscountType,
+  CouponRedemptionStatus,
   CouponRedemptionType,
   CouponType,
 } from "@app/types/coupon";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
   ArchiveIcon,
   Button,
   ChevronDownIcon,
   ChevronRightIcon,
+  Chip,
   DataTable,
   PlusIcon,
   Spinner,
@@ -25,8 +28,24 @@ import type { ColumnDef } from "@tanstack/react-table";
 import type { MouseEvent } from "react";
 import { useMemo, useState } from "react";
 
-function formatUsd(microUsd: number): string {
-  return `$${(microUsd / 1_000_000).toFixed(2)}`;
+function formatAmount(amount: number): string {
+  return String(amount);
+}
+
+function getStatusChipColor(status: CouponRedemptionStatus) {
+  switch (status) {
+    case "active":
+      return "success";
+    case "pending":
+      return "primary";
+    case "failed":
+      return "rose";
+    case "revoked":
+      return "warning";
+    default:
+      assertNeverAndIgnore(status);
+      return "primary";
+  }
 }
 
 interface CouponRowData {
@@ -34,11 +53,11 @@ interface CouponRowData {
   code: string;
   description: string | null;
   discountType: CouponDiscountType;
-  amountMicroUsd: number;
+  amount: number;
   durationMonths: number | null;
   maxRedemptions: number | null;
   redemptionCount: number;
-  redeemBy: Date | null;
+  expirationDate: Date | null;
   archivedAt: Date | null;
   isExpanded: boolean;
   onClick?: () => void;
@@ -50,6 +69,7 @@ interface CouponRedemptionRowData {
   workspaceId: string;
   redeemedByUserId: string | null;
   redeemedAt: Date;
+  status: CouponRedemptionStatus;
   onClick?: () => void;
   menuItems?: MenuItem[];
 }
@@ -74,9 +94,7 @@ const couponColumns: ColumnDef<CouponRowData>[] = [
         <div className="flex items-center gap-2">
           <span>{row.original.code}</span>
           {row.original.archivedAt && (
-            <span className="rounded bg-muted px-1.5 py-0.5 text-xs dark:bg-muted-night">
-              archived
-            </span>
+            <Chip size="xs" color="primary" label="archived" />
           )}
         </div>
       </DataTable.CellContent>
@@ -103,11 +121,11 @@ const couponColumns: ColumnDef<CouponRowData>[] = [
     ),
   },
   {
-    accessorKey: "amountMicroUsd",
-    header: "Amount (USD)",
+    accessorKey: "amount",
+    header: "Amount",
     cell: ({ row }) => (
       <DataTable.BasicCellContent
-        label={formatUsd(row.original.amountMicroUsd)}
+        label={formatAmount(row.original.amount)}
         disabled={!!row.original.archivedAt}
       />
     ),
@@ -133,14 +151,14 @@ const couponColumns: ColumnDef<CouponRowData>[] = [
     ),
   },
   {
-    accessorKey: "redeemBy",
-    header: "Redeem by",
+    accessorKey: "expirationDate",
+    header: "Expiration date",
     cell: ({ row }) => (
       <DataTable.BasicCellContent
         label={
-          row.original.redeemBy
+          row.original.expirationDate
             ? formatTimestampToFriendlyDate(
-                new Date(row.original.redeemBy).getTime(),
+                new Date(row.original.expirationDate).getTime(),
                 "compactWithDay"
               )
             : "—"
@@ -188,6 +206,19 @@ const redemptionColumns: ColumnDef<CouponRedemptionRowData>[] = [
       />
     ),
   },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => (
+      <DataTable.CellContent>
+        <Chip
+          size="xs"
+          color={getStatusChipColor(row.original.status)}
+          label={row.original.status}
+        />
+      </DataTable.CellContent>
+    ),
+  },
 ];
 
 interface CouponRedemptionsPanelProps {
@@ -207,6 +238,7 @@ function CouponRedemptionsPanel({ coupon }: CouponRedemptionsPanelProps) {
         workspaceId: r.workspaceId,
         redeemedByUserId: r.redeemedByUserId,
         redeemedAt: r.redeemedAt,
+        status: r.status,
       })),
     [redemptions]
   );

--- a/front/components/poke/pages/CouponsPage.tsx
+++ b/front/components/poke/pages/CouponsPage.tsx
@@ -28,10 +28,6 @@ import type { ColumnDef } from "@tanstack/react-table";
 import type { MouseEvent } from "react";
 import { useMemo, useState } from "react";
 
-function formatAmount(amount: number): string {
-  return String(amount);
-}
-
 function getStatusChipColor(status: CouponRedemptionStatus) {
   switch (status) {
     case "active":
@@ -125,7 +121,7 @@ const couponColumns: ColumnDef<CouponRowData>[] = [
     header: "Amount",
     cell: ({ row }) => (
       <DataTable.BasicCellContent
-        label={formatAmount(row.original.amount)}
+        label={String(row.original.amount)}
         disabled={!!row.original.archivedAt}
       />
     ),

--- a/front/lib/resources/coupon_redemption_resource.test.ts
+++ b/front/lib/resources/coupon_redemption_resource.test.ts
@@ -37,17 +37,17 @@ describe("CouponRedemptionResource.makeNew", () => {
     expect(redemption.redeemedByUserSId).toBe(user.sId);
   });
 
-  it("increments the coupon redemptionCount", async () => {
+  it("creates redemption with pending status and empty metronomeCreditIds", async () => {
     const { auth } = await makeWorkspaceWithUserAuth();
-    const coupon = await CouponFactory.create({ maxRedemptions: 10 });
+    const coupon = await CouponFactory.create();
 
-    await CouponRedemptionResource.makeNew(auth, { coupon });
+    const redemption = await CouponRedemptionResource.makeNew(auth, { coupon });
 
-    const updated = await CouponResource.fetchByCouponId(coupon.sId);
-    expect(updated?.redemptionCount).toBe(1);
+    expect(redemption.status).toBe("pending");
+    expect(redemption.metronomeCreditIds).toEqual([]);
   });
 
-  it("enforces one redemption per workspace per coupon", async () => {
+  it("enforces at most one pending/active redemption per workspace per coupon", async () => {
     const { auth } = await makeWorkspaceWithUserAuth();
     const coupon = await CouponFactory.create();
 
@@ -58,6 +58,55 @@ describe("CouponRedemptionResource.makeNew", () => {
   });
 });
 
+describe("CouponRedemptionResource lifecycle methods", () => {
+  it("markActive sets status to active and stores credit IDs", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create();
+    const redemption = await CouponRedemptionResource.makeNew(auth, { coupon });
+
+    const creditIds = ["credit-1", "credit-2"];
+    const result = await redemption.markActive(creditIds);
+
+    expect(result.isOk()).toBe(true);
+    expect(redemption.status).toBe("active");
+    expect(redemption.metronomeCreditIds).toEqual(creditIds);
+  });
+
+  it("markFailed sets status to failed", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create();
+    const redemption = await CouponRedemptionResource.makeNew(auth, { coupon });
+
+    const result = await redemption.markFailed();
+
+    expect(result.isOk()).toBe(true);
+    expect(redemption.status).toBe("failed");
+  });
+
+  it("markRevoked sets status to revoked", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create();
+    const redemption = await CouponRedemptionResource.makeNew(auth, { coupon });
+    await redemption.markActive(["credit-1"]);
+
+    const result = await redemption.markRevoked();
+
+    expect(result.isOk()).toBe(true);
+    expect(redemption.status).toBe("revoked");
+  });
+
+  it("allows a new redemption after a failed one for the same workspace+coupon", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create();
+
+    const first = await CouponRedemptionResource.makeNew(auth, { coupon });
+    await first.markFailed();
+
+    const second = await CouponRedemptionResource.makeNew(auth, { coupon });
+    expect(second.status).toBe("pending");
+  });
+});
+
 describe("CouponRedemptionResource.listAllByCoupon", () => {
   it("returns an empty array when no redemptions exist", async () => {
     const coupon = await CouponFactory.create();
@@ -65,7 +114,7 @@ describe("CouponRedemptionResource.listAllByCoupon", () => {
     expect(redemptions).toHaveLength(0);
   });
 
-  it("returns all redemptions across workspaces and increments count per redemption", async () => {
+  it("returns all redemptions across workspaces", async () => {
     const [{ workspace: ws1, auth: auth1 }, { workspace: ws2, auth: auth2 }] =
       await Promise.all([
         makeWorkspaceWithUserAuth(),
@@ -81,9 +130,6 @@ describe("CouponRedemptionResource.listAllByCoupon", () => {
     expect(redemptions.map((r) => r.workspaceSId).sort()).toEqual(
       [ws1.sId, ws2.sId].sort()
     );
-
-    const updated = await CouponResource.fetchByCouponId(coupon.sId);
-    expect(updated?.redemptionCount).toBe(2);
   });
 
   it("resolves redeemedByUserSId when a user redeemed", async () => {
@@ -94,6 +140,23 @@ describe("CouponRedemptionResource.listAllByCoupon", () => {
 
     const [redemption] = await CouponRedemptionResource.listAllByCoupon(coupon);
     expect(redemption.redeemedByUserSId).toBe(user.sId);
+  });
+});
+
+describe("CouponResource.incrementRedemptionCount / decrementRedemptionCount", () => {
+  it("increments and decrements independently of redemption creation", async () => {
+    const coupon = await CouponFactory.create();
+
+    await coupon.incrementRedemptionCount();
+    await coupon.incrementRedemptionCount();
+
+    const afterIncrement = await CouponResource.fetchByCouponId(coupon.sId);
+    expect(afterIncrement?.redemptionCount).toBe(2);
+
+    await coupon.decrementRedemptionCount();
+
+    const afterDecrement = await CouponResource.fetchByCouponId(coupon.sId);
+    expect(afterDecrement?.redemptionCount).toBe(1);
   });
 });
 

--- a/front/lib/resources/coupon_redemption_resource.ts
+++ b/front/lib/resources/coupon_redemption_resource.ts
@@ -2,13 +2,15 @@ import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { CouponResource } from "@app/lib/resources/coupon_resource";
 import { CouponRedemptionModel } from "@app/lib/resources/storage/models/coupon_redemptions";
-import { CouponModel } from "@app/lib/resources/storage/models/coupons";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import type { CouponRedemptionType } from "@app/types/coupon";
+import type {
+  CouponRedemptionStatus,
+  CouponRedemptionType,
+} from "@app/types/coupon";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -70,22 +72,17 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
   ): Promise<CouponRedemptionResource> {
     const workspace = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
-    const [redemption] = await Promise.all([
-      CouponRedemptionModel.create(
-        {
-          couponId: coupon.id,
-          workspaceId: workspace.id,
-          redeemedByUserId: user.id,
-          redeemedAt: new Date(),
-        },
-        { transaction }
-      ),
-      CouponModel.increment("redemptionCount", {
-        by: 1,
-        where: { id: coupon.id },
-        transaction,
-      }),
-    ]);
+    const redemption = await CouponRedemptionModel.create(
+      {
+        couponId: coupon.id,
+        workspaceId: workspace.id,
+        redeemedByUserId: user.id,
+        redeemedAt: new Date(),
+        status: "pending",
+        metronomeCreditIds: [],
+      },
+      { transaction }
+    );
     return new this(this.model, redemption.get(), {
       workspaceSId: workspace.sId,
       couponSId: coupon.sId,
@@ -125,6 +122,44 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
     );
   }
 
+  private async applyStatusUpdate(
+    fields: { status: CouponRedemptionStatus; metronomeCreditIds?: string[] },
+    transaction?: Transaction
+  ): Promise<Result<void, Error>> {
+    try {
+      await this.update(fields, transaction);
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  async markActive(
+    creditIds: string[],
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<void, Error>> {
+    return this.applyStatusUpdate(
+      { status: "active", metronomeCreditIds: creditIds },
+      transaction
+    );
+  }
+
+  async markFailed({
+    transaction,
+  }: {
+    transaction?: Transaction;
+  } = {}): Promise<Result<void, Error>> {
+    return this.applyStatusUpdate({ status: "failed" }, transaction);
+  }
+
+  async markRevoked({
+    transaction,
+  }: {
+    transaction?: Transaction;
+  } = {}): Promise<Result<void, Error>> {
+    return this.applyStatusUpdate({ status: "revoked" }, transaction);
+  }
+
   toJSON(): CouponRedemptionType {
     return {
       sId: this.sId,
@@ -132,6 +167,8 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
       workspaceId: this.workspaceSId,
       redeemedByUserId: this.redeemedByUserSId,
       redeemedAt: this.redeemedAt,
+      metronomeCreditIds: this.metronomeCreditIds,
+      status: this.status,
     };
   }
 

--- a/front/lib/resources/coupon_resource.test.ts
+++ b/front/lib/resources/coupon_resource.test.ts
@@ -24,9 +24,9 @@ describe("CouponResource.validateRedemption", () => {
     }
   });
 
-  it("returns 'expired' when redeemBy is in the past", async () => {
+  it("returns 'expired' when expirationDate is in the past", async () => {
     const past = new Date(Date.now() - 1000);
-    const coupon = await CouponFactory.create({ redeemBy: past });
+    const coupon = await CouponFactory.create({ expirationDate: past });
     const result = coupon.validateRedemption();
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {

--- a/front/lib/resources/coupon_resource.ts
+++ b/front/lib/resources/coupon_resource.ts
@@ -16,7 +16,7 @@ import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 export type CouponValidationError =
-  | { code: "expired"; redeemBy: Date }
+  | { code: "expired"; expirationDate: Date }
   | { code: "exhausted"; maxRedemptions: number }
   | { code: "archived" };
 
@@ -51,6 +51,7 @@ export class CouponResource extends BaseResource<CouponModel> {
       const coupon = await CouponModel.create(
         {
           ...body,
+          discountType: "seat",
           createdByUserId: user.id,
         },
         { transaction }
@@ -105,8 +106,8 @@ export class CouponResource extends BaseResource<CouponModel> {
       return new Err({ code: "archived" });
     }
 
-    if (this.redeemBy && this.redeemBy < new Date()) {
-      return new Err({ code: "expired", redeemBy: this.redeemBy });
+    if (this.expirationDate && this.expirationDate < new Date()) {
+      return new Err({ code: "expired", expirationDate: this.expirationDate });
     }
 
     if (
@@ -122,18 +123,41 @@ export class CouponResource extends BaseResource<CouponModel> {
     return new Ok(undefined);
   }
 
+  async incrementRedemptionCount({
+    transaction,
+  }: {
+    transaction?: Transaction;
+  } = {}): Promise<void> {
+    await CouponModel.increment("redemptionCount", {
+      by: 1,
+      where: { id: this.id },
+      transaction,
+    });
+  }
+
+  async decrementRedemptionCount({
+    transaction,
+  }: {
+    transaction?: Transaction;
+  } = {}): Promise<void> {
+    await CouponModel.increment("redemptionCount", {
+      by: -1,
+      where: { id: this.id },
+      transaction,
+    });
+  }
+
   toJSON(): CouponType {
     return {
       sId: this.sId,
       code: this.code,
       description: this.description,
       discountType: this.discountType,
-      amountMicroUsd: this.amountMicroUsd,
-      creditTypeId: this.creditTypeId,
+      amount: this.amount,
       durationMonths: this.durationMonths,
       maxRedemptions: this.maxRedemptions,
       redemptionCount: this.redemptionCount,
-      redeemBy: this.redeemBy,
+      expirationDate: this.expirationDate,
       archivedAt: this.archivedAt,
     };
   }

--- a/front/lib/resources/storage/models/coupon_redemptions.ts
+++ b/front/lib/resources/storage/models/coupon_redemptions.ts
@@ -12,6 +12,8 @@ export class CouponRedemptionModel extends WorkspaceAwareModel<CouponRedemptionM
   declare couponId: ForeignKey<CouponModel["id"]>;
   declare redeemedByUserId: ForeignKey<UserModel["id"]> | null;
   declare redeemedAt: CreationOptional<Date>;
+  declare metronomeCreditIds: string[];
+  declare status: "pending" | "failed" | "active" | "revoked";
 
   declare coupon: NonAttribute<CouponModel>;
   declare redeemedByUser: NonAttribute<UserModel>;
@@ -34,6 +36,16 @@ CouponRedemptionModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
+    metronomeCreditIds: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: false,
+      defaultValue: [],
+    },
+    status: {
+      type: DataTypes.STRING(16),
+      allowNull: false,
+      defaultValue: "pending",
+    },
   },
   {
     modelName: "coupon_redemption",
@@ -48,7 +60,8 @@ CouponRedemptionModel.init(
       {
         fields: ["couponId", "workspaceId"],
         unique: true,
-        name: "coupon_redemptions_coupon_workspace_idx",
+        where: { status: ["pending", "active"] },
+        name: "coupon_redemptions_coupon_workspace_active_idx",
       },
     ],
   }

--- a/front/lib/resources/storage/models/coupons.ts
+++ b/front/lib/resources/storage/models/coupons.ts
@@ -10,13 +10,12 @@ export class CouponModel extends BaseModel<CouponModel> {
 
   declare code: string;
   declare description: string | null;
-  declare discountType: "fixed" | "usage_credit";
-  declare creditTypeId: string;
-  declare amountMicroUsd: number;
+  declare discountType: "seat";
+  declare amount: number;
   declare durationMonths: number | null;
   declare maxRedemptions: number | null;
   declare redemptionCount: CreationOptional<number>;
-  declare redeemBy: Date | null;
+  declare expirationDate: Date | null;
   declare archivedAt: Date | null;
   declare createdByUserId: ForeignKey<UserModel["id"]> | null;
 
@@ -48,12 +47,8 @@ CouponModel.init(
       type: DataTypes.STRING(32),
       allowNull: false,
     },
-    creditTypeId: {
-      type: DataTypes.STRING(64),
-      allowNull: false,
-    },
-    amountMicroUsd: {
-      type: DataTypes.BIGINT,
+    amount: {
+      type: DataTypes.FLOAT,
       allowNull: false,
     },
     durationMonths: {
@@ -71,7 +66,7 @@ CouponModel.init(
       allowNull: false,
       defaultValue: 0,
     },
-    redeemBy: {
+    expirationDate: {
       type: DataTypes.DATE,
       allowNull: true,
       defaultValue: null,

--- a/front/migrations/db/migration_618.sql
+++ b/front/migrations/db/migration_618.sql
@@ -1,0 +1,17 @@
+-- Migration created on Apr 29, 2026
+-- coupons: creditTypeId removed from model
+ALTER TABLE "coupons" DROP COLUMN "creditTypeId";
+-- coupon_redemptions: new columns added to model
+ALTER TABLE "coupon_redemptions"
+ADD COLUMN "metronomeCreditIds" VARCHAR(255)[] NOT NULL DEFAULT '{}';
+ALTER TABLE "coupon_redemptions"
+ADD COLUMN "status" VARCHAR(16) NOT NULL DEFAULT 'pending';
+-- coupon_redemptions: replace full unique index with partial (active/pending only)
+DROP INDEX CONCURRENTLY "coupon_redemptions_coupon_workspace_idx";
+CREATE UNIQUE INDEX CONCURRENTLY "coupon_redemptions_coupon_workspace_active_idx" ON "coupon_redemptions" ("couponId", "workspaceId")
+WHERE status IN ('pending', 'active');
+-- coupons: rename amountMicroUsd to amount and change type from BIGINT to DOUBLE PRECISION
+ALTER TABLE "coupons" RENAME COLUMN "amountMicroUsd" TO "amount";
+ALTER TABLE "coupons" ALTER COLUMN "amount" TYPE DOUBLE PRECISION;
+-- coupons: rename redeemBy to expirationDate
+ALTER TABLE "coupons" RENAME COLUMN "redeemBy" TO "expirationDate";

--- a/front/tests/utils/CouponFactory.ts
+++ b/front/tests/utils/CouponFactory.ts
@@ -4,12 +4,10 @@ import { faker } from "@faker-js/faker";
 
 interface CouponOverrides {
   code?: string;
-  discountType?: "fixed" | "usage_credit";
-  amountMicroUsd?: number;
-  creditTypeId?: string;
+  amount?: number;
   maxRedemptions?: number | null;
   redemptionCount?: number;
-  redeemBy?: Date | null;
+  expirationDate?: Date | null;
   archivedAt?: Date | null;
   durationMonths?: number | null;
   description?: string | null;
@@ -22,13 +20,12 @@ export class CouponFactory {
     const row = await CouponModel.create({
       code: overrides.code ?? faker.string.alphanumeric(8).toUpperCase(),
       description: overrides.description ?? null,
-      discountType: overrides.discountType ?? "fixed",
-      amountMicroUsd: overrides.amountMicroUsd ?? 10_000_000,
-      creditTypeId: overrides.creditTypeId ?? faker.string.uuid(),
+      discountType: "seat",
+      amount: overrides.amount ?? 10.0,
       durationMonths: overrides.durationMonths ?? null,
       maxRedemptions: overrides.maxRedemptions ?? null,
       redemptionCount: overrides.redemptionCount ?? 0,
-      redeemBy: overrides.redeemBy ?? null,
+      expirationDate: overrides.expirationDate ?? null,
       archivedAt: overrides.archivedAt ?? null,
       createdByUserId: null,
     });

--- a/front/types/coupon.ts
+++ b/front/types/coupon.ts
@@ -1,18 +1,23 @@
 import { z } from "zod";
 
-export type CouponDiscountType = "fixed" | "usage_credit";
+export type CouponDiscountType = "seat";
+
+export type CouponRedemptionStatus =
+  | "pending"
+  | "failed"
+  | "active"
+  | "revoked";
 
 export interface CouponType {
   sId: string;
   code: string;
   description: string | null;
   discountType: CouponDiscountType;
-  amountMicroUsd: number;
-  creditTypeId: string;
+  amount: number;
   durationMonths: number | null;
   maxRedemptions: number | null;
   redemptionCount: number;
-  redeemBy: Date | null;
+  expirationDate: Date | null;
   archivedAt: Date | null;
 }
 
@@ -22,19 +27,20 @@ export interface CouponRedemptionType {
   workspaceId: string;
   redeemedByUserId: string | null;
   redeemedAt: Date;
+  metronomeCreditIds: string[];
+  status: CouponRedemptionStatus;
 }
 
-export const CouponDiscountTypeSchema = z.enum(["fixed", "usage_credit"]);
+export const CouponDiscountTypeSchema = z.enum(["seat"]);
 
 export const CreateCouponBodySchema = z.object({
   code: z.string().min(1).max(64),
   description: z.string().max(255).nullable(),
   discountType: CouponDiscountTypeSchema,
-  amountMicroUsd: z.number().int().positive(),
-  creditTypeId: z.string().min(1),
+  amount: z.number().positive(),
   durationMonths: z.number().int().positive().nullable(),
   maxRedemptions: z.number().int().positive().nullable(),
-  redeemBy: z.coerce.date().nullable(),
+  expirationDate: z.coerce.date().nullable(),
 });
 
 export type CreateCouponBody = z.infer<typeof CreateCouponBodySchema>;


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/7931
Cleaning needed for redemption (more info in the ticket)

- Remove creditTypeId from CouponModel/CouponType (mapped in code by discount type)
- Rename discountType "fixed" → "seat", drop "usage_credit"
- Add metronomeCreditIds (JSONB) and status ("pending"|"failed"|"active"|"revoked") to CouponRedemptionModel
- Replace simple unique index on (couponId, workspaceId) with partial index WHERE status IN ('pending', 'active')
- Move redemptionCount increment out of CouponRedemptionResource.makeNew into dedicated CouponResource.incrementRedemptionCount / decrementRedemptionCount
- Add CouponRedemptionResource.markActive / markFailed / markRevoked lifecycle methods
- Poke: remove creditTypeId + discountType inputs from CreateCouponForm; add Status badge column in redemptions sub-row
- Rename redeemBy into expirationDate
- Turn amountMicroUsd into amount (float)

## Tests

Tested locally

## Risk

None, coupons are still not linked

## Deploy Plan

Apply migration
Deploy front
