### PR TITLE
fix(sbx): revert prod E2B cap to 24h (Pro max)

### DIFF
--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -15,7 +15,6 @@ import {
   traceSandboxOperation,
 } from "@app/lib/api/sandbox/provider";
 import logger from "@app/logger/logger";
-import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -23,19 +22,14 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { CommandExitError, NotFoundError, Sandbox } from "e2b";
 
 const ONE_HOUR_MS = 60 * 60 * 1_000;
-const ONE_DAY_MS = 24 * ONE_HOUR_MS;
 
 /**
- * In development, cap sandbox lifetime at 24h (E2B Pro max) so forgotten
- * local sandboxes don't linger. In production, set a 30-day cap: the reaper
- * destroys after 4 days *inactive*, but an actively-used sandbox can keep
- * refreshing its inactivity timer for much longer than 4 days of wall-clock
- * time. 30 days gives any realistic active session plenty of headroom while
- * still keeping a hard E2B-side safety net.
+ * E2B Pro hard-caps sandbox lifetime at 24h — passing a larger value errors
+ * out at create/connect time. Long-running sessions need to recreate/wake on
+ * expiry; the reaper still owns the inactivity-based teardown below this
+ * ceiling.
  */
-const SANDBOX_LIFETIME_MS = isDevelopment()
-  ? 24 * ONE_HOUR_MS
-  : 30 * ONE_DAY_MS;
+const SANDBOX_LIFETIME_MS = 24 * ONE_HOUR_MS;
 
 /** Timeout for individual API calls to E2B (create, connect, etc.). */
 const REQUEST_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
## Description

Reverts the production E2B sandbox lifetime cap from 30 days back to 24h. E2B Pro hard-caps sandbox lifetime at **24h** ([docs](https://e2b.dev/docs/sandbox/persistence)) — passing anything larger errors out at create/connect time, so the 30d value shipped in #25035 was simply wrong.

**Root cause:** when shipping #25035 I assumed an actively-refreshed sandbox could outlive the 4-day reaper indefinitely and wanted a long safety net on top. Turns out E2B caps `timeoutMs` at 24h per session — but each `Sandbox.connect()` resets the window, so long-running agent sessions are still fine: the wake path naturally extends lifetime past 24h of wall-clock time.

**What this PR does:**
1. Sets `SANDBOX_LIFETIME_MS = 24 * ONE_HOUR_MS` for both dev and prod.
2. Drops the now-useless `isDevelopment()` branch + `ONE_DAY_MS` constant.

> [!NOTE]
> The reaper-vs-active-refresh story from #25035 still holds via `connect()` resetting the per-session timeout — we just can't lean on a single create-time cap to cover it. The 4d inactivity teardown remains the operational owner.

Reverts the prod half of #25035.

## Risk

Worst case, prod sandbox creates that were silently failing at the API level now use the actual valid ceiling. Safe to rollback.