### PR TITLE
Add: toggle to opt-in sugested to-dos

### DIFF
--- a/front/components/assistant/conversation/space/FirstSyncTodoLookbackForm.tsx
+++ b/front/components/assistant/conversation/space/FirstSyncTodoLookbackForm.tsx
@@ -1,0 +1,74 @@
+import type { InitialTodoSyncLookbackValue } from "@app/lib/project_todo/analyze_document/types";
+import { useState } from "react";
+
+const OPTIONS: {
+  value: InitialTodoSyncLookbackValue;
+  title: string;
+  description: string;
+}[] = [
+  {
+    value: "now",
+    title: "About now",
+    description: "Roughly the last hour of activity.",
+  },
+  {
+    value: "last_24h",
+    title: "Last 24 hours",
+    description: "Same default window as a typical catch-up run.",
+  },
+  {
+    value: "max",
+    title: "As far back as possible",
+    description:
+      "Search with no fixed lower time bound (subject to limits below).",
+  },
+];
+
+export function FirstSyncTodoLookbackForm({
+  onValueChange,
+}: {
+  onValueChange: (value: InitialTodoSyncLookbackValue) => void;
+}) {
+  const [value, setValue] = useState<InitialTodoSyncLookbackValue>("last_24h");
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-foreground dark:text-foreground-night">
+        Choose how far back the first automatic scan should look for content to
+        turn into suggested to-dos.
+      </p>
+      <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+        The first sync is not unlimited: connectors and search caps apply, so
+        context is best-effort. Later runs cover everything new since the
+        previous scan.
+      </p>
+      <div className="flex flex-col gap-2">
+        {OPTIONS.map((opt) => (
+          <label
+            key={opt.value}
+            className="border-border hover:bg-muted-background/50 dark:border-border-night dark:hover:bg-muted-background-night/50 flex cursor-pointer flex-col gap-0.5 rounded-lg border p-3"
+          >
+            <span className="flex items-center gap-2">
+              <input
+                type="radio"
+                className="mt-0.5"
+                name="initial-todo-sync-lookback"
+                checked={value === opt.value}
+                onChange={() => {
+                  setValue(opt.value);
+                  onValueChange(opt.value);
+                }}
+              />
+              <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                {opt.title}
+              </span>
+            </span>
+            <span className="pl-6 text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {opt.description}
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/space/SpaceTodosTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTodosTab.tsx
@@ -2,8 +2,22 @@ import {
   ProjectTodosPanel,
   type TodoOwnerFilter,
 } from "@app/components/assistant/conversation/space/conversations/ProjectTodosPanel";
+import { FirstSyncTodoLookbackForm } from "@app/components/assistant/conversation/space/FirstSyncTodoLookbackForm";
+import { ConfirmContext } from "@app/components/Confirm";
+import type { InitialTodoSyncLookbackValue } from "@app/lib/project_todo/analyze_document/types";
+import { useUpdateProjectMetadata } from "@app/lib/swr/spaces";
+import { timeAgoFrom } from "@app/lib/utils";
 import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { WorkspaceType } from "@app/types/user";
+import {
+  Chip,
+  Icon,
+  InformationCircleIcon,
+  SliderToggle,
+  SparklesIcon,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import { useCallback, useContext, useRef, useState } from "react";
 
 interface SpaceTodosTabProps {
   owner: WorkspaceType;
@@ -12,15 +26,168 @@ interface SpaceTodosTabProps {
   onTodoOwnerFilterChange: (value: TodoOwnerFilter) => void;
 }
 
+const SUGGEST_TO_DOS_TOOLTIP =
+  "When this is on, Dust periodically reviews this project’s conversations and connected sources and adds suggested to-dos. Turn it off if you only want to-dos you create yourself.";
+
+const SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR = `${SUGGEST_TO_DOS_TOOLTIP} Only project editors can change this.`;
+
+const LAST_SCAN_NEVER_TOOLTIP =
+  "Dust has not run an automatic scan for to-do suggestions for this project yet.";
+
+function lastScanTooltip(lastTodoAnalysisAt: number | null): string {
+  if (lastTodoAnalysisAt == null) {
+    return LAST_SCAN_NEVER_TOOLTIP;
+  }
+  const relative = timeAgoFrom(lastTodoAnalysisAt, { useLongFormat: true });
+  return `Last automatic scan for new to-do suggestions: ${relative} ago.`;
+}
+
 export function SpaceTodosTab({
   owner,
   spaceInfo,
   todoOwnerFilter,
   onTodoOwnerFilterChange,
 }: SpaceTodosTabProps) {
+  const confirm = useContext(ConfirmContext);
+  const updateProjectMetadata = useUpdateProjectMetadata({
+    owner,
+    spaceId: spaceInfo.sId,
+  });
+  const [isUpdatingTodoGeneration, setIsUpdatingTodoGeneration] =
+    useState(false);
+  const firstSyncLookbackRef = useRef<InitialTodoSyncLookbackValue>("last_24h");
+  const onFirstSyncLookbackChange = useCallback(
+    (v: InitialTodoSyncLookbackValue) => {
+      firstSyncLookbackRef.current = v;
+    },
+    []
+  );
+
+  const isProjectArchived = !!spaceInfo.archivedAt;
+  const structurallyDisabled =
+    !spaceInfo.isMember || isProjectArchived || !spaceInfo.isEditor;
+  const sliderDisabled = structurallyDisabled || isUpdatingTodoGeneration;
+
+  const toggleTooltip = isProjectArchived
+    ? "This project is archived; suggestion settings cannot be changed."
+    : !spaceInfo.isEditor && spaceInfo.isMember
+      ? SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR
+      : SUGGEST_TO_DOS_TOOLTIP;
+
+  const handleTodoGenerationToggle = useCallback(async () => {
+    if (structurallyDisabled) {
+      return;
+    }
+    if (spaceInfo.todoGenerationEnabled) {
+      setIsUpdatingTodoGeneration(true);
+      try {
+        await updateProjectMetadata({
+          todoGenerationEnabled: false,
+        });
+      } finally {
+        setIsUpdatingTodoGeneration(false);
+      }
+      return;
+    }
+
+    if (spaceInfo.lastTodoAnalysisAt === null) {
+      firstSyncLookbackRef.current = "last_24h";
+      const confirmed = await confirm({
+        title: "Turn on suggested to-dos?",
+        message: (
+          <FirstSyncTodoLookbackForm
+            onValueChange={onFirstSyncLookbackChange}
+          />
+        ),
+        validateLabel: "Turn on",
+        validateVariant: "primary",
+        cancelLabel: "Cancel",
+      });
+      if (!confirmed) {
+        return;
+      }
+      setIsUpdatingTodoGeneration(true);
+      try {
+        await updateProjectMetadata({
+          todoGenerationEnabled: true,
+          initialTodoAnalysisLookback: firstSyncLookbackRef.current,
+        });
+      } finally {
+        setIsUpdatingTodoGeneration(false);
+      }
+      return;
+    }
+
+    setIsUpdatingTodoGeneration(true);
+    try {
+      await updateProjectMetadata({
+        todoGenerationEnabled: true,
+      });
+    } finally {
+      setIsUpdatingTodoGeneration(false);
+    }
+  }, [
+    confirm,
+    onFirstSyncLookbackChange,
+    structurallyDisabled,
+    spaceInfo.lastTodoAnalysisAt,
+    spaceInfo.todoGenerationEnabled,
+    updateProjectMetadata,
+  ]);
+
   return (
     <div className="flex h-full min-h-0 w-full flex-1 overflow-y-auto px-6">
       <div className="mx-auto flex h-full w-full max-w-4xl flex-col py-8">
+        <div className="mb-6 flex flex-col gap-3 border-b border-border pb-6 dark:border-border-night">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <div className="flex flex-wrap items-center gap-2">
+                <SparklesIcon
+                  className="h-4 w-4 shrink-0 text-foreground dark:text-foreground-night"
+                  aria-hidden
+                />
+                <span className="heading-sm text-foreground dark:text-foreground-night">
+                  Suggested to-dos
+                </span>
+                <Chip color="golden" label="Beta" size="mini" />
+              </div>
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                Automatic to-do suggestions from project activity
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Tooltip
+                label={toggleTooltip}
+                trigger={
+                  <div>
+                    <SliderToggle
+                      size="xs"
+                      selected={spaceInfo.todoGenerationEnabled}
+                      disabled={sliderDisabled}
+                      onClick={
+                        structurallyDisabled
+                          ? () => {}
+                          : handleTodoGenerationToggle
+                      }
+                    />
+                  </div>
+                }
+              />
+              <Tooltip
+                label={lastScanTooltip(spaceInfo.lastTodoAnalysisAt)}
+                trigger={
+                  <button
+                    type="button"
+                    className="text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night inline-flex rounded-md p-1"
+                    aria-label="Last automatic to-do suggestion scan"
+                  >
+                    <Icon visual={InformationCircleIcon} size="sm" />
+                  </button>
+                }
+              />
+            </div>
+          </div>
+        </div>
         <ProjectTodosPanel
           owner={owner}
           spaceId={spaceInfo.sId}

--- a/front/lib/project_todo/analyze_document/types.ts
+++ b/front/lib/project_todo/analyze_document/types.ts
@@ -81,3 +81,25 @@ export const ExtractTakeawaysInputSchema = z.object({
 });
 
 export type ExtractionResult = z.infer<typeof ExtractTakeawaysInputSchema>;
+
+/**
+ * One-time lookback for the first automatic to-do analysis run after enabling generation.
+ * Stored on project_metadata for the workflow only; not exposed in public API types.
+ */
+export const INITIAL_TODO_SYNC_LOOKBACK_VALUES = [
+  "now",
+  "last_24h",
+  "max",
+] as const;
+
+export type InitialTodoSyncLookbackValue =
+  (typeof INITIAL_TODO_SYNC_LOOKBACK_VALUES)[number];
+
+export function isInitialTodoSyncLookback(
+  value: string | null | undefined
+): value is InitialTodoSyncLookbackValue {
+  return (
+    value != null &&
+    (INITIAL_TODO_SYNC_LOOKBACK_VALUES as readonly string[]).includes(value)
+  );
+}

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -1,6 +1,6 @@
 // This module merges the latest takeaway snapshots for all conversations in a
 // project into project_todo rows. It is called by mergeTodosForProjectActivity,
-// which itself is invoked by the per-project projectTodoWorkflow at most once
+// which itself is invoked by the per-project durable projectTodoWorkflow (serialized runs)
 // per hour (based on the cron schedule).
 //
 // High-level algorithm (3 phases):

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -113,6 +113,8 @@ describe("ProjectMetadataResource", () => {
       expect(json.spaceId).toBe(projectSpace.sId);
       expect(json.description).toBe("JSON test");
       expect(typeof json.createdAt).toBe("number");
+      expect(json.todoGenerationEnabled).toBe(false);
+      expect(json.lastTodoAnalysisAt).toBeNull();
     });
   });
 });

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -128,6 +128,34 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     await this.update({ lastTodoAnalysisAt }, transaction);
   }
 
+  /** Sets last analysis time and clears one-time first-sync lookback (if any). */
+  async recordTodoAnalysisComplete(
+    documentsLastFetchedAt: Date,
+    transaction?: Transaction
+  ) {
+    await this.update(
+      {
+        lastTodoAnalysisAt: documentsLastFetchedAt,
+        initialTodoAnalysisLookback: null,
+      },
+      transaction
+    );
+  }
+
+  async updateTodoGenerationEnabled(
+    todoGenerationEnabled: boolean,
+    transaction?: Transaction
+  ) {
+    await this.update({ todoGenerationEnabled }, transaction);
+  }
+
+  async updateInitialTodoAnalysisLookback(
+    initialTodoAnalysisLookback: string | null,
+    transaction?: Transaction
+  ) {
+    await this.update({ initialTodoAnalysisLookback }, transaction);
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction }
@@ -153,6 +181,8 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       }),
       description: this.description,
       archivedAt: this.archivedAt?.getTime() ?? null,
+      todoGenerationEnabled: this.todoGenerationEnabled,
+      lastTodoAnalysisAt: this.lastTodoAnalysisAt?.getTime() ?? null,
     };
   }
 }

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -10,6 +10,9 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   declare updatedAt: CreationOptional<Date>;
   declare archivedAt: CreationOptional<Date | null>;
   declare lastTodoAnalysisAt: CreationOptional<Date | null>;
