### PR TITLE
Filter Microsoft MCP tools based on sensitivity labels

### DIFF
--- a/front/lib/api/actions/servers/microsoft/utils.ts
+++ b/front/lib/api/actions/servers/microsoft/utils.ts
@@ -384,19 +384,29 @@ export async function searchMicrosoftDriveItems({
   client,
   query,
   pageSize = 25,
+  allowedLabels = [],
 }: {
   client: Client;
   query: string;
   pageSize?: number;
+  allowedLabels?: string[];
 }): Promise<any> {
   const endpoint = `/search/query`;
+
+  let queryString = query;
+  if (allowedLabels.length > 0) {
+    const labelKql = allowedLabels
+      .map((label) => `InformationProtectionLabelId:${label}`)
+      .join(" OR ");
+    queryString = query ? `(${query}) AND (${labelKql})` : labelKql;
+  }
 
   const requestBody = {
     requests: [
       {
         entityTypes: ["driveItem"],
         query: {
-          queryString: query,
+          queryString,
         },
         size: pageSize,
       },

--- a/front/lib/api/actions/servers/microsoft/utils.ts
+++ b/front/lib/api/actions/servers/microsoft/utils.ts
@@ -145,7 +145,7 @@ export async function getAllowedLabelsForMCPServer(
       sourceType: "mcp_connection",
       sourceId: internalMCPServerId,
     });
-  return (labelConfig?.allowedLabels ?? []) as string[];
+  return labelConfig?.allowedLabels || [];
 }
 
 export async function getGraphClient(

--- a/front/lib/api/actions/servers/microsoft/utils.ts
+++ b/front/lib/api/actions/servers/microsoft/utils.ts
@@ -1,5 +1,9 @@
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
 import { untrustedFetch } from "@app/lib/egress/server";
+import { WorkspaceSensitivityLabelConfigResource } from "@app/lib/resources/workspace_sensitivity_label_config_resource";
 import logger from "@app/logger/logger";
 import {
   isTextExtractionSupportedContentType,
@@ -120,6 +124,28 @@ export interface TeamsUser {
   displayName: string;
   mail: string;
   userPrincipalName: string;
+}
+
+export async function getAllowedLabelsForMCPServer(
+  auth: Authenticator,
+  agentLoopContext: AgentLoopContextType | undefined
+): Promise<string[]> {
+  const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
+  const internalMCPServerId =
+    toolConfig && isLightServerSideMCPToolConfiguration(toolConfig)
+      ? toolConfig.internalMCPServerId
+      : null;
+
+  if (!internalMCPServerId) {
+    return [];
+  }
+
+  const labelConfig =
+    await WorkspaceSensitivityLabelConfigResource.fetchBySource(auth, {
+      sourceType: "mcp_connection",
+      sourceId: internalMCPServerId,
+    });
+  return (labelConfig?.allowedLabels ?? []) as string[];
 }
 
 export async function getGraphClient(

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -9,9 +9,9 @@ import {
   getFileFromConversationAttachment,
   sanitizeFilename,
 } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
-import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
   downloadAndProcessMicrosoftFile,
+  getAllowedLabelsForMCPServer,
   getDriveItemEndpoint,
   getGraphClient,
   searchMicrosoftDriveItems,
@@ -20,7 +20,6 @@ import {
 } from "@app/lib/api/actions/servers/microsoft/utils";
 import { MICROSOFT_DRIVE_TOOLS_METADATA } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { untrustedFetch } from "@app/lib/egress/server";
-import { WorkspaceSensitivityLabelConfigResource } from "@app/lib/resources/workspace_sensitivity_label_config_resource";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type AdmZip from "adm-zip";
@@ -75,21 +74,10 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       );
     }
 
-    const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
-    const internalMCPServerId =
-      toolConfig && isLightServerSideMCPToolConfiguration(toolConfig)
-        ? toolConfig.internalMCPServerId
-        : null;
-
-    let allowedLabels: string[] = [];
-    if (internalMCPServerId) {
-      const labelConfig =
-        await WorkspaceSensitivityLabelConfigResource.fetchBySource(auth, {
-          sourceType: "mcp_connection",
-          sourceId: internalMCPServerId,
-        });
-      allowedLabels = (labelConfig?.allowedLabels ?? []) as string[];
-    }
+    const allowedLabels = await getAllowedLabelsForMCPServer(
+      auth,
+      agentLoopContext
+    );
 
     try {
       const response = await searchMicrosoftDriveItems({
@@ -213,24 +201,10 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       );
     }
 
-    const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
-    const internalMCPServerId =
-      toolConfig && isLightServerSideMCPToolConfiguration(toolConfig)
-        ? toolConfig.internalMCPServerId
-        : null;
-
-    let allowedLabels: string[] = [];
-    if (internalMCPServerId) {
-      const labelConfig =
-        await WorkspaceSensitivityLabelConfigResource.fetchBySource(auth, {
-          sourceType: "mcp_connection",
-          sourceId: internalMCPServerId,
-        });
-      allowedLabels = (labelConfig?.allowedLabels ?? []) as string[];
-    }
-
-    console.log("====");
-    console.log("Allowed labels for this connection:", allowedLabels);
+    const allowedLabels = await getAllowedLabelsForMCPServer(
+      auth,
+      agentLoopContext
+    );
 
     try {
       const endpoint = await getDriveItemEndpoint(itemId, driveId, siteId);
@@ -241,8 +215,6 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         .get();
 
       if (allowedLabels.length > 0) {
-        console.log("====");
-        console.log("File sensitivity label:", response?.sensitivityLabel);
         const labelId = response?.sensitivityLabel?.id;
         if (labelId && !allowedLabels.includes(labelId)) {
           return new Err(

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -9,6 +9,7 @@ import {
   getFileFromConversationAttachment,
   sanitizeFilename,
 } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
   downloadAndProcessMicrosoftFile,
   getDriveItemEndpoint,
@@ -19,6 +20,7 @@ import {
 } from "@app/lib/api/actions/servers/microsoft/utils";
 import { MICROSOFT_DRIVE_TOOLS_METADATA } from "@app/lib/api/actions/servers/microsoft_drive/metadata";
 import { untrustedFetch } from "@app/lib/egress/server";
+import { WorkspaceSensitivityLabelConfigResource } from "@app/lib/resources/workspace_sensitivity_label_config_resource";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type AdmZip from "adm-zip";
@@ -62,7 +64,10 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
     }
   },
 
-  search_drive_items: async ({ query }, { authInfo }) => {
+  search_drive_items: async (
+    { query },
+    { auth, authInfo, agentLoopContext }
+  ) => {
     const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
@@ -70,10 +75,27 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       );
     }
 
+    const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
+    const internalMCPServerId =
+      toolConfig && isLightServerSideMCPToolConfiguration(toolConfig)
+        ? toolConfig.internalMCPServerId
+        : null;
+
+    let allowedLabels: string[] = [];
+    if (internalMCPServerId) {
+      const labelConfig =
+        await WorkspaceSensitivityLabelConfigResource.fetchBySource(auth, {
+          sourceType: "mcp_connection",
+          sourceId: internalMCPServerId,
+        });
+      allowedLabels = (labelConfig?.allowedLabels ?? []) as string[];
+    }
+
     try {
       const response = await searchMicrosoftDriveItems({
         client,
         query,
+        allowedLabels,
       });
 
       return new Ok([
@@ -182,7 +204,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
   get_file_content: async (
     { itemId, driveId, siteId, offset, limit, getAsXml },
-    { authInfo }
+    { auth, authInfo, agentLoopContext }
   ) => {
     const client = await getGraphClient(authInfo);
     if (!client) {
@@ -191,10 +213,45 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       );
     }
 
+    const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
+    const internalMCPServerId =
+      toolConfig && isLightServerSideMCPToolConfiguration(toolConfig)
+        ? toolConfig.internalMCPServerId
+        : null;
+
+    let allowedLabels: string[] = [];
+    if (internalMCPServerId) {
+      const labelConfig =
+        await WorkspaceSensitivityLabelConfigResource.fetchBySource(auth, {
+          sourceType: "mcp_connection",
+          sourceId: internalMCPServerId,
+        });
+      allowedLabels = (labelConfig?.allowedLabels ?? []) as string[];
+    }
+
+    console.log("====");
+    console.log("Allowed labels for this connection:", allowedLabels);
+
     try {
       const endpoint = await getDriveItemEndpoint(itemId, driveId, siteId);
 
-      const response = await client.api(endpoint).get();
+      const response = await client
+        .api(endpoint)
+        .select("sensitivityLabel,name,file,@microsoft.graph.downloadUrl")
+        .get();
+
+      if (allowedLabels.length > 0) {
+        console.log("====");
+        console.log("File sensitivity label:", response?.sensitivityLabel);
+        const labelId = response?.sensitivityLabel?.id;
+        if (labelId && !allowedLabels.includes(labelId)) {
+          return new Err(
+            new MCPError(
+              "Access denied: this file is not accessible with the current sensitivity label configuration."
+            )
+          );
+        }
+      }
 
       const downloadUrl = response["@microsoft.graph.downloadUrl"];
       const mimeType = response.file.mimeType;

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -6,7 +6,9 @@ import {
   processAttachment,
 } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { sanitizeFilename } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { OUTLOOK_TOOLS_METADATA } from "@app/lib/api/actions/servers/outlook/mail_metadata";
+import { WorkspaceSensitivityLabelConfigResource } from "@app/lib/resources/workspace_sensitivity_label_config_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types/shared/result";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -134,7 +136,7 @@ interface OutlookFolder {
 const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   get_messages: async (
     { search, folderName, top = 10, skip = 0, select, sharedMailboxAddress },
-    { authInfo }
+    { authInfo, auth, agentLoopContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -142,6 +144,8 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     }
 
     const basePath = getMailboxBasePath(sharedMailboxAddress);
+
+    console.log("GET MESSAGES CALLED WITH PARAMS");
 
     // If folderName is provided, search for the folder and get its ID
     let folderId: string | undefined;
@@ -182,6 +186,188 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       folderId = folder.id;
     }
 
+    // Check if the workspace has sensitivity label filtering configured.
+    const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
+    const internalMCPServerId =
+      toolConfig && isLightServerSideMCPToolConfiguration(toolConfig)
+        ? toolConfig.internalMCPServerId
+        : null;
+
+    let allowedLabels: string[] = [];
+    if (internalMCPServerId) {
+      const labelConfig =
+        await WorkspaceSensitivityLabelConfigResource.fetchBySource(auth, {
+          sourceType: "mcp_connection",
+          sourceId: internalMCPServerId,
+        });
+      allowedLabels = (labelConfig?.allowedLabels ?? []) as string[];
+    }
+
+    if (allowedLabels.length > 0) {
+      // Two parallel requests:
+      // 1. /search/query with KQL to get messages that have an allowed label.
+      // 2. Regular messages endpoint expanded with the MIP MAPI property
+      //    (msip_labels). Messages where singleValueExtendedProperties is absent
+      //    have no sensitivity label and are safe to include.
+      // Results are merged and deduplicated by id.
+      const MIP_EXTENDED_PROP =
+        "String {00020386-0000-0000-C000-000000000046} Name msip_labels";
+
+      const labelQueryParts = allowedLabels.map(
+        (label) => `InformationProtectionLabelId:${label}`
+      );
+      const labelKql = labelQueryParts.join(" OR ");
+      const labeledQueryString = search
+        ? `(${search}) AND (${labelKql})`
+        : labelKql;
+
+      const defaultSearchFields = [
+        "id",
+        "conversationId",
+        "subject",
+        "bodyPreview",
+        "importance",
+        "receivedDateTime",
+        "sentDateTime",
+        "hasAttachments",
+        "isDraft",
+        "isRead",
+        "from",
+        "toRecipients",
+        "ccRecipients",
+        "bccRecipients",
+        "replyTo",
+        "parentFolderId",
+      ];
+
+      const searchRequest: Record<string, unknown> = {
+        entityTypes: ["message"],
+        query: { queryString: labeledQueryString },
+        from: skip,
+        size: Math.min(top, 100),
+        fields: select && select.length > 0 ? select : defaultSearchFields,
+      };
+      if (sharedMailboxAddress) {
+        searchRequest.contentSources = [
+          `/users/${encodeURIComponent(sharedMailboxAddress)}/messages`,
+        ];
+      }
+
+      // Build the unlabeled messages request using the regular messages endpoint.
+      const unlabeledParams = new URLSearchParams();
+      // Over-fetch to compensate for labeled messages that will be filtered out client-side.
+      unlabeledParams.append("$top", Math.min(top * 2, 100).toString());
+      unlabeledParams.append("$skip", skip.toString());
+      unlabeledParams.append(
+        "$expand",
+        `singleValueExtendedProperties($filter=id eq '${MIP_EXTENDED_PROP}')`
+      );
+      if (search) {
+        unlabeledParams.append("$search", `"${search}"`);
+      }
+      if (select && select.length > 0) {
+        unlabeledParams.append("$select", select.join(","));
+      } else {
+        unlabeledParams.append(
+          "$select",
+          "id,conversationId,subject,bodyPreview,importance,receivedDateTime,sentDateTime,hasAttachments,isDraft,isRead,from,toRecipients,ccRecipients,bccRecipients,replyTo,parentFolderId"
+        );
+      }
+      const unlabeledEndpoint = folderId
+        ? `${basePath}/mailFolders/${folderId}/messages?${unlabeledParams.toString()}`
+        : `${basePath}/messages?${unlabeledParams.toString()}`;
+
+      const [labeledResponse, unlabeledResponse] = await Promise.all([
+        fetchFromOutlook("/search/query", accessToken, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ requests: [searchRequest] }),
+        }),
+        fetchFromOutlook(unlabeledEndpoint, accessToken, { method: "GET" }),
+      ]);
+
+      if (!labeledResponse.ok) {
+        const errorText = await getErrorText(labeledResponse);
+        return new Err(
+          new MCPError(
+            `Failed to get messages: ${labeledResponse.status} ${labeledResponse.statusText} - ${errorText}`
+          )
+        );
+      }
+      if (!unlabeledResponse.ok) {
+        const errorText = await getErrorText(unlabeledResponse);
+        return new Err(
+          new MCPError(
+            `Failed to get messages: ${unlabeledResponse.status} ${unlabeledResponse.statusText} - ${errorText}`
+          )
+        );
+      }
+
+      const [labeledResult, unlabeledResult] = await Promise.all([
+        labeledResponse.json(),
+        unlabeledResponse.json(),
+      ]);
+
+      const labeledHits: Array<{ hitId: string; resource: OutlookMessage }> =
+        labeledResult?.value?.[0]?.hitsContainers?.[0]?.hits ?? [];
+      const allUnlabeled: Array<
+        OutlookMessage & {
+          singleValueExtendedProperties?: unknown[];
+        }
+      > = unlabeledResult?.value ?? [];
+      const unlabeledMessages = allUnlabeled.filter(
+        (m) =>
+          !m.singleValueExtendedProperties ||
+          m.singleValueExtendedProperties.length === 0
+      );
+
+      const messages: OutlookMessage[] = [
+        ...labeledHits.map((hit) => ({ ...hit.resource, id: hit.hitId })),
+        ...unlabeledMessages,
+      ]
+        .sort((a, b) => {
+          const aTime = a.sentDateTime ? new Date(a.sentDateTime).getTime() : 0;
+          const bTime = b.sentDateTime ? new Date(b.sentDateTime).getTime() : 0;
+          return bTime - aTime;
+        })
+        .slice(0, top);
+      console.log("===LABELED MESSAGES===", labeledHits.length);
+
+      console.log(
+        "===UNLABELED MESSAGES===",
+        JSON.stringify(unlabeledMessages, null, 2)
+      );
+
+      console.log(
+        "===TOTAL MESSAGES AFTER MERGE===",
+        JSON.stringify(messages, null, 2)
+      );
+
+      const labeledContainer =
+        labeledResult?.value?.[0]?.hitsContainers?.[0] ?? {};
+
+      return new Ok([
+        { type: "text" as const, text: "Messages fetched successfully" },
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              messages,
+              totalCount:
+                (labeledContainer.total ?? 0) +
+                (unlabeledResult?.["@odata.count"] ?? 0),
+              moreResultsAvailable:
+                labeledContainer.moreResultsAvailable ||
+                !!unlabeledResult?.["@odata.nextLink"],
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    }
+
+    // Standard path: no sensitivity label filter configured.
     const params = new URLSearchParams();
     params.append("$top", Math.min(top, 100).toString());
 

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -6,9 +6,8 @@ import {
   processAttachment,
 } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { sanitizeFilename } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
-import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import { getAllowedLabelsForMCPServer } from "@app/lib/api/actions/servers/microsoft/utils";
 import { OUTLOOK_TOOLS_METADATA } from "@app/lib/api/actions/servers/outlook/mail_metadata";
-import { WorkspaceSensitivityLabelConfigResource } from "@app/lib/resources/workspace_sensitivity_label_config_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types/shared/result";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -145,8 +144,6 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
 
     const basePath = getMailboxBasePath(sharedMailboxAddress);
 
-    console.log("GET MESSAGES CALLED WITH PARAMS");
-
     // If folderName is provided, search for the folder and get its ID
     let folderId: string | undefined;
     if (folderName) {
@@ -186,22 +183,10 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       folderId = folder.id;
     }
 
-    // Check if the workspace has sensitivity label filtering configured.
-    const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
-    const internalMCPServerId =
-      toolConfig && isLightServerSideMCPToolConfiguration(toolConfig)
-        ? toolConfig.internalMCPServerId
-        : null;
-
-    let allowedLabels: string[] = [];
-    if (internalMCPServerId) {
-      const labelConfig =
-        await WorkspaceSensitivityLabelConfigResource.fetchBySource(auth, {
-          sourceType: "mcp_connection",
-          sourceId: internalMCPServerId,
-        });
-      allowedLabels = (labelConfig?.allowedLabels ?? []) as string[];
-    }
+    const allowedLabels = await getAllowedLabelsForMCPServer(
+      auth,
+      agentLoopContext
+    );
 
     if (allowedLabels.length > 0) {
       // Two parallel requests:
@@ -331,17 +316,6 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
           return bTime - aTime;
         })
         .slice(0, top);
-      console.log("===LABELED MESSAGES===", labeledHits.length);
-
-      console.log(
-        "===UNLABELED MESSAGES===",
-        JSON.stringify(unlabeledMessages, null, 2)
-      );
-
-      console.log(
-        "===TOTAL MESSAGES AFTER MERGE===",
-        JSON.stringify(messages, null, 2)
-      );
 
       const labeledContainer =
         labeledResult?.value?.[0]?.hitsContainers?.[0] ?? {};

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -13,6 +13,25 @@ import { Err, Ok } from "@app/types/shared/result";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import sanitizeHtml from "sanitize-html";
 
+const DEFAULT_MESSAGE_FIELDS = [
+  "id",
+  "conversationId",
+  "subject",
+  "bodyPreview",
+  "importance",
+  "receivedDateTime",
+  "sentDateTime",
+  "hasAttachments",
+  "isDraft",
+  "isRead",
+  "from",
+  "toRecipients",
+  "ccRecipients",
+  "bccRecipients",
+  "replyTo",
+  "parentFolderId",
+];
+
 const fetchFromOutlook = async (
   endpoint: string,
   accessToken: string,
@@ -206,31 +225,12 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
         ? `(${search}) AND (${labelKql})`
         : labelKql;
 
-      const defaultSearchFields = [
-        "id",
-        "conversationId",
-        "subject",
-        "bodyPreview",
-        "importance",
-        "receivedDateTime",
-        "sentDateTime",
-        "hasAttachments",
-        "isDraft",
-        "isRead",
-        "from",
-        "toRecipients",
-        "ccRecipients",
-        "bccRecipients",
-        "replyTo",
-        "parentFolderId",
-      ];
-
       const searchRequest: Record<string, unknown> = {
         entityTypes: ["message"],
         query: { queryString: labeledQueryString },
         from: skip,
         size: Math.min(top, 100),
-        fields: select && select.length > 0 ? select : defaultSearchFields,
+        fields: select && select.length > 0 ? select : DEFAULT_MESSAGE_FIELDS,
       };
       if (sharedMailboxAddress) {
         searchRequest.contentSources = [
@@ -253,10 +253,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       if (select && select.length > 0) {
         unlabeledParams.append("$select", select.join(","));
       } else {
-        unlabeledParams.append(
-          "$select",
-          "id,conversationId,subject,bodyPreview,importance,receivedDateTime,sentDateTime,hasAttachments,isDraft,isRead,from,toRecipients,ccRecipients,bccRecipients,replyTo,parentFolderId"
-        );
+        unlabeledParams.append("$select", DEFAULT_MESSAGE_FIELDS.join(","));
       }
       const unlabeledEndpoint = folderId
         ? `${basePath}/mailFolders/${folderId}/messages?${unlabeledParams.toString()}`
@@ -354,10 +351,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     if (select && select.length > 0) {
       params.append("$select", select.join(","));
     } else {
-      params.append(
-        "$select",
-        "id,conversationId,subject,bodyPreview,importance,receivedDateTime,sentDateTime,hasAttachments,isDraft,isRead,from,toRecipients,ccRecipients,bccRecipients,replyTo,parentFolderId"
-      );
+      params.append("$select", DEFAULT_MESSAGE_FIELDS.join(","));
     }
 
     // Use different endpoint if folderId is provided


### PR DESCRIPTION
## Description

Implements sensitivity label filtering for Microsoft MCP tools (Outlook, Microsoft Drive). 

When admins configure allowed sensitivity labels via the workspace settings, the MCP tools now filter items to only return those matching the allowed labels plus unlabeled items. This uses the helper `getAllowedLabelsForMCPServer` to retrieve the label configuration and applies filtering via Microsoft Graph API search queries using `InformationProtectionLabelId` KQL filters.

- For Microsoft Drive, it's quite straightforward basically all the items have a label (no need to fetch unlabeled items).
- For Outlook, we need to make two different queries to get labeled and unlabeled emails.

## Tests

Manually tested with Microsoft Purview labels configured on casquedelumiere tenant.

## Risk

Changes how Microsoft MCP tools retrieve data when sensitivity labels are configured. For Outlook's `get_messages`, the implementation uses two parallel requests (labeled items via `/search/query` and unlabeled items via the regular endpoint) to work around Graph API limitations.

## Deploy Plan

Deploy front