### PR TITLE
[front] chore: fix icon picker scrollbar overlap

### DIFF
--- a/front/components/skill_builder/SkillBuilderIconSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIconSection.tsx
@@ -52,7 +52,7 @@ export function SkillBuilderIconSection() {
         </div>
       </PopoverTrigger>
       <PopoverContent
-        className="w-fit py-0"
+        className="w-fit p-0"
         onInteractOutside={closePopover}
         onEscapeKeyDown={closePopover}
       >

--- a/sparkle/src/components/Picker.tsx
+++ b/sparkle/src/components/Picker.tsx
@@ -57,7 +57,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({
 }) => {
   return (
     <ScrollArea className="s-h-[340px] s-w-fit s-overflow-auto">
-      <div className="s-grid-rows-20 w-auto s-grid s-h-fit s-w-fit s-grid-cols-8 s-gap-1.5 s-py-4 s-pr-5">
+      <div className="s-grid-rows-20 w-auto s-grid s-h-fit s-w-fit s-grid-cols-8 s-gap-1.5 s-p-4">
         {Object.entries(icons).map(([name, IconComponent]) => (
           <IconSwatch
             key={name}

--- a/sparkle/src/components/Picker.tsx
+++ b/sparkle/src/components/Picker.tsx
@@ -57,7 +57,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({
 }) => {
   return (
     <ScrollArea className="s-h-[340px] s-w-fit s-overflow-auto">
-      <div className="s-grid-rows-20 w-auto s-grid s-h-fit s-w-fit s-grid-cols-8 s-gap-1.5 s-py-4">
+      <div className="s-grid-rows-20 w-auto s-grid s-h-fit s-w-fit s-grid-cols-8 s-gap-1.5 s-py-4 s-pr-5">
         {Object.entries(icons).map(([name, IconComponent]) => (
           <IconSwatch
             key={name}


### PR DESCRIPTION
## Description

This PR prevents the icon picker scrollbar from overlapping the last column of icons, which made those icons harder to click and visually cramped.

It does this by removing the asymmetrical padding handling between the Popover and the Picker and instead have the downstream Picker handle the padding entirely (it has the scrollbar).

Before
<img width="384" height="422" alt="Screenshot 2026-04-30 at 11 46 50 PM" src="https://github.com/user-attachments/assets/491c2a86-af61-4cd2-937f-b92914864608" />

After
<img width="420" height="438" alt="Screenshot 2026-05-01 at 8 21 00 AM" src="https://github.com/user-attachments/assets/c7a158da-2a9f-469a-bcdc-6121d8cb0f63" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
