### PR TITLE
Fix: serialization of todos.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -845,7 +845,7 @@ function EditableProjectTodosPanel({
         if (viewerUserId === null) {
           return [];
         }
-        return todos.filter((todo) => todo.userId === viewerUserId);
+        return todos.filter((todo) => todo.user?.sId === viewerUserId);
       case "users":
         if (selectedUserSIds.size === 0) {
           return todos;
@@ -863,8 +863,8 @@ function EditableProjectTodosPanel({
     >();
 
     for (const todo of filteredTodos) {
-      const user = todo.user ?? usersBySId.get(todo.userId) ?? null;
-      const key = user?.sId ?? `unknown-${todo.userId}`;
+      const user = todo.user ?? null;
+      const key = user?.sId ?? `unknown-${todo.id}`;
       const existing = groups.get(key);
       if (existing) {
         existing.todos.push(todo);
@@ -883,7 +883,7 @@ function EditableProjectTodosPanel({
       const bName = b.user?.fullName ?? "";
       return aName.localeCompare(bName, undefined, { sensitivity: "base" });
     });
-  }, [filteredTodos, usersBySId, viewerUserId]);
+  }, [filteredTodos, viewerUserId]);
 
   // Optimistically update a todo's status in the SWR cache and send the PATCH.
   // On failure the cache is revalidated from the server.
@@ -892,7 +892,6 @@ function EditableProjectTodosPanel({
       const optimistic = (prev: GetProjectTodosResponseBody | undefined) => ({
         lastReadAt: prev?.lastReadAt ?? null,
         viewerUserId: prev?.viewerUserId ?? viewerUserId,
-        users: prev?.users ?? [],
         todos: (prev?.todos ?? []).map((t) =>
           t.sId === todo.sId ? { ...t, status } : t
         ),
@@ -936,7 +935,6 @@ function EditableProjectTodosPanel({
       const optimistic = (prev: GetProjectTodosResponseBody | undefined) => ({
         lastReadAt: prev?.lastReadAt ?? null,
         viewerUserId: prev?.viewerUserId ?? viewerUserId,
-        users: prev?.users ?? [],
         todos: (prev?.todos ?? []).map((t) =>
           targetIdSet.has(t.sId) ? { ...t, status } : t
         ),
@@ -1009,7 +1007,6 @@ function EditableProjectTodosPanel({
           (prev: GetProjectTodosResponseBody | undefined) => ({
             lastReadAt: prev?.lastReadAt ?? null,
             viewerUserId: prev?.viewerUserId ?? viewerUserId,
-            users: prev?.users ?? [],
             todos: (prev?.todos ?? []).map((t) =>
               t.sId === todo.sId
                 ? {
@@ -1181,7 +1178,7 @@ function EditableProjectTodosPanel({
           <div className="flex flex-col">
             {groupedTodosForAll.map((group) => (
               <div
-                key={group.user?.sId ?? `unknown-${group.todos[0]?.userId}`}
+                key={group.user?.sId ?? `unknown-${group.todos[0]?.id}`}
                 className="mb-4 last:mb-0"
               >
                 <TodoAssigneeHeader

--- a/front/components/markdown/TodoDirectiveBlock.tsx
+++ b/front/components/markdown/TodoDirectiveBlock.tsx
@@ -1,4 +1,4 @@
-import { AttachmentChip, ListCheckIcon } from "@dust-tt/sparkle";
+import { Chip, ListCheckIcon } from "@dust-tt/sparkle";
 import { visit } from "unist-util-visit";
 
 export function TodoDirectiveBlock({
@@ -10,11 +10,7 @@ export function TodoDirectiveBlock({
 }) {
   return (
     <span data-project-todo-sid={sId} className="inline-block">
-      <AttachmentChip
-        label={label}
-        icon={{ visual: ListCheckIcon }}
-        color="green"
-      />
+      <Chip label={label} icon={ListCheckIcon} color="green" />
     </span>
   );
 }

--- a/front/lib/api/actions/servers/project_todos/tools/index.ts
+++ b/front/lib/api/actions/servers/project_todos/tools/index.ts
@@ -52,9 +52,10 @@ async function resolveAgentConfigurationIdByName(
 }
 
 function formatTodo(todo: ProjectTodoResource): string {
+  const json = todo.toJSON();
   const lines = [
-    `- [${todo.sId}] ${todo.text}`,
-    `  Status: ${todo.status} | Created: ${todo.createdAt.toISOString().slice(0, 10)}`,
+    `- [${json.sId}] ${json.text}`,
+    ` Assignee: ${json.user?.fullName} (${json.user?.sId}) | Status: ${json.status} | Created: ${json.createdAt.toISOString().slice(0, 10)}`,
   ];
   if (todo.doneAt) {
     lines.push(`  Done: ${todo.doneAt.toISOString().slice(0, 10)}`);
@@ -69,8 +70,8 @@ export function createProjectTodosTools(
   const owner = auth.getNonNullableWorkspace();
   const handlers: ToolHandlers<typeof PROJECT_TODOS_TOOLS_METADATA> = {
     list_todos: async ({
-      assigneeFilter,
-      statusFilter,
+      assigneeFilter = "mine",
+      statusFilter = "all",
       daysAgo = 7,
       dustProject,
     }) => {

--- a/front/lib/project_todo/start_agent.ts
+++ b/front/lib/project_todo/start_agent.ts
@@ -7,7 +7,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { serializeProjectTodoDirective } from "@app/lib/project_todo/format";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { APIErrorType } from "@app/types/error";
 import type { ProjectTodoType } from "@app/types/project_todo";
@@ -186,9 +185,6 @@ export async function startAgentForProjectTodo(
     });
   }
 
-  const [assigneeUser] = await UserResource.fetchByModelIds([todo.userId]);
-  const assigneeId = assigneeUser?.sId ?? "";
-
   const updatedTodo = await todo.updateWithVersion(auth, {
     status: "in_progress",
     doneAt: null,
@@ -199,7 +195,7 @@ export async function startAgentForProjectTodo(
 
   return new Ok({
     todo: {
-      ...updatedTodo.toJSON({ assigneeId }),
+      ...updatedTodo.toJSON(),
       conversationId,
     },
     conversationId,

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -12,8 +12,10 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
+  ProjectTodoAssigneeType,
   ProjectTodoSourceInfo,
   ProjectTodoType,
 } from "@app/types/project_todo";
@@ -42,12 +44,23 @@ export interface ProjectTodoResource
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
   static model: ModelStaticWorkspaceAware<ProjectTodoModel> = ProjectTodoModel;
+  private readonly assignee: ProjectTodoAssigneeType | null;
+  private readonly conversationSId: string | null;
 
   constructor(
     model: ModelStatic<ProjectTodoModel>,
-    blob: Attributes<ProjectTodoModel>
+    blob: Attributes<ProjectTodoModel>,
+    {
+      assignee,
+      conversationSId,
+    }: {
+      assignee?: ProjectTodoAssigneeType | null;
+      conversationSId?: string | null;
+    } = {}
   ) {
     super(ProjectTodoModel, blob);
+    this.assignee = assignee ?? null;
+    this.conversationSId = conversationSId ?? null;
   }
 
   // The stable string identifier for this todo, computed from the model's
@@ -186,8 +199,58 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       return [];
     }
 
-    return todos.map((t) => {
-      return new this(ProjectTodoModel, t.get());
+    const todoModelIds = todos.map((todo) => todo.id);
+    const assigneeModelIds = [...new Set(todos.map((todo) => todo.userId))];
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const [assignees, conversationRows] = await Promise.all([
+      UserResource.fetchByModelIds(assigneeModelIds, { transaction }),
+      ProjectTodoConversationModel.findAll({
+        where: {
+          workspaceId,
+          projectTodoId: { [Op.in]: todoModelIds },
+        },
+        include: [
+          {
+            model: ConversationModel,
+            as: "conversation",
+            attributes: ["sId"],
+            required: true,
+          },
+        ],
+        order: [["createdAt", "DESC"]],
+        transaction,
+      }),
+    ]);
+
+    const assigneeByModelId = new Map<ModelId, ProjectTodoAssigneeType>(
+      assignees.map((assignee) => [
+        assignee.id,
+        {
+          sId: assignee.sId,
+          fullName: assignee.fullName(),
+          image: assignee.imageUrl,
+        },
+      ])
+    );
+
+    const conversationIdByTodoModelId = new Map<ModelId, string>();
+    for (const row of conversationRows) {
+      const conversationId = row.conversation?.sId;
+      if (
+        !conversationId ||
+        conversationIdByTodoModelId.has(row.projectTodoId)
+      ) {
+        continue;
+      }
+      conversationIdByTodoModelId.set(row.projectTodoId, conversationId);
+    }
+
+    return todos.map((todo) => {
+      return new this(ProjectTodoModel, todo.get(), {
+        assignee: assigneeByModelId.get(todo.userId) ?? null,
+        conversationSId: conversationIdByTodoModelId.get(todo.id) ?? null,
+      });
     });
   }
 
@@ -517,12 +580,12 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
   // ── Serialization ──────────────────────────────────────────────────────────
 
-  toJSON({ assigneeId }: { assigneeId: string }): ProjectTodoType {
+  toJSON(): ProjectTodoType {
     return {
+      id: this.id,
       sId: this.sId,
-      userId: assigneeId,
-      user: null,
-      conversationId: null,
+      user: this.assignee,
+      conversationId: this.conversationSId,
       text: this.text,
       status: this.status,
       doneAt: this.doneAt,

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -342,7 +342,13 @@ export function useProjectTodos({
   );
 
   const sortedUsers = useMemo(() => {
-    const users = data?.users ?? emptyArray<ProjectTodoAssigneeType>();
+    const usersById = new Map<string, ProjectTodoAssigneeType>();
+    for (const todo of data?.todos ?? emptyArray<ProjectTodoType>()) {
+      if (todo.user) {
+        usersById.set(todo.user.sId, todo.user);
+      }
+    }
+    const users = [...usersById.values()];
     const viewerUserId = data?.viewerUserId ?? null;
 
     return [...users].sort((a, b) => {
@@ -355,7 +361,7 @@ export function useProjectTodos({
         sensitivity: "base",
       });
     });
-  }, [data?.users, data?.viewerUserId]);
+  }, [data?.todos, data?.viewerUserId]);
 
   return {
     todos: data?.todos ?? [],
@@ -387,7 +393,6 @@ export function useMarkProjectTodosRead({
       todosKey,
       (prev: GetProjectTodosResponseBody | undefined) => ({
         todos: prev?.todos ?? [],
-        users: prev?.users ?? [],
         viewerUserId: prev?.viewerUserId ?? null,
         lastReadAt: immediateReadAt,
       }),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.test.ts
@@ -144,7 +144,7 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]", () => {
     const { todo: updated } = res._getJSONData();
     expect(updated.text).toBe("Edited by project member");
     expect(updated.status).toBe("done");
-    expect(updated.userId).toBe(otherUser.sId);
+    expect(updated.user?.sId).toBe(otherUser.sId);
   });
 
   it("should return 400 when no update fields are provided", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/index.ts
@@ -4,7 +4,6 @@ import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import {
@@ -113,14 +112,10 @@ async function handler(
 
       const updatedTodo = await todo.updateWithVersion(auth, updates);
       const conversationId = await updatedTodo.getLatestConversationId(auth);
-      const [assigneeUser] = await UserResource.fetchByModelIds([
-        updatedTodo.userId,
-      ]);
-      const assigneeId = assigneeUser?.sId ?? "";
 
       return res.status(200).json({
         todo: {
-          ...updatedTodo.toJSON({ assigneeId }),
+          ...updatedTodo.toJSON(),
           conversationId,
         },
       });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start.test.ts
@@ -71,7 +71,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos/[todoId]/start", () =
     const data = res._getJSONData();
     expect(data.todo.sId).toBe(todo.sId);
     expect(data.todo.status).toBe("in_progress");
-    expect(data.todo.userId).toBe(otherUser.sId);
+    expect(data.todo.user?.sId).toBe(otherUser.sId);
     expect(data.todo.conversationId).toBeTruthy();
   });
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
@@ -84,7 +84,6 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_todos", () => {
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
     expect(data.todos).toHaveLength(2);
-    expect(data.users).toHaveLength(2);
     expect(data.viewerUserId).toBe(user.sId);
     expect(data.todos[0].user).not.toBeNull();
     expect(data.todos[1].user).not.toBeNull();

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
@@ -5,21 +5,15 @@ import type { Authenticator } from "@app/lib/auth";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type {
-  ProjectTodoAssigneeType,
-  ProjectTodoType,
-} from "@app/types/project_todo";
-import type { ModelId } from "@app/types/shared/model_id";
+import type { ProjectTodoType } from "@app/types/project_todo";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export interface GetProjectTodosResponseBody {
   todos: ProjectTodoType[];
   lastReadAt: string | null;
   viewerUserId: string | null;
-  users: ProjectTodoAssigneeType[];
 }
 
 async function handler(
@@ -49,39 +43,23 @@ async function handler(
         spaceId: space.id,
         lastCleanedAt: state?.lastCleanedAt ?? null,
       });
-      const assigneeIds = [...new Set(todos.map((todo) => todo.userId))];
-      const assignees = await UserResource.fetchByModelIds(assigneeIds);
-      const assigneeByModelId = new Map<ModelId, ProjectTodoAssigneeType>(
-        assignees.map((user) => [
-          user.id,
-          {
-            sId: user.sId,
-            fullName: user.fullName(),
-            image: user.imageUrl,
-          },
-        ])
-      );
 
       const todoIds = todos.map((t) => t.sId);
 
       // Fetch sources for all todos (across all version rows).
-      const [sourcesByTodoId, conversationIdByTodoId] = await Promise.all([
-        ProjectTodoResource.fetchSourcesForTodoIds(auth, {
+      const sourcesByTodoId = await ProjectTodoResource.fetchSourcesForTodoIds(
+        auth,
+        {
           sIds: todoIds,
-        }),
-        ProjectTodoResource.fetchConversationIdsForTodoIds(auth, {
-          sIds: todoIds,
-        }),
-      ]);
+        }
+      );
 
       // TODO: enrich todos with creator/done-by user info when supporting multiple users.
       const todosWithSources: ProjectTodoType[] = todos.map((t) => {
         const sources = sourcesByTodoId.get(t.sId) ?? [];
-        const assignee = assigneeByModelId.get(t.userId);
+        const serializedTodo = t.toJSON();
         return {
-          ...t.toJSON({ assigneeId: assignee?.sId ?? "" }),
-          user: assignee ?? null,
-          conversationId: conversationIdByTodoId.get(t.sId) ?? null,
+          ...serializedTodo,
           sources: sources.map((s) => ({
             sourceType: s.sourceType,
             sourceId: s.sourceId,
@@ -95,7 +73,6 @@ async function handler(
         todos: todosWithSources,
         lastReadAt: state ? state.lastReadAt.toISOString() : null,
         viewerUserId: currentUser.sId,
-        users: [...assigneeByModelId.values()],
       });
     }
 

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -1,3 +1,5 @@
+import type { ModelId } from "@app/types/shared/model_id";
+
 export const PROJECT_TODO_STATUSES = ["todo", "in_progress", "done"] as const;
 
 export type ProjectTodoStatus = (typeof PROJECT_TODO_STATUSES)[number];
@@ -33,8 +35,8 @@ export type ProjectTodoAssigneeType = {
 };
 
 export type ProjectTodoType = {
+  id: ModelId;
   sId: string;
-  userId: string;
   user: ProjectTodoAssigneeType | null;
   conversationId: string | null;
   text: string;


### PR DESCRIPTION
## Description

`toJSON()` required an `{ assigneeId }` parameter that forced every call site to run a separate `UserResource.fetchByModelIds`, while `user` and `conversationId` were always `null` in the output (callers had to patch them in manually). This was fragile and scattered enrichment logic across multiple files. Moving enrichment into `fetchAll` makes `toJSON()` self-contained and fixes two bugs along the way.

- **Enrich at fetch time** — `fetchAll` now bulk-loads assignees via `UserResource.fetchByModelIds` and linked conversations via `ProjectTodoConversationModel` in a single `Promise.all`; stores results as `private readonly assignee` and `private readonly conversationSId` on the resource instance
- **Simplify `toJSON()`** — remove `{ assigneeId }` param; `user` is now `this.assignee`, `conversationId` is `this.conversationSId`, expose `id` for stable group keys
- **Remove `UserResource.fetchByModelIds` from all call sites** — PATCH endpoint, `startAgentForProjectTodo`, and `formatTodo` in `project_todos` tools now just call `todo.toJSON()` directly; `formatTodo` gains `Assignee: fullName (sId)` line from the enriched data
- **Fix `"mine"` filter bug** — was comparing `todo.userId` (integer model id) against `viewerUserId` (sId string); now correctly compares `todo.user?.sId === viewerUserId`
- **Fix group key stability** — `unknown-${todo.userId}` → `unknown-${todo.id}` for todos with no resolved user
- **Derive `sortedUsers` from todos** — `useProjectTodos` builds the user list by scanning `todo.user` instead of a separate `data?.users` field; drop `users` from `GetProjectTodosResponseBody` and all optimistic SWR cache updates
- **Add `assigneeFilter`/`statusFilter` defaults** in the `list_todos` handler (`"mine"` and `"all"`)
- Update tests

## Tests

Local + green (tests updated)

## Risk

Low — serialization is now richer; `user` and `conversationId` are no longer `null` where they were previously patched in manually

## Deploy Plan

Deploy `front`
