### PR TITLE
sparkle: fix diacritic-insensitive member search in DropdownMenu filters [CLOSED - wrong file]

### DIFF
--- a/sparkle/playground/src/stories/Projects_Spaces.tsx
+++ b/sparkle/playground/src/stories/Projects_Spaces.tsx
@@ -50,6 +50,7 @@ import {
   StarStrokeIcon,
   TrashIcon,
   UserIcon,
+  normalizeForSearch,
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 
@@ -214,9 +215,9 @@ function DustMain() {
     if (!searchText.trim()) {
       return allConversations;
     }
-    const lowerSearch = searchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(searchText);
     return allConversations.filter((conv) =>
-      conv.title.toLowerCase().includes(lowerSearch)
+      normalizeForSearch(conv.title).includes(normalizedSearch)
     );
   }, [searchText, allConversations]);
 
@@ -260,9 +261,9 @@ function DustMain() {
     if (!agentSearchText.trim()) {
       return mockAgents;
     }
-    const lowerSearch = agentSearchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(agentSearchText);
     return mockAgents.filter((agent) =>
-      agent.name.toLowerCase().includes(lowerSearch)
+      normalizeForSearch(agent.name).includes(normalizedSearch)
     );
   }, [agentSearchText]);
 
@@ -270,11 +271,11 @@ function DustMain() {
     if (!peopleSearchText.trim()) {
       return mockUsers;
     }
-    const lowerSearch = peopleSearchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(peopleSearchText);
     return mockUsers.filter(
       (person) =>
-        person.fullName.toLowerCase().includes(lowerSearch) ||
-        person.email.toLowerCase().includes(lowerSearch)
+        normalizeForSearch(person.fullName).includes(normalizedSearch) ||
+        normalizeForSearch(person.email).includes(normalizedSearch)
     );
   }, [peopleSearchText]);
 
@@ -290,19 +291,19 @@ function DustMain() {
     if (!searchText.trim()) {
       return sortedCollaborators;
     }
-    const lowerSearch = searchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(searchText);
     return sortedCollaborators.filter((collaborator) => {
       if (collaborator.type === "agent") {
         const agent = collaborator.data;
         return (
-          agent.name.toLowerCase().includes(lowerSearch) ||
-          agent.description.toLowerCase().includes(lowerSearch)
+          normalizeForSearch(agent.name).includes(normalizedSearch) ||
+          normalizeForSearch(agent.description).includes(normalizedSearch)
         );
       } else {
         const person = collaborator.data;
         return (
-          person.fullName.toLowerCase().includes(lowerSearch) ||
-          person.email.toLowerCase().includes(lowerSearch)
+          normalizeForSearch(person.fullName).includes(normalizedSearch) ||
+          normalizeForSearch(person.email).includes(normalizedSearch)
         );
       }
     });
@@ -328,11 +329,11 @@ function DustMain() {
     if (!searchText.trim()) {
       return sortedSpaces;
     }
-    const lowerSearch = searchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(searchText);
     return sortedSpaces.filter(
       (space) =>
-        space.name.toLowerCase().includes(lowerSearch) ||
-        space.description.toLowerCase().includes(lowerSearch)
+        normalizeForSearch(space.name).includes(normalizedSearch) ||
+        normalizeForSearch(space.description).includes(normalizedSearch)
     );
   }, [searchText, sortedSpaces]);
 

