### PR TITLE
fix(front): strip diacritics in project-todo member search filters

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
@@ -29,6 +29,7 @@ import {
   useUpdateProjectTodo,
 } from "@app/lib/swr/projects";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { removeDiacritics } from "@app/lib/utils";
 import type { GetProjectTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import type {
@@ -192,13 +193,13 @@ export function EditableProjectTodosPanel({
     [todoOwnerFilter.selectedUserSIds]
   );
   const filteredUsers = useMemo(() => {
-    const normalizedSearch = assigneeSearch.trim().toLowerCase();
-    if (!normalizedSearch) {
+    const q = removeDiacritics(assigneeSearch.trim()).toLowerCase();
+    if (!q) {
       return users;
     }
 
     return users.filter((user) =>
-      user.fullName.toLowerCase().includes(normalizedSearch)
+      removeDiacritics(user.fullName).toLowerCase().includes(q)
     );
   }, [assigneeSearch, users]);
   const todoScopeLabel = formatTodoScopeLabel({

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -11,6 +11,7 @@ import {
   useAutosizeTextArea,
 } from "@app/components/assistant/conversation/space/conversations/project_todos/utils";
 import { useAppRouter } from "@app/lib/platform";
+import { removeDiacritics } from "@app/lib/utils";
 import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -124,9 +125,11 @@ export const EditableTodoItem = memo(function EditableTodoItem({
   useAutosizeTextArea(editInputRef, draftText, isEditing);
 
   const filteredReassignMembers = useMemo(() => {
-    const q = reassignSearch.trim().toLowerCase();
+    const q = removeDiacritics(reassignSearch.trim()).toLowerCase();
     const filtered = q
-      ? projectMembers.filter((m) => m.fullName.toLowerCase().includes(q))
+      ? projectMembers.filter((m) =>
+          removeDiacritics(m.fullName).toLowerCase().includes(q)
+        )
       : [...projectMembers];
     // Sort: members with at least one active (non-done) todo come first,
     // preserving alphabetical order within each group.


### PR DESCRIPTION
## Problem

Member search in the project-todo dropdowns used raw `toLowerCase()`, so searching `seb` would not match `Sébastien`.

## Fix

Uses the existing `removeDiacritics()` helper from `front/lib/utils.ts`:

```ts
// already existed in front/lib/utils.ts
export function removeDiacritics(input: string): string {
  return input.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
}
```

### Files changed

**`EditableTodoItem.tsx`** — `filteredReassignMembers` (the "Reassign" submenu search)
```ts
const q = removeDiacritics(reassignSearch.trim()).toLowerCase();
return projectMembers.filter((m) =>
  removeDiacritics(m.fullName).toLowerCase().includes(q)
);
```

**`EditableProjectTodosPanel.tsx`** — `filteredUsers` (the assignee-filter dropdown at the top of the panel)
```ts
const q = removeDiacritics(assigneeSearch.trim()).toLowerCase();
return users.filter((user) =>
  removeDiacritics(user.fullName).toLowerCase().includes(q)
);
```

Supersedes #25123