### PR TITLE
[front] feat: surface skill reference usage in Manage Skills

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -135,7 +135,7 @@ export function ManageSkillsPage() {
     return {
       active: sortedActiveSkills,
       editable_by_me: sortedActiveSkills.filter((s) =>
-        s.relations.editors?.some((e) => e.sId === user?.sId)
+        s.relations.editors?.some((e) => e.sId === user?.sId),
       ),
       default: sortedActiveSkills
         .filter((s) => s.isDefault || s.relations.editors === null)
@@ -152,14 +152,14 @@ export function ManageSkillsPage() {
       archived: sortedArchivedSkills,
       search: activeSkills
         .filter((s) =>
-          subFilter(skillSearch.toLowerCase(), getSkillSearchString(s))
+          subFilter(skillSearch.toLowerCase(), getSkillSearchString(s)),
         )
         .sort((a, b) =>
           compareForFuzzySort(
             skillSearch.toLowerCase(),
             getSkillSearchString(a),
-            getSkillSearchString(b)
-          )
+            getSkillSearchString(b),
+          ),
         ),
     };
   }, [activeSkills, archivedSkills, skillSearch, user]);
@@ -181,7 +181,21 @@ export function ManageSkillsPage() {
       setSelectedSkill(skill);
       setSkillIdParam(skill?.sId);
     },