--- a/sparkle/playground/src/stories/Projects_WithInbox.tsx
+++ b/sparkle/playground/src/stories/Projects_WithInbox.tsx
@@ -63,6 +63,7 @@ import {
   Spinner,
   AtomIcon,
   CodeSlashIcon,
+  normalizeForSearch,
 } from "@dust-tt/sparkle";
 import {
   SearchInput,
@@ -378,16 +379,15 @@ function DustMain() {
       return [];
     }
 
-    const searchLower = trimmed.toLowerCase();
+    const searchLower = normalizeForSearch(trimmed);
 
     const documentResults = defaultDocumentSpace
       ? documentDataSources.reduce<UniversalSearchItem[]>((acc, dataSource) => {
           const title = dataSource.fileName;
           const description = getFakeDocumentFirstLine(dataSource);
-          const titleMatch = title.toLowerCase().includes(searchLower);
-          const descriptionMatch = description
-            .toLowerCase()
-            .includes(searchLower);
+          const titleMatch = normalizeForSearch(title).includes(searchLower);
+          const descriptionMatch =
+            normalizeForSearch(description).includes(searchLower);
           if (titleMatch || descriptionMatch) {
             acc.push({
               type: "document",
@@ -406,10 +406,9 @@ function DustMain() {
       (acc, space) => {
         const title = space.name;
         const description = space.description;
-        const titleMatch = title.toLowerCase().includes(searchLower);
-        const descriptionMatch = description
-          .toLowerCase()
-          .includes(searchLower);
+        const titleMatch = normalizeForSearch(title).includes(searchLower);
+        const descriptionMatch =
+          normalizeForSearch(description).includes(searchLower);
         if (titleMatch || descriptionMatch) {
           acc.push({
             type: "project",
@@ -454,10 +453,10 @@ function DustMain() {
         const searchableTitle = creator
           ? `${creator.fullName} ${title}`
           : title;
-        const titleMatch = searchableTitle.toLowerCase().includes(searchLower);
-        const descriptionMatch = description
-          .toLowerCase()
-          .includes(searchLower);
+        const titleMatch =
+          normalizeForSearch(searchableTitle).includes(searchLower);
+        const descriptionMatch =
+          normalizeForSearch(description).includes(searchLower);
         if (titleMatch || descriptionMatch) {
           acc.push({
             type: "conversation",
@@ -611,9 +610,9 @@ function DustMain() {
     if (!searchText.trim()) {
       return allConversations;
     }
-    const lowerSearch = searchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(searchText);
     return allConversations.filter((conv) =>
-      conv.title.toLowerCase().includes(lowerSearch)
+      normalizeForSearch(conv.title).includes(normalizedSearch)
     );
   }, [searchText, allConversations]);
 
@@ -657,9 +656,9 @@ function DustMain() {
     if (!agentSearchText.trim()) {
       return mockAgents;
     }
-    const lowerSearch = agentSearchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(agentSearchText);
     return mockAgents.filter((agent) =>
-      agent.name.toLowerCase().includes(lowerSearch)
+      normalizeForSearch(agent.name).includes(normalizedSearch)
     );
   }, [agentSearchText]);
 
@@ -667,11 +666,11 @@ function DustMain() {
     if (!peopleSearchText.trim()) {
       return mockUsers;
     }
-    const lowerSearch = peopleSearchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(peopleSearchText);
     return mockUsers.filter(
       (person) =>
-        person.fullName.toLowerCase().includes(lowerSearch) ||
-        person.email.toLowerCase().includes(lowerSearch)
+        normalizeForSearch(person.fullName).includes(normalizedSearch) ||
+        normalizeForSearch(person.email).includes(normalizedSearch)
     );
   }, [peopleSearchText]);
 
@@ -687,19 +686,19 @@ function DustMain() {
     if (!searchText.trim()) {
       return sortedCollaborators;
     }
-    const lowerSearch = searchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(searchText);
     return sortedCollaborators.filter((collaborator) => {
       if (collaborator.type === "agent") {
         const agent = collaborator.data;
         return (
-          agent.name.toLowerCase().includes(lowerSearch) ||
-          agent.description.toLowerCase().includes(lowerSearch)
+          normalizeForSearch(agent.name).includes(normalizedSearch) ||
+          normalizeForSearch(agent.description).includes(normalizedSearch)
         );
       } else {
         const person = collaborator.data;
         return (
-          person.fullName.toLowerCase().includes(lowerSearch) ||
-          person.email.toLowerCase().includes(lowerSearch)
+          normalizeForSearch(person.fullName).includes(normalizedSearch) ||
+          normalizeForSearch(person.email).includes(normalizedSearch)
         );
       }
     });
@@ -740,11 +739,11 @@ function DustMain() {
     if (!searchText.trim()) {
       return sortedSpaces;
     }
-    const lowerSearch = searchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(searchText);
     return sortedSpaces.filter(
       (space) =>
-        space.name.toLowerCase().includes(lowerSearch) ||
-        space.description.toLowerCase().includes(lowerSearch)
+        normalizeForSearch(space.name).includes(normalizedSearch) ||
+        normalizeForSearch(space.description).includes(normalizedSearch)
     );
   }, [searchText, sortedSpaces]);
 
@@ -755,11 +754,11 @@ function DustMain() {
     if (!projectSearchText.trim()) {
       return allSpaces;
     }
-    const lowerSearch = projectSearchText.toLowerCase();
+    const normalizedSearch = normalizeForSearch(projectSearchText);
     return allSpaces.filter(
       (space) =>
-        space.name.toLowerCase().includes(lowerSearch) ||
-        space.description.toLowerCase().includes(lowerSearch)
+        normalizeForSearch(space.name).includes(normalizedSearch) ||
+        normalizeForSearch(space.description).includes(normalizedSearch)
     );
   }, [projectSearchText]);
 

--- a/sparkle/src/lib/utils.ts
+++ b/sparkle/src/lib/utils.ts
@@ -9,3 +9,18 @@ export function assertNever(x: never): never {
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Normalizes a string for search comparison by:
+ * 1. Decomposing accented characters (NFD normalization)
+ * 2. Removing diacritic marks (so "é" becomes "e", "ü" becomes "u", etc.)
+ * 3. Converting to lowercase
+ *
+ * This allows searching "seb" to match "Sébastien".
+ */
+export function normalizeForSearch(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}


### PR DESCRIPTION
## Problem

Searching `seb` in the member/collaborator/agent DropdownMenu filter did not match `Sébastien` because comparisons used raw `toLowerCase()`, which does not strip diacritic marks.

## Fix

**`sparkle/src/lib/utils.ts`** — Added `normalizeForSearch()` utility:
```ts
export function normalizeForSearch(text: string): string {
  return text
    .normalize("NFD")          // decompose "é" → "e" + combining accent
    .replace(/[\u0300-\u036f]/g, "")  // strip combining diacritics
    .toLowerCase();
}
```
This is exported from the main sparkle package so consumers can use it too.

**`sparkle/playground/src/stories/Projects_WithInbox.tsx`** and **`Projects_Spaces.tsx`** — All `useMemo` filter hooks now use `normalizeForSearch()` on both the query and the field values:

- `filteredCollaborators` (people full name + email, agent name + description)
- `filteredPeople` (full name + email)
- `filteredAgents` (name)
- `filteredSpaces` (name + description)
- `filteredProjects` (name + description)
- `filteredConversations` (title)
- `universalSearchResults` (all entity types)

## Testing

Searching `seb` → matches `Sébastien`  
Searching `uber` → matches `Überschall`  
Searching `cafe` → matches `Café`