### PR TITLE
[front] fix: add back support for MCP tool names with dots in stake editor

### DIFF
--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -5,6 +5,9 @@ import {
 } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import { ToolsList } from "@app/components/actions/mcp/ToolsList";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import type { LightWorkspaceType } from "@app/types/user";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { act, fireEvent, render, screen } from "@testing-library/react";
@@ -38,62 +41,40 @@ vi.mock("@dust-tt/sparkle", () => ({
   InformationCircleIcon: () => null,
 }));
 
-// Treat the test server as remote so default-stake lookups skip the internal
-// server registry.
-vi.mock("@app/lib/actions/mcp_helper", () => ({
-  isRemoteMCPServerType: () => true,
-  requiresBearerTokenConfiguration: () => false,
-  getMcpServerViewDescription: (view: { description?: string }) =>
-    view.description ?? "test description",
-}));
-
 const TOOL_NAME_WITH_DOT = "weather.get_current";
 
-const owner = {
-  sId: "ws_1",
-  id: 1,
-  name: "Test Workspace",
-  segmentation: null,
-  role: "admin",
-  whiteListedProviders: null,
-  defaultEmbeddingProvider: null,
-  metadata: {},
-  sharingPolicy: "workspace_only",
-  metronomeCustomerId: null,
-} satisfies LightWorkspaceType;
+type ToolsListTestSetup = {
+  owner: LightWorkspaceType;
+  mcpServerView: MCPServerViewType;
+};
 
