### PR TITLE
Factor parse-mentions logic into business layer and switch private endpoint to zod

### DIFF
--- a/front/lib/api/assistant/parse_mentions.ts
+++ b/front/lib/api/assistant/parse_mentions.ts
@@ -1,0 +1,108 @@
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import type { Authenticator } from "@app/lib/auth";
+import { serializeMention } from "@app/lib/mentions/format";
+import type { RichAgentMention } from "@app/types/assistant/mentions";
+import { toRichAgentMentionType } from "@app/types/assistant/mentions";
+
+const MAX_MENTION_LABEL_LENGTH = 1000;
+
+/**
+ * Parses pasted text containing @ mentions and converts them to the proper
+ * mention format. Matches @agentName patterns against available agents in the
+ * workspace and replaces them with the serialized mention representation.
+ */
+export async function parseMentionsInMarkdown({
+  auth,
+  markdown,
+}: {
+  auth: Authenticator;
+  markdown: string;
+}): Promise<string> {
+  // Fetch agent configurations.
+  const agentConfigurations = await getAgentConfigurationsForView({
+    auth,
+    agentsGetView: "list",
+    variant: "light",
+  });
+
+  // Build agent mentions map.
+  const agentMentions: RichAgentMention[] = agentConfigurations
+    .filter((a) => a.status === "active")
+    .map(toRichAgentMentionType);
+
+  // Disabling user mentions for now, as it may lead to customer pinging users unintentionally.
+  //
+  // const userMentions: RichUserMention[] = [];
+  // const { members } = await getMembers(auth, { activeOnly: true });
+  //
+  // userMentions.push(...members.map(toRichUserMentionType));
+
+  // Combine all mentions for matching.
+  const allMentions = [...agentMentions /*, ...userMentions*/];
+
+  // Sort mentions by label length (descending) to match longer names first.
+  // This prevents "AI Assistant Pro" from being matched as "AI" when both exist.
+  allMentions.sort((a, b) => b.label.length - a.label.length);
+
+  let processedMarkdown = markdown;
+
+  for (const mention of allMentions) {
+    // Use a safe case-insensitive substring search instead of compiling a RegExp
+    // per mention. This avoids expensive regex compilation on potentially
+    // attacker-controlled large labels or markdown bodies while preserving the
+    // previous matching semantics: an @mention must be at the start or preceded
+    // by whitespace, and must be followed by whitespace, end-of-string, or
+    // punctuation.
+
+    // Skip empty labels and extremely long labels to avoid pathological work.
+    if (!mention.label || mention.label.length > MAX_MENTION_LABEL_LENGTH) {
+      continue;
+    }
+
+    const serialized = serializeMention(mention);
+
+    // Work with a lowercase copy for case-insensitive searching, but perform
+    // replacements on the original string to preserve character casing outside
+    // of the inserted serialized mention.
+    let lowerText = processedMarkdown.toLowerCase();
+    const needle = `@${mention.label}`.toLowerCase();
+    let searchIndex = 0;
+
+    while (true) {
+      const pos = lowerText.indexOf(needle, searchIndex);
+      if (pos === -1) {
+        break;
+      }
+
+      // Check character before the match (if any) is start or whitespace
+      const beforeIdx = pos - 1;
+      if (beforeIdx >= 0) {
+        const beforeChar = lowerText.charAt(beforeIdx);
+        if (!/\s/.test(beforeChar)) {
+          searchIndex = pos + 1; // continue searching
+          continue;
+        }
+      }
+
+      // Check character after the match (if any) is whitespace, punctuation, or end
+      const afterIdx = pos + needle.length;
+      const afterChar = lowerText.charAt(afterIdx);
+      if (afterChar && !/\s|[.,!?;:]/.test(afterChar)) {
+        searchIndex = pos + 1;
+        continue;
+      }
+
+      // Valid mention found — replace the @label with the serialized mention
+      processedMarkdown =
+        processedMarkdown.slice(0, pos) +
+        serialized +
+        processedMarkdown.slice(afterIdx);
+
+      // Update lowercase copy and continue searching after the inserted text
+      lowerText = processedMarkdown.toLowerCase();
+      searchIndex = pos + serialized.length;
+    }
+  }
+
+  return processedMarkdown;
+}

--- a/front/pages/api/v1/w/[wId]/assistant/mentions/parse.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/mentions/parse.ts
@@ -1,10 +1,7 @@
-import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { parseMentionsInMarkdown } from "@app/lib/api/assistant/parse_mentions";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { serializeMention } from "@app/lib/mentions/format";
 import { apiError } from "@app/logger/withlogging";
-import type { RichAgentMention } from "@app/types/assistant/mentions";
-import { toRichAgentMentionType } from "@app/types/assistant/mentions";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ParseMentionsResponseBodyType } from "@dust-tt/client";
 import { ParseMentionsRequestBodySchema } from "@dust-tt/client";
