### PR TITLE
Fix yearly credits, reconcile with metronome

### DIFF
--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -1,4 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
+import { getMetronomeClient } from "@app/lib/metronome/client";
+import { getProductFreeMonthlyCreditId } from "@app/lib/metronome/constants";
 import {
   getSubscriptionInvoices,
   isEnterpriseSubscription,
@@ -13,6 +15,8 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
 import type Stripe from "stripe";
 
@@ -149,6 +153,101 @@ export async function getCustomerPaymentStatus(
   }
 
   return "not_paying";
+}
+
+/**
+ * Reconcile a freshly granted free credit with the Metronome credit that was
+ * automatically created by the recurring credit on the customer's contract.
+ *
+ * The Metronome recurring credit fires at the rounded hour, so by the time we
+ * handle the Stripe webhook the corresponding credit segment usually already
+ * exists on the customer. We look it up and store its id on our credit row.
+ *
+ * Best-effort: if the contract / recurring credit / segment can't be found we
+ * log and return — the backfill script can fix the link later.
+ */
+async function linkMetronomeRecurringCreditToCredit({
+  workspace,
+  credit,
+}: {
+  workspace: LightWorkspaceType;
+  credit: CreditResource;
+}): Promise<void> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return;
+  }
+
+  try {
+    const client = getMetronomeClient();
+    const contractsResponse = await client.v2.contracts.list({
+      customer_id: metronomeCustomerId,
+      covering_date: new Date().toISOString(),
+    });
+    const contract = contractsResponse.data[0];
+    if (!contract) {
+      logger.info(
+        { workspaceId: workspace.sId, creditId: credit.id },
+        "[Free Credits] No active Metronome contract, skipping linking"
+      );
+      return;
+    }
+
+    const freeCreditProductId = getProductFreeMonthlyCreditId();
+    const existingRecurringCredit = contract.recurring_credits?.find(
+      (rc) => rc.product.id === freeCreditProductId
+    );
+    if (!existingRecurringCredit) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          contractId: contract.id,
+          creditId: credit.id,
+        },
+        "[Free Credits] No recurring credit on contract, skipping linking"
+      );
+      return;
+    }
+
+    const creditsResponse = await client.v1.customers.credits.list({
+      customer_id: metronomeCustomerId,
+      covering_date: new Date().toISOString(),
+      include_contract_credits: true,
+    });
+    const currentRecurringCredit = creditsResponse.data.find(
+      (c) => c.recurring_credit_id === existingRecurringCredit.id
+    );
+    if (!currentRecurringCredit) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          contractId: contract.id,
+          creditId: credit.id,
+        },
+        "[Free Credits] No active credit found for recurring credit, skipping linking"
+      );
+      return;
+    }
+
+    await credit.setMetronomeCreditId(currentRecurringCredit.id);
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        creditId: credit.id,
+        metronomeCreditId: currentRecurringCredit.id,
+      },
+      "[Free Credits] Linked credit to existing Metronome recurring credit"
+    );
+  } catch (err) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        creditId: credit.id,
+        err: normalizeError(err),
+      },
+      "[Free Credits] Failed to link credit to Metronome recurring credit"
+    );
+  }
 }
 
 export async function grantFreeCreditsFromSubscriptionStateChange({
@@ -325,10 +424,12 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
     "[Free Credits] Successfully granted and activated free credit on renewal"
   );
 
+  await linkMetronomeRecurringCreditToCredit({ workspace, credit });
+
   return new Ok(undefined);
 }
 
