### PR TITLE
[front] feat: add skill reference chips to the skill editor

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -1,6 +1,10 @@
 import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
+import {
+  SKILL_NODE_TYPE,
+  type SkillReferenceItem,
+} from "@app/components/editor/extensions/skill_builder/SkillNode";
 import { SlashCommandExtension } from "@app/components/editor/extensions/skill_builder/SlashCommandExtension";
 import {
   buildSkillInstructionsExtensions,
@@ -30,6 +34,24 @@ function useEditorService(editor: Editor | null) {
         editor.state.doc.descendants((node) => {
           if (node.type.name === KNOWLEDGE_NODE_TYPE) {
             const selectedItems = node.attrs.selectedItems as KnowledgeItem[];
+            if (selectedItems && selectedItems.length > 0) {
+              items.push(...selectedItems);
+            }
+          }
+        });
+        return items;
+      },
+
+      getSkillReferenceItems(): SkillReferenceItem[] {
+        if (!editor) {
+          return [];
+        }
+
+        const items: SkillReferenceItem[] = [];
+        editor.state.doc.descendants((node) => {
+          if (node.type.name === SKILL_NODE_TYPE) {
+            const selectedItems = node.attrs
+              .selectedItems as SkillReferenceItem[];
             if (selectedItems && selectedItems.length > 0) {
               items.push(...selectedItems);
             }

--- a/front/components/editor/extensions/skill_builder/SkillNode.tsx
+++ b/front/components/editor/extensions/skill_builder/SkillNode.tsx
@@ -1,0 +1,639 @@
+import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
+import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
+import { getSkillIcon } from "@app/lib/skill";
+import { useSkill, useSkills } from "@app/lib/swr/skill_configurations";
+import {
+  parseSkillReferences,
+  serializeSkillReference,
+} from "@app/lib/skill_references";
+import type {
+  SkillType,
+  SkillWithoutInstructionsAndToolsType,
+} from "@app/types/assistant/skill_configuration";
+import {
+  AttachmentChip,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  ExclamationCircleIcon,
+  Icon,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { Node } from "@tiptap/core";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import type React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+export interface BaseSkillReferenceItem {
+  icon: string | null;
+  name: string;
+  skillId: string;
+}
+
+export interface FullSkillReferenceItem extends BaseSkillReferenceItem {
+  skill: SkillType | SkillWithoutInstructionsAndToolsType;
+}
+
+export type SkillReferenceItem =
+  | BaseSkillReferenceItem
+  | FullSkillReferenceItem;
+
+export interface SkillNodeAttributes {
+  selectedItems: SkillReferenceItem[];
+}
+
+export function isFullSkillReferenceItem(
+  item: SkillReferenceItem,
+): item is FullSkillReferenceItem {
+  return "skill" in item && item.skill !== undefined;
+}
+
+const SKILL_CHIP_CLASS =
+  "inline-flex items-center gap-0.5 border border-current/40 rounded px-0.5 text-xs leading-tight";
+const SKILL_REFERENCE_TAG_REGEX = /^<skill\s+([^>]+)\s*\/>/;
+
+const SkillNodeReadOnlyView: React.FC<NodeViewProps> = ({ node }) => {
+  const { selectedItems } = node.attrs as SkillNodeAttributes;
+  const item = selectedItems[0];
+  if (!item) {
+    return null;
+  }
+
+  return (
+    <NodeViewWrapper as="span" className={SKILL_CHIP_CLASS}>
+      <span>Skill</span>
+      <span>{` ${item.name}`}</span>
+    </NodeViewWrapper>
+  );
+};
+
+interface SkillReferenceChipProps {
+  color?: React.ComponentProps<typeof AttachmentChip>["color"];
+  icon: string | null;
+  name: string;
+  onRemove?: () => void;
+}
+
+export function SkillReferenceChip({
+  color = "white",
+  icon,
+  name,
+  onRemove,
+}: SkillReferenceChipProps) {
+  return (
+    <AttachmentChip
+      label={name}
+      icon={{ visual: getSkillIcon(icon) }}
+      color={color}
+      onRemove={onRemove}
+      size="xs"
+    />
+  );
+}
+
+interface SkillReferenceErrorChipProps {
+  name: string;
+  onRemove?: () => void;
+}
+
+function SkillReferenceErrorChip({
+  name,
+  onRemove,
+}: SkillReferenceErrorChipProps) {
+  return (
+    <AttachmentChip
+      label={name}
+      icon={{ visual: ExclamationCircleIcon }}
+      color="white"
+      onRemove={onRemove}
+      size="xs"
+    />
+  );
+}
+
+interface SkillDisplayProps {
+  item: SkillReferenceItem;
+  onRemove?: () => void;
+  updateAttributes: (attrs: Partial<SkillNodeAttributes>) => void;
+}
+
+function SkillDisplayComponent({
+  item,
+  onRemove,
+  updateAttributes,
+}: SkillDisplayProps) {
+  const { owner } = useSpacesContext();
+  const needsFetch = !isFullSkillReferenceItem(item);
+  const { skill, isSkillLoading, isSkillError } = useSkill({
+    workspaceId: owner.sId,
+    skillId: item.skillId,
+    disabled: !needsFetch,
+  });
+
+  useEffect(() => {
+    if (!needsFetch || !skill || skill.status !== "active") {
+      return;
+    }
+
+    updateAttributes({
+      selectedItems: [
+        {
+          icon: skill.icon,
+          name: skill.name,
+          skill,
+          skillId: skill.sId,
+        },
+      ],
+    });
+  }, [needsFetch, skill, updateAttributes]);
+
+  if (
+    isSkillError ||
+    (needsFetch && skill && skill.status !== "active") ||
+    (needsFetch && !isSkillLoading && !skill)
+  ) {
+    return <SkillReferenceErrorChip name={item.name} onRemove={onRemove} />;
+  }
+
+  if (needsFetch && isSkillLoading) {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 rounded-md bg-gray-100 px-2 py-1",
+          "text-sm text-gray-600",
+        )}
+      >
+        <Spinner size="xs" />
+        <span>{item.name}</span>
+      </span>
+    );
+  }
+
+  return (
+    <SkillReferenceChip icon={item.icon} name={item.name} onRemove={onRemove} />
+  );
+}
+
+interface SkillSearchProps {
+  clientRect?: () => DOMRect | null;
+  onCancel: () => void;
+  onSelect: (item: SkillReferenceItem) => void;
+}
+
+function SkillSearchComponent({
+  clientRect,
+  onCancel,
+  onSelect,
+}: SkillSearchProps) {
+  const { owner } = useSpacesContext();
+  const { skillId: currentSkillId } = useSkillBuilderContext();
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [searchQuery, setSearchQuery] = useState("");
+  const contentRef = useRef<HTMLSpanElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const [virtualTriggerStyle, setVirtualTriggerStyle] =
+    useState<React.CSSProperties>({});
+
+  const { skills, isSkillsLoading } = useSkills({
+    owner,
+    status: "active",
+    viewType: "summary",
+  });
+
+  const skillItems: FullSkillReferenceItem[] = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (query.length < 2) {
+      return [];
+    }
+
+    return skills
+      .filter((skill) => skill.createdAt !== null)
+      .filter((skill) => skill.sId !== currentSkillId)
+      .filter((skill) => skill.name.toLowerCase().includes(query))
+      .slice(0, 10)
+      .map((skill) => ({
+        icon: skill.icon,
+        name: skill.name,
+        skill,
+        skillId: skill.sId,
+      }));
+  }, [currentSkillId, searchQuery, skills]);
+
+  const updateTriggerPosition = useCallback(() => {
+    const triggerRect = clientRect?.();
+    if (triggerRect && triggerRef.current) {
+      setVirtualTriggerStyle({
+        position: "fixed",
+        left: triggerRect.left,
+        top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
+        width: 1,
+        height: triggerRect.height || 1,
+        pointerEvents: "none",
+        zIndex: -1,
+      });
+    }
+  }, [clientRect]);
+
+  useEffect(() => {
+    updateTriggerPosition();
+  }, [updateTriggerPosition]);
+
+  useEffect(() => {
+    if (!contentRef.current) {
+      return;
+    }
+
+    setTimeout(() => {
+      if (!contentRef.current) {
+        return;
+      }
+
+      contentRef.current.focus();
+      const range = document.createRange();
+      const selection = window.getSelection();
+      if (!selection) {
+        return;
+      }
+
+      range.selectNodeContents(contentRef.current);
+      range.collapse(false);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }, 10);
+  }, []);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+    setIsOpen(searchQuery.trim().length > 0);
+  }, [searchQuery]);
+
+  const handleItemSelect = useCallback(
+    (index: number) => {
+      const item = skillItems[index];
+      if (!item) {
+        return;
+      }
+
+      onSelect(item);
+      setIsOpen(false);
+      setSelectedIndex(0);
+      setSearchQuery("");
+    },
+    [onSelect, skillItems],
+  );
+
+  const deleteIfEmpty = useCallback(
+    (delayMs: number = 50) => {
+      setTimeout(() => {
+        if (!searchQuery.trim()) {
+          onCancel();
+        }
+      }, delayMs);
+    },
+    [onCancel, searchQuery],
+  );
+
+  const handleInput = useCallback((e: React.FormEvent<HTMLSpanElement>) => {
+    setSearchQuery(e.currentTarget.textContent ?? "");
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onCancel();
+        return;
+      }
+
+      if (!isOpen || skillItems.length === 0) {
+        return;
+      }
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        e.stopPropagation();
+        setSelectedIndex((selectedIndex + 1) % skillItems.length);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        e.stopPropagation();
+        setSelectedIndex(
+          (selectedIndex + skillItems.length - 1) % skillItems.length,
+        );
+      } else if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        e.stopPropagation();
+        handleItemSelect(selectedIndex);
+      }
+    },
+    [handleItemSelect, isOpen, onCancel, selectedIndex, skillItems.length],
+  );
+
+  const handleInteractOutside = useCallback(() => {
+    setIsOpen(false);
+    deleteIfEmpty(50);
+  }, [deleteIfEmpty]);
+
+  return (
+    <div className="relative inline-block">
+      <span
+        className={cn(
+          "inline-block h-7 cursor-text px-3 py-1 text-sm font-normal",
+          "rounded bg-gray-100 dark:bg-gray-800",
+          "text-center text-gray-500 dark:text-gray-500-night",
+          "empty:before:content-[attr(data-placeholder)] focus:outline-none",
+          "min-w-36 text-left",
+        )}
+        contentEditable
+        suppressContentEditableWarning
+        ref={contentRef}
+        onKeyDown={handleKeyDown}
+        onInput={handleInput}
+        data-placeholder="Search for a skill..."
+      />
+
+      {isOpen && (
+        <DropdownMenu open={true}>
+          <DropdownMenuTrigger asChild>
+            <div ref={triggerRef} style={virtualTriggerStyle} />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="w-96"
+            align="start"
+            avoidCollisions
+            onInteractOutside={handleInteractOutside}
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            onCloseAutoFocus={(e) => e.preventDefault()}
+          >
+            {isSkillsLoading ? (
+              <div className="flex h-14 items-center justify-center">
+                <Spinner size="sm" />
+                <span className="ml-2 text-sm text-gray-500 dark:text-gray-500-night">
+                  Searching skills...
+                </span>
+              </div>
+            ) : skillItems.length === 0 ? (
+              <div className="flex h-14 items-center justify-center text-center text-sm text-gray-500 dark:text-gray-500-night">
+                {searchQuery.length < 2
+                  ? "Type at least 2 characters to search"
+                  : "No skills found"}
+              </div>
+            ) : (
+              skillItems.map((item, index) => (
+                <DropdownMenuItem
+                  key={item.skillId}
+                  icon={<Icon visual={getSkillIcon(item.icon)} size="md" />}
+                  label={item.name}
+                  description={item.skill.userFacingDescription}
+                  truncateText
+                  onClick={() => handleItemSelect(index)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  className={
+                    index === selectedIndex
+                      ? "bg-gray-100 dark:bg-gray-800"
+                      : ""
+                  }
+                />
+              ))
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    skillNode: {
+      insertSkillNode: () => ReturnType;
+    };
+  }
+}
+
+export const SKILL_NODE_TYPE = "skillNode";
+
+export interface SkillNodeOptions {
+  readOnly: boolean;
+}
+
+export const SkillNode = Node.create<SkillNodeOptions>({
+  addOptions() {
+    return { readOnly: false };
+  },
+  name: SKILL_NODE_TYPE,
+
+  group: "inline",
+  inline: true,
+  atom: false,
+  selectable: false,
+
+  markdownTokenizer: {
+    name: "skillNode",
+    level: "inline",
+    start: (src) => src.indexOf("<skill"),
+    tokenize: (src) => {
+      const match = SKILL_REFERENCE_TAG_REGEX.exec(src);
+      if (!match) {
+        return undefined;
+      }
+
+      const reference = parseSkillReferences(match[0])[0];
+      if (!reference) {
+        return undefined;
+      }
+
+      return {
+        type: "skillNode",
+        raw: match[0],
+        skillId: reference.skillId,
+        skillName: reference.name,
+      };
+    },
+  },
+
+  addAttributes() {
+    return {
+      selectedItems: {
+        default: [],
+        parseHTML: (element) => {
+          if (element.tagName.toLowerCase() !== "skill") {
+            return [];
+          }
+
+          const skillId = element.getAttribute("id");
+          const name = element.getAttribute("name");
+          if (!skillId || !name) {
+            return [];
+          }
+
+          return [
+            {
+              icon: null,
+              name,
+              skillId,
+            } satisfies BaseSkillReferenceItem,
+          ];
+        },
+        renderHTML: (attributes) => {
+          const item = (attributes.selectedItems as SkillReferenceItem[])[0];
+          if (!item) {
+            return {};
+          }
+
+          return {
+            id: item.skillId,
+            name: item.name,
+          };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "skill" }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const { selectedItems } = node.attrs as SkillNodeAttributes;
+    const item = selectedItems[0];
+
+    if (item) {
+      return [
+        "skill",
+        HTMLAttributes,
+        [
+          "span",
+          { class: SKILL_CHIP_CLASS },
+          ["span", {}, "Skill"],
+          ["span", {}, ` ${item.name}`],
+        ],
+      ];
+    }
+
+    return ["span", {}];
+  },
+
+  renderMarkdown: (node) => {
+    const selectedItems = node.attrs?.selectedItems as
+      | SkillReferenceItem[]
+      | undefined;
+    const item = selectedItems?.[0];
+    if (!item) {
+      return "";
+    }
+
+    return serializeSkillReference({
+      name: item.name,
+      skillId: item.skillId,
+    });
+  },
+
+  parseMarkdown: (token) => {
+    return {
+      type: "skillNode",
+      attrs: {
+        selectedItems: [
+          {
+            icon: null,
+            name: token.skillName,
+            skillId: token.skillId,
+          },
+        ],
+      },
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(
+      this.options.readOnly ? SkillNodeReadOnlyView : SkillNodeView,
+    );
+  },
+
+  addCommands() {
+    return {
+      insertSkillNode:
+        () =>
+        ({ commands }) => {
+          return commands.insertContent({
+            type: this.name,
+            attrs: {
+              selectedItems: [],
+            },
+          });
+        },
+    };
+  },
+});
+
+interface ExtendedNodeViewProps extends NodeViewProps {
+  clientRect?: () => DOMRect | null;
+}
+
+const SkillNodeView: React.FC<ExtendedNodeViewProps> = ({
+  clientRect,
+  deleteNode,
+  editor,
+  node,
+  updateAttributes,
+}) => {
+  const { selectedItems } = node.attrs as SkillNodeAttributes;
+
+  const handleRemove = useCallback(
+    (e?: React.MouseEvent) => {
+      e?.stopPropagation();
+      deleteNode();
+    },
+    [deleteNode],
+  );
+
+  const handleCancel = useCallback(() => {
+    deleteNode();
+    queueMicrotask(() => {
+      if (editor && !editor.isDestroyed) {
+        editor.chain().focus().run();
+      }
+    });
+  }, [deleteNode, editor]);
+
+  const handleSelect = useCallback(
+    (item: SkillReferenceItem) => {
+      updateAttributes({
+        selectedItems: [item],
+      });
+
+      queueMicrotask(() => {
+        if (editor && !editor.isDestroyed) {
+          editor.chain().focus().insertContent(" ").run();
+        }
+      });
+    },
+    [editor, updateAttributes],
+  );
+
+  if (selectedItems.length > 0) {
+    return (
+      <NodeViewWrapper className="inline">
+        <SkillDisplayComponent
+          item={selectedItems[0]}
+          onRemove={editor.isEditable ? handleRemove : undefined}
+          updateAttributes={updateAttributes}
+        />
+      </NodeViewWrapper>
+    );
+  }
+
+  return (
+    <NodeViewWrapper className="inline">
+      <SkillSearchComponent
+        onSelect={handleSelect}
+        onCancel={handleCancel}
+        clientRect={clientRect}
+      />
+    </NodeViewWrapper>
+  );
+};

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -3,7 +3,7 @@ import type {
   SlashCommandDropdownRef,
 } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
 import { SlashCommandDropdown } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
-import { AttachmentIcon } from "@dust-tt/sparkle";
+import { AttachmentIcon, PuzzleIcon } from "@dust-tt/sparkle";
 import { Extension } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
@@ -14,6 +14,7 @@ import { exitSuggestion, Suggestion } from "@tiptap/suggestion";
 const slashCommandPluginKey = new PluginKey("slashCommand");
 
 const INSERT_KNOWLEDGE_NODE_ACTION = "insert-knowledge-node";
+const INSERT_SKILL_NODE_ACTION = "insert-skill-node";
 
 // Define available slash commands.
 const SLASH_COMMANDS: SlashCommand[] = [
@@ -31,6 +32,15 @@ const SLASH_COMMANDS: SlashCommand[] = [
           src="/static/landing/product/Knowledge_Tooltips.jpg"
         />
       ),
+    },
+  },
+  {
+    id: "reference-skill",
+    action: INSERT_SKILL_NODE_ACTION,
+    icon: PuzzleIcon,
+    label: "Reference skill",
+    tooltip: {
+      description: "Point to another skill that can be enabled when needed.",
     },
   },
 ];
@@ -95,6 +105,13 @@ export const SlashCommandExtension =
                 .focus()
                 .deleteRange(range)
                 .insertKnowledgeNode()
+                .run();
+            } else if (props.action === INSERT_SKILL_NODE_ACTION) {
+              editor
+                .chain()
+                .focus()
+                .deleteRange(range)
+                .insertSkillNode()
                 .run();
             }
           },

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -2,6 +2,10 @@ import { editorVariants } from "@app/components/editor/editorStyles";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import {
+  SKILL_NODE_TYPE,
+  type SkillReferenceItem,
+} from "@app/components/editor/extensions/skill_builder/SkillNode";
+import {
   SkillInstructionsEditorContent,
   useSkillInstructionsEditor,
 } from "@app/components/editor/SkillInstructionsEditor";
@@ -39,8 +43,26 @@ function collectKnowledgeItems(editor: Editor): KnowledgeItem[] {
   return items;
 }
 
+function hasEmptyNode(editor: Editor, nodeType: string): boolean {
+  let hasEmptyTargetNode = false;
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === nodeType) {
+      const selectedItems = node.attrs?.selectedItems as
+        | KnowledgeItem[]
+        | SkillReferenceItem[]
+        | undefined;
+      if (!selectedItems || selectedItems.length === 0) {
+        hasEmptyTargetNode = true;
+        return false;
+      }
+    }
+    return true;
+  });
+  return hasEmptyTargetNode;
+}
+
 function toAttachedKnowledge(
-  items: readonly KnowledgeItem[]
+  items: readonly KnowledgeItem[],
 ): SkillBuilderFormData["attachedKnowledge"] {
   return items.map((item) => ({
     dataSourceViewId: item.dataSourceViewId,
@@ -53,8 +75,8 @@ function toAttachedKnowledge(
 function sanitizeSkillInstructionsHtml(html: string): string {
   try {
     const config: Config = {
-      ADD_TAGS: ["knowledge"],
-      ADD_ATTR: ["space", "dsv", "hasChildren"],
+      ADD_TAGS: ["knowledge", "skill"],
+      ADD_ATTR: ["space", "dsv", "hasChildren", "id", "name"],
       FORBID_ATTR: ["style", "class"],
     };
     return DOMPurify.sanitize(html, config);
@@ -67,10 +89,12 @@ const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
 
 interface SkillBuilderInstructionsEditorProps {
   onAddKnowledge?: (addKnowledge: () => void) => void;
+  onAddSkill?: (addSkill: () => void) => void;
 }
 
 export function SkillBuilderInstructionsEditor({
   onAddKnowledge,
+  onAddSkill,
 }: SkillBuilderInstructionsEditorProps) {
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
   const { setValue } = useFormContext<SkillBuilderFormData>();
@@ -104,21 +128,21 @@ export function SkillBuilderInstructionsEditor({
           setValue(
             INSTRUCTIONS_FIELD_NAME,
             postProcessMarkdown(editor.getMarkdown()).trim(),
-            { shouldDirty: true }
+            { shouldDirty: true },
           );
           setValue(
             INSTRUCTIONS_HTML_FIELD_NAME,
             sanitizeSkillInstructionsHtml(editor.getHTML()),
-            { shouldDirty: true }
+            { shouldDirty: true },
           );
           setValue(
             ATTACHED_KNOWLEDGE_FIELD_NAME,
             toAttachedKnowledge(collectKnowledgeItems(editor)),
-            { shouldDirty: true }
+            { shouldDirty: true },
           );
         }
       }, 250),
-    [isDiffMode, setValue]
+    [isDiffMode, setValue],
   );
 
   const handleUpdate = useCallback(
@@ -127,12 +151,12 @@ export function SkillBuilderInstructionsEditor({
         debouncedUpdate(editor);
       }
     },
-    [debouncedUpdate]
+    [debouncedUpdate],
   );
 
   const handleBlur = useCallback(() => {
     window.dispatchEvent(
-      new CustomEvent(SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT)
+      new CustomEvent(SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT),
     );
   }, []);
 
@@ -141,10 +165,10 @@ export function SkillBuilderInstructionsEditor({
       setValue(
         ATTACHED_KNOWLEDGE_FIELD_NAME,
         toAttachedKnowledge(collectKnowledgeItems(editorInstance)),
-        { shouldDirty: true }
+        { shouldDirty: true },
       );
     },
-    [setValue]
+    [setValue],
   );
 
   const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
@@ -175,28 +199,23 @@ export function SkillBuilderInstructionsEditor({
       return;
     }
 
-    // Check if there's already an empty knowledge node (in search mode).
-    // If so, do nothing - clicking the button already dismissed it via handleInteractOutside.
-    const { doc } = editor.state;
-    let hasEmptyKnowledgeNode = false;
-    doc.descendants((node) => {
-      if (node.type.name === KNOWLEDGE_NODE_TYPE) {
-        const selectedItems = node.attrs?.selectedItems as
-          | KnowledgeItem[]
-          | undefined;
-        if (!selectedItems || selectedItems.length === 0) {
-          hasEmptyKnowledgeNode = true;
-          return false;
-        }
-      }
-      return true;
-    });
-
-    if (hasEmptyKnowledgeNode) {
+    if (hasEmptyNode(editor, KNOWLEDGE_NODE_TYPE)) {
       return;
     }
 
     editor.chain().focus().insertKnowledgeNode().run();
+  }, [editor]);
+
+  const handleAddSkill = useCallback(() => {
+    if (!editor) {
+      return;
+    }
+
+    if (hasEmptyNode(editor, SKILL_NODE_TYPE)) {
+      return;
+    }
+
+    editor.chain().focus().insertSkillNode().run();
   }, [editor]);
 
   useEffect(() => {
@@ -204,6 +223,12 @@ export function SkillBuilderInstructionsEditor({
       onAddKnowledge(handleAddKnowledge);
     }
   }, [editor, handleAddKnowledge, onAddKnowledge]);
+
+  useEffect(() => {
+    if (editor && onAddSkill) {
+      onAddSkill(handleAddSkill);
+    }
+  }, [editor, handleAddSkill, onAddSkill]);
 
   // Register a callback that the suggestions panel can call to accept a
   // suggestion directly via the editor's ProseMirror commands.
@@ -230,14 +255,14 @@ export function SkillBuilderInstructionsEditor({
       setValue(
         INSTRUCTIONS_HTML_FIELD_NAME,
         sanitizeSkillInstructionsHtml(editor.getHTML()),
-        { shouldDirty: true }
+        { shouldDirty: true },
       );
       setValue(
         INSTRUCTIONS_FIELD_NAME,
         postProcessMarkdown(editor.getMarkdown()).trim(),
         {
           shouldDirty: true,
-        }
+        },
       );
     });
 
@@ -280,7 +305,7 @@ export function SkillBuilderInstructionsEditor({
     if (selectedSuggestionId) {
       requestAnimationFrame(() => {
         const firstEdit = editor.view.dom.querySelector(
-          `[data-suggestion-id^="${selectedSuggestionId}:"]`
+          `[data-suggestion-id^="${selectedSuggestionId}:"]`,
         );
         firstEdit?.scrollIntoView({ behavior: "smooth", block: "center" });
       });
@@ -321,7 +346,7 @@ export function SkillBuilderInstructionsEditor({
               disabled: isDiffMode,
               readOnly: hasSuggestions,
             }),
-            INSTRUCTIONS_EDITOR_SIZE
+            INSTRUCTIONS_EDITOR_SIZE,
           ),
         },
       },
@@ -370,7 +395,7 @@ export function SkillBuilderInstructionsEditor({
       });
       editor.commands.applyDiff(
         preprocessMarkdownForEditor(compareText),
-        preprocessMarkdownForEditor(currentText)
+        preprocessMarkdownForEditor(currentText),
       );
       editor.setEditable(false);
     } else if (editor.storage.agentInstructionDiff?.isDiffMode) {

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   ContentMessage,
   InformationCircleIcon,
+  PuzzleIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
@@ -19,6 +20,7 @@ export function SkillBuilderInstructionsSection() {
   const { setValue, watch } = useFormContext<SkillBuilderFormData>();
   const { compareVersion } = useSkillVersionComparisonContext();
   const [addKnowledge, setAddKnowledge] = useState<(() => void) | null>(null);
+  const [addSkill, setAddSkill] = useState<(() => void) | null>(null);
 
   const currentInstructions = watch(INSTRUCTIONS_FIELD_NAME);
   const instructionsDiffer =
@@ -52,13 +54,22 @@ export function SkillBuilderInstructionsSection() {
             />
           )}
           {!compareVersion && (
-            <Button
-              variant="primary"
-              label="Attach knowledge"
-              icon={BookOpenIcon}
-              onClick={addKnowledge ?? undefined}
-              disabled={!addKnowledge}
-            />
+            <>
+              <Button
+                variant="outline"
+                label="Reference skill"
+                icon={PuzzleIcon}
+                onClick={addSkill ?? undefined}
+                disabled={!addSkill}
+              />
+              <Button
+                variant="primary"
+                label="Attach knowledge"
+                icon={BookOpenIcon}
+                onClick={addKnowledge ?? undefined}
+                disabled={!addKnowledge}
+              />
+            </>
           )}
         </div>
       </div>
@@ -76,6 +87,7 @@ export function SkillBuilderInstructionsSection() {
       )}
       <SkillBuilderInstructionsEditor
         onAddKnowledge={(fn) => setAddKnowledge(() => fn)}
+        onAddSkill={(fn) => setAddSkill(() => fn)}
       />
     </section>
   );

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -10,6 +10,7 @@ import {
   RawMarkdownBlock,
   rawMarkdownBlockParsers,
 } from "@app/components/editor/extensions/skill_builder/RawMarkdownBlock";
+import { SkillNode } from "@app/components/editor/extensions/skill_builder/SkillNode";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import { markdownStyles } from "@dust-tt/sparkle";
 import type { Extensions } from "@tiptap/core";
@@ -26,7 +27,7 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
  */
 export function buildSkillInstructionsExtensions(
   isReadOnly: boolean,
-  editableExtensions: Extensions = []
+  editableExtensions: Extensions = [],
 ): Extensions {
   const baseExtensions: Extensions = [
     InstructionsDocumentExtension,
@@ -86,6 +87,7 @@ export function buildSkillInstructionsExtensions(
     }),
     BlockIdExtension,
     KnowledgeNode.configure({ readOnly: isReadOnly }),
+    SkillNode.configure({ readOnly: isReadOnly }),
     InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
     RawMarkdownBlock,
     ...rawMarkdownBlockParsers,

--- a/front/lib/editor/skill_instructions_preprocessing.test.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.test.ts
@@ -1,0 +1,40 @@
+import {
+  postProcessMarkdown,
+  preprocessMarkdownForEditor,
+} from "@app/lib/editor/skill_instructions_preprocessing";
+import {
+  parseSkillReferences,
+  serializeSkillReference,
+} from "@app/lib/skill_references";
+import { describe, expect, it } from "vitest";
+
+describe("skill instructions preprocessing", () => {
+  it("preserves skill reference attributes while post-processing markdown", () => {
+    const serialized = serializeSkillReference({
+      name: 'R&D "Ops"',
+      skillId: "skill_123",
+    });
+
+    const processed = postProcessMarkdown(serialized);
+
+    expect(processed).toBe(
+      '<skill name="R&amp;D &quot;Ops&quot;" id="skill_123" />',
+    );
+    expect(parseSkillReferences(processed)).toEqual([
+      {
+        name: 'R&D "Ops"',
+        skillId: "skill_123",
+      },
+    ]);
+  });
+
+  it("preserves skill tags while escaping other XML-like tags for the editor", () => {
+    expect(
+      preprocessMarkdownForEditor(
+        'Use <skill name="Research" id="skill_123" /> then <internal>.',
+      ),
+    ).toBe(
+      'Use <skill name="Research" id="skill_123" /> then <\u200Binternal>.',
+    );
+  });
+});

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -1,6 +1,8 @@
 import { unescape } from "html-escaper";
 
 const ZWS = "\u200B";
+const SKILL_REFERENCE_TAG_REGEX = /<skill\s+[^>]*\s*\/>/g;
+const SKILL_REFERENCE_TAG_PLACEHOLDER = "DUST_SKILL_REFERENCE_TAG_PLACEHOLDER_";
 
 /**
  * Escape emphasis delimiters (_ and *) inside $$ ... $$ math blocks so
@@ -8,7 +10,7 @@ const ZWS = "\u200B";
  */
 function escapeMathEmphasis(markdown: string): string {
   return markdown.replace(/\$\$([\s\S]*?)\$\$/g, (block) =>
-    block.replace(/(?<!\\)_/g, "\\_").replace(/(?<!\\)\*/g, "\\*")
+    block.replace(/(?<!\\)_/g, "\\_").replace(/(?<!\\)\*/g, "\\*"),
   );
 }
 
@@ -17,7 +19,7 @@ function escapeMathEmphasis(markdown: string): string {
  */
 export function preprocessMarkdownForEditor(markdown: string): string {
   return escapeMathEmphasis(
-    markdown.replace(/<(?!\/?knowledge[\s>/])(\/?\w)/g, `<${ZWS}$1`)
+    markdown.replace(/<(?!\/?(knowledge|skill)[\s>/])(\/?\w)/g, `<${ZWS}$2`),
   );
 }
 
@@ -25,9 +27,24 @@ export function preprocessMarkdownForEditor(markdown: string): string {
  * Normalize markdown serialized out of the TipTap editor before saving.
  */
 export function postProcessMarkdown(markdown: string): string {
-  return unescape(markdown)
+  const skillReferenceTags: string[] = [];
+  const markdownWithProtectedSkillReferences = markdown.replace(
+    SKILL_REFERENCE_TAG_REGEX,
+    (tag) => {
+      const index = skillReferenceTags.push(tag) - 1;
+      return `${SKILL_REFERENCE_TAG_PLACEHOLDER}${index}`;
+    },
+  );
+
+  const processedMarkdown = unescape(markdownWithProtectedSkillReferences)
     .replace(new RegExp(ZWS, "g"), "")
     .replace(/\$\$([\s\S]*?)\$\$/g, (block) =>
-      block.replace(/\\_/g, "_").replace(/\\\*/g, "*")
+      block.replace(/\\_/g, "_").replace(/\\\*/g, "*"),
     );
+
+  return skillReferenceTags.reduce(
+    (result, tag, index) =>
+      result.replaceAll(`${SKILL_REFERENCE_TAG_PLACEHOLDER}${index}`, tag),
+    processedMarkdown,
+  );
 }


### PR DESCRIPTION
## Description

This PR adds the builder/editor UX for referencing another skill from skill instructions. Builders can insert a skill reference from the slash menu or the instructions toolbar, search active custom skills, and save the reference as a serialized `<skill name="..." id="..." />` directive.

It also teaches the skill instructions editor to render these references as chips and preserves escaped skill-reference attributes during markdown post-processing.

## Tests

## Risk

## Deploy Plan

- Deploy front
