### PR TITLE
[front] feat: add nested skill reference data model

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -55,6 +55,7 @@ import {
   SkillDataSourceConfigurationModel,
   SkillFileAttachmentModel,
   SkillMCPServerConfigurationModel,
+  SkillReferenceModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
 import {
@@ -223,6 +224,7 @@ export function loadAllModels() {
     OnboardingTaskModel,
     UserToolApprovalModel,
     SkillConfigurationModel,
+    SkillReferenceModel,
     SkillDataSourceConfigurationModel,
     SkillVersionModel,
     GroupSkillModel,

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -12,7 +12,12 @@ import type {
   SkillStatus,
 } from "@app/types/assistant/skill_configuration";
 import isNil from "lodash/isNil";
-import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
+import type {
+  CreationOptional,
+  ForeignKey,
+  ModelAttributes,
+  NonAttribute,
+} from "sequelize";
 import { DataTypes } from "sequelize";
 
 const SKILL_MODEL_ATTRIBUTES = {
@@ -210,6 +215,67 @@ SkillVersionModel.init(
   }
 );
 
+export class SkillReferenceModel extends WorkspaceAwareModel<SkillReferenceModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare parentSkillId: ForeignKey<SkillConfigurationModel["id"]>;
+  declare childSkillId: ForeignKey<SkillConfigurationModel["id"]>;
+
+  declare parentSkill?: NonAttribute<SkillConfigurationModel>;
+  declare childSkill?: NonAttribute<SkillConfigurationModel>;
+}
+
+SkillReferenceModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    parentSkillId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: SkillConfigurationModel,
+        key: "id",
+      },
+    },
+    childSkillId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: SkillConfigurationModel,
+        key: "id",
+      },
+    },
+  },
+  {
+    modelName: "skill_reference",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["parentSkillId"],
+        concurrently: true,
+      },
+      {
+        fields: ["childSkillId"],
+        concurrently: true,
+      },
+      {
+        unique: true,
+        fields: ["workspaceId", "parentSkillId", "childSkillId"],
+        concurrently: true,
+      },
+    ],
+  }
+);
+
 // Skill config <> Edited by
 UserModel.hasMany(SkillConfigurationModel, {
   foreignKey: { name: "editedBy", allowNull: true },
@@ -228,6 +294,27 @@ UserModel.hasMany(SkillVersionModel, {
 SkillVersionModel.belongsTo(UserModel, {
   foreignKey: { name: "editedBy", allowNull: true },
   as: "editedByUser",
+});
+
+// Skill references (parent skill <> child skill)
+SkillConfigurationModel.hasMany(SkillReferenceModel, {
+  foreignKey: { name: "parentSkillId", allowNull: false },
+  onDelete: "CASCADE",
+  as: "childSkillReferences",
+});
+SkillReferenceModel.belongsTo(SkillConfigurationModel, {
+  foreignKey: { name: "parentSkillId", allowNull: false },
+  as: "parentSkill",
+});
+
+SkillConfigurationModel.hasMany(SkillReferenceModel, {
+  foreignKey: { name: "childSkillId", allowNull: false },
+  onDelete: "CASCADE",
+  as: "parentSkillReferences",
+});
+SkillReferenceModel.belongsTo(SkillConfigurationModel, {
+  foreignKey: { name: "childSkillId", allowNull: false },
+  as: "childSkill",
 });
 
 // Skill MCP Server Configuration (tools associated with a skill)

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1,10 +1,14 @@
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { SkillDataSourceConfigurationModel } from "@app/lib/models/skill";
+import {
+  SkillDataSourceConfigurationModel,
+  SkillReferenceModel,
+} from "@app/lib/models/skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { serializeSkillReference } from "@app/lib/skill_references";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -65,17 +69,17 @@ describe("SkillResource", () => {
       dataSourceView1 = await DataSourceViewFactory.folder(
         testContext.workspace,
         testContext.globalSpace,
-        testContext.user
+        testContext.user,
       );
       dataSourceView2 = await DataSourceViewFactory.folder(
         testContext.workspace,
         testContext.globalSpace,
-        testContext.user
+        testContext.user,
       );
       dataSourceView3 = await DataSourceViewFactory.folder(
         testContext.workspace,
         testContext.globalSpace,
-        testContext.user
+        testContext.user,
       );
     });
 
@@ -99,7 +103,7 @@ describe("SkillResource", () => {
             attachedKnowledge,
             existingConfigurations: [], // No existing configurations.
             skillConfigurationId: 123, // Mock skill ID.
-          }
+          },
         );
 
       expect(toDelete).toHaveLength(0);
@@ -147,7 +151,7 @@ describe("SkillResource", () => {
             attachedKnowledge,
             existingConfigurations: [],
             skillConfigurationId: 123,
-          }
+          },
         );
 
       expect(toDelete).toHaveLength(0);
@@ -155,13 +159,13 @@ describe("SkillResource", () => {
 
       // Find the configuration for dataSourceView1.
       const config1 = toUpsert.find(
-        (config) => config.dataSourceViewId === dataSourceView1.id
+        (config) => config.dataSourceViewId === dataSourceView1.id,
       );
       expect(config1?.parentsIn).toEqual(["node1", "node2"]);
 
       // Find the configuration for dataSourceView2.
       const config2 = toUpsert.find(
-        (config) => config.dataSourceViewId === dataSourceView2.id
+        (config) => config.dataSourceViewId === dataSourceView2.id,
       );
       expect(config2?.parentsIn).toEqual(["node3"]);
     });
@@ -169,7 +173,7 @@ describe("SkillResource", () => {
     it("should detect configurations that need deletion", async () => {
       const skillResource = await SkillFactory.create(
         testContext.authenticator,
-        {}
+        {},
       );
 
       // Create real database configurations.
@@ -201,7 +205,7 @@ describe("SkillResource", () => {
             attachedKnowledge,
             existingConfigurations,
             skillConfigurationId: 123,
-          }
+          },
         );
 
       expect(toDelete).toHaveLength(1);
@@ -213,7 +217,7 @@ describe("SkillResource", () => {
     it("should detect when parentsIn has changed", async () => {
       const skillResource = await SkillFactory.create(
         testContext.authenticator,
-        {}
+        {},
       );
 
       const existingConfigurations = [
@@ -243,7 +247,7 @@ describe("SkillResource", () => {
             attachedKnowledge,
             existingConfigurations,
             skillConfigurationId: 123,
-          }
+          },
         );
 
       // Should delete the old configuration and upsert the new one.
@@ -256,7 +260,7 @@ describe("SkillResource", () => {
     it("should not include unchanged configurations in toUpsert", async () => {
       const skillResource = await SkillFactory.create(
         testContext.authenticator,
-        {}
+        {},
       );
 
       const existingConfigurations = [
@@ -286,7 +290,7 @@ describe("SkillResource", () => {
             attachedKnowledge,
             existingConfigurations,
             skillConfigurationId: 123,
-          }
+          },
         );
 
       expect(toDelete).toHaveLength(0);
@@ -296,7 +300,7 @@ describe("SkillResource", () => {
     it("should handle mixed scenarios: add, update, delete", async () => {
       const skillResource = await SkillFactory.create(
         testContext.authenticator,
-        {}
+        {},
       );
 
       const existingConfigurations = [
@@ -335,7 +339,7 @@ describe("SkillResource", () => {
             attachedKnowledge,
             existingConfigurations,
             skillConfigurationId: 123,
-          }
+          },
         );
 
       // Should delete dataSourceView1 and dataSourceView2.
@@ -347,12 +351,12 @@ describe("SkillResource", () => {
       expect(toUpsert).toHaveLength(2);
 
       const updatedConfig = toUpsert.find(
-        (config) => config.dataSourceViewId === dataSourceView1.id
+        (config) => config.dataSourceViewId === dataSourceView1.id,
       );
       expect(updatedConfig?.parentsIn).toEqual(["node1", "node1_new"]);
 
       const newConfig = toUpsert.find(
-        (config) => config.dataSourceViewId === dataSourceView3.id
+        (config) => config.dataSourceViewId === dataSourceView3.id,
       );
       expect(newConfig?.parentsIn).toEqual(["node3"]);
     });
@@ -380,7 +384,7 @@ describe("SkillResource", () => {
             attachedKnowledge,
             existingConfigurations: [],
             skillConfigurationId: 123,
-          }
+          },
         );
 
       expect(toDelete).toHaveLength(0);
@@ -391,7 +395,7 @@ describe("SkillResource", () => {
     it("should create unique configurations and handle updates properly", async () => {
       const skillResource = await SkillFactory.create(
         testContext.authenticator,
-        {}
+        {},
       );
 
       // Initial creation - add two nodes to same data source view
@@ -426,7 +430,7 @@ describe("SkillResource", () => {
             attachedKnowledge,
             existingConfigurations: initialConfigurations,
             skillConfigurationId: skillResource.id,
-          }
+          },
         );
 
       // Should delete the old configuration
@@ -449,12 +453,12 @@ describe("SkillResource", () => {
 
       const skillResource = await SkillFactory.create(
         testContext.authenticator,
-        { name: "Test Skill For Update" }
+        { name: "Test Skill For Update" },
       );
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         testContext.authenticator,
-        { name: "Test Agent With Skill" }
+        { name: "Test Agent With Skill" },
       );
       await SkillFactory.linkToAgent(testContext.authenticator, {
         skillId: skillResource.id,
@@ -481,7 +485,7 @@ describe("SkillResource", () => {
         where: { id: agent.id, workspaceId: testContext.workspace.id },
       });
       expect(agentAfter?.requestedSpaceIds.map((id) => Number(id))).toContain(
-        restrictedSpace.id
+        restrictedSpace.id,
       );
     });
 
@@ -493,17 +497,17 @@ describe("SkillResource", () => {
         {
           name: "Test Skill With Space",
           requestedSpaceIds: [restrictedSpace.id],
-        }
+        },
       );
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         testContext.authenticator,
-        { name: "Test Agent With Space" }
+        { name: "Test Agent With Space" },
       );
 
       await AgentConfigurationModel.update(
         { requestedSpaceIds: [restrictedSpace.id] },
-        { where: { id: agent.id, workspaceId: testContext.workspace.id } }
+        { where: { id: agent.id, workspaceId: testContext.workspace.id } },
       );
 
       await SkillFactory.linkToAgent(testContext.authenticator, {
@@ -527,7 +531,7 @@ describe("SkillResource", () => {
       });
       const spaceIds = agentAfter?.requestedSpaceIds.map((id) => Number(id));
       expect(spaceIds?.filter((id) => id === restrictedSpace.id)).toHaveLength(
-        1
+        1,
       );
     });
 
@@ -542,17 +546,17 @@ describe("SkillResource", () => {
         {
           name: "Test Skill With Spaces",
           requestedSpaceIds: [space1.id, space2.id],
-        }
+        },
       );
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         testContext.authenticator,
-        { name: "Test Agent" }
+        { name: "Test Agent" },
       );
 
       await AgentConfigurationModel.update(
         { requestedSpaceIds: [space1.id, space2.id] },
-        { where: { id: agent.id, workspaceId: testContext.workspace.id } }
+        { where: { id: agent.id, workspaceId: testContext.workspace.id } },
       );
 
       await SkillFactory.linkToAgent(testContext.authenticator, {
@@ -587,7 +591,7 @@ describe("SkillResource", () => {
       await GroupSpaceFactory.associate(sharedSpace, testContext.globalGroup);
       await GroupSpaceFactory.associate(
         skill1OnlySpace,
-        testContext.globalGroup
+        testContext.globalGroup,
       );
 
       const skill1 = await SkillFactory.create(testContext.authenticator, {
@@ -602,12 +606,12 @@ describe("SkillResource", () => {
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         testContext.authenticator,
-        { name: "Test Agent" }
+        { name: "Test Agent" },
       );
 
       await AgentConfigurationModel.update(
         { requestedSpaceIds: [sharedSpace.id, skill1OnlySpace.id] },
-        { where: { id: agent.id, workspaceId: testContext.workspace.id } }
+        { where: { id: agent.id, workspaceId: testContext.workspace.id } },
       );
 
       await SkillFactory.linkToAgent(testContext.authenticator, {
@@ -640,6 +644,244 @@ describe("SkillResource", () => {
       expect(spaceIds).toContain(sharedSpace.id);
       expect(spaceIds).toContain(skill1OnlySpace.id);
     });
+
+    it("should store referenced skills and expose both directions", async () => {
+      const childSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Child Skill",
+      });
+      const parentSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Parent Skill",
+      });
+
+      await parentSkill.updateSkill(testContext.authenticator, {
+        name: parentSkill.name,
+        agentFacingDescription: parentSkill.agentFacingDescription,
+        userFacingDescription: parentSkill.userFacingDescription,
+        instructions: serializeSkillReference({
+          name: childSkill.name,
+          skillId: childSkill.sId,
+        }),
+        icon: parentSkill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        referencedSkills: [childSkill],
+        requestedSpaceIds: [],
+      });
+
+      const references = await SkillReferenceModel.findAll({
+        where: {
+          workspaceId: testContext.workspace.id,
+          parentSkillId: parentSkill.id,
+        },
+      });
+      expect(references).toHaveLength(1);
+      expect(references[0].childSkillId).toBe(childSkill.id);
+
+      const freshParent = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId,
+      );
+      const freshChild = await SkillResource.fetchById(
+        testContext.authenticator,
+        childSkill.sId,
+      );
+
+      expect(
+        (
+          await freshParent!.listReferencedSkills(testContext.authenticator)
+        ).map((s) => s.sId),
+      ).toEqual([childSkill.sId]);
+      expect(
+        (
+          await freshChild!.listReferencingSkills(testContext.authenticator)
+        ).map((s) => s.sId),
+      ).toEqual([parentSkill.sId]);
+    });
+
+    it("should add referenced skill space requirements to parent skills and agents", async () => {
+      const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(
+        restrictedSpace,
+        testContext.globalGroup,
+      );
+
+      const childSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Child Skill With Space",
+        requestedSpaceIds: [restrictedSpace.id],
+      });
+      const parentSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Parent Skill With Child",
+      });
+
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        testContext.authenticator,
+        { name: "Agent With Parent Skill" },
+      );
+      await SkillFactory.linkToAgent(testContext.authenticator, {
+        skillId: parentSkill.id,
+        agentConfigurationId: agent.id,
+      });
+
+      await parentSkill.updateSkill(testContext.authenticator, {
+        name: parentSkill.name,
+        agentFacingDescription: parentSkill.agentFacingDescription,
+        userFacingDescription: parentSkill.userFacingDescription,
+        instructions: serializeSkillReference({
+          name: childSkill.name,
+          skillId: childSkill.sId,
+        }),
+        icon: parentSkill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        referencedSkills: [childSkill],
+        requestedSpaceIds: [],
+      });
+
+      const freshParent = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId,
+      );
+      expect(freshParent?.requestedSpaceIds).toContain(restrictedSpace.id);
+
+      const agentAfter = await AgentConfigurationModel.findOne({
+        where: { id: agent.id, workspaceId: testContext.workspace.id },
+      });
+      expect(agentAfter?.requestedSpaceIds.map((id) => Number(id))).toContain(
+        restrictedSpace.id,
+      );
+    });
+
+    it("should propagate referenced skill space changes to parents and agents", async () => {
+      const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(
+        restrictedSpace,
+        testContext.globalGroup,
+      );
+
+      const childSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Child Skill Updated Later",
+      });
+      const parentSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Parent Skill Propagated",
+      });
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        testContext.authenticator,
+        { name: "Agent With Propagated Parent" },
+      );
+
+      await SkillFactory.linkToAgent(testContext.authenticator, {
+        skillId: parentSkill.id,
+        agentConfigurationId: agent.id,
+      });
+
+      await parentSkill.updateSkill(testContext.authenticator, {
+        name: parentSkill.name,
+        agentFacingDescription: parentSkill.agentFacingDescription,
+        userFacingDescription: parentSkill.userFacingDescription,
+        instructions: serializeSkillReference({
+          name: childSkill.name,
+          skillId: childSkill.sId,
+        }),
+        icon: parentSkill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        referencedSkills: [childSkill],
+        requestedSpaceIds: [],
+      });
+
+      await childSkill.updateSkill(testContext.authenticator, {
+        name: childSkill.name,
+        agentFacingDescription: childSkill.agentFacingDescription,
+        userFacingDescription: childSkill.userFacingDescription,
+        instructions: childSkill.instructions,
+        icon: childSkill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: [restrictedSpace.id],
+      });
+
+      const freshParent = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId,
+      );
+      expect(freshParent?.requestedSpaceIds).toContain(restrictedSpace.id);
+
+      const agentAfter = await AgentConfigurationModel.findOne({
+        where: { id: agent.id, workspaceId: testContext.workspace.id },
+      });
+      expect(agentAfter?.requestedSpaceIds.map((id) => Number(id))).toContain(
+        restrictedSpace.id,
+      );
+    });
+
+    it("should update parent serialized references when a child skill is renamed", async () => {
+      const childSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Old Child Name",
+      });
+      const parentSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Parent With Rename Ref",
+      });
+
+      await parentSkill.updateSkill(testContext.authenticator, {
+        name: parentSkill.name,
+        agentFacingDescription: parentSkill.agentFacingDescription,
+        userFacingDescription: parentSkill.userFacingDescription,
+        instructions: `Use ${serializeSkillReference({
+          name: childSkill.name,
+          skillId: childSkill.sId,
+        })}`,
+        icon: parentSkill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        referencedSkills: [childSkill],
+        requestedSpaceIds: [],
+      });
+
+      await childSkill.updateSkill(testContext.authenticator, {
+        name: "New Child Name",
+        agentFacingDescription: childSkill.agentFacingDescription,
+        userFacingDescription: childSkill.userFacingDescription,
+        instructions: childSkill.instructions,
+        icon: childSkill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: [],
+      });
+
+      const freshParent = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId,
+      );
+      expect(freshParent?.instructions).toContain(
+        serializeSkillReference({
+          name: "New Child Name",
+          skillId: childSkill.sId,
+        }),
+      );
+    });
+  });
+
+  describe("enableForAgent", () => {
+    it("should allow enabling any active readable skill", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Readable Skill",
+      });
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        testContext.authenticator,
+        { name: "Agent Without Skill Link" },
+      );
+      const conversation = await ConversationFactory.create(
+        testContext.authenticator,
+        { agentConfigurationId: agent.sId, messagesCreatedAt: [] },
+      );
+
+      const result = await skill.enableForAgent(testContext.authenticator, {
+        agentConfiguration: agent,
+        conversation,
+      });
+
+      expect(result.isOk()).toBe(true);
+    });
   });
 
   describe("archive and restore", () => {
@@ -658,11 +900,11 @@ describe("SkillResource", () => {
       });
       expect(membershipsBeforeArchive.length).toBeGreaterThan(0);
       expect(membershipsBeforeArchive.every((m) => m.status === "active")).toBe(
-        true
+        true,
       );
 
       const { affectedCount: archiveCount } = await skill.archive(
-        testContext.authenticator
+        testContext.authenticator,
       );
       expect(archiveCount).toBe(1);
 
@@ -673,11 +915,11 @@ describe("SkillResource", () => {
         },
       });
       expect(
-        membershipsAfterArchive.every((m) => m.status === "suspended")
+        membershipsAfterArchive.every((m) => m.status === "suspended"),
       ).toBe(true);
 
       const { affectedCount: restoreCount } = await skill.restore(
-        testContext.authenticator
+        testContext.authenticator,
       );
       expect(restoreCount).toBe(1);
 
@@ -688,7 +930,7 @@ describe("SkillResource", () => {
         },
       });
       expect(membershipsAfterRestore.every((m) => m.status === "active")).toBe(
-        true
+        true,
       );
     });
   });
