### PR TITLE
Fix: Todo display width in agent message. Limit text size in todo creation via models. Add tools to remove from context.

### DIFF
--- a/front/components/markdown/TodoDirectiveBlock.tsx
+++ b/front/components/markdown/TodoDirectiveBlock.tsx
@@ -1,4 +1,4 @@
-import { Chip, ListCheckIcon } from "@dust-tt/sparkle";
+import { AttachmentChip, ListCheckIcon } from "@dust-tt/sparkle";
 import { visit } from "unist-util-visit";
 
 export function TodoDirectiveBlock({
@@ -10,7 +10,11 @@ export function TodoDirectiveBlock({
 }) {
   return (
     <span data-project-todo-sid={sId} className="inline-block">
-      <Chip label={label} icon={ListCheckIcon} color="green" />
+      <AttachmentChip
+        label={label.replaceAll("\n", " ").replaceAll("\r", " ")}
+        icon={{ visual: ListCheckIcon }}
+        color="green"
+      />
     </span>
   );
 }

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -508,6 +508,8 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_conversations": "never_ask",
     "list_members": "never_ask",
     "list_projects": "never_ask",
+    "remove_content_node": "medium",
+    "remove_file": "medium",
     "retrieve_recent_documents": "never_ask",
     "semantic_search": "never_ask",
     "update_file": "medium",

--- a/front/lib/api/actions/servers/project_manager/index.ts
+++ b/front/lib/api/actions/servers/project_manager/index.ts
@@ -10,7 +10,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  * Creates the project_manager MCP server.
  *
  * This server provides tools for managing projects:
- * - File operations: list, add, and update project files
+ * - File operations: list, add, update, and remove project knowledge files
+ * - Linked data: add/remove Company Data nodes from project context
  * - Metadata operations: edit description, add/edit URLs
  * - Retrieval: recent documents from the project data source and context nodes
  * - Semantic search: project knowledge, project conversations, or both

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -109,6 +109,53 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
       done: "Update file in project",
     },
   },
+  remove_file: {
+    description:
+      "Remove an existing file from the project context. The file will no longer be available to conversations in this project. " +
+      "Deletes the underlying file (cannot be undone). Use file IDs from get_information like other project context files.",
+    schema: {
+      fileId: z
+        .string()
+        .describe("ID of an existing file in the project context to remove"),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to remove the file from, will fallback to the conversation's project."
+        ),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Removing file from project",
+      done: "Remove file from project",
+    },
+  },
+  remove_content_node: {
+    description:
+      "Remove a content node reference from the project context. The node will no longer be available to conversations in this project. " +
+      "Use nodeId with nodeDataSourceViewId from get_information attachments for this reference.",
+    schema: {
+      nodeId: z.string().describe("Internal node ID to remove"),
+      nodeDataSourceViewId: z
+        .string()
+        .describe(
+          "Internal data source view ID for the content node reference (from get_information attachments)"
+        ),
+      dustProject: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+      ]
+        .optional()
+        .describe(
+          "Optional project to remove the content node from, will fallback to the conversation's project."
+        ),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Removing content node from project",
+      done: "Remove content node from project",
+    },
+  },
   attach_to_conversation: {
     description:
       "Attach an existing project context file to the current conversation without creating or copying a new file.",
@@ -406,6 +453,7 @@ const PROJECT_MANAGER_INSTRUCTIONS =
   "Project files and metadata are shared across all conversations in this project. " +
   "You can add all sorts of files but only text-based files are supported for updating. " +
   "You can add/update files by providing text content directly, or by copying from existing files (like those you've generated). " +
+  "You can remove a file from the project context (remove_file) or remove a content node reference from Company Data (remove_content_node). " +
   "You can also attach an existing project context file to the current conversation without recreating it. " +
   "Use list_projects to discover projects you can access and obtain the dustProject uri for other tools. " +
   "Use semantic_search to find relevant chunks in project knowledge and/or conversations (scope: knowledge, conversations, or all). " +
@@ -419,7 +467,7 @@ export const PROJECT_MANAGER_SERVER = {
     name: "project_manager",
     version: "1.0.0",
     description:
-      "Manage project files and metadata. Add, update, list files, and organize project resources.",
+      "Manage project files and metadata. Add, update, or remove files in the project context and content node references from Company Data, list files, and organize project resources.",
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -33,6 +33,8 @@ import {
   addFileToProject,
   fetchLatestProjectContextFileContentFragment,
   listProjectContextAttachments,
+  removeContentNodeFromProject,
+  removeFileFromProject,
 } from "@app/lib/api/projects/context";
 import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
@@ -447,6 +449,73 @@ export function createProjectManagerTools(
           },
         ]);
       }, "Failed to update file");
