### PR TITLE
Fix old skill version rollback with html

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -330,7 +330,7 @@ export function SkillBuilderInstructionsEditor({
 
   // Sync external changes to the editor content
   useEffect(() => {
-    if (!editor || !instructionsHtmlField.value) {
+    if (!editor || isDiffMode || !instructionsHtmlField.value) {
       return;
     }
 
@@ -349,37 +349,66 @@ export function SkillBuilderInstructionsEditor({
     if (currentHtml !== incomingHtml) {
       editor.commands.setContent(incomingHtml, { emitUpdate: false });
     }
-  }, [editor, instructionsHtmlField.value]);
+  }, [editor, isDiffMode, instructionsHtmlField.value]);
 
   useEffect(() => {
-    if (!editor) {
+    if (!editor || editor.isDestroyed) {
       return;
     }
 
-    if (compareVersion) {
-      if (editor.storage.agentInstructionDiff?.isDiffMode) {
-        editor.commands.exitDiff();
+    const frameId = requestAnimationFrame(() => {
+      if (!editor || editor.isDestroyed) {
+        return;
       }
 
-      const compareText = compareVersion.instructions ?? "";
-      const currentText = instructionsField.value ?? "";
+      if (compareVersion) {
+        if (editor.storage.agentInstructionDiff?.isDiffMode) {
+          editor.commands.exitDiff();
+        }
 
-      editor.commands.setContent(preprocessMarkdownForEditor(currentText), {
-        emitUpdate: false,
-        contentType: "markdown",
-      });
-      editor.commands.applyDiff(
-        preprocessMarkdownForEditor(compareText),
-        preprocessMarkdownForEditor(currentText)
-      );
-      editor.setEditable(false);
-    } else if (editor.storage.agentInstructionDiff?.isDiffMode) {
-      editor.commands.exitDiff();
-      editor.setEditable(true);
-    }
+        const compareText = compareVersion.instructions ?? "";
+        const currentText = instructionsField.value ?? "";
+
+        editor.commands.setContent(preprocessMarkdownForEditor(currentText), {
+          emitUpdate: false,
+          contentType: "markdown",
+        });
+        editor.commands.applyDiff(
+          preprocessMarkdownForEditor(compareText),
+          preprocessMarkdownForEditor(currentText)
+        );
+        editor.setEditable(false);
+      } else if (editor.storage.agentInstructionDiff?.isDiffMode) {
+        editor.commands.exitDiff();
+        editor.setEditable(true);
+
+        if (instructionsHtmlField.value) {
+          editor.commands.setContent(instructionsHtmlField.value, {
+            emitUpdate: false,
+          });
+        } else {
+          editor.commands.setContent(
+            preprocessMarkdownForEditor(instructionsField.value ?? ""),
+            {
+              emitUpdate: false,
+              contentType: "markdown",
+            }
+          );
+        }
+      }
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
     // Re-run when instructionsField.value changes so that restoring a single
     // field updates the diff overlay.
-  }, [compareVersion, editor, instructionsField.value]);
+  }, [
+    compareVersion,
+    editor,
+    instructionsField.value,
+    instructionsHtmlField.value,
+  ]);
 
   return (
     <div className="space-y-1 p-px">

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -14,10 +14,11 @@ import { useFormContext } from "react-hook-form";
 const LARGE_INSTRUCTIONS_CHARACTER_THRESHOLD = 40_000;
 
 const INSTRUCTIONS_FIELD_NAME = "instructions";
+const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 
 export function SkillBuilderInstructionsSection() {
   const { setValue, watch } = useFormContext<SkillBuilderFormData>();
-  const { compareVersion } = useSkillVersionComparisonContext();
+  const { compareVersion, exitDiffMode } = useSkillVersionComparisonContext();
   const [addKnowledge, setAddKnowledge] = useState<(() => void) | null>(null);
 
   const currentInstructions = watch(INSTRUCTIONS_FIELD_NAME);
@@ -33,6 +34,12 @@ export function SkillBuilderInstructionsSection() {
       shouldDirty: true,
       shouldValidate: true,
     });
+    setValue(
+      INSTRUCTIONS_HTML_FIELD_NAME,
+      compareVersion.instructionsHtml ?? "",
+      { shouldDirty: true }
+    );
+    exitDiffMode();
   };
 
   return (

--- a/front/components/skill_builder/SkillBuilderVersionComparisonFooter.tsx
+++ b/front/components/skill_builder/SkillBuilderVersionComparisonFooter.tsx
@@ -16,6 +16,9 @@ export function SkillBuilderVersionComparisonFooter() {
     setValue("instructions", compareVersion.instructions ?? "", {
       shouldDirty: true,
     });
+    setValue("instructionsHtml", compareVersion.instructionsHtml ?? "", {
+      shouldDirty: true,
+    });
     setValue("agentFacingDescription", compareVersion.agentFacingDescription, {
       shouldDirty: true,
     });

--- a/front/pages/api/w/[wId]/skills/[sId]/history/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/history/index.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
 import { GetSkillHistoryQuerySchema } from "@app/types/api/internal/skill";
@@ -75,10 +76,19 @@ async function handler(
         skillVersionResources = skillVersionResources.slice(0, limit);
       }
 
-      const skillVersions = skillVersionResources.map((resource) => ({
-        ...resource.toJSON(auth),
-        version: resource.version,
-      }));
+      const skillVersions = skillVersionResources.map((resource) => {
+        const serializedSkill = resource.toJSON(auth);
+
+        return {
+          ...serializedSkill,
+          instructionsHtml:
+            serializedSkill.instructionsHtml ??
+            (serializedSkill.instructions
+              ? convertMarkdownToBlockHtml(serializedSkill.instructions)
+              : null),
+          version: resource.version,
+        };
+      });
 
       return res.status(200).json({ history: skillVersions });
     default:


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/7849
* I was not able to reproduce the exact issue, but found this to be a potential risk. We did not migrate all old skill versions to use instructionsHtml. Since this is not required for reinforced workflows, we can do this as required in the browser
* Also didn't understand why we didn't exitDiff mode after selecting restore selections, so did that so you can continue editing without saving/refreshing the page

## Tests

<img width="1095" height="563" alt="Screenshot 2026-05-01 at 12 33 09 PM" src="https://github.com/user-attachments/assets/7700c73e-5c23-477f-816d-63770e6c6152" />


## Risk

* Low (already broken in some cases)

## Deploy Plan

* Deploy front