-    [setSkillIdParam]
+    [setSkillIdParam],
+  );
+
+  const handleSkillIdSelect = useCallback(
+    (skillId: string) => {
+      const skill = [
+        ...activeSkills,
+        ...archivedSkills,
+        ...suggestedSkills,
+      ].find((s) => s.sId === skillId);
+      if (skill) {
+        handleSkillSelect(skill);
+      }
+    },
+    [activeSkills, archivedSkills, suggestedSkills, handleSkillSelect],
   );
 
   const visibleTabs = useMemo(() => {
@@ -220,7 +234,7 @@ export function ManageSkillsPage() {
 
   const navChildren = useMemo(
     () => <AgentSidebarMenu owner={owner} />,
-    [owner]
+    [owner],
   );
 
   useSetContentWidth("wide");
@@ -317,6 +331,7 @@ export function ManageSkillsPage() {
                   owner={owner}
                   skills={skillsByTab[activeTab]}
                   onSkillClick={handleSkillSelect}
+                  onSkillIdClick={handleSkillIdSelect}
                   onAgentClick={setAgentId}
                 />
               </>

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -1,6 +1,7 @@
 import { KnowledgeChip } from "@app/components/editor/extensions/skill_builder/KnowledgeChip";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { isFullKnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
+import { SkillReferenceChip } from "@app/components/editor/extensions/skill_builder/SkillNode";
 import { SkillInstructionsReadOnlyEditor } from "@app/components/skills/SkillInstructionsReadOnlyEditor";
 import {
   getMcpServerViewDescription,
@@ -13,7 +14,10 @@ import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillRelations,
+  SkillType,
+} from "@app/types/assistant/skill_configuration";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -28,7 +32,7 @@ import sortBy from "lodash/sortBy";
 import { useCallback, useMemo, useState } from "react";
 
 interface SkillInfoTabProps {
-  skill: SkillType;
+  skill: SkillType & { relations?: SkillRelations };
   owner: LightWorkspaceType;
   spaces?: SpaceType[];
   showDescription?: boolean;
@@ -65,7 +69,7 @@ export function SkillInfoTab({
 
   const sortedMCPServerViews = useMemo(
     () => sortBy(skill.tools.map(renderMCPServerView), "title"),
-    [skill.tools]
+    [skill.tools],
   );
 
   const requestedSpaces = useMemo(
@@ -77,13 +81,14 @@ export function SkillInfoTab({
           name: getSpaceName(space),
           Icon: getSpaceIcon(space),
         })),
-    [resolvedSpaces, skill.requestedSpaceIds]
+    [resolvedSpaces, skill.requestedSpaceIds],
   );
 
   const sortedSpaces = useMemo(
     () => sortBy(requestedSpaces, "name"),
-    [requestedSpaces]
+    [requestedSpaces],
   );
+  const referencedSkills = skill.relations?.referencedSkills ?? [];
 
   const handleKnowledgeItemsChange = useCallback((items: KnowledgeItem[]) => {
     setKnowledgeItems(items);
@@ -92,6 +97,7 @@ export function SkillInfoTab({
   const showSeparator =
     !!skill.instructions ||
     knowledgeItems.length > 0 ||
+    referencedSkills.length > 0 ||
     (hasFeature("sandbox_tools") && skill.fileAttachments.length > 0) ||
     sortedMCPServerViews.length > 0 ||
     showDiscoverableSkills ||
@@ -132,6 +138,23 @@ export function SkillInfoTab({
                 key={item.nodeId}
                 node={item.node}
                 title={item.label}
+                color="primary"
+              />
+            ))}
+          </div>
+        </div>
+      )}
+      {referencedSkills.length > 0 && (
+        <div className="flex flex-col gap-4">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Referenced Skills
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {referencedSkills.map((referencedSkill) => (
+              <SkillReferenceChip
+                key={referencedSkill.sId}
+                icon={referencedSkill.icon}
+                name={referencedSkill.name}
                 color="primary"
               />
             ))}

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -6,15 +6,26 @@ import { getSkillAvatarIcon } from "@app/lib/skill";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
-import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillWithRelationsType,
+  SkillWithoutInstructionsAndToolsType,
+} from "@app/types/assistant/skill_configuration";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
+  Button,
   ClipboardIcon,
   DataTable,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
   EyeIcon,
   PencilSquareIcon,
+  PuzzleIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
 import type { CellContext } from "@tanstack/react-table";
@@ -26,6 +37,7 @@ type RowData = {
   description: string;
   editors: UserType[] | null;
   usage: AgentsUsageType;
+  usedBySkills: SkillWithoutInstructionsAndToolsType[];
   updatedAt: number | null;
   createdAt: number | null;
   onClick: () => void;
@@ -103,6 +115,125 @@ const usedByColumn = (onAgentClick: (agentId: string) => void) => ({
   },
 });
 
+function UsedBySkillsButton({
+  skills,
+  onSkillClick,
+}: {
+  skills: SkillWithoutInstructionsAndToolsType[];
+  onSkillClick: (skillId: string) => void;
+}) {
+  const [searchText, setSearchText] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (skills.length === 0) {
+    return (
+      <Button
+        icon={PuzzleIcon}
+        variant="ghost-secondary"
+        isSelect={false}
+        size="xs"
+        label="0"
+        disabled
+      />
+    );
+  }
+
+  const query = searchText.toLowerCase();
+  const filteredSkills =
+    query.length === 0
+      ? skills
+      : skills.filter((skill) => skill.name.toLowerCase().includes(query));
+
+  return (
+    <DropdownMenu
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (open) {
+          setSearchText("");
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          icon={PuzzleIcon}
+          variant="ghost-secondary"
+          isSelect
+          size="xs"
+          label={`${skills.length}`}
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+          }}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="h-96 w-72"
+        align="end"
+        onClick={(e) => e.stopPropagation()}
+        dropdownHeaders={
+          <>
+            <DropdownMenuSearchbar
+              autoFocus
+              name="search-used-by-skills"
+              placeholder="Search skills"
+              value={searchText}
+              onChange={setSearchText}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && filteredSkills.length > 0) {
+                  onSkillClick(filteredSkills[0].sId);
+                  setSearchText("");
+                  setIsOpen(false);
+                }
+              }}
+            />
+            <DropdownMenuSeparator />
+          </>
+        }
+      >
+        {filteredSkills.length > 0 ? (
+          filteredSkills.map((skill) => {
+            const SkillAvatar = getSkillAvatarIcon(skill.icon);
+            return (
+              <DropdownMenuItem
+                key={`skill-picker-${skill.sId}`}
+                icon={SkillAvatar}
+                label={skill.name}
+                truncateText
+                className="py-1"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSkillClick(skill.sId);
+                  setIsOpen(false);
+                }}
+              />
+            );
+          })
+        ) : (
+          <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+            No skills found
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+const usedBySkillsColumn = (onSkillClick: (skillId: string) => void) => ({
+  header: "Used by skills",
+  accessorFn: (row: RowData) => row.usedBySkills.length,
+  cell: (info: CellContext<RowData, number>) => (
+    <DataTable.CellContent>
+      <UsedBySkillsButton
+        skills={info.row.original.usedBySkills}
+        onSkillClick={onSkillClick}
+      />
+    </DataTable.CellContent>
+  ),
+  meta: {
+    className: "hidden @lg:w-28 @lg:table-cell",
+  },
+});
+
 const lastEditedColumn = {
   header: "Last Edited",
   accessorKey: "updatedAt",
@@ -129,7 +260,13 @@ const menuColumn = {
   },
 };
 
-const getTableColumns = (onAgentClick: (agentId: string) => void) => {
+const getTableColumns = ({
+  onAgentClick,
+  onUsedBySkillClick,
+}: {
+  onAgentClick: (agentId: string) => void;
+  onUsedBySkillClick: (skillId: string) => void;
+}) => {
   /**
    * Columns order:
    * - Name (always)
@@ -142,6 +279,7 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
   return [
     nameColumn,
     usedByColumn(onAgentClick),
+    usedBySkillsColumn(onUsedBySkillClick),
     editorsColumn,
     lastEditedColumn,
     menuColumn,
@@ -152,6 +290,7 @@ type SkillsTableProps = {
   skills: SkillWithRelationsType[];
   owner: LightWorkspaceType;
   onSkillClick: (skill: SkillWithRelationsType) => void;
+  onSkillIdClick: (skillId: string) => void;
   onAgentClick: (agentId: string) => void;
 };
 
@@ -159,6 +298,7 @@ export function SkillsTable({
   skills,
   owner,
   onSkillClick,
+  onSkillIdClick,
   onAgentClick,
 }: SkillsTableProps) {
   const router = useAppRouter();
@@ -175,6 +315,7 @@ export function SkillsTable({
         description: skill.userFacingDescription,
         editors: skill.relations.editors,
         usage: skill.relations.usage,
+        usedBySkills: skill.relations.referencedBy,
         updatedAt: skill.updatedAt,
         createdAt: skill.createdAt,
         onClick: () => {
@@ -190,7 +331,7 @@ export function SkillsTable({
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();
                     void router.push(
-                      getSkillBuilderRoute(owner.sId, skill.sId)
+                      getSkillBuilderRoute(owner.sId, skill.sId),
                     );
                   },
                   kind: "item" as const,
@@ -214,8 +355,8 @@ export function SkillsTable({
                       getSkillBuilderRoute(
                         owner.sId,
                         "new",
-                        `extends=${skill.sId}`
-                      )
+                        `extends=${skill.sId}`,
+                      ),
                     );
                   },
                   kind: "item" as const,
@@ -235,7 +376,7 @@ export function SkillsTable({
             : [],
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work
-    [skills, onSkillClick, owner.sId]
+    [skills, onSkillClick, owner.sId],
   );
 
   if (rows.length === 0) {
@@ -257,7 +398,10 @@ export function SkillsTable({
       <DataTable
         className="relative"
         data={rows}
-        columns={getTableColumns(onAgentClick)}
+        columns={getTableColumns({
+          onAgentClick,
+          onUsedBySkillClick: onSkillIdClick,
+        })}
         pagination={pagination}
         setPagination={setPagination}
       />


### PR DESCRIPTION
## Description

This PR surfaces nested skill references in the management UI. The skill info sheet now lists referenced skills, and the Manage Skills table adds a `Used by skills` column with a searchable dropdown that opens the referencing skill side panel.

This is intentionally only presentation over the relations added earlier in the stack.

## Tests

## Risk

## Deploy Plan

- Run migration
- Deploy front
