### PR TITLE
fix: css imports extension

### DIFF
--- a/extension/platforms/chrome/webpack.config.ts
+++ b/extension/platforms/chrome/webpack.config.ts
@@ -136,7 +136,15 @@ export const getConfig = async ({
           test: /\.css$/,
           use: [
             "style-loader",
-            "css-loader",
+            {
+              loader: "css-loader",
+              options: {
+                modules: {
+                  auto: true,
+                  namedExport: false,
+                },
+              },
+            },
             {
               loader: "postcss-loader",
               options: {

--- a/extension/platforms/firefox/webpack.config.ts
+++ b/extension/platforms/firefox/webpack.config.ts
@@ -148,7 +148,15 @@ export const getConfig = async ({
           test: /\.css$/,
           use: [
             "style-loader",
-            "css-loader",
+            {
+              loader: "css-loader",
+              options: {
+                modules: {
+                  auto: true,
+                  namedExport: false,
+                },
+              },
+            },
             {
               loader: "postcss-loader",
               options: {

--- a/extension/platforms/front/webpack.config.ts
+++ b/extension/platforms/front/webpack.config.ts
@@ -55,7 +55,15 @@ export const getConfig = ({ env }: { env: Environment }) => {
           test: /\.css$/,
           use: [
             "style-loader",
-            "css-loader",
+            {
+              loader: "css-loader",
+              options: {
+                modules: {
+                  auto: true,
+                  namedExport: false,
+                },
+              },
+            },
             {
               loader: "postcss-loader",
               options: {


### PR DESCRIPTION
## Description

The `ThinkingStep` component was broken in the browser extension (not in the currently published version).

**Why it was broken:** `ThinkingStep.tsx` uses CSS Modules to drive its expand/collapse animation. It imports a stylesheet as an object:

```ts
import styles from "./ThinkingStep.module.css";
```

...and applies scoped class names like `styles.root`, `styles.content`, `styles.expanded`, and `styles.fade` to control the collapse behavior, height transitions, and fade overlay. However, in the extension webpack configs, the CSS loader was configured as a plain string (`"css-loader"`) with no options. Without explicitly enabling CSS modules, webpack's `css-loader` does not treat `.module.css` files as CSS modules — it simply processes them as plain global CSS. As a result, `styles` would be an undefined, so none of the scoped class names were ever applied, completely breaking the component's visual behavior.

**How this fixes it:** The plain `"css-loader"` string is replaced with a proper configuration object with the following options:

- **`auto: true`** — Tells `css-loader` to automatically detect and enable CSS modules for files whose name matches the `.module.css` convention. This ensures `ThinkingStep.module.css` (and any future `.module.css` files) are processed correctly.
- **`namedExport: false`** — Keeps the default export style (`import styles from "..."` → `styles.root`), rather than forcing named ES module exports (`import { root } from "..."`), which would require changes to all consuming components.

The fix is applied consistently across Chrome, Firefox, and Front extension webpack configs.

## Tests

Manually.

## Risks

Low — the extension is currently broken.

## Deploy Plan

Standard deployment — no special steps required.