### PR TITLE
Filter microsoft connector based on sensitivity labels

### DIFF
--- a/connectors/migrations/db/migration_121.sql
+++ b/connectors/migrations/db/migration_121.sql
@@ -1,0 +1,2 @@
+-- Migration created on Apr 28, 2026
+ALTER TABLE "public"."microsoft_configurations" ADD COLUMN "allowedSensitivityLabels" JSONB;

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -36,12 +36,14 @@ import {
   launchMicrosoftFullSyncWorkflow,
   launchMicrosoftGarbageCollectionWorkflow,
   launchMicrosoftIncrementalSyncWorkflow,
+  launchMicrosoftSensitivityLabelsReconciliationWorkflow,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/microsoft/temporal/client";
 import {
   microsoftFullSyncWorkflowId,
   microsoftGarbageCollectionWorkflowId,
   microsoftIncrementalSyncWorkflowId,
+  microsoftSensitivityLabelsReconciliationWorkflowId,
 } from "@connectors/connectors/microsoft/temporal/workflows";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import type { SelectedSiteMetadata } from "@connectors/lib/models/microsoft";
@@ -147,6 +149,14 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     const gcRes = await launchMicrosoftGarbageCollectionWorkflow(connector.id);
     if (gcRes.isErr()) {
       throw gcRes.error;
+    }
+
+    const sensitivityLabelsReconciliationRes =
+      await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
+        connector.id
+      );
+    if (sensitivityLabelsReconciliationRes.isErr()) {
+      throw sensitivityLabelsReconciliationRes.error;
     }
 
     return new Ok(connector.id.toString());
@@ -584,6 +594,9 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     await terminateWorkflow(
       microsoftGarbageCollectionWorkflowId(this.connectorId)
     );
