### PR TITLE
[front] fix: support root-level skill.md in ZIP import

### DIFF
--- a/front/lib/api/skills/detection/zip/detect_skills.test.ts
+++ b/front/lib/api/skills/detection/zip/detect_skills.test.ts
@@ -79,6 +79,29 @@ describe("detectSkillsFromZip", () => {
     }
   });
 
+  test("detects a single skill directory at the top level", () => {
+    const zipBuffer = buildZipBuffer({
+      "my-skill/SKILL.md": makeSkillMd("foo", "Foo skill", "Do foo."),
+      "my-skill/helper.py": "print('hello')",
+    });
+
+    const result = detectSkillsFromZip({ zipBuffer });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0].name).toBe("foo");
+      expect(result.value[0].skillMdPath).toBe("my-skill/SKILL.md");
+      expect(result.value[0].attachments).toEqual([
+        {
+          path: "my-skill/helper.py",
+          sizeBytes: 14,
+          contentType: "text/x-python",
+          originalEntryName: "my-skill/helper.py",
+        },
+      ]);
+    }
+  });
+
   test("returns empty array when no SKILL.md files found", () => {
     const zipBuffer = buildZipBuffer({
       "README.md": "# Hello",

--- a/front/lib/api/skills/detection/zip/parsing.test.ts
+++ b/front/lib/api/skills/detection/zip/parsing.test.ts
@@ -56,6 +56,19 @@ describe("stripCommonZipPrefix", () => {
     expect(result.map((e) => e.path)).toEqual(["SKILL.md", "README.md"]);
   });
 
+  test("does not strip when common top-level directory is a skill", () => {
+    const entries = [
+      makeEntry("my-skill/SKILL.md"),
+      makeEntry("my-skill/helper.py"),
+    ];
+
+    const result = stripCommonZipPrefix(entries);
+    expect(result.map((e) => e.path)).toEqual([
+      "my-skill/SKILL.md",
+      "my-skill/helper.py",
+    ]);
+  });
+
   test("returns entries unchanged when all are directories", () => {
     const entries = [
       makeEntry("repo-main", { isDirectory: true }),

--- a/front/lib/api/skills/detection/zip/parsing.ts
+++ b/front/lib/api/skills/detection/zip/parsing.ts
@@ -4,6 +4,8 @@ import type { ZipEntry } from "@app/lib/api/skills/detection/zip/types";
  * Strips the common top-level directory prefix that many ZIP archives include
  * (e.g. "repo-main/skills/foo/SKILL.md" -> "skills/foo/SKILL.md"). If the
  * archive has no single common prefix the entries are returned unchanged.
+ * If the common top-level directory is itself a skill directory, it is kept so
+ * that the generic skill scanner does not treat its SKILL.md as root-level.
  */
 export function stripCommonZipPrefix(entries: ZipEntry[]): ZipEntry[] {
   const fileEntries = entries.filter((e) => !e.isDirectory);
@@ -20,6 +22,17 @@ export function stripCommonZipPrefix(entries: ZipEntry[]): ZipEntry[] {
 
   const allSharePrefix = fileEntries.every((e) => e.path.startsWith(prefix));
   if (!allSharePrefix) {
+    return entries;
+  }
+
+  const prefixContainsSkillMd = fileEntries.some((e) => {
+    const relativePath = e.path.slice(prefix.length);
+
+    return (
+      !relativePath.includes("/") && relativePath.toLowerCase() === "skill.md"
+    );
+  });
+  if (prefixContainsSkillMd) {
     return entries;
   }
 


### PR DESCRIPTION
## Description

This PR fixes skill imports from ZIP archives that contain a single top-level skill folder, such as `my-skill/SKILL.md`.

The ZIP detector still strips wrapper folders for archive shapes like GitHub exports, but now preserves the shared top-level folder when that folder directly contains `SKILL.md`. This prevents the skill from being normalized into root-level `SKILL.md`, which the shared skill scanner intentionally skips.

## Tests

- Tested locally, both a single-folder skill and a multi-skill folder with nested folders.

## Risk

- Low.

## Deploy Plan

- Deploy front.
