### PR TITLE
Fix redirection/flicker on public pages

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -84,9 +84,12 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
   // Fetch user data whenever there is a session (or posthogId). We need the
   // user's sId for posthog.identify() in all contexts, including authenticated
   // SPAs where hasCookiesAccepted is auto-true.
+  // `silent` -> a stale `dust-has-session` cookie on a public page must not
+  // bounce the visitor through login; treat a 401 as anonymous and move on.
   const disabled = !posthogId && !hasSession;
   const { user } = useUser({
     disabled,
+    silent: true,
   });
 
   const cookieValue = cookies[DUST_COOKIES_ACCEPTED];

--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -84,12 +84,14 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
   // Fetch user data whenever there is a session (or posthogId). We need the
   // user's sId for posthog.identify() in all contexts, including authenticated
   // SPAs where hasCookiesAccepted is auto-true.
-  // `silent` -> a stale `dust-has-session` cookie on a public page must not
-  // bounce the visitor through login; treat a 401 as anonymous and move on.
+  // This tracker is mounted globally (every page, public + app). On public
+  // pages a stale `dust-has-session` cookie can yield a 401 here; we must
+  // not redirect to login in that case. Real session expiry on app pages is
+  // still handled by other authenticated SWR calls.
   const disabled = !posthogId && !hasSession;
   const { user } = useUser({
     disabled,
-    silent: true,
+    redirectOnUnauthenticated: false,
   });
 
   const cookieValue = cookies[DUST_COOKIES_ACCEPTED];

--- a/front/lib/swr/fetcher.ts
+++ b/front/lib/swr/fetcher.ts
@@ -16,54 +16,63 @@ const addClientVersionHeaders = (headers: HeadersInit = {}): HeadersInit => ({
   "X-Build-Date": BUILD_DATE,
 });
 
-const resHandler = async (res: Response) => {
-  if (res.headers.get("X-Reload-Required") === "true") {
-    const lastReloadMs = sessionStorage.getItem(FORCE_RELOAD_SESSION_KEY);
-    const nowMs = Date.now();
-    const lastMs = lastReloadMs !== null ? Number(lastReloadMs) : Number.NaN;
-    const shouldReload =
-      (!Number.isFinite(lastMs) || nowMs - lastMs > FORCE_RELOAD_INTERVAL_MS) &&
-      !isNavigationLocked();
-    if (shouldReload) {
-      sessionStorage.setItem(FORCE_RELOAD_SESSION_KEY, nowMs.toString());
-      window.location.reload();
-      // Return a never-resolving promise to prevent SWR from processing.
-      return new Promise(() => {});
-    }
-  }
-
-  if (res.status >= 300) {
-    const errorText = await res.text();
-    datadogLogger.error(
-      {
-        url: res.url,
-        statusCode: res.status,
-        errorText:
-          errorText.length > 1000 ? errorText.substring(0, 1000) : errorText,
-      },
-      "Error returned by the front API"
-    );
-
-    const parseRes = safeParseJSON(errorText);
-    if (parseRes.isOk()) {
-      if (isAPIErrorResponse(parseRes.value)) {
-        if (parseRes.value.error.type === "not_authenticated") {
-          const returnTo =
-            window.location.pathname !== "/"
-              ? `?returnTo=${encodeURIComponent(window.location.pathname + window.location.search)}`
-              : "";
-          window.location.href = `${config.getApiBaseUrl()}/api/workos/login${returnTo}`;
-          // Return a never-resolving promise to prevent SWR from processing.
-          return new Promise(() => {});
-        }
-        throw parseRes.value;
+const makeResHandler =
+  ({ redirectOnUnauthenticated }: { redirectOnUnauthenticated: boolean }) =>
+  async (res: Response) => {
+    if (res.headers.get("X-Reload-Required") === "true") {
+      const lastReloadMs = sessionStorage.getItem(FORCE_RELOAD_SESSION_KEY);
+      const nowMs = Date.now();
+      const lastMs = lastReloadMs !== null ? Number(lastReloadMs) : Number.NaN;
+      const shouldReload =
+        (!Number.isFinite(lastMs) ||
+          nowMs - lastMs > FORCE_RELOAD_INTERVAL_MS) &&
+        !isNavigationLocked();
+      if (shouldReload) {
+        sessionStorage.setItem(FORCE_RELOAD_SESSION_KEY, nowMs.toString());
+        window.location.reload();
+        // Return a never-resolving promise to prevent SWR from processing.
+        return new Promise(() => {});
       }
     }
 
-    throw new Error(errorText);
-  }
-  return res.json();
-};
+    if (res.status >= 300) {
+      const errorText = await res.text();
+      datadogLogger.error(
+        {
+          url: res.url,
+          statusCode: res.status,
+          errorText:
+            errorText.length > 1000 ? errorText.substring(0, 1000) : errorText,
+        },
+        "Error returned by the front API"
+      );
+
+      const parseRes = safeParseJSON(errorText);
+      if (parseRes.isOk()) {
+        if (isAPIErrorResponse(parseRes.value)) {
+          if (
+            parseRes.value.error.type === "not_authenticated" &&
+            redirectOnUnauthenticated
+          ) {
+            const returnTo =
+              window.location.pathname !== "/"
+                ? `?returnTo=${encodeURIComponent(window.location.pathname + window.location.search)}`
+                : "";
+            window.location.href = `${config.getApiBaseUrl()}/api/workos/login${returnTo}`;
+            // Return a never-resolving promise to prevent SWR from processing.
+            return new Promise(() => {});
+          }
+          throw parseRes.value;
+        }
+      }
+
+      throw new Error(errorText);
+    }
+    return res.json();
+  };
+
+const resHandler = makeResHandler({ redirectOnUnauthenticated: true });
+const silentResHandler = makeResHandler({ redirectOnUnauthenticated: false });
 
 export type FetcherFn = (url: string, init?: RequestInit) => Promise<any>;
 
@@ -78,6 +87,17 @@ export const fetcher: FetcherFn = async (url, init) => {
     headers: addClientVersionHeaders(init?.headers),
   });
   return resHandler(res);
+};
+
+// Throws on `not_authenticated` instead of redirecting to login. Use when a
+// 401 should leave the page in place (e.g. a stale `dust-has-session` cookie
+// on the public website should not bounce the visitor through login).
+export const silentFetcher: FetcherFn = async (url, init) => {
+  const res = await clientFetch(url, {
+    ...init,
+    headers: addClientVersionHeaders(init?.headers),
+  });
+  return silentResHandler(res);
 };
 
 export const fetcherWithBody: FetcherWithBodyFn = async (

--- a/front/lib/swr/fetcher.ts
+++ b/front/lib/swr/fetcher.ts
@@ -72,7 +72,9 @@ const makeResHandler =
   };
 
 const resHandler = makeResHandler({ redirectOnUnauthenticated: true });
