### PR TITLE
fix(hubspot): surface engagement content fields (notes, calls, meetings, emails)

### DIFF
--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -1204,13 +1204,30 @@ export const getDeal = async (
 
 export const getMeeting = async (
   accessToken: string,
-  meetingId: string
+  meetingId: string,
+  extraProperties?: string[]
 ): Promise<SimplePublicObject | null> => {
   const hubspotClient = new Client({ accessToken });
   try {
+    const defaultProperties = [
+      "hs_engagement_type",
+      "hs_timestamp",
+      "hs_meeting_title",
+      "hs_meeting_body",
+      "hs_meeting_outcome",
+      "hs_meeting_start_time",
+      "hs_meeting_end_time",
+      "hs_meeting_location",
+      "hs_meeting_external_url",
+      "hubspot_owner_id",
+    ];
+    // HubSpot CRM v3: meetings are created via "engagements" but retrieved via "meetings".
     const meeting = await hubspotClient.crm.objects.basicApi.getById(
-      "engagements",
-      meetingId
+      "meetings",
+      meetingId,
+      extraProperties
+        ? [...defaultProperties, ...extraProperties]
+        : defaultProperties
     );
     return meeting;
   } catch (error: any) {
@@ -1219,7 +1236,7 @@ export const getMeeting = async (
     }
     localLogger.error(
       { error, meetingId },
-      `Error fetching meeting (engagement) ${meetingId}:`
+      `Error fetching meeting ${meetingId}:`
     );
     throw normalizeError(error);
   }

--- a/front/lib/api/actions/servers/hubspot/rendering.ts
+++ b/front/lib/api/actions/servers/hubspot/rendering.ts
@@ -26,6 +26,32 @@ const IMPORTANT_DATE_FIELDS: Record<string, string[]> = {
   deals: ["closedate", "createdate", "lastmodifieddate"],
 };
 
+// hs_* fields that carry actual engagement content and must not be stripped.
+const HS_CONTENT_FIELDS = new Set([
+  "hs_note_body",
+  "hs_meeting_title",
+  "hs_meeting_body",
+  "hs_meeting_outcome",
+  "hs_meeting_start_time",
+  "hs_meeting_end_time",
+  "hs_meeting_location",
+  "hs_meeting_external_url",
+  "hs_call_body",
+  "hs_call_title",
+  "hs_call_duration",
+  "hs_call_direction",
+  "hs_call_status",
+  "hs_email_subject",
+  "hs_email_text",
+  "hs_email_html",
+  "hs_task_subject",
+  "hs_task_body",
+  "hs_task_status",
+  "hs_task_priority",
+  "hs_timestamp",
+  "hs_engagement_type",
+]);
+
 export function formatHubSpotObject(
   object: SimplePublicObject,
   objectType: string,
@@ -74,8 +100,10 @@ export function formatHubSpotObject(
         value !== null &&
         value !== undefined &&
         value !== "" &&
-        !key.startsWith("hs_") &&
-        ((!key.includes("_date") && !key.includes("_timestamp")) ||
+        (HS_CONTENT_FIELDS.has(key) ||
+          (!key.startsWith("hs_") &&
+            !key.includes("_date") &&
+            !key.includes("_timestamp")) ||
           allowlist.includes(key))
     )
     .reduce(


### PR DESCRIPTION
## Problem

Customers using the HubSpot agent could see that activity existed — a meeting happened, a note was written, a call was logged — but the agent had no access to the actual content. Meeting titles, agendas, and outcome notes were invisible. Note bodies were blank. Call summaries were missing. The agent itself was flagging to users that it wasn't getting the data and suggesting the tool configuration needed to be updated, eroding trust in the integration.

## Root cause

`formatHubSpotObject` filtered out all `hs_*` prefixed properties to strip HubSpot's internal metadata fields (e.g. `hs_object_id`, `hs_pipeline`). But HubSpot uses the same `hs_*` prefix for all engagement content fields — meeting titles, note bodies, call summaries, email subjects. The filter was too broad: it stripped both noise and signal.

Separately, `getMeeting` was calling `getById("engagements", ...)` which is not a valid v3 CRM object type and returns 404 on every call. And without an explicit properties list, HubSpot's API returns only 4 internal default fields regardless — so even a correct call would have returned no content.

## Fix

- Add `HS_CONTENT_FIELDS` allowlist Set in `rendering.ts` to exempt known engagement content fields from the `hs_*` strip filter. Includes a short-circuit on the date/timestamp clause so `hs_timestamp` (which contains `"_timestamp"` as a substring) is not re-stripped by the second condition.
- Fix `getMeeting` in `client.ts`: use `"meetings"` (correct v3 object type) and pass explicit `defaultProperties` so HubSpot returns content fields.
- Add `extraProperties?: string[]` to `getMeeting` for consistency with `getCompany`/`getDeal`.

## What's affected

| Path | Impact |
|---|---|
| `search_crm_objects` for notes/calls/meetings/emails/tasks | Content fields now returned to agent |
| `get_associated_meetings` | Meetings now resolve (was 404) and return title, body, outcome, location, video URL |
| Contacts / companies / deals rendering | No change — filter logic for non-`hs_*` fields is identical |

## Test plan

- [ ] Search HubSpot notes — `hs_note_body` present in results
- [ ] Search HubSpot calls — `hs_call_body` / `hs_call_title` present in results
- [ ] Search HubSpot meetings — `hs_meeting_title`, `hs_meeting_body`, `hs_meeting_outcome` present
- [ ] Search HubSpot emails — `hs_email_subject`, `hs_email_text` / `hs_email_html` present
- [ ] `get_associated_meetings` for a contact with linked meetings — returns content (previously 404)
- [ ] Search contacts / companies / deals — verify no regression in existing fields returned