### PR TITLE
fix(todos): show '...' more options button on mobile

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -497,7 +497,14 @@ export const EditableTodoItem = memo(function EditableTodoItem({
           ))
         )}
         {canEdit && (
-          <div className="opacity-0 transition-opacity group-hover/todo:opacity-100">
+          <div
+            className={cn(
+              "transition-opacity",
+              overflowMenuOpen
+                ? "opacity-100"
+                : "sm:opacity-0 sm:group-hover/todo:opacity-100"
+            )}
+          >
             <DropdownMenu
               modal={false}
               open={overflowMenuOpen}


### PR DESCRIPTION
## Problem

On touch/mobile screens, the `...` (more options) button on todo items was completely invisible and inaccessible. It was wrapped in a div with `opacity-0 group-hover/todo:opacity-100`, which requires a hover event — something that doesn't exist on touch devices.

## Fix

Follows the same prior art pattern used in `AgentMessage.tsx`:

- **Mobile (< `sm` breakpoint)**: button is always visible (no `opacity-0` applied by default)
- **Desktop (`sm`+)**: hidden until hover, same as before
- **When menu is open** (`overflowMenuOpen === true`): always visible on any screen size

### Before
```tsx
<div className="opacity-0 transition-opacity group-hover/todo:opacity-100">
```

### After
```tsx
<div
  className={cn(
    "transition-opacity",
    overflowMenuOpen
      ? "opacity-100"
      : "sm:opacity-0 sm:group-hover/todo:opacity-100"
  )}
>
```

## Files changed
- `front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx`