### PR TITLE
[front] fix: support MCP tool names containing dots in stake editor

### DIFF
--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -58,7 +58,9 @@ const owner = {
   whiteListedProviders: null,
   defaultEmbeddingProvider: null,
   metadata: {},
-} as unknown as LightWorkspaceType;
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+} satisfies LightWorkspaceType;
 
 const mcpServerView = {
   id: 1,
@@ -75,10 +77,13 @@ const mcpServerView = {
   server: {
     sId: "rms_1",
     name: "test-server",
+    version: "1.0.0",
     description: "Test server description",
-    icon: "Cog",
+    icon: "ToolsIcon",
+    authorization: null,
     availability: "manual",
     allowMultipleInstances: true,
+    documentationUrl: null,
     tools: [
       {
         name: TOOL_NAME_WITH_DOT,
@@ -86,34 +91,39 @@ const mcpServerView = {
       },
     ],
   },
-} as unknown as MCPServerViewType;
+} satisfies MCPServerViewType;
 
-interface HarnessProps {
-  formRef: { current: UseFormReturn<MCPServerFormValues> | null };
-}
+function renderToolsList() {
+  let form!: UseFormReturn<MCPServerFormValues>;
 
-function Harness({ formRef }: HarnessProps) {
-  const defaults = getMCPServerFormDefaults(mcpServerView);
-  const form = useForm<MCPServerFormValues>({
-    values: defaults,
-    mode: "onChange",
-    shouldUnregister: false,
-    resolver: zodResolver(
-      getMCPServerFormSchema(mcpServerView, { existingViewNames: [] })
-    ),
-  });
-  formRef.current = form;
-  return (
-    <FormProvider {...form}>
-      <ToolsList owner={owner} mcpServerView={mcpServerView} />
-    </FormProvider>
-  );
+  function Harness() {
+    const defaults = getMCPServerFormDefaults(mcpServerView);
+    const currentForm = useForm<MCPServerFormValues>({
+      values: defaults,
+      mode: "onChange",
+      shouldUnregister: false,
+      resolver: zodResolver(
+        getMCPServerFormSchema(mcpServerView, { existingViewNames: [] })
+      ),
+    });
+
+    form = currentForm;
+
+    return (
+      <FormProvider {...currentForm}>
+        <ToolsList owner={owner} mcpServerView={mcpServerView} />
+      </FormProvider>
+    );
+  }
+
+  render(<Harness />);
+
+  return { form };
 }
 
 describe("ToolsList", () => {
   it("keeps form state flat and validates when a tool name contains a dot", async () => {
-    const formRef: HarnessProps["formRef"] = { current: null };
-    render(<Harness formRef={formRef} />);
+    const { form } = renderToolsList();
 
     // Toggling the dotted-name tool's enabled state used to corrupt RHF state
     // because dots in field paths are interpreted as nested-object separators.
@@ -122,16 +132,13 @@ describe("ToolsList", () => {
       fireEvent.click(checkbox);
     });
 
-    const form = formRef.current!;
     const values = form.getValues();
 
     // The dotted key must remain a flat record entry, not a nested path.
     expect(values.toolSettings[TOOL_NAME_WITH_DOT]).toBeDefined();
     expect(values.toolSettings[TOOL_NAME_WITH_DOT].enabled).toBe(false);
     // No nested object should have been created at the path "weather.get_current".
-    expect(
-      (values.toolSettings as Record<string, unknown>).weather
-    ).toBeUndefined();
+    expect(values.toolSettings["weather"]).toBeUndefined();
 
     // Schema validation must pass — this is the user-facing failure mode.
     const isValid = await form.trigger();

--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -1,0 +1,141 @@
+import {
+  getMCPServerFormDefaults,
+  getMCPServerFormSchema,
+  type MCPServerFormValues,
+} from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import { ToolsList } from "@app/components/actions/mcp/ToolsList";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { LightWorkspaceType } from "@app/types/user";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { FormProvider, type UseFormReturn, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+
+// Stub Sparkle UI primitives so they render plain DOM and let us click the checkbox.
+vi.mock("@dust-tt/sparkle", () => ({
+  Button: ({ label, isSelect: _isSelect, ...rest }: any) => (
+    <button {...rest}>{label}</button>
+  ),
+  Card: ({ children, ...rest }: any) => <div {...rest}>{children}</div>,
+  Checkbox: ({ checked, onClick }: any) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onClick={onClick}
+      onChange={() => {}}
+    />
+  ),
+  Collapsible: ({ children }: any) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: any) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: any) => (
+    <button type="button">{children}</button>
+  ),
+  ContentMessage: ({ children }: any) => <div>{children}</div>,
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuItem: ({ label }: any) => <button type="button">{label}</button>,
+  DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
+  InformationCircleIcon: () => null,
+}));
+
+// Treat the test server as remote so default-stake lookups skip the internal
+// server registry.
+vi.mock("@app/lib/actions/mcp_helper", () => ({
+  isRemoteMCPServerType: () => true,
+  requiresBearerTokenConfiguration: () => false,
+  getMcpServerViewDescription: (view: { description?: string }) =>
+    view.description ?? "test description",
+}));
+
+const TOOL_NAME_WITH_DOT = "weather.get_current";
+
+const owner = {
+  sId: "ws_1",
+  id: 1,
+  name: "Test Workspace",
+  segmentation: null,
+  role: "admin",
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  metadata: {},
+} as unknown as LightWorkspaceType;
+
+const mcpServerView = {
+  id: 1,
+  sId: "msv_1",
+  name: "Test Server",
+  description: "Test server description",
+  spaceId: "sp_1",
+  serverType: "remote",
+  oAuthUseCase: null,
+  editedByUser: null,
+  createdAt: 0,
+  updatedAt: 0,
+  toolsMetadata: undefined,
+  server: {
+    sId: "rms_1",
+    name: "test-server",
+    description: "Test server description",
+    icon: "Cog",
+    availability: "manual",
+    allowMultipleInstances: true,
+    tools: [
+      {
+        name: TOOL_NAME_WITH_DOT,
+        description: "Get current weather",
+      },
+    ],
+  },
+} as unknown as MCPServerViewType;
+
+interface HarnessProps {
+  formRef: { current: UseFormReturn<MCPServerFormValues> | null };
+}
+
+function Harness({ formRef }: HarnessProps) {
+  const defaults = getMCPServerFormDefaults(mcpServerView);
+  const form = useForm<MCPServerFormValues>({
+    values: defaults,
+    mode: "onChange",
+    shouldUnregister: false,
+    resolver: zodResolver(
+      getMCPServerFormSchema(mcpServerView, { existingViewNames: [] })
+    ),
+  });
+  formRef.current = form;
+  return (
+    <FormProvider {...form}>
+      <ToolsList owner={owner} mcpServerView={mcpServerView} />
+    </FormProvider>
+  );
+}
+
+describe("ToolsList", () => {
+  it("keeps form state flat and validates when a tool name contains a dot", async () => {
+    const formRef: HarnessProps["formRef"] = { current: null };
+    render(<Harness formRef={formRef} />);
+
+    // Toggling the dotted-name tool's enabled state used to corrupt RHF state
+    // because dots in field paths are interpreted as nested-object separators.
+    const checkbox = screen.getByRole("checkbox");
+    await act(async () => {
+      fireEvent.click(checkbox);
+    });
+
+    const form = formRef.current!;
+    const values = form.getValues();
+
+    // The dotted key must remain a flat record entry, not a nested path.
+    expect(values.toolSettings[TOOL_NAME_WITH_DOT]).toBeDefined();
+    expect(values.toolSettings[TOOL_NAME_WITH_DOT].enabled).toBe(false);
+    // No nested object should have been created at the path "weather.get_current".
+    expect(
+      (values.toolSettings as Record<string, unknown>).weather
+    ).toBeUndefined();
+
+    // Schema validation must pass — this is the user-facing failure mode.
+    const isValid = await form.trigger();
+    expect(isValid).toBe(true);
+    expect(form.formState.errors.toolSettings).toBeUndefined();
+  });
+});

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -137,8 +137,8 @@ export const ToolsList = memo(
     );
 
     // We use a single controller for the whole `toolSettings` record because
-    // RHF treats dots in field paths as nested-object separators, which would
-    // corrupt form state for tool names that contain dots.
+    // React Hook Form treats dots in field paths as nested-object separators,
+    // which would corrupt form state for tool names that contain dots.
     const { control } = useFormContext<MCPServerFormValues>();
     const { field } = useController({
       control,

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -1,4 +1,7 @@
-import type { MCPServerFormValues } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import type {
+  MCPServerFormValues,
+  ToolSettings,
+} from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import { getDefaultInternalToolStakeLevel } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
@@ -33,11 +36,8 @@ interface ToolItemProps {
   tool: { name: string; description: string };
   mayUpdate: boolean;
   availableStakeLevels: MCPToolStakeLevelType[];
-  metadata?: {
-    enabled: boolean;
-    permission: MCPToolStakeLevelType;
-  };
-  defaultPermission: MCPToolStakeLevelType;
+  settings: ToolSettings;
+  onChange: (settings: ToolSettings) => void;
 }
 
 const ToolItem = memo(
@@ -45,32 +45,22 @@ const ToolItem = memo(
     tool,
     mayUpdate,
     availableStakeLevels,
-    metadata,
-    defaultPermission,
+    settings,
+    onChange,
   }: ToolItemProps) => {
-    const { control } = useFormContext<MCPServerFormValues>();
-    const { field } = useController({
-      control,
-      name: `toolSettings.${tool.name}`,
-      defaultValue: {
-        enabled: metadata?.enabled ?? true,
-        permission: metadata?.permission ?? defaultPermission,
-      },
-    });
-
-    const toolPermission = field.value.permission;
-    const toolEnabled = field.value.enabled;
+    const toolPermission = settings.permission;
+    const toolEnabled = settings.enabled;
 
     const handleToggle = () => {
-      field.onChange({
-        ...field.value,
+      onChange({
+        ...settings,
         enabled: !toolEnabled,
       });
     };
 
     const handlePermissionChange = (permission: MCPToolStakeLevelType) => {
-      field.onChange({
-        ...field.value,
+      onChange({
+        ...settings,
         permission,
       });
     };
@@ -146,6 +136,22 @@ export const ToolsList = memo(
       [mcpServerView.server.tools]
     );
 
+    // We use a single controller for the whole `toolSettings` record because
+    // RHF treats dots in field paths as nested-object separators, which would
+    // corrupt form state for tool names that contain dots.
+    const { control } = useFormContext<MCPServerFormValues>();
+    const { field } = useController({
+      control,
+      name: "toolSettings",
+    });
+
+    const handleToolChange = (toolName: string, settings: ToolSettings) => {
+      field.onChange({
+        ...field.value,
+        [toolName]: settings,
+      });
+    };
+
     const getAvailableStakeLevels = (): MCPToolStakeLevelType[] => {
       return [...MCP_TOOL_STAKE_LEVELS];
     };
@@ -204,14 +210,24 @@ export const ToolsList = memo(
                               tool.name
                             );
 
+                          const settings: ToolSettings = field.value[
+                            tool.name
+                          ] ?? {
+                            enabled: metadata?.enabled ?? true,
+                            permission:
+                              metadata?.permission ?? defaultPermission,
+                          };
+
                           return (
                             <ToolItem
                               key={index}
                               tool={tool}
                               mayUpdate={mayUpdate}
                               availableStakeLevels={availableStakeLevels}
-                              metadata={metadata}
-                              defaultPermission={defaultPermission}
+                              settings={settings}
+                              onChange={(next) =>
+                                handleToolChange(tool.name, next)
+                              }
                             />
                           );
                         }


### PR DESCRIPTION
## Description

[fixes this eng-runner ticket](https://github.com/dust-tt/tasks/issues/7776)

react-hook-form interprets dots in field paths as nested-object separators, so registering each ToolItem at toolSettings.${tool.name} corrupted the form state for tools whose names contain dots and made the Zod schema fail with "toolSettings: invalid". Lift the controller to a single useController on toolSettings and update the record by key to keep dotted names intact.

## Tests

Local + test file

## Risk

Low

## Deploy Plan

Front
