### PR TITLE
Add: tooltip for conversations filters

### DIFF
--- a/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectTodosPanel.tsx
@@ -322,7 +322,7 @@ function ReadOnlyTodoItem({
         <div className="flex flex-col gap-0.5">
           <span
             className={cn(
-              "text-base min-h-6",
+              "select-text text-base min-h-6",
               isDone
                 ? "text-faint dark:text-faint-night line-through"
                 : "text-foreground dark:text-foreground-night"
@@ -497,13 +497,7 @@ function EditableTodoItem({
       </div>
       <TodoMetadataTooltip todo={todo} agentNameById={agentNameById}>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <button
-            type="button"
-            className="cursor-default text-left"
-            onClick={(event) => {
-              event.preventDefault();
-            }}
-          >
+          <div className="cursor-default select-text text-left">
             <span
               className={cn(
                 "text-base min-h-6 transition-all duration-300",
@@ -522,7 +516,7 @@ function EditableTodoItem({
                 todo.text
               )}
             </span>
-          </button>
+          </div>
           <div className="ml-1">
             <TodoSources sources={todo.sources} owner={owner} isDone={isDone} />
           </div>

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -217,62 +217,56 @@ export function SpaceConversationsTab({
             /* Space conversations section */
             <div className="w-full">
               <div className="flex flex-col gap-3">
-                <div className="flex flex-row gap-2 my-3 px-3">
-                  <SearchInputWithPopover
-                    name="conversation-search"
-                    value={searchText}
-                    onChange={setSearchText}
-                    placeholder={`Search in ${spaceInfo.name}`}
-                    open={isSearchPopoverOpen && searchText.trim().length > 0}
-                    onOpenChange={setIsSearchPopoverOpen}
-                    items={searchResults}
-                    isLoading={isSearching}
-                    noResults={
-                      searchText.trim().length > 0 && !isSearching
-                        ? isSearchError
-                          ? "Failed to search conversations. Please try again."
-                          : "No conversations found."
-                        : ""
-                    }
-                    displayItemCount={true}
-                    renderItem={(conversation, selected) => {
-                      const conversationLabel =
-                        getConversationDisplayTitle(conversation);
-                      const time = moment(conversation.updated).fromNow();
+                <div className="my-3 flex min-w-0 flex-row gap-2 px-3">
+                  <div className="min-w-0 flex-1">
+                    <SearchInputWithPopover
+                      name="conversation-search"
+                      value={searchText}
+                      onChange={setSearchText}
+                      placeholder={`Search in ${spaceInfo.name}`}
+                      open={isSearchPopoverOpen && searchText.trim().length > 0}
+                      onOpenChange={setIsSearchPopoverOpen}
+                      items={searchResults}
+                      isLoading={isSearching}
+                      noResults={
+                        searchText.trim().length > 0 && !isSearching
+                          ? isSearchError
+                            ? "Failed to search conversations. Please try again."
+                            : "No conversations found."
+                          : ""
+                      }
+                      displayItemCount={true}
+                      renderItem={(conversation, selected) => {
+                        const conversationLabel =
+                          getConversationDisplayTitle(conversation);
+                        const time = moment(conversation.updated).fromNow();
 
-                      return (
-                        <div
-                          className={cn(
-                            "cursor-pointer px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-800",
-                            selected && "bg-gray-100 dark:bg-gray-700"
-                          )}
-                          onClick={() => navigateToConversation(conversation)}
-                        >
-                          <div className="flex items-center justify-between gap-2">
-                            <div className="min-w-0 flex-1 truncate">
-                              <div className="text-sm font-medium text-foreground dark:text-foreground-night">
-                                {conversationLabel}
+                        return (
+                          <div
+                            className={cn(
+                              "cursor-pointer px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-800",
+                              selected && "bg-gray-100 dark:bg-gray-700"
+                            )}
+                            onClick={() => navigateToConversation(conversation)}
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <div className="min-w-0 flex-1 truncate">
+                                <div className="text-sm font-medium text-foreground dark:text-foreground-night">
+                                  {conversationLabel}
+                                </div>
+                              </div>
+                              <div className="shrink-0 text-xs text-muted-foreground dark:text-muted-foreground-night">
+                                {time}
                               </div>
                             </div>
-                            <div className="shrink-0 text-xs text-muted-foreground dark:text-muted-foreground-night">
-                              {time}
-                            </div>
                           </div>
-                        </div>
-                      );
-                    }}
-                    onItemSelect={navigateToConversation}
-                  />
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    label="Mark all as read"
-                    onClick={() => markAllAsRead(unreadConversationIds)}
-                    isLoading={isMarkingAllAsRead}
-                    disabled={unreadConversationIds.length === 0}
-                  />
+                        );
+                      }}
+                      onItemSelect={navigateToConversation}
+                    />
+                  </div>
                 </div>
-                <div className="flex justify-center">
+                <div className="flex flex-row items-center justify-between gap-3">
                   <ButtonsSwitchList
                     key={conversationFilter}
                     defaultValue={conversationFilter}
@@ -281,21 +275,33 @@ export function SpaceConversationsTab({
                     <ButtonsSwitch
                       value="all"
                       label="All"
+                      tooltip="Show every conversation in this project."
                       onClick={() => onConversationFilterChange("all")}
                     />
                     <ButtonsSwitch
                       value="group"
                       label="Group"
+                      tooltip="Show only threads where at least two people have sent messages."
                       onClick={() => onConversationFilterChange("group")}
                     />
                     <ButtonsSwitch
                       value="with_me"
                       label="Mine"
+                      tooltip="Show only conversations where you have sent a message."
                       onClick={() => onConversationFilterChange("with_me")}
                     />
                   </ButtonsSwitchList>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    label="Mark all as read"
+                    className="shrink-0"
+                    onClick={() => markAllAsRead(unreadConversationIds)}
+                    isLoading={isMarkingAllAsRead}
+                    disabled={unreadConversationIds.length === 0}
+                  />
                 </div>
-                <div className="flex flex-col -mt-6">
+                <div className="flex flex-col -mt-2">
                   {isConversationsLoading ? (
                     <>
                       <ListItemSection>


### PR DESCRIPTION
## Description

Two small layout and UX improvements to the conversations tab toolbar.

- **Add tooltips to filter buttons** — "All", "Group", and "Mine" now show a `tooltip` prop explaining what each filter does ("Show every conversation in this project.", "Show only threads where at least two people have sent messages.", "Show only conversations where you have sent a message.")
- **Move "Mark all as read" next to the filter** — the button moves from above the search bar (full-width row) to a `flex-row items-center justify-between` row alongside the `ButtonsSwitchList`, shrunk to `xs` size with `shrink-0` so it doesn't push the filters; search bar gets its own `min-w-0 flex-1` wrapper to prevent overflow; top margin adjusted from `-mt-6` to `-mt-2`

## Tests

Local

## Risk

Low — layout and copy only

## Deploy Plan

Deploy `front`
