### PR TITLE
feat(projects): sort reassignment list with active-todo members first

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
@@ -136,6 +136,16 @@ export function EditableProjectTodosPanel({
     );
   }, [spaceInfo?.members]);
 
+  const membersWithActiveTodoIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const todo of todos) {
+      if (todo.status !== "done" && todo.user?.sId) {
+        ids.add(todo.user.sId);
+      }
+    }
+    return ids;
+  }, [todos]);
+
   const defaultNewAssigneeSId = useMemo(() => {
     if (projectMembers.length === 0) {
       return null;
@@ -685,6 +695,7 @@ export function EditableProjectTodosPanel({
                       isStarting={startingTodoIds.has(todo.sId)}
                       isReadOnly={isReadOnly}
                       projectMembers={projectMembers}
+                      membersWithActiveTodoIds={membersWithActiveTodoIds}
                       onPatchTodo={patchTodoItem}
                     />
                   ))}

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -65,6 +65,7 @@ export interface EditableTodoItemProps {
   isStarting: boolean;
   isReadOnly?: boolean;
   projectMembers: SpaceUserType[];
+  membersWithActiveTodoIds: Set<string>;
   onPatchTodo: (
     todoId: string,
     updates: { text?: string; assigneeUserId?: string }
@@ -87,6 +88,7 @@ export const EditableTodoItem = memo(function EditableTodoItem({
   isStarting,
   isReadOnly,
   projectMembers,
+  membersWithActiveTodoIds,
   onPatchTodo,
 }: EditableTodoItemProps) {
   const router = useAppRouter();
@@ -123,11 +125,17 @@ export const EditableTodoItem = memo(function EditableTodoItem({
 
   const filteredReassignMembers = useMemo(() => {
     const q = reassignSearch.trim().toLowerCase();
-    if (!q) {
-      return projectMembers;
-    }
-    return projectMembers.filter((m) => m.fullName.toLowerCase().includes(q));
-  }, [reassignSearch, projectMembers]);
+    const filtered = q
+      ? projectMembers.filter((m) => m.fullName.toLowerCase().includes(q))
+      : [...projectMembers];
+    // Sort: members with at least one active (non-done) todo come first,
+    // preserving alphabetical order within each group.
+    return filtered.sort((a, b) => {
+      const aActive = membersWithActiveTodoIds.has(a.sId) ? 0 : 1;
+      const bActive = membersWithActiveTodoIds.has(b.sId) ? 0 : 1;
+      return aActive - bActive;
+    });
+  }, [reassignSearch, projectMembers, membersWithActiveTodoIds]);
 
   useEffect(() => {
     if (!isNewlyDone) {


### PR DESCRIPTION
## Description

When reassigning a todo, the member picker now floats members who have at least one active (non-done) todo to the top of the list. Alphabetical order is preserved within each group.

### Changes

- **`EditableProjectTodosPanel`**: derives `membersWithActiveTodoIds` — a `Set<string>` of user sIds that own at least one `todo` or `in_progress` todo — from the existing `todos` array and passes it down to each `EditableTodoItem`.
- **`EditableTodoItem`**: accepts `membersWithActiveTodoIds` as a new required prop; `filteredReassignMembers` now stable-sorts members with active todos before members without, preserving the existing A-Z alphabetical order within each group.

No server-side or API changes required.

## Tests

Local

## Risk

Low — pure UI sort; no data or API changes.

## Deploy Plan

Deploy `front`
