### PR TITLE
Only capture pageviews in posthog on path change.

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -146,6 +146,7 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
   const hasInitialized = useRef(false);
   const hasUpgradedPersistence = useRef(false);
   const lastIdentifiedUserId = useRef<string | null>(null);
+  const lastPageviewPathnameRef = useRef<string | null>(null);
 
   // Phase 1: Initialize PostHog with memory-only persistence (no cookies).
   // This captures events for all visitors including anonymous ad traffic,
@@ -417,14 +418,24 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
     currentWorkspace?.role,
   ]);
 
-  // Track pageviews on route changes.
+  // Track pageviews on client navigations when the pathname changes. Shallow
+  // query updates (e.g. space search `?q=`) still fire routeChangeComplete but
+  // must not emit a new $pageview.
   useEffect(() => {
     if (!posthog.__loaded || !isTrackablePage) {
       return;
     }
 
+    lastPageviewPathnameRef.current = router.pathname;
+
     const handleRouteChange = () => {
       const pathname = router.pathname;
+
+      if (pathname === lastPageviewPathnameRef.current) {
+        return;
+      }
+
+      lastPageviewPathnameRef.current = pathname;
 
       // Don't track pageviews on conversation pages (/conversation/[cId]), but track /conversation/new.
       const isConversationPage = /\/conversation\/(?!new$)[^/]+$/.test(


### PR DESCRIPTION
## Description

Shallow route updates (e.g. the space search `?q=` query param from #25117) fire Next.js `routeChangeComplete` without changing the pathname. The PostHog tracker was emitting a `$pageview` event on every `routeChangeComplete`, so typing in the search box was generating a flood of spurious pageview events and inflating analytics.

- Add `lastPageviewPathnameRef` to track the pathname of the last emitted pageview
- Initialize it to `router.pathname` on mount (so the initial pageview is not double-counted)
- In `handleRouteChange`: early-return when `router.pathname === lastPageviewPathnameRef.current`; otherwise update the ref and proceed with the existing pageview logic

## Tests

Local

## Risk

Low — only skips pageviews when the pathname hasn't changed; real navigations are unaffected

## Deploy Plan

Deploy `front`
