### PR TITLE
[front] feat: introduce inline skill tag primitives

### DIFF
--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -1,0 +1,120 @@
+import {
+  parseSkillTag,
+  SKILL_TAG_NAME,
+  SKILL_TAG_REGEX_BEGINNING,
+  serializeSkillTag,
+} from "@app/lib/skills/format";
+import { mergeAttributes, Node } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { SkillNodeComponent } from "../../input_bar/SkillNodeComponent";
+
+export type SkillNodeAttributes = {
+  skillId: string;
+  skillName: string;
+};
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    skillNode: {
+      insertSkillNode: (attrs: SkillNodeAttributes) => ReturnType;
+    };
+  }
+}
+
+export const SkillNode = Node.create({
+  name: "skill",
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: false,
+
+  addAttributes() {
+    return {
+      skillId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("id"),
+        renderHTML: (attributes) =>
+          typeof attributes.skillId === "string"
+            ? { id: attributes.skillId }
+            : {},
+      },
+      skillName: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("name"),
+        renderHTML: (attributes) =>
+          typeof attributes.skillName === "string"
+            ? { name: attributes.skillName }
+            : {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: SKILL_TAG_NAME }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [SKILL_TAG_NAME, mergeAttributes(HTMLAttributes)];
+  },
+
+  renderText({ node }) {
+    return `/${node.attrs.skillName ?? "skill"}`;
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(SkillNodeComponent);
+  },
+
+  addCommands() {
+    return {
+      insertSkillNode:
+        (attrs: SkillNodeAttributes) =>
+        ({ commands }) =>
+          commands.insertContent([
+            {
+              type: this.name,
+              attrs,
+            },
+            { type: "text", text: " " },
+          ]),
+    };
+  },
+
+  markdownTokenizer: {
+    name: "skill",
+    level: "inline",
+    start: (src) => src.indexOf(`<${SKILL_TAG_NAME}`),
+    tokenize: (src) => {
+      const match = SKILL_TAG_REGEX_BEGINNING.exec(src);
+      if (!match) {
+        return undefined;
+      }
+
+      const skill = parseSkillTag(match[0]);
+      if (!skill) {
+        return undefined;
+      }
+
+      return {
+        type: "skill",
+        raw: match[0],
+        skillId: skill.id,
+        skillName: skill.name,
+      };
+    },
+  },
+
+  parseMarkdown: (token) => ({
+    type: "skill",
+    attrs: {
+      skillId: token.skillId,
+      skillName: token.skillName,
+    },
+  }),
+
+  renderMarkdown: (node) =>
+    serializeSkillTag({
+      id: node.attrs?.skillId ?? "",
+      name: node.attrs?.skillName ?? "",
+    }),
+});

--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -5,6 +5,7 @@ import {
   SKILL_TAG_REGEX_BEGINNING,
   serializeSkillTag,
 } from "@app/lib/skills/format";
+import { isString } from "@app/types/shared/utils/general";
 import { Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 
@@ -36,17 +37,13 @@ export const SkillNode = Node.create({
         default: null,
         parseHTML: (element) => element.getAttribute("id"),
         renderHTML: (attributes) =>
-          typeof attributes.skillId === "string"
-            ? { id: attributes.skillId }
-            : {},
+          isString(attributes.skillId) ? { id: attributes.skillId } : {},
       },
       skillName: {
         default: null,
         parseHTML: (element) => element.getAttribute("name"),
         renderHTML: (attributes) =>
-          typeof attributes.skillName === "string"
-            ? { name: attributes.skillName }
-            : {},
+          isString(attributes.skillName) ? { name: attributes.skillName } : {},
       },
     };
   },

--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -11,6 +11,7 @@ import { ReactNodeViewRenderer } from "@tiptap/react";
 
 export type SkillNodeAttributes = {
   skillId: string;
+  skillIcon?: string | null;
   skillName: string;
 };
 
@@ -44,6 +45,12 @@ export const SkillNode = Node.create({
         parseHTML: (element) => element.getAttribute("name"),
         renderHTML: (attributes) =>
           isString(attributes.skillName) ? { name: attributes.skillName } : {},
+      },
+      skillIcon: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("icon"),
+        renderHTML: (attributes) =>
+          isString(attributes.skillIcon) ? { icon: attributes.skillIcon } : {},
       },
     };
   },
