### PR TITLE
feat: add version field to ConfluencePageSchema

### DIFF
--- a/front/lib/api/actions/servers/confluence/types.ts
+++ b/front/lib/api/actions/servers/confluence/types.ts
@@ -67,6 +67,13 @@ export const ConfluencePageSchema = z
     parentId: z.string().nullable().optional(),
     spaceId: z.string().optional(),
     body: ConfluencePageBodySchema.optional(),
+    version: z
+      .object({
+        number: z.number().optional(),
+        message: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
   })
   .passthrough()
   .transform((data) => ({
@@ -76,6 +83,7 @@ export const ConfluencePageSchema = z
     parentId: data.parentId,
     spaceId: data.spaceId,
     body: data.body,
+    version: data.version,
   }));
 
 export type ConfluencePage = z.infer<typeof ConfluencePageSchema>;


### PR DESCRIPTION
## Description

- get_page in the Confluence MCP server was silently dropping the version field via the ConfluencePageSchema transform, even though the API returns it.
- This forced agents into a wasteful flow: call update_page → get a 409 → parse the current version out of the error → retry.
- Fix: declare version in the zod object and pass it through the transform. Kept the inner shape minimal (number, message) mirroring ConfluenceUpdatePageRequestSchema; .passthrough() lets the extra fields (createdBy, createdAt, authorId) flow through at runtime so the existing renderVersionLine() keeps working via the RenderablePage & { version?: ConfluenceVersionInfo } intersection.

Fixes https://github.com/dust-tt/tasks/issues/7339

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low, and that MCP is under flag

## Deploy Plan

Front