-const YEARLY_MULTIPLIER = 12;
+export const YEARLY_MULTIPLIER = 12;
 
 export async function grantFreeCreditFromSubscriptionStateChangeYearly({
   auth,
@@ -496,6 +597,8 @@ export async function grantFreeCreditFromSubscriptionStateChangeYearly({
     },
     "[Free Credits Yearly] Successfully granted and activated free credit on yearly renewal"
   );
+
+  await linkMetronomeRecurringCreditToCredit({ workspace, credit });
 
   return new Ok(undefined);
 }

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -3,6 +3,7 @@ import apiConfig from "@app/lib/api/config";
 import {
   calculateFreeCreditAmountMicroUsd,
   countEligibleUsersForFreeCredits,
+  YEARLY_MULTIPLIER,
 } from "@app/lib/credits/free";
 import {
   getMetronomeClient,
@@ -234,8 +235,21 @@ async function handler(
             break;
           }
 
+          // Detect whether this credit comes from an annual recurring credit
+          // (annual contracts) so we grant a yearly amount instead of monthly.
+          const recurringCredit = credit.recurring_credit_id
+            ? contractResult.value.recurring_credits?.find(
+                (rc) => rc.id === credit.recurring_credit_id
+              )
+            : undefined;
+          const isAnnual = recurringCredit?.recurrence_frequency === "ANNUAL";
+
           const userCount = await countEligibleUsersForFreeCredits(workspace);
-          const amountMicroUsd = calculateFreeCreditAmountMicroUsd(userCount);
+          const monthlyAmountMicroUsd =
+            calculateFreeCreditAmountMicroUsd(userCount);
+          const amountMicroUsd = isAnnual
+            ? monthlyAmountMicroUsd * YEARLY_MULTIPLIER
+            : monthlyAmountMicroUsd;
           const amount = amountMicroUsd / 1_000_000;
 
           const updateResult = await updateMetronomeCreditSegmentAmount({
@@ -275,6 +289,7 @@ async function handler(
               segmentId,
               amountMicroUsd,
               userCount,
+              isAnnual,
               workspaceId: workspace.sId,
             },
             "[Metronome Webhook] credit.segment.start: free credit amount updated"

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -332,7 +332,7 @@ const PRODUCTS: ProductDef[] = [
   { name: "MAU Commit", type: "FIXED" },
   // FIXED products for credit grants — separate products for distinct invoice line items.
   {
-    name: "Free Monthly Credits",
+    name: "Free Credits",
     type: "FIXED",
   },
   {
@@ -696,12 +696,12 @@ function getRateCards(): RateCardDef[] {
   ];
 }
 
-// Recurring free credit definition shared by all packages.
+// Recurring free credit definition shared by all monthly packages.
 // Quantity starts at 0 — the credit.segment.start webhook updates it each period
 // to the actual user-based amount.
 function getFreeMonthlyRecurringCredits(): RecurringCreditDef {
   return {
-    product_name: "Free Monthly Credits",
+    product_name: "Free Credits",
     access_amount: {
       credit_type_id: getCreditTypeProgrammaticUsdId(),
       unit_price: 0,
@@ -713,6 +713,26 @@ function getFreeMonthlyRecurringCredits(): RecurringCreditDef {
     applicable_product_tags: [USAGE_TAG],
     recurrence_frequency: "MONTHLY",
     name: "Free Monthly Credits",
+  };
+}
+
+// Annual variant for annual packages. Same product, but the credit is granted
+// once per year. The credit.segment.start webhook detects ANNUAL recurrence
+// and multiplies the monthly bracket amount by 12.
+function getFreeAnnualRecurringCredits(): RecurringCreditDef {
+  return {
+    product_name: "Free Credits",
+    access_amount: {
+      credit_type_id: getCreditTypeProgrammaticUsdId(),
+      unit_price: 0,
+      quantity: 1,
+    },
+    commit_duration: { value: 1, unit: "PERIODS" },
+    priority: 1,
+    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
+    applicable_product_tags: [USAGE_TAG],
+    recurrence_frequency: "ANNUAL",
+    name: "Free Annual Credits",
   };
 }
 
@@ -771,7 +791,7 @@ function getPackages(): PackageDef[] {
       aliases: [{ name: "legacy-pro-annual" }],
       rate_card_name: "Legacy Pro Annual USD",
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      recurring_credits: [getFreeAnnualRecurringCredits()],
       ...BILLING_CYCLE_CONFIG,
     },
     // Enterprise: MAU-based billing, no seat subscriptions.
@@ -805,7 +825,7 @@ function getPackages(): PackageDef[] {
       aliases: [{ name: "legacy-pro-annual-eur" }],
       rate_card_name: "Legacy Pro Annual EUR",
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      recurring_credits: [getFreeAnnualRecurringCredits()],
       ...BILLING_CYCLE_CONFIG,
     },
     {
@@ -1510,6 +1530,12 @@ function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
       return false;
     }
     if (match.priority !== desiredCredit.priority) {
+      return false;
+    }
+    if (
+      (match.recurrence_frequency ?? undefined) !==
+      (desiredCredit.recurrence_frequency ?? undefined)
+    ) {
       return false;
     }
   }


### PR DESCRIPTION
## Description

Two related fixes around free credits in Metronome:

- **Reconcile DB credits with Metronome recurring credits**: when `grantFreeCreditsFromSubscriptionStateChange` (and its yearly variant) creates a free credit, look up the credit segment that the recurring credit auto-generated on the contract and store its id on the DB row via `metronomeCreditId`. Same lookup logic as `backfill_metronome_credits.ts`, applied live so the link is set as the credit is granted instead of relying on the backfill script. Best-effort — failures are logged, the backfill remains the safety net.
- **Annual contracts get an annual recurring credit**: `metronome_setup` now provisions the two annual packages (`legacy-pro-annual`, `legacy-pro-annual-eur`) with `recurrence_frequency: ANNUAL`. `packageMatches` also checks `recurrence_frequency` so the change actually triggers package re-creation.
- **Webhook handles yearly amounts**: in `credit.segment.start`, the handler now finds the parent recurring credit on the contract and, if its frequency is `ANNUAL`, multiplies the monthly bracket amount by `YEARLY_MULTIPLIER` (12) — same factor used by `grantFreeCreditFromSubscriptionStateChangeYearly`. The constant is now exported from `lib/credits/free` so both code paths share it.

## Tests

Type-checks cleanly (`npx tsgo --noEmit`). Existing unit tests for `grantFreeCreditsFromSubscriptionStateChange` still pass. The Metronome lookup is best-effort and exercised by the existing backfill script in dry-run.

## Risk

Low.
- The link step is best-effort and wrapped in try/catch — a Metronome API failure logs an error but does not break credit granting.
- The webhook change only kicks in when the recurring credit's `recurrence_frequency` is `ANNUAL`; monthly contracts behave exactly as before.
- `metronome_setup` is idempotent; running it will recreate the two annual packages with the new annual recurring credit.

## Deploy Plan

1. Merge & deploy `front`.
2. Run `npx tsx scripts/metronome_setup.ts --execute` to recreate the two annual packages with the annual recurring credit.
3. Existing annual contracts created before this change will keep their previous monthly recurring credit until the contract is migrated; new annual contracts will pick up the annual one automatically.