### PR TITLE
Show custom MCP server view names in Poke

### DIFF
--- a/front/components/poke/mcp_server_views/columns.tsx
+++ b/front/components/poke/mcp_server_views/columns.tsx
@@ -39,9 +39,7 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
       cell: ({ row }) => {
         const { mcpServerViewLink, name } = row.original;
 
-        return (
-          <LinkWrapper href={mcpServerViewLink}>{name ?? ""}</LinkWrapper>
-        );
+        return <LinkWrapper href={mcpServerViewLink}>{name ?? ""}</LinkWrapper>;
       },
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Custom name" />

--- a/front/components/poke/mcp_server_views/columns.tsx
+++ b/front/components/poke/mcp_server_views/columns.tsx
@@ -5,6 +5,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 
 interface MCPServerView {
   sId: string;
+  name: string | null;
   createdAt: number;
   updatedAt: number;
   spaceId: string;
@@ -31,6 +32,19 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
       },
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="sId" />
+      ),
+    },
+    {
+      accessorKey: "name",
+      cell: ({ row }) => {
+        const { mcpServerViewLink, name } = row.original;
+
+        return (
+          <LinkWrapper href={mcpServerViewLink}>{name ?? ""}</LinkWrapper>
+        );
+      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Custom name" />
       ),
     },
     {

--- a/front/components/poke/mcp_server_views/table.tsx
+++ b/front/components/poke/mcp_server_views/table.tsx
@@ -26,7 +26,6 @@ function prepareMCPServerViewsForDisplay(
         spaceLink: `/poke/${owner.sId}/spaces/${sv.spaceId}`,
         editedAt: sv.editedByUser?.editedAt ?? undefined,
         editedBy: sv.editedByUser?.fullName ?? undefined,
-        name: sv.server.name,
       };
 
       return result;

--- a/front/components/poke/mcp_server_views/view.tsx
+++ b/front/components/poke/mcp_server_views/view.tsx
@@ -8,10 +8,7 @@ import {
   PokeTableHead,
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
-import {
-  getMcpServerViewDescription,
-  getMcpServerViewDisplayName,
-} from "@app/lib/actions/mcp_helper";
+import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { PokeMCPServerViewType } from "@app/types/poke";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -39,9 +36,13 @@ export function ViewMCPServerViewTable({
                 <PokeTableCellWithCopy label={mcpServerView.id.toString()} />
               </PokeTableRow>
               <PokeTableRow>
+                <PokeTableHead>Custom Name</PokeTableHead>
+                <PokeTableCell>{mcpServerView.customName ?? ""}</PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
                 <PokeTableHead>Server Name</PokeTableHead>
                 <PokeTableCell>
-                  {getMcpServerViewDisplayName(mcpServerView)}
+                  {getMcpServerDisplayName(mcpServerView.server)}
                 </PokeTableCell>
               </PokeTableRow>
               <PokeTableRow>
@@ -49,9 +50,13 @@ export function ViewMCPServerViewTable({
                 <PokeTableCellWithCopy label={mcpServerView.server.sId} />
               </PokeTableRow>
               <PokeTableRow>
+                <PokeTableHead>Custom Description</PokeTableHead>
+                <PokeTableCell>{mcpServerView.description ?? ""}</PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
                 <PokeTableHead>Server Description</PokeTableHead>
                 <PokeTableCell>
-                  {getMcpServerViewDescription(mcpServerView)}
+                  {mcpServerView.server.description}
                 </PokeTableCell>
               </PokeTableRow>
               <PokeTableRow>

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -108,7 +108,8 @@ export async function mcpServerViewToPokeJSON(
     link: workspace
       ? `${config.getPokeAppUrl()}/${workspace.sId}/spaces/${mcpServerView.space.sId}/mcp_server_views/${mcpServerView.sId}`
       : null,
-    name: json.server.name,
+    name: json.name ?? json.server.name,
+    customName: json.name,
     type: "MCP Server View",
     space: spaceToPokeJSON(mcpServerView.space),
     connections: connections,

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -49,6 +49,7 @@ export type PokeDataSourceViewType = DataSourceViewType &
 
 export type PokeMCPServerViewType = MCPServerViewType &
   PokeItemBase & {
+    customName: string | null;
     space: PokeSpaceType;
     connections: {
       connectionType: "workspace" | "personal";


### PR DESCRIPTION
## Description

Poke wasn't surfacing the user-set custom name and description on MCP server views, only the underlying server's cached name. This made it hard to find the correct one when there are many instances.

## Tests

Manual

## Risk

Poke only

## Deploy Plan

Main