@@ -697,7 +939,7 @@ describe("SkillResource", () => {
     it("should delete the skill and its associated editor group", async () => {
       const skillResource = await SkillFactory.create(
         testContext.authenticator,
-        { name: "Skill To Delete" }
+        { name: "Skill To Delete" },
       );
 
       // Verify the skill and its editor group exist.
@@ -712,7 +954,7 @@ describe("SkillResource", () => {
       const editorGroupId = groupSkillBefore!.groupId;
       const [editorGroupBefore] = await GroupResource.fetchByModelIds(
         testContext.authenticator,
-        [editorGroupId]
+        [editorGroupId],
       );
       expect(editorGroupBefore).not.toBeNull();
       expect(editorGroupBefore!.kind).toBe("skill_editors");
@@ -724,7 +966,7 @@ describe("SkillResource", () => {
       // Verify the skill is deleted.
       const skillAfter = await SkillResource.fetchByModelIdWithAuth(
         testContext.authenticator,
-        skillResource.id
+        skillResource.id,
       );
       expect(skillAfter).toBeNull();
 
@@ -740,7 +982,7 @@ describe("SkillResource", () => {
       // Verify the editor group is deleted.
       const editorGroupsAfter = await GroupResource.fetchByModelIds(
         testContext.authenticator,
-        [editorGroupId]
+        [editorGroupId],
       );
       expect(editorGroupsAfter).toHaveLength(0);
     });
@@ -748,13 +990,13 @@ describe("SkillResource", () => {
     it("should delete agent-skill links when deleting a skill", async () => {
       const skillResource = await SkillFactory.create(
         testContext.authenticator,
-        { name: "Skill With Agent Link" }
+        { name: "Skill With Agent Link" },
       );
 
       // Link the skill to an agent.
       const agent = await AgentConfigurationFactory.createTestAgent(
         testContext.authenticator,
-        { name: "Test Agent With Skill" }
+        { name: "Test Agent With Skill" },
       );
       await SkillFactory.linkToAgent(testContext.authenticator, {
         skillId: skillResource.id,
@@ -764,10 +1006,10 @@ describe("SkillResource", () => {
       // Verify agent-skill link exists before deletion using Resource.
       const skillsForAgentBefore = await SkillResource.listByAgentConfiguration(
         testContext.authenticator,
-        agent
+        agent,
       );
       expect(skillsForAgentBefore.some((s) => s.id === skillResource.id)).toBe(
-        true
+        true,
       );
 
       // Delete the skill.
@@ -777,10 +1019,10 @@ describe("SkillResource", () => {
       // Verify agent-skill link is deleted.
       const skillsForAgentAfter = await SkillResource.listByAgentConfiguration(
         testContext.authenticator,
-        agent
+        agent,
       );
       expect(skillsForAgentAfter.some((s) => s.id === skillResource.id)).toBe(
-        false
+        false,
       );
     });
   });
@@ -794,7 +1036,7 @@ describe("SkillResource", () => {
       const serverView = await MCPServerViewFactory.create(
         testContext.workspace,
         server.sId,
-        space
+        space,
       );
 
       // Create a skill with the MCP server view
@@ -813,7 +1055,7 @@ describe("SkillResource", () => {
       // Test that skills with the MCP server view are returned
       const skillsWithMCP = await SkillResource.listByMCPServerViewIds(
         testContext.authenticator,
-        [serverView.id]
+        [serverView.id],
       );
       expect(skillsWithMCP).toHaveLength(1);
       expect(skillsWithMCP[0].id).toBe(skill1.id);
@@ -821,14 +1063,14 @@ describe("SkillResource", () => {
       // Test with empty array returns empty
       const emptyResult = await SkillResource.listByMCPServerViewIds(
         testContext.authenticator,
-        []
+        [],
       );
       expect(emptyResult).toHaveLength(0);
 
       // Test with non-existent IDs returns empty
       const nonExistentResult = await SkillResource.listByMCPServerViewIds(
         testContext.authenticator,
-        [999999]
+        [999999],
       );
       expect(nonExistentResult).toHaveLength(0);
     });
@@ -842,12 +1084,12 @@ describe("SkillResource", () => {
       const dsv1 = await DataSourceViewFactory.folder(
         testContext.workspace,
         space,
-        testContext.user
+        testContext.user,
       );
       const dsv2 = await DataSourceViewFactory.folder(
         testContext.workspace,
         space,
-        testContext.user
+        testContext.user,
       );
       const skill1 = await SkillFactory.create(testContext.authenticator, {
         name: "Skill With DSV1",
@@ -869,7 +1111,7 @@ describe("SkillResource", () => {
       // Test that skills with dsv1 are returned
       const skillsWithDsv1 = await SkillResource.listByDataSourceViewIds(
         testContext.authenticator,
-        [dsv1.id]
+        [dsv1.id],
       );
       expect(skillsWithDsv1).toHaveLength(1);
       expect(skillsWithDsv1[0].id).toBe(skill1.id);
@@ -877,14 +1119,14 @@ describe("SkillResource", () => {
       // Test with non-existent ID returns empty
       const emptyResult = await SkillResource.listByDataSourceViewIds(
         testContext.authenticator,
-        [dsv2.id]
+        [dsv2.id],
       );
       expect(emptyResult).toHaveLength(0);
 
       // Test with empty array returns empty
       const emptyArrayResult = await SkillResource.listByDataSourceViewIds(
         testContext.authenticator,
-        []
+        [],
       );
       expect(emptyArrayResult).toHaveLength(0);
     });
@@ -898,7 +1140,7 @@ describe("SkillResource", () => {
       const dsv = await DataSourceViewFactory.folder(
         testContext.workspace,
         space,
-        testContext.user
+        testContext.user,
       );
 
       const skill = await SkillFactory.create(testContext.authenticator, {
@@ -916,12 +1158,12 @@ describe("SkillResource", () => {
       // Re-fetch the skill to get the updated data source configurations
       const freshSkill = await SkillResource.fetchByModelIdWithAuth(
         testContext.authenticator,
-        skill.id
+        skill.id,
       );
       expect(freshSkill).not.toBeNull();
 
       const attachedKnowledge = await freshSkill!.getAttachedKnowledge(
-        testContext.authenticator
+        testContext.authenticator,
       );
 
       expect(attachedKnowledge).toHaveLength(2);
@@ -939,7 +1181,7 @@ describe("SkillResource", () => {
       const dsv = await DataSourceViewFactory.folder(
         testContext.workspace,
         space,
-        testContext.user
+        testContext.user,
       );
 
       const attachedKnowledge: SkillAttachedKnowledge[] = [
@@ -951,7 +1193,7 @@ describe("SkillResource", () => {
         {
           mcpServerViews: [],
           attachedKnowledge,
-        }
+        },
       );
 
       expect(requestedSpaceIds).toContain(space.id);
@@ -974,11 +1216,11 @@ describe("SkillResource", () => {
       // Verify both skills exist.
       const fetched1 = await SkillResource.fetchByModelIdWithAuth(
         testContext.authenticator,
-        skill1.id
+        skill1.id,
       );
       const fetched2 = await SkillResource.fetchByModelIdWithAuth(
         testContext2.authenticator,
-        skill2.id
+        skill2.id,
       );
       expect(fetched1).not.toBeNull();
       expect(fetched2).not.toBeNull();
@@ -989,14 +1231,14 @@ describe("SkillResource", () => {
       // Verify workspace1 skill is deleted.
       const deletedSkill1 = await SkillResource.fetchByModelIdWithAuth(
         testContext.authenticator,
-        skill1.id
+        skill1.id,
       );
       expect(deletedSkill1).toBeNull();
 
       // Verify workspace2 skill still exists.
       const stillExistsSkill2 = await SkillResource.fetchByModelIdWithAuth(
         testContext2.authenticator,
-        skill2.id
+        skill2.id,
       );
       expect(stillExistsSkill2).not.toBeNull();
       expect(stillExistsSkill2?.id).toBe(skill2.id);
@@ -1021,11 +1263,11 @@ describe("SkillResource", () => {
       // Verify editor groups exist.
       const editorGroupsBefore = await GroupResource.fetchByModelIds(
         testContext.authenticator,
-        editorGroupIds
+        editorGroupIds,
       );
       expect(editorGroupsBefore.length).toBe(editorGroupIds.length);
       expect(editorGroupsBefore.every((g) => g.kind === "skill_editors")).toBe(
-        true
+        true,
       );
 
       // Delete all skills for the workspace.
@@ -1034,11 +1276,11 @@ describe("SkillResource", () => {
       // Verify skills are deleted.
       const skill1After = await SkillResource.fetchByModelIdWithAuth(
         testContext.authenticator,
-        skill1.id
+        skill1.id,
       );
       const skill2After = await SkillResource.fetchByModelIdWithAuth(
         testContext.authenticator,
-        skill2.id
+        skill2.id,
       );
       expect(skill1After).toBeNull();
       expect(skill2After).toBeNull();
@@ -1052,7 +1294,7 @@ describe("SkillResource", () => {
       // Verify editor groups are deleted.
       const editorGroupsAfter = await GroupResource.fetchByModelIds(
         testContext.authenticator,
-        editorGroupIds
+        editorGroupIds,
       );
       expect(editorGroupsAfter).toHaveLength(0);
     });
@@ -1062,7 +1304,7 @@ describe("SkillResource", () => {
     it("returns an empty array when no skills are provided", async () => {
       const results = await SkillResource.listAgentMessageSkillsByCustomSkills(
         testContext.authenticator,
-        []
+        [],
       );
       expect(results).toEqual([]);
     });
@@ -1077,7 +1319,7 @@ describe("SkillResource", () => {
 
       const agent = await AgentConfigurationFactory.createTestAgent(
         testContext.authenticator,
-        { name: "Agent For Skill Test" }
+        { name: "Agent For Skill Test" },
       );
 
       await SkillFactory.linkToAgent(testContext.authenticator, {
@@ -1091,7 +1333,7 @@ describe("SkillResource", () => {
 
       const conv1 = await ConversationFactory.create(
         testContext.authenticator,
-        { agentConfigurationId: agent.sId, messagesCreatedAt: [] }
+        { agentConfigurationId: agent.sId, messagesCreatedAt: [] },
       );
       const { agentMessage: msg1 } =
         await ConversationFactory.createAgentMessage(
@@ -1100,12 +1342,12 @@ describe("SkillResource", () => {
             workspace: testContext.workspace,
             conversation: conv1,
             agentConfig: agent,
-          }
+          },
         );
 
       const conv2 = await ConversationFactory.create(
         testContext.authenticator,
-        { agentConfigurationId: agent.sId, messagesCreatedAt: [] }
+        { agentConfigurationId: agent.sId, messagesCreatedAt: [] },
       );
       const { agentMessage: msg2 } =
         await ConversationFactory.createAgentMessage(
@@ -1114,7 +1356,7 @@ describe("SkillResource", () => {
             workspace: testContext.workspace,
             conversation: conv2,
             agentConfig: agent,
-          }
+          },
         );
 
       // Enable skillA on conv1 and skillB on conv2
@@ -1135,7 +1377,7 @@ describe("SkillResource", () => {
           agentConfigurationId: agent.sId,
           agentMessageId: msg1.agentMessageId,
           conversationId: conv1.id,
-        }
+        },
       );
       await SkillResource.snapshotConversationSkillsForMessage(
         testContext.authenticator,
@@ -1143,12 +1385,12 @@ describe("SkillResource", () => {
           agentConfigurationId: agent.sId,
           agentMessageId: msg2.agentMessageId,
           conversationId: conv2.id,
-        }
+        },
       );
 
       const results = await SkillResource.listAgentMessageSkillsByCustomSkills(
         testContext.authenticator,
-        [skillA]
+        [skillA],
       );
 
       expect(results).toHaveLength(1);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -13,6 +13,7 @@ import {
   SkillDataSourceConfigurationModel,
   SkillFileAttachmentModel,
   SkillMCPServerConfigurationModel,
+  SkillReferenceModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
 import {
@@ -41,6 +42,7 @@ import {
   isResourceSId,
   makeSId,
 } from "@app/lib/resources/string_ids";
+import { replaceSkillReferenceName } from "@app/lib/skill_references";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -132,7 +134,7 @@ type ConversationSkillCreationAttributes =
     );
 
 function isSkillResourceWithVersion(
-  skill: SkillResource
+  skill: SkillResource,
 ): skill is SkillResource & { version: number } {
   return skill.version !== null;
 }
@@ -142,11 +144,14 @@ export interface SkillAttachedKnowledge {
   nodeId: string;
 }
 
+type SkillReferencesUpdateOptions = {
+  referencedSkills?: SkillResource[];
+};
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface SkillResource
-  extends ReadonlyAttributesType<SkillConfigurationModel> {}
+export interface SkillResource extends ReadonlyAttributesType<SkillConfigurationModel> {}
 
 /**
  * SkillResource handles both custom (database-backed) and global (code-defined)
@@ -215,7 +220,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       mcpServerConfigurations,
       editorGroup,
       version,
-    }: SkillResourceConstructorOptions
+    }: SkillResourceConstructorOptions,
   ) {
     super(SkillConfigurationModel, blob);
 
@@ -250,24 +255,28 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return this._mcpServerConfigurations;
   }
 
+  get isCustomSkill(): boolean {
+    return this.globalSId === null;
+  }
+
   /**
    * Get attached knowledge from the skill's data source configurations.
    * Requires data source views to be fetched first.
    */
   async getAttachedKnowledge(
-    auth: Authenticator
+    auth: Authenticator,
   ): Promise<SkillAttachedKnowledge[]> {
     if (this.dataSourceConfigurations.length === 0) {
       return [];
     }
 
     const dataSourceViewIds = uniq(
-      this.dataSourceConfigurations.map((c) => c.dataSourceViewId)
+      this.dataSourceConfigurations.map((c) => c.dataSourceViewId),
     );
 
     const dataSourceViews = await DataSourceViewResource.fetchByModelIds(
       auth,
-      dataSourceViewIds
+      dataSourceViewIds,
     );
 
     const dataSourceViewMap = new Map(dataSourceViews.map((v) => [v.id, v]));
@@ -301,23 +310,65 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }: {
       mcpServerViews: MCPServerViewResource[];
       attachedKnowledge: SkillAttachedKnowledge[];
-    }
+    },
   ): Promise<ModelId[]> {
     const mcpServerViewIds = mcpServerViews.map((v) => v.sId);
     const spaceIdsFromMcpServerViews =
       await MCPServerViewResource.listSpaceRequirementsByIds(
         auth,
-        mcpServerViewIds
+        mcpServerViewIds,
       );
 
     const spaceIdsFromAttachedKnowledge = attachedKnowledge.map(
-      (k) => k.dataSourceView.space.id
+      (k) => k.dataSourceView.space.id,
     );
 
     return uniq([
       ...spaceIdsFromMcpServerViews,
       ...spaceIdsFromAttachedKnowledge,
     ]);
+  }
+
+  static async computeRequestedSpaceIdsWithReferences(
+    auth: Authenticator,
+    {
+      ownRequestedSpaceIds,
+      parentSkillId,
+      referencedSkills,
+      transaction,
+    }: {
+      ownRequestedSpaceIds: ModelId[];
+      parentSkillId?: ModelId;
+      referencedSkills: SkillResource[];
+      transaction?: Transaction;
+    },
+  ): Promise<ModelId[]> {
+    const requestedSpaceIds = new Set(ownRequestedSpaceIds);
+    const visitedSkillModelIds = new Set<ModelId>(
+      parentSkillId ? [parentSkillId] : [],
+    );
+    const queue = [...referencedSkills];
+
+    for (let i = 0; i < queue.length; i++) {
+      const skill = queue[i];
+
+      if (!skill.isCustomSkill || visitedSkillModelIds.has(skill.id)) {
+        continue;
+      }
+
+      visitedSkillModelIds.add(skill.id);
+
+      for (const spaceId of skill.requestedSpaceIds) {
+        requestedSpaceIds.add(spaceId);
+      }
+
+      const childSkills = await skill.listReferencedSkills(auth, {
+        transaction,
+      });
+      queue.push(...childSkills);
+    }
+
+    return [...requestedSpaceIds];
   }
 
   get isSystemSkill(): boolean {
@@ -335,10 +386,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return (
       GlobalSkillsRegistry.doesSkillInheritAgentConfigurationDataSources(
-        this.globalSId
+        this.globalSId,
       ) ||
       SystemSkillsRegistry.doesSkillInheritAgentConfigurationDataSources(
-        this.globalSId
+        this.globalSId,
       )
     );
   }
@@ -356,12 +407,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       addCurrentUserAsEditor = true,
       attachedKnowledge = [],
       fileAttachments = [],
+      referencedSkills = [],
     }: {
       mcpServerViews: MCPServerViewResource[];
       addCurrentUserAsEditor?: boolean;
       attachedKnowledge?: SkillAttachedKnowledge[];
       fileAttachments?: FileResource[];
-    }
+    } & SkillReferencesUpdateOptions,
   ): Promise<SkillResource> {
     const owner = auth.getNonNullableWorkspace();
 
@@ -374,7 +426,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         },
         {
           transaction,
-        }
+        },
       );
 
       const editorGroup = await this.makeNewSkillEditorsGroup(auth, skill, {
@@ -389,7 +441,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           skillConfigurationId: skill.id,
           mcpServerViewId: mcpServerView.id,
         })),
-        { transaction }
+        { transaction },
       );
 
       // File attachments for the skill.
@@ -400,7 +452,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           fileId: file.id,
           fileName: file.fileName,
         })),
-        { transaction }
+        { transaction },
       );
 
       // Compute what data source configurations to create (no existing configs for new skill).
@@ -414,6 +466,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         await SkillDataSourceConfigurationModel.bulkCreate(toUpsert, {
           transaction,
         });
+
+      await this.replaceSkillReferences(auth, {
+        parentSkillId: skill.id,
+        referencedSkills,
+        transaction,
+      });
 
       return new this(this.model, skill.get(), {
         dataSourceConfigurations,
@@ -436,11 +494,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       mcpServerViewIds,
     }: {
       mcpServerViewIds: string[];
-    }
+    },
   ): Promise<Result<SkillResource, Error>> {
     const mcpServerViews = await MCPServerViewResource.fetchByIds(
       auth,
-      mcpServerViewIds
+      mcpServerViewIds,
     );
 
     if (mcpServerViews.length !== mcpServerViewIds.length) {
@@ -458,10 +516,52 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       {
         mcpServerViews,
         addCurrentUserAsEditor: false,
-      }
+      },
     );
 
     return new Ok(createdSuggestedSkill);
+  }
+
+  private static async replaceSkillReferences(
+    auth: Authenticator,
+    {
+      parentSkillId,
+      referencedSkills,
+      transaction,
+    }: {
+      parentSkillId: ModelId;
+      referencedSkills: SkillResource[];
+      transaction?: Transaction;
+    },
+  ): Promise<void> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    await SkillReferenceModel.destroy({
+      where: {
+        workspaceId: workspace.id,
+        parentSkillId,
+      },
+      transaction,
+    });
+
+    const childSkillIds = uniq(
+      referencedSkills
+        .filter((skill) => skill.isCustomSkill && skill.id !== parentSkillId)
+        .map((skill) => skill.id),
+    );
+
+    if (childSkillIds.length === 0) {
+      return;
+    }
+
+    await SkillReferenceModel.bulkCreate(
+      childSkillIds.map((childSkillId) => ({
+        workspaceId: workspace.id,
+        parentSkillId,
+        childSkillId,
+      })),
+      { transaction },
+    );
   }
 
   /**
@@ -477,13 +577,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }: {
       addCurrentUserAsEditor?: boolean;
       transaction?: Transaction;
-    } = {}
+    } = {},
   ): Promise<GroupResource> {
     const workspace = auth.getNonNullableWorkspace();
 
     assert(
       skill.workspaceId === workspace.id,
-      "Unexpected: skill and workspace mismatch"
+      "Unexpected: skill and workspace mismatch",
     );
 
     const defaultGroup = await GroupResource.makeNew(
@@ -495,7 +595,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       {
         memberIds: addCurrentUserAsEditor ? [auth.getNonNullableUser().id] : [],
         transaction,
-      }
+      },
     );
 
     await GroupSkillModel.create(
@@ -504,7 +604,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         skillConfigurationId: skill.id,
         workspaceId: workspace.id,
       },
-      { transaction }
+      { transaction },
     );
 
     return defaultGroup;
@@ -516,7 +616,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     context: {
       agentLoopData?: AgentLoopExecutionData;
       transaction?: Transaction;
-    } = {}
+    } = {},
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
     const { agentLoopData, transaction } = context;
@@ -544,7 +644,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // Check if the user has access to skill requested spaces.
     const uniqueRequestedSpaceIds = uniq(
-      customSkills.flatMap((c) => c.requestedSpaceIds)
+      customSkills.flatMap((c) => c.requestedSpaceIds),
     );
     const spaces =
       uniqueRequestedSpaceIds.length > 0
@@ -556,16 +656,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const foundSpaceIds = new Set(spaces.map((s) => s.id));
 
     const validCustomSkills = customSkills.filter((skill) =>
-      skill.requestedSpaceIds.every((id) => foundSpaceIds.has(id))
+      skill.requestedSpaceIds.every((id) => foundSpaceIds.has(id)),
     );
 
     const allowedCustomSkills = validCustomSkills.filter((skill) =>
       auth.canRead(
         createResourcePermissionsFromSpacesWithMap(
           spaceIdToGroupsMap,
-          skill.requestedSpaceIds
-        )
-      )
+          skill.requestedSpaceIds,
+        ),
+      ),
     );
     const allowedCustomSkillIds = allowedCustomSkills.map((skill) => skill.id);
 
@@ -589,16 +689,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         allMCPServerViews = await MCPServerViewResource.fetchByModelIds(
           auth,
           removeNulls(mcpServerConfigurations.map((c) => c.mcpServerViewId)),
-          { includeMetadata: false }
+          { includeMetadata: false },
         );
       }
 
       const skillMCPServerConfigsBySkillId = groupBy(
         mcpServerConfigurations,
-        "skillConfigurationId"
+        "skillConfigurationId",
       );
       const mcpServerViewsById = new Map(
-        allMCPServerViews.map((view) => [view.id, view])
+        allMCPServerViews.map((view) => [view.id, view]),
       );
 
       const dataSourceConfigurations =
@@ -614,7 +714,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
       const dataSourceConfigsBySkillId = groupBy(
         dataSourceConfigurations,
-        "skillConfigurationId"
+        "skillConfigurationId",
       );
 
       const fileAttachmentModels = await SkillFileAttachmentModel.findAll({
@@ -630,14 +730,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const allFileResources = await FileResource.fetchByModelIdsWithAuth(
         auth,
         fileAttachmentModels.map((a) => a.fileId),
-        transaction
+        transaction,
       );
 
       const fileResourceById = new Map(allFileResources.map((f) => [f.id, f]));
 
       const fileAttachmentsBySkillId = groupBy(
         fileAttachmentModels,
-        "skillConfigurationId"
+        "skillConfigurationId",
       );
 
       // Fetch editor groups for all skills.
@@ -659,23 +759,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
       if (editorGroupSkills.length > 0) {
         const uniqueGroupIds = Array.from(
-          new Set(editorGroupSkills.map((eg) => eg.groupId))
+          new Set(editorGroupSkills.map((eg) => eg.groupId)),
         );
         const editorGroups = await GroupResource.fetchByModelIds(
           auth,
           uniqueGroupIds,
-          { transaction }
+          { transaction },
         );
 
         // Build a map from a skill's ID to its editor group.
         for (const editorGroupSkill of editorGroupSkills) {
           const group = editorGroups.find(
-            (g) => g.id === editorGroupSkill.groupId
+            (g) => g.id === editorGroupSkill.groupId,
           );
           if (group) {
             skillEditorGroupsMap.set(
               editorGroupSkill.skillConfigurationId,
-              group
+              group,
             );
           }
         }
@@ -691,8 +791,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
         const skillMCPServerViews = removeNulls(
           [...new Set(skillMCPServerViewIds ?? [])].map(
-            (viewId) => mcpServerViewsById.get(viewId) ?? null
-          )
+            (viewId) => mcpServerViewsById.get(viewId) ?? null,
+          ),
         );
 
         return new this(this.model, customSkill.get(), {
@@ -703,8 +803,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           dataSourceConfigurations: skillDataSourceConfigs,
           fileAttachments: removeNulls(
             (fileAttachmentsBySkillId[customSkill.id] ?? []).map(
-              (a) => fileResourceById.get(a.fileId) ?? null
-            )
+              (a) => fileResourceById.get(a.fileId) ?? null,
+            ),
           ),
         });
       });
@@ -717,11 +817,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const globalSkillDefinitions = await GlobalSkillsRegistry.findAll(
       auth,
-      where
+      where,
     );
     const systemSkillDefinitions = await SystemSkillsRegistry.findAll(
       auth,
-      where
+      where,
     );
 
     const allCodeDefinedSkills = [
@@ -730,13 +830,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     ];
 
     const enabledCodeDefinedSkills = allCodeDefinedSkills.filter(
-      (def) => !agentLoopData || !def.isDisabledForAgentLoop?.(agentLoopData)
+      (def) => !agentLoopData || !def.isDisabledForAgentLoop?.(agentLoopData),
     );
 
     const requestedSpaceModelIds = removeNulls(
       (agentLoopData?.agentConfiguration?.requestedSpaceIds ?? []).map(
-        getResourceIdFromSId
-      )
+        getResourceIdFromSId,
+      ),
     );
 
     // Batch-fetch MCP server views for all enabled global skills in a single query.
@@ -744,20 +844,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     if (withTools) {
       const mcpServerIds = uniq(
         enabledCodeDefinedSkills.flatMap(
-          (def) => def.mcpServers?.map((s) => s.name) ?? []
-        )
+          (def) => def.mcpServers?.map((s) => s.name) ?? [],
+        ),
       ).map((name) =>
-        autoInternalMCPServerNameToSId({ name, workspaceId: workspace.id })
+        autoInternalMCPServerNameToSId({ name, workspaceId: workspace.id }),
       );
       const allMCPServerViews = await MCPServerViewResource.listByMCPServers(
         auth,
         mcpServerIds,
-        transaction
+        transaction,
       );
       mcpServerViews = allMCPServerViews.filter(
         (view) =>
           requestedSpaceModelIds.includes(view.vaultId) ||
-          view.space.kind === "global"
+          view.space.kind === "global",
       );
     }
 
@@ -769,7 +869,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           mcpServerViews,
           withInstructions,
         }),
-      { concurrency: 5 }
+      { concurrency: 5 },
     );
 
     return [...allowedCustomSkillsRes, ...globalSkills];
@@ -777,7 +877,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async fetchByModelIdWithAuth(
     auth: Authenticator,
-    id: ModelId
+    id: ModelId,
   ): Promise<SkillResource | null> {
     const resources = await this.baseFetch(auth, {
       where: {
@@ -796,21 +896,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async fetchByModelIds(
     auth: Authenticator,
-    ids: ModelId[]
+    ids: ModelId[],
+    { transaction }: { transaction?: Transaction } = {},
   ): Promise<SkillResource[]> {
-    return this.baseFetch(auth, {
-      where: {
-        id: {
-          [Op.in]: ids,
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          id: {
+            [Op.in]: ids,
+          },
         },
+        onlyCustom: true,
       },
-      onlyCustom: true,
-    });
+      { transaction },
+    );
   }
 
   static async fetchById(
     auth: Authenticator,
-    sId: string
+    sId: string,
   ): Promise<SkillResource | null> {
     const result = await this.fetchByIds(auth, [sId]);
 
@@ -819,7 +924,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async fetchByIds(
     auth: Authenticator,
-    sIds: string[]
+    sIds: string[],
   ): Promise<SkillResource[]> {
     if (sIds.length === 0) {
       return [];
@@ -841,7 +946,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
         return acc;
       },
-      { customSkillIds: [], globalSkillIds: [] }
+      { customSkillIds: [], globalSkillIds: [] },
     );
 
     // When fetching by specific IDs, return skills regardless of status.
@@ -856,7 +961,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async fetchActiveByName(
     auth: Authenticator,
-    name: string
+    name: string,
   ): Promise<SkillResource | null> {
     const resources = await this.baseFetch(auth, {
       where: {
@@ -875,7 +980,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async fetchByNames(
     auth: Authenticator,
-    names: string[]
+    names: string[],
   ): Promise<SkillResource[]> {
     if (names.length === 0) {
       return [];
@@ -905,7 +1010,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       agentLoopData?: AgentLoopExecutionData;
       status?: SkillStatus | SkillStatus[];
       transaction?: Transaction;
-    } = {}
+    } = {},
   ): Promise<SkillResource[]> {
     const customSkillModelIds = removeNulls(refs.map((r) => r.customSkillId));
     const globalSkillIds = removeNulls(refs.map((r) => r.globalSkillId));
@@ -919,7 +1024,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(status ? { status } : {}),
         },
       },
-      { agentLoopData, transaction }
+      { agentLoopData, transaction },
     );
   }
 
@@ -937,11 +1042,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async listByAgentConfiguration(
     auth: Authenticator,
     agentConfiguration: AgentConfigurationType,
-    { agentLoopData }: { agentLoopData?: AgentLoopExecutionData } = {}
+    { agentLoopData }: { agentLoopData?: AgentLoopExecutionData } = {},
   ): Promise<SkillResource[]> {
     const refs = await this.getSkillReferencesForAgent(
       auth,
-      agentConfiguration
+      agentConfiguration,
     );
 
     if (refs.length === 0) {
@@ -959,13 +1064,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async listByAgentConfigurations(
     auth: Authenticator,
-    agentConfigurations: AgentConfigurationType[]
+    agentConfigurations: AgentConfigurationType[],
   ): Promise<
     { agentConfiguration: AgentConfigurationType; skill: SkillResource }[]
   > {
     assert(
       agentConfigurations.every((c) => !isGlobalAgentId(c.sId)),
-      "Global agents are not supported"
+      "Global agents are not supported",
     );
 
     if (agentConfigurations.length === 0) {
@@ -988,7 +1093,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       agentSkills.map((s) => ({
         customSkillId: s.customSkillId,
         globalSkillId: s.globalSkillId,
-      }))
+      })),
     );
 
     const skillByCustomId = new Map<ModelId, SkillResource>();
@@ -1005,7 +1110,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const configById = new Map(agentConfigurations.map((c) => [c.id, c]));
     return removeNulls(
       Object.entries(
-        groupBy(agentSkills, (s) => s.agentConfigurationId)
+        groupBy(agentSkills, (s) => s.agentConfigurationId),
       ).flatMap(([configId, refs]) => {
         const agentConfiguration = configById.get(parseInt(configId, 10));
         if (!agentConfiguration) {
@@ -1020,7 +1125,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             return skill ? { agentConfiguration, skill } : null;
           }
         });
-      })
+      }),
     );
   }
 
@@ -1033,7 +1138,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async getSkillReferencesForAgent(
     auth: Authenticator,
-    agentConfiguration: AgentConfigurationType
+    agentConfiguration: AgentConfigurationType,
   ): Promise<
     {
       customSkillId: ModelId | null;
@@ -1079,6 +1184,54 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
+  async listReferencedSkills(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {},
+  ): Promise<SkillResource[]> {
+    if (!this.isCustomSkill) {
+      return [];
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const references = await SkillReferenceModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        parentSkillId: this.id,
+      },
+      transaction,
+    });
+
+    return SkillResource.fetchByModelIds(
+      auth,
+      uniq(references.map((r) => r.childSkillId)),
+      { transaction },
+    );
+  }
+
+  async listReferencingSkills(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {},
+  ): Promise<SkillResource[]> {
+    if (!this.isCustomSkill) {
+      return [];
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const references = await SkillReferenceModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        childSkillId: this.id,
+      },
+      transaction,
+    });
+
+    return SkillResource.fetchByModelIds(
+      auth,
+      uniq(references.map((r) => r.parentSkillId)),
+      { transaction },
+    );
+  }
+
   static async listByWorkspace(
     auth: Authenticator,
     {
@@ -1101,7 +1254,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       reinforcementNotOff?: boolean;
       withInstructions?: boolean;
       withTools?: boolean;
-    } = {}
+    } = {},
   ): Promise<SkillResource[]> {
     const skills = await this.baseFetch(auth, {
       where: {
@@ -1119,7 +1272,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     if (globalSpaceOnly) {
       const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
       return skills.filter((skill) =>
-        skill.requestedSpaceIds.every((id) => id === globalSpace.id)
+        skill.requestedSpaceIds.every((id) => id === globalSpace.id),
       );
     }
 
@@ -1144,7 +1297,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async listByMCPServerViewIds(
     auth: Authenticator,
-    mcpServerViewIds: ModelId[]
+    mcpServerViewIds: ModelId[],
   ): Promise<SkillResource[]> {
     if (mcpServerViewIds.length === 0) {
       return [];
@@ -1186,7 +1339,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async listByDataSourceViewIds(
     auth: Authenticator,
-    dataSourceViewIds: ModelId[]
+    dataSourceViewIds: ModelId[],
   ): Promise<SkillResource[]> {
     if (dataSourceViewIds.length === 0) {
       return [];
@@ -1237,7 +1390,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       conversation: ConversationWithoutContentType;
       agentLoopData?: AgentLoopExecutionData;
       transaction?: Transaction;
-    }
+    },
   ): Promise<SkillResource[]> {
     const { agentConfiguration } = agentLoopData ?? {};
     const workspace = auth.getNonNullableWorkspace();
@@ -1276,7 +1429,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       | {
           agentConfiguration: AgentConfigurationType;
           conversation: ConversationWithoutContentType;
-        }
+        },
   ): Promise<{
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     systemSkills: SkillResource[];
@@ -1291,12 +1444,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       {
         conversation,
         agentLoopData,
-      }
+      },
     );
     const allAgentSkills = await this.listByAgentConfiguration(
       auth,
       agentConfiguration,
-      { agentLoopData }
+      { agentLoopData },
     );
 
     let discoverableSkills: SkillResource[] = [];
@@ -1319,7 +1472,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         ? await SkillResource.fetchBySkillReferences(
             auth,
             [{ globalSkillId: "projects", customSkillId: null }],
-            { agentLoopData }
+            { agentLoopData },
           )
         : [];
 
@@ -1331,7 +1484,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const augmentedEnabledSkills = await this.augmentSkillsWithExtendedSkills(
       auth,
-      enabledSkills
+      enabledSkills,
     );
 
     // Compute the equipped skills: all non-system agent skills plus
@@ -1340,10 +1493,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const agentEquippedSkills = allAgentSkills.filter((s) => !s.isSystemSkill);
 
     const agentEquippedSkillIds = new Set(
-      agentEquippedSkills.map((s) => s.sId)
+      agentEquippedSkills.map((s) => s.sId),
     );
     const discoveredSkills = discoverableSkills.filter(
-      (s) => !agentEquippedSkillIds.has(s.sId)
+      (s) => !agentEquippedSkillIds.has(s.sId),
     );
 
     const equippedSkills = removeNulls([
@@ -1360,16 +1513,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   private static async augmentSkillsWithExtendedSkills(
     auth: Authenticator,
-    skills: SkillResource[]
+    skills: SkillResource[],
   ): Promise<(SkillResource & { extendedSkill: SkillResource | null })[]> {
     const extendedSkillIds = removeNulls(
-      uniq(skills.map((skill) => skill.extendedSkillId))
+      uniq(skills.map((skill) => skill.extendedSkillId)),
     );
     const extendedSkills = await this.fetchByIds(auth, extendedSkillIds);
 
     // Create a map for a quick lookup of extended skills.
     const extendedSkillsMap = new Map(
-      extendedSkills.map((skill) => [skill.sId, skill])
+      extendedSkills.map((skill) => [skill.sId, skill]),
     );
 
     return skills.map((skill) =>
@@ -1377,7 +1530,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         extendedSkill: skill.extendedSkillId
           ? (extendedSkillsMap.get(skill.extendedSkillId) ?? null)
           : null,
-      })
+      }),
     );
   }
 
@@ -1390,7 +1543,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       conversationId: ModelId;
       enabled: boolean;
     },
-    { transaction }: { transaction?: Transaction } = {}
+    { transaction }: { transaction?: Transaction } = {},
   ): Promise<Result<undefined, Error>> {
     const user = auth.user();
     if (!user) {
@@ -1424,7 +1577,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           source: "conversation",
           addedByUserId: user.id,
         } satisfies ConversationSkillCreationAttributes,
-        { transaction }
+        { transaction },
       );
       return new Ok(undefined);
     }
@@ -1443,7 +1596,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       skills: SkillResource[];
       enabled: boolean;
     },
-    { transaction }: { transaction?: Transaction } = {}
+    { transaction }: { transaction?: Transaction } = {},
   ): Promise<Result<undefined, Error>> {
     for (const skill of skills) {
       const result = await skill.upsertToConversation(
@@ -1452,7 +1605,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           conversationId,
           enabled,
         },
-        { transaction }
+        { transaction },
       );
 
       if (result.isErr()) {
@@ -1474,19 +1627,19 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       agentLoopData?: AgentLoopExecutionData;
       mcpServerViews: MCPServerViewResource[];
       withInstructions?: boolean;
-    }
+    },
   ): Promise<SkillResource> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
     const { agentConfiguration } = agentLoopData ?? {};
     const requestedSpaceIds = agentConfiguration?.requestedSpaceIds ?? [];
     const requestedSpaceModelIds = removeNulls(
-      requestedSpaceIds.map(getResourceIdFromSId)
+      requestedSpaceIds.map(getResourceIdFromSId),
     );
 
     const viewsByServerId = groupBy(
       mcpServerViews.filter((v) => v.internalMCPServerId !== null),
-      "internalMCPServerId"
+      "internalMCPServerId",
     );
 
     const mcpServerConfigurations: SkillMCPServerConfiguration[] = (
@@ -1496,7 +1649,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         viewsByServerId[
           autoInternalMCPServerNameToSId({ name, workspaceId })
         ] ?? []
-      ).map((view) => ({ view, childAgentId, serverNameOverride }))
+      ).map((view) => ({ view, childAgentId, serverNameOverride })),
     );
 
     const instructions = withInstructions
@@ -1538,7 +1691,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         globalSId: def.sId,
         mcpServerConfigurations,
         fileAttachments: [],
-      }
+      },
     );
   }
 
@@ -1556,7 +1709,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   private async listActiveAgents(
-    auth: Authenticator
+    auth: Authenticator,
   ): Promise<AgentConfigurationModel[]> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -1602,7 +1755,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   private async updateActiveAgentsRequirements(
     auth: Authenticator,
     { previousRequestedSpaceIds }: { previousRequestedSpaceIds: ModelId[] },
-    { transaction }: { transaction?: Transaction }
+    { transaction }: { transaction?: Transaction },
   ): Promise<void> {
     if (
       previousRequestedSpaceIds.length === this.requestedSpaceIds.length &&
@@ -1620,7 +1773,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     const spaceIdsRemovedFromThisSkill = previousRequestedSpaceIds.filter(
-      (spaceId) => !this.requestedSpaceIds.includes(spaceId)
+      (spaceId) => !this.requestedSpaceIds.includes(spaceId),
     );
 
     const workspace = auth.getNonNullableWorkspace();
@@ -1648,11 +1801,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       // We only need to consider custom skills, as global skill have no effect on space requirements.
       const customSkills = await SkillResource.fetchByModelIds(
         auth,
-        removeNulls(agentSkillModels.map((skill) => skill.customSkillId))
+        removeNulls(agentSkillModels.map((skill) => skill.customSkillId)),
       );
 
       const skillByModelId = new Map<ModelId, SkillResource>(
-        customSkills.map((skill) => [skill.id, skill])
+        customSkills.map((skill) => [skill.id, skill]),
       );
       for (const agentSkill of agentSkillModels) {
         if (!agentSkill.customSkillId) {
@@ -1688,7 +1841,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           });
 
         const otherCapabilitiesRequestedSpaceIds = new Set(
-          agentOtherCapabilitiesRequirements.requestedSpaceIds
+          agentOtherCapabilitiesRequirements.requestedSpaceIds,
         );
 
         for (const spaceId of spaceIdsRemovedFromThisSkill) {
@@ -1703,7 +1856,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const newSpaceIds = uniq(
         agent.requestedSpaceIds
           .filter((id) => !spaceIdsToRemoveFromAgent.has(id))
-          .concat(this.requestedSpaceIds)
+          .concat(this.requestedSpaceIds),
       );
 
       await updateAgentRequirements(
@@ -1712,13 +1865,128 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           agentModelId: agent.id,
           newSpaceIds,
         },
-        { transaction }
+        { transaction },
+      );
+    }
+  }
+
+  private async computeOwnRequestedSpaceIds(
+    auth: Authenticator,
+  ): Promise<ModelId[]> {
+    return SkillResource.computeRequestedSpaceIds(auth, {
+      mcpServerViews: this.mcpServerViews,
+      attachedKnowledge: await this.getAttachedKnowledge(auth),
+    });
+  }
+
+  private async updateParentSkillsRequirements(
+    auth: Authenticator,
+    {
+      transaction,
+      visitedSkillIds,
+    }: {
+      transaction?: Transaction;
+      visitedSkillIds: Set<ModelId>;
+    },
+  ): Promise<void> {
+    if (!this.isCustomSkill) {
+      return;
+    }
+
+    const parents = await this.listReferencingSkills(auth, { transaction });
+
+    for (const parent of parents) {
+      if (visitedSkillIds.has(parent.id)) {
+        continue;
+      }
+
+      visitedSkillIds.add(parent.id);
+
+      const previousRequestedSpaceIds = [...parent.requestedSpaceIds];
+      const ownRequestedSpaceIds =
+        await parent.computeOwnRequestedSpaceIds(auth);
+      const referencedSkills = await parent.listReferencedSkills(auth, {
+        transaction,
+      });
+      const nextRequestedSpaceIds =
+        await SkillResource.computeRequestedSpaceIdsWithReferences(auth, {
+          ownRequestedSpaceIds,
+          parentSkillId: parent.id,
+          referencedSkills,
+          transaction,
+        });
+
+      await parent.update(
+        { requestedSpaceIds: nextRequestedSpaceIds },
+        transaction,
+      );
+      await parent.updateActiveAgentsRequirements(
+        auth,
+        { previousRequestedSpaceIds },
+        { transaction },
+      );
+      await parent.updateParentSkillsRequirements(auth, {
+        transaction,
+        visitedSkillIds,
+      });
+    }
+  }
+
+  private async updateParentSkillReferenceNames(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction },
+  ): Promise<void> {
+    if (!this.isCustomSkill) {
+      return;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const references = await SkillReferenceModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        childSkillId: this.id,
+      },
+      transaction,
+    });
+
+    if (references.length === 0) {
+      return;
+    }
+
+    const parentSkills = await SkillConfigurationModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        id: { [Op.in]: uniq(references.map((r) => r.parentSkillId)) },
+      },
+      transaction,
+    });
+
+    for (const parentSkill of parentSkills) {
+      const nextInstructions = replaceSkillReferenceName(
+        parentSkill.instructions,
+        {
+          skillId: this.sId,
+          name: this.name,
+        },
+      );
+
+      if (nextInstructions === parentSkill.instructions) {
+        continue;
+      }
+
+      await parentSkill.update(
+        {
+          instructions: nextInstructions,
+          instructionsHtml: null,
+          editedBy: auth.user()?.id,
+        },
+        { transaction },
       );
     }
   }
 
   async listVersions(
-    auth: Authenticator
+    auth: Authenticator,
   ): Promise<(SkillResource & { version: number })[]> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -1734,38 +2002,38 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // Sort application-side by version number DESC.
     const sortedVersionModels = versionModels.sort(
-      (a, b) => b.version - a.version
+      (a, b) => b.version - a.version,
     );
 
     // Build map to cache MCPServerViewResource instances.
     const allMcpServerViewIds = uniq(
-      sortedVersionModels.flatMap((model) => model.mcpServerViewIds)
+      sortedVersionModels.flatMap((model) => model.mcpServerViewIds),
     );
     const allMcpServerViews = await MCPServerViewResource.fetchByModelIds(
       auth,
-      allMcpServerViewIds
+      allMcpServerViewIds,
     );
     const mcpServerViewMap = new Map(
-      allMcpServerViews.map((view) => [view.id, view])
+      allMcpServerViews.map((view) => [view.id, view]),
     );
 
     // Build map to cache FileResource instances.
     const allFileAttachmentIds = uniq(
-      sortedVersionModels.flatMap((model) => model.fileAttachmentIds)
+      sortedVersionModels.flatMap((model) => model.fileAttachmentIds),
     );
     const allFiles = await FileResource.fetchByModelIdsWithAuth(
       auth,
-      allFileAttachmentIds
+      allFileAttachmentIds,
     );
     const fileMap = new Map(allFiles.map((file) => [file.id, file]));
 
     // Convert version models to SkillResource instances.
     return sortedVersionModels.map((versionModel) => {
       const mcpServerViews = removeNulls(
-        versionModel.mcpServerViewIds.map((id) => mcpServerViewMap.get(id))
+        versionModel.mcpServerViewIds.map((id) => mcpServerViewMap.get(id)),
       );
       const fileAttachments = removeNulls(
-        versionModel.fileAttachmentIds.map((id) => fileMap.get(id))
+        versionModel.fileAttachmentIds.map((id) => fileMap.get(id)),
       );
 
       const skill = new SkillResource(
@@ -1801,7 +2069,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             view,
           })),
           version: versionModel.version,
-        }
+        },
       );
       assert(isSkillResourceWithVersion(skill));
       return skill;
@@ -1867,11 +2135,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       if (existingArchivedSkill) {
         const timestamp = formatTimestampToFriendlyDate(
           existingArchivedSkill.updatedAt.getTime(),
-          "compactWithDay"
+          "compactWithDay",
         );
         await existingArchivedSkill.update(
           { name: `${existingArchivedSkill.name} (archived on ${timestamp})` },
-          { transaction }
+          { transaction },
         );
       }
 
@@ -1916,6 +2184,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       mcpServerViews,
       name,
       reinforcement,
+      referencedSkills,
       requestedSpaceIds,
       source,
       sourceMetadata,
@@ -1932,12 +2201,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       mcpServerViews: MCPServerViewResource[];
       name: string;
       reinforcement?: SkillReinforcementMode;
+      referencedSkills?: SkillResource[];
       requestedSpaceIds: ModelId[];
       source?: SkillSourceType;
       sourceMetadata?: SkillSourceMetadata;
       status?: SkillStatus;
       userFacingDescription: string;
-    }
+    },
   ): Promise<void> {
     assert(this.canWrite(auth), "User is not authorized to update this skill");
 
@@ -1947,8 +2217,18 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
       // Snapshot the previous requested space IDs before updating.
       const previousRequestedSpaceIds = [...this.requestedSpaceIds];
+      const previousName = this.name;
 
       const editedBy = auth.user()?.id;
+      const finalRequestedSpaceIds =
+        referencedSkills === undefined
+          ? requestedSpaceIds
+          : await SkillResource.computeRequestedSpaceIdsWithReferences(auth, {
+              ownRequestedSpaceIds: requestedSpaceIds,
+              parentSkillId: this.id,
+              referencedSkills,
+              transaction,
+            });
 
       await this.update(
         {
@@ -1960,7 +2240,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
             ? { instructionsHtml: instructionsHtml ?? null }
             : {}),
           icon,
-          requestedSpaceIds,
+          requestedSpaceIds: finalRequestedSpaceIds,
           editedBy,
           ...(status ? { status } : {}),
           ...(source ? { source } : {}),
@@ -1968,8 +2248,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(isDefault !== undefined ? { isDefault } : {}),
           ...(reinforcement !== undefined ? { reinforcement } : {}),
         },
-        transaction
+        transaction,
       );
+
+      if (referencedSkills !== undefined) {
+        await SkillResource.replaceSkillReferences(auth, {
+          parentSkillId: this.id,
+          referencedSkills,
+          transaction,
+        });
+      }
 
       await this.updateMCPServerViews(auth, mcpServerViews, { transaction });
 
@@ -1978,14 +2266,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         {
           attachedKnowledge,
         },
-        { transaction }
+        { transaction },
       );
 
       await this.updateActiveAgentsRequirements(
         auth,
         { previousRequestedSpaceIds },
-        { transaction }
+        { transaction },
       );
+
+      await this.updateParentSkillsRequirements(auth, {
+        transaction,
+        visitedSkillIds: new Set([this.id]),
+      });
+
+      if (previousName !== name) {
+        await this.updateParentSkillReferenceNames(auth, { transaction });
+      }
     });
 
     if (fileAttachments) {
@@ -1996,7 +2293,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   async updateReinforcement(
-    reinforcement: SkillReinforcementMode
+    reinforcement: SkillReinforcementMode,
   ): Promise<void> {
     await this.update({ reinforcement });
   }
@@ -2012,7 +2309,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   private async updateMCPServerViews(
     auth: Authenticator,
     mcpServerViews: MCPServerViewResource[],
-    { transaction }: { transaction?: Transaction } = {}
+    { transaction }: { transaction?: Transaction } = {},
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -2025,7 +2322,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     const existingMcpServerViewIds = new Set(
-      existingConfigs.map((config) => config.mcpServerViewId)
+      existingConfigs.map((config) => config.mcpServerViewId),
     );
     const mcpServerViewIds = new Set(mcpServerViews.map((msv) => msv.id));
 
@@ -2045,7 +2342,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // Create new tools.
     const toCreate = mcpServerViews.filter(
-      (msv) => !existingMcpServerViewIds.has(msv.id)
+      (msv) => !existingMcpServerViewIds.has(msv.id),
     );
     if (toCreate.length > 0) {
       await SkillMCPServerConfigurationModel.bulkCreate(
@@ -2054,7 +2351,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           skillConfigurationId: this.id,
           mcpServerViewId: mcpServerView.id,
         })),
-        { transaction }
+        { transaction },
       );
     }
 
@@ -2074,7 +2371,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       attachedKnowledge: SkillAttachedKnowledge[];
       existingConfigurations: SkillDataSourceConfigurationModel[];
       skillConfigurationId: ModelId;
-    }
+    },
   ): {
     toDelete: SkillDataSourceConfigurationModel[];
     toUpsert: CreationAttributes<SkillDataSourceConfigurationModel>[];
@@ -2133,11 +2430,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // Create new or changed configurations.
     for (const desiredConfig of Object.values(
-      desiredConfigsByDataSourceViewId
+      desiredConfigsByDataSourceViewId,
     )) {
       const hasExisting = existingConfigurations.some(
         (existing) =>
-          existing.dataSourceViewId === desiredConfig.dataSourceViewId
+          existing.dataSourceViewId === desiredConfig.dataSourceViewId,
       );
 
       if (!hasExisting || toRecreate.has(desiredConfig.dataSourceViewId)) {
@@ -2159,11 +2456,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }: {
       attachedKnowledge: SkillAttachedKnowledge[];
     },
-    { transaction }: { transaction?: Transaction } = {}
+    { transaction }: { transaction?: Transaction } = {},
   ): Promise<void> {
     assert(
       this.canWrite(auth),
-      "User does not have permission to update this skill."
+      "User does not have permission to update this skill.",
     );
 
     const workspace = auth.getNonNullableWorkspace();
@@ -2200,7 +2497,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   private async setFileAttachments(
     auth: Authenticator,
-    fileAttachments: FileResource[]
+    fileAttachments: FileResource[],
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -2213,12 +2510,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const desiredFileModelIds = new Set(fileAttachments.map((f) => f.id));
     const existingFileModelIds = new Set(
-      existingAttachments.map((a) => a.fileId)
+      existingAttachments.map((a) => a.fileId),
     );
 
     // Remove join table rows for detached files (keep the files for version history).
     const toRemove = existingAttachments.filter(
-      (a) => !desiredFileModelIds.has(a.fileId)
+      (a) => !desiredFileModelIds.has(a.fileId),
     );
     if (toRemove.length > 0) {
       await SkillFileAttachmentModel.destroy({
@@ -2231,7 +2528,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // Create new attachments.
     const toCreate = fileAttachments.filter(
-      (f) => !existingFileModelIds.has(f.id)
+      (f) => !existingFileModelIds.has(f.id),
     );
     if (toCreate.length > 0) {
       await SkillFileAttachmentModel.bulkCreate(
@@ -2240,7 +2537,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           skillConfigurationId: this.id,
           fileId: file.id,
           fileName: file.fileName,
-        }))
+        })),
       );
     }
 
@@ -2252,7 +2549,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     try {
       assert(
         this.canWrite(auth),
-        "User does not have permission to delete this skill."
+        "User does not have permission to delete this skill.",
       );
 
       const workspace = auth.getNonNullableWorkspace();
@@ -2277,7 +2574,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const allFileIds = [...new Set([...currentFileIds, ...versionFileIds])];
       const filesToDelete = await FileResource.fetchByModelIdsWithAuth(
         auth,
-        allFileIds
+        allFileIds,
       );
 
       const affectedCount = await withTransaction(async (transaction) => {
@@ -2312,6 +2609,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
         await SkillMCPServerConfigurationModel.destroy({
           where: whereWorkspaceIdAndSkillId,
+          transaction,
+        });
+
+        await SkillReferenceModel.destroy({
+          where: {
+            workspaceId: workspace.id,
+            [Op.or]: [{ parentSkillId: this.id }, { childSkillId: this.id }],
+          },
           transaction,
         });
 
@@ -2350,7 +2655,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   async addToAgent(
     auth: Authenticator,
-    agentConfiguration: LightAgentConfigurationType
+    agentConfiguration: LightAgentConfigurationType,
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -2369,33 +2674,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }: {
       agentConfiguration: AgentConfigurationType;
       conversation: ConversationType;
-    }
+    },
   ): Promise<Result<{ alreadyEnabled: boolean }, Error>> {
     const workspace = auth.getNonNullableWorkspace();
-
-    const refs = await SkillResource.getSkillReferencesForAgent(
-      auth,
-      agentConfiguration
-    );
-
-    const hasSkill = refs.some(
-      (ref) =>
-        (ref.globalSkillId !== null && ref.globalSkillId === this.globalSId) ||
-        (ref.customSkillId !== null && ref.customSkillId === this.id)
-    );
-
-    // Allow enabling default skills if the agent has the discover_skills skill.
-    const hasDiscoverSkills =
-      this.isDefault &&
-      refs.some((ref) => ref.globalSkillId === "discover_skills");
-
-    if (!hasSkill && !hasDiscoverSkills) {
-      return new Err(
-        new Error(
-          `Skill ${this.name} is not equipped by agent ${agentConfiguration.name}.`
-        )
-      );
-    }
 
     const conversationSkillBlob: ConversationSkillCreationAttributes = {
       ...this.skillReference,
@@ -2430,7 +2711,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       agentConfigurationId: string;
       agentMessageId: ModelId;
       conversationId: ModelId;
-    }
+    },
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -2452,13 +2733,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         conversationId: cs.conversationId,
         source: cs.source,
         addedByUserId: cs.addedByUserId,
-      }))
+      })),
     );
   }
 
   static async listByAgentMessageId(
     auth: Authenticator,
-    agentMessageId: ModelId
+    agentMessageId: ModelId,
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -2479,7 +2760,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async listByConversationModelId(
     auth: Authenticator,
-    conversationModelId: ModelId
+    conversationModelId: ModelId,
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -2498,7 +2779,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async listAgentMessageSkillsByCustomSkills(
     auth: Authenticator,
-    customSkills: SkillResource[]
+    customSkills: SkillResource[],
   ): Promise<
     {
       skill: SkillResource;
@@ -2543,7 +2824,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           agentConfigurationId: r.agentConfigurationId,
           createdAt: r.createdAt,
         };
-      })
+      }),
     );
   }
 
@@ -2560,7 +2841,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
     const editorGroups = await GroupResource.fetchByModelIds(
       auth,
-      groupSkills.map((gs) => gs.groupId)
+      groupSkills.map((gs) => gs.groupId),
     );
 
     await GroupSkillModel.destroy({
@@ -2578,7 +2859,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     if (fileAttachments.length > 0) {
       const filesToDelete = await FileResource.fetchByModelIdsWithAuth(
         auth,
-        fileAttachments.map((a) => a.fileId)
+        fileAttachments.map((a) => a.fileId),
       );
       await SkillFileAttachmentModel.destroy({
         where: { workspaceId },
@@ -2596,6 +2877,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     await SkillMCPServerConfigurationModel.destroy({
+      where: { workspaceId },
+    });
+
+    await SkillReferenceModel.destroy({
       where: { workspaceId },
     });
 
@@ -2617,7 +2902,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       SpaceResource.modelIdToSId({
         id: spaceId,
         workspaceId: this.workspaceId,
-      })
+      }),
     );
 
     return {
@@ -2670,7 +2955,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   private async saveVersion(
     auth: Authenticator,
-    { transaction }: { transaction?: Transaction } = {}
+    { transaction }: { transaction?: Transaction } = {},
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -2685,7 +2970,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       });
 
     const mcpServerViewIds = mcpServerConfigurations.map(
-      (config) => config.mcpServerViewId
+      (config) => config.mcpServerViewId,
     );
 
     // Fetch current file attachment IDs for this skill.

--- a/front/lib/skill_references.test.ts
+++ b/front/lib/skill_references.test.ts
@@ -1,0 +1,44 @@
+import {
+  parseSkillReferences,
+  replaceSkillReferenceName,
+  serializeSkillReference,
+} from "@app/lib/skill_references";
+import { describe, expect, it } from "vitest";
+
+describe("skill reference serialization", () => {
+  it("parses unique serialized skill references", () => {
+    const serialized =
+      'Use <skill name="Research" id="skill_123" /> then <skill id="skill_456" name="Write" /> and <skill name="Research" id="skill_123" />.';
+
+    expect(parseSkillReferences(serialized)).toEqual([
+      { name: "Research", skillId: "skill_123" },
+      { name: "Write", skillId: "skill_456" },
+    ]);
+  });
+
+  it("serializes and parses escaped skill names", () => {
+    const serialized = serializeSkillReference({
+      name: "R&D",
+      skillId: "skill_123",
+    });
+
+    expect(serialized).toBe('<skill name="R&amp;D" id="skill_123" />');
+    expect(parseSkillReferences(serialized)).toEqual([
+      { name: "R&D", skillId: "skill_123" },
+    ]);
+  });
+
+  it("replaces a referenced skill name by id", () => {
+    const instructions =
+      'Use <skill name="Old" id="skill_123" /> and <skill name="Other" id="skill_456" />.';
+
+    expect(
+      replaceSkillReferenceName(instructions, {
+        skillId: "skill_123",
+        name: "New",
+      }),
+    ).toBe(
+      'Use <skill name="New" id="skill_123" /> and <skill name="Other" id="skill_456" />.',
+    );
+  });
+});

--- a/front/lib/skill_references.ts
+++ b/front/lib/skill_references.ts
@@ -1,0 +1,80 @@
+import { escape, unescape } from "html-escaper";
+
+export const SKILL_REFERENCE_TAG = "skill";
+
+export interface SerializedSkillReference {
+  name: string;
+  skillId: string;
+}
+
+const SELF_CLOSING_SKILL_REFERENCE_REGEX = new RegExp(
+  `<${SKILL_REFERENCE_TAG}\\s+([^>]+)\\s*/>`,
+  "g",
+);
+
+const SKILL_REFERENCE_TAG_REGEX = new RegExp(
+  `<${SKILL_REFERENCE_TAG}\\s+([^>]+?)(?:\\s*/>|>[\\s\\S]*?</${SKILL_REFERENCE_TAG}>)`,
+  "g",
+);
+
+function parseXmlLikeAttributes(attributesString: string): Map<string, string> {
+  const attrs = new Map<string, string>();
+  const attributeRegex = /([A-Za-z0-9_-]+)="([^"]*)"/g;
+
+  for (const match of attributesString.matchAll(attributeRegex)) {
+    attrs.set(match[1], unescape(match[2]));
+  }
+
+  return attrs;
+}
+
+export function serializeSkillReference({
+  name,
+  skillId,
+}: SerializedSkillReference): string {
+  return `<${SKILL_REFERENCE_TAG} name="${escape(name)}" id="${escape(skillId)}" />`;
+}
+
+export function parseSkillReferences(
+  instructions: string,
+): SerializedSkillReference[] {
+  const referencesById = new Map<string, SerializedSkillReference>();
+
+  for (const match of instructions.matchAll(SKILL_REFERENCE_TAG_REGEX)) {
+    const attrs = parseXmlLikeAttributes(match[1]);
+    const skillId = attrs.get("id");
+    const name = attrs.get("name");
+
+    if (!skillId || !name || referencesById.has(skillId)) {
+      continue;
+    }
+
+    referencesById.set(skillId, { skillId, name });
+  }
+
+  return [...referencesById.values()];
+}
+
+export function replaceSkillReferenceName(
+  instructions: string,
+  {
+    name,
+    skillId,
+  }: {
+    name: string;
+    skillId: string;
+  },
+): string {
+  return instructions.replaceAll(
+    SELF_CLOSING_SKILL_REFERENCE_REGEX,
+    (fullMatch, attributesString: string) => {
+      const attrs = parseXmlLikeAttributes(attributesString);
+
+      if (attrs.get("id") !== skillId) {
+        return fullMatch;
+      }
+
+      return serializeSkillReference({ name, skillId });
+    },
+  );
+}

--- a/front/migrations/db/migration_616.sql
+++ b/front/migrations/db/migration_616.sql
@@ -1,0 +1,19 @@
+-- Migration created on Apr 30, 2026
+CREATE TABLE IF NOT EXISTS "skill_references" (
+    "id" BIGSERIAL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "parentSkillId" BIGINT NOT NULL REFERENCES "skill_configurations" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    "childSkillId" BIGINT NOT NULL REFERENCES "skill_configurations" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY ("id")
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_skill_references_parent_skill_id"
+    ON "skill_references" ("parentSkillId");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_skill_references_child_skill_id"
+    ON "skill_references" ("childSkillId");
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "idx_skill_references_workspace_parent_child"
+    ON "skill_references" ("workspaceId", "parentSkillId", "childSkillId");

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -4,6 +4,7 @@ import {
   SkillVersionModel,
 } from "@app/lib/models/skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { serializeSkillReference } from "@app/lib/skill_references";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -26,7 +27,7 @@ async function setupTest(
     skillOwnerRole?: "admin" | "builder" | "user";
     requestUserRole?: "admin" | "builder" | "user";
     method?: RequestMethod;
-  } = {}
+  } = {},
 ) {
   const skillOwnerRole = options.skillOwnerRole ?? "admin";
   const requestUserRole = options.requestUserRole ?? "admin";
@@ -50,7 +51,7 @@ async function setupTest(
   if (requestUserRole === "admin") {
     const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
       requestUser.sId,
-      workspace.sId
+      workspace.sId,
     );
     await SpaceFactory.defaults(adminAuth);
   } else {
@@ -59,14 +60,14 @@ async function setupTest(
     await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
     const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
       adminUser.sId,
-      workspace.sId
+      workspace.sId,
     );
     await SpaceFactory.defaults(adminAuth);
   }
 
   let requestUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
     requestUser.sId,
-    workspace.sId
+    workspace.sId,
   );
 
   // Create skill owner (might be the same as requestUser or different)
@@ -82,7 +83,7 @@ async function setupTest(
     });
     skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       skillOwner.sId,
-      workspace.sId
+      workspace.sId,
     );
   }
 
@@ -90,7 +91,7 @@ async function setupTest(
   const skillModel = await SkillFactory.create(skillOwnerAuth);
   const skill = await SkillResource.fetchByModelIdWithAuth(
     skillOwnerAuth,
-    skillModel.id
+    skillModel.id,
   );
   if (!skill) {
     throw new Error("Failed to create skill");
@@ -99,11 +100,11 @@ async function setupTest(
   // Regenerate auth to pick up the new group membership
   skillOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
     skillOwner.sId,
-    workspace.sId
+    workspace.sId,
   );
   requestUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
     requestUser.sId,
-    workspace.sId
+    workspace.sId,
   );
 
   // Set up query parameters for the skill
@@ -259,7 +260,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     expect(res._getStatusCode()).toBe(404);
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
     expect(res._getJSONData().error.message).toContain(
-      "MCP server views not all found"
+      "MCP server views not all found",
     );
   });
 
@@ -277,6 +278,33 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     await handler(req, res);
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should return 400 when a skill references itself", async () => {
+    const { req, res, skill } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    req.body = {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: serializeSkillReference({
+        name: skill.name,
+        skillId: skill.sId,
+      }),
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toBe(
+      "A skill cannot reference itself.",
+    );
   });
 
   it("should successfully update the description", async () => {
@@ -309,7 +337,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     // Verify the update persisted by fetching the resource
     const updatedSkill = await SkillResource.fetchById(
       requestUserAuth,
-      skill.sId
+      skill.sId,
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.agentFacingDescription).toBe(newDescription);
@@ -340,12 +368,12 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     const serverView1 = await MCPServerViewFactory.create(
       workspace,
       server1.sId,
-      space1
+      space1,
     );
     const serverView2 = await MCPServerViewFactory.create(
       workspace,
       server2.sId,
-      space2
+      space2,
     );
 
     // Update skill with both tools
@@ -376,7 +404,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     // Verify the update persisted in the database
     const updatedSkill = await SkillResource.fetchById(
       requestUserAuth,
-      skill.sId
+      skill.sId,
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.requestedSpaceIds).toHaveLength(2);
@@ -399,7 +427,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     const serverView = await MCPServerViewFactory.create(
       workspace,
       server.sId,
-      space
+      space,
     );
 
     // Update skill with the tool
@@ -427,12 +455,12 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     // Verify fetching the skill also shows the tool
     const updatedSkill = await SkillResource.fetchById(
       requestUserAuth,
-      skill.sId
+      skill.sId,
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.toJSON(requestUserAuth).tools).toHaveLength(1);
     expect(updatedSkill?.toJSON(requestUserAuth).tools[0].sId).toBe(
-      serverView.sId
+      serverView.sId,
     );
   });
 
@@ -453,12 +481,12 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     const dataSourceView1 = await DataSourceViewFactory.folder(
       workspace,
       globalSpace,
-      requestUser
+      requestUser,
     );
     const dataSourceView2 = await DataSourceViewFactory.folder(
       workspace,
       globalSpace,
-      requestUser
+      requestUser,
     );
 
     req.body = {
@@ -494,7 +522,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     // Verify persistence by fetching the skill again.
     const updatedSkill = await SkillResource.fetchById(
       requestUserAuth,
-      skill.sId
+      skill.sId,
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.dataSourceConfigurations).toHaveLength(2);
@@ -515,7 +543,7 @@ describe("PATCH /api/w/[wId]/skills/[sId] - Suggested skill activation", () => {
 
     const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
       requestUser.sId,
-      workspace.sId
+      workspace.sId,
     );
     await SpaceFactory.defaults(adminAuth);
 
@@ -549,7 +577,7 @@ describe("PATCH /api/w/[wId]/skills/[sId] - Suggested skill activation", () => {
 
     const updatedSkill = await SkillResource.fetchById(
       adminAuth,
-      suggestedSkill.sId
+      suggestedSkill.sId,
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.status).toBe("active");
@@ -609,11 +637,11 @@ describe("PATCH /api/w/[wId]/skills/[sId] - file attachments", () => {
     // Verify persistence.
     const updatedSkill = await SkillResource.fetchById(
       requestUserAuth,
-      skill.sId
+      skill.sId,
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill!.toJSON(requestUserAuth).fileAttachments).toHaveLength(
-      1
+      1,
     );
   });
 
@@ -697,10 +725,10 @@ describe("PATCH /api/w/[wId]/skills/[sId] - file attachments", () => {
     // Verify the file was added.
     const skillAfterAdd = await SkillResource.fetchById(
       requestUserAuth,
-      skill.sId
+      skill.sId,
     );
     expect(skillAfterAdd!.toJSON(requestUserAuth).fileAttachments).toHaveLength(
-      1
+      1,
     );
 
     // Now remove via the API.
@@ -723,10 +751,10 @@ describe("PATCH /api/w/[wId]/skills/[sId] - file attachments", () => {
     // Verify persistence.
     const updatedSkill = await SkillResource.fetchById(
       requestUserAuth,
-      skill.sId
+      skill.sId,
     );
     expect(updatedSkill!.toJSON(requestUserAuth).fileAttachments).toHaveLength(
-      0
+      0,
     );
 
     // Verify the join table row was deleted.
@@ -793,7 +821,7 @@ describe("DELETE /api/w/[wId]/skills/[sId]", () => {
     // Verify the skill is now archived.
     const archivedSkill = await SkillResource.fetchById(
       requestUserAuth,
-      suggestedSkill.sId
+      suggestedSkill.sId,
     );
     expect(archivedSkill).not.toBeNull();
     expect(archivedSkill?.status).toBe("archived");

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -7,6 +7,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
+import { parseSkillReferences } from "@app/lib/skill_references";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { AttachedKnowledgeSchema } from "@app/pages/api/w/[wId]/skills";
@@ -15,6 +16,7 @@ import type {
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { Err, Ok } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -57,7 +59,7 @@ const PatchSkillRequestBodySchema = t.intersection([
     tools: t.array(
       t.type({
         mcpServerViewId: t.string,
-      })
+      }),
     ),
     attachedKnowledge: t.array(AttachedKnowledgeSchema),
     instructionsHtml: t.union([t.string, t.null]),
@@ -75,6 +77,58 @@ const PatchSkillRequestBodySchema = t.intersection([
 
 type PatchSkillRequestBody = t.TypeOf<typeof PatchSkillRequestBodySchema>;
 
+async function fetchReferencedSkillsFromInstructions(
+  auth: Authenticator,
+  instructions: string,
+  { excludeSkillId }: { excludeSkillId: string },
+) {
+  const references = parseSkillReferences(instructions);
+  const referencedSkillIds = uniq(references.map((r) => r.skillId));
+
+  if (referencedSkillIds.includes(excludeSkillId)) {
+    return new Err(new Error("A skill cannot reference itself."));
+  }
+
+  if (referencedSkillIds.length === 0) {
+    return new Ok<SkillResource[]>([]);
+  }
+
+  const referencedSkills = await SkillResource.fetchByIds(
+    auth,
+    referencedSkillIds,
+  );
+
+  const activeReferencedSkillIds = new Set(
+    referencedSkills
+      .filter((skill) => skill.status === "active")
+      .map((skill) => skill.sId),
+  );
+  const missingOrInactiveSkillIds = referencedSkillIds.filter(
+    (skillId) => !activeReferencedSkillIds.has(skillId),
+  );
+
+  if (missingOrInactiveSkillIds.length > 0) {
+    return new Err(
+      new Error(
+        `Referenced skills not found or inactive: ${missingOrInactiveSkillIds.join(", ")}`,
+      ),
+    );
+  }
+
+  return new Ok(referencedSkills);
+}
+
+function serializeSkillSummary(auth: Authenticator, skill: SkillResource) {
+  const {
+    instructions,
+    instructionsHtml,
+    tools,
+    ...skillWithoutInstructionsAndTools
+  } = skill.toJSON(auth);
+
+  return skillWithoutInstructionsAndTools;
+}
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
@@ -85,7 +139,7 @@ async function handler(
       | DeleteSkillResponseBody
     >
   >,
-  auth: Authenticator
+  auth: Authenticator,
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
 
@@ -124,6 +178,8 @@ async function handler(
         const extendedSkill = serializedSkill.extendedSkillId
           ? await SkillResource.fetchById(auth, serializedSkill.extendedSkillId)
           : null;
+        const referencedSkills = await skill.listReferencedSkills(auth);
+        const referencedBy = await skill.listReferencingSkills(auth);
 
         const skillWithRelations: SkillWithRelationsType = {
           ...serializedSkill,
@@ -132,6 +188,12 @@ async function handler(
             editors: editors ? editors.map((e) => e.toJSON()) : null,
             editedByUser: editedByUser ? editedByUser.toJSON() : null,
             extendedSkill: extendedSkill ? extendedSkill.toJSON(auth) : null,
+            referencedSkills: referencedSkills.map((s) =>
+              serializeSkillSummary(auth, s),
+            ),
+            referencedBy: referencedBy.map((s) =>
+              serializeSkillSummary(auth, s),
+            ),
           },
         };
 
@@ -210,7 +272,7 @@ async function handler(
       const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
       const mcpServerViews = await MCPServerViewResource.fetchByIds(
         auth,
-        mcpServerViewIds
+        mcpServerViewIds,
       );
 
       if (mcpServerViewIds.length !== mcpServerViews.length) {
@@ -227,12 +289,12 @@ async function handler(
 
       // Validate all data source views from attached knowledge exist and user has access.
       const dataSourceViewIds = uniq(
-        attachedKnowledge.map((attachment) => attachment.dataSourceViewId)
+        attachedKnowledge.map((attachment) => attachment.dataSourceViewId),
       );
 
       const dataSourceViews = await DataSourceViewResource.fetchByIds(
         auth,
-        dataSourceViewIds
+        dataSourceViewIds,
       );
       if (dataSourceViews.length !== dataSourceViewIds.length) {
         return apiError(req, res, {
@@ -245,14 +307,14 @@ async function handler(
       }
 
       const dataSourceViewIdMap = new Map(
-        dataSourceViews.map((dsv) => [dsv.sId, dsv])
+        dataSourceViews.map((dsv) => [dsv.sId, dsv]),
       );
 
       const attachedKnowledgeWithDataSourceViews = attachedKnowledge.map(
         (attachment) => ({
           dataSourceView: dataSourceViewIdMap.get(attachment.dataSourceViewId)!,
           nodeId: attachment.nodeId,
-        })
+        }),
       );
 
       const requestedSpaceIds = await SkillResource.computeRequestedSpaceIds(
@@ -260,8 +322,23 @@ async function handler(
         {
           mcpServerViews,
           attachedKnowledge: attachedKnowledgeWithDataSourceViews,
-        }
+        },
       );
+
+      const referencedSkillsRes = await fetchReferencedSkillsFromInstructions(
+        auth,
+        body.instructions,
+        { excludeSkillId: skill.sId },
+      );
+      if (referencedSkillsRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: referencedSkillsRes.error.message,
+          },
+        });
+      }
 
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;
@@ -314,7 +391,7 @@ async function handler(
             skillId: skill.sId,
             workspaceId: owner.sId,
           },
-          "Suggested skill accepted"
+          "Suggested skill accepted",
         );
       }
 
@@ -329,6 +406,7 @@ async function handler(
         mcpServerViews,
         name,
         reinforcement: body.reinforcement,
+        referencedSkills: referencedSkillsRes.value,
         requestedSpaceIds,
         userFacingDescription: body.userFacingDescription,
         ...(shouldActivate ? { status: "active" as const } : {}),
@@ -359,7 +437,7 @@ async function handler(
             skillId: skill.sId,
             workspaceId: owner.sId,
           },
-          "Suggested skill rejected"
+          "Suggested skill rejected",
         );
       }
 

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -2,6 +2,7 @@ import { Authenticator } from "@app/lib/auth";
 import {
   SkillConfigurationModel,
   SkillMCPServerConfigurationModel,
+  SkillReferenceModel,
 } from "@app/lib/models/skill";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
@@ -15,6 +16,7 @@ import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { serializeSkillReference } from "@app/lib/skill_references";
 import type {
   SkillType,
   SkillWithoutInstructionsAndToolsType,
@@ -28,7 +30,7 @@ import handler from "./index";
 
 async function setupTest(
   method: RequestMethod = "GET",
-  role: MembershipRoleType = "builder"
+  role: MembershipRoleType = "builder",
 ) {
   const mockRequest = await createPrivateApiMockRequest({
     method,
@@ -44,7 +46,7 @@ describe("GET /api/w/[wId]/skills", () => {
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
-      workspace.sId
+      workspace.sId,
     );
 
     await SkillFactory.create(auth, {
@@ -74,7 +76,7 @@ describe("GET /api/w/[wId]/skills", () => {
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
-      workspace.sId
+      workspace.sId,
     );
 
     await SkillFactory.create(auth, {
@@ -107,7 +109,7 @@ describe("GET /api/w/[wId]/skills", () => {
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
-      workspace.sId
+      workspace.sId,
     );
 
     await SkillFactory.create(auth, {
@@ -142,7 +144,7 @@ describe("GET /api/w/[wId]/skills", () => {
 
       const auth = await Authenticator.fromUserIdAndWorkspaceId(
         user.sId,
-        workspace.sId
+        workspace.sId,
       );
 
       await SkillFactory.create(auth, {
@@ -230,7 +232,7 @@ describe("GET /api/w/[wId]/skills", () => {
     const skillWithoutInstructionsAndTools = res
       ._getJSONData()
       .skills.find(
-        (s: SkillWithoutInstructionsAndToolsType) => s.sId === skill.sId
+        (s: SkillWithoutInstructionsAndToolsType) => s.sId === skill.sId,
       );
 
     expect(skillWithoutInstructionsAndTools).toMatchObject({
@@ -251,7 +253,7 @@ describe("GET /api/w/[wId]/skills", () => {
     expect(skillWithoutInstructionsAndTools).toHaveProperty("sourceMetadata");
     expect(skillWithoutInstructionsAndTools).not.toHaveProperty("instructions");
     expect(skillWithoutInstructionsAndTools).not.toHaveProperty(
-      "instructionsHtml"
+      "instructionsHtml",
     );
     expect(skillWithoutInstructionsAndTools).not.toHaveProperty("tools");
   });
@@ -261,7 +263,7 @@ describe("GET /api/w/[wId]/skills", () => {
 
     const fetchInstructionsSpy = vi.spyOn(
       discoverToolsSkill,
-      "fetchInstructions"
+      "fetchInstructions",
     );
     try {
       req.query = {
@@ -279,8 +281,8 @@ describe("GET /api/w/[wId]/skills", () => {
           ._getJSONData()
           .skills.some(
             (s: SkillWithoutInstructionsAndToolsType) =>
-              s.sId === discoverToolsSkill.sId
-          )
+              s.sId === discoverToolsSkill.sId,
+          ),
       ).toBe(true);
       expect(fetchInstructionsSpy).not.toHaveBeenCalled();
     } finally {
@@ -295,7 +297,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
-      workspace.sId
+      workspace.sId,
     );
 
     const skill = await SkillFactory.create(auth, {
@@ -340,7 +342,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
-      workspace.sId
+      workspace.sId,
     );
 
     const agent = await AgentConfigurationFactory.createTestAgent(auth, {
@@ -377,7 +379,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
-      workspace.sId
+      workspace.sId,
     );
 
     const skill = await SkillFactory.create(auth, {
@@ -413,7 +415,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
-      workspace.sId
+      workspace.sId,
     );
 
     const skill = await SkillFactory.create(auth, {
@@ -443,7 +445,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
-      workspace.sId
+      workspace.sId,
     );
 
     const skill = await SkillFactory.create(auth, {
@@ -530,10 +532,53 @@ describe("POST /api/w/[wId]/skills", () => {
     expect(skillConfiguration).not.toBeNull();
   });
 
+  it("creates skill references from serialized instructions", async () => {
+    const { req, res, workspace, auth } = await setupTest("POST", "admin");
+
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Referenced Child Skill",
+    });
+
+    req.body = {
+      name: "Parent Skill",
+      agentFacingDescription: "Uses another skill when needed",
+      userFacingDescription: "A parent skill",
+      instructions: `When needed, enable ${serializeSkillReference({
+        name: childSkill.name,
+        skillId: childSkill.sId,
+      })}`,
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+
+    const skillConfiguration = await SkillConfigurationModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        name: "Parent Skill",
+      },
+    });
+    expect(skillConfiguration).not.toBeNull();
+
+    const references = await SkillReferenceModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        parentSkillId: skillConfiguration!.id,
+      },
+    });
+    expect(references).toHaveLength(1);
+    expect(references[0].childSkillId).toBe(childSkill.id);
+  });
+
   it("creates a skill configuration with 2 tools", async () => {
     const { req, res, workspace, auth, user, globalSpace } = await setupTest(
       "POST",
-      "admin"
+      "admin",
     );
 
     const server1 = await RemoteMCPServerFactory.create(workspace, {
@@ -546,12 +591,12 @@ describe("POST /api/w/[wId]/skills", () => {
     const serverView1 = await MCPServerViewFactory.create(
       workspace,
       server1.sId,
-      globalSpace
+      globalSpace,
     );
     const serverView2 = await MCPServerViewFactory.create(
       workspace,
       server2.sId,
-      globalSpace
+      globalSpace,
     );
 
     req.body = {
@@ -591,10 +636,10 @@ describe("POST /api/w/[wId]/skills", () => {
     });
     expect(skillConfiguration).not.toBeNull();
     expect(skillConfiguration!.agentFacingDescription).toBe(
-      "Use this skill all the time"
+      "Use this skill all the time",
     );
     expect(skillConfiguration!.instructions).toBe(
-      "Test instructions for the skill"
+      "Test instructions for the skill",
     );
     expect(skillConfiguration!.editedBy).toBe(user.id);
 
@@ -627,7 +672,7 @@ describe("POST /api/w/[wId]/skills", () => {
     const serverView = await MCPServerViewFactory.create(
       workspace,
       server.sId,
-      regularSpace
+      regularSpace,
     );
 
     req.body = {
@@ -664,19 +709,19 @@ describe("POST /api/w/[wId]/skills", () => {
   it("creates a skill with attached knowledge", async () => {
     const { req, res, auth, workspace, user, globalSpace } = await setupTest(
       "POST",
-      "admin"
+      "admin",
     );
 
     const dataSourceView = await DataSourceViewFactory.folder(
       workspace,
       globalSpace,
-      user
+      user,
     );
 
     const dataSourceView1 = await DataSourceViewFactory.folder(
       workspace,
       globalSpace,
-      user
+      user,
     );
 
     req.body = {
@@ -727,7 +772,7 @@ describe("POST /api/w/[wId]/skills", () => {
     const dataSourceView = await DataSourceViewFactory.folder(
       workspace,
       regularSpace,
-      user
+      user,
     );
 
     const nodeId = "node1";
@@ -815,7 +860,7 @@ describe("POST /api/w/[wId]/skills - file attachments", () => {
     expect(data.skill.fileAttachments).toHaveLength(2);
 
     const fileNames = data.skill.fileAttachments.map(
-      (f: { fileName: string }) => f.fileName
+      (f: { fileName: string }) => f.fileName,
     );
     expect(fileNames).toContain("template.txt");
     expect(fileNames).toContain("schema.json");
@@ -853,7 +898,7 @@ describe("POST /api/w/[wId]/skills - file attachments", () => {
     await handler(req, res);
     expect(res._getStatusCode()).toBe(403);
     expect(res._getJSONData().error.message).toContain(
-      "File attachments are not supported"
+      "File attachments are not supported",
     );
   });
 
@@ -912,7 +957,7 @@ describe("POST /api/w/[wId]/skills - file attachments", () => {
     await handler(req, res);
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.message).toContain(
-      "not ready or not a skill_attachment"
+      "not ready or not a skill_attachment",
     );
   });
 });

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -6,6 +6,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { parseSkillReferences } from "@app/lib/skill_references";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -17,6 +18,7 @@ import {
   type SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { Err, Ok } from "@app/types/shared/result";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { isBuilder } from "@app/types/user";
 import { isLeft } from "fp-ts/lib/Either";
@@ -52,6 +54,56 @@ function isSkillViewType(value: string): value is SkillViewType {
   return SKILL_VIEWS.some((skillViewType) => skillViewType === value);
 }
 
+async function fetchReferencedSkillsFromInstructions(
+  auth: Authenticator,
+  instructions: string,
+) {
+  const references = parseSkillReferences(instructions);
+  const referencedSkillIds = uniq(references.map((r) => r.skillId));
+
+  if (referencedSkillIds.length === 0) {
+    return new Ok<SkillResource[]>([]);
+  }
+
+  const referencedSkills = await SkillResource.fetchByIds(
+    auth,
+    referencedSkillIds,
+  );
+
+  const activeReferencedSkillIds = new Set(
+    referencedSkills
+      .filter((skill) => skill.status === "active")
+      .map((skill) => skill.sId),
+  );
+  const missingOrInactiveSkillIds = referencedSkillIds.filter(
+    (skillId) => !activeReferencedSkillIds.has(skillId),
+  );
+
+  if (missingOrInactiveSkillIds.length > 0) {
+    return new Err(
+      new Error(
+        `Referenced skills not found or inactive: ${missingOrInactiveSkillIds.join(", ")}`,
+      ),
+    );
+  }
+
+  return new Ok(referencedSkills);
+}
+
+function serializeSkillSummary(
+  auth: Authenticator,
+  skill: SkillResource,
+): SkillWithoutInstructionsAndToolsType {
+  const {
+    instructions,
+    instructionsHtml,
+    tools,
+    ...skillWithoutInstructionsAndTools
+  } = skill.toJSON(auth);
+
+  return skillWithoutInstructionsAndTools;
+}
+
 // Schema for attached knowledge.
 export const AttachedKnowledgeSchema = t.type({
   dataSourceViewId: t.string,
@@ -71,7 +123,7 @@ const PostSkillRequestBodySchema = t.intersection([
     tools: t.array(
       t.type({
         mcpServerViewId: t.string,
-      })
+      }),
     ),
     extendedSkillId: t.union([t.string, t.null]),
     attachedKnowledge: t.array(AttachedKnowledgeSchema),
@@ -109,7 +161,7 @@ async function handler(
       | PostSkillResponseBody
     >
   >,
-  auth: Authenticator
+  auth: Authenticator,
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
 
@@ -167,10 +219,10 @@ async function handler(
       if (withRelations === "true") {
         const extendedSkills = await SkillResource.fetchByIds(
           auth,
-          removeNulls(uniq(skills.map((skill) => skill.extendedSkillId)))
+          removeNulls(uniq(skills.map((skill) => skill.extendedSkillId))),
         );
         const extendedSkillsMap = new Map(
-          extendedSkills.map((skill) => [skill.sId, skill])
+          extendedSkills.map((skill) => [skill.sId, skill]),
         );
 
         const skillsWithRelations = await concurrentExecutor(
@@ -179,6 +231,8 @@ async function handler(
             const usage = await sc.fetchUsage(auth);
             const editors = await sc.listEditors(auth);
             const editedByUser = await sc.fetchEditedByUser(auth);
+            const referencedSkills = await sc.listReferencedSkills(auth);
+            const referencedBy = await sc.listReferencingSkills(auth);
 
             return {
               ...sc.toJSON(auth),
@@ -190,10 +244,16 @@ async function handler(
                   ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
                     null)
                   : null,
+                referencedSkills: referencedSkills.map((skill) =>
+                  serializeSkillSummary(auth, skill),
+                ),
+                referencedBy: referencedBy.map((skill) =>
+                  serializeSkillSummary(auth, skill),
+                ),
               },
             } satisfies SkillWithRelationsType;
           },
-          { concurrency: 10 }
+          { concurrency: 10 },
         );
 
         return res.status(200).json({ skills: skillsWithRelations });
@@ -201,16 +261,7 @@ async function handler(
 
       if (skillView === "summary") {
         return res.status(200).json({
-          skills: skills.map((sc) => {
-            const {
-              instructions,
-              instructionsHtml,
-              tools,
-              ...skillWithoutInstructionsAndTools
-            } = sc.toJSON(auth);
-
-            return skillWithoutInstructionsAndTools;
-          }),
+          skills: skills.map((sc) => serializeSkillSummary(auth, sc)),
         });
       }
 
@@ -274,7 +325,7 @@ async function handler(
       const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
       const mcpServerViews = await MCPServerViewResource.fetchByIds(
         auth,
-        mcpServerViewIds
+        mcpServerViewIds,
       );
 
       if (mcpServerViewIds.length !== mcpServerViews.length) {
@@ -291,12 +342,12 @@ async function handler(
 
       // Validate all data source views from attached knowledge exist and user has access.
       const dataSourceViewIds = uniq(
-        attachedKnowledge.map((attachment) => attachment.dataSourceViewId)
+        attachedKnowledge.map((attachment) => attachment.dataSourceViewId),
       );
 
       const dataSourceViews = await DataSourceViewResource.fetchByIds(
         auth,
-        dataSourceViewIds
+        dataSourceViewIds,
       );
       if (dataSourceViews.length !== dataSourceViewIds.length) {
         return apiError(req, res, {
@@ -309,30 +360,50 @@ async function handler(
       }
 
       const dataSourceViewIdMap = new Map(
-        dataSourceViews.map((dsv) => [dsv.sId, dsv])
+        dataSourceViews.map((dsv) => [dsv.sId, dsv]),
       );
 
       const attachedKnowledgeWithDataSourceViews = attachedKnowledge.map(
         (attachment) => ({
           dataSourceView: dataSourceViewIdMap.get(attachment.dataSourceViewId)!,
           nodeId: attachment.nodeId,
-        })
+        }),
       );
 
       const spaceIdsFromMcpServerViews =
         await MCPServerViewResource.listSpaceRequirementsByIds(
           auth,
-          mcpServerViewIds
+          mcpServerViewIds,
         );
 
       const spaceIdsFromAttachedKnowledge = dataSourceViews.map(
-        (dsv) => dsv.space.id
+        (dsv) => dsv.space.id,
       );
 
-      const requestedSpaceIds = uniq([
+      const ownRequestedSpaceIds = uniq([
         ...spaceIdsFromMcpServerViews,
         ...spaceIdsFromAttachedKnowledge,
       ]);
+
+      const referencedSkillsRes = await fetchReferencedSkillsFromInstructions(
+        auth,
+        body.instructions,
+      );
+      if (referencedSkillsRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: referencedSkillsRes.error.message,
+          },
+        });
+      }
+
+      const requestedSpaceIds =
+        await SkillResource.computeRequestedSpaceIdsWithReferences(auth, {
+          ownRequestedSpaceIds,
+          referencedSkills: referencedSkillsRes.value,
+        });
 
       const extendedSkill = body.extendedSkillId
         ? await SkillResource.fetchById(auth, body.extendedSkillId)
@@ -404,7 +475,7 @@ async function handler(
         } else {
           logger.warn(
             { error: iconResult.error },
-            "Failed to generate icon suggestion for skill"
+            "Failed to generate icon suggestion for skill",
           );
         }
       }
@@ -430,7 +501,8 @@ async function handler(
           mcpServerViews,
           attachedKnowledge: attachedKnowledgeWithDataSourceViews,
           fileAttachments: files,
-        }
+          referencedSkills: referencedSkillsRes.value,
+        },
       );
 
       // Update file useCaseMetadata with the newly created skill's sId.

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -48,7 +48,7 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
     z.object({
       fileId: z.string(),
       fileName: z.string(),
-    })
+    }),
   ),
   canWrite: z.boolean(),
   isExtendable: z.boolean(),
@@ -73,6 +73,8 @@ export type SkillRelations = {
   editors: UserType[] | null;
   editedByUser: UserType | null;
   extendedSkill: SkillType | null;
+  referencedSkills: SkillWithoutInstructionsAndToolsType[];
+  referencedBy: SkillWithoutInstructionsAndToolsType[];
 };
 
 export type SkillWithRelationsType = SkillType & {


### PR DESCRIPTION
## Description

This PR adds the persistence and runtime foundation for nested skill references. Skill instructions can now carry serialized `<skill name="..." id="..." />` references, while a new `skill_references` join table keeps parent/child lookups efficient.

It validates references on skill create/update, exposes referenced/referencing skills in relations, propagates referenced skill space requirements to parent skills and related agents, updates serialized parent references on child rename, and relaxes `enable_skill` to active readable skills.

## Tests

## Risk

## Deploy Plan

- Run migration
- Deploy front