### PR TITLE
Improve projects conversations sync to add more metadata. Focus on group conversations and connected datas during takeaways process.

### DIFF
--- a/connectors/src/connectors/dust_project/lib/sync_conversation.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_conversation.ts
@@ -7,7 +7,7 @@ import logger from "@connectors/logger/logger";
 import { DustProjectConversationResource } from "@connectors/resources/dust_project_conversation_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types/shared/internal_mime_types";
-import type { ConversationPublicType } from "@dust-tt/client";
+import { type ConversationPublicType, removeNulls } from "@dust-tt/client";
 
 import {
   buildConversationMessageSections,
@@ -149,6 +149,24 @@ export async function syncConversation({
     conversation.updated ?? conversation.created
   );
 
+  // Check if the conversation is a group conversation by checking if there are multiple user IDs in the conversation
+  const isGroupConversation =
+    new Set(
+      removeNulls(
+        conversation.content
+          .map((versions) => versions[-1])
+          .map((m) =>
+            m?.type === "user_message" && m.user ? m.user.sId : null
+          )
+      )
+    ).size > 1;
+
+  const tags = [
+    `project:${projectId}`,
+    `conversation:${conversation.sId}`,
+    isGroupConversation ? "group" : "single-user",
+  ];
+
   try {
     const messageSections = buildConversationMessageSections(conversation);
     const chunks = chunkMessageSectionsForDocuments(messageSections);
@@ -214,7 +232,7 @@ export async function syncConversation({
         documentId: baseDocumentId,
         documentContent,
         timestampMs: conversation.updated ?? conversation.created,
-        tags: [`project:${projectId}`, `conversation:${conversation.sId}`],
+        tags,
         documentUrl: conversation.url,
         parents: [baseDocumentId, folderInternalId],
         parentId: folderInternalId,
@@ -249,7 +267,7 @@ export async function syncConversation({
           documentId: partDocumentId,
           documentContent,
           timestampMs: conversation.updated ?? conversation.created,
-          tags: [`project:${projectId}`, `conversation:${conversation.sId}`],
+          tags,
           documentUrl: conversation.url,
           parents: [partDocumentId, folderInternalId],
           parentId: folderInternalId,

--- a/front/lib/api/actions/servers/project_manager/build_project_search_data_sources.ts
+++ b/front/lib/api/actions/servers/project_manager/build_project_search_data_sources.ts
@@ -6,7 +6,10 @@ import {
   isContentFragmentDataSourceNode,
   isContentNodeAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
-import { listProjectContextAttachments } from "@app/lib/api/projects/context";
+import {
+  getProjectConversationFolderInternalId,
+  listProjectContextAttachments,
+} from "@app/lib/api/projects/context";
 import {
   fetchProjectDataSource,
   fetchProjectDataSourceView,
@@ -16,17 +19,6 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 export type ProjectSemanticSearchScope = "knowledge" | "conversations" | "all";
-
-/**
- * Folder internal id under which conversation transcripts are indexed in the dust_project
- * data source (see connectors/dust_project/lib/conversation_formatting.ts).
- */
-export function getProjectConversationFolderInternalId(
-  dustProjectConnectorId: string,
-  spaceSId: string
-): string {
-  return `dust-project-${dustProjectConnectorId}-project-${spaceSId}`;
-}
 
 /**
  * One config per data source view; merges parent node ids when several project context

--- a/front/lib/api/actions/servers/project_manager/helpers.test.ts
+++ b/front/lib/api/actions/servers/project_manager/helpers.test.ts
@@ -1,3 +1,4 @@
+import { getProjectConversationFolderInternalId } from "@app/lib/api/projects/context";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -15,9 +16,27 @@ vi.mock("@app/lib/api/projects/data_sources", () => ({
   fetchProjectDataSourceView: mockFetchProjectDataSourceView,
 }));
 
-vi.mock("@app/lib/api/projects/context", () => ({
-  listProjectContextAttachments: mockListProjectContextAttachments,
-}));
+vi.mock("@app/lib/api/projects/context", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/projects/context")>();
+  return {
+    ...actual,
+    listProjectContextAttachments: mockListProjectContextAttachments,
+  };
+});
+
+function mockProjectDataSourceViewResource(
+  sId: string,
+  connectorId?: string | null
+) {
+  return {
+    sId,
+    toJSON: () => ({
+      dataSource:
+        connectorId != null && connectorId !== "" ? { connectorId } : {},
+    }),
+  };
+}
 
 describe("buildProjectRetrieveDataSources", () => {
   beforeEach(() => {
@@ -32,7 +51,7 @@ describe("buildProjectRetrieveDataSources", () => {
 
     mockFetchProjectDataSourceView.mockResolvedValue({
       isOk: () => true,
-      value: { sId: "dsv_project" },
+      value: mockProjectDataSourceViewResource("dsv_project"),
     });
     mockListProjectContextAttachments.mockResolvedValue([
       // Content node attachment.
@@ -59,10 +78,10 @@ describe("buildProjectRetrieveDataSources", () => {
       },
     ]);
 
-    const dataSources = await buildProjectRetrieveDataSources(
-      auth,
-      projectSpace
-    );
+    const dataSources = await buildProjectRetrieveDataSources(auth, {
+      space: projectSpace,
+      onlyGroupConversationsAndConnectedData: false,
+    });
 
     expect(dataSources).toEqual([
       {
@@ -97,12 +116,117 @@ describe("buildProjectRetrieveDataSources", () => {
       },
     ]);
 
-    const dataSources = await buildProjectRetrieveDataSources(
-      auth,
-      projectSpace
-    );
+    const dataSources = await buildProjectRetrieveDataSources(auth, {
+      space: projectSpace,
+      onlyGroupConversationsAndConnectedData: false,
+    });
 
     expect(dataSources).toEqual([
+      {
+        uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_views/dsv_node_1/filter/%7B%22parents%22%3A%7B%22in%22%3A%5B%22node_1%22%5D%2C%22not%22%3A%5B%5D%7D%2C%22tags%22%3Anull%7D`,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      },
+    ]);
+  });
+
+  it("scopes the project data source view to group conversations when onlyGroupConversationsAndConnectedData is true and a connector id is set", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const projectSpace = await SpaceFactory.project(workspace);
+    const connectorId = "connector_test";
+
+    mockFetchProjectDataSourceView.mockResolvedValue({
+      isOk: () => true,
+      value: mockProjectDataSourceViewResource("dsv_project", connectorId),
+    });
+    mockListProjectContextAttachments.mockResolvedValue([]);
+
+    const folderInternalId = getProjectConversationFolderInternalId(
+      connectorId,
+      projectSpace.sId
+    );
+    const filter = {
+      parents: { in: [folderInternalId], not: [] },
+      tags: { in: ["group"], not: [], mode: "custom" as const },
+    };
+
+    const dataSources = await buildProjectRetrieveDataSources(auth, {
+      space: projectSpace,
+      onlyGroupConversationsAndConnectedData: true,
+    });
+
+    expect(dataSources).toEqual([
+      {
+        uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_views/dsv_project/filter/${encodeURIComponent(JSON.stringify(filter))}`,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      },
+    ]);
+  });
+
+  it("leaves the project data source view unfiltered when onlyGroupConversationsAndConnectedData is true but connector id is absent", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const projectSpace = await SpaceFactory.project(workspace);
+
+    mockFetchProjectDataSourceView.mockResolvedValue({
+      isOk: () => true,
+      value: mockProjectDataSourceViewResource("dsv_project"),
+    });
+    mockListProjectContextAttachments.mockResolvedValue([]);
+
+    const dataSources = await buildProjectRetrieveDataSources(auth, {
+      space: projectSpace,
+      onlyGroupConversationsAndConnectedData: true,
+    });
+
+    expect(dataSources).toEqual([
+      {
+        uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_views/dsv_project/filter/%7B%22parents%22%3Anull%2C%22tags%22%3Anull%7D`,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      },
+    ]);
+  });
+
+  it("still adds content-node data sources when the project view is scoped with onlyGroupConversationsAndConnectedData", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const projectSpace = await SpaceFactory.project(workspace);
+    const connectorId = "connector_test";
+
+    mockFetchProjectDataSourceView.mockResolvedValue({
+      isOk: () => true,
+      value: mockProjectDataSourceViewResource("dsv_project", connectorId),
+    });
+    mockListProjectContextAttachments.mockResolvedValue([
+      {
+        contentFragmentId: "cf_1",
+        nodeDataSourceViewId: "dsv_node_1",
+        nodeId: "node_1",
+      },
+    ]);
+
+    const folderInternalId = getProjectConversationFolderInternalId(
+      connectorId,
+      projectSpace.sId
+    );
+    const projectFilter = {
+      parents: { in: [folderInternalId], not: [] },
+      tags: { in: ["group"], not: [], mode: "custom" as const },
+    };
+
+    const dataSources = await buildProjectRetrieveDataSources(auth, {
+      space: projectSpace,
+      onlyGroupConversationsAndConnectedData: true,
+    });
+
+    expect(dataSources).toEqual([
+      {
+        uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_views/dsv_project/filter/${encodeURIComponent(JSON.stringify(projectFilter))}`,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      },
       {
         uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_views/dsv_node_1/filter/%7B%22parents%22%3A%7B%22in%22%3A%5B%22node_1%22%5D%2C%22not%22%3A%5B%5D%7D%2C%22tags%22%3Anull%7D`,
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,

--- a/front/lib/api/actions/servers/project_manager/helpers.ts
+++ b/front/lib/api/actions/servers/project_manager/helpers.ts
@@ -6,8 +6,12 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { parseProjectConfigurationURI } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { DataSourceFilter } from "@app/lib/api/assistant/configuration/types";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
-import { listProjectContextAttachments } from "@app/lib/api/projects/context";
+import {
+  getProjectConversationFolderInternalId,
+  listProjectContextAttachments,
+} from "@app/lib/api/projects/context";
 import { fetchProjectDataSourceView } from "@app/lib/api/projects/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -25,18 +29,38 @@ export interface ProjectSpaceContext {
 
 export async function buildProjectRetrieveDataSources(
   auth: Authenticator,
-  space: SpaceResource
+  {
+    space,
+    onlyGroupConversationsAndConnectedData,
+  }: { space: SpaceResource; onlyGroupConversationsAndConnectedData: boolean }
 ): Promise<DataSourcesToolConfigurationType> {
   const owner = auth.getNonNullableWorkspace();
   const dataSources: DataSourcesToolConfigurationType = [];
 
   const projectDsViewRes = await fetchProjectDataSourceView(auth, space);
   if (projectDsViewRes.isOk()) {
+    let filter: DataSourceFilter = { parents: null, tags: null };
+    const dsView = projectDsViewRes.value.toJSON();
+    if (
+      onlyGroupConversationsAndConnectedData &&
+      dsView.dataSource.connectorId
+    ) {
+      const conversationsFolderInternalId =
+        getProjectConversationFolderInternalId(
+          dsView.dataSource.connectorId,
+          space.sId
+        );
+      filter = {
+        parents: { in: [conversationsFolderInternalId], not: [] },
+        tags: { in: ["group"], not: [], mode: "custom" },
+      };
+    }
+
     dataSources.push({
       uri: getDataSourceURI({
         workspaceId: owner.sId,
         dataSourceViewId: projectDsViewRes.value.sId,
-        filter: { parents: null, tags: null },
+        filter,
       }),
       mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
     });

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -962,7 +962,10 @@ export function createProjectManagerTools(
         }
 
         const { space } = contextRes.value;
-        const dataSources = await buildProjectRetrieveDataSources(auth, space);
+        const dataSources = await buildProjectRetrieveDataSources(auth, {
+          space,
+          onlyGroupConversationsAndConnectedData: false,
+        });
 
         if (dataSources.length === 0) {
           return new Err(

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -30,6 +30,17 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import { slugify } from "@app/types/shared/utils/string_utils";
 import { Op } from "sequelize";
 
+/**
+ * Folder internal id under which conversation transcripts are indexed in the dust_project
+ * data source (see connectors/dust_project/lib/conversation_formatting.ts).
+ */
+export function getProjectConversationFolderInternalId(
+  dustProjectConnectorId: string,
+  spaceSId: string
+): string {
+  return `dust-project-${dustProjectConnectorId}-project-${spaceSId}`;
+}
+
 export async function listProjectContentFragments(
   auth: Authenticator,
   space: SpaceResource

--- a/front/lib/project_todo/analyze_document/types.ts
+++ b/front/lib/project_todo/analyze_document/types.ts
@@ -42,7 +42,6 @@ const UpdatedActionItemSchema = z.object({
   short_description: z
     .string()
     .min(MIN_SHORT_DESCRIPTION_LENGTH)
-    .max(MAX_SHORT_DESCRIPTION_LENGTH)
     .optional()
     .describe(
       "Updated description. Only set when the document materially changes the description; omit otherwise."

--- a/front/temporal/project_todo/activities.ts
+++ b/front/temporal/project_todo/activities.ts
@@ -152,7 +152,13 @@ export async function analyzeProjectTodosActivity({
   const results = await runIncludeDataRetrieval(auth, {
     citationsOffset: 0,
     retrievalTopK: 128,
-    dataSources: await buildProjectRetrieveDataSources(auth, space),
+    dataSources: await buildProjectRetrieveDataSources(auth, {
+      space,
+      // Only include group conversations and connected data.
+      // Goal is to reduce noise by not generating TODOs for purely agentic conversations or files that might be the output of agentic conversations.
+      // If one wants to have more sophisticated TODOs lifecycle management, they can do it via custom agents.
+      onlyGroupConversationsAndConnectedData: true,
+    }),
     timeFrame,
   });
 


### PR DESCRIPTION
## Description

Two improvements to reduce noise in the takeaway extraction pipeline.

**1. Tag project conversations as `group` or `single-user` during sync**

When syncing a conversation to the `dust_project` data source, collect distinct user sIds from the latest version of each message to determine whether multiple humans participated. Tag each indexed document with `project:{id}`, `conversation:{sId}`, and either `"group"` or `"single-user"`. This makes conversations filterable by type downstream.

**2. Focus takeaway extraction on group conversations and connected data**

Purely agentic conversations (single-user, with only the agent producing output) are poor sources for action items — the agent making commitments like "I'll summarize this" creates false todo signals. The cron should focus on content produced by real human collaboration.

- Add `onlyGroupConversationsAndConnectedData` option to `buildProjectRetrieveDataSources` — when `true` and the project data source has a `connectorId`, scopes the data source to documents tagged `"group"` under the conversations folder via `getProjectConversationFolderInternalId`; content node attachments are always included regardless; falls back to unfiltered when `connectorId` is absent
- In `analyzeProjectTodosActivity`: pass `onlyGroupConversationsAndConnectedData: true`

**3. Move `getProjectConversationFolderInternalId` to `context.ts`** — shared between `helpers.ts`, `build_project_search_data_sources.ts`, and connectors

**4. Remove `.max` from `UpdatedActionItemSchema.short_description`** — the max-length constraint was causing the LLM to emit truncated updates; the field is optional so it should be unconstrained when present

- Update tests for new `buildProjectRetrieveDataSources` signature and tag-filter assertions (4 new cases)

## Tests

Local + green (tests updated)

## Risk

Low — the tag and filter are additive; conversations indexed before this deploy have no `group`/`single-user` tag, so they'll be excluded from the filter until re-synced. A full re-sync is not required for correctness — missing older conversations from the todo window is acceptable.

## Deploy Plan

Deploy `connectors`, deploy `front`
