### PR TITLE
Remove tooltip to avoid double tooltip and popover

### DIFF
--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -92,7 +92,6 @@ export function ContextUsageIndicator({
             variant="ghost-secondary"
             size={buttonSize}
             icon={() => <CircleProgress percentage={percentage} size={16} />}
-            tooltip={`${percentage}% of context used.`}
           />
         </PopoverTrigger>
         <PopoverContent side="top" align="end" className="w-auto p-3">


### PR DESCRIPTION
## Description

Disable compaction tooltip as it can double with the popover and they have the same content which is then super confusing.

## Tests

Tested locally

## Risk

N/A

## Deploy Plan

- deploy `front`