@@ -100,6 +107,7 @@ export const SkillNode = Node.create({
         type: SKILL_NODE_TYPE,
         raw: match[0],
         skillId: skill.id,
+        skillIcon: skill.icon,
         skillName: skill.name,
       };
     },
@@ -109,6 +117,7 @@ export const SkillNode = Node.create({
     type: SKILL_NODE_TYPE,
     attrs: {
       skillId: token.skillId,
+      skillIcon: token.skillIcon,
       skillName: token.skillName,
     },
   }),
@@ -116,6 +125,7 @@ export const SkillNode = Node.create({
   renderMarkdown: (node) =>
     serializeSkillTag({
       id: node.attrs?.skillId ?? "",
+      icon: node.attrs?.skillIcon ?? null,
       name: node.attrs?.skillName ?? "",
     }),
 });

--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -1,17 +1,19 @@
+import { SkillNodeComponent } from "@app/components/editor/input_bar/SkillNodeComponent";
 import {
   parseSkillTag,
   SKILL_TAG_NAME,
   SKILL_TAG_REGEX_BEGINNING,
   serializeSkillTag,
 } from "@app/lib/skills/format";
-import { mergeAttributes, Node } from "@tiptap/core";
+import { Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
-import { SkillNodeComponent } from "../../input_bar/SkillNodeComponent";
 
 export type SkillNodeAttributes = {
   skillId: string;
   skillName: string;
 };
+
+export const SKILL_NODE_TYPE = "skill";
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -22,7 +24,7 @@ declare module "@tiptap/core" {
 }
 
 export const SkillNode = Node.create({
-  name: "skill",
+  name: SKILL_NODE_TYPE,
   group: "inline",
   inline: true,
   atom: true,
@@ -49,12 +51,13 @@ export const SkillNode = Node.create({
     };
   },
 
+  // HTML serialization and deserialization.
   parseHTML() {
     return [{ tag: SKILL_TAG_NAME }];
   },
 
   renderHTML({ HTMLAttributes }) {
-    return [SKILL_TAG_NAME, mergeAttributes(HTMLAttributes)];
+    return [SKILL_TAG_NAME, HTMLAttributes];
   },
 
   renderText({ node }) {
@@ -72,7 +75,7 @@ export const SkillNode = Node.create({
         ({ commands }) =>
           commands.insertContent([
             {
-              type: this.name,
+              type: SKILL_NODE_TYPE,
               attrs,
             },
             { type: "text", text: " " },
@@ -80,8 +83,9 @@ export const SkillNode = Node.create({
     };
   },
 
+  // Markdown serialization and deserialization.
   markdownTokenizer: {
-    name: "skill",
+    name: SKILL_NODE_TYPE,
     level: "inline",
     start: (src) => src.indexOf(`<${SKILL_TAG_NAME}`),
     tokenize: (src) => {
@@ -96,7 +100,7 @@ export const SkillNode = Node.create({
       }
 
       return {
-        type: "skill",
+        type: SKILL_NODE_TYPE,
         raw: match[0],
         skillId: skill.id,
         skillName: skill.name,
@@ -105,7 +109,7 @@ export const SkillNode = Node.create({
   },
 
   parseMarkdown: (token) => ({
-    type: "skill",
+    type: SKILL_NODE_TYPE,
     attrs: {
       skillId: token.skillId,
       skillName: token.skillName,

--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -25,6 +25,8 @@ declare module "@tiptap/core" {
   }
 }
 
+// TODO(2026-05-02 aubin): Check whether we can share logic with KnowledgeNode,
+// for example through a base extension.
 export const SkillNode = Node.create({
   name: SKILL_NODE_TYPE,
   group: "inline",

--- a/front/components/editor/input_bar/SkillNodeComponent.tsx
+++ b/front/components/editor/input_bar/SkillNodeComponent.tsx
@@ -1,0 +1,29 @@
+import { getSkillIcon } from "@app/lib/skill";
+import { Chip } from "@dust-tt/sparkle";
+import { NodeViewWrapper } from "@tiptap/react";
+// biome-ignore lint/correctness/noUnusedImports: React is required by JSX runtime in this file.
+import React from "react";
+
+interface SkillNodeComponentProps {
+  node: {
+    attrs: {
+      skillId?: string;
+      skillName?: string;
+    };
+  };
+}
+
+export function SkillNodeComponent({ node }: SkillNodeComponentProps) {
+  const skillName = node.attrs.skillName ?? "Skill";
+
+  return (
+    <NodeViewWrapper className="inline-flex align-middle">
+      <Chip
+        label={skillName}
+        icon={getSkillIcon(null)}
+        color="white"
+        size="xs"
+      />
+    </NodeViewWrapper>
+  );
+}

--- a/front/components/editor/input_bar/SkillNodeComponent.tsx
+++ b/front/components/editor/input_bar/SkillNodeComponent.tsx
@@ -6,19 +6,21 @@ interface SkillNodeComponentProps {
   node: {
     attrs: {
       skillId?: string;
+      skillIcon?: string | null;
       skillName?: string;
     };
   };
 }
 
 export function SkillNodeComponent({ node }: SkillNodeComponentProps) {
+  const skillIcon = node.attrs.skillIcon ?? null;
   const skillName = node.attrs.skillName ?? "Skill";
 
   return (
     <NodeViewWrapper className="inline-flex align-middle">
       <Chip
         label={skillName}
-        icon={getSkillIcon(null)}
+        icon={getSkillIcon(skillIcon)}
         color="white"
         size="xs"
       />

--- a/front/components/editor/input_bar/SkillNodeComponent.tsx
+++ b/front/components/editor/input_bar/SkillNodeComponent.tsx
@@ -1,8 +1,6 @@
 import { getSkillIcon } from "@app/lib/skill";
 import { Chip } from "@dust-tt/sparkle";
 import { NodeViewWrapper } from "@tiptap/react";
-// biome-ignore lint/correctness/noUnusedImports: React is required by JSX runtime in this file.
-import React from "react";
 
 interface SkillNodeComponentProps {
   node: {

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -157,6 +157,24 @@ describe("buildEditorExtensions", () => {
   });
 
   it("round-trips inline skill tags as skill nodes", () => {
+    editor.commands.setContent(
+      '<skill id="skill_123" name="commit" icon="book_open" />',
+      {
+        contentType: "markdown",
+      }
+    );
+
+    const json = editor.getJSON();
+    expect(JSON.stringify(json)).toContain('"type":"skill"');
+    expect(JSON.stringify(json)).toContain('"skillId":"skill_123"');
+    expect(JSON.stringify(json)).toContain('"skillName":"commit"');
+    expect(JSON.stringify(json)).toContain('"skillIcon":"book_open"');
+    expect(editor.getMarkdown()).toContain(
+      '<skill id="skill_123" name="commit" icon="book_open" />'
+    );
+  });
+
+  it("round-trips inline skill tags without an icon", () => {
     editor.commands.setContent('<skill id="skill_123" name="commit" />', {
       contentType: "markdown",
     });

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -156,6 +156,20 @@ describe("buildEditorExtensions", () => {
     expect(hasCodeMark).toBe(true);
   });
 
+  it("round-trips inline skill tags as skill nodes", () => {
+    editor.commands.setContent('<skill id="skill_123" name="commit" />', {
+      contentType: "markdown",
+    });
+
+    const json = editor.getJSON();
+    expect(JSON.stringify(json)).toContain('"type":"skill"');
+    expect(JSON.stringify(json)).toContain('"skillId":"skill_123"');
+    expect(JSON.stringify(json)).toContain('"skillName":"commit"');
+    expect(editor.getMarkdown()).toContain(
+      '<skill id="skill_123" name="commit" />'
+    );
+  });
+
   it("should handle bullet list with `*`", () => {
     editor.commands.setContent("* hello\n* world", {
       contentType: "markdown",

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -53,27 +53,6 @@ const useEditorService = (editor: Editor | null) => {
       insertText: (text: string) => {
         editor?.chain().focus().insertContent(text).run();
       },
-      insertSkill: ({ id, name }: { id: string; name: string }) => {
-        const selectionFrom = editor?.state.selection.from ?? 0;
-        const characterBefore =
-          selectionFrom > 0
-            ? (editor?.state.doc.textBetween(
-                Math.max(0, selectionFrom - 1),
-                selectionFrom,
-                " ",
-                "\ufffc"
-              ) ?? "")
-            : "";
-        const shouldAddSpaceBeforeSkill =
-          characterBefore.length > 0 && !/\s/.test(characterBefore);
-
-        editor
-          ?.chain()
-          .focus()
-          .insertContent(shouldAddSpaceBeforeSkill ? " " : "")
-          .insertSkillNode({ skillId: id, skillName: name })
-          .run();
-      },
       // Insert mention helper function.
       insertMention: ({
         type,

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -8,6 +8,7 @@ import {
 import type { InputBarSlashSuggestionCapability } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import { KeyboardShortcutsExtension } from "@app/components/editor/extensions/input_bar/KeyboardShortcutsExtension";
 import { PastedAttachmentExtension } from "@app/components/editor/extensions/input_bar/PastedAttachmentExtension";
+import { SkillNode } from "@app/components/editor/extensions/input_bar/SkillNode";
 import { URLDetectionExtension } from "@app/components/editor/extensions/input_bar/URLDetectionExtension";
 import { URLStorageExtension } from "@app/components/editor/extensions/input_bar/URLStorageExtension";
 import {
@@ -51,6 +52,27 @@ const useEditorService = (editor: Editor | null) => {
       // Insert text helper function.
       insertText: (text: string) => {
         editor?.chain().focus().insertContent(text).run();
+      },
+      insertSkill: ({ id, name }: { id: string; name: string }) => {
+        const selectionFrom = editor?.state.selection.from ?? 0;
+        const characterBefore =
+          selectionFrom > 0
+            ? (editor?.state.doc.textBetween(
+                Math.max(0, selectionFrom - 1),
+                selectionFrom,
+                " ",
+                "\ufffc"
+              ) ?? "")
+            : "";
+        const shouldAddSpaceBeforeSkill =
+          characterBefore.length > 0 && !/\s/.test(characterBefore);
+
+        editor
+          ?.chain()
+          .focus()
+          .insertContent(shouldAddSpaceBeforeSkill ? " " : "")
+          .insertSkillNode({ skillId: id, skillName: name })
+          .run();
       },
       // Insert mention helper function.
       insertMention: ({
@@ -130,12 +152,16 @@ const useEditorService = (editor: Editor | null) => {
           return {
             markdown: "",
             mentions: [],
+            skills: [],
           };
         }
 
+        const { mentions, skills } = extractFromEditorJSON(editor?.getJSON());
+
         return {
           markdown: editor.getMarkdown(),
-          mentions: extractFromEditorJSON(editor?.getJSON()).mentions,
+          mentions,
+          skills,
         };
       },
 
@@ -347,6 +373,7 @@ export const buildEditorExtensions = ({
         onAgentSelect,
       }),
     }),
+    SkillNode,
     EmojiExtension,
     Placeholder.configure({
       placeholder: ({ node }) => {

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -15,6 +15,7 @@ import type {
   UserMention,
 } from "@app/types/assistant/mentions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
 import type { JSONContent } from "@tiptap/react";
 
 type SkillReference = {
@@ -140,7 +141,7 @@ export function extractFromEditorJSON(node?: JSONContent): {
     const skillId = node.attrs?.skillId;
     const skillName = node.attrs?.skillName;
 
-    if (typeof skillId === "string" && typeof skillName === "string") {
+    if (isString(skillId) && isString(skillName)) {
       skills.push({
         id: skillId,
         name: skillName,

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -134,15 +134,20 @@ export function extractFromEditorJSON(node?: JSONContent): {
 
   if (node.type === "skill") {
     const skillId = node.attrs?.skillId;
+    const skillIcon = isString(node.attrs?.skillIcon)
+      ? node.attrs.skillIcon
+      : null;
     const skillName = node.attrs?.skillName;
 
     if (isString(skillId) && isString(skillName)) {
       skills.push({
         id: skillId,
+        icon: skillIcon,
         name: skillName,
       });
       textContent += serializeSkillTag({
         id: skillId,
+        icon: skillIcon,
         name: skillName,
       });
     }

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -7,6 +7,7 @@
  * - Plain text with @ symbols
  */
 
+import { serializeSkillTag } from "@app/lib/skills/format";
 import type {
   AgentMention,
   MentionType,
@@ -15,6 +16,11 @@ import type {
 } from "@app/types/assistant/mentions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { JSONContent } from "@tiptap/react";
+
+type SkillReference = {
+  id: string;
+  name: string;
+};
 
 /**
  * Regular expression for parsing agent mention strings.
@@ -99,12 +105,14 @@ export function replaceMentionsWithAt(text: string): string {
 export function extractFromEditorJSON(node?: JSONContent): {
   text: string;
   mentions: RichMention[];
+  skills: SkillReference[];
 } {
   let textContent = "";
   let mentions: RichMention[] = [];
+  let skills: SkillReference[] = [];
 
   if (!node) {
-    return { text: textContent, mentions };
+    return { text: textContent, mentions, skills };
   }
 
   // Check if the node is of type 'text' and concatenate its text.
@@ -128,6 +136,22 @@ export function extractFromEditorJSON(node?: JSONContent): {
     });
   }
 
+  if (node.type === "skill") {
+    const skillId = node.attrs?.skillId;
+    const skillName = node.attrs?.skillName;
+
+    if (typeof skillId === "string" && typeof skillName === "string") {
+      skills.push({
+        id: skillId,
+        name: skillName,
+      });
+      textContent += serializeSkillTag({
+        id: skillId,
+        name: skillName,
+      });
+    }
+  }
+
   // If the node is a 'hardBreak' or a 'paragraph', add a newline character.
   if (node.type && ["hardBreak", "paragraph"].includes(node.type)) {
     textContent += "\n";
@@ -145,8 +169,9 @@ export function extractFromEditorJSON(node?: JSONContent): {
       const childResult = extractFromEditorJSON(childNode);
       textContent += childResult.text;
       mentions = mentions.concat(childResult.mentions);
+      skills = skills.concat(childResult.skills);
     });
   }
 
-  return { text: textContent, mentions };
+  return { text: textContent, mentions, skills };
 }

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -7,7 +7,7 @@
  * - Plain text with @ symbols
  */
 
-import { serializeSkillTag } from "@app/lib/skills/format";
+import { type SkillReference, serializeSkillTag } from "@app/lib/skills/format";
 import type {
   AgentMention,
   MentionType,
@@ -17,11 +17,6 @@ import type {
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { JSONContent } from "@tiptap/react";
-
-type SkillReference = {
-  id: string;
-  name: string;
-};
 
 /**
  * Regular expression for parsing agent mention strings.

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -8,28 +8,6 @@ export const SKILL_TAG_NAME = "skill";
 export const SKILL_TAG_REGEX = /<skill\s+([^>]*?)\s*\/>/g;
 export const SKILL_TAG_REGEX_BEGINNING = /^<skill\s+([^>]*?)\s*\/>/;
 
-const XML_ENTITY_REPLACEMENTS: Record<string, string> = {
-  "&quot;": '"',
-  "&lt;": "<",
-  "&gt;": ">",
-  "&amp;": "&",
-};
-
-function escapeXml(text: string): string {
-  return text
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
-}
-
-function decodeXml(text: string): string {
-  return text.replaceAll(
-    /&quot;|&lt;|&gt;|&amp;/g,
-    (match) => XML_ENTITY_REPLACEMENTS[match] ?? match
-  );
-}
-
 function parseSkillTagAttributes(attributes: string): SkillTag | null {
   const id = attributes.match(/\bid="([^"]+)"/)?.[1];
   const name = attributes.match(/\bname="([^"]+)"/)?.[1];
@@ -39,8 +17,8 @@ function parseSkillTagAttributes(attributes: string): SkillTag | null {
   }
 
   return {
-    id: decodeXml(id),
-    name: decodeXml(name),
+    id,
+    name,
   };
 }
 
@@ -61,7 +39,7 @@ export function extractSkillTags(markdown: string): SkillTag[] {
 }
 
 export function serializeSkillTag({ id, name }: SkillTag): string {
-  return `<${SKILL_TAG_NAME} id="${escapeXml(id)}" name="${escapeXml(name)}" />`;
+  return `<${SKILL_TAG_NAME} id="${id}" name="${name}" />`;
 }
 
 export function replaceSkillTagsWithDirectives(markdown: string): string {

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -1,6 +1,7 @@
 export type SkillReference = {
   id: string;
   name: string;
+  icon?: string | null;
 };
 
 export const SKILL_TAG_NAME = "skill";
@@ -11,6 +12,7 @@ export const SKILL_TAG_REGEX_BEGINNING = /^<skill\s+([^>]*?)\s*\/>/;
 function parseSkillTagAttributes(attributes: string): SkillReference | null {
   const id = attributes.match(/\bid="([^"]+)"/)?.[1];
   const name = attributes.match(/\bname="([^"]+)"/)?.[1];
+  const icon = attributes.match(/\bicon="([^"]+)"/)?.[1] ?? null;
 
   if (!id || !name) {
     return null;
@@ -18,6 +20,7 @@ function parseSkillTagAttributes(attributes: string): SkillReference | null {
 
   return {
     id,
+    icon,
     name,
   };
 }
@@ -38,6 +41,8 @@ export function extractSkillTags(markdown: string): SkillReference[] {
     .filter((skill): skill is SkillReference => skill !== null);
 }
 
-export function serializeSkillTag({ id, name }: SkillReference): string {
-  return `<${SKILL_TAG_NAME} id="${id}" name="${name}" />`;
+export function serializeSkillTag({ id, name, icon }: SkillReference): string {
+  const iconAttribute = icon ? ` icon="${icon}"` : "";
+
+  return `<${SKILL_TAG_NAME} id="${id}" name="${name}"${iconAttribute} />`;
 }

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -1,4 +1,4 @@
-export type SkillTag = {
+export type SkillReference = {
   id: string;
   name: string;
 };
@@ -8,7 +8,7 @@ export const SKILL_TAG_NAME = "skill";
 export const SKILL_TAG_REGEX = /<skill\s+([^>]*?)\s*\/>/g;
 export const SKILL_TAG_REGEX_BEGINNING = /^<skill\s+([^>]*?)\s*\/>/;
 
-function parseSkillTagAttributes(attributes: string): SkillTag | null {
+function parseSkillTagAttributes(attributes: string): SkillReference | null {
   const id = attributes.match(/\bid="([^"]+)"/)?.[1];
   const name = attributes.match(/\bname="([^"]+)"/)?.[1];
 
@@ -22,7 +22,7 @@ function parseSkillTagAttributes(attributes: string): SkillTag | null {
   };
 }
 
-export function parseSkillTag(tag: string): SkillTag | null {
+export function parseSkillTag(tag: string): SkillReference | null {
   const attributes = SKILL_TAG_REGEX_BEGINNING.exec(tag)?.[1];
 
   if (!attributes) {
@@ -32,12 +32,12 @@ export function parseSkillTag(tag: string): SkillTag | null {
   return parseSkillTagAttributes(attributes);
 }
 
-export function extractSkillTags(markdown: string): SkillTag[] {
+export function extractSkillTags(markdown: string): SkillReference[] {
   return [...markdown.matchAll(SKILL_TAG_REGEX)]
     .map((match) => parseSkillTag(match[0]))
-    .filter((skill): skill is SkillTag => skill !== null);
+    .filter((skill): skill is SkillReference => skill !== null);
 }
 
-export function serializeSkillTag({ id, name }: SkillTag): string {
+export function serializeSkillTag({ id, name }: SkillReference): string {
   return `<${SKILL_TAG_NAME} id="${id}" name="${name}" />`;
 }

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -1,0 +1,87 @@
+export type SkillTag = {
+  id: string;
+  name: string;
+};
+
+export const SKILL_TAG_NAME = "skill";
+
+export const SKILL_TAG_REGEX = /<skill\s+([^>]*?)\s*\/>/g;
+export const SKILL_TAG_REGEX_BEGINNING = /^<skill\s+([^>]*?)\s*\/>/;
+
+const XML_ENTITY_REPLACEMENTS: Record<string, string> = {
+  "&quot;": '"',
+  "&lt;": "<",
+  "&gt;": ">",
+  "&amp;": "&",
+};
+
+function escapeXml(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function decodeXml(text: string): string {
+  return text.replaceAll(
+    /&quot;|&lt;|&gt;|&amp;/g,
+    (match) => XML_ENTITY_REPLACEMENTS[match] ?? match
+  );
+}
+
+function parseSkillTagAttributes(attributes: string): SkillTag | null {
+  const id = attributes.match(/\bid="([^"]+)"/)?.[1];
+  const name = attributes.match(/\bname="([^"]+)"/)?.[1];
+
+  if (!id || !name) {
+    return null;
+  }
+
+  return {
+    id: decodeXml(id),
+    name: decodeXml(name),
+  };
+}
+
+export function parseSkillTag(tag: string): SkillTag | null {
+  const attributes = SKILL_TAG_REGEX_BEGINNING.exec(tag)?.[1];
+
+  if (!attributes) {
+    return null;
+  }
+
+  return parseSkillTagAttributes(attributes);
+}
+
+export function extractSkillTags(markdown: string): SkillTag[] {
+  return [...markdown.matchAll(SKILL_TAG_REGEX)]
+    .map((match) => parseSkillTag(match[0]))
+    .filter((skill): skill is SkillTag => skill !== null);
+}
+
+export function serializeSkillTag({ id, name }: SkillTag): string {
+  return `<${SKILL_TAG_NAME} id="${escapeXml(id)}" name="${escapeXml(name)}" />`;
+}
+
+export function replaceSkillTagsWithDirectives(markdown: string): string {
+  return markdown.replace(SKILL_TAG_REGEX, (match) => {
+    const skill = parseSkillTag(match);
+    if (!skill) {
+      return match;
+    }
+
+    return `:skill[${skill.name}]{sId=${skill.id}}`;
+  });
+}
+
+export function replaceSkillTagsWithSlashNames(markdown: string): string {
+  return markdown.replace(SKILL_TAG_REGEX, (match) => {
+    const skill = parseSkillTag(match);
+    if (!skill) {
+      return match;
+    }
+
+    return `/${skill.name}`;
+  });
+}

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -41,25 +41,3 @@ export function extractSkillTags(markdown: string): SkillTag[] {
 export function serializeSkillTag({ id, name }: SkillTag): string {
   return `<${SKILL_TAG_NAME} id="${id}" name="${name}" />`;
 }
-
-export function replaceSkillTagsWithDirectives(markdown: string): string {
-  return markdown.replace(SKILL_TAG_REGEX, (match) => {
-    const skill = parseSkillTag(match);
-    if (!skill) {
-      return match;
-    }
-
-    return `:skill[${skill.name}]{sId=${skill.id}}`;
-  });
-}
-
-export function replaceSkillTagsWithSlashNames(markdown: string): string {
-  return markdown.replace(SKILL_TAG_REGEX, (match) => {
-    const skill = parseSkillTag(match);
-    if (!skill) {
-      return match;
-    }
-
-    return `/${skill.name}`;
-  });
-}


### PR DESCRIPTION
## Description

This PR is part of a work to change the way JIT skills are represented in user messages.

The end goal is to make those references part of the message content itself, so a selected skill can appear inline in the draft as a chip and be rendered to the model as an explicit `<skill ... />` reference.

This first PR adds some required building blocks without changing the input bar flow yet.
Introduces a `SkillNode` for the input-bar editor with markdown serialization for `<skill id="..." name="..." />`, and the editor extraction plumbing needed to round-trip those tags cleanly.

## Tests

- Added a unit test.

## Risk

- Low.

## Deploy Plan

- Deploy front.
