### PR TITLE
Display full Poke url in error metadata

### DIFF
--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -183,7 +183,7 @@ export const checkActiveWorkflows: CheckFunction = async (
     if (missingActiveWorkflows.length > 0) {
       const actionLinks: ActionLink[] = missingActiveWorkflows.map((c) => ({
         label: `${provider}: ${c.dataSourceId}`,
-        url: `/poke/${c.workspaceId}/data_sources/${c.dataSourceId}`,
+        url: `https://poke.dust.tt/${c.workspaceId}/data_sources/${c.dataSourceId}`,
       }));
       reportFailure(
         { missingActiveWorkflows, actionLinks },

--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { getConnectorsPrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
 import {
@@ -183,7 +184,7 @@ export const checkActiveWorkflows: CheckFunction = async (
     if (missingActiveWorkflows.length > 0) {
       const actionLinks: ActionLink[] = missingActiveWorkflows.map((c) => ({
         label: `${provider}: ${c.dataSourceId}`,
-        url: `https://poke.dust.tt/${c.workspaceId}/data_sources/${c.dataSourceId}`,
+        url: `${config.getPokeAppUrl()}/${c.workspaceId}/data_sources/${c.dataSourceId}`,
       }));
       reportFailure(
         { missingActiveWorkflows, actionLinks },

--- a/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
+++ b/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import {
   isBotTypeProvider,
   isWebhookBasedProvider,
@@ -91,7 +92,7 @@ export const checkConnectorsLastSyncSuccess: CheckFunction = async (
   if (stalledLastSyncConnectors.length > 0) {
     const actionLinks: ActionLink[] = stalledLastSyncConnectors.map((c) => ({
       label: `${c.provider}: ${c.dataSourceId}`,
-      url: `https://poke.dust.tt/${c.workspaceId}/data_sources/${c.dataSourceId}`,
+      url: `${config.getPokeAppUrl()}/${c.workspaceId}/data_sources/${c.dataSourceId}`,
     }));
     reportFailure(
       { stalledLastSyncConnectors, actionLinks },

--- a/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
+++ b/front/lib/production_checks/checks/check_connectors_last_sync_success.ts
@@ -91,7 +91,7 @@ export const checkConnectorsLastSyncSuccess: CheckFunction = async (
   if (stalledLastSyncConnectors.length > 0) {
     const actionLinks: ActionLink[] = stalledLastSyncConnectors.map((c) => ({
       label: `${c.provider}: ${c.dataSourceId}`,
-      url: `/poke/${c.workspaceId}/data_sources/${c.dataSourceId}`,
+      url: `https://poke.dust.tt/${c.workspaceId}/data_sources/${c.dataSourceId}`,
     }));
     reportFailure(
       { stalledLastSyncConnectors, actionLinks },

--- a/front/lib/production_checks/checks/check_data_sources_consistency.ts
+++ b/front/lib/production_checks/checks/check_data_sources_consistency.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import { Op } from "sequelize";
@@ -19,7 +20,7 @@ export const checkDataSourcesConsistency: CheckFunction = async (
     const actionLinks: ActionLink[] = managedDataSourcesWithoutConnector.map(
       (ds) => ({
         label: `Data Source: ${ds.name}`,
-        url: `https://poke.dust.tt/${ds.workspaceId}/data_sources/${ds.name}`,
+        url: `${config.getPokeAppUrl()}/${ds.workspaceId}/data_sources/${ds.name}`,
       })
     );
     reportFailure(

--- a/front/lib/production_checks/checks/check_data_sources_consistency.ts
+++ b/front/lib/production_checks/checks/check_data_sources_consistency.ts
@@ -19,7 +19,7 @@ export const checkDataSourcesConsistency: CheckFunction = async (
     const actionLinks: ActionLink[] = managedDataSourcesWithoutConnector.map(
       (ds) => ({
         label: `Data Source: ${ds.name}`,
-        url: `/poke/${ds.workspaceId}/data_sources/${ds.name}`,
+        url: `https://poke.dust.tt/${ds.workspaceId}/data_sources/${ds.name}`,
       })
     );
     reportFailure(

--- a/front/lib/production_checks/checks/check_ended_backend_only_subscriptions.ts
+++ b/front/lib/production_checks/checks/check_ended_backend_only_subscriptions.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { getFrontReplicaDbConnection } from "@app/lib/production_checks/utils";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import { QueryTypes } from "sequelize";
@@ -40,7 +41,7 @@ export const checkEndedBackendOnlySubscriptions: CheckFunction = async (
   if (staleSubscriptions.length > 0) {
     const actionLinks: ActionLink[] = staleSubscriptions.map((s) => ({
       label: `${s.workspaceName} (sub: ${s.sId})`,
-      url: `https://poke.dust.tt/${s.workspaceId}`,
+      url: `${config.getPokeAppUrl()}/${s.workspaceId}`,
     }));
 
     const message =

--- a/front/lib/production_checks/checks/check_ended_backend_only_subscriptions.ts
+++ b/front/lib/production_checks/checks/check_ended_backend_only_subscriptions.ts
@@ -40,7 +40,7 @@ export const checkEndedBackendOnlySubscriptions: CheckFunction = async (
   if (staleSubscriptions.length > 0) {
     const actionLinks: ActionLink[] = staleSubscriptions.map((s) => ({
       label: `${s.workspaceName} (sub: ${s.sId})`,
-      url: `/poke/${s.workspaceId}`,
+      url: `https://poke.dust.tt/${s.workspaceId}`,
     }));
 
     const message =

--- a/front/lib/production_checks/checks/check_excess_credits.ts
+++ b/front/lib/production_checks/checks/check_excess_credits.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import {
   getAnnualizedSubscriptionValueMicroUsd,
@@ -152,7 +153,7 @@ export const checkExcessCredits: CheckFunction = async (
 
     const actionLinks: ActionLink[] = significantExcessWorkspaces.map((w) => ({
       label: `${w.workspaceName} ($${(Number(w.totalExcessMicroUsd) / 1_000_000).toFixed(2)})`,
-      url: `https://poke.dust.tt/${w.workspaceId}`,
+      url: `${config.getPokeAppUrl()}/${w.workspaceId}`,
     }));
 
     const thresholdDollars = EXCESS_ABSOLUTE_THRESHOLD_MICRO_USD / 1_000_000;

--- a/front/lib/production_checks/checks/check_excess_credits.ts
+++ b/front/lib/production_checks/checks/check_excess_credits.ts
@@ -152,7 +152,7 @@ export const checkExcessCredits: CheckFunction = async (
 
     const actionLinks: ActionLink[] = significantExcessWorkspaces.map((w) => ({
       label: `${w.workspaceName} ($${(Number(w.totalExcessMicroUsd) / 1_000_000).toFixed(2)})`,
-      url: `/poke/${w.workspaceId}`,
+      url: `https://poke.dust.tt/${w.workspaceId}`,
     }));
 
     const thresholdDollars = EXCESS_ABSOLUTE_THRESHOLD_MICRO_USD / 1_000_000;

--- a/front/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors.ts
+++ b/front/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors.ts
@@ -78,7 +78,7 @@ export const checkExtraneousWorkflows: CheckFunction = async (
   if (hasExtraneousWorklows.length > 0) {
     const actionLinks: ActionLink[] = hasExtraneousWorklows.map((c) => ({
       label: `${c.provider}: ${c.dataSourceId}`,
-      url: `/poke/${c.workspaceId}/data_sources/${c.dataSourceId}`,
+      url: `https://poke.dust.tt/${c.workspaceId}/data_sources/${c.dataSourceId}`,
     }));
     reportFailure(
       { hasExtraneousWorklows, actionLinks },

--- a/front/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors.ts
+++ b/front/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { getConnectorsPrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
 import type { ConnectorProvider } from "@app/types/data_source";
@@ -78,7 +79,7 @@ export const checkExtraneousWorkflows: CheckFunction = async (
   if (hasExtraneousWorklows.length > 0) {
     const actionLinks: ActionLink[] = hasExtraneousWorklows.map((c) => ({
       label: `${c.provider}: ${c.dataSourceId}`,
-      url: `https://poke.dust.tt/${c.workspaceId}/data_sources/${c.dataSourceId}`,
+      url: `${config.getPokeAppUrl()}/${c.workspaceId}/data_sources/${c.dataSourceId}`,
     }));
     reportFailure(
       { hasExtraneousWorklows, actionLinks },


### PR DESCRIPTION
## Description

Adds the full Poke url in the production checks errors. Eng-oncalls can now copy-paste the url drectly.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