-const mcpServerView = {
-  id: 1,
-  sId: "msv_1",
-  name: "Test Server",
-  description: "Test server description",
-  spaceId: "sp_1",
-  serverType: "remote",
-  oAuthUseCase: null,
-  editedByUser: null,
-  createdAt: 0,
-  updatedAt: 0,
-  toolsMetadata: undefined,
-  server: {
-    sId: "rms_1",
+async function setupToolsListTest(): Promise<ToolsListTestSetup> {
+  const { workspace, globalSpace, authenticator } = await createResourceTest({
+    role: "admin",
+  });
+  const server = await RemoteMCPServerFactory.create(workspace, {
     name: "test-server",
-    version: "1.0.0",
     description: "Test server description",
-    icon: "ToolsIcon",
-    authorization: null,
-    availability: "manual",
-    allowMultipleInstances: true,
-    documentationUrl: null,
     tools: [
       {
         name: TOOL_NAME_WITH_DOT,
         description: "Get current weather",
       },
     ],
-  },
-} satisfies MCPServerViewType;
+  });
+  const serverView = await MCPServerViewFactory.create(
+    workspace,
+    server.sId,
+    globalSpace
+  );
 
-function renderToolsList() {
+  return {
+    owner: authenticator.getNonNullableWorkspace(),
+    mcpServerView: serverView.toJSON(),
+  };
+}
+
+function renderToolsList({ owner, mcpServerView }: ToolsListTestSetup) {
   let form!: UseFormReturn<MCPServerFormValues>;
 
   function Harness() {
@@ -123,7 +104,8 @@ function renderToolsList() {
 
 describe("ToolsList", () => {
   it("keeps form state flat and validates when a tool name contains a dot", async () => {
-    const { form } = renderToolsList();
+    const setup = await setupToolsListTest();
+    const { form } = renderToolsList(setup);
 
     // Toggling the dotted-name tool's enabled state used to corrupt RHF state
     // because dots in field paths are interpreted as nested-object separators.
@@ -140,8 +122,11 @@ describe("ToolsList", () => {
     // No nested object should have been created at the path "weather.get_current".
     expect(values.toolSettings["weather"]).toBeUndefined();
 
-    // Schema validation must pass — this is the user-facing failure mode.
-    const isValid = await form.trigger();
+    // Schema validation must pass: this is the user-facing failure mode.
+    let isValid = false;
+    await act(async () => {
+      isValid = await form.trigger();
+    });
     expect(isValid).toBe(true);
     expect(form.formState.errors.toolSettings).toBeUndefined();
   });

--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -1,0 +1,148 @@
+import {
+  getMCPServerFormDefaults,
+  getMCPServerFormSchema,
+  type MCPServerFormValues,
+} from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import { ToolsList } from "@app/components/actions/mcp/ToolsList";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { LightWorkspaceType } from "@app/types/user";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { FormProvider, type UseFormReturn, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+
+// Stub Sparkle UI primitives so they render plain DOM and let us click the checkbox.
+vi.mock("@dust-tt/sparkle", () => ({
+  Button: ({ label, isSelect: _isSelect, ...rest }: any) => (
+    <button {...rest}>{label}</button>
+  ),
+  Card: ({ children, ...rest }: any) => <div {...rest}>{children}</div>,
+  Checkbox: ({ checked, onClick }: any) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onClick={onClick}
+      onChange={() => {}}
+    />
+  ),
+  Collapsible: ({ children }: any) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: any) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: any) => (
+    <button type="button">{children}</button>
+  ),
+  ContentMessage: ({ children }: any) => <div>{children}</div>,
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuItem: ({ label }: any) => <button type="button">{label}</button>,
+  DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
+  InformationCircleIcon: () => null,
+}));
+
+// Treat the test server as remote so default-stake lookups skip the internal
+// server registry.
+vi.mock("@app/lib/actions/mcp_helper", () => ({
+  isRemoteMCPServerType: () => true,
+  requiresBearerTokenConfiguration: () => false,
+  getMcpServerViewDescription: (view: { description?: string }) =>
+    view.description ?? "test description",
+}));
+
+const TOOL_NAME_WITH_DOT = "weather.get_current";
+
+const owner = {
+  sId: "ws_1",
+  id: 1,
+  name: "Test Workspace",
+  segmentation: null,
+  role: "admin",
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  metadata: {},
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+} satisfies LightWorkspaceType;
+
+const mcpServerView = {
+  id: 1,
+  sId: "msv_1",
+  name: "Test Server",
+  description: "Test server description",
+  spaceId: "sp_1",
+  serverType: "remote",
+  oAuthUseCase: null,
+  editedByUser: null,
+  createdAt: 0,
+  updatedAt: 0,
+  toolsMetadata: undefined,
+  server: {
+    sId: "rms_1",
+    name: "test-server",
+    version: "1.0.0",
+    description: "Test server description",
+    icon: "ToolsIcon",
+    authorization: null,
+    availability: "manual",
+    allowMultipleInstances: true,
+    documentationUrl: null,
+    tools: [
+      {
+        name: TOOL_NAME_WITH_DOT,
+        description: "Get current weather",
+      },
+    ],
+  },
+} satisfies MCPServerViewType;
+
+function renderToolsList() {
+  let form!: UseFormReturn<MCPServerFormValues>;
+
+  function Harness() {
+    const defaults = getMCPServerFormDefaults(mcpServerView);
+    const currentForm = useForm<MCPServerFormValues>({
+      values: defaults,
+      mode: "onChange",
+      shouldUnregister: false,
+      resolver: zodResolver(
+        getMCPServerFormSchema(mcpServerView, { existingViewNames: [] })
+      ),
+    });
+
+    form = currentForm;
+
+    return (
+      <FormProvider {...currentForm}>
+        <ToolsList owner={owner} mcpServerView={mcpServerView} />
+      </FormProvider>
+    );
+  }
+
+  render(<Harness />);
+
+  return { form };
+}
+
+describe("ToolsList", () => {
+  it("keeps form state flat and validates when a tool name contains a dot", async () => {
+    const { form } = renderToolsList();
+
+    // Toggling the dotted-name tool's enabled state used to corrupt RHF state
+    // because dots in field paths are interpreted as nested-object separators.
+    const checkbox = screen.getByRole("checkbox");
+    await act(async () => {
+      fireEvent.click(checkbox);
+    });
+
+    const values = form.getValues();
+
+    // The dotted key must remain a flat record entry, not a nested path.
+    expect(values.toolSettings[TOOL_NAME_WITH_DOT]).toBeDefined();
+    expect(values.toolSettings[TOOL_NAME_WITH_DOT].enabled).toBe(false);
+    // No nested object should have been created at the path "weather.get_current".
+    expect(values.toolSettings["weather"]).toBeUndefined();
+
+    // Schema validation must pass — this is the user-facing failure mode.
+    const isValid = await form.trigger();
+    expect(isValid).toBe(true);
+    expect(form.formState.errors.toolSettings).toBeUndefined();
+  });
+});

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -1,4 +1,7 @@
-import type { MCPServerFormValues } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import type {
+  MCPServerFormValues,
+  ToolSettings,
+} from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import { getDefaultInternalToolStakeLevel } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
@@ -33,11 +36,8 @@ interface ToolItemProps {
   tool: { name: string; description: string };
   mayUpdate: boolean;
   availableStakeLevels: MCPToolStakeLevelType[];
-  metadata?: {
-    enabled: boolean;
-    permission: MCPToolStakeLevelType;
-  };
-  defaultPermission: MCPToolStakeLevelType;
+  settings: ToolSettings;
+  onChange: (settings: ToolSettings) => void;
 }
 
 const ToolItem = memo(
@@ -45,32 +45,22 @@ const ToolItem = memo(
     tool,
     mayUpdate,
     availableStakeLevels,
-    metadata,
-    defaultPermission,
+    settings,
+    onChange,
   }: ToolItemProps) => {
-    const { control } = useFormContext<MCPServerFormValues>();
-    const { field } = useController({
-      control,
-      name: `toolSettings.${tool.name}`,
-      defaultValue: {
-        enabled: metadata?.enabled ?? true,
-        permission: metadata?.permission ?? defaultPermission,
-      },
-    });
-
-    const toolPermission = field.value.permission;
-    const toolEnabled = field.value.enabled;
+    const toolPermission = settings.permission;
+    const toolEnabled = settings.enabled;
 
     const handleToggle = () => {
-      field.onChange({
-        ...field.value,
+      onChange({
+        ...settings,
         enabled: !toolEnabled,
       });
     };
 
     const handlePermissionChange = (permission: MCPToolStakeLevelType) => {
-      field.onChange({
-        ...field.value,
+      onChange({
+        ...settings,
         permission,
       });
     };
@@ -146,6 +136,22 @@ export const ToolsList = memo(
       [mcpServerView.server.tools]
     );
 
+    // We use a single controller for the whole `toolSettings` record because
+    // React Hook Form treats dots in field paths as nested-object separators,
+    // which would corrupt form state for tool names that contain dots.
+    const { control } = useFormContext<MCPServerFormValues>();
+    const { field } = useController({
+      control,
+      name: "toolSettings",
+    });
+
+    const handleToolChange = (toolName: string, settings: ToolSettings) => {
+      field.onChange({
+        ...field.value,
+        [toolName]: settings,
+      });
+    };
+
     const getAvailableStakeLevels = (): MCPToolStakeLevelType[] => {
       return [...MCP_TOOL_STAKE_LEVELS];
     };
@@ -204,14 +210,24 @@ export const ToolsList = memo(
                               tool.name
                             );
 
+                          const settings: ToolSettings = field.value[
+                            tool.name
+                          ] ?? {
+                            enabled: metadata?.enabled ?? true,
+                            permission:
+                              metadata?.permission ?? defaultPermission,
+                          };
+
                           return (
                             <ToolItem
                               key={index}
                               tool={tool}
                               mayUpdate={mayUpdate}
                               availableStakeLevels={availableStakeLevels}
-                              metadata={metadata}
-                              defaultPermission={defaultPermission}
+                              settings={settings}
+                              onChange={(next) =>
+                                handleToolChange(tool.name, next)
+                              }
                             />
                           );
                         }

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -147,7 +147,7 @@ export const ToolsList = memo(
 
     const handleToolChange = (toolName: string, settings: ToolSettings) => {
       field.onChange({
-        ...field.value,
+        ...(field.value ?? {}),
         [toolName]: settings,
       });
     };
@@ -210,7 +210,7 @@ export const ToolsList = memo(
                               tool.name
                             );
 
-                          const settings: ToolSettings = field.value[
+                          const settings: ToolSettings = field.value?.[
                             tool.name
                           ] ?? {
                             enabled: metadata?.enabled ?? true,


### PR DESCRIPTION
## Description

This PR adds back https://github.com/dust-tt/dust/pull/25052, which was reverted in https://github.com/dust-tt/dust/pull/25080

Also contains a fix for a hard crash when opening an existing tool whose info view renders `ToolsList` inside a form that does not define `toolSettings`. See commit https://github.com/dust-tt/dust/pull/25081/changes/956b1ed4bc339c3230a3d1a065befb80e607c34d

The fix makes `ToolsList` tolerate missing `toolSettings` by using optional access when reading tool settings and an empty object fallback when updating them.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
