### PR TITLE
feat(sbx): redact env var values from bash output, instruct agent on disclosure

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -369,7 +369,7 @@ describe("runSandboxBashTool", () => {
     expect(result.value[0].text).not.toContain(secretValue);
   });
 
-  it("does not redact short or low-value values and logs ineligibility once per name", async () => {
+  it("does not redact short or low-entropy values", async () => {
     mockLoadEnv.mockResolvedValue(
       new Ok({
         DST_SHORT_VALUE: "12345678",
@@ -400,31 +400,19 @@ describe("runSandboxBashTool", () => {
     );
     mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
 
-    const firstResult = await runSandboxBashTool(
-      { command: "echo values", description: "Run command" },
-      makeExtra()
-    );
-    const secondResult = await runSandboxBashTool(
+    const result = await runSandboxBashTool(
       { command: "echo values", description: "Run command" },
       makeExtra()
     );
 
-    expect(firstResult.isOk()).toBe(true);
-    expect(secondResult.isOk()).toBe(true);
-    if (firstResult.isErr() || secondResult.isErr()) {
-      throw new Error("Unexpected bash tool failure");
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
     }
-    expect(firstResult.value[0].text).toContain(
+    expect(result.value[0].text).toContain(
       "12345678 true 1234567890123456 abc123def456"
     );
-    expect(firstResult.value[0].text).not.toContain("«redacted:");
-
-    const ineligibleLogCalls = mockLoggerInfo.mock.calls.filter(
-      (call) =>
-        call[1] ===
-        "sandbox env var value not eligible for output redaction (too short or low-value)"
-    );
-    expect(ineligibleLogCalls).toHaveLength(4);
+    expect(result.value[0].text).not.toContain("«redacted:");
     expect(mockLoggerWarn).not.toHaveBeenCalledWith(
       expect.anything(),
       "sandbox bash output contained env var values; redacted"

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -21,6 +21,10 @@ const {
   mockStartTelemetry,
   mockWrapCommand,
   mockEnsureActive,
+  mockLoadEnv,
+  mockLoggerError,
+  mockLoggerInfo,
+  mockLoggerWarn,
 } = vi.hoisted(() => ({
   mockAddSandboxPolicyDomain: vi.fn(),
   mockCheckEgressForwarderHealth: vi.fn(),
@@ -37,6 +41,10 @@ const {
   mockStartTelemetry: vi.fn(),
   mockWrapCommand: vi.fn(),
   mockEnsureActive: vi.fn(),
+  mockLoadEnv: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/config", () => ({
@@ -119,11 +127,17 @@ vi.mock("@app/lib/resources/sandbox_resource", () => ({
   },
 }));
 
+vi.mock("@app/lib/resources/workspace_sandbox_env_var_resource", () => ({
+  WorkspaceSandboxEnvVarResource: {
+    loadEnv: mockLoadEnv,
+  },
+}));
+
 vi.mock("@app/logger/logger", () => ({
   default: {
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
+    error: mockLoggerError,
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
   },
 }));
 
@@ -204,6 +218,7 @@ describe("runSandboxBashTool", () => {
     mockGetSandboxImage.mockReturnValue(new Ok({}));
     mockMountConversationFiles.mockResolvedValue(new Ok(undefined));
     mockRefreshGcsToken.mockResolvedValue(new Ok(undefined));
+    mockLoadEnv.mockResolvedValue(new Ok({}));
     mockReadNewDenyLogEntries.mockResolvedValue(new Ok([]));
     mockRevokeExecToken.mockResolvedValue(undefined);
     mockSetupEgressForwarder.mockResolvedValue(new Ok(undefined));
@@ -270,6 +285,190 @@ describe("runSandboxBashTool", () => {
         user: "agent-proxied",
       })
     );
+  });
+
+  it("redacts eligible workspace env var values from final bash output", async () => {
+    const secretValue = "high-entropy-token-123";
+    mockLoadEnv.mockResolvedValue(
+      new Ok({ DST_API_TOKEN: secretValue })
+    );
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi.fn().mockResolvedValue(
+        new Ok({
+          exitCode: 0,
+          stdout: `token=${secretValue}`,
+          stderr: "",
+        })
+      ),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
+
+    const result = await runSandboxBashTool(
+      { command: "echo token", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value[0].text).toContain("«redacted: $DST_API_TOKEN»");
+    expect(result.value[0].text).not.toContain(secretValue);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      {
+        workspaceId: "workspace-id",
+        varNames: ["DST_API_TOKEN"],
+      },
+      "sandbox bash output contained env var values; redacted"
+    );
+  });
+
+  it("redacts eligible values from appended network proxy logs", async () => {
+    const secretValue = "another-high-entropy-token";
+    mockLoadEnv.mockResolvedValue(
+      new Ok({ DST_API_TOKEN: secretValue })
+    );
+    mockReadNewDenyLogEntries.mockResolvedValue(
+      new Ok([`denied example.com ${secretValue}`])
+    );
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi
+        .fn()
+        .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ok", stderr: "" })),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
+
+    const result = await runSandboxBashTool(
+      { command: "echo ok", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value[0].text).toContain(
+      "<network_proxy_logs>\ndenied example.com «redacted: $DST_API_TOKEN»\n</network_proxy_logs>"
+    );
+    expect(result.value[0].text).not.toContain(secretValue);
+  });
+
+  it("does not redact short or low-value values and logs ineligibility once per name", async () => {
+    mockLoadEnv.mockResolvedValue(
+      new Ok({
+        DST_SHORT_VALUE: "12345678",
+        DST_BOOLEAN_VALUE: "true",
+        DST_NUMERIC_VALUE: "1234567890123456",
+        DST_WORD_VALUE: "abc123def456",
+      })
+    );
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi.fn().mockResolvedValue(
+        new Ok({
+          exitCode: 0,
+          stdout:
+            "12345678 true 1234567890123456 abc123def456 high-entropy-token",
+          stderr: "",
+        })
+      ),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
+
+    const firstResult = await runSandboxBashTool(
+      { command: "echo values", description: "Run command" },
+      makeExtra()
+    );
+    const secondResult = await runSandboxBashTool(
+      { command: "echo values", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(firstResult.isOk()).toBe(true);
+    expect(secondResult.isOk()).toBe(true);
+    if (firstResult.isErr() || secondResult.isErr()) {
+      throw new Error("Unexpected bash tool failure");
+    }
+    expect(firstResult.value[0].text).toContain(
+      "12345678 true 1234567890123456 abc123def456"
+    );
+    expect(firstResult.value[0].text).not.toContain("«redacted:");
+
+    const ineligibleLogCalls = mockLoggerInfo.mock.calls.filter(
+      (call) =>
+        call[1] ===
+        "sandbox env var value not eligible for output redaction (too short or low-value)"
+    );
+    expect(ineligibleLogCalls).toHaveLength(4);
+    expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "sandbox bash output contained env var values; redacted"
+    );
+  });
+
+  it("fails closed when env var redaction materialization fails", async () => {
+    mockLoadEnv.mockResolvedValue(
+      new Err(new Error("bad ciphertext for DST_API_TOKEN"))
+    );
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi
+        .fn()
+        .mockResolvedValue(
+          new Ok({ exitCode: 0, stdout: "secret", stderr: "" })
+        ),
+    };
+
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: false,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
+
+    const result = await runSandboxBashTool(
+      { command: "echo secret", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(
+        "Failed to safely return sandbox output."
+      );
+    }
   });
 
   it("restarts the forwarder when the health check fails", async () => {

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -289,9 +289,7 @@ describe("runSandboxBashTool", () => {
 
   it("redacts eligible workspace env var values from final bash output", async () => {
     const secretValue = "high-entropy-token-123";
-    mockLoadEnv.mockResolvedValue(
-      new Ok({ DST_API_TOKEN: secretValue })
-    );
+    mockLoadEnv.mockResolvedValue(new Ok({ DST_API_TOKEN: secretValue }));
     const sandbox = {
       providerId: "provider-id",
       sId: "sandbox-id",
@@ -335,9 +333,7 @@ describe("runSandboxBashTool", () => {
 
   it("redacts eligible values from appended network proxy logs", async () => {
     const secretValue = "another-high-entropy-token";
-    mockLoadEnv.mockResolvedValue(
-      new Ok({ DST_API_TOKEN: secretValue })
-    );
+    mockLoadEnv.mockResolvedValue(new Ok({ DST_API_TOKEN: secretValue }));
     mockReadNewDenyLogEntries.mockResolvedValue(
       new Ok([`denied example.com ${secretValue}`])
     );

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -55,22 +55,8 @@ const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
 const ADD_EGRESS_DOMAIN_TOOL_NAME = "add_egress_domain" as const;
 const REDACTION_MARKER_PREFIX = "«redacted:";
 const REDACTION_MARKER_SUFFIX = "»";
-const LOW_VALUE_DENYLIST = new Set([
-  "true",
-  "false",
-  "production",
-  "staging",
-  "development",
-  "admin",
-  "root",
-  "localhost",
-]);
-// Process-scoped: dedupes the per-(workspace, name) "ineligible value" log so
-// a workspace with a misconfigured short value doesn't spam logs on every bash
-// invocation. Cleared on process restart — fine, the log is a hint, not a
-// metric. Set cardinality is bounded by #(workspace × ineligible env var
-// name) on a single pod, which is small in practice.
-const loggedIneligibleRedactionValues = new Set<string>();
+const REDACTION_MIN_LENGTH = 16;
+const REDACTION_MIN_ENTROPY_BITS_PER_CHAR = 3.5;
 
 interface FormatExecOutputOpts {
   denyLogEntries?: string[];
@@ -103,52 +89,31 @@ function formatExecOutput(
   return sections.join("\n") || "(no output)";
 }
 
-// Eligibility floor for output redaction. Goal: avoid mass-redacting common
-// short substrings ("true", "1234", "admin", ...) that would randomly collide
-// with unrelated bash output and turn legitimate text into «redacted: $FOO».
-// The thresholds (12 chars min, 16 chars for pure-alphanumeric, denylist of
-// low-entropy words, no pure digits) are heuristic and conservative; they
-// trade off a small false-negative rate (legit short secrets won't be
-// stripped) against a much smaller false-positive rate. The skill instruction
-// is the primary disclosure control — this is a safety net.
-function isRedactionEligible(value: string): boolean {
-  const normalizedValue = value.toLowerCase();
-
-  if (value.length < 12) {
-    return false;
+// Shannon entropy in bits/char. Uniform random characters approach
+// log2(alphabet size); dictionary words and uniform-digit strings sit well
+// below.
+function shannonEntropyBitsPerChar(value: string): number {
+  const counts = new Map<string, number>();
+  for (const ch of value) {
+    counts.set(ch, (counts.get(ch) ?? 0) + 1);
   }
-
-  if (LOW_VALUE_DENYLIST.has(normalizedValue)) {
-    return false;
+  let entropy = 0;
+  for (const count of counts.values()) {
+    const p = count / value.length;
+    entropy -= p * Math.log2(p);
   }
-
-  if (/^[0-9]+$/.test(value)) {
-    return false;
-  }
-
-  if (/^[A-Za-z0-9]+$/.test(value) && value.length < 16) {
-    return false;
-  }
-
-  return true;
+  return entropy;
 }
 
-function logIneligibleRedactionValueOnce({
-  workspaceId,
-  name,
-}: {
-  workspaceId: string;
-  name: string;
-}) {
-  const key = `${workspaceId}:${name}`;
-  if (loggedIneligibleRedactionValues.has(key)) {
-    return;
-  }
-
-  loggedIneligibleRedactionValues.add(key);
-  logger.info(
-    { workspaceId, name },
-    "sandbox env var value not eligible for output redaction (too short or low-value)"
+// Skip values too short or too low-entropy to be worth redacting. The goal
+// is to avoid mass-redacting common substrings (timestamps, short tokens,
+// dictionary words) that randomly collide with unrelated bash output and
+// turn legitimate text into «redacted: $FOO». False-negative tolerance is
+// the trade-off; the skill instruction is the primary disclosure control.
+function isRedactionEligible(value: string): boolean {
+  return (
+    value.length >= REDACTION_MIN_LENGTH &&
+    shannonEntropyBitsPerChar(value) >= REDACTION_MIN_ENTROPY_BITS_PER_CHAR
   );
 }
 
@@ -174,7 +139,6 @@ async function redactSandboxEnvVarsFromOutput(
   // MAX_VARS_PER_WORKSPACE, output capped upstream).
   for (const [name, value] of Object.entries(envResult.value)) {
     if (!isRedactionEligible(value)) {
-      logIneligibleRedactionValueOnce({ workspaceId, name });
       continue;
     }
 

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -422,9 +422,7 @@ export async function runSandboxBashTool(
     return new Err(new MCPError("Failed to safely return sandbox output."));
   }
 
-  return new Ok([
-    { type: "text" as const, text: redactedOutputResult.value },
-  ]);
+  return new Ok([{ type: "text" as const, text: redactedOutputResult.value }]);
 }
 
 export async function addEgressDomainTool(

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -44,6 +44,7 @@ import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import logger from "@app/logger/logger";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isDevelopment } from "@app/types/shared/env";
@@ -52,6 +53,24 @@ import { Err, Ok, type Result } from "@app/types/shared/result";
 const DEFAULT_WORKING_DIRECTORY = "/home/agent";
 const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
 const ADD_EGRESS_DOMAIN_TOOL_NAME = "add_egress_domain" as const;
+const REDACTION_MARKER_PREFIX = "«redacted:";
+const REDACTION_MARKER_SUFFIX = "»";
+const LOW_VALUE_DENYLIST = new Set([
+  "true",
+  "false",
+  "production",
+  "staging",
+  "development",
+  "admin",
+  "root",
+  "localhost",
+]);
+// Process-scoped: dedupes the per-(workspace, name) "ineligible value" log so
+// a workspace with a misconfigured short value doesn't spam logs on every bash
+// invocation. Cleared on process restart — fine, the log is a hint, not a
+// metric. Set cardinality is bounded by #(workspace × ineligible env var
+// name) on a single pod, which is small in practice.
+const loggedIneligibleRedactionValues = new Set<string>();
 
 interface FormatExecOutputOpts {
   denyLogEntries?: string[];
@@ -82,6 +101,99 @@ function formatExecOutput(
   }
 
   return sections.join("\n") || "(no output)";
+}
+
+// Eligibility floor for output redaction. Goal: avoid mass-redacting common
+// short substrings ("true", "1234", "admin", ...) that would randomly collide
+// with unrelated bash output and turn legitimate text into «redacted: $FOO».
+// The thresholds (12 chars min, 16 chars for pure-alphanumeric, denylist of
+// low-entropy words, no pure digits) are heuristic and conservative; they
+// trade off a small false-negative rate (legit short secrets won't be
+// stripped) against a much smaller false-positive rate. The skill instruction
+// is the primary disclosure control — this is a safety net.
+function isRedactionEligible(value: string): boolean {
+  const normalizedValue = value.toLowerCase();
+
+  if (value.length < 12) {
+    return false;
+  }
+
+  if (LOW_VALUE_DENYLIST.has(normalizedValue)) {
+    return false;
+  }
+
+  if (/^[0-9]+$/.test(value)) {
+    return false;
+  }
+
+  if (/^[A-Za-z0-9]+$/.test(value) && value.length < 16) {
+    return false;
+  }
+
+  return true;
+}
+
+function logIneligibleRedactionValueOnce({
+  workspaceId,
+  name,
+}: {
+  workspaceId: string;
+  name: string;
+}) {
+  const key = `${workspaceId}:${name}`;
+  if (loggedIneligibleRedactionValues.has(key)) {
+    return;
+  }
+
+  loggedIneligibleRedactionValues.add(key);
+  logger.info(
+    { workspaceId, name },
+    "sandbox env var value not eligible for output redaction (too short or low-value)"
+  );
+}
+
+// Best-effort final-payload redaction for accidental bash output leaks.
+// This does not catch transformed values, short/low-entropy values, other
+// sandbox tools, or out-of-band exfiltration. The sandbox skill instruction
+// remains the primary disclosure control.
+async function redactSandboxEnvVarsFromOutput(
+  auth: Authenticator,
+  output: string
+): Promise<Result<string, Error>> {
+  const envResult = await WorkspaceSandboxEnvVarResource.loadEnv(auth);
+  if (envResult.isErr()) {
+    return envResult;
+  }
+
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  let redactedOutput = output;
+  const redactedNames: string[] = [];
+
+  // O(env_count × output_size): split/join scans the full output once per
+  // eligible env var. Acceptable at current bounds (env_count ≤ 50 per
+  // MAX_VARS_PER_WORKSPACE, output capped upstream).
+  for (const [name, value] of Object.entries(envResult.value)) {
+    if (!isRedactionEligible(value)) {
+      logIneligibleRedactionValueOnce({ workspaceId, name });
+      continue;
+    }
+
+    if (redactedOutput.includes(value)) {
+      redactedOutput = redactedOutput
+        .split(value)
+        .join(`${REDACTION_MARKER_PREFIX} $${name}${REDACTION_MARKER_SUFFIX}`);
+      redactedNames.push(name);
+    }
+  }
+
+  if (redactedNames.length > 0) {
+    logger.warn(
+      { workspaceId, varNames: redactedNames },
+      "sandbox bash output contained env var values; redacted"
+    );
+  }
+
+  return new Ok(redactedOutput);
 }
 
 function isSandboxAgentEgressRequestsAllowed(auth: Authenticator): boolean {
@@ -298,8 +410,21 @@ export async function runSandboxBashTool(
   }
 
   const output = formatExecOutput(execResult.value, { denyLogEntries });
+  const redactedOutputResult = await redactSandboxEnvVarsFromOutput(
+    auth,
+    output
+  );
+  if (redactedOutputResult.isErr()) {
+    logger.error(
+      { err: redactedOutputResult.error },
+      "Failed to load sandbox env vars for bash output redaction"
+    );
+    return new Err(new MCPError("Failed to safely return sandbox output."));
+  }
 
-  return new Ok([{ type: "text" as const, text: output }]);
+  return new Ok([
+    { type: "text" as const, text: redactedOutputResult.value },
+  ]);
 }
 
 export async function addEgressDomainTool(

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -121,25 +121,24 @@ block first; a denied egress is a possible cause.`;
 function buildEnvironmentVariablesSection(): string {
   return `#### Sandbox Environment Variables
 
-The sandbox may have workspace-configured environment variables available to
-your code via standard environment APIs such as \`process.env\` or
-\`os.environ\`. All workspace-configured names are prefixed with \`DST_\`
-(e.g. \`DST_OPENAI_API_KEY\`, \`DST_GITHUB_TOKEN\`). If a tool, CLI, or SDK
-expects a specific unprefixed name (e.g. \`OPENAI_API_KEY\`), you must read
+The sandbox may have workspace-configured environment variables available
+in the bash shell and to any code you run. All workspace-configured names
+are prefixed with \`DST_\` (e.g. \`DST_API_TOKEN\`, \`DST_SERVICE_KEY\`).
+If a tool, CLI, or SDK expects a specific unprefixed name, you must read
 the \`DST_\`-prefixed variable and re-export it under the expected name
 yourself before invoking the tool — for example
-\`OPENAI_API_KEY=\$DST_OPENAI_API_KEY some-cli ...\` in bash, or
-\`os.environ[\"OPENAI_API_KEY\"] = os.environ[\"DST_OPENAI_API_KEY\"]\` in
-Python. You may use these variables to authenticate with APIs or pass them
-into code paths that consume them, but you must never print, echo, \`cat\`,
-or otherwise disclose an environment variable value. Do not include a value
-in output, logs, error messages, or final answers. Do not re-encode,
-transform, or split a value to bypass this rule. Do not list available
-environment variable names just to enumerate what is configured.
+\`SOMETOOL_TOKEN=\$DST_SOMETOOL_TOKEN some-cli ...\`. You may use these
+variables to authenticate with APIs or pass them into code paths that
+consume them, but you must never print, echo, \`cat\`, or otherwise
+disclose an environment variable value. Do not include a value in output,
+logs, error messages, or final answers. Do not re-encode, transform, or
+split a value to bypass this rule. Do not list available environment
+variable names just to enumerate what is configured.
 
 If a user asks for a secret value, refuse and say it is not viewable. If you
-need to confirm a variable is set, check a boolean condition such as
-\`"FOO" in os.environ\` and do not read or print the value.
+need to confirm a variable is set, check whether it is non-empty without
+printing its content (e.g. \`[ -n "\$DST_FOO" ]\` in bash) — do not read or
+print the value.
 
 Bash tool output that contains a configured environment variable value is
 post-processed and replaced with a marker like \`«redacted: $FOO»\`. If you

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -123,12 +123,19 @@ function buildEnvironmentVariablesSection(): string {
 
 The sandbox may have workspace-configured environment variables available to
 your code via standard environment APIs such as \`process.env\` or
-\`os.environ\`. You may use them to authenticate with APIs or pass them into
-code paths that consume them, but you must never print, echo, \`cat\`, or
-otherwise disclose an environment variable value. Do not include a value in
-output, logs, error messages, or final answers. Do not re-encode, transform, or
-split a value to bypass this rule. Do not list available environment variable
-names just to enumerate what is configured.
+\`os.environ\`. All workspace-configured names are prefixed with \`DST_\`
+(e.g. \`DST_OPENAI_API_KEY\`, \`DST_GITHUB_TOKEN\`). If a tool, CLI, or SDK
+expects a specific unprefixed name (e.g. \`OPENAI_API_KEY\`), you must read
+the \`DST_\`-prefixed variable and re-export it under the expected name
+yourself before invoking the tool — for example
+\`OPENAI_API_KEY=\$DST_OPENAI_API_KEY some-cli ...\` in bash, or
+\`os.environ[\"OPENAI_API_KEY\"] = os.environ[\"DST_OPENAI_API_KEY\"]\` in
+Python. You may use these variables to authenticate with APIs or pass them
+into code paths that consume them, but you must never print, echo, \`cat\`,
+or otherwise disclose an environment variable value. Do not include a value
+in output, logs, error messages, or final answers. Do not re-encode,
+transform, or split a value to bypass this rule. Do not list available
+environment variable names just to enumerate what is configured.
 
 If a user asks for a secret value, refuse and say it is not viewable. If you
 need to confirm a variable is set, check a boolean condition such as

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -118,12 +118,36 @@ hangs or fails with TLS/DNS errors, check the \`<network_proxy_logs>\`
 block first; a denied egress is a possible cause.`;
 }
 
+function buildEnvironmentVariablesSection(): string {
+  return `#### Sandbox Environment Variables
+
+The sandbox may have workspace-configured environment variables available to
+your code via standard environment APIs such as \`process.env\` or
+\`os.environ\`. You may use them to authenticate with APIs or pass them into
+code paths that consume them, but you must never print, echo, \`cat\`, or
+otherwise disclose an environment variable value. Do not include a value in
+output, logs, error messages, or final answers. Do not re-encode, transform, or
+split a value to bypass this rule. Do not list available environment variable
+names just to enumerate what is configured.
+
+If a user asks for a secret value, refuse and say it is not viewable. If you
+need to confirm a variable is set, check a boolean condition such as
+\`"FOO" in os.environ\` and do not read or print the value.
+
+Bash tool output that contains a configured environment variable value is
+post-processed and replaced with a marker like \`«redacted: $FOO»\`. If you
+see such a marker in tool output, treat it as evidence that you printed a
+value you should not have — apologize, do not retry the command, and do not
+attempt to reconstruct, decode, or otherwise recover the value.`;
+}
+
 async function buildSandboxInstructions(
   auth: Authenticator,
   providerId: ModelProviderIdType | undefined,
   hasDsbxTools: boolean
 ): Promise<string> {
   const networkAccessSection = await buildNetworkAccessSection(auth);
+  const environmentVariablesSection = buildEnvironmentVariablesSection();
   const sandboxInstructions = buildSandboxInstructionProse({ hasDsbxTools });
 
   let toolsResult;
@@ -135,7 +159,7 @@ async function buildSandboxInstructions(
   } else {
     const imageResult = getSandboxImage(auth);
     if (imageResult.isErr()) {
-      return `${sandboxInstructions}\n\n${networkAccessSection}`;
+      return `${sandboxInstructions}\n\n${networkAccessSection}\n\n${environmentVariablesSection}`;
     }
     toolsResult = new Ok(
       filterDsbxToolEntries(imageResult.value.tools, {
@@ -145,7 +169,7 @@ async function buildSandboxInstructions(
   }
 
   if (toolsResult.isErr()) {
-    return `${sandboxInstructions}\n\n${networkAccessSection}`;
+    return `${sandboxInstructions}\n\n${networkAccessSection}\n\n${environmentVariablesSection}`;
   }
 
   const manifest = createToolManifest(toolsResult.value);
@@ -154,6 +178,8 @@ async function buildSandboxInstructions(
   return `${sandboxInstructions}
 
 ${networkAccessSection}
+
+${environmentVariablesSection}
 
 #### Sandbox Available Tools and Libraries
 


### PR DESCRIPTION
## Description

Adds two layers of disclosure control on top of the workspace sandbox env var infrastructure (already shipped in earlier PRs).

### 1. Skill instruction

`buildEnvironmentVariablesSection` in `front/lib/resources/skill/code_defined/sandbox.ts`. Tells the agent:

- Workspace env vars are available in the bash shell and to any code the agent runs. All workspace-configured names are prefixed with `DST_` (e.g. `DST_API_TOKEN`).
- If a tool / CLI / SDK expects a specific unprefixed name, the agent must read the `DST_`-prefixed variable and re-export it under the expected name itself before invoking the tool — example: `SOMETOOL_TOKEN=$DST_SOMETOOL_TOKEN some-cli ...`.
- **Never** print, echo, `cat`, encode, transform, split, or otherwise emit a value. Don't list configured names just to enumerate.
- If a user asks for a value, refuse — values are not viewable.
- Presence-check via a non-empty test that doesn't print the content (`[ -n "$DST_FOO" ]`).
- Explains what the `«redacted: $FOO»` marker means if it ever shows up in tool output: evidence that something leaked, don't retry, don't try to reconstruct.

Threaded into `buildSandboxInstructions` between the network access section and the tools manifest, with both fallback paths (image error / toolsResult error) also including it.

### 2. Bash-tool output redactor

In `runSandboxBashTool`, after `formatExecOutput` and before returning content blocks, the assembled payload is scanned for occurrences of any eligible workspace env var value. Each occurrence is substring-replaced with `«redacted: $NAME»`.

Eligibility — kept deliberately simple:

- `value.length >= 16` (`REDACTION_MIN_LENGTH`).
- Shannon entropy `>= 3.5` bits/char (`REDACTION_MIN_ENTROPY_BITS_PER_CHAR`).

Goal: avoid mass-redacting common substrings (timestamps, short tokens, dictionary words, uniform-digit strings) that randomly collide with unrelated bash output. Real secrets — random tokens, base64 / hex / mixed strings — clear both bars comfortably; pure-digit IDs, repeated patterns, and short dictionary-like values do not. False-negative tolerance is the trade-off; the skill instruction is the primary disclosure control.

Observability: `logger.warn({ workspaceId, varNames }, "sandbox bash output contained env var values; redacted")` whenever any value was redacted.

Fail-closed: if `loadEnv` returns `Err` (e.g. decryption failure), the bash tool returns an MCP error (`Failed to safely return sandbox output.`) instead of leaking the unredacted output.

### What this is *not*

This is defense-in-depth, not a guarantee. It does not catch:

- Values that have been transformed (base64, slicing, hashing) before being printed.
- Network exfiltration from sandbox code.
- Other sandbox tools (only the bash final-payload is scanned today).
- Short or low-entropy values (deliberately, to avoid mangling output).

The skill instruction is the primary control.

## Tests

`front/lib/api/actions/servers/sandbox/tools/index.test.ts` — 4 new tests inside the existing `describe("runSandboxBashTool")`:

- Eligible value in stdout → redacted, `logger.warn` called with `varNames: ["DST_API_TOKEN"]`.
- Eligible value in the appended `<network_proxy_logs>` block → redacted there too.
- Four ineligible values (short / boolean / pure digits / short pure-alphanumeric) → not redacted, no `logger.warn`.
- `loadEnv` returns `Err` → bash tool returns `Err(MCPError("Failed to safely return sandbox output."))`.

17/17 tests pass in the file. `npx tsc --noEmit` clean.

## Risk

Low. The feature gate is unchanged (`sandbox_tools` Dust-only flag), the redactor is an output-only post-processor, and `loadEnv` returning empty (no env vars configured) is a no-op for the redaction path.

The most plausible regression is the redactor over-replacing — a 16-char-plus value happening to be a substring of legitimate bash output. Mitigations: the entropy floor + length floor, and the `logger.warn` at the redaction site provides quick post-hoc visibility into what was redacted in production.

If the redactor itself errors (currently can only error via `loadEnv` decrypt failure), the bash tool fails closed — the agent sees an MCP error rather than the unredacted output.

Rollback: revert. No migrations, no schema, no flag.

## Deploy Plan

1. Merge.
2. Deploy `front`.
3. Smoke-test on a Dust workspace with `sandbox_tools` enabled: with a `DST_FOO` env var configured (>= 16 chars, high-entropy value), ask the agent to `echo $DST_FOO` from bash; confirm the response shows `«redacted: $DST_FOO»` and `logger.warn` fires with `varNames: ["DST_FOO"]`. Then ask the agent to confirm `DST_FOO` is set without revealing it; confirm the agent uses a presence-check.