### PR TITLE
[front] enh: fix padding in consumers of `IconPicker`

### DIFF
--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -115,7 +115,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
                   />
                 </PopoverTrigger>
                 <PopoverContent
-                  className="w-fit py-0"
+                  className="w-fit p-0"
                   onInteractOutside={closePopover}
                   onEscapeKeyDown={closePopover}
                 >

--- a/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
+++ b/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
@@ -159,7 +159,7 @@ export function CreateSkillSuggestionSheet({
                   />
                 </PopoverTrigger>
                 <PopoverContent
-                  className="w-fit py-0"
+                  className="w-fit p-0"
                   onInteractOutside={() => setIsIconPickerOpen(false)}
                   onEscapeKeyDown={() => setIsIconPickerOpen(false)}
                 >

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -141,7 +141,7 @@ export function WebhookSourceDetailsInfo({
                   />
                 </PopoverTrigger>
                 <PopoverContent
-                  className="w-fit py-0"
+                  className="w-fit p-0"
                   onInteractOutside={() => setIsPopoverOpen(false)}
                   onEscapeKeyDown={() => setIsPopoverOpen(false)}
                 >

--- a/sparkle/src/stories/Picker.stories.tsx
+++ b/sparkle/src/stories/Picker.stories.tsx
@@ -152,7 +152,7 @@ const IconPickerExample = () => {
               isSelect
             />
           </PopoverTrigger>
-          <PopoverContent className="s-w-fit s-py-0">
+          <PopoverContent className="s-w-fit s-p-0">
             <IconPicker
               icons={ActionIcons}
               selectedIcon={selectedIcon}


### PR DESCRIPTION
## Description

Follow up on https://github.com/dust-tt/dust/pull/25083
This PR applies the same fix in other consumers of the `IconPicker` component: `RemoteMCPForm`, `CreateSkillSuggestionSheet`, `WebhookSourceDetailsInfo`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
