### PR TITLE
[front] chore: document `skills` field in public agent PATCH endpoint

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -144,6 +144,19 @@ import { fromError } from "zod-validation-error";
  *                       type: string
  *                     full_name:
  *                       type: string
+ *               skills:
+ *                 type: array
+ *                 description: Replaces the skills enabled on the agent configuration.
+ *                 items:
+ *                   type: object
+ *                   required:
+ *                     - sId
+ *                     - name
+ *                   properties:
+ *                     sId:
+ *                       type: string
+ *                     name:
+ *                       type: string
  *               toolset:
  *                 type: array
  *                 items:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -704,6 +704,25 @@
                       }
                     }
                   },
+                  "skills": {
+                    "type": "array",
+                    "description": "Replaces the skills enabled on the agent configuration.",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "sId",
+                        "name"
+                      ],
+                      "properties": {
+                        "sId": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "toolset": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
## Description

- This PR documents the `skills` payload accepted by the public agent configuration PATCH endpoint.
- We could rename the `sId` field into id.

## Tests

- Tested locally to confirm the PATCH works

```
curl -sS -X PATCH "http://localhost:17000/api/v1/w/DevWkSpace/assistant/agent_configurations/YHSR5Ts6Pt" \
    -H "Authorization: Bearer $DUST_API_KEY" \
    -H "Content-Type: application/json" \
    -d '{
      "skills": [
        {
          "sId": "discover_tools",
          "name": "Discover Tools"
        }
      ]
    }' | jq
```

## Risk

- N/A. No runtime change

## Deploy Plan

- Deploy docs
