### PR TITLE
Context-Usage: move to InputBarContext

### DIFF
--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -1,3 +1,4 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useCompactConversation } from "@app/hooks/conversations";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -8,7 +9,6 @@ import {
   PopoverTrigger,
 } from "@dust-tt/sparkle";
 import { useContext } from "react";
-import { InputBarContext } from "./InputBarContext";
 
 interface ContextUsageIndicatorProps {
   buttonSize: "xs" | "sm";

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -1,7 +1,4 @@
-import {
-  useCompactConversation,
-  useConversationContextUsage,
-} from "@app/hooks/conversations";
+import { useCompactConversation } from "@app/hooks/conversations";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -10,6 +7,8 @@ import {
   PopoverRoot,
   PopoverTrigger,
 } from "@dust-tt/sparkle";
+import { useContext } from "react";
+import { InputBarContext } from "./InputBarContext";
 
 interface ContextUsageIndicatorProps {
   buttonSize: "xs" | "sm";
@@ -65,10 +64,7 @@ export function ContextUsageIndicator({
   owner,
   conversationId,
 }: ContextUsageIndicatorProps) {
-  const { contextUsage, isContextUsageLoading } = useConversationContextUsage({
-    conversationId,
-    workspaceId: owner.sId,
-  });
+  const { contextUsage, isContextUsageLoading } = useContext(InputBarContext);
 
   const { compact, isCompacting } = useCompactConversation({
     owner,

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -1,9 +1,11 @@
+import { useConversationContextUsage } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import {
   type FileUploaderService,
   useFileUploaderService,
 } from "@app/hooks/useFileUploaderService";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import type { GetConversationContextUsageResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage";
 import type { RichAgentMention } from "@app/types/assistant/mentions";
 import {
   createContext,
@@ -13,9 +15,17 @@ import {
   useState,
 } from "react";
 
-export const InputBarContext = createContext<{
+type ContextUsageMutator = ReturnType<
+  typeof useConversationContextUsage
+>["mutateContextUsage"];
+
+type InputBarContextValue = {
   animate: boolean;
+  contextUsage: GetConversationContextUsageResponse | null;
   getAndClearSelectedAgent: () => RichAgentMention | null;
+  isContextUsageLoading: boolean;
+  isContextUsageError: unknown;
+  mutateContextUsage: ContextUsageMutator;
   setAnimate: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
   selectedSingleAgent: RichAgentMention | null;
@@ -27,9 +37,15 @@ export const InputBarContext = createContext<{
     onCapture: (type: "text" | "screenshot") => void;
     isCapturing: boolean;
   };
-}>({
+};
+
+export const InputBarContext = createContext<InputBarContextValue>({
   animate: false,
+  contextUsage: null,
   getAndClearSelectedAgent: () => null,
+  isContextUsageLoading: false,
+  isContextUsageError: null,
+  mutateContextUsage: async () => undefined,
   setAnimate: () => {},
   setSelectedAgent: () => {},
   selectedSingleAgent: null,
@@ -52,6 +68,10 @@ export const InputBarContext = createContext<{
 interface InputBarContextProviderProps {
   children: ReactNode;
   fileUploaderService: FileUploaderService;
+  contextUsage: GetConversationContextUsageResponse | null;
+  isContextUsageLoading: boolean;
+  isContextUsageError: unknown;
+  mutateContextUsage: ContextUsageMutator;
   captureActions?: {
     onCapture: (type: "text" | "screenshot") => void;
     isCapturing: boolean;
@@ -61,6 +81,10 @@ interface InputBarContextProviderProps {
 export function InputBarContextProvider({
   children,
   fileUploaderService,
+  contextUsage,
+  isContextUsageLoading,
+  isContextUsageError,
+  mutateContextUsage,
   captureActions,
 }: InputBarContextProviderProps) {
   const [animate, setAnimate] = useState<boolean>(false);
@@ -113,8 +137,12 @@ export function InputBarContextProvider({
   const value = useMemo(
     () => ({
       animate,
+      contextUsage,
       setAnimate,
       getAndClearSelectedAgent,
+      isContextUsageLoading,
+      isContextUsageError,
+      mutateContextUsage,
       setSelectedAgent: setSelectedAgentOuter,
       selectedSingleAgent,
       setSelectedSingleAgent,
@@ -125,7 +153,11 @@ export function InputBarContextProvider({
     }),
     [
       animate,
+      contextUsage,
       getAndClearSelectedAgent,
+      isContextUsageLoading,
+      isContextUsageError,
+      mutateContextUsage,
       setSelectedAgentOuter,
       selectedSingleAgent,
       getAndClearPendingInputText,
@@ -149,6 +181,8 @@ export function InputBarProvider({ children }: InputBarProviderProps) {
   const conversationId = useActiveConversationId();
 
   const { workspace } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const isCompactionEnabled = hasFeature("enable_compaction");
 
   const useCaseMetadata = useMemo(() => {
     if (!conversationId) {
@@ -165,6 +199,17 @@ export function InputBarProvider({ children }: InputBarProviderProps) {
     useCaseMetadata,
   });
 
+  const {
+    contextUsage,
+    isContextUsageLoading,
+    isContextUsageError,
+    mutateContextUsage,
+  } = useConversationContextUsage({
+    conversationId: isCompactionEnabled ? conversationId : null,
+    workspaceId: workspace.sId,
+    options: { disabled: !isCompactionEnabled },
+  });
+
   // Reset fileBlobs when conversationId changes.
   // We intentionally avoid using a key prop as it would remount
   // the entire page subtree (InputBarStateProvider wraps children)
@@ -176,7 +221,13 @@ export function InputBarProvider({ children }: InputBarProviderProps) {
   }
 
   return (
-    <InputBarContextProvider fileUploaderService={fileUploaderService}>
+    <InputBarContextProvider
+      fileUploaderService={fileUploaderService}
+      contextUsage={contextUsage}
+      isContextUsageLoading={isContextUsageLoading}
+      isContextUsageError={isContextUsageError}
+      mutateContextUsage={mutateContextUsage}
+    >
       {children}
     </InputBarContextProvider>
   );

--- a/front/hooks/conversations/useConversationContextUsage.ts
+++ b/front/hooks/conversations/useConversationContextUsage.ts
@@ -25,7 +25,8 @@ export function useConversationContextUsage({
 
   return {
     contextUsage: data ?? null,
-    isContextUsageLoading: !error && !data,
+    isContextUsageLoading:
+      !options?.disabled && !!conversationId && !error && !data,
     isContextUsageError: error,
     mutateContextUsage: mutate,
   };


### PR DESCRIPTION
## Description

Preparatory work to `/compact` and forcing compaction when context usage is very high: move context-usage rertrieval to InputBarContext so that the related information can be used easily from the entire input bar.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`