### PR TITLE
Add: show conversation status on conversation button related to todo's items.

### DIFF
--- a/front/components/assistant/conversation/ConversationSidebarStatusDot.tsx
+++ b/front/components/assistant/conversation/ConversationSidebarStatusDot.tsx
@@ -1,0 +1,29 @@
+import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
+import { cn } from "@dust-tt/sparkle";
+
+/**
+ * Same colors as Sparkle `NavigationListItem` status dots (sidebar conversation rows).
+ */
+export function ConversationSidebarStatusDot({
+  status,
+  className,
+}: {
+  status: ConversationDotStatus;
+  className?: string;
+}) {
+  if (status === "idle") {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "heading-xs m-1 flex h-2 w-2 shrink-0 items-center justify-center rounded-full",
+        status === "unread" && "bg-highlight-500 dark:bg-highlight-500-night",
+        status === "blocked" && "bg-golden-400 dark:bg-golden-400-night",
+        className
+      )}
+      aria-hidden
+    />
+  );
+}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -40,6 +40,7 @@ import { SKILL_ICON } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
   getAgentBuilderRoute,
@@ -1222,21 +1223,6 @@ function WakeUpSuffix({ nextWakeupAt }: WakeUpSuffixProps) {
       {formatWakeUpSidebarLabel(nextWakeupAt)}
     </span>
   );
