### PR TITLE
[front] fix: improve validation focus on errors when saving in Skill Builder

### DIFF
--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -110,6 +110,19 @@ export function SkillBuilderAgentFacingDescriptionSection() {
   });
 
   useEffect(() => {
+    if (!editor || editor.isDestroyed) {
+      return;
+    }
+
+    // This allows RHF to focus this custom editor when validation fails.
+    descriptionField.ref(editor.view.dom);
+
+    return () => {
+      descriptionField.ref(null);
+    };
+  }, [descriptionField.ref, editor]);
+
+  useEffect(() => {
     if (!editor) {
       return;
     }

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -87,12 +87,14 @@ export function SkillBuilderInstructionsEditor({
     name: INSTRUCTIONS_HTML_FIELD_NAME,
   });
 
-  const { fieldState: attachedKnowledgeFieldState } = useController<
-    SkillBuilderFormData,
-    typeof ATTACHED_KNOWLEDGE_FIELD_NAME
-  >({
-    name: ATTACHED_KNOWLEDGE_FIELD_NAME,
-  });
+  const {
+    field: attachedKnowledgeField,
+    fieldState: attachedKnowledgeFieldState,
+  } = useController<SkillBuilderFormData, typeof ATTACHED_KNOWLEDGE_FIELD_NAME>(
+    {
+      name: ATTACHED_KNOWLEDGE_FIELD_NAME,
+    }
+  );
 
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
@@ -169,6 +171,21 @@ export function SkillBuilderInstructionsEditor({
     onBlur: handleBlur,
     onDelete: handleDelete,
   });
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) {
+      return;
+    }
+
+    // This allows RHF to focus this custom editor when validation fails.
+    instructionsField.ref(editor.view.dom);
+    attachedKnowledgeField.ref(editor.view.dom);
+
+    return () => {
+      instructionsField.ref(null);
+      attachedKnowledgeField.ref(null);
+    };
+  }, [attachedKnowledgeField.ref, editor, instructionsField.ref]);
 
   const handleAddKnowledge = useCallback(() => {
     if (!editor) {


### PR DESCRIPTION
## Description

- This PR makes the skill builder scroll to the relevant field when saving with validation errors in RHF
- Particularly useful for the agent facing description, which sits at the top of the Skill Builder: having an error on it when saving could cause the user to not see where the error comes from if not visible

## Tests

- Tested locally using a description that is too long.

## Risk

- Low. Very local to the Skill Builder

## Deploy Plan

- Deploy front.
