### PR TITLE
fix: remove redundant confirm dialog when saving project description

### DIFF
--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -154,16 +154,6 @@ export function SpaceAboutTab({
   };
 
   const onSaveDescription = async () => {
-    const confirmed = await confirm({
-      title: "Update project description?",
-      message: "The project description will be updated.",
-      validateVariant: "warning",
-    });
-
-    if (!confirmed) {
-      return;
-    }
-
     await doUpdateMetadata({ description: projectDescription });
     setIsEditingDescription(false);
   };


### PR DESCRIPTION
## Description

The description field in project settings already shows explicit **Save** / **Cancel** buttons that only appear when the textarea has been modified. The extra confirmation dialog ("Update project description?") on top of that was unnecessary friction — the user already expressed clear intent by clicking Save.

This PR removes the `confirm()` call inside `onSaveDescription`.

**What stays protected by a dialog:**
- Name change (renaming a project is higher-impact)
- Visibility toggle (public ↔ restricted, structural change)
- Archive action

**What changes:**
- Editing the description textarea → Save/Cancel buttons appear → clicking Save saves immediately, no modal interstitial

## Tests

Manually verify:
1. Go to a project → Settings tab
2. Edit the description → Save/Cancel buttons appear
3. Click **Save** → description updates directly, no dialog appears
4. Click **Cancel** → reverts to previous value

## Risks

Low — pure UX simplification, no changes to data logic or API calls.

## Deploy Plan

Standard deployment.