-}
-
-function getConversationDotStatus(
-  conversation: ConversationListItemType
-): "blocked" | "unread" | "idle" {
-  if (conversation.actionRequired) {
-    return "blocked";
-  }
-  if (conversation.hasError) {
-    return conversation.unread ? "blocked" : "idle";
-  }
-  if (conversation.unread) {
-    return "unread";
-  }
-  return "idle";
 }
 
 const ConversationListItem = memo(

--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -1,4 +1,5 @@
 import { AgentPicker } from "@app/components/assistant/AgentPicker";
+import { ConversationSidebarStatusDot } from "@app/components/assistant/conversation/ConversationSidebarStatusDot";
 import {
   useSpaceConversations,
   useSpaceConversationsSummary,
@@ -19,6 +20,7 @@ import {
   useUpdateProjectTodo,
 } from "@app/lib/swr/projects";
 import { timeAgoFrom } from "@app/lib/utils";
+import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetProjectTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -427,6 +429,8 @@ function EditableTodoItem({
   const hasConversationLink =
     (todo.status === "in_progress" || todo.status === "done") &&
     !!todo.conversationId;
+  const conversationDotStatus: ConversationDotStatus =
+    todo.conversationSidebarStatus ?? "idle";
   const isDoneWithoutConversation = isDone && !hasConversationLink;
   const canEdit = viewerUserId !== null;
   const showInProgressTextAnimation = todo.status === "in_progress";
@@ -527,21 +531,27 @@ function EditableTodoItem({
           <Tooltip
             label="Open to-do conversation"
             trigger={
-              <Button
-                icon={ChatBubbleLeftRightIcon}
-                size="xs"
-                variant="outline"
-                onClick={() => {
-                  if (!todo.conversationId) {
-                    return;
-                  }
-                  void router.push(
-                    getConversationRoute(owner.sId, todo.conversationId),
-                    undefined,
-                    { shallow: true }
-                  );
-                }}
-              />
+              <span className="relative inline-flex shrink-0">
+                <Button
+                  icon={ChatBubbleLeftRightIcon}
+                  size="xs"
+                  variant="outline"
+                  onClick={() => {
+                    if (!todo.conversationId) {
+                      return;
+                    }
+                    void router.push(
+                      getConversationRoute(owner.sId, todo.conversationId),
+                      undefined,
+                      { shallow: true }
+                    );
+                  }}
+                />
+                <ConversationSidebarStatusDot
+                  status={conversationDotStatus}
+                  className="pointer-events-none absolute -right-0.5 -top-0.5 m-0 ring-2 ring-background dark:ring-background-night"
+                />
+              </span>
             }
           />
         ) : (
@@ -762,9 +772,6 @@ function EditableProjectTodosPanel({
   const doCleanDone = useCleanDoneProjectTodos({ owner, spaceId });
   const markRead = useMarkProjectTodosRead({ owner, spaceId });
 
-  // Disabled subscriptions used only to invalidate the space conversations list
-  // and summary when a todo conversation is started — the parent page already
-  // owns the active fetch for these keys.
   const { mutateConversations: mutateSpaceConversations } =
     useSpaceConversations({
       workspaceId: owner.sId,
@@ -864,6 +871,7 @@ function EditableProjectTodosPanel({
         );
     }
   }, [selectedUserSIds, todoOwnerFilter.assigneeScope, todos, viewerUserId]);
+
   const hasDoneItems = filteredTodos.some((todo) => todo.status === "done");
   const groupedTodosForAll = useMemo(() => {
     const groups = new Map<
@@ -1025,6 +1033,7 @@ function EditableProjectTodosPanel({
                     markedAsDoneByType: null,
                     markedAsDoneByAgentConfigurationId: null,
                     conversationId,
+                    conversationSidebarStatus: "idle",
                   }
                 : t
             ),
@@ -1035,6 +1044,7 @@ function EditableProjectTodosPanel({
         // appears right away.
         void mutateSpaceConversations();
         void mutateSpaceSummary();
+        void mutateTodos();
       }
       setStartingTodoIds((prev) => {
         const next = new Set(prev);

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -999,6 +999,27 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return conversations;
   }
 
+  /**
+   * Hydrates participation + read state so {@link ConversationResource#toListItem}
+   * matches sidebar rows (same fields as inbox Elasticsearch lists, minus volatile ES-only bits).
+   * Conversations the user cannot access are omitted from the map.
+   */
+  static async fetchListItemsBySIds(
+    auth: Authenticator,
+    sIds: string[]
+  ): Promise<Map<string, ConversationListItemType>> {
+    if (sIds.length === 0) {
+      return new Map();
+    }
+    const uniqueSIds = [...new Set(sIds)];
+    const conversations = await this.fetchByIds(auth, uniqueSIds);
+    if (conversations.length === 0) {
+      return new Map();
+    }
+    await this.enrichWithParticipationAndReadState(auth, conversations);
+    return new Map(conversations.map((c) => [c.sId, c.toListItem()]));
+  }
+
   static async listAll(
     auth: Authenticator,
     options?: FetchConversationOptions

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -586,6 +586,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       sId: this.sId,
       user: this.assignee,
       conversationId: this.conversationSId,
+      conversationSidebarStatus: null,
       text: this.text,
       status: this.status,
       doneAt: this.doneAt,

--- a/front/lib/utils/conversation_dot_status.ts
+++ b/front/lib/utils/conversation_dot_status.ts
@@ -1,0 +1,18 @@
+import type { ConversationListItemType } from "@app/types/assistant/conversation";
+
+export type ConversationDotStatus = "blocked" | "idle" | "unread";
+
+export function getConversationDotStatus(
+  conversation: ConversationListItemType
+): ConversationDotStatus {
+  if (conversation.actionRequired) {
+    return "blocked";
+  }
+  if (conversation.hasError) {
+    return conversation.unread ? "blocked" : "idle";
+  }
+  if (conversation.unread) {
+    return "unread";
+  }
+  return "idle";
+}

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
@@ -2,9 +2,11 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ProjectTodoType } from "@app/types/project_todo";
@@ -54,20 +56,44 @@ async function handler(
         }
       );
 
+      const serializedBase = todos.map((t) => t.toJSON());
+      const conversationSIds = [
+        ...new Set(
+          serializedBase
+            .map((s) => s.conversationId)
+            .filter((id): id is string => id !== null)
+        ),
+      ];
+      const listItemByConversationSId =
+        await ConversationResource.fetchListItemsBySIds(auth, conversationSIds);
+
       // TODO: enrich todos with creator/done-by user info when supporting multiple users.
-      const todosWithSources: ProjectTodoType[] = todos.map((t) => {
-        const sources = sourcesByTodoId.get(t.sId) ?? [];
-        const serializedTodo = t.toJSON();
-        return {
-          ...serializedTodo,
-          sources: sources.map((s) => ({
-            sourceType: s.sourceType,
-            sourceId: s.sourceId,
-            sourceTitle: s.sourceTitle,
-            sourceUrl: s.sourceUrl,
-          })),
-        };
-      });
+      const todosWithSources: ProjectTodoType[] = serializedBase.map(
+        (serializedTodo, i) => {
+          const t = todos[i]!;
+          const sources = sourcesByTodoId.get(t.sId) ?? [];
+          const { conversationId } = serializedTodo;
+          let conversationSidebarStatus: ProjectTodoType["conversationSidebarStatus"] =
+            null;
+          if (conversationId) {
+            const listItem = listItemByConversationSId.get(conversationId);
+            conversationSidebarStatus = listItem
+              ? getConversationDotStatus(listItem)
+              : "idle";
+          }
+
+          return {
+            ...serializedTodo,
+            conversationSidebarStatus,
+            sources: sources.map((s) => ({
+              sourceType: s.sourceType,
+              sourceId: s.sourceId,
+              sourceTitle: s.sourceTitle,
+              sourceUrl: s.sourceUrl,
+            })),
+          };
+        }
+      );
 
       return res.status(200).json({
         todos: todosWithSources,

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -1,3 +1,4 @@
+import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import type { ModelId } from "@app/types/shared/model_id";
 
 export const PROJECT_TODO_STATUSES = ["todo", "in_progress", "done"] as const;
@@ -39,6 +40,8 @@ export type ProjectTodoType = {
   sId: string;
   user: ProjectTodoAssigneeType | null;
   conversationId: string | null;
+  /** Same semantics as the left sidebar conversation row (see `getConversationDotStatus`). */
+  conversationSidebarStatus: ConversationDotStatus | null;
   text: string;
   status: ProjectTodoStatus;
   doneAt: Date | null;


### PR DESCRIPTION
## Description

The "Open conversation" button on a todo gave no indication of whether the linked conversation had new activity, needed attention, or was idle. This PR adds the same status dot used in the sidebar to the button, so users can tell at a glance which todo conversations need their attention.

- Extract `getConversationDotStatus` from `SidebarMenu.tsx` into a shared `lib/utils/conversation_dot_status.ts` module; export `ConversationDotStatus` type (`"blocked"` | `"idle"` | `"unread"`)
- Add `ConversationSidebarStatusDot` component — renders a color-coded dot (`highlight` for unread, `golden` for blocked, hidden for idle) with an absolute `ring-2` offset over the button; returns `null` for `"idle"` to avoid DOM noise
- Add `conversationSidebarStatus: ConversationDotStatus | null` to `ProjectTodoType`
- In `GET /project_todos`: bulk-fetch `ConversationListItemType` for all linked conversation sIds via the new `ConversationResource.fetchListItemsBySIds` (hydrates participation + read state in one query); compute `getConversationDotStatus` per todo; set `"idle"` when the conversation exists but isn't accessible, `null` when no conversation is linked
- Add `ConversationResource.fetchListItemsBySIds` static helper — deduplicates, calls `fetchByIds`, then `enrichWithParticipationAndReadState`, returns a `Map<sId, ConversationListItemType>`
- In `EditableTodoItem`: wrap the chat `Button` in a `relative` span and overlay the `ConversationSidebarStatusDot`
- Add `conversationSidebarStatus: "idle"` to the optimistic SWR update when starting a todo (the conversation is fresh, so unread/blocked is impossible); trigger `mutateTodos()` after start so the dot syncs on next revalidation

## Tests

Local

<img width="921" height="340" alt="image" src="https://github.com/user-attachments/assets/119f4c94-0a72-4f75-998f-5ae4a023a19e" />


## Risk

Low — the new field is nullable; existing todos without a conversation are unaffected; the bulk fetch adds one extra query per `GET /project_todos` call

## Deploy Plan

Deploy `front`