+    await terminateWorkflow(
+      microsoftSensitivityLabelsReconciliationWorkflowId(this.connectorId)
+    );
     // Sweep for any remaining child/transient workflows via visibility query.
     await terminateAllWorkflowsForConnectorId({
       connectorId: this.connectorId,
@@ -604,6 +617,14 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
 
     if (gcRes.isErr()) {
       return gcRes;
+    }
+
+    const sensitivityLabelsReconciliationRes =
+      await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
+        this.connectorId
+      );
+    if (sensitivityLabelsReconciliationRes.isErr()) {
+      return sensitivityLabelsReconciliationRes;
     }
 
     return new Ok(undefined);
@@ -633,28 +654,19 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    if (!["true", "false"].includes(configValue)) {
-      return new Err(
-        new Error(`Invalid config value ${configValue}, must be true or false`)
-      );
-    }
-
     switch (configKey) {
-      case "pdfEnabled": {
-        await config.update({
-          pdfEnabled: configValue === "true",
-        });
-        const workflowRes = await launchMicrosoftFullSyncWorkflow(
-          this.connectorId
-        );
-        if (workflowRes.isErr()) {
-          return workflowRes;
+      case "pdfEnabled":
+      case "csvEnabled":
+      case "largeFilesEnabled": {
+        if (!["true", "false"].includes(configValue)) {
+          return new Err(
+            new Error(
+              `Invalid config value ${configValue}, must be true or false`
+            )
+          );
         }
-        return new Ok(undefined);
-      }
-      case "csvEnabled": {
         await config.update({
-          csvEnabled: configValue === "true",
+          [configKey]: configValue === "true",
         });
         const workflowRes = await launchMicrosoftFullSyncWorkflow(
           this.connectorId
@@ -665,13 +677,21 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
         return new Ok(undefined);
       }
 
-      case "largeFilesEnabled": {
-        await config.update({
-          largeFilesEnabled: configValue === "true",
-        });
-        const workflowRes = await launchMicrosoftFullSyncWorkflow(
-          this.connectorId
-        );
+      case "microsoftSensitivityLabelsToInclude": {
+        const labels =
+          configValue.trim() === "" ? null : JSON.parse(configValue);
+        if (labels !== null && !Array.isArray(labels)) {
+          return new Err(
+            new Error(
+              "Sensitivity labels to include must be an array or empty."
+            )
+          );
+        }
+        await config.update({ allowedSensitivityLabels: labels });
+        const workflowRes =
+          await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
+            this.connectorId
+          );
         if (workflowRes.isErr()) {
           return workflowRes;
         }
@@ -714,6 +734,13 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       }
       case "largeFilesEnabled": {
         return new Ok(config.largeFilesEnabled ? "true" : "false");
+      }
+      case "microsoftSensitivityLabelsToInclude": {
+        return new Ok(
+          config.allowedSensitivityLabels
+            ? JSON.stringify(config.allowedSensitivityLabels)
+            : ""
+        );
       }
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -2,7 +2,10 @@ import type {
   DriveItem,
   MicrosoftNode,
 } from "@connectors/connectors/microsoft/lib/types";
-import { DRIVE_ITEM_EXPANDS_AND_SELECTS } from "@connectors/connectors/microsoft/lib/types";
+import {
+  DRIVE_ITEM_EXPANDS_AND_SELECTS,
+  DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS,
+} from "@connectors/connectors/microsoft/lib/types";
 import {
   internalIdFromTypeAndPath,
   typeAndPathFromInternalId,
@@ -138,7 +141,8 @@ export async function getFilesAndFolders(
   logger: LoggerInterface,
   client: Client,
   parentInternalId: string,
-  nextLink?: string
+  nextLink?: string,
+  withLabels = false
 ): Promise<{ results: DriveItem[]; nextLink?: string }> {
   const { nodeType, itemAPIPath: parentResourcePath } =
     typeAndPathFromInternalId(parentInternalId);
@@ -149,10 +153,13 @@ export async function getFilesAndFolders(
     );
   }
 
+  const expandsAndSelects = withLabels
+    ? DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS
+    : DRIVE_ITEM_EXPANDS_AND_SELECTS;
   const endpoint =
     nodeType === "drive"
-      ? `${parentResourcePath}/root/children?${DRIVE_ITEM_EXPANDS_AND_SELECTS}`
-      : `${parentResourcePath}/children?${DRIVE_ITEM_EXPANDS_AND_SELECTS}`;
+      ? `${parentResourcePath}/root/children?${expandsAndSelects}`
+      : `${parentResourcePath}/children?${expandsAndSelects}`;
 
   const res = nextLink
     ? await clientApiGet(logger, client, nextLink)
@@ -178,10 +185,12 @@ export async function getDeltaResults({
   parentInternalId,
   nextLink,
   token,
+  withLabels = false,
 }: {
   logger: LoggerInterface;
   client: Client;
   parentInternalId: string;
+  withLabels?: boolean;
 } & (
   | { nextLink?: string; token?: never }
   | { nextLink?: never; token: string }
@@ -201,10 +210,13 @@ export async function getDeltaResults({
     { parentInternalId, itemAPIPath, nextLink, token },
     "Getting delta"
   );
+  const expandsAndSelects = withLabels
+    ? DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS
+    : DRIVE_ITEM_EXPANDS_AND_SELECTS;
   const deltaPath =
     (nodeType === "folder"
-      ? `${itemAPIPath}/delta?${DRIVE_ITEM_EXPANDS_AND_SELECTS}`
-      : `${itemAPIPath}/root/delta?${DRIVE_ITEM_EXPANDS_AND_SELECTS}`) +
+      ? `${itemAPIPath}/delta?${expandsAndSelects}`
+      : `${itemAPIPath}/root/delta?${expandsAndSelects}`) +
     (token ? `&token=${token}` : "");
 
   const res = nextLink

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -22,7 +22,11 @@ export type DriveItem = Pick<
 // This must match the type above and be used when using the graph API
 // Note: for some reason, $select do not work for @microsoft.graph.downloadUrl but select does.
 export const DRIVE_ITEM_EXPANDS_AND_SELECTS =
-  "$select=id,name,parentReference,webUrl,file,folder,root,deleted,createdBy,lastModifiedBy,createdDateTime,lastModifiedDateTime,size,sharepointIds&$expand=listItem($expand=fields)&select=@microsoft.graph.downloadUrl";
+  "$select=id,name,parentReference,webUrl,file,folder,root,deleted,createdBy,lastModifiedBy,createdDateTime,lastModifiedDateTime,size,sharepointIds&$expand=listItem($expand=fields($select=_IpLabelId))&select=@microsoft.graph.downloadUrl";
+
+// Value stored in `microsoft_nodes.skipReason` when a file is excluded by sensitivity label allowlist.
+export const MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED =
+  "sensitivity_label_not_allowed" as const;
 
 export const MICROSOFT_NODE_TYPES = [
   "sites-root",

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -22,6 +22,11 @@ export type DriveItem = Pick<
 // This must match the type above and be used when using the graph API
 // Note: for some reason, $select do not work for @microsoft.graph.downloadUrl but select does.
 export const DRIVE_ITEM_EXPANDS_AND_SELECTS =
+  "$select=id,name,parentReference,webUrl,file,folder,root,deleted,createdBy,lastModifiedBy,createdDateTime,lastModifiedDateTime,size,sharepointIds&$expand=listItem($expand=fields)&select=@microsoft.graph.downloadUrl";
+
+// Extends the base query to also fetch the sensitivity label ID (_IpLabelId).
+// Requires the SensitivityLabels.Read.All OAuth scope — only use when labels are configured.
+export const DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS =
   "$select=id,name,parentReference,webUrl,file,folder,root,deleted,createdBy,lastModifiedBy,createdDateTime,lastModifiedDateTime,size,sharepointIds&$expand=listItem($expand=fields($select=_IpLabelId))&select=@microsoft.graph.downloadUrl";
 
 // Value stored in `microsoft_nodes.skipReason` when a file is excluded by sensitivity label allowlist.

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -15,9 +15,10 @@ import {
   getSites,
   itemToMicrosoftNode,
 } from "@connectors/connectors/microsoft/lib/graph_api";
-import type {
-  DriveItem,
-  MicrosoftNode,
+import {
+  type DriveItem,
+  MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED,
+  type MicrosoftNode,
 } from "@connectors/connectors/microsoft/lib/types";
 import {
   getDriveInternalIdFromItemId,
@@ -38,6 +39,8 @@ import {
   getParents,
   isAlreadySeenItem,
   recursiveNodeDeletion,
+  removeFileBasedOnSensitivityLabel,
+  shouldSyncFileBasedOnSensitivityLabels,
   syncOneFile,
   updateDescendantsParentsInCore,
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
@@ -639,7 +642,6 @@ export async function syncFiles({
   const client = await getMicrosoftClient(connector.connectionId);
 
   try {
-    // TODO(pr): handle pagination
     const childrenResult = await getFilesAndFolders(
       logger,
       client,
@@ -799,6 +801,128 @@ export async function syncFiles({
 
     throw e;
   }
+}
+
+export async function reconcileSensitivityLabelsForParent({
+  connectorId,
+  parentInternalId,
+  startSyncTs,
+  nextPageLink,
+}: {
+  connectorId: ModelId;
+  parentInternalId: string;
+  startSyncTs: number;
+  nextPageLink?: string;
+}): Promise<{
+  childNodes: string[];
+  nextLink?: string;
+}> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const logger = getActivityLogger(connector);
+
+  const providerConfig =
+    await MicrosoftConfigurationResource.fetchByConnectorId(connectorId);
+  if (!providerConfig) {
+    throw new Error(`Configuration for connector ${connectorId} not found`);
+  }
+
+  const allowedLabels = providerConfig.allowedSensitivityLabels ?? [];
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const client = await getMicrosoftClient(connector.connectionId);
+  const childrenResult = await getFilesAndFolders(
+    logger,
+    client,
+    parentInternalId,
+    nextPageLink
+  );
+
+  const mimeTypesToSync = await getMimeTypesToSync({
+    pdfEnabled: providerConfig.pdfEnabled || false,
+    csvEnabled: providerConfig.csvEnabled || false,
+  });
+
+  let removedCount = 0;
+  let addedCount = 0;
+
+  for (const child of childrenResult.results) {
+    await heartbeat();
+
+    if (!child.file) {
+      continue;
+    }
+
+    if (!child.parentReference) {
+      throw new Error(`Unexpected: parent reference missing: ${child}`);
+    }
+
+    const mimeType = child.file.mimeType;
+    if (!mimeType || !mimeTypesToSync.includes(mimeType)) {
+      continue;
+    }
+
+    const internalId = getDriveItemInternalId(child);
+    const fileResource = await MicrosoftNodeResource.fetchByInternalId(
+      connectorId,
+      internalId
+    );
+
+    const shouldSync = shouldSyncFileBasedOnSensitivityLabels({
+      fields: child.listItem?.fields,
+      allowedLabels,
+    });
+
+    const isHiddenBySensitivityLabel =
+      fileResource?.skipReason ===
+      MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED;
+
+    if (!shouldSync) {
+      await removeFileBasedOnSensitivityLabel({
+        connectorId,
+        dataSourceConfig,
+        file: child,
+        fileResource,
+        parentInternalId,
+        logger,
+      });
+      removedCount++;
+    } else if (!fileResource || isHiddenBySensitivityLabel) {
+      const didSync = await syncOneFile({
+        connectorId,
+        dataSourceConfig,
+        providerConfig,
+        file: child,
+        parentInternalId: getParentReferenceInternalId(child.parentReference),
+        startSyncTs,
+        heartbeat,
+      });
+      if (didSync) {
+        addedCount++;
+      }
+    }
+  }
+
+  logger.info(
+    {
+      connectorId,
+      parentInternalId,
+      removedCount,
+      addedCount,
+    },
+    "[ReconcileSensitivityLabels] Parent page reconciled"
+  );
+
+  const childNodes = childrenResult.results
+    .filter((item) => item.folder)
+    .map((item) => getDriveInternalIdFromItem(item));
+
+  return {
+    childNodes,
+    nextLink: childrenResult.nextLink,
+  };
 }
 
 // Legacy activity, only for compatibilty.

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -646,7 +646,8 @@ export async function syncFiles({
       logger,
       client,
       parent.internalId,
-      nextPageLink
+      nextPageLink,
+      (providerConfig.allowedSensitivityLabels ?? []).length > 0
     );
 
     const children = childrenResult.results;
@@ -837,7 +838,8 @@ export async function reconcileSensitivityLabelsForParent({
     logger,
     client,
     parentInternalId,
-    nextPageLink
+    nextPageLink,
+    allowedLabels.length > 0
   );
 
   const mimeTypesToSync = await getMimeTypesToSync({

--- a/connectors/src/connectors/microsoft/temporal/client.ts
+++ b/connectors/src/connectors/microsoft/temporal/client.ts
@@ -9,6 +9,8 @@ import {
   microsoftFullSyncWorkflowId,
   microsoftGarbageCollectionWorkflow,
   microsoftIncrementalSyncWorkflowId,
+  microsoftSensitivityLabelsReconciliationWorkflow,
+  microsoftSensitivityLabelsReconciliationWorkflowId,
 } from "@connectors/connectors/microsoft/temporal/workflows";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { getTemporalClient, terminateWorkflow } from "@connectors/lib/temporal";
@@ -135,6 +137,56 @@ export async function launchMicrosoftIncrementalSyncWorkflow(
         error: e,
       },
       `Failed starting workflow.`
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
+export async function launchMicrosoftSensitivityLabelsReconciliationWorkflow(
+  connectorId: ModelId
+): Promise<Result<string, Error>> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    return new Err(new Error(`Connector ${connectorId} not found`));
+  }
+  const client = await getTemporalClient();
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const workflowId =
+    microsoftSensitivityLabelsReconciliationWorkflowId(connectorId);
+
+  try {
+    await terminateWorkflow(workflowId);
+    await client.workflow.start(
+      microsoftSensitivityLabelsReconciliationWorkflow,
+      {
+        args: [{ connectorId }],
+        taskQueue: QUEUE_NAME,
+        workflowId,
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
+        memo: {
+          connectorId,
+        },
+      }
+    );
+    logger.info(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+      },
+      `Started Microsoft sensitivity labels reconciliation workflow.`
+    );
+    return new Ok(workflowId);
+  } catch (e) {
+    logger.error(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+        error: e,
+      },
+      `Failed starting Microsoft sensitivity labels reconciliation workflow.`
     );
     return new Err(normalizeError(e));
   }

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -5,7 +5,10 @@ import {
   getItem,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
-import { DRIVE_ITEM_EXPANDS_AND_SELECTS } from "@connectors/connectors/microsoft/lib/types";
+import {
+  DRIVE_ITEM_EXPANDS_AND_SELECTS,
+  MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED,
+} from "@connectors/connectors/microsoft/lib/types";
 import {
   getColumnsFromListItem,
   typeAndPathFromInternalId,
@@ -59,6 +62,85 @@ import type { Result } from "@dust-tt/client";
 import axios from "axios";
 
 const PARENT_SYNC_CACHE_TTL_MS = 30 * 60 * 1000;
+
+function getStringListItemField(
+  fields: unknown,
+  fieldName: string
+): string | null {
+  if (!fields || typeof fields !== "object") {
+    return null;
+  }
+
+  const field = Object.entries(fields).find(([key]) => key === fieldName);
+  if (!field) {
+    return null;
+  }
+
+  const [, value] = field;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function getSensitivityLabelIdFromListItemFields(
+  fields: unknown
+): string | null {
+  return getStringListItemField(fields, "_IpLabelId");
+}
+
+export function shouldSyncFileBasedOnSensitivityLabels({
+  fields,
+  allowedLabels,
+}: {
+  fields: unknown;
+  allowedLabels: string[];
+}): boolean {
+  if (allowedLabels.length === 0) {
+    return true;
+  }
+  const labelGuid = getSensitivityLabelIdFromListItemFields(fields);
+  // We always sync files that don't have a sensitivity label.
+  return !labelGuid || allowedLabels.includes(labelGuid);
+}
+
+export async function removeFileBasedOnSensitivityLabel({
+  connectorId,
+  dataSourceConfig,
+  file,
+  fileResource,
+  parentInternalId,
+  logger,
+}: {
+  connectorId: ModelId;
+  dataSourceConfig: DataSourceConfig;
+  file: DriveItem;
+  fileResource: MicrosoftNodeResource | null;
+  parentInternalId: string;
+  logger: Logger;
+}) {
+  const documentId = getDriveItemInternalId(file);
+
+  // Remove from data store if it was previously indexed.
+  if (fileResource) {
+    await deleteFile({
+      connectorId,
+      dataSourceConfig,
+      internalId: documentId,
+      logger,
+    });
+  }
+
+  const resourceBlob: WithCreationAttributes<MicrosoftNodeModel> = {
+    internalId: documentId,
+    connectorId,
+    lastSeenTs: new Date(),
+    nodeType: "file",
+    name: file.name ?? "",
+    parentInternalId,
+    mimeType: file.file?.mimeType ?? "",
+    webUrl: file.webUrl ?? null,
+    skipReason: MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED,
+  };
+  await MicrosoftNodeResource.upsert(resourceBlob);
+}
 
 export async function syncOneFile({
   connectorId,
@@ -116,9 +198,13 @@ export async function syncOneFile({
     connectorId,
     documentId
   );
+  const isHiddenBySensitivityLabel =
+    fileResource?.skipReason ===
+    MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED;
 
   if (
     fileResource &&
+    !isHiddenBySensitivityLabel &&
     isAlreadySeenItem({
       driveItemResource: fileResource,
       startSyncTs,
@@ -127,7 +213,7 @@ export async function syncOneFile({
     return false;
   }
 
-  if (fileResource?.skipReason) {
+  if (fileResource?.skipReason && !isHiddenBySensitivityLabel) {
     localLogger.info(
       { skipReason: fileResource.skipReason },
       "Skipping file sync"
@@ -169,6 +255,27 @@ export async function syncOneFile({
 
   if (!fields) {
     localLogger.warn("Unexpected missing fields for file");
+  }
+
+  const allowedLabels = providerConfig.allowedSensitivityLabels ?? [];
+  if (allowedLabels.length > 0) {
+    const shouldSync = shouldSyncFileBasedOnSensitivityLabels({
+      fields,
+      allowedLabels,
+    });
+
+    if (!shouldSync) {
+      await removeFileBasedOnSensitivityLabel({
+        connectorId,
+        dataSourceConfig,
+        file,
+        fileResource,
+        parentInternalId,
+        logger: localLogger,
+      });
+
+      return false;
+    }
   }
 
   const maxDocumentLen = providerConfig.largeFilesEnabled

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -7,6 +7,7 @@ import {
 import type { DriveItem } from "@connectors/connectors/microsoft/lib/types";
 import {
   DRIVE_ITEM_EXPANDS_AND_SELECTS,
+  DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS,
   MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED,
 } from "@connectors/connectors/microsoft/lib/types";
 import {
@@ -229,6 +230,7 @@ export async function syncOneFile({
 
   let url = file["@microsoft.graph.downloadUrl"];
   let fields = file.listItem?.fields;
+  const allowedLabels = providerConfig.allowedSensitivityLabels ?? [];
 
   if (!url || !fields) {
     if (!url) {
@@ -241,7 +243,7 @@ export async function syncOneFile({
     const item = (await getItem(
       localLogger,
       client,
-      `${itemAPIPath}?${DRIVE_ITEM_EXPANDS_AND_SELECTS}`
+      `${itemAPIPath}?${allowedLabels.length > 0 ? DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS : DRIVE_ITEM_EXPANDS_AND_SELECTS}`
     )) as DriveItem;
 
     url = item["@microsoft.graph.downloadUrl"];
@@ -256,8 +258,6 @@ export async function syncOneFile({
   if (!fields) {
     localLogger.warn("Unexpected missing fields for file");
   }
-
-  const allowedLabels = providerConfig.allowedSensitivityLabels ?? [];
   if (allowedLabels.length > 0) {
     const shouldSync = shouldSyncFileBasedOnSensitivityLabels({
       fields,

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -20,6 +20,7 @@ const {
   populateDeltas,
   groupRootItemsByDriveId,
   isMicrosoftFullSyncRunning,
+  reconcileSensitivityLabelsForParent,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
 });
@@ -308,6 +309,69 @@ export async function microsoftGarbageCollectionWorkflow({
   }
 }
 
+export async function microsoftSensitivityLabelsReconciliationWorkflow({
+  connectorId,
+  startSyncTs,
+  nodeIdsToReconcile = [],
+}: {
+  connectorId: ModelId;
+  startSyncTs?: number;
+  nodeIdsToReconcile?: string[];
+}) {
+  await syncStarted(connectorId);
+
+  if (startSyncTs === undefined) {
+    startSyncTs = new Date().getTime();
+  }
+
+  let pendingNodeIds =
+    nodeIdsToReconcile.length === 0
+      ? await getRootNodesToSync(connectorId)
+      : nodeIdsToReconcile;
+  pendingNodeIds = uniq(pendingNodeIds);
+
+  while (pendingNodeIds.length > 0) {
+    const nodeId = pendingNodeIds.pop();
+
+    if (!nodeId) {
+      break;
+    }
+
+    let nextPageLink: string | undefined = undefined;
+
+    do {
+      const res: Awaited<
+        ReturnType<typeof activities.reconcileSensitivityLabelsForParent>
+      > = await reconcileSensitivityLabelsForParent({
+        connectorId,
+        parentInternalId: nodeId,
+        startSyncTs,
+        nextPageLink,
+      });
+
+      pendingNodeIds = uniq(pendingNodeIds.concat(res.childNodes));
+      nextPageLink = res.nextLink;
+    } while (nextPageLink);
+
+    if (workflowInfo().historyLength > 4000) {
+      await continueAsNew<
+        typeof microsoftSensitivityLabelsReconciliationWorkflow
+      >({
+        connectorId,
+        startSyncTs,
+        nodeIdsToReconcile: pendingNodeIds,
+      });
+    }
+  }
+
+  await syncSucceeded(connectorId);
+
+  await sleep("1 hour");
+  await continueAsNew<typeof microsoftSensitivityLabelsReconciliationWorkflow>({
+    connectorId,
+  });
+}
+
 export function microsoftFullSyncWorkflowId(connectorId: ModelId) {
   return `microsoft-fullSync-${connectorId}`;
 }
@@ -322,4 +386,10 @@ export function microsoftIncrementalSyncWorkflowId(connectorId: ModelId) {
 
 export function microsoftGarbageCollectionWorkflowId(connectorId: ModelId) {
   return `microsoft-garbageCollection-${connectorId}`;
+}
+
+export function microsoftSensitivityLabelsReconciliationWorkflowId(
+  connectorId: ModelId
+) {
+  return `microsoft-sensitivityLabelsReconciliation-${connectorId}`;
 }

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -19,6 +19,7 @@ export class MicrosoftConfigurationModel extends ConnectorBaseModel<MicrosoftCon
   declare largeFilesEnabled: boolean;
   declare tenantId: string | null;
   declare selectedSites: SelectedSiteMetadata[] | null;
+  declare allowedSensitivityLabels: string[] | null;
 }
 MicrosoftConfigurationModel.init(
   {
@@ -52,6 +53,11 @@ MicrosoftConfigurationModel.init(
       allowNull: true,
     },
     selectedSites: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: null,
+    },
+    allowedSensitivityLabels: {
       type: DataTypes.JSONB,
       allowNull: true,
       defaultValue: null,

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -6,6 +6,7 @@ import { CreateOrUpdateConnectionBigQueryModal } from "@app/components/data_sour
 import { CreateOrUpdateConnectionSnowflakeModal } from "@app/components/data_source/CreateOrUpdateConnectionSnowflakeModal";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
 import { SetupNotionPrivateIntegrationModal } from "@app/components/data_source/SetupNotionPrivateIntegrationModal";
+import type { LabelsHandle } from "@app/components/shared/labels/types";
 import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
 import { AdvancedNotionManagement } from "@app/components/spaces/AdvancedNotionManagement";
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";
@@ -82,7 +83,14 @@ import {
 } from "@dust-tt/sparkle";
 import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import type React from "react";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import { useSWRConfig } from "swr";
 
@@ -813,31 +821,39 @@ export function ConnectorPermissionsModal({
   const plan = activeSubscription ? activeSubscription.plan : null;
 
   const [saving, setSaving] = useState(false);
+  const [advancedOptionsHasChanges, setAdvancedOptionsHasChanges] =
+    useState(false);
+  const labelsRef = useRef<LabelsHandle>(null);
   const sendNotification = useSendNotification();
   const { user } = useAuth();
 
   function closeModal(save: boolean) {
     setModalToShow(null);
     onClose(save);
+    setAdvancedOptionsHasChanges(false);
     setTimeout(() => {
       setSelectedNodes({});
     }, 300);
   }
 
   async function save() {
-    if (
-      !(await confirmPrivateNodesSync({
-        selectedNodes: Object.values(selectedNodes)
-          .filter((sn) => sn.isSelected)
-          .map((sn) => sn.node),
-        confirm,
-      }))
-    ) {
-      return;
+    if (!isUnchanged) {
+      if (
+        !(await confirmPrivateNodesSync({
+          selectedNodes: Object.values(selectedNodes)
+            .filter((sn) => sn.isSelected)
+            .map((sn) => sn.node),
+          confirm,
+        }))
+      ) {
+        return;
+      }
     }
     setSaving(true);
     try {
-      if (Object.keys(selectedNodes).length) {
+      let didSave = false;
+
+      if (!isUnchanged && Object.keys(selectedNodes).length) {
         const r = await clientFetch(
           `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/permissions`,
           {
@@ -870,6 +886,7 @@ export function ConnectorPermissionsModal({
             title: error.error.message,
             description: error.error.connectors_error.message,
           });
+          return;
         } else {
           void mutate(
             (key) =>
@@ -878,22 +895,35 @@ export function ConnectorPermissionsModal({
                 `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/permissions`
               )
           );
-
-          // Display the data updated modal.
-          setModalToShow("data_updated");
+          didSave = true;
         }
+      }
+
+      if (advancedOptionsHasChanges) {
+        const advancedSaveSucceeded = (await labelsRef.current?.save()) ?? true;
+        if (!advancedSaveSucceeded) {
+          return;
+        }
+        setAdvancedOptionsHasChanges(false);
+        didSave = true;
+      }
+
+      if (didSave) {
+        setModalToShow("data_updated");
       } else {
         closeModal(false);
       }
     } catch (e) {
       sendNotification({
         type: "error",
-        title: "Error saving permissions",
-        description: "An unexpected error occurred while saving permissions.",
+        title: "Error saving connector configuration",
+        description:
+          "An unexpected error occurred while saving connector configuration.",
       });
       console.error(e);
+    } finally {
+      setSaving(false);
     }
-    setSaving(false);
   }
 
   const isUnchanged = useMemo(
@@ -1061,7 +1091,15 @@ export function ConnectorPermissionsModal({
                         </CollapsibleTrigger>
                         <CollapsibleContent>
                           <AdvancedOptionsComponent
-                            {...{ owner, readOnly, isAdmin, dataSource, plan }}
+                            {...{
+                              owner,
+                              readOnly,
+                              isAdmin,
+                              dataSource,
+                              plan,
+                              onDirtyChange: setAdvancedOptionsHasChanges,
+                              labelsRef,
+                            }}
                           />
                         </CollapsibleContent>
                       </Collapsible>
@@ -1086,7 +1124,8 @@ export function ConnectorPermissionsModal({
                   rightButtonProps={{
                     label: saving ? "Saving..." : "Save",
                     variant: "primary",
-                    disabled: isUnchanged || saving,
+                    disabled:
+                      (isUnchanged && !advancedOptionsHasChanges) || saving,
                     onClick: save,
                   }}
                 />

--- a/front/components/shared/labels/AdvancedLabelsOptions.tsx
+++ b/front/components/shared/labels/AdvancedLabelsOptions.tsx
@@ -1,31 +1,34 @@
 import { SensitivityLabelsConfig } from "@app/components/shared/labels/SensitivityLabelsConfig";
-import type { SensitivityLabelSource } from "@app/components/shared/labels/types";
+import type {
+  LabelsHandle,
+  SensitivityLabelSource,
+} from "@app/components/shared/labels/types";
 import type { LightWorkspaceType } from "@app/types/user";
+import type { Ref } from "react";
 
 interface AdvancedLabelsOptionsProps {
   owner: LightWorkspaceType;
   source: SensitivityLabelSource;
   readOnly?: boolean;
+  onDirtyChange?: (dirty: boolean) => void;
+  labelsRef?: Ref<LabelsHandle>;
 }
 
 export const AdvancedLabelsOptions = ({
   owner,
   source,
   readOnly = false,
+  onDirtyChange,
+  labelsRef,
 }: AdvancedLabelsOptionsProps) => {
   return (
-    <div className="flex flex-col gap-2 mt-4">
-      <span className="heading-sm text-foreground dark:text-foreground-night">
-        Allowed labels
-      </span>
-      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-        Only labeled content matching one of these labels will be synced.
-        Unlabeled content is always included.
-      </span>
+    <div className="mt-4">
       <SensitivityLabelsConfig
         owner={owner}
         source={source}
         readOnly={readOnly}
+        onDirtyChange={onDirtyChange}
+        labelsRef={labelsRef}
       />
     </div>
   );

--- a/front/components/shared/labels/MicrosoftLabelsSelector.tsx
+++ b/front/components/shared/labels/MicrosoftLabelsSelector.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { SensitivityLabelSource } from "./types";
 
 interface MicrosoftLabelsSelectorProps {
@@ -18,7 +18,7 @@ interface MicrosoftLabelsSelectorProps {
   source: SensitivityLabelSource;
   labels: MicrosoftSensitivityLabel[];
   savedAllowedLabels: MicrosoftAllowedLabel[];
-  onSaved: () => void;
+  onSaved: () => Promise<unknown> | unknown;
   readOnly: boolean;
   hasError: boolean;
 }
@@ -40,40 +40,53 @@ export function MicrosoftLabelsSelector({
 
   const isAdminUser = isAdmin(owner);
 
-  const toggle = (id: string) => {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  };
+  useEffect(() => {
+    if (!isSaving) {
+      setSelected(new Set(savedAllowedLabels));
+    }
+  }, [savedAllowedLabels, isSaving]);
 
-  const handleSave = async () => {
+  const toggleAndSave = async (id: string) => {
+    const previousSelection = selected;
+    const nextSelection = new Set(selected);
+    if (nextSelection.has(id)) {
+      nextSelection.delete(id);
+    } else {
+      nextSelection.add(id);
+    }
+    const allowedLabels = Array.from(nextSelection);
+
+    setSelected(nextSelection);
     setIsSaving(true);
     try {
       const result = await saveDataClassificationLabels({
         owner,
         source,
-        allowedLabels: Array.from(selected),
+        allowedLabels,
       });
       if (result.success) {
+        await onSaved();
         sendNotification({
           type: "success",
-          title: "Microsoft Purview labels saved.",
-          description: "Label filtering configuration updated.",
+          title: "Labels setting updated successfully",
+          description: "Sensitivity label filtering has been updated.",
         });
-        onSaved();
       } else {
+        setSelected(previousSelection);
         sendNotification({
           type: "error",
-          title: "Failed to save Microsoft Purview labels.",
+          title: "Failed to update labels setting",
           description: result.error,
         });
       }
+    } catch (error) {
+      setSelected(previousSelection);
+      sendNotification({
+        type: "error",
+        title: "Failed to update sensitivity labels setting",
+        description:
+          error instanceof Error ? error.message : "An unknown error occurred.",
+      });
     } finally {
       setIsSaving(false);
     }
@@ -106,7 +119,7 @@ export function MicrosoftLabelsSelector({
               size="sm"
               isSelect
               className="flex-1 justify-between"
-              disabled={readOnly || !isAdminUser}
+              disabled={readOnly || !isAdminUser || isSaving}
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent className="w-80" align="start">
@@ -118,22 +131,13 @@ export function MicrosoftLabelsSelector({
                       key={label.id}
                       label={label.name}
                       checked={selected.has(label.id)}
-                      onCheckedChange={() => toggle(label.id)}
+                      onCheckedChange={() => void toggleAndSave(label.id)}
                       onSelect={(e) => e.preventDefault()}
                     />
                   ))}
             </div>
           </DropdownMenuContent>
         </DropdownMenu>
-        {labels.length > 0 && (
-          <Button
-            label="Save"
-            size="sm"
-            variant="primary"
-            disabled={readOnly || !isAdminUser || isSaving}
-            onClick={() => void handleSave()}
-          />
-        )}
       </div>
     </div>
   );

--- a/front/components/shared/labels/MicrosoftLabelsSelector.tsx
+++ b/front/components/shared/labels/MicrosoftLabelsSelector.tsx
@@ -3,15 +3,16 @@ import type { MicrosoftAllowedLabel } from "@app/lib/models/workspace_sensitivit
 import { saveDataClassificationLabels } from "@app/lib/swr/data_classification_labels";
 import type { MicrosoftSensitivityLabel } from "@app/pages/api/w/[wId]/data-classification-labels";
 import { isAdmin, type LightWorkspaceType } from "@app/types/user";
+import { Chip, Input, SliderToggle } from "@dust-tt/sparkle";
 import {
-  Button,
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
-import type { SensitivityLabelSource } from "./types";
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from "react";
+import type { LabelsHandle, SensitivityLabelSource } from "./types";
 
 interface MicrosoftLabelsSelectorProps {
   owner: LightWorkspaceType;
@@ -21,42 +22,63 @@ interface MicrosoftLabelsSelectorProps {
   onSaved: () => Promise<unknown> | unknown;
   readOnly: boolean;
   hasError: boolean;
+  isLoading?: boolean;
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
-export function MicrosoftLabelsSelector({
-  owner,
-  source,
-  labels,
-  savedAllowedLabels,
-  onSaved,
-  readOnly,
-  hasError,
-}: MicrosoftLabelsSelectorProps) {
+export const MicrosoftLabelsSelector = forwardRef<
+  LabelsHandle,
+  MicrosoftLabelsSelectorProps
+>(function MicrosoftLabelsSelector(
+  {
+    owner,
+    source,
+    labels,
+    savedAllowedLabels,
+    onSaved,
+    readOnly,
+    hasError,
+    isLoading = false,
+    onDirtyChange,
+  },
+  ref
+) {
   const sendNotification = useSendNotification();
-  const [selected, setSelected] = useState<Set<string>>(
+  const [pendingSelected, setPendingSelected] = useState<Set<string>>(
     new Set(savedAllowedLabels)
   );
+  const [isEnabled, setIsEnabled] = useState(savedAllowedLabels.length > 0);
+  const [searchText, setSearchText] = useState("");
+  const [isSearchFocused, setIsSearchFocused] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
   const isAdminUser = isAdmin(owner);
 
   useEffect(() => {
-    if (!isSaving) {
-      setSelected(new Set(savedAllowedLabels));
+    if (!isSaving && !isLoading) {
+      setPendingSelected(new Set(savedAllowedLabels));
+      setIsEnabled(savedAllowedLabels.length > 0);
     }
-  }, [savedAllowedLabels, isSaving]);
+  }, [savedAllowedLabels, isSaving, isLoading]);
 
-  const toggleAndSave = async (id: string) => {
-    const previousSelection = selected;
-    const nextSelection = new Set(selected);
-    if (nextSelection.has(id)) {
-      nextSelection.delete(id);
-    } else {
-      nextSelection.add(id);
+  const filteredLabels = labels.filter(
+    (l) =>
+      !pendingSelected.has(l.id) &&
+      l.name.toLowerCase().includes(searchText.toLowerCase())
+  );
+  const shouldShowSuggestions = isEnabled && isSearchFocused;
+
+  const hasPendingChanges = useMemo(() => {
+    const effective = isEnabled ? Array.from(pendingSelected).sort() : [];
+    const saved = [...savedAllowedLabels].sort();
+    if (effective.length !== saved.length) {
+      return true;
     }
-    const allowedLabels = Array.from(nextSelection);
+    return effective.some((id, i) => id !== saved[i]);
+  }, [pendingSelected, isEnabled, savedAllowedLabels]);
 
-    setSelected(nextSelection);
+  const persistChanges = useCallback(async () => {
+    const allowedLabels = isEnabled ? Array.from(pendingSelected) : [];
     setIsSaving(true);
     try {
       const result = await saveDataClassificationLabels({
@@ -66,79 +88,146 @@ export function MicrosoftLabelsSelector({
       });
       if (result.success) {
         await onSaved();
-        sendNotification({
-          type: "success",
-          title: "Labels setting updated successfully",
-          description: "Sensitivity label filtering has been updated.",
-        });
       } else {
-        setSelected(previousSelection);
         sendNotification({
           type: "error",
           title: "Failed to update labels setting",
           description: result.error,
         });
+        return false;
       }
     } catch (error) {
-      setSelected(previousSelection);
       sendNotification({
         type: "error",
         title: "Failed to update sensitivity labels setting",
         description:
           error instanceof Error ? error.message : "An unknown error occurred.",
       });
+      return false;
     } finally {
       setIsSaving(false);
     }
+    return true;
+  }, [isEnabled, onSaved, owner, pendingSelected, sendNotification, source]);
+
+  useEffect(() => {
+    onDirtyChange?.(hasPendingChanges);
+  }, [hasPendingChanges, onDirtyChange]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      isDirty: hasPendingChanges,
+      save: persistChanges,
+    }),
+    [hasPendingChanges, persistChanges]
+  );
+
+  const handleToggle = () => {
+    if (isEnabled) {
+      setIsEnabled(false);
+      setPendingSelected(new Set());
+      setSearchText("");
+    } else {
+      setIsEnabled(true);
+    }
   };
 
-  const triggerLabel =
-    selected.size === 0
-      ? "Select labels"
-      : `${selected.size} label${selected.size === 1 ? "" : "s"} selected`;
+  const handleSelectLabel = (labelId: string) => {
+    const next = new Set(pendingSelected);
+    next.add(labelId);
+    setPendingSelected(next);
+    setSearchText("");
+    setIsSearchFocused(false);
+  };
 
-  const emptyContent = hasError ? (
-    <p className="px-2 py-3 text-sm text-muted-foreground dark:text-muted-foreground-night">
-      Labels could not be retrieved. Make sure to grant the necessary
-      permissions to your Dust app in Azure.
-    </p>
-  ) : (
-    <p className="px-2 py-3 text-sm text-muted-foreground dark:text-muted-foreground-night">
-      No labels found. Configure them in your Microsoft Purview console first.
-    </p>
-  );
+  const handleRemoveLabel = (labelId: string) => {
+    const next = new Set(pendingSelected);
+    next.delete(labelId);
+    setPendingSelected(next);
+    if (next.size === 0) {
+      setIsEnabled(false);
+    }
+  };
+
+  const isDisabled = readOnly || !isAdminUser || isSaving || isLoading;
 
   return (
-    <div className="mb-4 flex flex-col gap-3">
-      <div className="flex items-center gap-2">
-        <DropdownMenu modal={false}>
-          <DropdownMenuTrigger asChild>
-            <Button
-              label={triggerLabel}
-              variant="outline"
-              size="sm"
-              isSelect
-              className="flex-1 justify-between"
-              disabled={readOnly || !isAdminUser || isSaving}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-80" align="start">
-            <div className="max-h-80 overflow-auto">
-              {labels.length === 0
-                ? emptyContent
-                : labels.map((label) => (
-                    <DropdownMenuCheckboxItem
-                      key={label.id}
-                      label={label.name}
-                      checked={selected.has(label.id)}
-                      onCheckedChange={() => void toggleAndSave(label.id)}
-                      onSelect={(e) => e.preventDefault()}
-                    />
-                  ))}
-            </div>
-          </DropdownMenuContent>
-        </DropdownMenu>
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="heading-sm text-foreground dark:text-foreground-night">
+          Allowed labels
+        </span>
+        <SliderToggle
+          selected={isEnabled}
+          onClick={handleToggle}
+          disabled={isDisabled}
+        />
       </div>
+      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+        Only labeled content matching one of these labels will be synced.
+        Unlabeled content is always included.
+      </span>
+      {isEnabled && (
+        <div className="flex flex-col gap-2">
+          <Input
+            placeholder="Type a label"
+            value={searchText}
+            disabled={isDisabled}
+            onChange={(e) => setSearchText(e.target.value)}
+            onFocus={() => setIsSearchFocused(true)}
+            onBlur={() => setIsSearchFocused(false)}
+          />
+          {shouldShowSuggestions && (
+            <div className="max-h-48 overflow-auto rounded-md border border-border bg-background shadow-md dark:border-border-night dark:bg-background-night">
+              {hasError ? (
+                <p className="px-3 py-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  Labels could not be retrieved. Make sure to grant the
+                  necessary permissions to your Dust app in Azure.
+                </p>
+              ) : filteredLabels.length === 0 ? (
+                <p className="px-3 py-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  {labels.length === 0
+                    ? "No labels found. Configure them in your Microsoft Purview console first."
+                    : "No matching labels."}
+                </p>
+              ) : (
+                filteredLabels.map((label) => (
+                  <button
+                    key={label.id}
+                    type="button"
+                    className="block w-full cursor-pointer px-3 py-2 text-left text-sm hover:bg-muted dark:hover:bg-muted-night"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      handleSelectLabel(label.id);
+                    }}
+                  >
+                    {label.name}
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+          {pendingSelected.size > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {Array.from(pendingSelected).map((id) => {
+                const label = labels.find((l) => l.id === id);
+                return (
+                  <Chip
+                    key={id}
+                    size="xs"
+                    color="primary"
+                    label={label?.name ?? id}
+                    onRemove={
+                      isDisabled ? undefined : () => handleRemoveLabel(id)
+                    }
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
-}
+});

--- a/front/components/shared/labels/SensitivityLabelsConfig.tsx
+++ b/front/components/shared/labels/SensitivityLabelsConfig.tsx
@@ -1,18 +1,23 @@
 import { useDataClassificationLabels } from "@app/lib/swr/data_classification_labels";
 import type { LightWorkspaceType } from "@app/types/user";
+import type { Ref } from "react";
 import { MicrosoftLabelsSelector } from "./MicrosoftLabelsSelector";
-import type { SensitivityLabelSource } from "./types";
+import type { LabelsHandle, SensitivityLabelSource } from "./types";
 
 interface SensitivityLabelsConfigProps {
   owner: LightWorkspaceType;
   source: SensitivityLabelSource;
   readOnly?: boolean;
+  onDirtyChange?: (dirty: boolean) => void;
+  labelsRef?: Ref<LabelsHandle>;
 }
 
 export function SensitivityLabelsConfig({
   owner,
   source,
   readOnly = false,
+  onDirtyChange,
+  labelsRef,
 }: SensitivityLabelsConfigProps) {
   const {
     dataClassificationLabels,
@@ -21,12 +26,9 @@ export function SensitivityLabelsConfig({
     mutateDataClassificationLabels,
   } = useDataClassificationLabels({ owner, source });
 
-  if (isDataClassificationLabelsLoading) {
-    return null;
-  }
-
   return (
     <MicrosoftLabelsSelector
+      ref={labelsRef}
       owner={owner}
       source={source}
       labels={dataClassificationLabels?.labels ?? []}
@@ -34,6 +36,8 @@ export function SensitivityLabelsConfig({
       onSaved={mutateDataClassificationLabels}
       readOnly={readOnly}
       hasError={!!isDataClassificationLabelsError}
+      isLoading={isDataClassificationLabelsLoading}
+      onDirtyChange={onDirtyChange}
     />
   );
 }

--- a/front/components/shared/labels/types.ts
+++ b/front/components/shared/labels/types.ts
@@ -1,3 +1,8 @@
 export type SensitivityLabelSource =
   | { dataSourceId: string; internalMCPServerId?: never }
   | { internalMCPServerId: string; dataSourceId?: never };
+
+export interface LabelsHandle {
+  isDirty: boolean;
+  save: () => Promise<boolean>;
+}

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -37,6 +37,7 @@ import { VantaOAuthProvider } from "@app/lib/api/oauth/providers/vanta";
 import { ZendeskOAuthProvider } from "@app/lib/api/oauth/providers/zendesk";
 import { finalizeUriForProvider } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type {
   ExtraConfigType,
@@ -230,6 +231,11 @@ export async function createConnectionAndGetSetupUrl(
     },
   });
 
+  const forceLabelsScope =
+    provider === "microsoft"
+      ? await hasFeatureFlag(auth, "sensitivity_labels")
+      : false;
+
   return new Ok(
     providerStrategy.setupUri({
       connection,
@@ -237,6 +243,7 @@ export async function createConnectionAndGetSetupUrl(
       relatedCredential,
       useCase,
       clientId,
+      forceLabelsScope,
     })
   );
 }

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -39,6 +39,7 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
         "User.Read",
         "Sites.Read.All",
         "Files.Read.All",
+        "SensitivityLabels.Read.All",
         "offline_access",
       ];
 

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -24,9 +24,11 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
   setupUri({
     connection,
     relatedCredential,
+    forceLabelsScope,
   }: {
     connection: OAuthConnectionType;
     useCase: OAuthUseCase;
+    forceLabelsScope?: boolean;
     relatedCredential?: {
       content: Record<string, string>;
       metadata: { workspace_id: string; user_id: string };
@@ -39,7 +41,7 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
         "User.Read",
         "Sites.Read.All",
         "Files.Read.All",
-        "SensitivityLabels.Read.All",
+        ...(forceLabelsScope ? ["SensitivityLabels.Read.All"] : []),
         "offline_access",
       ];
 

--- a/front/lib/connector_providers_ui.ts
+++ b/front/lib/connector_providers_ui.ts
@@ -9,6 +9,7 @@ import { SalesforceOauthExtraConfig } from "@app/components/data_source/salesfor
 import { ZendeskConfigView } from "@app/components/data_source/ZendeskConfigView";
 import { ZendeskOAuthExtraConfig } from "@app/components/data_source/ZendeskOAuthExtraConfig";
 import { AdvancedLabelsOptions } from "@app/components/shared/labels/AdvancedLabelsOptions";
+import type { LabelsHandle } from "@app/components/shared/labels/types";
 import type { ConnectorPermission } from "@app/types/connectors/connectors_api";
 import type { ConnectorProvider, DataSourceType } from "@app/types/data_source";
 import type { PlanType } from "@app/types/plan";
@@ -41,6 +42,8 @@ export interface ConnectorOptionsProps {
   isAdmin: boolean;
   dataSource: DataSourceType;
   plan: PlanType;
+  onDirtyChange?: (dirty: boolean) => void;
+  labelsRef?: React.Ref<LabelsHandle>;
 }
 
 export interface ConnectorOauthExtraConfigProps {
@@ -298,11 +301,19 @@ export const CONNECTOR_UI_CONFIGURATIONS: Record<
     optionsComponent: createConnectorOptionsPdfEnabled(
       "When enabled, PDF documents from your Microsoft OneDrive and SharePoint will be synced and processed by Dust."
     ),
-    advancedOptionsComponent: ({ owner, readOnly, dataSource }) =>
+    advancedOptionsComponent: ({
+      owner,
+      readOnly,
+      dataSource,
+      onDirtyChange,
+      labelsRef,
+    }) =>
       React.createElement(AdvancedLabelsOptions, {
         owner,
         source: { dataSourceId: dataSource.sId },
         readOnly,
+        onDirtyChange,
+        labelsRef,
       }),
     isNested: true,
     isTitleFilterEnabled: true,

--- a/front/pages/api/w/[wId]/data-classification-labels.ts
+++ b/front/pages/api/w/[wId]/data-classification-labels.ts
@@ -19,6 +19,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const MICROSOFT_SENSITIVITY_LABELS_CONFIG_KEY =
+  "microsoftSensitivityLabelsToInclude";
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type MicrosoftSensitivityLabel = {
@@ -50,6 +53,32 @@ const SourceSchema = z
 const PostBodySchema = z.object({
   allowedLabels: z.array(z.string()),
 });
+
+const AllowedLabelsConfigSchema = z.array(z.string());
+
+function parseAllowedLabelsConfig(
+  configValue: string
+):
+  | { isValid: true; allowedLabels: MicrosoftAllowedLabel[] }
+  | { isValid: false; error: unknown } {
+  if (configValue.trim() === "") {
+    return { isValid: true, allowedLabels: [] };
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(configValue);
+  } catch (error) {
+    return { isValid: false, error };
+  }
+
+  const parsed = AllowedLabelsConfigSchema.safeParse(parsedJson);
+  if (!parsed.success) {
+    return { isValid: false, error: fromError(parsed.error) };
+  }
+
+  return { isValid: true, allowedLabels: parsed.data };
+}
 
 // ─── Token helpers ───────────────────────────────────────────────────────────
 
@@ -178,6 +207,7 @@ async function handler(
   let sourceType: "connector" | "mcp_connection";
   let sourceId: string;
   let accessToken: string | null;
+  let resolvedConnectorId: string | null = null;
 
   if (dataSourceId) {
     // Connector path.
@@ -205,6 +235,7 @@ async function handler(
 
     sourceType = "connector";
     sourceId = dataSource.sId;
+    resolvedConnectorId = dataSource.connectorId ?? null;
     accessToken = await getConnectorAccessToken(dataSource);
 
     if (!accessToken) {
@@ -248,11 +279,58 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const savedConfig =
-        await WorkspaceSensitivityLabelConfigResource.fetchBySource(auth, {
-          sourceType,
-          sourceId,
-        });
+      let allowedLabels: MicrosoftAllowedLabel[] = [];
+      if (sourceType === "connector" && resolvedConnectorId) {
+        const connectorsAPI = new ConnectorsAPI(
+          config.getConnectorsAPIConfig(),
+          logger
+        );
+        const configRes = await connectorsAPI.getConnectorConfig(
+          resolvedConnectorId,
+          MICROSOFT_SENSITIVITY_LABELS_CONFIG_KEY
+        );
+        if (configRes.isErr()) {
+          logger.warn(
+            { error: configRes.error, connectorId: resolvedConnectorId },
+            "Error fetching Microsoft sensitivity labels connector config"
+          );
+          return apiError(req, res, {
+            status_code: 502,
+            api_error: {
+              type: "connector_update_error",
+              message:
+                "Failed to fetch Microsoft Purview sensitivity labels configuration.",
+            },
+          });
+        }
+
+        const parsedConfig = parseAllowedLabelsConfig(
+          configRes.value.configValue
+        );
+        if (!parsedConfig.isValid) {
+          logger.warn(
+            { error: parsedConfig.error, connectorId: resolvedConnectorId },
+            "Error parsing Microsoft sensitivity labels connector config"
+          );
+          return apiError(req, res, {
+            status_code: 502,
+            api_error: {
+              type: "connector_update_error",
+              message:
+                "Failed to fetch Microsoft Purview sensitivity labels configuration.",
+            },
+          });
+        }
+
+        allowedLabels = parsedConfig.allowedLabels;
+      } else if (sourceType === "mcp_connection") {
+        const savedConfig =
+          await WorkspaceSensitivityLabelConfigResource.fetchBySource(auth, {
+            sourceType,
+            sourceId,
+          });
+        allowedLabels = savedConfig?.allowedLabels ?? [];
+      }
 
       let labels: MicrosoftSensitivityLabel[] = [];
       if (accessToken) {
@@ -275,8 +353,7 @@ async function handler(
 
       return res.status(200).json({
         labels,
-        allowedLabels: (savedConfig?.allowedLabels ??
-          []) as MicrosoftAllowedLabel[],
+        allowedLabels,
       });
     }
 
@@ -292,6 +369,42 @@ async function handler(
         });
       }
       const { allowedLabels } = postValidation.data;
+
+      if (sourceType === "connector") {
+        if (!resolvedConnectorId) {
+          return apiError(req, res, {
+            status_code: 404,
+            api_error: {
+              type: "data_source_not_found",
+              message: "No connector found for the data source.",
+            },
+          });
+        }
+
+        const connectorsAPI = new ConnectorsAPI(
+          config.getConnectorsAPIConfig(),
+          logger
+        );
+        const setConfigRes = await connectorsAPI.setConnectorConfig(
+          resolvedConnectorId,
+          MICROSOFT_SENSITIVITY_LABELS_CONFIG_KEY,
+          allowedLabels.length > 0 ? JSON.stringify(allowedLabels) : ""
+        );
+        if (setConfigRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "data_source_error",
+              message: "Failed to save Microsoft Purview sensitivity labels.",
+              connectors_error: setConfigRes.error,
+            },
+          });
+        }
+
+        return res.status(200).json({
+          config: { sourceType, sourceId, allowedLabels },
+        });
+      }
 
       const updated = await WorkspaceSensitivityLabelConfigResource.upsert(
         auth,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -98,6 +98,7 @@ async function handler(
       "gongPermissionProfiles",
       "gongExcludeTitleKeywords",
       "privateIntegrationCredentialId",
+      "microsoftSensitivityLabelsToInclude",
     ].includes(configKey)
   ) {
     return apiError(req, res, {


### PR DESCRIPTION
## Description

* Add ability for connector to filter ingested data based on sensitivity labels
* Minor UX tweaks to be more consistent with other connectors (where we do not have a second save button)
* Notably, using connector configuration table to store preferences as opposed to using the front database used by tools
* If someone changes only a label for a doc and nothing else, it will NOT be picked up by incremental sync. To combat this, i created an additional workflow to "reconcile" any inconsistent label filtering.

## Tests

<img width="983" height="333" alt="Screenshot 2026-04-29 at 6 38 13 PM" src="https://github.com/user-attachments/assets/4ed9c187-16a8-46f5-8765-170762b19a9c" />

<img width="756" height="260" alt="Screenshot 2026-05-04 at 5 08 11 PM" src="https://github.com/user-attachments/assets/15cb4501-e53e-4815-b189-1234d75908e2" />


## Risk

* Not customer facing yet

## Deploy Plan

1. Migration
2. Deploy connectors
3. Deploy front