### PR TITLE
Persist last navigation in projects.

### DIFF
--- a/front/components/assistant/conversation/space/SpaceTodosTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTodosTab.tsx
@@ -1,13 +1,23 @@
-import { ProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/ProjectTodosPanel";
+import {
+  ProjectTodosPanel,
+  type TodoOwnerFilter,
+} from "@app/components/assistant/conversation/space/conversations/ProjectTodosPanel";
 import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { WorkspaceType } from "@app/types/user";
 
 interface SpaceTodosTabProps {
   owner: WorkspaceType;
   spaceInfo: GetSpaceResponseBody["space"];
+  todoOwnerFilter: TodoOwnerFilter;
+  onTodoOwnerFilterChange: (value: TodoOwnerFilter) => void;
 }
 
-export function SpaceTodosTab({ owner, spaceInfo }: SpaceTodosTabProps) {
+export function SpaceTodosTab({
+  owner,
+  spaceInfo,
+  todoOwnerFilter,
+  onTodoOwnerFilterChange,
+}: SpaceTodosTabProps) {
   return (
     <div className="flex h-full min-h-0 w-full flex-1 overflow-y-auto px-6">
       <div className="mx-auto flex h-full w-full max-w-4xl flex-col py-8">
@@ -15,6 +25,8 @@ export function SpaceTodosTab({ owner, spaceInfo }: SpaceTodosTabProps) {
           owner={owner}
           spaceId={spaceInfo.sId}
           isReadOnly={!!spaceInfo.archivedAt || !spaceInfo.isMember}
+          todoOwnerFilter={todoOwnerFilter}
+          onTodoOwnerFilterChange={onTodoOwnerFilterChange}
         />
       </div>
     </div>

--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -653,7 +653,12 @@ function EditableTodoItem({
   );
 }
 
-type TodoAssigneeScope = "mine" | "all" | "users";
+export type TodoAssigneeScope = "mine" | "all" | "users";
+
+export interface TodoOwnerFilter {
+  assigneeScope: TodoAssigneeScope;
+  selectedUserSIds: string[];
+}
 
 function formatTodoScopeLabel({
   scope,
@@ -725,14 +730,14 @@ function TodoAssigneeHeader({
 function EditableProjectTodosPanel({
   owner,
   spaceId,
+  todoOwnerFilter,
+  onTodoOwnerFilterChange,
 }: {
   owner: LightWorkspaceType;
   spaceId: string;
+  todoOwnerFilter: TodoOwnerFilter;
+  onTodoOwnerFilterChange: (value: TodoOwnerFilter) => void;
 }) {
-  const [assigneeScope, setAssigneeScope] = useState<TodoAssigneeScope>("all");
-  const [selectedUserSIds, setSelectedUserSIds] = useState<Set<string>>(
-    new Set()
-  );
   const [assigneeSearch, setAssigneeSearch] = useState("");
   const [isAssigneeMenuOpen, setIsAssigneeMenuOpen] = useState(false);
   const {
@@ -820,6 +825,10 @@ function EditableProjectTodosPanel({
     () => new Map(users.map((user) => [user.sId, user])),
     [users]
   );
+  const selectedUserSIds = useMemo(
+    () => new Set(todoOwnerFilter.selectedUserSIds),
+    [todoOwnerFilter.selectedUserSIds]
+  );
   const filteredUsers = useMemo(() => {
     const normalizedSearch = assigneeSearch.trim().toLowerCase();
     if (!normalizedSearch) {
@@ -831,14 +840,14 @@ function EditableProjectTodosPanel({
     );
   }, [assigneeSearch, users]);
   const todoScopeLabel = formatTodoScopeLabel({
-    scope: assigneeScope,
+    scope: todoOwnerFilter.assigneeScope,
     selectedUserSIds,
     usersBySId,
     viewerUserId,
   });
 
   const filteredTodos = useMemo(() => {
-    switch (assigneeScope) {
+    switch (todoOwnerFilter.assigneeScope) {
       case "all":
         return todos;
       case "mine":
@@ -854,7 +863,7 @@ function EditableProjectTodosPanel({
           (todo) => !!todo.user?.sId && selectedUserSIds.has(todo.user.sId)
         );
     }
-  }, [assigneeScope, selectedUserSIds, todos, viewerUserId]);
+  }, [selectedUserSIds, todoOwnerFilter.assigneeScope, todos, viewerUserId]);
   const hasDoneItems = filteredTodos.some((todo) => todo.status === "done");
   const groupedTodosForAll = useMemo(() => {
     const groups = new Map<
@@ -1086,10 +1095,12 @@ function EditableProjectTodosPanel({
             <DropdownMenuCheckboxItem
               icon={UserIcon}
               label="Your to-dos"
-              checked={assigneeScope === "mine"}
+              checked={todoOwnerFilter.assigneeScope === "mine"}
               onClick={() => {
-                setAssigneeScope("mine");
-                setSelectedUserSIds(new Set());
+                onTodoOwnerFilterChange({
+                  assigneeScope: "mine",
+                  selectedUserSIds: [],
+                });
                 setIsAssigneeMenuOpen(false);
               }}
               onSelect={(event) => {
@@ -1099,10 +1110,12 @@ function EditableProjectTodosPanel({
             <DropdownMenuCheckboxItem
               icon={UserGroupIcon}
               label="Project's to-dos"
-              checked={assigneeScope === "all"}
+              checked={todoOwnerFilter.assigneeScope === "all"}
               onClick={() => {
-                setAssigneeScope("all");
-                setSelectedUserSIds(new Set());
+                onTodoOwnerFilterChange({
+                  assigneeScope: "all",
+                  selectedUserSIds: [],
+                });
                 setIsAssigneeMenuOpen(false);
               }}
               onSelect={(event) => {
@@ -1125,19 +1138,19 @@ function EditableProjectTodosPanel({
                     )}
                     label={`${user.fullName}${viewerUserId === user.sId ? " (you)" : ""}`}
                     checked={
-                      assigneeScope === "users" &&
+                      todoOwnerFilter.assigneeScope === "users" &&
                       selectedUserSIds.has(user.sId)
                     }
                     onClick={() => {
-                      setSelectedUserSIds((previous) => {
-                        const next = new Set(previous);
-                        if (next.has(user.sId)) {
-                          next.delete(user.sId);
-                        } else {
-                          next.add(user.sId);
-                        }
-                        setAssigneeScope(next.size === 0 ? "all" : "users");
-                        return next;
+                      const next = new Set(selectedUserSIds);
+                      if (next.has(user.sId)) {
+                        next.delete(user.sId);
+                      } else {
+                        next.add(user.sId);
+                      }
+                      onTodoOwnerFilterChange({
+                        assigneeScope: next.size === 0 ? "all" : "users",
+                        selectedUserSIds: [...next],
                       });
                     }}
                     onSelect={(event) => {
@@ -1229,16 +1242,27 @@ interface ProjectTodosPanelProps {
   owner: LightWorkspaceType;
   spaceId: string;
   isReadOnly: boolean;
+  todoOwnerFilter: TodoOwnerFilter;
+  onTodoOwnerFilterChange: (value: TodoOwnerFilter) => void;
 }
 
 export function ProjectTodosPanel({
   owner,
   spaceId,
   isReadOnly,
+  todoOwnerFilter,
+  onTodoOwnerFilterChange,
 }: ProjectTodosPanelProps) {
   if (isReadOnly) {
     return <ReadOnlyProjectTodosPanel owner={owner} spaceId={spaceId} />;
   }
 
-  return <EditableProjectTodosPanel owner={owner} spaceId={spaceId} />;
+  return (
+    <EditableProjectTodosPanel
+      owner={owner}
+      spaceId={spaceId}
+      todoOwnerFilter={todoOwnerFilter}
+      onTodoOwnerFilterChange={onTodoOwnerFilterChange}
+    />
+  );
 }

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -1,4 +1,5 @@
 import { SpaceAboutTab } from "@app/components/assistant/conversation/space/about/SpaceAboutTab";
+import type { TodoOwnerFilter } from "@app/components/assistant/conversation/space/conversations/ProjectTodosPanel";
 import { SpaceConversationsTab } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsTab";
 import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
 import { ProjectHeaderActions } from "@app/components/assistant/conversation/space/ProjectHeaderActions";
@@ -11,6 +12,12 @@ import type { SpaceConversationListFilter } from "@app/hooks/conversations/useSp
 import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useScopedUIPreferences } from "@app/hooks/useScopedUIPreferences";
+import {
+  DEFAULT_SPACE_PROJECT_UI_PREFERENCES,
+  type SpaceProjectTab,
+  useSpaceProjectTabs,
+} from "@app/hooks/useSpaceProjectTabs";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import {
   useAuth,
@@ -45,9 +52,7 @@ import {
   TabsTrigger,
   TestTubeIcon,
 } from "@dust-tt/sparkle";
-import React, { useCallback, useRef, useState } from "react";
-
-type SpaceTab = "conversations" | "todos" | "knowledge" | "settings";
+import { useCallback, useState } from "react";
 
 export function SpaceConversationsPage() {
   const owner = useWorkspace();
@@ -73,8 +78,14 @@ export function SpaceConversationsPage() {
     owner,
     user,
   });
-  const [conversationFilter, setConversationFilter] =
-    useState<SpaceConversationListFilter>("all");
+
+  const { value: projectUIPreferences, setValue: setProjectUIPreferences } =
+    useScopedUIPreferences({
+      scope: "projectUI",
+      resourceId: spaceId,
+      defaultValue: DEFAULT_SPACE_PROJECT_UI_PREFERENCES,
+    });
+  const conversationFilter = projectUIPreferences.conversationsFilter;
 
   const {
     conversations,
@@ -93,100 +104,34 @@ export function SpaceConversationsPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [_planLimitReached, setPlanLimitReached] = useState(false);
   const [isInvitePanelOpen, setIsInvitePanelOpen] = useState(false);
-  const canShowTodosTab =
-    hasFeature("project_todo") && spaceInfo?.kind === "project";
+  const canShowTodosTab = hasFeature("project_todo");
 
-  // Parse and validate the current tab from URL hash
-  const getCurrentTabFromHash = useCallback((): SpaceTab => {
-    if (typeof window === "undefined") {
-      return "conversations";
-    }
-    const hash = window.location.hash.slice(1); // Remove the # prefix
-    // Backward compatibility: treat "context" as "knowledge"
-    if (hash === "context") {
-      return "knowledge";
-    }
-    if (
-      hash === "knowledge" ||
-      hash === "settings" ||
-      hash === "conversations" ||
-      hash === "todos"
-    ) {
-      return hash;
-    }
-    return "conversations";
-  }, []);
+  const { currentTab, handleTabChange } = useSpaceProjectTabs({
+    spaceId,
+    projectUIPreferences,
+    setProjectUIPreferences,
+    canShowTodosTab,
+  });
 
-  const [currentTab, setCurrentTab] = useState<SpaceTab>(getCurrentTabFromHash);
+  const handleConversationFilterChange = useCallback(
+    (filter: SpaceConversationListFilter) => {
+      setProjectUIPreferences({
+        ...projectUIPreferences,
+        conversationsFilter: filter,
+      });
+    },
+    [projectUIPreferences, setProjectUIPreferences]
+  );
 
-  // Sync current tab with URL hash
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  React.useEffect(() => {
-    const updateTabFromHash = () => {
-      const newTab = getCurrentTabFromHash();
-      setCurrentTab(newTab);
-
-      // Ensure URL has a hash. Defer with setTimeout so the route-change
-      // event fires with the empty hash first (otherwise useHashParam sees a
-      // non-empty hash and won't clear the conversation side-panel state when
-      // navigating into a project).
-      if (!window.location.hash) {
-        setTimeout(() => {
-          if (!window.location.hash) {
-            window.history.replaceState(
-              null,
-              "",
-              `${window.location.pathname}${window.location.search}#${newTab}`
-            );
-          }
-        }, 0);
-      }
-    };
-
-    // Update on mount
-    updateTabFromHash();
-
-    // Listen for hash changes
-    window.addEventListener("hashchange", updateTabFromHash);
-    return () => window.removeEventListener("hashchange", updateTabFromHash);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only run on mount and cleanup on unmount
-
-  // Reset tab to conversations when navigating to a different project.
-  const prevSpaceIdRef = useRef(spaceId);
-  React.useEffect(() => {
-    if (prevSpaceIdRef.current !== spaceId) {
-      prevSpaceIdRef.current = spaceId;
-      setCurrentTab("conversations");
-      setConversationFilter("all");
-      window.history.replaceState(
-        null,
-        "",
-        `${window.location.pathname}${window.location.search}#conversations`
-      );
-    }
-  }, [spaceId]);
-
-  React.useEffect(() => {
-    if (currentTab === "todos" && !canShowTodosTab) {
-      setCurrentTab("conversations");
-      window.history.replaceState(
-        null,
-        "",
-        `${window.location.pathname}${window.location.search}#conversations`
-      );
-    }
-  }, [canShowTodosTab, currentTab]);
-
-  const handleTabChange = useCallback((tab: SpaceTab) => {
-    // Use replaceState to avoid adding to browser history for each tab switch
-    window.history.replaceState(
-      null,
-      "",
-      `${window.location.pathname}${window.location.search}#${tab}`
-    );
-    setCurrentTab(tab);
-  }, []);
+  const handleTodoOwnerFilterChange = useCallback(
+    (todosOwnerFilter: TodoOwnerFilter) => {
+      setProjectUIPreferences({
+        ...projectUIPreferences,
+        todosOwnerFilter,
+      });
+    },
+    [projectUIPreferences, setProjectUIPreferences]
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const handleConversationCreation = useCallback(
@@ -341,7 +286,7 @@ export function SpaceConversationsPage() {
           spaceInfo={spaceInfo}
           isSpaceEmpty={isSpaceEmpty}
           conversationFilter={conversationFilter}
-          onConversationFilterChange={setConversationFilter}
+          onConversationFilterChange={handleConversationFilterChange}
           onSubmit={handleConversationCreation}
           onOpenMembersPanel={() => setIsInvitePanelOpen(true)}
         />
@@ -353,7 +298,7 @@ export function SpaceConversationsPage() {
     <div className="flex h-full w-full flex-col">
       <Tabs
         value={currentTab}
-        onValueChange={(value) => handleTabChange(value as SpaceTab)}
+        onValueChange={(value) => handleTabChange(value as SpaceProjectTab)}
         className="flex min-h-0 flex-1 flex-col pt-3"
       >
         <div className="flex items-start justify-between border-b border-separator pl-14 pr-6 lg:px-6 dark:border-separator-night">
@@ -410,7 +355,7 @@ export function SpaceConversationsPage() {
             spaceInfo={spaceInfo}
             isSpaceEmpty={isSpaceEmpty}
             conversationFilter={conversationFilter}
-            onConversationFilterChange={setConversationFilter}
+            onConversationFilterChange={handleConversationFilterChange}
             onSubmit={handleConversationCreation}
             onOpenMembersPanel={() => setIsInvitePanelOpen(true)}
           />
@@ -422,7 +367,12 @@ export function SpaceConversationsPage() {
 
         {canShowTodosTab && (
           <TabsContent value="todos">
-            <SpaceTodosTab owner={owner} spaceInfo={spaceInfo} />
+            <SpaceTodosTab
+              owner={owner}
+              spaceInfo={spaceInfo}
+              todoOwnerFilter={projectUIPreferences.todosOwnerFilter}
+              onTodoOwnerFilterChange={handleTodoOwnerFilterChange}
+            />
           </TabsContent>
         )}
 

--- a/front/hooks/useScopedUIPreferences.ts
+++ b/front/hooks/useScopedUIPreferences.ts
@@ -1,0 +1,145 @@
+import { useCallback, useLayoutEffect, useMemo, useState } from "react";
+import { z } from "zod";
+
+const SCOPED_UI_PREFERENCES_KEY_PREFIX = "scopedUIPreferences";
+
+const scopedUIPreferencesSchemaByScope = {
+  projectUI: z.object({
+    tab: z.enum(["conversations", "todos", "knowledge", "settings", "alpha"]),
+    conversationsFilter: z.enum(["all", "group", "with_me"]),
+    todosOwnerFilter: z.object({
+      assigneeScope: z.enum(["mine", "all", "users"]),
+      selectedUserSIds: z.array(z.string()),
+    }),
+  }),
+} as const;
+
+export type ProjectUIScopedPreferences = z.infer<
+  (typeof scopedUIPreferencesSchemaByScope)["projectUI"]
+>;
+
+export type ScopedUIPreferencesScope =
+  keyof typeof scopedUIPreferencesSchemaByScope;
+type ScopeSchema<TScope extends ScopedUIPreferencesScope> =
+  (typeof scopedUIPreferencesSchemaByScope)[TScope];
+type ScopeValue<TScope extends ScopedUIPreferencesScope> =
+  ScopeSchema<TScope>["_output"];
+
+interface UseScopedUIPreferencesOptions<
+  TScope extends ScopedUIPreferencesScope,
+> {
+  scope: TScope;
+  /** When null/undefined/empty, preferences are not read or written (avoids a shared `"null"` key). */
+  resourceId: string | null | undefined;
+  defaultValue: ScopeValue<TScope>;
+}
+
+interface ScopedUIPreferencesState<TScope extends ScopedUIPreferencesScope> {
+  value: ScopeValue<TScope>;
+  setValue: (value: ScopeValue<TScope>) => void;
+  resetValue: () => void;
+}
+
+function readPersistedValue(storageKey: string): unknown {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const rawValue = localStorage.getItem(storageKey);
+    if (!rawValue) {
+      return null;
+    }
+
+    return JSON.parse(rawValue);
+  } catch {
+    // Corrupted or unavailable localStorage — start fresh.
+    return null;
+  }
+}
+
+function writePersistedValue(storageKey: string, value: unknown) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(value));
+  } catch {
+    // localStorage may be full or unavailable — silently ignore.
+  }
+}
+
+/** Read persisted preferences synchronously (e.g. when `spaceId` changes before hook state catches up). */
+export function readScopedUIPreferencesValue<
+  TScope extends ScopedUIPreferencesScope,
+>(
+  scope: TScope,
+  resourceId: string | null | undefined,
+  defaultValue: ScopeValue<TScope>
+): ScopeValue<TScope> {
+  if (resourceId === null || resourceId === undefined || resourceId === "") {
+    return defaultValue;
+  }
+  const storageKey = `${SCOPED_UI_PREFERENCES_KEY_PREFIX}:${scope}:${resourceId}`;
+  const schema = scopedUIPreferencesSchemaByScope[scope];
+  const candidateValue = readPersistedValue(storageKey);
+  const parsedValue = schema.safeParse(candidateValue);
+  return parsedValue.success ? parsedValue.data : defaultValue;
+}
+
+export function useScopedUIPreferences<
+  TScope extends ScopedUIPreferencesScope,
+>({
+  scope,
+  resourceId,
+  defaultValue,
+}: UseScopedUIPreferencesOptions<TScope>): ScopedUIPreferencesState<TScope> {
+  const schema = scopedUIPreferencesSchemaByScope[scope];
+  const storageKey = useMemo(() => {
+    if (resourceId === null || resourceId === undefined || resourceId === "") {
+      return null;
+    }
+    return `${SCOPED_UI_PREFERENCES_KEY_PREFIX}:${scope}:${resourceId}`;
+  }, [resourceId, scope]);
+
+  const readValue = useCallback((): ScopeValue<TScope> => {
+    if (!storageKey) {
+      return defaultValue;
+    }
+    const candidateValue = readPersistedValue(storageKey);
+    const parsedValue = schema.safeParse(candidateValue);
+    return parsedValue.success ? parsedValue.data : defaultValue;
+  }, [defaultValue, schema, storageKey]);
+
+  const [value, setValueState] = useState<ScopeValue<TScope>>(() =>
+    readValue()
+  );
+
+  useLayoutEffect(() => {
+    setValueState(readValue());
+  }, [readValue]);
+
+  const setValue = useCallback(
+    (newValue: ScopeValue<TScope>) => {
+      setValueState(newValue);
+      if (storageKey) {
+        writePersistedValue(storageKey, newValue);
+      }
+    },
+    [storageKey]
+  );
+
+  const resetValue = useCallback(() => {
+    setValueState(defaultValue);
+    if (storageKey) {
+      writePersistedValue(storageKey, defaultValue);
+    }
+  }, [defaultValue, storageKey]);
+
+  return {
+    value,
+    setValue,
+    resetValue,
+  };
+}

--- a/front/hooks/useSpaceProjectTabs.ts
+++ b/front/hooks/useSpaceProjectTabs.ts
@@ -1,0 +1,159 @@
+import {
+  type ProjectUIScopedPreferences,
+  readScopedUIPreferencesValue,
+} from "@app/hooks/useScopedUIPreferences";
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+
+export type SpaceProjectTab = ProjectUIScopedPreferences["tab"];
+
+export const DEFAULT_SPACE_PROJECT_UI_PREFERENCES: ProjectUIScopedPreferences =
+  {
+    tab: "conversations",
+    conversationsFilter: "all",
+    todosOwnerFilter: {
+      assigneeScope: "all",
+      selectedUserSIds: [],
+    },
+  };
+
+/** Hash segment → tab when the user navigates with the hash (same space). */
+export function parseSpaceTabFromLocationHash(
+  fallbackTab: SpaceProjectTab
+): SpaceProjectTab {
+  if (typeof window === "undefined") {
+    return fallbackTab;
+  }
+  const hash = window.location.hash.slice(1);
+  if (hash === "context") {
+    return "knowledge";
+  }
+  if (
+    hash === "knowledge" ||
+    hash === "settings" ||
+    hash === "conversations" ||
+    hash === "todos" ||
+    hash === "alpha"
+  ) {
+    return hash;
+  }
+  return fallbackTab;
+}
+
+function replaceUrlHashWithTab(tab: SpaceProjectTab) {
+  window.history.replaceState(
+    null,
+    "",
+    `${window.location.pathname}${window.location.search}#${tab}`
+  );
+}
+
+interface UseSpaceProjectTabsParams {
+  spaceId: string | null;
+  projectUIPreferences: ProjectUIScopedPreferences;
+  setProjectUIPreferences: (value: ProjectUIScopedPreferences) => void;
+  canShowTodosTab: boolean;
+}
+
+/**
+ * Space page tabs: URL hash + `projectUI` scoped preferences (per space).
+ * - On `spaceId` change: restore persisted tab and sync the hash.
+ * - On `hashchange`: follow hash and persist.
+ * - Empty hash: deferred `replaceState` so other layout hooks can observe an empty hash first.
+ */
+export function useSpaceProjectTabs({
+  spaceId,
+  projectUIPreferences,
+  setProjectUIPreferences,
+  canShowTodosTab,
+}: UseSpaceProjectTabsParams): {
+  currentTab: SpaceProjectTab;
+  handleTabChange: (tab: SpaceProjectTab) => void;
+} {
+  const [currentTab, setCurrentTab] =
+    useState<SpaceProjectTab>("conversations");
+
+  useLayoutEffect(() => {
+    if (!spaceId || typeof window === "undefined") {
+      return;
+    }
+    const persisted = readScopedUIPreferencesValue(
+      "projectUI",
+      spaceId,
+      DEFAULT_SPACE_PROJECT_UI_PREFERENCES
+    );
+    const newTab = persisted.tab;
+    setCurrentTab(newTab);
+    replaceUrlHashWithTab(newTab);
+  }, [spaceId]);
+
+  useEffect(() => {
+    if (!spaceId) {
+      return;
+    }
+    const onHashChange = () => {
+      const persisted = readScopedUIPreferencesValue(
+        "projectUI",
+        spaceId,
+        DEFAULT_SPACE_PROJECT_UI_PREFERENCES
+      );
+      const tab = parseSpaceTabFromLocationHash(persisted.tab);
+      setCurrentTab(tab);
+      setProjectUIPreferences({
+        ...persisted,
+        tab,
+      });
+    };
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, [setProjectUIPreferences, spaceId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !spaceId) {
+      return;
+    }
+    if (!window.location.hash) {
+      const persisted = readScopedUIPreferencesValue(
+        "projectUI",
+        spaceId,
+        DEFAULT_SPACE_PROJECT_UI_PREFERENCES
+      );
+      const newTab = persisted.tab;
+      const timeoutId = window.setTimeout(() => {
+        if (!window.location.hash) {
+          replaceUrlHashWithTab(newTab);
+        }
+      }, 0);
+      return () => window.clearTimeout(timeoutId);
+    }
+  }, [spaceId]);
+
+  useEffect(() => {
+    if (currentTab === "todos" && !canShowTodosTab) {
+      setCurrentTab("conversations");
+      setProjectUIPreferences({
+        ...projectUIPreferences,
+        tab: "conversations",
+      });
+      replaceUrlHashWithTab("conversations");
+    }
+  }, [
+    canShowTodosTab,
+    currentTab,
+    projectUIPreferences,
+    setProjectUIPreferences,
+  ]);
+
+  const handleTabChange = useCallback(
+    (tab: SpaceProjectTab) => {
+      replaceUrlHashWithTab(tab);
+      setCurrentTab(tab);
+      setProjectUIPreferences({
+        ...projectUIPreferences,
+        tab,
+      });
+    },
+    [projectUIPreferences, setProjectUIPreferences]
+  );
+
+  return { currentTab, handleTabChange };
+}


### PR DESCRIPTION
## Description

All navigation state in the project page — active tab, conversation filter, and todo owner filter — was ephemeral `useState`. Navigating away from a project and back reset everything to defaults. This PR persists it all to `localStorage` scoped by project, so the user returns to where they left off.

- **`useScopedUIPreferences`** — new generic hook backed by `localStorage` with Zod schema validation per scope; keyed as `scopedUIPreferences:{scope}:{resourceId}` (here `projectUI:{spaceId}`); validates on read with `safeParse` and falls back to `defaultValue` on failure or missing storage; exposes `value`, `setValue`, `resetValue`; `useLayoutEffect` re-reads when `spaceId` changes to avoid stale-closure bugs
- **`useSpaceProjectTabs`** — extracts tab management out of `SpaceConversationsPage`: hash sync on mount + `hashchange`, space-change reset (via `readScopedUIPreferencesValue` for SSR-safe synchronous read), `canShowTodosTab` guard redirect; persists active tab into `projectUIPreferences`
- **`TodoOwnerFilter` lifted to props** — `assigneeScope` and `selectedUserSIds` move from `EditableProjectTodosPanel` internal `useState` to `todoOwnerFilter` / `onTodoOwnerFilterChange` props; threaded through `ProjectTodosPanel` → `SpaceTodosTab` → `SpaceConversationsPage`
- **`SpaceConversationsPage`** — replace `useState` + manual `window.history` effects with `useScopedUIPreferences` + `useSpaceProjectTabs`; persists `conversationsFilter` and `todosOwnerFilter` changes via `setProjectUIPreferences`; remove `prevSpaceIdRef` and all hash effects

## Tests

Local

## Risk

Low — falls back to defaults when `localStorage` is unavailable (private browsing, quota exceeded, corrupted value); schema validation ensures stale/invalid stored values are ignored

## Deploy Plan

Deploy `front`