+    },
+
+    remove_file: async (params) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getWritableProjectContext(auth, {
+          agentLoopContext,
+          dustProject: params.dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { space } = contextRes.value;
+        const { fileId } = params;
+
+        const removeRes = await removeFileFromProject(auth, {
+          space,
+          fileId,
+        });
+        if (removeRes.isErr()) {
+          return new Err(
+            new MCPError(removeRes.error.message, { tracked: false })
+          );
+        }
+
+        return new Ok(
+          makeSuccessResponse({
+            success: true,
+            message: `File "${fileId}" removed from the project context.`,
+          })
+        );
+      }, "Failed to remove file from project");
+    },
+
+    remove_content_node: async (params) => {
+      return withErrorHandling(async () => {
+        const contextRes = await getWritableProjectContext(auth, {
+          agentLoopContext,
+          dustProject: params.dustProject,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { space } = contextRes.value;
+
+        const removeRes = await removeContentNodeFromProject(auth, {
+          space,
+          nodeId: params.nodeId,
+          nodeDataSourceViewId: params.nodeDataSourceViewId,
+        });
+        if (removeRes.isErr()) {
+          return new Err(
+            new MCPError(removeRes.error.message, { tracked: false })
+          );
+        }
+
+        return new Ok(
+          makeSuccessResponse({
+            success: true,
+            nodeId: params.nodeId,
+            nodeDataSourceViewId: params.nodeDataSourceViewId,
+            message:
+              "Content node reference removed from the project context if present (Company Data unchanged).",
+          })
+        );
+      }, "Failed to remove linked content from project");
     },
 
     attach_to_conversation: async (params) => {

--- a/front/lib/api/actions/servers/project_todos/metadata.ts
+++ b/front/lib/api/actions/servers/project_todos/metadata.ts
@@ -63,7 +63,8 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
           z.object({
             text: z
               .string()
-              .min(1)
+              .min(16)
+              .max(256)
               .describe(
                 "The TODO description. Do not include the assignee's name — " +
                   "the assignee is tracked separately via userId. Refer to the " +
@@ -131,7 +132,12 @@ export const PROJECT_TODOS_TOOLS_METADATA = createToolsRecord({
     description: "Update a TODO.",
     schema: {
       todoId: z.string().describe("The sId of the TODO."),
-      text: z.string().optional().describe("The new TODO description."),
+      text: z
+        .string()
+        .min(16)
+        .max(256)
+        .optional()
+        .describe("The new TODO description."),
       userId: z
         .string()
         .optional()

--- a/front/lib/project_todo/analyze_document/types.ts
+++ b/front/lib/project_todo/analyze_document/types.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 export const EXTRACT_DOCUMENT_TAKEAWAYS_FUNCTION_NAME =
   "extract_document_takeaways";
 
+export const MIN_SHORT_DESCRIPTION_LENGTH = 16;
+export const MAX_SHORT_DESCRIPTION_LENGTH = 256;
+
 // New items require an assignee_user_id matching a known project member. Items
 // whose assignee cannot be resolved to a project member are intentionally
 // dropped — we'd rather miss an item than track one we can't route to a real
@@ -10,6 +13,8 @@ export const EXTRACT_DOCUMENT_TAKEAWAYS_FUNCTION_NAME =
 const NewActionItemSchema = z.object({
   short_description: z
     .string()
+    .min(MIN_SHORT_DESCRIPTION_LENGTH)
+    .max(MAX_SHORT_DESCRIPTION_LENGTH)
     .describe("Short description of the action item."),
   assignee_name: z
     .string()
@@ -36,6 +41,8 @@ const UpdatedActionItemSchema = z.object({
     ),
   short_description: z
     .string()
+    .min(MIN_SHORT_DESCRIPTION_LENGTH)
+    .max(MAX_SHORT_DESCRIPTION_LENGTH)
     .optional()
     .describe(
       "Updated description. Only set when the document materially changes the description; omit otherwise."


### PR DESCRIPTION
## Description

Three independent fixes bundled in one commit.

**Fix: Todo display width in agent messages**

`TodoDirectiveBlock` was using `Chip`, which doesn't constrain width when rendered inline in an agent message bubble. Switch to `AttachmentChip` (the correct component for inline attachment display) and normalize `\n` / `\r` in the label to avoid multiline chips.

**Limit text size in todo creation via models**

The `text` field on todos had only `min(1)`, letting models create/update todos with arbitrarily long or trivially short descriptions.
- Add `min(16)` and `max(256)` to `create_todos` and `update_todo` tool schemas
- Apply the same limits to `NewActionItemSchema` and `UpdatedActionItemSchema` in the takeaway extractor
- Extract as named constants `MIN_SHORT_DESCRIPTION_LENGTH = 16` and `MAX_SHORT_DESCRIPTION_LENGTH = 256` in `analyze_document/types.ts` for shared use

**Add tools to remove from context**

`project_manager` could add files and content nodes to a project but had no way to remove them.
- Add `remove_file` — deletes a project context file by `fileId`; stake `medium`
- Add `remove_content_node` — removes a Company Data node reference by `nodeId` + `nodeDataSourceViewId` without touching the underlying data; stake `medium`
- Back both with `removeFileFromProject` and `removeContentNodeFromProject` from `lib/api/projects/context`
- Update server description and instructions

## Tests

Local + green (snapshot updated)

## Risk

Low

## Deploy Plan

Deploy `front`
