### PR TITLE
Return pending context usage instead of 404

### DIFF
--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -80,7 +80,10 @@ export function ContextUsageIndicator({
   }
 
   const percentage =
-    contextUsage && contextUsage.contextSize > 0
+    contextUsage &&
+    contextUsage.contextUsage !== null &&
+    contextUsage.contextSize !== null &&
+    contextUsage.contextSize > 0
       ? Math.round((contextUsage.contextUsage / contextUsage.contextSize) * 100)
       : 0;
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
@@ -147,4 +147,87 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/context-usage", () => {
     expect(compactionRun.listRunUsages).not.toHaveBeenCalled();
     expect(agentRun.listRunUsages).toHaveBeenCalledOnce();
   });
+
+  it("returns pending usage when the latest compaction run has no usage rows yet", async () => {
+    const { req, res } = await setupTest();
+
+    const agentRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 111, completionTokens: 11 }),
+    ]);
+    const compactionRun = makeRunWithUsages([]);
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: {
+        rank: 10,
+        run: agentRun,
+      },
+      latestCompactionMessageRun: {
+        rank: 20,
+        run: compactionRun,
+      },
+    });
+
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      model: null,
+      contextUsage: null,
+      contextSize: null,
+    });
+    expect(agentRun.listRunUsages).not.toHaveBeenCalled();
+    expect(compactionRun.listRunUsages).toHaveBeenCalledOnce();
+  });
+
+  it("returns pending usage when the latest agent run has no usage rows yet", async () => {
+    const { req, res } = await setupTest();
+
+    const agentRun = makeRunWithUsages([]);
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: {
+        rank: 20,
+        run: agentRun,
+      },
+      latestCompactionMessageRun: null,
+    });
+
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      model: null,
+      contextUsage: null,
+      contextSize: null,
+    });
+    expect(agentRun.listRunUsages).toHaveBeenCalledOnce();
+  });
+
+  it("returns pending usage when the conversation has no run data yet", async () => {
+    const { req, res } = await setupTest();
+
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: null,
+      latestCompactionMessageRun: null,
+    });
+
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      model: null,
+      contextUsage: null,
+      contextSize: null,
+    });
+  });
 });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -10,9 +10,15 @@ import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetConversationContextUsageResponse = {
-  model: SupportedModel;
-  contextUsage: number;
-  contextSize: number;
+  model: SupportedModel | null;
+  contextUsage: number | null;
+  contextSize: number | null;
+};
+
+const PENDING_CONTEXT_USAGE_RESPONSE: GetConversationContextUsageResponse = {
+  model: null,
+  contextUsage: null,
+  contextSize: null,
 };
 
 async function handler(
@@ -61,13 +67,7 @@ async function handler(
         // minimal way to show reduciton of context usage as soon as possible.
         const usages = await lastCompactionRun.run.listRunUsages(auth);
         if (usages.length === 0) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "conversation_context_usage_not_found",
-              message: "No run usage found for the latest conversation run.",
-            },
-          });
+          return res.status(200).json(PENDING_CONTEXT_USAGE_RESPONSE);
         }
 
         const maxUsage = usages.reduce((max, u) =>
@@ -86,24 +86,12 @@ async function handler(
         });
       } else {
         if (!lastAgentRun) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "conversation_context_usage_not_found",
-              message: "Conversation has no run data.",
-            },
-          });
+          return res.status(200).json(PENDING_CONTEXT_USAGE_RESPONSE);
         }
 
         const usages = await lastAgentRun.run.listRunUsages(auth);
         if (usages.length === 0) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "conversation_context_usage_not_found",
-              message: "No run usage found for the latest conversation run.",
-            },
-          });
+          return res.status(200).json(PENDING_CONTEXT_USAGE_RESPONSE);
         }
 
         // Take the max promptTokens across usages of the latest run — this represents the peak


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7820

Return a successful pending context-usage payload when the latest conversation run exists but its usage rows have not been written yet. This avoids the transient `conversation_context_usage_not_found` 404 race during streaming and prevents SWR retry amplification while preserving `404` for genuinely missing conversations.

The context usage indicator now handles nullable usage fields explicitly and displays 0% while usage is pending.

## Tests

- NODE_ENV=test npm test 'pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts'
- tested locally

## Risk

Low. 

## Deploy Plan

- deploy `front`