### PR TITLE
Add commit hash in browser key cache

### DIFF
--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -176,6 +176,9 @@ export function withLogging<T>(
     const cliVersion =
       req.headers["x-dust-cli-version"] ?? req.query.cliVersion;
 
+    // Key the browser cache by X-Commit-Hash
+    res.setHeader("Vary", "X-Commit-Hash");
+
     if (typeof commitHash === "string" && commitHash.length > 0) {
       if (await shouldForceClientReload(commitHash)) {
         logger.info(


### PR DESCRIPTION
## Description

Adds `Vary: X-Commit-Hash` to every API response in `withLogging` to fix a cross-tab cache contamination bug that caused unrelated tabs to enter `X-Reload-Required` reload loops via Chrome's shared HTTP cache.

### Background

The SPA's force-reload mechanism works as follows:

- The client sends `X-Commit-Hash` on every API request.
- `withLogging` (in `front/logger/withlogging.ts`) checks Redis via `shouldForceClientReload(commitHash)`. If the commit is flagged, the response carries `X-Reload-Required: true`.
- The SWR `resHandler` in `front/lib/swr/fetcher.ts` reads that header and triggers `window.location.reload()` (guarded by a 10s `FORCE_RELOAD_SESSION_KEY` to prevent loops).

### Bug

With multiple tabs open on the same workspace:

1. Tab A is on a flagged commit → API responses carry `X-Reload-Required: true`. Chrome caches these responses keyed by URL alone.
2. Tab B is on the up-to-date commit → it hits the same URLs. Chrome finds the cached entry and issues a conditional request (`If-None-Match`).
3. Server returns `304 Not Modified` (no `X-Reload-Required` in the 304).
4. Per HTTP spec, the browser **merges 304 headers with the stored response headers**. The stored entry still has `X-Reload-Required: true` → JS sees `true` → Tab B reloads even though the server never told it to.
5. The Network tab shows clean 304 headers, but `res.headers.get("X-Reload-Required")` returns `"true"` because JS reads the merged stored headers.

Without a `Vary` header, Chrome treats responses for the same URL as interchangeable across tabs regardless of which commit hash the request carried.

### Fix

Set `Vary: X-Commit-Hash` unconditionally on every response flowing through `withLogging`. Chrome then keys cache entries per commit-hash value, so:

- Tab A's old-hash response and Tab B's new-hash response do not share a cache entry.
- Tab B's request never matches Tab A's cached entry → fresh 200 from the server → no `X-Reload-Required` leakage.

The header has to be set on **all** responses, not just the ones with `X-Reload-Required: true`. Cache poisoning happens at cache-write time: if a non-flagged 200 response is cached without `Vary`, Chrome will reuse it (or merge a 304 into it) regardless of commit hash, and no later response can fix the entry.

### Side effect: cache no longer shared across client versions

With `Vary: X-Commit-Hash`, cache entries are keyed per commit hash. Every time the client reloads onto a new app version, the previously cached API responses no longer match the new request key, so the browser issues fresh HTTP calls instead of serving from cache (it can't even fall back to a conditional `If-None-Match` request — a non-matching Vary makes the entry ineligible, not just stale).

This is acceptable: cache reuse across versions was incidental rather than something we relied on, the loss only affects responses that were cacheable to begin with, and correctness here clearly outweighs the marginal cache-hit savings.

## Tests

Manual: confirmed no existing `Vary` header usage anywhere in `front` (no risk of being overwritten by per-endpoint logic). Type-check passes.

To verify in production: with two tabs on different commit hashes, force-flag one commit via the poke plugin and confirm only the flagged tab reloads.

## Risk

Very low. The change adds a single response header on all `withLogging`-wrapped routes. `Vary: X-Commit-Hash` is purely a hint to downstream HTTP caches (browser, CDN) about cache key composition — it does not change response bodies, status codes, or any application behavior. Safe to roll back by reverting the one-line addition.

One caveat: if a future endpoint sets its own `Vary` header it would overwrite this one. None exist today.

## Deploy Plan

Standard deploy. No coordination required.