### PR TITLE
Add: separate tab for todos.

### DIFF
--- a/front/components/assistant/conversation/space/SpaceTodosTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTodosTab.tsx
@@ -1,0 +1,22 @@
+import { ProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/ProjectTodosPanel";
+import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
+import type { WorkspaceType } from "@app/types/user";
+
+interface SpaceTodosTabProps {
+  owner: WorkspaceType;
+  spaceInfo: GetSpaceResponseBody["space"];
+}
+
+export function SpaceTodosTab({ owner, spaceInfo }: SpaceTodosTabProps) {
+  return (
+    <div className="flex h-full min-h-0 w-full flex-1 overflow-y-auto px-6">
+      <div className="mx-auto flex h-full w-full max-w-4xl flex-col py-8">
+        <ProjectTodosPanel
+          owner={owner}
+          spaceId={spaceInfo.sId}
+          isReadOnly={!!spaceInfo.archivedAt || !spaceInfo.isMember}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -68,7 +68,7 @@ import {
   WindIcon,
 } from "@dust-tt/sparkle";
 import type React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 const SUMMARY_ITEM_TRANSITION_MS = 240;
 
@@ -296,68 +296,6 @@ function TodoSources({
   );
 }
 
-// ── Collapsible wrapper ──────────────────────────────────────────────────────
-
-const COLLAPSED_MAX_HEIGHT_PX = 650;
-
-interface CollapsibleTodoListProps {
-  children: React.ReactNode;
-}
-
-function CollapsibleTodoList({ children }: CollapsibleTodoListProps) {
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [needsCollapse, setNeedsCollapse] = useState(false);
-
-  useEffect(() => {
-    const el = contentRef.current;
-    if (!el) {
-      return;
-    }
-
-    const observer = new ResizeObserver(() => {
-      setNeedsCollapse(el.scrollHeight > COLLAPSED_MAX_HEIGHT_PX);
-    });
-    observer.observe(el);
-
-    return () => observer.disconnect();
-  }, []);
-
-  return (
-    <div className="flex flex-col gap-2">
-      <div className="relative">
-        <div
-          ref={contentRef}
-          className="flex flex-col gap-4"
-          style={{
-            maxHeight:
-              isExpanded || !needsCollapse
-                ? undefined
-                : COLLAPSED_MAX_HEIGHT_PX,
-            overflow: "hidden",
-            transition: "max-height 200ms ease",
-          }}
-        >
-          {children}
-        </div>
-        {!isExpanded && needsCollapse && (
-          <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-b from-transparent to-background dark:to-background-night" />
-        )}
-      </div>
-      {needsCollapse && (
-        <div>
-          <Button
-            size="xs"
-            variant="outline"
-            label={isExpanded ? "Show less" : "Show more"}
-            onClick={() => setIsExpanded((prev) => !prev)}
-          />
-        </div>
-      )}
-    </div>
-  );
-}
-
 // ── Read-only panel (archived projects) ───────────────────────────────────────
 
 function ReadOnlyTodoItem({
@@ -417,7 +355,7 @@ function ReadOnlyProjectTodosPanel({
           <Spinner size="sm" />
         </div>
       ) : (
-        <CollapsibleTodoList>
+        <div className="flex flex-col gap-4">
           <div className="flex flex-col">
             {todos.map((todo) => (
               <ReadOnlyTodoItem
@@ -433,7 +371,7 @@ function ReadOnlyProjectTodosPanel({
               You're all caught up!
             </p>
           )}
-        </CollapsibleTodoList>
+        </div>
       )}
     </div>
   );
@@ -892,13 +830,12 @@ function EditableProjectTodosPanel({
       user.fullName.toLowerCase().includes(normalizedSearch)
     );
   }, [assigneeSearch, users]);
-  const selectedAssigneeLabel = formatTodoScopeLabel({
+  const todoScopeLabel = formatTodoScopeLabel({
     scope: assigneeScope,
     selectedUserSIds,
     usersBySId,
     viewerUserId,
   });
-  const assigneeLabel = selectedAssigneeLabel;
 
   const filteredTodos = useMemo(() => {
     switch (assigneeScope) {
@@ -1127,8 +1064,8 @@ function EditableProjectTodosPanel({
               type="button"
               className="inline-flex items-center gap-1 rounded-md px-1 py-0.5 hover:bg-muted/40 dark:hover:bg-muted-night/40"
             >
-              <h3 className="heading-xl text-foreground dark:text-foreground-night">
-                {assigneeLabel}
+              <h3 className="heading-2xl text-foreground dark:text-foreground-night">
+                {todoScopeLabel}
               </h3>
               <Icon
                 visual={ChevronDownIcon}
@@ -1239,7 +1176,7 @@ function EditableProjectTodosPanel({
           <Spinner size="sm" />
         </div>
       ) : (
-        <CollapsibleTodoList>
+        <div className="flex flex-col gap-4">
           {/* Todo items */}
           <div className="flex flex-col">
             {groupedTodosForAll.map((group) => (
@@ -1283,7 +1220,7 @@ function EditableProjectTodosPanel({
               You're all caught up!
             </p>
           )}
-        </CollapsibleTodoList>
+        </div>
       )}
     </div>
   );

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -1,5 +1,4 @@
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import { ProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/ProjectTodosPanel";
 import { SpaceConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceConversationListItem";
 import { SpaceConversationsActions } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsActions";
 import { SpaceLoadingConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceLoadingConversationListItem";
@@ -10,7 +9,6 @@ import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
 import { useSpaceUnreadConversationIds } from "@app/hooks/conversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSearchConversations } from "@app/hooks/useSearchConversations";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
@@ -77,7 +75,6 @@ export function SpaceConversationsTab({
   onOpenMembersPanel,
 }: SpaceConversationsTabProps) {
   const { isEditor: isProjectEditor } = spaceInfo;
-  const { hasFeature } = useFeatureFlags();
   const router = useAppRouter();
   const hasHistory = useMemo(() => conversations.length > 0, [conversations]);
 
@@ -187,14 +184,6 @@ export function SpaceConversationsTab({
               />
             )}
           </div>
-
-          {hasFeature("project_todo") && (
-            <ProjectTodosPanel
-              owner={owner}
-              spaceId={spaceInfo.sId}
-              isReadOnly={!!spaceInfo.archivedAt || !spaceInfo.isMember}
-            />
-          )}
 
           {/* Suggestions for empty rooms */}
           {isEmpty ? (

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -4,13 +4,18 @@ import { ManageUsersPanel } from "@app/components/assistant/conversation/space/M
 import { ProjectHeaderActions } from "@app/components/assistant/conversation/space/ProjectHeaderActions";
 import { SpaceAlphaTab } from "@app/components/assistant/conversation/space/SpaceAlphaTab";
 import { SpaceKnowledgeTab } from "@app/components/assistant/conversation/space/SpaceKnowledgeTab";
+import { SpaceTodosTab } from "@app/components/assistant/conversation/space/SpaceTodosTab";
 
 import { useSpaceConversations } from "@app/hooks/conversations";
 import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
@@ -31,6 +36,7 @@ import {
   BookOpenIcon,
   ChatBubbleLeftRightIcon,
   Cog6ToothIcon,
+  ListCheckIcon,
   Spinner,
   Tabs,
   TabsContent,
@@ -40,11 +46,12 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useCallback, useRef, useState } from "react";
 
-type SpaceTab = "conversations" | "knowledge" | "settings";
+type SpaceTab = "conversations" | "todos" | "knowledge" | "settings";
 
 export function SpaceConversationsPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
+  const { hasFeature } = useFeatureFlags();
   const clientType = useClientType();
   const router = useAppRouter();
   const spaceId = useActiveSpaceId();
@@ -81,6 +88,8 @@ export function SpaceConversationsPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [_planLimitReached, setPlanLimitReached] = useState(false);
   const [isInvitePanelOpen, setIsInvitePanelOpen] = useState(false);
+  const canShowTodosTab =
+    hasFeature("project_todo") && spaceInfo?.kind === "project";
 
   // Parse and validate the current tab from URL hash
   const getCurrentTabFromHash = useCallback((): SpaceTab => {
@@ -95,7 +104,8 @@ export function SpaceConversationsPage() {
     if (
       hash === "knowledge" ||
       hash === "settings" ||
-      hash === "conversations"
+      hash === "conversations" ||
+      hash === "todos"
     ) {
       return hash;
     }
@@ -150,6 +160,17 @@ export function SpaceConversationsPage() {
       );
     }
   }, [spaceId]);
+
+  React.useEffect(() => {
+    if (currentTab === "todos" && !canShowTodosTab) {
+      setCurrentTab("conversations");
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${window.location.search}#conversations`
+      );
+    }
+  }, [canShowTodosTab, currentTab]);
 
   const handleTabChange = useCallback((tab: SpaceTab) => {
     // Use replaceState to avoid adding to browser history for each tab switch
@@ -332,6 +353,9 @@ export function SpaceConversationsPage() {
               label="Conversations"
               icon={ChatBubbleLeftRightIcon}
             />
+            {canShowTodosTab && (
+              <TabsTrigger value="todos" label="To-dos" icon={ListCheckIcon} />
+            )}
             <TabsTrigger
               value="knowledge"
               label="Knowledge"
@@ -382,6 +406,12 @@ export function SpaceConversationsPage() {
         <TabsContent value="knowledge">
           <SpaceKnowledgeTab owner={owner} space={spaceInfo} />
         </TabsContent>
+
+        {canShowTodosTab && (
+          <TabsContent value="todos">
+            <SpaceTodosTab owner={owner} spaceInfo={spaceInfo} />
+          </TabsContent>
+        )}
 
         <TabsContent value="settings">
           <SpaceAboutTab


### PR DESCRIPTION
## Description

The todos panel was embedded inline in the conversations tab, which made it easy to miss and forced users to scroll past the conversation list to reach it. Giving it a dedicated tab makes it a first-class destination and removes the need for the `CollapsibleTodoList` height cap.

- Add `SpaceTodosTab` component — thin wrapper rendering `ProjectTodosPanel` with the project's `spaceId` and archived/membership state
- Add `"todos"` to `SpaceTab` type and register it as a hash-based URL tab (`#todos`)
- Add `"To-dos"` `TabsTrigger` with `ListCheckIcon` in `SpaceConversationsPage`, gated by `canShowTodosTab` (`project_todo` feature flag + `spaceInfo.kind === "project"`)
- Add `SpaceTodosTab` as a `TabsContent` entry, also gated by `canShowTodosTab`
- Guard against `#todos` hash when the tab is unavailable — redirects to `#conversations` via `replaceState`
- Remove `ProjectTodosPanel` from `SpaceConversationsTab` and the associated `useFeatureFlags` import
- Remove `CollapsibleTodoList` (and `COLLAPSED_MAX_HEIGHT_PX`) from `ProjectTodosPanel` — no longer needed now that the panel has the full page height; replace both usages with a plain `flex flex-col gap-4`
- Bump title heading from `heading-xl` to `heading-2xl`

## Tests

Local

## Risk

Low — todos panel behavior is unchanged; it just lives at a new URL hash; old inlined location is removed

## Deploy Plan

Deploy `front`
