### PR TITLE
[front] fix: support MCP tool names containing dots in stake editor

### DIFF
--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -4,8 +4,8 @@ import {
   type MCPServerFormValues,
 } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import { ToolsList } from "@app/components/actions/mcp/ToolsList";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
+import { MCPServerViewTypeFactory } from "@app/tests/utils/MCPServerViewTypeFactory";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { FormProvider, type UseFormReturn, useForm } from "react-hook-form";
@@ -52,28 +52,8 @@ const TOOL_NAME_WITH_UNDERSCORE = "get_messages";
 
 const owner = LightWorkspaceFactory.build();
 
-const mcpServerView = {
-  id: 1,
-  sId: "msv_1",
-  name: "Test Server",
-  description: "Test server description",
-  spaceId: "sp_1",
-  serverType: "remote",
-  oAuthUseCase: null,
-  editedByUser: null,
-  createdAt: 0,
-  updatedAt: 0,
-  toolsMetadata: undefined,
+const mcpServerView = MCPServerViewTypeFactory.build({
   server: {
-    sId: "rms_1",
-    name: "test-server",
-    version: "1.0.0",
-    description: "Test server description",
-    icon: "ToolsIcon",
-    authorization: null,
-    availability: "manual",
-    allowMultipleInstances: true,
-    documentationUrl: null,
     tools: [
       {
         name: TOOL_NAME_WITH_DOT,
@@ -81,12 +61,10 @@ const mcpServerView = {
       },
     ],
   },
-} satisfies MCPServerViewType;
+});
 
-const readOnlyMcpServerView = {
-  ...mcpServerView,
+const readOnlyMcpServerView = MCPServerViewTypeFactory.build({
   server: {
-    ...mcpServerView.server,
     tools: [
       {
         name: TOOL_NAME_WITH_UNDERSCORE,
@@ -94,7 +72,7 @@ const readOnlyMcpServerView = {
       },
     ],
   },
-} satisfies MCPServerViewType;
+});
 
 function renderToolsList() {
   let form!: UseFormReturn<MCPServerFormValues>;

--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -5,7 +5,7 @@ import {
 } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import { ToolsList } from "@app/components/actions/mcp/ToolsList";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import type { LightWorkspaceType } from "@app/types/user";
+import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { FormProvider, type UseFormReturn, useForm } from "react-hook-form";
@@ -50,18 +50,7 @@ vi.mock("@app/lib/actions/mcp_helper", () => ({
 const TOOL_NAME_WITH_DOT = "weather.get_current";
 const TOOL_NAME_WITH_UNDERSCORE = "get_messages";
 
-const owner = {
-  sId: "ws_1",
-  id: 1,
-  name: "Test Workspace",
-  segmentation: null,
-  role: "admin",
-  whiteListedProviders: null,
-  defaultEmbeddingProvider: null,
-  metadata: {},
-  sharingPolicy: "workspace_only",
-  metronomeCustomerId: null,
-} satisfies LightWorkspaceType;
+const owner = LightWorkspaceFactory.build();
 
 const mcpServerView = {
   id: 1,

--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -1,0 +1,148 @@
+import {
+  getMCPServerFormDefaults,
+  getMCPServerFormSchema,
+  type MCPServerFormValues,
+} from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import { ToolsList } from "@app/components/actions/mcp/ToolsList";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { LightWorkspaceType } from "@app/types/user";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { FormProvider, type UseFormReturn, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+
+// Stub Sparkle UI primitives so they render plain DOM and let us click the checkbox.
+vi.mock("@dust-tt/sparkle", () => ({
+  Button: ({ label, isSelect: _isSelect, ...rest }: any) => (
+    <button {...rest}>{label}</button>
+  ),
+  Card: ({ children, ...rest }: any) => <div {...rest}>{children}</div>,
+  Checkbox: ({ checked, onClick }: any) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onClick={onClick}
+      onChange={() => {}}
+    />
+  ),
+  Collapsible: ({ children }: any) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: any) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: any) => (
+    <button type="button">{children}</button>
+  ),
+  ContentMessage: ({ children }: any) => <div>{children}</div>,
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuItem: ({ label }: any) => <button type="button">{label}</button>,
+  DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
+  InformationCircleIcon: () => null,
+}));
+
+// Treat the test server as remote so default-stake lookups skip the internal
+// server registry.
+vi.mock("@app/lib/actions/mcp_helper", () => ({
+  isRemoteMCPServerType: () => true,
+  requiresBearerTokenConfiguration: () => false,
+  getMcpServerViewDescription: (view: { description?: string }) =>
+    view.description ?? "test description",
+}));
+
+const TOOL_NAME_WITH_DOT = "weather.get_current";
+
+const owner = {
+  sId: "ws_1",
+  id: 1,
+  name: "Test Workspace",
+  segmentation: null,
+  role: "admin",
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  metadata: {},
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+} satisfies LightWorkspaceType;
+
+const mcpServerView = {
+  id: 1,
+  sId: "msv_1",
+  name: "Test Server",
+  description: "Test server description",
+  spaceId: "sp_1",
+  serverType: "remote",
+  oAuthUseCase: null,
+  editedByUser: null,
+  createdAt: 0,
+  updatedAt: 0,
+  toolsMetadata: undefined,
+  server: {
+    sId: "rms_1",
+    name: "test-server",
+    version: "1.0.0",
+    description: "Test server description",
+    icon: "ToolsIcon",
+    authorization: null,
+    availability: "manual",
+    allowMultipleInstances: true,
+    documentationUrl: null,
+    tools: [
+      {
+        name: TOOL_NAME_WITH_DOT,
+        description: "Get current weather",
+      },
+    ],
+  },
+} satisfies MCPServerViewType;
+
+function renderToolsList() {
+  let form!: UseFormReturn<MCPServerFormValues>;
+
+  function Harness() {
+    const defaults = getMCPServerFormDefaults(mcpServerView);
+    const currentForm = useForm<MCPServerFormValues>({
+      values: defaults,
+      mode: "onChange",
+      shouldUnregister: false,
+      resolver: zodResolver(
+        getMCPServerFormSchema(mcpServerView, { existingViewNames: [] })
+      ),
+    });
+
+    form = currentForm;
+
+    return (
+      <FormProvider {...currentForm}>
+        <ToolsList owner={owner} mcpServerView={mcpServerView} />
+      </FormProvider>
+    );
+  }
+
+  render(<Harness />);
+
+  return { form };
+}
+
+describe("ToolsList", () => {
+  it("keeps form state flat and validates when a tool name contains a dot", async () => {
+    const { form } = renderToolsList();
+
+    // Toggling the dotted-name tool's enabled state used to corrupt RHF state
+    // because dots in field paths are interpreted as nested-object separators.
+    const checkbox = screen.getByRole("checkbox");
+    await act(async () => {
+      fireEvent.click(checkbox);
+    });
+
+    const values = form.getValues();
+
+    // The dotted key must remain a flat record entry, not a nested path.
+    expect(values.toolSettings[TOOL_NAME_WITH_DOT]).toBeDefined();
+    expect(values.toolSettings[TOOL_NAME_WITH_DOT].enabled).toBe(false);
+    // No nested object should have been created at the path "weather.get_current".
+    expect(values.toolSettings["weather"]).toBeUndefined();
+
+    // Schema validation must pass — this is the user-facing failure mode.
+    const isValid = await form.trigger();
+    expect(isValid).toBe(true);
+    expect(form.formState.errors.toolSettings).toBeUndefined();
+  });
+});

--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -48,6 +48,7 @@ vi.mock("@app/lib/actions/mcp_helper", () => ({
 }));
 
 const TOOL_NAME_WITH_DOT = "weather.get_current";
+const TOOL_NAME_WITH_UNDERSCORE = "get_messages";
 
 const owner = {
   sId: "ws_1",
@@ -88,6 +89,19 @@ const mcpServerView = {
       {
         name: TOOL_NAME_WITH_DOT,
         description: "Get current weather",
+      },
+    ],
+  },
+} satisfies MCPServerViewType;
+
+const readOnlyMcpServerView = {
+  ...mcpServerView,
+  server: {
+    ...mcpServerView.server,
+    tools: [
+      {
+        name: TOOL_NAME_WITH_UNDERSCORE,
+        description: "Get messages",
       },
     ],
   },
@@ -144,5 +158,21 @@ describe("ToolsList", () => {
     const isValid = await form.trigger();
     expect(isValid).toBe(true);
     expect(form.formState.errors.toolSettings).toBeUndefined();
+  });
+
+  it("renders in read-only mode without relying on the MCP settings form context", () => {
+    render(
+      <ToolsList
+        owner={owner}
+        mcpServerView={readOnlyMcpServerView}
+        disableUpdates
+      />
+    );
+
+    expect(screen.getByText(/available tools/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /get messages/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).toBeNull();
   });
 });

--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -127,19 +127,23 @@ describe("ToolsList", () => {
     expect(form.formState.errors.toolSettings).toBeUndefined();
   });
 
-  it("renders in read-only mode without relying on the MCP settings form context", () => {
-    render(
-      <ToolsList
-        owner={owner}
-        mcpServerView={readOnlyMcpServerView}
-        disableUpdates
-      />
-    );
+  it("does not throw when rendered outside an MCPServerFormValues FormProvider", () => {
+    // Regression: the agent builder mounts <ToolsList disableUpdates /> with
+    // no surrounding FormProvider for MCPServerFormValues. An earlier version
+    // called useFormContext / useController unconditionally and crashed in
+    // that context.
+    expect(() =>
+      render(
+        <ToolsList
+          owner={owner}
+          mcpServerView={readOnlyMcpServerView}
+          disableUpdates
+        />
+      )
+    ).not.toThrow();
 
-    expect(screen.getByText(/available tools/i)).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: /get messages/i })
     ).toBeInTheDocument();
-    expect(screen.queryByRole("checkbox")).toBeNull();
   });
 });

--- a/front/components/actions/mcp/ToolsList.test.tsx
+++ b/front/components/actions/mcp/ToolsList.test.tsx
@@ -1,4 +1,5 @@
 import {
+  encodeMCPToolNameForForm,
   getMCPServerFormDefaults,
   getMCPServerFormSchema,
   type MCPServerFormValues,
@@ -48,6 +49,7 @@ vi.mock("@app/lib/actions/mcp_helper", () => ({
 }));
 
 const TOOL_NAME_WITH_DOT = "weather.get_current";
+const SECOND_TOOL_NAME = "calendar.sync";
 const TOOL_NAME_WITH_UNDERSCORE = "get_messages";
 
 const owner = LightWorkspaceFactory.build();
@@ -63,6 +65,49 @@ const mcpServerView = MCPServerViewTypeFactory.build({
   },
 });
 
+const mcpServerViewWithTwoTools = MCPServerViewTypeFactory.build({
+  server: {
+    tools: [
+      {
+        name: TOOL_NAME_WITH_DOT,
+        description: "Get current weather",
+      },
+      {
+        name: SECOND_TOOL_NAME,
+        description: "Sync calendar",
+      },
+    ],
+  },
+  toolsMetadata: [
+    {
+      toolName: TOOL_NAME_WITH_DOT,
+      enabled: true,
+      permission: "low",
+    },
+    {
+      toolName: SECOND_TOOL_NAME,
+      enabled: true,
+      permission: "low",
+    },
+  ],
+});
+
+const updatedMcpServerViewWithTwoTools = MCPServerViewTypeFactory.build({
+  ...mcpServerViewWithTwoTools,
+  toolsMetadata: [
+    {
+      toolName: TOOL_NAME_WITH_DOT,
+      enabled: true,
+      permission: "low",
+    },
+    {
+      toolName: SECOND_TOOL_NAME,
+      enabled: false,
+      permission: "high",
+    },
+  ],
+});
+
 const readOnlyMcpServerView = MCPServerViewTypeFactory.build({
   server: {
     tools: [
@@ -74,17 +119,26 @@ const readOnlyMcpServerView = MCPServerViewTypeFactory.build({
   },
 });
 
-function renderToolsList() {
+function renderToolsList({
+  view = mcpServerView,
+  keepDirtyValues = false,
+}: {
+  view?: typeof mcpServerView;
+  keepDirtyValues?: boolean;
+} = {}) {
   let form!: UseFormReturn<MCPServerFormValues>;
 
-  function Harness() {
-    const defaults = getMCPServerFormDefaults(mcpServerView);
+  function Harness({ currentView }: { currentView: typeof mcpServerView }) {
+    const defaults = getMCPServerFormDefaults(currentView);
     const currentForm = useForm<MCPServerFormValues>({
       values: defaults,
       mode: "onChange",
       shouldUnregister: false,
+      resetOptions: {
+        keepDirtyValues,
+      },
       resolver: zodResolver(
-        getMCPServerFormSchema(mcpServerView, { existingViewNames: [] })
+        getMCPServerFormSchema(currentView, { existingViewNames: [] })
       ),
     });
 
@@ -92,14 +146,18 @@ function renderToolsList() {
 
     return (
       <FormProvider {...currentForm}>
-        <ToolsList owner={owner} mcpServerView={mcpServerView} />
+        <ToolsList owner={owner} mcpServerView={currentView} />
       </FormProvider>
     );
   }
 
-  render(<Harness />);
+  const rendered = render(<Harness currentView={view} />);
 
-  return { form };
+  return {
+    form,
+    rerender: (currentView: typeof mcpServerView) =>
+      rendered.rerender(<Harness currentView={currentView} />),
+  };
 }
 
 describe("ToolsList", () => {
@@ -116,15 +174,48 @@ describe("ToolsList", () => {
     const values = form.getValues();
 
     // The dotted key must remain a flat record entry, not a nested path.
-    expect(values.toolSettings[TOOL_NAME_WITH_DOT]).toBeDefined();
-    expect(values.toolSettings[TOOL_NAME_WITH_DOT].enabled).toBe(false);
+    const encodedToolName = encodeMCPToolNameForForm(TOOL_NAME_WITH_DOT);
+
+    expect(values.toolSettings[encodedToolName]).toBeDefined();
+    expect(values.toolSettings[encodedToolName].enabled).toBe(false);
     // No nested object should have been created at the path "weather.get_current".
     expect(values.toolSettings["weather"]).toBeUndefined();
+    expect(values.toolSettings[TOOL_NAME_WITH_DOT]).toBeUndefined();
 
     // Schema validation must pass — this is the user-facing failure mode.
-    const isValid = await form.trigger();
+    let isValid = false;
+    await act(async () => {
+      isValid = await form.trigger();
+    });
     expect(isValid).toBe(true);
     expect(form.formState.errors.toolSettings).toBeUndefined();
+  });
+
+  it("preserves only the edited tool on form resets", async () => {
+    const { form, rerender } = renderToolsList({
+      view: mcpServerViewWithTwoTools,
+      keepDirtyValues: true,
+    });
+
+    const [firstCheckbox] = screen.getAllByRole("checkbox");
+    await act(async () => {
+      fireEvent.click(firstCheckbox);
+    });
+
+    await act(async () => {
+      rerender(updatedMcpServerViewWithTwoTools);
+    });
+
+    const values = form.getValues();
+    expect(
+      values.toolSettings[encodeMCPToolNameForForm(TOOL_NAME_WITH_DOT)].enabled
+    ).toBe(false);
+    expect(
+      values.toolSettings[encodeMCPToolNameForForm(SECOND_TOOL_NAME)].enabled
+    ).toBe(false);
+    expect(
+      values.toolSettings[encodeMCPToolNameForForm(SECOND_TOOL_NAME)].permission
+    ).toBe("high");
   });
 
   it("does not throw when rendered outside an MCPServerFormValues FormProvider", () => {

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -322,14 +322,16 @@ export const ToolsList = memo(
     const toolMetadataByName = useMemo(
       () =>
         Object.fromEntries(
-          (mcpServerView.toolsMetadata ?? []).map((metadata) => [
-            metadata.toolName,
-            {
-              enabled: metadata.enabled,
-              permission: metadata.permission,
-            },
-          ])
-        ) as Record<string, ToolMetadata>,
+          (mcpServerView.toolsMetadata ?? []).map(
+            (metadata): [string, ToolMetadata] => [
+              metadata.toolName,
+              {
+                enabled: metadata.enabled,
+                permission: metadata.permission,
+              },
+            ]
+          )
+        ),
       [mcpServerView.toolsMetadata]
     );
 

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -37,7 +37,7 @@ interface ToolsListProps {
 
 type ToolDefinition = MCPServerViewType["server"]["tools"][number];
 
-interface ToolItemContentProps {
+interface ToolItemProps {
   tool: ToolDefinition;
   mayUpdate: boolean;
   availableStakeLevels: ReadonlyArray<MCPToolStakeLevelType>;
@@ -52,19 +52,13 @@ interface EditableToolItemProps {
   defaultSettings: ToolSettings;
 }
 
-interface ToolsListContentProps {
-  mayUpdate: boolean;
-  tools: ToolDefinition[];
-  renderToolItem: (tool: ToolDefinition) => JSX.Element;
-}
-
-function ToolItemContent({
+function ToolItem({
   tool,
   mayUpdate,
   availableStakeLevels,
   settings,
   onChange,
-}: ToolItemContentProps) {
+}: ToolItemProps) {
   const toolPermission = settings.permission;
   const toolEnabled = settings.enabled;
 
@@ -137,6 +131,30 @@ function ToolItemContent({
   );
 }
 
+function EditableToolItem({
+  tool,
+  mayUpdate,
+  availableStakeLevels,
+  defaultSettings,
+}: EditableToolItemProps) {
+  const { control } = useFormContext<MCPServerFormValues>();
+  const { field } = useController({
+    control,
+    name: `toolSettings.${encodeMCPToolNameForForm(tool.name)}`,
+    defaultValue: defaultSettings,
+  });
+
+  return (
+    <ToolItem
+      tool={tool}
+      mayUpdate={mayUpdate}
+      availableStakeLevels={availableStakeLevels}
+      settings={field.value ?? defaultSettings}
+      onChange={field.onChange}
+    />
+  );
+}
+
 function getDefaultToolSettings({
   tool,
   toolMetadataByName,
@@ -158,120 +176,14 @@ function getDefaultToolSettings({
   };
 }
 
-function EditableToolItem({
-  tool,
-  mayUpdate,
-  availableStakeLevels,
-  defaultSettings,
-}: EditableToolItemProps) {
-  const { control } = useFormContext<MCPServerFormValues>();
-  const { field } = useController({
-    control,
-    name: `toolSettings.${encodeMCPToolNameForForm(tool.name)}`,
-    defaultValue: defaultSettings,
-  });
-
-  return (
-    <ToolItemContent
-      tool={tool}
-      mayUpdate={mayUpdate}
-      availableStakeLevels={availableStakeLevels}
-      settings={field.value ?? defaultSettings}
-      onChange={field.onChange}
-    />
-  );
-}
-
-function ToolsListContent({
-  mayUpdate,
-  tools,
-  renderToolItem,
-}: ToolsListContentProps) {
-  return (
-    <>
-      {tools && tools.length > 0 && (
-        <Collapsible defaultOpen={tools.length <= 5}>
-          <CollapsibleTrigger>
-            <div className="heading-lg">Available Tools ({tools.length})</div>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <>
-              <ContentMessage
-                className="mb-4 mt-2 w-full"
-                variant="blue"
-                size="lg"
-                icon={InformationCircleIcon}
-                title="User Approval Settings"
-              >
-                <ul>
-                  <li>
-                    <b>High stake</b> tools need explicit user approval.
-                  </li>
-                  <li>
-                    <b>Medium stake</b> tools allow users to save per-agent
-                    confirmations.
-                  </li>
-                  <li>
-                    Users can completely disable confirmations for{" "}
-                    <b>low stake</b> tools.
-                  </li>
-                  <li>
-                    <b>Never ask</b> tools run automatically.
-                  </li>
-                </ul>
-              </ContentMessage>
-
-              <div>
-                {tools.length > 0 ? (
-                  <div className="flex flex-col gap-4">
-                    {tools.map((tool) => renderToolItem(tool))}
-                  </div>
-                ) : (
-                  <p className="text-sm text-faint">No tools available</p>
-                )}
-              </div>
-            </>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
-    </>
-  );
-}
-
-interface EditableToolsListProps {
-  mayUpdate: boolean;
-  tools: ToolDefinition[];
-  getDefaultSettings: (tool: ToolDefinition) => ToolSettings;
-}
-
-function EditableToolsList({
-  mayUpdate,
-  tools,
-  getDefaultSettings,
-}: EditableToolsListProps) {
-  return (
-    <ToolsListContent
-      mayUpdate={mayUpdate}
-      tools={tools}
-      renderToolItem={(tool) => (
-        <EditableToolItem
-          key={tool.name}
-          tool={tool}
-          mayUpdate={mayUpdate}
-          availableStakeLevels={MCP_TOOL_STAKE_LEVELS}
-          defaultSettings={getDefaultSettings(tool)}
-        />
-      )}
-    />
-  );
-}
+const noop = () => {};
 
 // We disable buttons for agent builder view because it would feel like
 // you can configure per agent
 export const ToolsList = memo(
   ({ owner, mcpServerView, disableUpdates }: ToolsListProps) => {
-    const mayUpdate = disableUpdates ? false : isAdmin(owner);
-    const tools = mcpServerView.server.tools;
+    const mayUpdate = !disableUpdates && isAdmin(owner);
+    const { tools } = mcpServerView.server;
     const toolMetadataByName = Object.fromEntries(
       (mcpServerView.toolsMetadata ?? []).map(
         (metadata): [string, ToolSettings] => [
@@ -283,37 +195,82 @@ export const ToolsList = memo(
         ]
       )
     );
-    const getDefaultSettings = (tool: ToolDefinition) =>
-      getDefaultToolSettings({ tool, toolMetadataByName, mcpServerView });
 
-    // Read-only path: render directly without binding to the surrounding
-    // MCPServerFormValues form, since this component is also rendered in
-    // contexts (e.g. agent builder) that have no such FormProvider.
-    if (disableUpdates) {
-      return (
-        <ToolsListContent
-          mayUpdate={mayUpdate}
-          tools={tools}
-          renderToolItem={(tool) => (
-            <ToolItemContent
-              key={tool.name}
-              tool={tool}
-              mayUpdate={mayUpdate}
-              availableStakeLevels={MCP_TOOL_STAKE_LEVELS}
-              settings={getDefaultSettings(tool)}
-              onChange={() => {}}
-            />
-          )}
-        />
-      );
+    if (!tools || tools.length === 0) {
+      return null;
     }
 
     return (
-      <EditableToolsList
-        mayUpdate={mayUpdate}
-        tools={tools}
-        getDefaultSettings={getDefaultSettings}
-      />
+      <Collapsible defaultOpen={tools.length <= 5}>
+        <CollapsibleTrigger>
+          <div className="heading-lg">Available Tools ({tools.length})</div>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <>
+            <ContentMessage
+              className="mb-4 mt-2 w-full"
+              variant="blue"
+              size="lg"
+              icon={InformationCircleIcon}
+              title="User Approval Settings"
+            >
+              <ul>
+                <li>
+                  <b>High stake</b> tools need explicit user approval.
+                </li>
+                <li>
+                  <b>Medium stake</b> tools allow users to save per-agent
+                  confirmations.
+                </li>
+                <li>
+                  Users can completely disable confirmations for{" "}
+                  <b>low stake</b> tools.
+                </li>
+                <li>
+                  <b>Never ask</b> tools run automatically.
+                </li>
+              </ul>
+            </ContentMessage>
+
+            <div className="flex flex-col gap-4">
+              {tools.map((tool) => {
+                const defaultSettings = getDefaultToolSettings({
+                  tool,
+                  toolMetadataByName,
+                  mcpServerView,
+                });
+
+                // Read-only path: render directly without binding to the
+                // surrounding MCPServerFormValues form, since this component is
+                // also rendered in contexts (e.g. agent builder) that have no
+                // such FormProvider.
+                if (disableUpdates) {
+                  return (
+                    <ToolItem
+                      key={tool.name}
+                      tool={tool}
+                      settings={defaultSettings}
+                      mayUpdate={mayUpdate}
+                      availableStakeLevels={MCP_TOOL_STAKE_LEVELS}
+                      onChange={noop}
+                    />
+                  );
+                }
+
+                return (
+                  <EditableToolItem
+                    key={tool.name}
+                    tool={tool}
+                    mayUpdate={mayUpdate}
+                    availableStakeLevels={MCP_TOOL_STAKE_LEVELS}
+                    defaultSettings={defaultSettings}
+                  />
+                );
+              })}
+            </div>
+          </>
+        </CollapsibleContent>
+      </Collapsible>
     );
   }
 );

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -233,15 +233,17 @@ const ToolsListContent = memo(
   }
 );
 
+interface EditableToolsListProps {
+  mayUpdate: boolean;
+  tools: ToolDefinition[];
+  getDefaultSettings: (tool: ToolDefinition) => ToolSettings;
+}
+
 function EditableToolsList({
   mayUpdate,
   tools,
   getDefaultSettings,
-}: {
-  mayUpdate: boolean;
-  tools: ToolDefinition[];
-  getDefaultSettings: (tool: ToolDefinition) => ToolSettings;
-}) {
+}: EditableToolsListProps) {
   // We use a single controller for the whole `toolSettings` record because
   // React Hook Form treats dots in field paths as nested-object separators,
   // which would corrupt form state for tool names that contain dots.

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -27,7 +27,7 @@ import {
   InformationCircleIcon,
 } from "@dust-tt/sparkle";
 import { memo } from "react";
-import { useController, useFormContext } from "react-hook-form";
+import { Controller, useFormContext } from "react-hook-form";
 
 interface ToolsListProps {
   owner: LightWorkspaceType;
@@ -43,13 +43,6 @@ interface ToolItemProps {
   availableStakeLevels: ReadonlyArray<MCPToolStakeLevelType>;
   settings: ToolSettings;
   onChange: (settings: ToolSettings) => void;
-}
-
-interface EditableToolItemProps {
-  tool: ToolDefinition;
-  mayUpdate: boolean;
-  availableStakeLevels: ReadonlyArray<MCPToolStakeLevelType>;
-  defaultSettings: ToolSettings;
 }
 
 function ToolItem({
@@ -131,30 +124,6 @@ function ToolItem({
   );
 }
 
-function EditableToolItem({
-  tool,
-  mayUpdate,
-  availableStakeLevels,
-  defaultSettings,
-}: EditableToolItemProps) {
-  const { control } = useFormContext<MCPServerFormValues>();
-  const { field } = useController({
-    control,
-    name: `toolSettings.${encodeMCPToolNameForForm(tool.name)}`,
-    defaultValue: defaultSettings,
-  });
-
-  return (
-    <ToolItem
-      tool={tool}
-      mayUpdate={mayUpdate}
-      availableStakeLevels={availableStakeLevels}
-      settings={field.value ?? defaultSettings}
-      onChange={field.onChange}
-    />
-  );
-}
-
 function getDefaultToolSettings({
   tool,
   toolMetadataByName,
@@ -182,6 +151,7 @@ const noop = () => {};
 // you can configure per agent
 export const ToolsList = memo(
   ({ owner, mcpServerView, disableUpdates }: ToolsListProps) => {
+    const formContext = useFormContext<MCPServerFormValues>();
     const mayUpdate = !disableUpdates && isAdmin(owner);
     const { tools } = mcpServerView.server;
     const toolMetadataByName = Object.fromEntries(
@@ -240,10 +210,6 @@ export const ToolsList = memo(
                   mcpServerView,
                 });
 
-                // Read-only path: render directly without binding to the
-                // surrounding MCPServerFormValues form, since this component is
-                // also rendered in contexts (e.g. agent builder) that have no
-                // such FormProvider.
                 if (disableUpdates) {
                   return (
                     <ToolItem
@@ -258,12 +224,20 @@ export const ToolsList = memo(
                 }
 
                 return (
-                  <EditableToolItem
+                  <Controller
                     key={tool.name}
-                    tool={tool}
-                    mayUpdate={mayUpdate}
-                    availableStakeLevels={MCP_TOOL_STAKE_LEVELS}
-                    defaultSettings={defaultSettings}
+                    control={formContext.control}
+                    name={`toolSettings.${encodeMCPToolNameForForm(tool.name)}`}
+                    defaultValue={defaultSettings}
+                    render={({ field }) => (
+                      <ToolItem
+                        tool={tool}
+                        mayUpdate={mayUpdate}
+                        availableStakeLevels={MCP_TOOL_STAKE_LEVELS}
+                        settings={field.value ?? defaultSettings}
+                        onChange={field.onChange}
+                      />
+                    )}
                   />
                 );
               })}

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -1,4 +1,7 @@
-import type { MCPServerFormValues } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import type {
+  MCPServerFormValues,
+  ToolSettings,
+} from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import { getDefaultInternalToolStakeLevel } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
@@ -33,11 +36,8 @@ interface ToolItemProps {
   tool: { name: string; description: string };
   mayUpdate: boolean;
   availableStakeLevels: MCPToolStakeLevelType[];
-  metadata?: {
-    enabled: boolean;
-    permission: MCPToolStakeLevelType;
-  };
-  defaultPermission: MCPToolStakeLevelType;
+  settings: ToolSettings;
+  onChange: (settings: ToolSettings) => void;
 }
 
 const ToolItem = memo(
@@ -45,32 +45,22 @@ const ToolItem = memo(
     tool,
     mayUpdate,
     availableStakeLevels,
-    metadata,
-    defaultPermission,
+    settings,
+    onChange,
   }: ToolItemProps) => {
-    const { control } = useFormContext<MCPServerFormValues>();
-    const { field } = useController({
-      control,
-      name: `toolSettings.${tool.name}`,
-      defaultValue: {
-        enabled: metadata?.enabled ?? true,
-        permission: metadata?.permission ?? defaultPermission,
-      },
-    });
-
-    const toolPermission = field.value.permission;
-    const toolEnabled = field.value.enabled;
+    const toolPermission = settings.permission;
+    const toolEnabled = settings.enabled;
 
     const handleToggle = () => {
-      field.onChange({
-        ...field.value,
+      onChange({
+        ...settings,
         enabled: !toolEnabled,
       });
     };
 
     const handlePermissionChange = (permission: MCPToolStakeLevelType) => {
-      field.onChange({
-        ...field.value,
+      onChange({
+        ...settings,
         permission,
       });
     };
@@ -146,6 +136,22 @@ export const ToolsList = memo(
       [mcpServerView.server.tools]
     );
 
+    // We use a single controller for the whole `toolSettings` record because
+    // React Hook Form treats dots in field paths as nested-object separators,
+    // which would corrupt form state for tool names that contain dots.
+    const { control } = useFormContext<MCPServerFormValues>();
+    const { field } = useController({
+      control,
+      name: "toolSettings",
+    });
+
+    const handleToolChange = (toolName: string, settings: ToolSettings) => {
+      field.onChange({
+        ...field.value,
+        [toolName]: settings,
+      });
+    };
+
     const getAvailableStakeLevels = (): MCPToolStakeLevelType[] => {
       return [...MCP_TOOL_STAKE_LEVELS];
     };
@@ -204,14 +210,24 @@ export const ToolsList = memo(
                               tool.name
                             );
 
+                          const settings: ToolSettings = field.value[
+                            tool.name
+                          ] ?? {
+                            enabled: metadata?.enabled ?? true,
+                            permission:
+                              metadata?.permission ?? defaultPermission,
+                          };
+
                           return (
                             <ToolItem
                               key={index}
                               tool={tool}
                               mayUpdate={mayUpdate}
                               availableStakeLevels={availableStakeLevels}
-                              metadata={metadata}
-                              defaultPermission={defaultPermission}
+                              settings={settings}
+                              onChange={(next) =>
+                                handleToolChange(tool.name, next)
+                              }
                             />
                           );
                         }

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -2,7 +2,10 @@ import type {
   MCPServerFormValues,
   ToolSettings,
 } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
-import { getDefaultInternalToolStakeLevel } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
+import {
+  encodeMCPToolNameForForm,
+  getDefaultInternalToolStakeLevel,
+} from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -34,7 +37,7 @@ interface ToolsListProps {
 
 type ToolDefinition = MCPServerViewType["server"]["tools"][number];
 
-interface ToolItemProps {
+interface ToolItemContentProps {
   tool: ToolDefinition;
   mayUpdate: boolean;
   availableStakeLevels: ReadonlyArray<MCPToolStakeLevelType>;
@@ -42,24 +45,26 @@ interface ToolItemProps {
   onChange: (settings: ToolSettings) => void;
 }
 
-interface ToolWithSettings {
+interface EditableToolItemProps {
   tool: ToolDefinition;
-  settings: ToolSettings;
+  mayUpdate: boolean;
+  availableStakeLevels: ReadonlyArray<MCPToolStakeLevelType>;
+  defaultSettings: ToolSettings;
 }
 
 interface ToolsListContentProps {
   mayUpdate: boolean;
-  tools: ToolWithSettings[];
-  onToolChange: (toolName: string, settings: ToolSettings) => void;
+  tools: ToolDefinition[];
+  renderToolItem: (tool: ToolDefinition) => JSX.Element;
 }
 
-function ToolItem({
+function ToolItemContent({
   tool,
   mayUpdate,
   availableStakeLevels,
   settings,
   onChange,
-}: ToolItemProps) {
+}: ToolItemContentProps) {
   const toolPermission = settings.permission;
   const toolEnabled = settings.enabled;
 
@@ -153,10 +158,34 @@ function getDefaultToolSettings({
   };
 }
 
+function EditableToolItem({
+  tool,
+  mayUpdate,
+  availableStakeLevels,
+  defaultSettings,
+}: EditableToolItemProps) {
+  const { control } = useFormContext<MCPServerFormValues>();
+  const { field } = useController({
+    control,
+    name: `toolSettings.${encodeMCPToolNameForForm(tool.name)}`,
+    defaultValue: defaultSettings,
+  });
+
+  return (
+    <ToolItemContent
+      tool={tool}
+      mayUpdate={mayUpdate}
+      availableStakeLevels={availableStakeLevels}
+      settings={field.value ?? defaultSettings}
+      onChange={field.onChange}
+    />
+  );
+}
+
 function ToolsListContent({
   mayUpdate,
   tools,
-  onToolChange,
+  renderToolItem,
 }: ToolsListContentProps) {
   return (
     <>
@@ -195,16 +224,7 @@ function ToolsListContent({
               <div>
                 {tools.length > 0 ? (
                   <div className="flex flex-col gap-4">
-                    {tools.map(({ tool, settings }, index) => (
-                      <ToolItem
-                        key={index}
-                        tool={tool}
-                        mayUpdate={mayUpdate}
-                        availableStakeLevels={MCP_TOOL_STAKE_LEVELS}
-                        settings={settings}
-                        onChange={(next) => onToolChange(tool.name, next)}
-                      />
-                    ))}
+                    {tools.map((tool) => renderToolItem(tool))}
                   </div>
                 ) : (
                   <p className="text-sm text-faint">No tools available</p>
@@ -229,35 +249,19 @@ function EditableToolsList({
   tools,
   getDefaultSettings,
 }: EditableToolsListProps) {
-  // We use a single controller for the whole `toolSettings` record because
-  // React Hook Form treats dots in field paths as nested-object separators,
-  // which would corrupt form state for tool names that contain dots.
-  const { control } = useFormContext<MCPServerFormValues>();
-  const { field } = useController({
-    control,
-    name: "toolSettings",
-    defaultValue: {},
-  });
-
-  const toolSettings = field.value ?? {};
-
-  const handleToolChange = (toolName: string, settings: ToolSettings) => {
-    field.onChange({
-      ...toolSettings,
-      [toolName]: settings,
-    });
-  };
-
-  const toolsWithSettings = tools.map((tool) => ({
-    tool,
-    settings: toolSettings[tool.name] ?? getDefaultSettings(tool),
-  }));
-
   return (
     <ToolsListContent
       mayUpdate={mayUpdate}
-      tools={toolsWithSettings}
-      onToolChange={handleToolChange}
+      tools={tools}
+      renderToolItem={(tool) => (
+        <EditableToolItem
+          key={tool.name}
+          tool={tool}
+          mayUpdate={mayUpdate}
+          availableStakeLevels={MCP_TOOL_STAKE_LEVELS}
+          defaultSettings={getDefaultSettings(tool)}
+        />
+      )}
     />
   );
 }
@@ -286,15 +290,20 @@ export const ToolsList = memo(
     // MCPServerFormValues form, since this component is also rendered in
     // contexts (e.g. agent builder) that have no such FormProvider.
     if (disableUpdates) {
-      const toolsWithSettings = tools.map((tool) => ({
-        tool,
-        settings: getDefaultSettings(tool),
-      }));
       return (
         <ToolsListContent
           mayUpdate={mayUpdate}
-          tools={toolsWithSettings}
-          onToolChange={() => {}}
+          tools={tools}
+          renderToolItem={(tool) => (
+            <ToolItemContent
+              key={tool.name}
+              tool={tool}
+              mayUpdate={mayUpdate}
+              availableStakeLevels={MCP_TOOL_STAKE_LEVELS}
+              settings={getDefaultSettings(tool)}
+              onChange={() => {}}
+            />
+          )}
         />
       );
     }

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -50,10 +50,14 @@ interface ToolItemProps {
   onChange: (settings: ToolSettings) => void;
 }
 
+interface ToolWithSettings {
+  tool: ToolDefinition;
+  settings: ToolSettings;
+}
+
 interface ToolsListContentProps {
   mayUpdate: boolean;
-  tools: ToolDefinition[];
-  getSettings: (tool: ToolDefinition) => ToolSettings;
+  tools: ToolWithSettings[];
   onToolChange: (toolName: string, settings: ToolSettings) => void;
 }
 
@@ -162,7 +166,7 @@ function getDefaultToolSettings({
 }
 
 const ToolsListContent = memo(
-  ({ mayUpdate, tools, getSettings, onToolChange }: ToolsListContentProps) => {
+  ({ mayUpdate, tools, onToolChange }: ToolsListContentProps) => {
     const getAvailableStakeLevels = (): MCPToolStakeLevelType[] => {
       return [...MCP_TOOL_STAKE_LEVELS];
     };
@@ -204,9 +208,8 @@ const ToolsListContent = memo(
                 <div>
                   {tools.length > 0 ? (
                     <div className="flex flex-col gap-4">
-                      {tools.map((tool, index) => {
+                      {tools.map(({ tool, settings }, index) => {
                         const availableStakeLevels = getAvailableStakeLevels();
-                        const settings = getSettings(tool);
 
                         return (
                           <ToolItem
@@ -263,13 +266,15 @@ function EditableToolsList({
     });
   };
 
+  const toolsWithSettings = tools.map((tool) => ({
+    tool,
+    settings: toolSettings[tool.name] ?? getDefaultSettings(tool),
+  }));
+
   return (
     <ToolsListContent
       mayUpdate={mayUpdate}
-      tools={tools}
-      getSettings={(tool) =>
-        toolSettings[tool.name] ?? getDefaultSettings(tool)
-      }
+      tools={toolsWithSettings}
       onToolChange={handleToolChange}
     />
   );
@@ -312,11 +317,14 @@ export const ToolsList = memo(
     // MCPServerFormValues form, since this component is also rendered in
     // contexts (e.g. agent builder) that have no such FormProvider.
     if (disableUpdates) {
+      const toolsWithSettings = tools.map((tool) => ({
+        tool,
+        settings: getDefaultSettings(tool),
+      }));
       return (
         <ToolsListContent
           mayUpdate={mayUpdate}
-          tools={tools}
-          getSettings={getDefaultSettings}
+          tools={toolsWithSettings}
           onToolChange={() => {}}
         />
       );

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -233,7 +233,7 @@ const ToolsListContent = memo(
   }
 );
 
-function EditableToolsListContent({
+function EditableToolsList({
   mayUpdate,
   tools,
   mcpServerView,
@@ -280,33 +280,6 @@ function EditableToolsListContent({
   );
 }
 
-function ReadOnlyToolsListContent({
-  mayUpdate,
-  tools,
-  mcpServerView,
-  toolMetadataByName,
-}: {
-  mayUpdate: boolean;
-  tools: ToolDefinition[];
-  mcpServerView: MCPServerViewType;
-  toolMetadataByName: Record<string, ToolMetadata>;
-}) {
-  return (
-    <ToolsListContent
-      mayUpdate={mayUpdate}
-      tools={tools}
-      getSettings={(tool) =>
-        getDefaultToolSettings({
-          tool,
-          toolMetadataByName,
-          mcpServerView,
-        })
-      }
-      onToolChange={() => {}}
-    />
-  );
-}
-
 // We disable buttons for agent builder view because it would feel like
 // you can configure per agent
 export const ToolsList = memo(
@@ -335,19 +308,28 @@ export const ToolsList = memo(
       [mcpServerView.toolsMetadata]
     );
 
+    // Read-only path: render directly without binding to the surrounding
+    // MCPServerFormValues form, since this component is also rendered in
+    // contexts (e.g. agent builder) that have no such FormProvider.
     if (disableUpdates) {
       return (
-        <ReadOnlyToolsListContent
+        <ToolsListContent
           mayUpdate={mayUpdate}
           tools={tools}
-          mcpServerView={mcpServerView}
-          toolMetadataByName={toolMetadataByName}
+          getSettings={(tool) =>
+            getDefaultToolSettings({
+              tool,
+              toolMetadataByName,
+              mcpServerView,
+            })
+          }
+          onToolChange={() => {}}
         />
       );
     }
 
     return (
-      <EditableToolsListContent
+      <EditableToolsList
         mayUpdate={mayUpdate}
         tools={tools}
         mcpServerView={mcpServerView}

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -23,7 +23,7 @@ import {
   DropdownMenuTrigger,
   InformationCircleIcon,
 } from "@dust-tt/sparkle";
-import { memo, useCallback, useMemo } from "react";
+import { memo } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 interface ToolsListProps {
@@ -32,20 +32,12 @@ interface ToolsListProps {
   disableUpdates?: boolean;
 }
 
-interface ToolDefinition {
-  name: string;
-  description: string;
-}
-
-interface ToolMetadata {
-  enabled: boolean;
-  permission: MCPToolStakeLevelType;
-}
+type ToolDefinition = MCPServerViewType["server"]["tools"][number];
 
 interface ToolItemProps {
   tool: ToolDefinition;
   mayUpdate: boolean;
-  availableStakeLevels: MCPToolStakeLevelType[];
+  availableStakeLevels: ReadonlyArray<MCPToolStakeLevelType>;
   settings: ToolSettings;
   onChange: (settings: ToolSettings) => void;
 }
@@ -61,88 +53,84 @@ interface ToolsListContentProps {
   onToolChange: (toolName: string, settings: ToolSettings) => void;
 }
 
-const ToolItem = memo(
-  ({
-    tool,
-    mayUpdate,
-    availableStakeLevels,
-    settings,
-    onChange,
-  }: ToolItemProps) => {
-    const toolPermission = settings.permission;
-    const toolEnabled = settings.enabled;
+function ToolItem({
+  tool,
+  mayUpdate,
+  availableStakeLevels,
+  settings,
+  onChange,
+}: ToolItemProps) {
+  const toolPermission = settings.permission;
+  const toolEnabled = settings.enabled;
 
-    const handleToggle = () => {
-      onChange({
-        ...settings,
-        enabled: !toolEnabled,
-      });
-    };
+  const handleToggle = () => {
+    onChange({
+      ...settings,
+      enabled: !toolEnabled,
+    });
+  };
 
-    const handlePermissionChange = (permission: MCPToolStakeLevelType) => {
-      onChange({
-        ...settings,
-        permission,
-      });
-    };
+  const handlePermissionChange = (permission: MCPToolStakeLevelType) => {
+    onChange({
+      ...settings,
+      permission,
+    });
+  };
 
-    const toolPermissionLabel: Record<MCPToolStakeLevelType, string> = {
-      high: "High (always ask for confirmation)",
-      medium: "Medium (allows per-agent confirmation save)",
-      low: "Low (allows user-global confirmation save)",
-      never_ask: "Never ask (automatic execution)",
-    };
+  const toolPermissionLabel: Record<MCPToolStakeLevelType, string> = {
+    high: "High (always ask for confirmation)",
+    medium: "Medium (allows per-agent confirmation save)",
+    low: "Low (allows user-global confirmation save)",
+    never_ask: "Never ask (automatic execution)",
+  };
 
-    return (
-      <div className="flex flex-col gap-1 pb-2">
-        <div className="flex items-center gap-2">
-          {mayUpdate && (
-            <Checkbox checked={toolEnabled} onClick={handleToggle} />
-          )}
-          <h4 className="heading-base flex-grow text-foreground dark:text-foreground-night">
-            {asDisplayName(tool.name)}
-          </h4>
-        </div>
-        {tool.description && (
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            {tool.description}
-          </p>
-        )}
-        {toolEnabled && (
-          <Card variant="primary" className="flex-col">
-            <div className="heading-sm text-muted-foreground dark:text-muted-foreground-night">
-              Tool stake setting
-            </div>
-            <div className="flex justify-end">
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  asChild
-                  disabled={!mayUpdate || !toolEnabled}
-                >
-                  <Button
-                    variant="outline"
-                    label={toolPermissionLabel[toolPermission]}
-                    isSelect
-                  />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent>
-                  {availableStakeLevels.map((permission) => (
-                    <DropdownMenuItem
-                      key={permission}
-                      onClick={() => handlePermissionChange(permission)}
-                      label={toolPermissionLabel[permission]}
-                      disabled={!toolEnabled}
-                    />
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </Card>
-        )}
+  return (
+    <div className="flex flex-col gap-1 pb-2">
+      <div className="flex items-center gap-2">
+        {mayUpdate && <Checkbox checked={toolEnabled} onClick={handleToggle} />}
+        <h4 className="heading-base flex-grow text-foreground dark:text-foreground-night">
+          {asDisplayName(tool.name)}
+        </h4>
       </div>
-    );
-  }
-);
+      {tool.description && (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {tool.description}
+        </p>
+      )}
+      {toolEnabled && (
+        <Card variant="primary" className="flex-col">
+          <div className="heading-sm text-muted-foreground dark:text-muted-foreground-night">
+            Tool stake setting
+          </div>
+          <div className="flex justify-end">
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                asChild
+                disabled={!mayUpdate || !toolEnabled}
+              >
+                <Button
+                  variant="outline"
+                  label={toolPermissionLabel[toolPermission]}
+                  isSelect
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                {availableStakeLevels.map((permission) => (
+                  <DropdownMenuItem
+                    key={permission}
+                    onClick={() => handlePermissionChange(permission)}
+                    label={toolPermissionLabel[permission]}
+                    disabled={!toolEnabled}
+                  />
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
 
 function getDefaultToolSettings({
   tool,
@@ -150,7 +138,7 @@ function getDefaultToolSettings({
   mcpServerView,
 }: {
   tool: ToolDefinition;
-  toolMetadataByName: Record<string, ToolMetadata>;
+  toolMetadataByName: Record<string, ToolSettings>;
   mcpServerView: MCPServerViewType;
 }): ToolSettings {
   const metadata = toolMetadataByName[tool.name];
@@ -165,76 +153,70 @@ function getDefaultToolSettings({
   };
 }
 
-const ToolsListContent = memo(
-  ({ mayUpdate, tools, onToolChange }: ToolsListContentProps) => {
-    const getAvailableStakeLevels = (): MCPToolStakeLevelType[] => {
-      return [...MCP_TOOL_STAKE_LEVELS];
-    };
+function ToolsListContent({
+  mayUpdate,
+  tools,
+  onToolChange,
+}: ToolsListContentProps) {
+  return (
+    <>
+      {tools && tools.length > 0 && (
+        <Collapsible defaultOpen={tools.length <= 5}>
+          <CollapsibleTrigger>
+            <div className="heading-lg">Available Tools ({tools.length})</div>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <>
+              <ContentMessage
+                className="mb-4 mt-2 w-full"
+                variant="blue"
+                size="lg"
+                icon={InformationCircleIcon}
+                title="User Approval Settings"
+              >
+                <ul>
+                  <li>
+                    <b>High stake</b> tools need explicit user approval.
+                  </li>
+                  <li>
+                    <b>Medium stake</b> tools allow users to save per-agent
+                    confirmations.
+                  </li>
+                  <li>
+                    Users can completely disable confirmations for{" "}
+                    <b>low stake</b> tools.
+                  </li>
+                  <li>
+                    <b>Never ask</b> tools run automatically.
+                  </li>
+                </ul>
+              </ContentMessage>
 
-    return (
-      <>
-        {tools && tools.length > 0 && (
-          <Collapsible defaultOpen={tools.length <= 5}>
-            <CollapsibleTrigger>
-              <div className="heading-lg">Available Tools ({tools.length})</div>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <>
-                <ContentMessage
-                  className="mb-4 mt-2 w-full"
-                  variant="blue"
-                  size="lg"
-                  icon={InformationCircleIcon}
-                  title="User Approval Settings"
-                >
-                  <ul>
-                    <li>
-                      <b>High stake</b> tools need explicit user approval.
-                    </li>
-                    <li>
-                      <b>Medium stake</b> tools allow users to save per-agent
-                      confirmations.
-                    </li>
-                    <li>
-                      Users can completely disable confirmations for{" "}
-                      <b>low stake</b> tools.
-                    </li>
-                    <li>
-                      <b>Never ask</b> tools run automatically.
-                    </li>
-                  </ul>
-                </ContentMessage>
-
-                <div>
-                  {tools.length > 0 ? (
-                    <div className="flex flex-col gap-4">
-                      {tools.map(({ tool, settings }, index) => {
-                        const availableStakeLevels = getAvailableStakeLevels();
-
-                        return (
-                          <ToolItem
-                            key={index}
-                            tool={tool}
-                            mayUpdate={mayUpdate}
-                            availableStakeLevels={availableStakeLevels}
-                            settings={settings}
-                            onChange={(next) => onToolChange(tool.name, next)}
-                          />
-                        );
-                      })}
-                    </div>
-                  ) : (
-                    <p className="text-sm text-faint">No tools available</p>
-                  )}
-                </div>
-              </>
-            </CollapsibleContent>
-          </Collapsible>
-        )}
-      </>
-    );
-  }
-);
+              <div>
+                {tools.length > 0 ? (
+                  <div className="flex flex-col gap-4">
+                    {tools.map(({ tool, settings }, index) => (
+                      <ToolItem
+                        key={index}
+                        tool={tool}
+                        mayUpdate={mayUpdate}
+                        availableStakeLevels={MCP_TOOL_STAKE_LEVELS}
+                        settings={settings}
+                        onChange={(next) => onToolChange(tool.name, next)}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-faint">No tools available</p>
+                )}
+              </div>
+            </>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </>
+  );
+}
 
 interface EditableToolsListProps {
   mayUpdate: boolean;
@@ -284,34 +266,21 @@ function EditableToolsList({
 // you can configure per agent
 export const ToolsList = memo(
   ({ owner, mcpServerView, disableUpdates }: ToolsListProps) => {
-    const mayUpdate = useMemo(
-      () => (disableUpdates ? false : isAdmin(owner)),
-      [owner, disableUpdates]
+    const mayUpdate = disableUpdates ? false : isAdmin(owner);
+    const tools = mcpServerView.server.tools;
+    const toolMetadataByName = Object.fromEntries(
+      (mcpServerView.toolsMetadata ?? []).map(
+        (metadata): [string, ToolSettings] => [
+          metadata.toolName,
+          {
+            enabled: metadata.enabled,
+            permission: metadata.permission,
+          },
+        ]
+      )
     );
-    const tools = useMemo(
-      () => mcpServerView.server.tools,
-      [mcpServerView.server.tools]
-    );
-    const toolMetadataByName = useMemo(
-      () =>
-        Object.fromEntries(
-          (mcpServerView.toolsMetadata ?? []).map(
-            (metadata): [string, ToolMetadata] => [
-              metadata.toolName,
-              {
-                enabled: metadata.enabled,
-                permission: metadata.permission,
-              },
-            ]
-          )
-        ),
-      [mcpServerView.toolsMetadata]
-    );
-    const getDefaultSettings = useCallback(
-      (tool: ToolDefinition) =>
-        getDefaultToolSettings({ tool, toolMetadataByName, mcpServerView }),
-      [toolMetadataByName, mcpServerView]
-    );
+    const getDefaultSettings = (tool: ToolDefinition) =>
+      getDefaultToolSettings({ tool, toolMetadataByName, mcpServerView });
 
     // Read-only path: render directly without binding to the surrounding
     // MCPServerFormValues form, since this component is also rendered in

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -32,12 +32,29 @@ interface ToolsListProps {
   disableUpdates?: boolean;
 }
 
+interface ToolDefinition {
+  name: string;
+  description: string;
+}
+
+interface ToolMetadata {
+  enabled: boolean;
+  permission: MCPToolStakeLevelType;
+}
+
 interface ToolItemProps {
-  tool: { name: string; description: string };
+  tool: ToolDefinition;
   mayUpdate: boolean;
   availableStakeLevels: MCPToolStakeLevelType[];
   settings: ToolSettings;
   onChange: (settings: ToolSettings) => void;
+}
+
+interface ToolsListContentProps {
+  mayUpdate: boolean;
+  tools: ToolDefinition[];
+  getSettings: (tool: ToolDefinition) => ToolSettings;
+  onToolChange: (toolName: string, settings: ToolSettings) => void;
 }
 
 const ToolItem = memo(
@@ -123,35 +140,29 @@ const ToolItem = memo(
   }
 );
 
-// We disable buttons for agent builder view because it would feel like
-// you can configure per agent
-export const ToolsList = memo(
-  ({ owner, mcpServerView, disableUpdates }: ToolsListProps) => {
-    const mayUpdate = useMemo(
-      () => (disableUpdates ? false : isAdmin(owner)),
-      [owner, disableUpdates]
-    );
-    const tools = useMemo(
-      () => mcpServerView.server.tools,
-      [mcpServerView.server.tools]
-    );
+function getDefaultToolSettings({
+  tool,
+  toolMetadataByName,
+  mcpServerView,
+}: {
+  tool: ToolDefinition;
+  toolMetadataByName: Record<string, ToolMetadata>;
+  mcpServerView: MCPServerViewType;
+}): ToolSettings {
+  const metadata = toolMetadataByName[tool.name];
+  const defaultPermission = getDefaultInternalToolStakeLevel(
+    mcpServerView.server,
+    tool.name
+  );
 
-    // We use a single controller for the whole `toolSettings` record because
-    // React Hook Form treats dots in field paths as nested-object separators,
-    // which would corrupt form state for tool names that contain dots.
-    const { control } = useFormContext<MCPServerFormValues>();
-    const { field } = useController({
-      control,
-      name: "toolSettings",
-    });
+  return {
+    enabled: metadata?.enabled ?? true,
+    permission: metadata?.permission ?? defaultPermission,
+  };
+}
 
-    const handleToolChange = (toolName: string, settings: ToolSettings) => {
-      field.onChange({
-        ...field.value,
-        [toolName]: settings,
-      });
-    };
-
+const ToolsListContent = memo(
+  ({ mayUpdate, tools, getSettings, onToolChange }: ToolsListContentProps) => {
     const getAvailableStakeLevels = (): MCPToolStakeLevelType[] => {
       return [...MCP_TOOL_STAKE_LEVELS];
     };
@@ -191,47 +202,23 @@ export const ToolsList = memo(
                 </ContentMessage>
 
                 <div>
-                  {tools && tools.length > 0 ? (
+                  {tools.length > 0 ? (
                     <div className="flex flex-col gap-4">
-                      {tools.map(
-                        (
-                          tool: { name: string; description: string },
-                          index: number
-                        ) => {
-                          const availableStakeLevels =
-                            getAvailableStakeLevels();
-                          const metadata = mcpServerView.toolsMetadata?.find(
-                            (m) => m.toolName === tool.name
-                          );
+                      {tools.map((tool, index) => {
+                        const availableStakeLevels = getAvailableStakeLevels();
+                        const settings = getSettings(tool);
 
-                          const defaultPermission =
-                            getDefaultInternalToolStakeLevel(
-                              mcpServerView.server,
-                              tool.name
-                            );
-
-                          const settings: ToolSettings = field.value[
-                            tool.name
-                          ] ?? {
-                            enabled: metadata?.enabled ?? true,
-                            permission:
-                              metadata?.permission ?? defaultPermission,
-                          };
-
-                          return (
-                            <ToolItem
-                              key={index}
-                              tool={tool}
-                              mayUpdate={mayUpdate}
-                              availableStakeLevels={availableStakeLevels}
-                              settings={settings}
-                              onChange={(next) =>
-                                handleToolChange(tool.name, next)
-                              }
-                            />
-                          );
-                        }
-                      )}
+                        return (
+                          <ToolItem
+                            key={index}
+                            tool={tool}
+                            mayUpdate={mayUpdate}
+                            availableStakeLevels={availableStakeLevels}
+                            settings={settings}
+                            onChange={(next) => onToolChange(tool.name, next)}
+                          />
+                        );
+                      })}
                     </div>
                   ) : (
                     <p className="text-sm text-faint">No tools available</p>
@@ -242,6 +229,128 @@ export const ToolsList = memo(
           </Collapsible>
         )}
       </>
+    );
+  }
+);
+
+function EditableToolsListContent({
+  mayUpdate,
+  tools,
+  mcpServerView,
+  toolMetadataByName,
+}: {
+  mayUpdate: boolean;
+  tools: ToolDefinition[];
+  mcpServerView: MCPServerViewType;
+  toolMetadataByName: Record<string, ToolMetadata>;
+}) {
+  // We use a single controller for the whole `toolSettings` record because
+  // React Hook Form treats dots in field paths as nested-object separators,
+  // which would corrupt form state for tool names that contain dots.
+  const { control } = useFormContext<MCPServerFormValues>();
+  const { field } = useController({
+    control,
+    name: "toolSettings",
+    defaultValue: {},
+  });
+
+  const toolSettings = field.value ?? {};
+
+  const handleToolChange = (toolName: string, settings: ToolSettings) => {
+    field.onChange({
+      ...toolSettings,
+      [toolName]: settings,
+    });
+  };
+
+  return (
+    <ToolsListContent
+      mayUpdate={mayUpdate}
+      tools={tools}
+      getSettings={(tool) =>
+        toolSettings[tool.name] ??
+        getDefaultToolSettings({
+          tool,
+          toolMetadataByName,
+          mcpServerView,
+        })
+      }
+      onToolChange={handleToolChange}
+    />
+  );
+}
+
+function ReadOnlyToolsListContent({
+  mayUpdate,
+  tools,
+  mcpServerView,
+  toolMetadataByName,
+}: {
+  mayUpdate: boolean;
+  tools: ToolDefinition[];
+  mcpServerView: MCPServerViewType;
+  toolMetadataByName: Record<string, ToolMetadata>;
+}) {
+  return (
+    <ToolsListContent
+      mayUpdate={mayUpdate}
+      tools={tools}
+      getSettings={(tool) =>
+        getDefaultToolSettings({
+          tool,
+          toolMetadataByName,
+          mcpServerView,
+        })
+      }
+      onToolChange={() => {}}
+    />
+  );
+}
+
+// We disable buttons for agent builder view because it would feel like
+// you can configure per agent
+export const ToolsList = memo(
+  ({ owner, mcpServerView, disableUpdates }: ToolsListProps) => {
+    const mayUpdate = useMemo(
+      () => (disableUpdates ? false : isAdmin(owner)),
+      [owner, disableUpdates]
+    );
+    const tools = useMemo(
+      () => mcpServerView.server.tools,
+      [mcpServerView.server.tools]
+    );
+    const toolMetadataByName = useMemo(
+      () =>
+        Object.fromEntries(
+          (mcpServerView.toolsMetadata ?? []).map((metadata) => [
+            metadata.toolName,
+            {
+              enabled: metadata.enabled,
+              permission: metadata.permission,
+            },
+          ])
+        ) as Record<string, ToolMetadata>,
+      [mcpServerView.toolsMetadata]
+    );
+
+    if (disableUpdates) {
+      return (
+        <ReadOnlyToolsListContent
+          mayUpdate={mayUpdate}
+          tools={tools}
+          mcpServerView={mcpServerView}
+          toolMetadataByName={toolMetadataByName}
+        />
+      );
+    }
+
+    return (
+      <EditableToolsListContent
+        mayUpdate={mayUpdate}
+        tools={tools}
+        mcpServerView={mcpServerView}
+        toolMetadataByName={toolMetadataByName}
+      />
     );
   }
 );

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -23,7 +23,7 @@ import {
   DropdownMenuTrigger,
   InformationCircleIcon,
 } from "@dust-tt/sparkle";
-import { memo, useMemo } from "react";
+import { memo, useCallback, useMemo } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 interface ToolsListProps {
@@ -236,13 +236,11 @@ const ToolsListContent = memo(
 function EditableToolsList({
   mayUpdate,
   tools,
-  mcpServerView,
-  toolMetadataByName,
+  getDefaultSettings,
 }: {
   mayUpdate: boolean;
   tools: ToolDefinition[];
-  mcpServerView: MCPServerViewType;
-  toolMetadataByName: Record<string, ToolMetadata>;
+  getDefaultSettings: (tool: ToolDefinition) => ToolSettings;
 }) {
   // We use a single controller for the whole `toolSettings` record because
   // React Hook Form treats dots in field paths as nested-object separators,
@@ -268,12 +266,7 @@ function EditableToolsList({
       mayUpdate={mayUpdate}
       tools={tools}
       getSettings={(tool) =>
-        toolSettings[tool.name] ??
-        getDefaultToolSettings({
-          tool,
-          toolMetadataByName,
-          mcpServerView,
-        })
+        toolSettings[tool.name] ?? getDefaultSettings(tool)
       }
       onToolChange={handleToolChange}
     />
@@ -307,6 +300,11 @@ export const ToolsList = memo(
         ),
       [mcpServerView.toolsMetadata]
     );
+    const getDefaultSettings = useCallback(
+      (tool: ToolDefinition) =>
+        getDefaultToolSettings({ tool, toolMetadataByName, mcpServerView }),
+      [toolMetadataByName, mcpServerView]
+    );
 
     // Read-only path: render directly without binding to the surrounding
     // MCPServerFormValues form, since this component is also rendered in
@@ -316,13 +314,7 @@ export const ToolsList = memo(
         <ToolsListContent
           mayUpdate={mayUpdate}
           tools={tools}
-          getSettings={(tool) =>
-            getDefaultToolSettings({
-              tool,
-              toolMetadataByName,
-              mcpServerView,
-            })
-          }
+          getSettings={getDefaultSettings}
           onToolChange={() => {}}
         />
       );
@@ -332,8 +324,7 @@ export const ToolsList = memo(
       <EditableToolsList
         mayUpdate={mayUpdate}
         tools={tools}
-        mcpServerView={mcpServerView}
-        toolMetadataByName={toolMetadataByName}
+        getDefaultSettings={getDefaultSettings}
       />
     );
   }

--- a/front/components/actions/mcp/forms/mcpServerFormSchema.ts
+++ b/front/components/actions/mcp/forms/mcpServerFormSchema.ts
@@ -25,6 +25,38 @@ export type ToolSettings = {
   permission: MCPToolStakeLevelType;
 };
 
+export function encodeMCPToolNameForForm(toolName: string): string {
+  // `encodeURIComponent` leaves dots untouched, but RHF treats dots as nested
+  // field separators, so we escape them explicitly as well.
+  return encodeURIComponent(toolName).replaceAll(".", "%2E");
+}
+
+export function decodeMCPToolNameFromForm(encodedToolName: string): string {
+  return decodeURIComponent(encodedToolName);
+}
+
+function encodeToolSettingsForForm(
+  toolSettings: Record<string, ToolSettings>
+): Record<string, ToolSettings> {
+  return Object.fromEntries(
+    Object.entries(toolSettings).map(([toolName, settings]) => [
+      encodeMCPToolNameForForm(toolName),
+      settings,
+    ])
+  );
+}
+
+function decodeToolSettingsFromForm(
+  toolSettings: Record<string, ToolSettings>
+): Record<string, ToolSettings> {
+  return Object.fromEntries(
+    Object.entries(toolSettings).map(([encodedToolName, settings]) => [
+      decodeMCPToolNameFromForm(encodedToolName),
+      settings,
+    ])
+  );
+}
+
 // Server settings fields (Info tab).
 export type ServerSettings = {
   name: string;
@@ -36,7 +68,7 @@ export type ServerSettings = {
 
 // Complete form values including all tabs.
 export type MCPServerFormValues = ServerSettings & {
-  // Tools tab - map of toolName to settings
+  // Tools tab - map of RHF-safe encoded tool names to settings.
   toolSettings: Record<string, ToolSettings>;
 
   // Sharing tab - map of spaceId to enabled/disabled
@@ -136,7 +168,7 @@ export function getMCPServerFormDefaults(
   const defaults: MCPServerFormValues = {
     name: view.name ?? view.server.name,
     description: getMcpServerViewDescription(view),
-    toolSettings,
+    toolSettings: encodeToolSettingsForForm(toolSettings),
     sharingSettings,
   };
 
@@ -278,11 +310,13 @@ export function diffMCPServerForm(
   }
 
   // Check tool changes.
+  const initialToolSettings = decodeToolSettingsFromForm(initial.toolSettings);
+  const currentToolSettings = decodeToolSettingsFromForm(current.toolSettings);
   const toolChanges: typeof out.toolChanges = [];
   for (const [toolName, currentSettings] of Object.entries(
-    current.toolSettings
+    currentToolSettings
   )) {
-    const initialSettings = initial.toolSettings[toolName];
+    const initialSettings = initialToolSettings[toolName];
     if (
       initialSettings &&
       (initialSettings.enabled !== currentSettings.enabled ||
@@ -291,7 +325,7 @@ export function diffMCPServerForm(
       toolChanges.push({
         toolName,
         enabled: currentSettings.enabled,
-        permission: currentSettings.permission as MCPToolStakeLevelType,
+        permission: currentSettings.permission,
       });
     }
   }

--- a/front/tests/utils/LightWorkspaceFactory.ts
+++ b/front/tests/utils/LightWorkspaceFactory.ts
@@ -1,0 +1,27 @@
+import type { LightWorkspaceType } from "@app/types/user";
+
+// Sync, in-memory factory for component tests. Unlike WorkspaceFactory, this
+// does not touch the database — use it from tests that render React
+// components and only need a plausibly-shaped workspace object.
+export class LightWorkspaceFactory {
+  private static counter = 0;
+
+  static build(
+    overrides: Partial<LightWorkspaceType> = {}
+  ): LightWorkspaceType {
+    const id = ++LightWorkspaceFactory.counter;
+    return {
+      id,
+      sId: `ws_${id}`,
+      name: `Test Workspace ${id}`,
+      role: "admin",
+      segmentation: null,
+      whiteListedProviders: null,
+      defaultEmbeddingProvider: null,
+      metadata: {},
+      sharingPolicy: "workspace_only",
+      metronomeCustomerId: null,
+      ...overrides,
+    };
+  }
+}

--- a/front/tests/utils/MCPServerViewTypeFactory.ts
+++ b/front/tests/utils/MCPServerViewTypeFactory.ts
@@ -1,0 +1,46 @@
+import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
+
+// Sync, in-memory factory for component tests. Distinct from the DB-backed
+// MCPServerViewFactory in this same folder, which produces an
+// MCPServerViewResource via Sequelize. Use this one for tests that render
+// components and only need a plausibly-shaped MCPServerViewType.
+export class MCPServerViewTypeFactory {
+  private static counter = 0;
+
+  static build(
+    overrides: Partial<Omit<MCPServerViewType, "server">> & {
+      server?: Partial<MCPServerType>;
+    } = {}
+  ): MCPServerViewType {
+    const id = ++MCPServerViewTypeFactory.counter;
+    const { server: serverOverrides, ...rest } = overrides;
+
+    return {
+      id,
+      sId: `msv_${id}`,
+      name: `Test Server ${id}`,
+      description: "Test server description",
+      spaceId: "sp_1",
+      serverType: "remote",
+      oAuthUseCase: null,
+      editedByUser: null,
+      createdAt: 0,
+      updatedAt: 0,
+      toolsMetadata: undefined,
+      server: {
+        sId: `rms_${id}`,
+        name: `test-server-${id}`,
+        version: "1.0.0",
+        description: "Test server description",
+        icon: "ToolsIcon",
+        authorization: null,
+        availability: "manual",
+        allowMultipleInstances: true,
+        documentationUrl: null,
+        tools: [],
+        ...serverOverrides,
+      },
+      ...rest,
+    };
+  }
+}


### PR DESCRIPTION
## Description

Add back the fix on tools with dot in their names, while fixing the regression caused on the agent builder.

## Tests

Added a specific test on the agent builder regression

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

front