+  declare todoGenerationEnabled: CreationOptional<boolean>;
+  /** First-run window only; cleared after first successful analysis. Internal / workflow. */
+  declare initialTodoAnalysisLookback: CreationOptional<string | null>;
   declare spaceId: ForeignKey<SpaceModel["id"]>;
 
   declare description: string | null;
@@ -37,6 +40,15 @@ ProjectMetadataModel.init(
     },
     lastTodoAnalysisAt: {
       type: DataTypes.DATE,
+      allowNull: true,
+    },
+    todoGenerationEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    initialTodoAnalysisLookback: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
   },

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -1034,7 +1034,11 @@ export function useUpdateProjectMetadata({
         ? updates.archive
           ? "Project archived"
           : "Project unarchived"
-        : "Project updated";
+        : updates.todoGenerationEnabled !== undefined
+          ? updates.todoGenerationEnabled
+            ? "Automatic to-do suggestions turned on"
+            : "Automatic to-do suggestions turned off"
+          : "Project updated";
 
     sendNotification({
       type: "success",

--- a/front/migrations/db/migration_616.sql
+++ b/front/migrations/db/migration_616.sql
@@ -1,0 +1,6 @@
+-- Migration created on May 2, 2026
+ALTER TABLE "public"."project_metadata"
+ADD COLUMN "todoGenerationEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "public"."project_metadata"
+ADD COLUMN "initialTodoAnalysisLookback" VARCHAR(32);

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -852,6 +852,13 @@
  *             archivedAt:
  *               type: integer
  *               nullable: true
+ *             todoGenerationEnabled:
+ *               type: boolean
+ *               description: Whether automatic todo suggestions from project activity are enabled.
+ *             lastTodoAnalysisAt:
+ *               type: integer
+ *               nullable: true
+ *               description: Unix timestamp (ms) of the last automatic todo suggestion scan, if any.
  *     PrivateDataSourceView:
  *       type: object
  *       description: A view on a data source within a space.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -191,8 +191,10 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       archivedAt: null,
       createdAt: expect.anything(),
       description: "Test project description",
+      lastTodoAnalysisAt: null,
       sId: expect.anything(),
       spaceId: space.sId,
+      todoGenerationEnabled: false,
       updatedAt: expect.anything(),
       members: [],
     });
@@ -245,8 +247,10 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       archivedAt: null,
       createdAt: expect.anything(),
       description: "Test project with members",
+      lastTodoAnalysisAt: null,
       sId: expect.anything(),
       spaceId: space.sId,
+      todoGenerationEnabled: false,
       updatedAt: expect.anything(),
       members: expect.arrayContaining([
         expect.stringContaining(member1.sId),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -75,6 +75,13 @@
  *                         archivedAt:
  *                           type: integer
  *                           nullable: true
+ *                         todoGenerationEnabled:
+ *                           type: boolean
+ *                           description: Whether automatic todo suggestions from project activity are enabled.
+ *                         lastTodoAnalysisAt:
+ *                           type: integer
+ *                           nullable: true
+ *                           description: Unix timestamp (ms) of the last automatic todo suggestion scan, if any.
  *       401:
  *         description: Unauthorized
  *   patch:
@@ -214,6 +221,9 @@ export type RichSpaceType = SpaceType & {
   // Useful in case of projects
   description: string | null;
   archivedAt: number | null;
+  /** Background todo suggestions from project activity (project spaces only). */
+  todoGenerationEnabled: boolean;
+  lastTodoAnalysisAt: number | null;
 };
 export type GetSpaceResponseBody = {
   space: RichSpaceType;
@@ -340,6 +350,10 @@ async function handler(
           members: currentMembers,
           description: projectMetadata?.description ?? null,
           archivedAt: projectMetadata?.archivedAt?.getTime() ?? null,
+          todoGenerationEnabled:
+            projectMetadata?.todoGenerationEnabled ?? false,
+          lastTodoAnalysisAt:
+            projectMetadata?.lastTodoAnalysisAt?.getTime() ?? null,
         },
       });
     }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -5,14 +5,20 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockLaunchOrSignalProjectTodoWorkflow, mockStopProjectTodoWorkflow } =
-  vi.hoisted(() => ({
-    mockLaunchOrSignalProjectTodoWorkflow: vi.fn(),
-    mockStopProjectTodoWorkflow: vi.fn(),
-  }));
+const {
+  mockLaunchOrSignalProjectTodoWorkflow,
+  mockStartImmediateProjectTodoWorkflowOnce,
+  mockStopProjectTodoWorkflow,
+} = vi.hoisted(() => ({
+  mockLaunchOrSignalProjectTodoWorkflow: vi.fn(),
+  mockStartImmediateProjectTodoWorkflowOnce: vi.fn(),
+  mockStopProjectTodoWorkflow: vi.fn(),
+}));
 
 vi.mock("@app/temporal/project_todo/client", () => ({
   launchOrSignalProjectTodoWorkflow: mockLaunchOrSignalProjectTodoWorkflow,
+  startImmediateProjectTodoWorkflowOnce:
+    mockStartImmediateProjectTodoWorkflowOnce,
   stopProjectTodoWorkflow: mockStopProjectTodoWorkflow,
 }));
 
@@ -130,6 +136,33 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       })
     );
     expect(mockLaunchOrSignalProjectTodoWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("updates todo generation opt-in", async () => {
+    const { req, res, workspace, auth } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    await FeatureFlagFactory.basic(auth, "project_todo");
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    await ProjectMetadataResource.makeNew(auth, projectSpace, {
+      description: "Test",
+    });
+
+    req.query.spaceId = projectSpace.sId;
+    req.body = {
+      todoGenerationEnabled: true,
+      initialTodoAnalysisLookback: "last_24h",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().projectMetadata.todoGenerationEnabled).toBe(true);
+    expect(mockLaunchOrSignalProjectTodoWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockStartImmediateProjectTodoWorkflowOnce).toHaveBeenCalledTimes(1);
   });
 
   it("restarts project todo workflow when unarchiving a project", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -7,6 +7,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import {
   launchOrSignalProjectTodoWorkflow,
+  startImmediateProjectTodoWorkflowOnce,
   stopProjectTodoWorkflow,
 } from "@app/temporal/project_todo/client";
 import { PatchProjectMetadataBodySchema } from "@app/types/api/internal/spaces";
@@ -57,7 +58,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message: "Only project members can update project metadata.",
+            message: "Only project editors can update project metadata.",
           },
         });
       }