-const silentResHandler = makeResHandler({ redirectOnUnauthenticated: false });
+const nonRedirectingResHandler = makeResHandler({
+  redirectOnUnauthenticated: false,
+});
 
 export type FetcherFn = (url: string, init?: RequestInit) => Promise<any>;
 
@@ -92,12 +94,12 @@ export const fetcher: FetcherFn = async (url, init) => {
 // Throws on `not_authenticated` instead of redirecting to login. Use when a
 // 401 should leave the page in place (e.g. a stale `dust-has-session` cookie
 // on the public website should not bounce the visitor through login).
-export const silentFetcher: FetcherFn = async (url, init) => {
+export const nonRedirectingFetcher: FetcherFn = async (url, init) => {
   const res = await clientFetch(url, {
     ...init,
     headers: addClientVersionHeaders(init?.headers),
   });
-  return silentResHandler(res);
+  return nonRedirectingResHandler(res);
 };
 
 export const fetcherWithBody: FetcherWithBodyFn = async (

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { silentFetcher } from "@app/lib/swr/fetcher";
+import { nonRedirectingFetcher } from "@app/lib/swr/fetcher";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -22,13 +22,15 @@ import type { Fetcher, SWRConfiguration } from "swr";
 export function useUser(
   swrOptions?: SWRConfiguration & {
     disabled?: boolean;
-    // When true, a 401 leaves the page in place instead of redirecting to login.
-    silent?: boolean;
+    // Defaults to true. Set to false on pages where a 401 should leave the
+    // page in place rather than bounce the visitor through the login flow.
+    redirectOnUnauthenticated?: boolean;
   }
 ) {
   const { fetcher } = useFetcher();
-  const userFetcher: Fetcher<GetUserResponseBody> = swrOptions?.silent
-    ? silentFetcher
+  const skipRedirect = swrOptions?.redirectOnUnauthenticated === false;
+  const userFetcher: Fetcher<GetUserResponseBody> = skipRedirect
+    ? nonRedirectingFetcher
     : fetcher;
   const { data, error, mutate } = useSWRWithDefaults("/api/user", userFetcher, {
     revalidateOnFocus: false,
@@ -36,7 +38,7 @@ export function useUser(
     revalidateIfStale: false,
     // 401 here is the expected outcome for anonymous visitors -> don't retry
     // (default would log it to datadog 16 times).
-    ...(swrOptions?.silent ? { shouldRetryOnError: false } : {}),
+    ...(skipRedirect ? { shouldRetryOnError: false } : {}),
     ...swrOptions,
   });
 

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -1,5 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import { silentFetcher } from "@app/lib/swr/fetcher";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -21,14 +22,21 @@ import type { Fetcher, SWRConfiguration } from "swr";
 export function useUser(
   swrOptions?: SWRConfiguration & {
     disabled?: boolean;
+    // When true, a 401 leaves the page in place instead of redirecting to login.
+    silent?: boolean;
   }
 ) {
   const { fetcher } = useFetcher();
-  const userFetcher: Fetcher<GetUserResponseBody> = fetcher;
+  const userFetcher: Fetcher<GetUserResponseBody> = swrOptions?.silent
+    ? silentFetcher
+    : fetcher;
   const { data, error, mutate } = useSWRWithDefaults("/api/user", userFetcher, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
     revalidateIfStale: false,
+    // 401 here is the expected outcome for anonymous visitors -> don't retry
+    // (default would log it to datadog 16 times).
+    ...(swrOptions?.silent ? { shouldRetryOnError: false } : {}),
     ...swrOptions,
   });
 


### PR DESCRIPTION
## Description

Stops the public website (homepage, blog, etc.) from redirecting visitors who have a stale `dust-has-session` cookie to the WorkOS login page. PostHogTracker was calling useUser through the global SWR fetcher whose 401 handler redirects to /api/workos/login; it now opts into a new non-redirecting silent mode since it only needs user.sId for `posthog.identify()`.

## Tests

Manually tested locally:
* Before: with dust-has-session=1 and no real session, / and /blog/<slug> would render briefly then redirect through the WorkOS hosted login.
* After: the page stays  put, /api/user returns 401 once (no retry storm), and no follow-up navigation fires. Verified the "Open Dust" CTA still appears on the same pages for a real session, and that the other useUser call sites (which don't pass silent) keep their existing redirect-on-401 behavior on /w/... app pages.

## Risk

Low. "silent" is opt-in and defaults to false, only PostHogTracker sets it. Safe to revert

## Deploy Plan 
