### PR TITLE
feat: improve extension content attachment

### DIFF
--- a/extension/shared/background.ts
+++ b/extension/shared/background.ts
@@ -822,7 +822,7 @@ export const registerMessageListener = (platform: PlatformService) => {
                 } else {
                   const [execution] = await chrome.scripting.executeScript({
                     target: { tabId: tab.id },
-                    func: extractPage(),
+                    func: extractPage,
                   });
                   const html = execution?.result;
                   content = html ? htmlToMarkdown(html) : "no content.";

--- a/extension/shared/lib/extraction.ts
+++ b/extension/shared/lib/extraction.ts
@@ -1,8 +1,37 @@
 /** DOM content extraction – runs inside the page context via chrome.scripting.executeScript. */
 
-/**
- * Returns a function that extracts the page's body innerHTML.
- */
 export const extractPage = () => {
-  return () => document.body.innerHTML;
+  // Clone so we can prune nodes without mutating the live DOM the user is viewing.
+  const clone = document.body.cloneNode(true) as HTMLElement;
+
+  // Strip non-content nodes: executable/styling tags, hidden elements, and SVGs
+  // (which tend to be icon noise that bloats output without informational value).
+  clone
+    .querySelectorAll(
+      'script, style, noscript, template, [hidden], [aria-hidden="true"], svg'
+    )
+    .forEach((el) => el.remove());
+
+  // Prefer semantic main-content landmarks in priority order: explicit ARIA role,
+  // then <main>, then <article>.
+  const main =
+    clone.querySelector('[role="main"]') ??
+    clone.querySelector("main") ??
+    clone.querySelector("article");
+
+  // Asides often carry supporting context (TOC, related links, metadata) that
+  // matters for downstream summarization, so keep them alongside the main content.
+  const aside =
+    clone.querySelector("aside") ??
+    clone.querySelector('[role="complementary"]');
+
+  if (main) {
+    return [main, aside]
+      .filter(Boolean)
+      .map((el) => el!.innerHTML)
+      .join("\n\n");
+  }
+
+  // Fallback for pages without semantic landmarks: return the whole pruned body.
+  return clone.innerHTML;
 };


### PR DESCRIPTION
## Description

This PR improves web page content extraction in the browser extension.

**Context:** When attaching content from a Gmail tab with an open email, the extension was capturing all emails visible in the thread list (with previews), making it difficult for agents to understand that the user was focused on a specific open email. This PR addresses that by being stricter about what content gets extracted.

- Strips non-content elements (scripts, styles, hidden elements, SVGs) that add noise without informational value
- Prioritizes semantic main content
- Preserves complementary content that may provide useful context

## Tests

Manually tested on Gmail and other pages.

## Risks

Low.

## Deploy Plan

Standard deployment. No special considerations needed.