@@ -82,11 +83,22 @@ async function handler(
       const featureFlags = await getFeatureFlags(auth);
       const projectTodoEnabled = featureFlags.includes("project_todo");
 
+      const priorLastTodoAnalysisAt = metadata?.lastTodoAnalysisAt ?? null;
+      const priorTodoGenerationEnabled =
+        metadata?.todoGenerationEnabled ?? false;
+
+      const shouldTriggerFirstImmediateSync =
+        projectTodoEnabled &&
+        body.todoGenerationEnabled === true &&
+        !priorTodoGenerationEnabled &&
+        priorLastTodoAnalysisAt === null;
+
       if (!metadata) {
-        // Create new metadata
         metadata = await ProjectMetadataResource.makeNew(auth, space, {
           description: body.description ?? null,
           archivedAt: body.archive ? new Date() : null,
+          todoGenerationEnabled: body.todoGenerationEnabled ?? false,
+          initialTodoAnalysisLookback: body.initialTodoAnalysisLookback ?? null,
         });
         if (!body.archive && projectTodoEnabled) {
           void launchOrSignalProjectTodoWorkflow({
@@ -94,8 +106,13 @@ async function handler(
             spaceId: space.sId,
           });
         }
+        if (shouldTriggerFirstImmediateSync && !body.archive) {
+          void startImmediateProjectTodoWorkflowOnce({
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            spaceId: space.sId,
+          });
+        }
       } else {
-        // Update existing metadata
         if (body.archive !== undefined) {
           if (body.archive) {
             await metadata.archive();
@@ -117,6 +134,35 @@ async function handler(
         }
         if (body.description !== undefined) {
           await metadata.updateDescription(body.description);
+        }
+        if (body.todoGenerationEnabled !== undefined) {
+          await metadata.updateTodoGenerationEnabled(
+            body.todoGenerationEnabled
+          );
+          if (!body.todoGenerationEnabled) {
+            await metadata.updateInitialTodoAnalysisLookback(null);
+          }
+        }
+        if (body.initialTodoAnalysisLookback !== undefined) {
+          await metadata.updateInitialTodoAnalysisLookback(
+            body.initialTodoAnalysisLookback
+          );
+        }
+        if (
+          projectTodoEnabled &&
+          body.todoGenerationEnabled === true &&
+          !priorTodoGenerationEnabled
+        ) {
+          void launchOrSignalProjectTodoWorkflow({
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            spaceId: space.sId,
+          });
+        }
+        if (shouldTriggerFirstImmediateSync) {
+          void startImmediateProjectTodoWorkflowOnce({
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            spaceId: space.sId,
+          });
         }
       }
 

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -9074,6 +9074,15 @@
                             "archivedAt": {
                               "type": "integer",
                               "nullable": true
+                            },
+                            "todoGenerationEnabled": {
+                              "type": "boolean",
+                              "description": "Whether automatic todo suggestions from project activity are enabled."
+                            },
+                            "lastTodoAnalysisAt": {
+                              "type": "integer",
+                              "nullable": true,
+                              "description": "Unix timestamp (ms) of the last automatic todo suggestion scan, if any."
                             }
                           }
                         }
@@ -11068,6 +11077,15 @@
               "archivedAt": {
                 "type": "integer",
                 "nullable": true
+              },
+              "todoGenerationEnabled": {
+                "type": "boolean",
+                "description": "Whether automatic todo suggestions from project activity are enabled."
+              },
+              "lastTodoAnalysisAt": {
+                "type": "integer",
+                "nullable": true,
+                "description": "Unix timestamp (ms) of the last automatic todo suggestion scan, if any."
               }
             }
           }

