### PR TITLE
Add: ButtonsSwith to filter conversations in project.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -7,6 +7,7 @@ import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
 import { useSpaceUnreadConversationIds } from "@app/hooks/conversations";
+import type { SpaceConversationListFilter } from "@app/hooks/conversations/useSpaceConversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSearchConversations } from "@app/hooks/useSearchConversations";
 import { useAppRouter } from "@app/lib/platform";
@@ -23,6 +24,8 @@ import type { Result } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import {
   Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
   Chip,
   cn,
   EmptyCTA,
@@ -53,6 +56,9 @@ interface SpaceConversationsTabProps {
   loadMore: () => void;
   isLoadingMore: boolean;
   spaceInfo: GetSpaceResponseBody["space"];
+  isSpaceEmpty: boolean;
+  conversationFilter: SpaceConversationListFilter;
+  onConversationFilterChange: (filter: SpaceConversationListFilter) => void;
   onSubmit: (
     input: string,
     mentions: RichMention[],
@@ -71,6 +77,9 @@ export function SpaceConversationsTab({
   loadMore,
   isLoadingMore,
   spaceInfo,
+  isSpaceEmpty,
+  conversationFilter,
+  onConversationFilterChange,
   onSubmit,
   onOpenMembersPanel,
 }: SpaceConversationsTabProps) {
@@ -88,6 +97,17 @@ export function SpaceConversationsTab({
   });
 
   const [isSearchPopoverOpen, setIsSearchPopoverOpen] = useState(false);
+
+  const noConversationsForFilterMessage = useMemo(() => {
+    switch (conversationFilter) {
+      case "all":
+        return "No conversations found.";
+      case "group":
+        return "No group conversations yet in this project.";
+      case "with_me":
+        return "You are not a participant in any conversation yet.";
+    }
+  }, [conversationFilter]);
 
   const {
     conversations: searchResults,
@@ -124,7 +144,9 @@ export function SpaceConversationsTab({
     [owner.sId, router, setSearchText]
   );
 
-  const isEmpty = !isConversationsLoading && !hasHistory;
+  const isProjectEmpty = !isConversationsLoading && isSpaceEmpty;
+  const isFilteredEmpty =
+    !isConversationsLoading && !isSpaceEmpty && !hasHistory;
 
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
@@ -134,8 +156,8 @@ export function SpaceConversationsTab({
       >
         <div
           className={cn(
-            "mx-auto flex w-full max-w-4xl flex-col gap-6 py-8",
-            isEmpty && "h-full justify-center py-8"
+            "mx-auto flex w-full max-w-4xl flex-col gap-3 py-8",
+            isProjectEmpty && "h-full justify-center py-8"
           )}
         >
           <div className="flex w-full flex-col gap-3">
@@ -153,7 +175,7 @@ export function SpaceConversationsTab({
                 <Chip size="xs" color="rose" label="Archived" />
               )}
             </div>
-            {isEmpty && (
+            {isProjectEmpty && (
               <h3 className="heading-lg text-foreground dark:text-foreground-night">
                 Start a first conversation!
               </h3>
@@ -186,7 +208,7 @@ export function SpaceConversationsTab({
           </div>
 
           {/* Suggestions for empty rooms */}
-          {isEmpty ? (
+          {isProjectEmpty ? (
             <SpaceConversationsActions
               isEditor={isProjectEditor}
               onOpenMembersPanel={onOpenMembersPanel}
@@ -195,7 +217,7 @@ export function SpaceConversationsTab({
             /* Space conversations section */
             <div className="w-full">
               <div className="flex flex-col gap-3">
-                <div className="px-3 flex flex-row gap-2">
+                <div className="flex flex-row gap-2 my-3 px-3">
                   <SearchInputWithPopover
                     name="conversation-search"
                     value={searchText}
@@ -250,7 +272,30 @@ export function SpaceConversationsTab({
                     disabled={unreadConversationIds.length === 0}
                   />
                 </div>
-                <div className="flex flex-col">
+                <div className="flex justify-center">
+                  <ButtonsSwitchList
+                    key={conversationFilter}
+                    defaultValue={conversationFilter}
+                    size="xs"
+                  >
+                    <ButtonsSwitch
+                      value="all"
+                      label="All"
+                      onClick={() => onConversationFilterChange("all")}
+                    />
+                    <ButtonsSwitch
+                      value="group"
+                      label="Group"
+                      onClick={() => onConversationFilterChange("group")}
+                    />
+                    <ButtonsSwitch
+                      value="with_me"
+                      label="Mine"
+                      onClick={() => onConversationFilterChange("with_me")}
+                    />
+                  </ButtonsSwitchList>
+                </div>
+                <div className="flex flex-col -mt-6">
                   {isConversationsLoading ? (
                     <>
                       <ListItemSection>
@@ -262,6 +307,13 @@ export function SpaceConversationsTab({
                         ))}
                       </ListGroup>
                     </>
+                  ) : isFilteredEmpty ? (
+                    <div className="px-3 py-8">
+                      <EmptyCTA
+                        message={noConversationsForFilterMessage}
+                        action={null}
+                      />
+                    </div>
                   ) : (
                     Object.keys(conversationsByDate).map((dateLabel) => {
                       const dateConversations =

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -7,6 +7,7 @@ import { SpaceKnowledgeTab } from "@app/components/assistant/conversation/space/
 import { SpaceTodosTab } from "@app/components/assistant/conversation/space/SpaceTodosTab";
 
 import { useSpaceConversations } from "@app/hooks/conversations";
+import type { SpaceConversationListFilter } from "@app/hooks/conversations/useSpaceConversations";
 import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -72,17 +73,21 @@ export function SpaceConversationsPage() {
     owner,
     user,
   });
+  const [conversationFilter, setConversationFilter] =
+    useState<SpaceConversationListFilter>("all");
 
   const {
     conversations,
     isConversationsLoading,
     mutateConversations,
     hasMore,
+    isEmpty: isSpaceEmpty,
     loadMore,
     isLoadingMore,
   } = useSpaceConversations({
     workspaceId: owner.sId,
     spaceId: spaceId,
+    filter: conversationFilter,
   });
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -153,6 +158,7 @@ export function SpaceConversationsPage() {
     if (prevSpaceIdRef.current !== spaceId) {
       prevSpaceIdRef.current = spaceId;
       setCurrentTab("conversations");
+      setConversationFilter("all");
       window.history.replaceState(
         null,
         "",
@@ -266,6 +272,7 @@ export function SpaceConversationsPage() {
                   conversations: [lightConversation],
                   hasMore: false,
                   lastValue: null,
+                  isEmpty: false,
                 },
               ];
             }
@@ -332,6 +339,9 @@ export function SpaceConversationsPage() {
           loadMore={loadMore}
           isLoadingMore={isLoadingMore}
           spaceInfo={spaceInfo}
+          isSpaceEmpty={isSpaceEmpty}
+          conversationFilter={conversationFilter}
+          onConversationFilterChange={setConversationFilter}
           onSubmit={handleConversationCreation}
           onOpenMembersPanel={() => setIsInvitePanelOpen(true)}
         />
@@ -398,6 +408,9 @@ export function SpaceConversationsPage() {
             loadMore={loadMore}
             isLoadingMore={isLoadingMore}
             spaceInfo={spaceInfo}
+            isSpaceEmpty={isSpaceEmpty}
+            conversationFilter={conversationFilter}
+            onConversationFilterChange={setConversationFilter}
             onSubmit={handleConversationCreation}
             onOpenMembersPanel={() => setIsInvitePanelOpen(true)}
           />

--- a/front/hooks/conversations/useSpaceConversations.ts
+++ b/front/hooks/conversations/useSpaceConversations.ts
@@ -37,15 +37,19 @@ export function useSpaceConversationsSummary({
 
 const DEFAULT_CONVERSATIONS_PAGE_SIZE = 12;
 
+export type SpaceConversationListFilter = "all" | "group" | "with_me";
+
 export function useSpaceConversations({
   workspaceId,
   spaceId,
   limit = DEFAULT_CONVERSATIONS_PAGE_SIZE,
+  filter = "all",
   options,
 }: {
   workspaceId: string;
   spaceId: string | null;
   limit?: number;
+  filter?: SpaceConversationListFilter;
   options?: { disabled?: boolean };
 }) {
   const { fetcher } = useFetcher();
@@ -62,15 +66,24 @@ export function useSpaceConversations({
           return null;
         }
 
+        const searchParams = new URLSearchParams({
+          filter,
+        });
+
         if (previousPageData === null) {
-          return `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}`;
+          return `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}?${searchParams.toString()}`;
         }
 
         if (!previousPageData.hasMore) {
           return null;
         }
 
-        return `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}?lastValue=${previousPageData.lastValue}&limit=${limit}`;
+        if (previousPageData.lastValue) {
+          searchParams.set("lastValue", previousPageData.lastValue);
+        }
+        searchParams.set("limit", limit.toString());
+
+        return `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}?${searchParams.toString()}`;
       },
       conversationsFetcher,
       {
@@ -88,6 +101,7 @@ export function useSpaceConversations({
   }, [data]);
 
   const hasMore = data ? (data[data.length - 1]?.hasMore ?? false) : false;
+  const isEmpty = data ? (data[0]?.isEmpty ?? false) : false;
 
   const loadMore = useCallback(() => {
     if (hasMore && !isValidating) {
@@ -102,6 +116,7 @@ export function useSpaceConversations({
     isLoadingMore: isValidating && size > 1,
     isValidating,
     hasMore,
+    isEmpty,
     loadMore,
     mutateConversations: mutate,
   };

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -81,6 +81,8 @@ export type FetchConversationOptions = {
   updatedSince?: number; // Filter conversations updated after this timestamp (milliseconds)
 };
 
+type SpaceConversationsFilter = "all" | "group" | "with_me";
+
 interface UserParticipation {
   actionRequired: boolean;
   updated: number;
@@ -1860,6 +1862,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       options,
       pagination,
       restrictToConversationModelIds,
+      filter = "all",
     }: {
       spaceId: string;
       options?: FetchConversationOptions;
@@ -1869,6 +1872,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         orderDirection?: "asc" | "desc";
       };
       restrictToConversationModelIds?: ModelId[];
+      filter?: SpaceConversationsFilter;
     }
   ): Promise<{
     conversations: ConversationResource[];
@@ -1918,22 +1922,136 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       }
     }
 
-    // Fetch limit + 1 to determine if there are more results
-    const fetchLimit = pagination.limit + 1;
+    const chunkSize = Math.max(pagination.limit + 1, 30);
+    const filteredConversations: ConversationResource[] = [];
+    let fetchCursor = pagination.lastValue;
+    let hasMoreRawConversations = true;
 
-    const conversations = await this.baseFetchWithAuthorization(auth, options, {
-      where: whereClause,
-      order: [["updatedAt", orderDirection === "desc" ? "DESC" : "ASC"]],
-      limit: fetchLimit,
-    });
+    while (
+      filteredConversations.length <= pagination.limit &&
+      hasMoreRawConversations
+    ) {
+      const batchWhereClause: WhereOptions<InferAttributes<ConversationModel>> =
+        {
+          ...whereClause,
+        };
 
-    let hasMore = false;
-    let resultConversations = conversations;
+      if (fetchCursor) {
+        const cursorMs = parseInt(fetchCursor, 10);
+        if (!Number.isNaN(cursorMs)) {
+          const operator = orderDirection === "desc" ? Op.lt : Op.gt;
+          const cursorConstraint = { [operator]: new Date(cursorMs) };
+          const existingUpdatedAt = batchWhereClause.updatedAt;
 
-    if (conversations.length > pagination.limit) {
-      hasMore = true;
-      resultConversations = conversations.slice(0, pagination.limit);
+          if (
+            existingUpdatedAt &&
+            typeof existingUpdatedAt === "object" &&
+            !Array.isArray(existingUpdatedAt)
+          ) {
+            batchWhereClause.updatedAt = {
+              ...existingUpdatedAt,
+              ...cursorConstraint,
+            };
+          } else {
+            batchWhereClause.updatedAt = cursorConstraint;
+          }
+        }
+      }
+
+      const conversationsBatch = await this.baseFetchWithAuthorization(
+        auth,
+        options,
+        {
+          where: batchWhereClause,
+          order: [["updatedAt", orderDirection === "desc" ? "DESC" : "ASC"]],
+          limit: chunkSize,
+        }
+      );
+
+      hasMoreRawConversations = conversationsBatch.length === chunkSize;
+
+      if (conversationsBatch.length === 0) {
+        break;
+      }
+
+      let matchingConversations = conversationsBatch;
+
+      if (filter === "with_me") {
+        const user = auth.user();
+        if (!user) {
+          matchingConversations = [];
+        } else {
+          const participations = await ConversationParticipantModel.findAll({
+            where: {
+              workspaceId: auth.getNonNullableWorkspace().id,
+              userId: user.id,
+              conversationId: {
+                [Op.in]: conversationsBatch.map((c) => c.id),
+              },
+              action: "posted",
+            },
+            attributes: ["conversationId"],
+          });
+
+          const matchingConversationIds = new Set(
+            participations.map((p) => p.conversationId)
+          );
+          matchingConversations = conversationsBatch.filter((conversation) =>
+            matchingConversationIds.has(conversation.id)
+          );
+        }
+      }
+
+      if (filter === "group") {
+        const participants = await ConversationParticipantModel.findAll({
+          where: {
+            workspaceId: auth.getNonNullableWorkspace().id,
+            conversationId: {
+              [Op.in]: conversationsBatch.map((c) => c.id),
+            },
+            action: "posted",
+          },
+          attributes: ["conversationId", "userId"],
+        });
+
+        const participantUserIdsByConversation = new Map<
+          ModelId,
+          Set<ModelId>
+        >();
+        for (const participant of participants) {
+          const existingUserIds =
+            participantUserIdsByConversation.get(participant.conversationId) ??
+            new Set<ModelId>();
+          existingUserIds.add(participant.userId);
+          participantUserIdsByConversation.set(
+            participant.conversationId,
+            existingUserIds
+          );
+        }
+
+        const groupConversationIds = new Set<ModelId>(
+          [...participantUserIdsByConversation.entries()].flatMap(
+            ([conversationId, participantUserIds]) =>
+              participantUserIds.size >= 2 ? [conversationId] : []
+          )
+        );
+
+        matchingConversations = conversationsBatch.filter((conversation) =>
+          groupConversationIds.has(conversation.id)
+        );
+      }
+
+      filteredConversations.push(...matchingConversations);
+
+      const lastConversationInBatch =
+        conversationsBatch[conversationsBatch.length - 1];
+      fetchCursor = lastConversationInBatch.updatedAt.getTime().toString();
     }
+
+    const hasMore = filteredConversations.length > pagination.limit;
+    const resultConversations = hasMore
+      ? filteredConversations.slice(0, pagination.limit)
+      : filteredConversations;
 
     await this.enrichWithParticipationAndReadState(auth, resultConversations);
 

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -12,10 +12,30 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+type SpaceConversationsFilter = "all" | "group" | "with_me";
+
+function getSpaceConversationsFilter(
+  filterQueryParam: string | string[] | undefined
+): SpaceConversationsFilter {
+  if (!isString(filterQueryParam)) {
+    return "all";
+  }
+
+  switch (filterQueryParam) {
+    case "all":
+    case "group":
+    case "with_me":
+      return filterQueryParam;
+    default:
+      return "all";
+  }
+}
+
 export type GetSpaceConversationsResponseBody = {
   conversations: LightConversationType[];
   hasMore: boolean;
   lastValue: string | null;
+  isEmpty: boolean;
 };
 
 async function handler(
@@ -25,7 +45,7 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET": {
-      const { spaceId } = req.query;
+      const { spaceId, filter } = req.query;
 
       if (!isString(spaceId)) {
         return apiError(req, res, {
@@ -55,6 +75,7 @@ async function handler(
       }
 
       const pagination = paginationRes.value;
+      const conversationFilter = getSpaceConversationsFilter(filter);
 
       // Fetch and verify space access
       const space = await SpaceResource.fetchById(auth, spaceId);
@@ -83,7 +104,22 @@ async function handler(
           lastValue: pagination.lastValue,
           orderDirection: pagination.orderDirection,
         },
+        filter: conversationFilter,
       });
+
+      const { conversations: allConversations } =
+        await ConversationResource.listConversationsInSpacePaginated(auth, {
+          spaceId,
+          options: {
+            excludeTest: true,
+          },
+          pagination: {
+            limit: 1,
+            orderDirection: pagination.orderDirection,
+          },
+          filter: "all",
+        });
+      const isEmpty = allConversations.length === 0;
 
       // Fetch full conversation details for the paginated results
       // We're doing N+1 queries here, very bad for scaling
@@ -100,6 +136,7 @@ async function handler(
         ),
         hasMore,
         lastValue,
+        isEmpty,
       });
     }
     default:


### PR DESCRIPTION
## Description

As projects grow, the flat conversation list becomes hard to navigate. Users want to find conversations they participated in or multi-participant threads without scrolling through everything. A `ButtonsSwitch` toggle gives instant, lightweight filtering.

- **Add `SpaceConversationListFilter`** (`"all"` | `"group"` | `"with_me"`) to `useSpaceConversations`; pass as a `?filter=` query param in the SWR key (alongside `lastValue` for pagination)
- **Add `isEmpty`** to `useSpaceConversations` — reads `data[0].isEmpty` from the first page to distinguish "project has no conversations at all" from "filter returned no results"
- **API — `listAll` filter implementation** — cursor-based iteration loop (chunk size `max(limit+1, 30)`) with post-fetch participant filtering:
  - `"with_me"`: bulk-query `ConversationParticipantModel` for the batch, keep only conversations where the viewer has `action: "posted"`
  - `"group"`: bulk-query participants, keep only conversations with ≥ 2 distinct `userId`s (human-only group threads)
  - `"all"`: pass-through (unchanged behavior)
- **UI: `ButtonsSwitchList` in `SpaceConversationsTab`** — centered below the search/filter bar with "All", "Group", and "Mine" options; resets to `"all"` on project navigation
- **Split `isEmpty` → `isProjectEmpty` + `isFilteredEmpty`** — `isProjectEmpty` drives the "Start a first conversation!" CTA; `isFilteredEmpty` shows a filter-specific `EmptyCTA` message inline in the list area
- Pass `isSpaceEmpty`, `conversationFilter`, and `onConversationFilterChange` down from `SpaceConversationsPage`; reset filter to `"all"` on space navigation

## Tests

Local

## Risk

Low — `"all"` is the default and has identical behavior to before; new filters add DB queries per page (bulk, not N+1)

## Deploy Plan

Deploy `front`
