### PR TITLE
[front] no-store on X-Reload-Required responses

### DIFF
--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -176,8 +176,9 @@ export function withLogging<T>(
     const cliVersion =
       req.headers["x-dust-cli-version"] ?? req.query.cliVersion;
 
-    // Key the browser cache by X-Commit-Hash
-    res.setHeader("Vary", "X-Commit-Hash");
+    // Key the browser cache by X-Commit-Hash and Origin so CORS responses and
+    // X-Reload-Required cannot leak across tabs / origins via the shared cache.
+    res.setHeader("Vary", "X-Commit-Hash, Origin");
 
     if (typeof commitHash === "string" && commitHash.length > 0) {
       if (await shouldForceClientReload(commitHash)) {
@@ -196,6 +197,10 @@ export function withLogging<T>(
           "Force client reload"
         );
         res.setHeader("X-Reload-Required", "true");
+        // Flagged-commit responses must never be cached: the flag can be
+        // cleared in Redis at any time, but a cached "true" response would
+        // keep the tab in a reload loop until it expires.
+        res.setHeader("Cache-Control", "no-store");
       }
     }
 

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -176,9 +176,8 @@ export function withLogging<T>(
     const cliVersion =
       req.headers["x-dust-cli-version"] ?? req.query.cliVersion;
 
-    // Key the browser cache by X-Commit-Hash and Origin so CORS responses and
-    // X-Reload-Required cannot leak across tabs / origins via the shared cache.
-    res.setHeader("Vary", "X-Commit-Hash, Origin");
+    // Key the browser cache by X-Commit-Hash
+    res.setHeader("Vary", "X-Commit-Hash");
 
     if (typeof commitHash === "string" && commitHash.length > 0) {
       if (await shouldForceClientReload(commitHash)) {


### PR DESCRIPTION
## Description

Follow-up to #25112. The Vary fix prevents tabs on different commits from sharing cache entries, but it doesn't prevent a single tab on the flagged commit from caching its own `X-Reload-Required: true` response.

### The remaining bug

Responses on flagged commits set `X-Reload-Required: true` but kept the default `Cache-Control: public, max-age=120, stale-while-revalidate=300`. Once a tab on the flagged commit cached one of these responses:

- Chrome serves the cached `X-Reload-Required: true` for the next 2 minutes from any subsequent request to the same URL with the same commit hash.
- Even if the flag is cleared in Redis, and even if `window.location.reload()` runs, the next request hits the cache and gets `true` again → reload loop persists.

This is the "still reload-looping after the Vary fix" symptom.

### Fix

`Cache-Control: no-store` on responses that set `X-Reload-Required: true` — flagged responses never enter the cache, so clearing the flag in Redis takes effect immediately on the next request.

## Tests

Verified via curl that responses with `X-Reload-Required: true` now also carry `Cache-Control: no-store`, and that Vary is unchanged for normal responses.

## Risk

Low. `no-store` only applies to the specific path where the server is asking the client to reload. It does not affect any normal response, so no caching behaviour changes for the steady state.

## Deploy Plan

Standard deploy. Pre-existing poisoned cache entries from before this fix will roll over as their `max-age` expires (≤ 2 min for `app-status`).