@@ -79,91 +76,7 @@ async function handler(
 
   const { markdown } = ParseMentionsRequestBodySchema.parse(req.body);
 
-  // Fetch agent configurations.
-  const agentConfigurations = await getAgentConfigurationsForView({
-    auth,
-    agentsGetView: "list",
-    variant: "light",
-  });
-
-  // Build agent mentions map.
-  const agentMentions: RichAgentMention[] = agentConfigurations
-    .filter((a) => a.status === "active")
-    .map(toRichAgentMentionType);
-
-  // Disabling user mentions for now, as it may lead to customer pinging users unintentionally.
-  //
-  // const userMentions: RichUserMention[] = [];
-  // const { members } = await getMembers(auth, { activeOnly: true });
-  //
-  // userMentions.push(...members.map(toRichUserMentionType));
-
-  // Combine all mentions for matching.
-  const allMentions = [...agentMentions /*, ...userMentions*/];
-
-  // Sort mentions by label length (descending) to match longer names first.
-  // This prevents "AI Assistant Pro" from being matched as "AI" when both exist.
-  allMentions.sort((a, b) => b.label.length - a.label.length);
-
-  let processedMarkdown = markdown;
-
-  for (const mention of allMentions) {
-    // Use a safe case-insensitive substring search instead of compiling a RegExp
-    // per mention. This avoids expensive regex compilation on potentially
-    // attacker-controlled large labels or markdown bodies while preserving the
-    // previous matching semantics: an @mention must be at the start or preceded
-    // by whitespace, and must be followed by whitespace, end-of-string, or
-    // punctuation.
-
-    // Skip empty labels and extremely long labels to avoid pathological work.
-    if (!mention.label || mention.label.length > 1000) {
-      continue;
-    }
-
-    const serialized = serializeMention(mention);
-
-    // Work with a lowercase copy for case-insensitive searching, but perform
-    // replacements on the original string to preserve character casing outside
-    // of the inserted serialized mention.
-    let lowerText = processedMarkdown.toLowerCase();
-    const needle = `@${mention.label}`.toLowerCase();
-    let searchIndex = 0;
-
-    while (true) {
-      const pos = lowerText.indexOf(needle, searchIndex);
-      if (pos === -1) {
-        break;
-      }
-
-      // Check character before the match (if any) is start or whitespace
-      const beforeIdx = pos - 1;
-      if (beforeIdx >= 0) {
-        const beforeChar = lowerText.charAt(beforeIdx);
-        if (!/\s/.test(beforeChar)) {
-          searchIndex = pos + 1; // continue searching
-          continue;
-        }
-      }
-
-      // Check character after the match (if any) is whitespace, punctuation, or end
-      const afterIdx = pos + needle.length;
-      const afterChar = lowerText.charAt(afterIdx);
-      if (afterChar && !/\s|[.,!?;:]/.test(afterChar)) {
-        searchIndex = pos + 1;
-        continue;
-      }
-
-      // Valid mention found — replace the @label with the serialized mention
-      processedMarkdown =
-        processedMarkdown.slice(0, pos) +
-        serialized +
-        processedMarkdown.slice(afterIdx);
-
-      // Update lowercase copy and continue searching after the inserted text
-      lowerText = processedMarkdown.toLowerCase();
-      searchIndex = pos + serialized.length;
-    }
-  }
+  const processedMarkdown = await parseMentionsInMarkdown({ auth, markdown });
 
   return res.status(200).json({ markdown: processedMarkdown });
 }

--- a/front/pages/api/w/[wId]/assistant/mentions/parse.ts
+++ b/front/pages/api/w/[wId]/assistant/mentions/parse.ts
@@ -5,12 +5,12 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-const ParseMentionsRequestBodySchema = t.type({
-  markdown: t.string,
+const ParseMentionsRequestBodySchema = z.object({
+  markdown: z.string(),
 });
 
 type ParseMentionsResponseBody = {
@@ -32,19 +32,18 @@ async function handler(
     });
   }
 
-  const parsedBody = ParseMentionsRequestBodySchema.decode(req.body);
-
-  if (isLeft(parsedBody)) {
+  const parseResult = ParseMentionsRequestBodySchema.safeParse(req.body);
+  if (!parseResult.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid request body, `markdown` (string) is required.",
+        message: fromError(parseResult.error).toString(),
       },
     });
   }
 
-  const { markdown } = parsedBody.right;
+  const { markdown } = parseResult.data;
 
   const processedMarkdown = await parseMentionsInMarkdown({ auth, markdown });
 

--- a/front/pages/api/w/[wId]/assistant/mentions/parse.ts
+++ b/front/pages/api/w/[wId]/assistant/mentions/parse.ts
@@ -1,11 +1,9 @@
 /** @ignoreswagger */
-import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+
+import { parseMentionsInMarkdown } from "@app/lib/api/assistant/parse_mentions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { serializeMention } from "@app/lib/mentions/format";
 import { apiError } from "@app/logger/withlogging";
-import type { RichAgentMention } from "@app/types/assistant/mentions";
-import { toRichAgentMentionType } from "@app/types/assistant/mentions";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -19,10 +17,6 @@ type ParseMentionsResponseBody = {
   markdown: string;
 };
 
