### PR TITLE
Use zod instead of io-ts in pages/api/poke/workspaces/[wId]/index.ts

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/index.ts
@@ -6,13 +6,12 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-export const WorkspaceTypeSchema = t.type({
-  segmentation: t.union([t.literal("interesting"), t.null]),
+export const WorkspaceTypeSchema = z.object({
+  segmentation: z.literal("interesting").nullable(),
 });
 
 export type SegmentWorkspaceResponseBody = {
@@ -51,18 +50,17 @@ async function handler(
 
   switch (req.method) {
     case "PATCH":
-      const bodyValidation = WorkspaceTypeSchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      const bodyValidation = WorkspaceTypeSchema.safeParse(req.body);
+      if (bodyValidation.error) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `The request body is invalid: ${pathError}`,
+            message: `The request body is invalid: ${fromError(bodyValidation.error).toString()}`,
           },
         });
       }
-      const body = bodyValidation.right;
+      const body = bodyValidation.data;
 
       const workspace = await setInternalWorkspaceSegmentation(
         auth,


### PR DESCRIPTION
## Description

Tiny experiment of a conversion to zod.

Worth noting that the error message is not as rich. With io-ts:

```
The request body is invalid: Expecting one of:
    "interesting"
    null
at segmentation but instead got: "qqq"
```

With zod:

```
The request body is invalid: Validation error: Invalid literal value, expected "interesting" at "segmentation"
```

So with zod:
- It doesn't mention that it's optional
- It doesn't include that bad value that was passed in

While we can customize the message using `errorMap`, that's just too painful to do everywhere.

Maye we just don't care about losing those small things?

## Tests

Manual

## Risk

Poke only, minor API

## Deploy Plan

Front