### PR TITLE
Add edit tool to Slack Bot MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -584,6 +584,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "slack_bot": {
     "add_reaction": "low",
+    "edit_message": "high",
     "list_public_channels": "never_ask",
     "post_message": "low",
     "read_channel_history": "never_ask",

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -877,6 +877,40 @@ export async function executePostMessage(
   ]);
 }
 
+export async function executeUpdateMessage({
+  accessToken,
+  channel,
+  timestamp,
+  message,
+}: {
+  accessToken: string;
+  channel: string;
+  timestamp: string;
+  message: string;
+}) {
+  const slackClient = await getSlackClient(accessToken);
+  const slackFormattedMessage = slackifyMarkdown(message);
+
+  const response = await slackClient.chat.update({
+    channel,
+    ts: timestamp,
+    text: slackFormattedMessage,
+    mrkdwn: true,
+  });
+
+  if (!response.ok) {
+    return new Err(new MCPError("Failed to update message"));
+  }
+
+  return new Ok([
+    {
+      type: "text" as const,
+      text: `Message ${timestamp} updated in ${channel}`,
+    },
+    { type: "text" as const, text: JSON.stringify(response, null, 2) },
+  ]);
+}
+
 export async function executeScheduleMessage(
   auth: Authenticator,
   agentLoopContext: AgentLoopContextType,

--- a/front/lib/api/actions/servers/slack/update_message.test.ts
+++ b/front/lib/api/actions/servers/slack/update_message.test.ts
@@ -1,0 +1,76 @@
+import { executeUpdateMessage } from "@app/lib/api/actions/servers/slack/helpers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockChatUpdate } = vi.hoisted(() => ({
+  mockChatUpdate: vi.fn(),
+}));
+
+vi.mock("@slack/web-api", () => {
+  return {
+    WebClient: class MockWebClient {
+      chat = {
+        update: mockChatUpdate,
+      };
+    },
+  };
+});
+
+vi.mock("@app/lib/cache/redis", () => ({
+  cacheWithRedis: (fn: unknown) => fn,
+}));
+
+describe("executeUpdateMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates a Slack message with Slack-formatted Markdown", async () => {
+    mockChatUpdate.mockResolvedValue({
+      ok: true,
+      channel: "C123",
+      ts: "1710000000.000100",
+    });
+
+    const result = await executeUpdateMessage({
+      accessToken: "xoxb-test-token",
+      channel: "C123",
+      timestamp: "1710000000.000100",
+      message: "**Edited** message",
+    });
+
+    expect(mockChatUpdate).toHaveBeenCalledOnce();
+    const updateArgs = mockChatUpdate.mock.calls[0][0];
+    expect(updateArgs).toMatchObject({
+      channel: "C123",
+      ts: "1710000000.000100",
+      mrkdwn: true,
+    });
+    expect(updateArgs.text).toContain("*Edited*");
+    expect(updateArgs.text).not.toContain("**Edited**");
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value[0].text).toBe(
+        "Message 1710000000.000100 updated in C123"
+      );
+    }
+  });
+
+  it("returns an error when Slack rejects the update", async () => {
+    mockChatUpdate.mockResolvedValue({
+      ok: false,
+      error: "message_not_found",
+    });
+
+    const result = await executeUpdateMessage({
+      accessToken: "xoxb-test-token",
+      channel: "C123",
+      timestamp: "1710000000.000100",
+      message: "Edited message",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Failed to update message");
+    }
+  });
+});

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -38,6 +38,28 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       done: "Post Slack message",
     },
   },
+  edit_message: {
+    description:
+      "Edit a message previously posted in a Slack channel by providing its timestamp and channel.",
+    schema: {
+      channel: z
+        .string()
+        .describe("The channel where the message to edit is located"),
+      timestamp: z
+        .string()
+        .describe("The timestamp (ts) of the message to edit"),
+      message: z
+        .string()
+        .describe(
+          "The new message content, using standard Markdown formatting. Do NOT use Slack-specific markup."
+        ),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Editing Slack message",
+      done: "Edit Slack message",
+    },
+  },
   search_user: {
     description: `Search for a Slack user by user ID or email address.
 
@@ -197,7 +219,7 @@ export const SLACK_BOT_SERVER = {
     instructions:
       "The Slack bot must be explicitly added to a channel before it can post messages or read history. " +
       "Direct messages and search operations are not supported. " +
-      "When posting a message on Slack, you MUST use standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). " +
+      "When posting or editing a message on Slack, you MUST use standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). " +
       "Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
       "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the id of the user you want to mention.\n" +
       "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID.",

--- a/front/lib/api/actions/servers/slack_bot/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/tools/index.ts
@@ -9,6 +9,7 @@ import {
   executeListPublicChannels,
   executePostMessage,
   executeSearchUser,
+  executeUpdateMessage,
   getSlackClient,
 } from "@app/lib/api/actions/servers/slack/helpers";
 import { SLACK_BOT_TOOLS_METADATA } from "@app/lib/api/actions/servers/slack_bot/metadata";
@@ -43,6 +44,25 @@ export function createSlackBotTools(
       } catch (error) {
         return new Err(
           new MCPError(`Error posting message: ${normalizeError(error)}`)
+        );
+      }
+    },
+    edit_message: async ({ channel, timestamp, message }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        return new Err(new MCPError("Access token not found"));
+      }
+
+      try {
+        return await executeUpdateMessage({
+          accessToken,
+          channel,
+          timestamp,
+          message,
+        });
+      } catch (error) {
+        return new Err(
+          new MCPError(`Error editing message: ${normalizeError(error)}`)
         );
       }
     },


### PR DESCRIPTION
## Description

This PR adds an `edit_message` tool to the Slack Bot MCP server.

Slack edits messages through `chat.update`, which requires both the channel id and the message timestamp. The tool therefore takes `channel`, `timestamp`, and `message`, then updates the matching Slack message.

A few implementation choices mirror the existing Slack Bot posting path:
- messages are provided as standard Markdown and converted with `slackifyMarkdown`
- the Slack client is created from the per-call access token
- the tool is marked high stake

Manual validation context: https://dust4ai.slack.com/archives/C066R3PMUAU/p1777555395983099?thread_ts=1777484257.415659&cid=C066R3PMUAU

## Tests

- `NODE_ENV=test npm test -- lib/api/actions/servers/slack/update_message.test.ts lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts`
- `npx biome check --error-on-warnings front/lib/api/actions/servers/slack/helpers.ts front/lib/api/actions/servers/slack_bot/metadata.ts front/lib/api/actions/servers/slack_bot/tools/index.ts front/lib/api/actions/servers/slack/update_message.test.ts front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap`
- Manual local Dust UI test in `#slack-demo`: posted a Slack Bot message, edited it, and confirmed Slack displayed the updated message with `(edited)`.

## Risk

Low. Scoped to a new Slack Bot MCP tool. Slack enforces token permissions and message editability. Safe to rollback.

## Deploy Plan

Deploy front.