-/**
- * Parses pasted text containing @ mentions and converts them to the proper mention format.
- * Matches @agentName or @userName patterns against available agents and users.
- */
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<ParseMentionsResponseBody>>,
@@ -52,91 +46,7 @@ async function handler(
 
   const { markdown } = parsedBody.right;
 
-  // Fetch agent configurations.
-  const agentConfigurations = await getAgentConfigurationsForView({
-    auth,
-    agentsGetView: "list",
-    variant: "light",
-  });
-
-  // Build agent mentions map.
-  const agentMentions: RichAgentMention[] = agentConfigurations
-    .filter((a) => a.status === "active")
-    .map(toRichAgentMentionType);
-
-  // Disabling user mentions for now, as it may lead to customer pinging users unintentionally.
-  //
-  // const userMentions: RichUserMention[] = [];
-  // const { members } = await getMembers(auth, { activeOnly: true });
-  //
-  // userMentions.push(...members.map(toRichUserMentionType));
-
-  // Combine all mentions for matching.
-  const allMentions = [...agentMentions /*, ...userMentions*/];
-
-  // Sort mentions by label length (descending) to match longer names first.
-  // This prevents "AI Assistant Pro" from being matched as "AI" when both exist.
-  allMentions.sort((a, b) => b.label.length - a.label.length);
-
-  let processedMarkdown = markdown;
-
-  for (const mention of allMentions) {
-    // Use a safe case-insensitive substring search instead of compiling a RegExp
-    // per mention. This avoids expensive regex compilation on potentially
-    // attacker-controlled large labels or markdown bodies while preserving the
-    // previous matching semantics: an @mention must be at the start or preceded
-    // by whitespace, and must be followed by whitespace, end-of-string, or
-    // punctuation.
-
-    // Skip empty labels and extremely long labels to avoid pathological work.
-    if (!mention.label || mention.label.length > 1000) {
-      continue;
-    }
-
-    const serialized = serializeMention(mention);
-
-    // Work with a lowercase copy for case-insensitive searching, but perform
-    // replacements on the original string to preserve character casing outside
-    // of the inserted serialized mention.
-    let lowerText = processedMarkdown.toLowerCase();
-    const needle = `@${mention.label}`.toLowerCase();
-    let searchIndex = 0;
-
-    while (true) {
-      const pos = lowerText.indexOf(needle, searchIndex);
-      if (pos === -1) {
-        break;
-      }
-
-      // Check character before the match (if any) is start or whitespace
-      const beforeIdx = pos - 1;
-      if (beforeIdx >= 0) {
-        const beforeChar = lowerText.charAt(beforeIdx);
-        if (!/\s/.test(beforeChar)) {
-          searchIndex = pos + 1; // continue searching
-          continue;
-        }
-      }
-
-      // Check character after the match (if any) is whitespace, punctuation, or end
-      const afterIdx = pos + needle.length;
-      const afterChar = lowerText.charAt(afterIdx);
-      if (afterChar && !/\s|[.,!?;:]/.test(afterChar)) {
-        searchIndex = pos + 1;
-        continue;
-      }
-
-      // Valid mention found — replace the @label with the serialized mention
-      processedMarkdown =
-        processedMarkdown.slice(0, pos) +
-        serialized +
-        processedMarkdown.slice(afterIdx);
-
-      // Update lowercase copy and continue searching after the inserted text
-      lowerText = processedMarkdown.toLowerCase();
-      searchIndex = pos + serialized.length;
-    }
-  }
+  const processedMarkdown = await parseMentionsInMarkdown({ auth, markdown });
 
   return res.status(200).json({ markdown: processedMarkdown });
 }

--- a/front/pages/api/w/[wId]/assistant/mentions/parse.ts
+++ b/front/pages/api/w/[wId]/assistant/mentions/parse.ts
@@ -17,6 +17,10 @@ type ParseMentionsResponseBody = {
   markdown: string;
 };
 
+/**
+ * Parses pasted text containing @ mentions and converts them to the proper mention format.
+ * Matches @agentName or @userName patterns against available agents and users.
+ */
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<ParseMentionsResponseBody>>,


### PR DESCRIPTION
## Description

- The session-auth (pages/api/w/[wId]/assistant/mentions/parse.ts) and public-API (pages/api/v1/w/[wId]/assistant/mentions/parse.ts) endpoints had identical bodies for fetching active agents and substituting @label occurrences in markdown with serialized mentions.
- Extracted that logic into parseMentionsInMarkdown({ auth, markdown }) in front/lib/api/assistant/parse_mentions.ts, following the existing convention that auth-dependent assistant logic lives under lib/api/assistant/.
- Switched the private endpoint from io-ts to a local zod schema with safeParse + zod-validation-error.fromError. The schema is local rather than shared with the SDK's ParseMentionsRequestBodySchema since @dust-tt/client is restricted to public API routes.
- Each endpoint now keeps only what legitimately differs: auth wrapper, response type, and swagger annotations. Behavior is unchanged.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
