### PR TITLE
Fix: super slow UI when filtering tools or triggers.

### DIFF
--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -1,4 +1,5 @@
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
+import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useQueryParams } from "@app/hooks/useQueryParams";
@@ -53,9 +54,9 @@ export const SpaceActionsList = ({
   space,
 }: SpaceActionsListProps) => {
   const router = useAppRouter();
+  const { frontendListFilterQuery } = React.useContext(SpaceSearchContext);
   const { q: searchParam } = useQueryParams(["q"]);
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const searchTerm = searchParam.value || "";
+  const searchTerm = frontendListFilterQuery ?? searchParam.value ?? "";
 
   const { serverViews, isMCPServerViewsLoading, mutateMCPServerViews } =
     useMCPServerViews({

--- a/front/components/spaces/SpaceAppsList.tsx
+++ b/front/components/spaces/SpaceAppsList.tsx
@@ -1,5 +1,6 @@
 import { SpaceCreateAppModal } from "@app/components/spaces/SpaceCreateAppModal";
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
+import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useQueryParams } from "@app/hooks/useQueryParams";
@@ -81,9 +82,9 @@ export const SpaceAppsList = ({
   const router = useAppRouter();
   const [isCreateAppModalOpened, setIsCreateAppModalOpened] = useState(false);
 
+  const { frontendListFilterQuery } = React.useContext(SpaceSearchContext);
   const { q: searchParam } = useQueryParams(["q"]);
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const searchTerm = searchParam.value || "";
+  const searchTerm = frontendListFilterQuery ?? searchParam.value ?? "";
 
   const { apps, isAppsLoading } = useApps({ owner, space });
 

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -506,16 +506,36 @@ function FrontendSearch({
   parentId,
 }: FullFrontendSearchProps) {
   const { q: searchParam } = useQueryParams(["q"]);
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const searchTerm = searchParam.value || "";
+  // Keep input value in local debounce state so it does not lag behind shallow
+  // router updates (useQueryParams syncs from router.query after each push).
+  const { inputValue: searchTerm, setValue: setSearchValue } = useDebounce(
+    searchParam.value || "",
+    {
+      delay: 300,
+      minLength: 0,
+    }
+  );
+
+  const handleSearchChange = (value: string) => {
+    searchParam.setParam(value || undefined);
+    setSearchValue(value);
+  };
+
+  const providerValue = useMemo(
+    () => ({
+      ...searchContextValue,
+      frontendListFilterQuery: searchTerm,
+    }),
+    [searchContextValue, searchTerm]
+  );
 
   return (
-    <SpaceSearchContext.Provider value={searchContextValue}>
+    <SpaceSearchContext.Provider value={providerValue}>
       <SearchInput
         name="search"
         placeholder={getSearchInputPlaceholder(space, category, dataSourceView)}
         value={searchTerm}
-        onChange={searchParam.setParam}
+        onChange={handleSearchChange}
         disabled={isSearchDisabled}
       />
       <div className="flex w-full justify-between gap-2">

--- a/front/components/spaces/SpaceTriggersList.tsx
+++ b/front/components/spaces/SpaceTriggersList.tsx
@@ -1,3 +1,4 @@
+import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { WebhookSourceViewIcon } from "@app/components/triggers/WebhookSourceViewIcon";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useQueryParams } from "@app/hooks/useQueryParams";
@@ -34,8 +35,9 @@ export const SpaceTriggersList = ({ owner, space }: SpaceActionsListProps) => {
     urlPrefix: "table",
   });
 
+  const { frontendListFilterQuery } = React.useContext(SpaceSearchContext);
   const { q: searchParam } = useQueryParams(["q"]);
-  const searchTerm = searchParam.value ?? "";
+  const searchTerm = frontendListFilterQuery ?? searchParam.value ?? "";
 
   const columns: ColumnDef<RowData, string>[] = [
     {

--- a/front/components/spaces/SystemSpaceActionsList.tsx
+++ b/front/components/spaces/SystemSpaceActionsList.tsx
@@ -1,5 +1,6 @@
 import { AdminActionsList } from "@app/components/actions/mcp/AdminActionsList";
 import { MCPServerDetails } from "@app/components/actions/mcp/MCPServerDetails";
+import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { useMCPServerViews } from "@app/lib/swr/mcp_servers";
@@ -7,7 +8,7 @@ import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import * as React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useContext, useMemo, useState } from "react";
 
 interface SpaceActionsListProps {
   isAdmin: boolean;
@@ -39,8 +40,9 @@ export const SystemSpaceActionsList = ({
     [serverViews, selectedMcpServer?.sId]
   );
 
+  const { frontendListFilterQuery } = useContext(SpaceSearchContext);
   const { q: searchParam } = useQueryParams(["q"]);
-  const searchTerm = searchParam.value ?? "";
+  const searchTerm = frontendListFilterQuery ?? searchParam.value ?? "";
 
   const handleClose = useCallback(() => {
     // Close the sheet but keep content mounted to avoid glitches.

--- a/front/components/spaces/SystemSpaceTriggersList.tsx
+++ b/front/components/spaces/SystemSpaceTriggersList.tsx
@@ -1,10 +1,11 @@
 import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
+import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { AdminTriggersList } from "@app/components/triggers/AdminTriggersList";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import { useWebhookSourcesWithViews } from "@app/lib/swr/webhook_source";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { useMemo, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 
 interface SpaceActionsListProps {
   isAdmin: boolean;
@@ -38,8 +39,9 @@ export const SystemSpaceTriggersList = ({
     [webhookSourcesWithViews, space.sId]
   );
 
+  const { frontendListFilterQuery } = useContext(SpaceSearchContext);
   const { q: searchParam } = useQueryParams(["q"]);
-  const searchTerm = searchParam.value ?? "";
+  const searchTerm = frontendListFilterQuery ?? searchParam.value ?? "";
 
   if (!isAdmin) {
     return null;

--- a/front/components/spaces/search/SpaceSearchContext.tsx
+++ b/front/components/spaces/search/SpaceSearchContext.tsx
@@ -1,4 +1,5 @@
 import type { DataSourceViewType } from "@app/types/data_source_view";
+import type { ReactNode } from "react";
 import { createContext } from "react";
 
 // Temporary context to share the search term between the SpaceLayout and the
@@ -12,6 +13,15 @@ export interface SpaceSearchContextType {
   // Data source view targeting for search
   targetDataSourceViews?: DataSourceViewType[];
   setTargetDataSourceViews: (value: DataSourceViewType[]) => void;
+
+  setActionButtons?: (buttons: ReactNode | null) => void;
+  actionButtons?: ReactNode | null;
+
+  /**
+   * Immediate search string for frontend-only space lists (actions, triggers, apps).
+   * URL `q` can lag behind shallow routing; lists should prefer this when set.
+   */
+  frontendListFilterQuery?: string;
 }
 
 export const SpaceSearchContext = createContext<SpaceSearchContextType>({
@@ -20,4 +30,6 @@ export const SpaceSearchContext = createContext<SpaceSearchContextType>({
 
   targetDataSourceViews: [],
   setTargetDataSourceViews: () => {},
+
+  frontendListFilterQuery: undefined,
 });


### PR DESCRIPTION
## Description

Typing in the search box on the tools/triggers/apps pages felt sluggish. The root cause: each keystroke called `searchParam.setParam(value)` which triggered a shallow `router.push`, which caused a full Next.js re-render cycle before the list could filter. On large lists (many MCP servers or triggers) this produced visible lag.

The fix is to decouple the UI update from the URL update: maintain an immediate local debounced value and propagate it to consumers via `SpaceSearchContext` instead of waiting for the router round-trip.

- Add `frontendListFilterQuery?: string` to `SpaceSearchContextType` — an immediate search string for frontend-only lists; documented as preferred over the URL `q` param when set
- In `FrontendSearch`: replace the raw `searchParam.value` read with `useDebounce(searchParam.value, { delay: 300 })` + a local `setValue`; call both `searchParam.setParam` and `setSearchValue` on change so the URL and the local state stay in sync; expose `frontendListFilterQuery: searchTerm` in the context `providerValue`
- In `SpaceActionsList`, `SpaceAppsList`, `SpaceTriggersList`, `SystemSpaceActionsList`, `SystemSpaceTriggersList`: consume `frontendListFilterQuery` from `SpaceSearchContext` and prefer it over `searchParam.value` (`frontendListFilterQuery ?? searchParam.value ?? ""`)

## Tests

Local

## Risk

Low — the URL still updates (bookmarking / sharing still works); the local value is only used to drive the visible filter ahead of the router commit

## Deploy Plan

Deploy `front`