--- a/front/temporal/project_todo/activities.ts
+++ b/front/temporal/project_todo/activities.ts
@@ -3,6 +3,7 @@ import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_da
 import { buildProjectRetrieveDataSources } from "@app/lib/api/actions/servers/project_manager/helpers";
 import { Authenticator } from "@app/lib/auth";
 import { extractDocumentTakeaways } from "@app/lib/project_todo/analyze_document";
+import { isInitialTodoSyncLookback } from "@app/lib/project_todo/analyze_document/types";
 import { mergeTakeawaysIntoProject } from "@app/lib/project_todo/merge_into_project";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -108,6 +109,14 @@ export async function analyzeProjectTodosActivity({
     return;
   }
 
+  const metadata = await ProjectMetadataResource.fetchBySpace(adminAuth, space);
+  if (!metadata?.todoGenerationEnabled) {
+    localLogger.info(
+      "Todo generation is disabled or not configured for this project; skipping project todo analysis"
+    );
+    return;
+  }
+
   const { groupsToProcess } =
     await space.fetchManualGroupsMemberships(adminAuth);
 
@@ -140,42 +149,53 @@ export async function analyzeProjectTodosActivity({
     return;
   }
 
-  const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
-  let timeFrame: TimeFrame = { duration: 1, unit: "day" }; // Default to one day if no metadata is found
-  if (metadata?.lastTodoAnalysisAt) {
+  let timeFrame: TimeFrame | undefined = { duration: 1, unit: "day" }; // Default when no prior run and no first-sync hint
+  if (metadata.lastTodoAnalysisAt) {
     const deltaMs = Date.now() - metadata.lastTodoAnalysisAt.getTime();
     const MS_PER_HOUR = 1000 * 60 * 60;
     timeFrame = { duration: deltaMs / MS_PER_HOUR, unit: "hour" };
+  } else if (
+    metadata.initialTodoAnalysisLookback &&
+    isInitialTodoSyncLookback(metadata.initialTodoAnalysisLookback)
+  ) {
+    switch (metadata.initialTodoAnalysisLookback) {
+      case "now":
+        timeFrame = { duration: 1, unit: "hour" };
+        break;
+      case "last_24h":
+        timeFrame = { duration: 24, unit: "hour" };
+        break;
+      case "max":
+        timeFrame = undefined;
+        break;
+    }
   }
+
+  const dataSources = await buildProjectRetrieveDataSources(auth, {
+    space,
+    // Only include group conversations and connected data.
+    // Goal is to reduce noise by not generating TODOs for purely agentic conversations or files that might be the output of agentic conversations.
+    // If one wants to have more sophisticated TODOs lifecycle management, they can do it via custom agents.
+    onlyGroupConversationsAndConnectedData: true,
+  });
 
   // Fetch all recent documents changes from the project knowledge and conversations.
   const results = await runIncludeDataRetrieval(auth, {
     citationsOffset: 0,
     retrievalTopK: 128,
-    dataSources: await buildProjectRetrieveDataSources(auth, {
-      space,
-      // Only include group conversations and connected data.
-      // Goal is to reduce noise by not generating TODOs for purely agentic conversations or files that might be the output of agentic conversations.
-      // If one wants to have more sophisticated TODOs lifecycle management, they can do it via custom agents.
-      onlyGroupConversationsAndConnectedData: true,
-    }),
+    dataSources,
     timeFrame,
   });
 
   if (results.isErr()) {
     localLogger.error(
-      { error: results.error },
+      { dataSources, error: results.error },
       "Failed to retrieve include data"
     );
     return;
   }
 
-  if (metadata) {
-    await metadata.updateLastTodoAnalysisAt(new Date());
-  } else {
-    // We should always have a metadata row for a project space, but just in case.
-    localLogger.warn({}, "No project metadata found for space");
-  }
+  const documentsLastFetchedAt = new Date();
 
   const documents = removeNulls(
     results.value.map((result) => resultToTakeawaySourceDocument(result))
@@ -211,9 +231,16 @@ export async function analyzeProjectTodosActivity({
   );
 
   localLogger.info(
-    { phase: "analyze", ...stats, durationMs: Date.now() - startMs },
+    {
+      phase: "analyze",
+      ...stats,
+      documentsLastFetchedAt,
+      durationMs: Date.now() - startMs,
+    },
     "Project todo analysis complete"
   );
+
+  await metadata.recordTodoAnalysisComplete(documentsLastFetchedAt);
 }
 
 // Called by projectTodoWorkflow. Merges the latest takeaway snapshots
@@ -234,6 +261,27 @@ export async function mergeTodosForProjectActivity({
 
   if (!workspaceId) {
     localLogger.error("Workspace ID is required");
+    return;
+  }
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    localLogger.error("Workspace not found");
+    return;
+  }
+
+  const adminAuth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const space = await SpaceResource.fetchById(adminAuth, spaceId);
+  if (!space || !space.isProject()) {
+    localLogger.error("Space not found or not a project");
+    return;
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(adminAuth, space);
+  if (!metadata?.todoGenerationEnabled) {
+    localLogger.info(
+      "Todo generation is disabled or not configured for this project; skipping project todo merge"
+    );
     return;
   }
 

--- a/front/temporal/project_todo/client.ts
+++ b/front/temporal/project_todo/client.ts
@@ -2,6 +2,7 @@ import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/project_todo/config";
+import { todoRefreshSignal } from "@app/temporal/project_todo/signals";
 import { projectTodoWorkflow } from "@app/temporal/project_todo/workflows";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
@@ -34,15 +35,12 @@ export async function launchOrSignalProjectTodoWorkflow({
     return;
   }
   const scheduleOffsetMinutes = spaceModelId % 60;
-  // Spread merges across the hour: one run per workspace project at this minute every hour (UTC).
-  const cronSchedule = `${scheduleOffsetMinutes} * * * *`;
-
+  // Durable loop inside the workflow: same UTC minute each hour (see workflows.ts).
   try {
     await client.workflow.start(projectTodoWorkflow, {
-      args: [{ workspaceId, spaceId }],
+      args: [{ workspaceId, spaceId, scheduleOffsetMinutes }],
       taskQueue: QUEUE_NAME,
       workflowId,
-      cronSchedule,
       memo: {
         workspaceId,
         spaceId,
@@ -62,6 +60,51 @@ export async function launchOrSignalProjectTodoWorkflow({
         "Failed starting project todo workflow"
       );
     }
+  }
+}
+
+/**
+ * Request an on-demand project todo run without starting a second workflow: signals the single
+ * durable workflow for this project (starts it with signalWithStart if not running).
+ */
+export async function startImmediateProjectTodoWorkflowOnce({
+  workspaceId,
+  spaceId,
+}: {
+  workspaceId: string;
+  spaceId: string;
+}): Promise<void> {
+  const spaceModelId = getResourceIdFromSId(spaceId);
+  if (!spaceModelId) {
+    logger.warn(
+      { workspaceId, spaceId },
+      "Skipping project todo refresh signal: invalid space ID"
+    );
+    return;
+  }
+
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeProjectTodoWorkflowId(workspaceId, spaceId);
+  const scheduleOffsetMinutes = spaceModelId % 60;
+
+  try {
+    await client.workflow.signalWithStart(projectTodoWorkflow, {
+      args: [{ workspaceId, spaceId, scheduleOffsetMinutes }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      signal: todoRefreshSignal,
+      signalArgs: ["refresh"],
+    });
+  } catch (e) {
+    logger.error(
+      {
+        workflowId,
+        workspaceId,
+        spaceId,
+        error: normalizeError(e),
+      },
+      "Failed signalWithStart for project todo refresh"
+    );
   }
 }
 

--- a/front/temporal/project_todo/workflows.ts
+++ b/front/temporal/project_todo/workflows.ts
@@ -1,23 +1,83 @@
 import type * as activities from "@app/temporal/project_todo/activities";
-import { proxyActivities, uuid4 } from "@temporalio/workflow";
+import {
+  condition,
+  continueAsNew,
+  proxyActivities,
+  setHandler,
+  uuid4,
+} from "@temporalio/workflow";
+
+import { todoRefreshSignal } from "./signals";
 
 const { analyzeProjectTodosActivity, mergeTodosForProjectActivity } =
   proxyActivities<typeof activities>({
     startToCloseTimeout: "10 minutes",
   });
 
-// Cron-driven workflow (see `cronSchedule` in `launchOrSignalProjectTodoWorkflow`): each
-// execution runs once and completes; Temporal starts the next run on schedule until the
-// workflow is terminated (e.g. project archived or deleted).
+/** Keep history bounded: ~500 hourly runs ≈ 3 weeks before a fresh execution (same workflow id). */
+const RUNS_BEFORE_CONTINUE_AS_NEW = 500;
+
+/** Milliseconds until the next UTC instant whose minute equals `offsetMinutes` (seconds/ms zero). */
+function msUntilNextUtcMinuteSlot(offsetMinutes: number): number {
+  const now = Date.now();
+  const target = new Date(now);
+  target.setUTCSeconds(0, 0);
+  target.setUTCMinutes(offsetMinutes);
+  if (target.getTime() <= now) {
+    target.setUTCHours(target.getUTCHours() + 1);
+  }
+  return Math.max(1, target.getTime() - now);
+}
+
+/**
+ * One durable workflow per project so analyze + merge never run concurrently for the same space.
+ * Each loop iteration **awaits** `condition` (timer or signal)—no busy spin.
+ * Waits until the next hourly UTC slot (minute = scheduleOffsetMinutes, spread across projects) or
+ * until `todoRefreshSignal` fires for an on-demand run (e.g. right after enabling generation).
+ * Periodically `continueAsNew` resets workflow history while keeping the same workflow id.
+ */
 export async function projectTodoWorkflow({
   workspaceId,
   spaceId,
+  scheduleOffsetMinutes,
 }: {
   workspaceId: string;
   spaceId: string;
+  scheduleOffsetMinutes: number;
 }): Promise<void> {
-  // Generate a unique run ID to correlate all log lines across both activities.
-  const runId = uuid4();
-  await analyzeProjectTodosActivity({ workspaceId, spaceId, runId });
-  await mergeTodosForProjectActivity({ workspaceId, spaceId, runId });
+  let pendingRefresh = false;
+
+  setHandler(todoRefreshSignal, (_payload: string) => {
+    pendingRefresh = true;
+  });
+
+  let completedRunsInThisExecution = 0;
+
+  while (true) {
+    const msUntilSlot = msUntilNextUtcMinuteSlot(scheduleOffsetMinutes);
+    const signaled = await condition(() => pendingRefresh, msUntilSlot);
+
+    if (signaled) {
+      pendingRefresh = false;
+    }
+
+    const runId = uuid4();
+    await analyzeProjectTodosActivity({ workspaceId, spaceId, runId });
+    await mergeTodosForProjectActivity({ workspaceId, spaceId, runId });
+
+    completedRunsInThisExecution++;
+
+    // Drain signalled runs before continueAsNew so we don't drop an immediate refresh.
+    if (pendingRefresh) {
+      continue;
+    }
+
+    if (completedRunsInThisExecution >= RUNS_BEFORE_CONTINUE_AS_NEW) {
+      await continueAsNew<typeof projectTodoWorkflow>({
+        workspaceId,
+        spaceId,
+        scheduleOffsetMinutes,
+      });
+    }
+  }
 }

--- a/front/types/api/internal/spaces.ts
+++ b/front/types/api/internal/spaces.ts
@@ -41,6 +41,8 @@ export type GetPostNotionSyncResponseBody = t.TypeOf<
 export const PatchProjectMetadataBodySchema = z.object({
   description: z.string().optional(),
   archive: z.boolean().optional(),
+  todoGenerationEnabled: z.boolean().optional(),
+  initialTodoAnalysisLookback: z.enum(["now", "last_24h", "max"]).optional(),
 });
 
 export type PatchProjectMetadataBodyType = z.infer<

--- a/front/types/project_metadata.ts
+++ b/front/types/project_metadata.ts
@@ -5,4 +5,6 @@ export interface ProjectMetadataType {
   spaceId: string;
   description: string | null;
   archivedAt: number | null;
+  todoGenerationEnabled: boolean;
+  lastTodoAnalysisAt: number | null;
 }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2639,6 +2639,9 @@ export const ProjectMetadataSchema = z.object({
   updatedAt: z.number(),
   spaceId: z.string(),
   description: z.string().nullable(),
+  archivedAt: z.number().nullable().optional(),
+  todoGenerationEnabled: z.boolean().optional(),
+  lastTodoAnalysisAt: z.number().nullable().optional(),
   members: z.array(z.string()),
 });
 export type ProjectMetadataType = z.infer<typeof ProjectMetadataSchema>;


### PR DESCRIPTION
## Description

The todo extraction workflow previously ran automatically for every project with the `project_todo` flag, with no per-project opt-in and a hardcoded 24-hour first-run window. This PR makes suggestions opt-in and lets project editors choose how far back the first scan looks.

**Database**

- Add `todoGenerationEnabled BOOLEAN NOT NULL DEFAULT false` and `initialTodoAnalysisLookback VARCHAR(32)` to `project_metadata` (`migration_616.sql`)
- `todoGenerationEnabled` defaults to `false` — no project gets automatic suggestions without explicitly opting in
- `initialTodoAnalysisLookback` is a one-time field; cleared by `recordTodoAnalysisComplete` after the first successful run

**API**

- Expose `todoGenerationEnabled` and `lastTodoAnalysisAt` on `RichSpaceType` / `GetSpaceResponseBody` and in Swagger schemas
- `PATCH /project_metadata`: accept `todoGenerationEnabled` + `initialTodoAnalysisLookback`; when turning on for the first time (no prior scan), also call `startImmediateProjectTodoWorkflowOnce` for an immediate run; clear `initialTodoAnalysisLookback` when disabling; fix auth error message ("editors" not "members")
- Add `startImmediateProjectTodoWorkflowOnce` Temporal client helper — fires a one-shot run outside the normal cron schedule

**Workflow**

- `analyzeProjectTodosActivity` and `mergeTodosForProjectActivity` both early-exit when `metadata.todoGenerationEnabled` is `false`
- `analyzeProjectTodosActivity` uses `initialTodoAnalysisLookback` to compute the first-run `timeFrame`: `"now"` → 1 h, `"last_24h"` → 24 h, `"max"` → `undefined` (no lower bound); subsequent runs use the elapsed-time delta as before
- Replace `updateLastTodoAnalysisAt` call with `recordTodoAnalysisComplete(documentsLastFetchedAt)` which atomically sets `lastTodoAnalysisAt` and clears `initialTodoAnalysisLookback`

**UI (`SpaceTodosTab`)**

- New "Suggested to-dos" header section: `SparklesIcon` label, Beta `Chip`, `SliderToggle` (disabled for non-editors and archived projects), and an info `Tooltip` showing when the last scan ran
- `FirstSyncTodoLookbackForm` — radio group with three options ("About now", "Last 24 hours", "As far back as possible"); shown in a `ConfirmContext` dialog only when enabling for the first time (no prior `lastTodoAnalysisAt`); subsequent re-enables skip the dialog
- `useUpdateProjectMetadata` toast messages updated for enable/disable

## Tests

Local + green (new test: `updates todo generation opt-in`)

<img width="945" height="171" alt="image" src="https://github.com/user-attachments/assets/e28c3d29-b7e3-4daf-bcdf-95d03976a78c" />
<img width="471" height="485" alt="image" src="https://github.com/user-attachments/assets/28914cf1-9015-4c6e-b1dc-f375b45392ac" />
<img width="1098" height="375" alt="image" src="https://github.com/user-attachments/assets/0f1941e5-13ad-45e4-a9eb-edd4b44e5c1b" />


## Risk

Low — defaults to `false`; existing projects are unaffected until they opt in

## Deploy Plan

Run migration (`migration_616.sql`), deploy `front`
