### PR TITLE
Customize display order of todos.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
@@ -17,6 +17,7 @@ import {
   useSpaceConversationsSummary,
 } from "@app/hooks/conversations";
 import { useTodoDiffAnimations } from "@app/hooks/useTodoDiffAnimations";
+import { compareProjectTodoAssigneeGroups } from "@app/lib/project_todo/display_order";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
   useBulkUpdateProjectTodoStatus,
@@ -246,16 +247,9 @@ export function EditableProjectTodosPanel({
       }
     }
 
-    return [...groups.values()].sort((a, b) => {
-      const aIsViewer = viewerUserId !== null && a.user?.sId === viewerUserId;
-      const bIsViewer = viewerUserId !== null && b.user?.sId === viewerUserId;
-      if (aIsViewer !== bIsViewer) {
-        return aIsViewer ? -1 : 1;
-      }
-      const aName = a.user?.fullName ?? "";
-      const bName = b.user?.fullName ?? "";
-      return aName.localeCompare(bName, undefined, { sensitivity: "base" });
-    });
+    return [...groups.values()].sort((a, b) =>
+      compareProjectTodoAssigneeGroups(a, b, viewerUserId)
+    );
   }, [filteredTodos, viewerUserId]);
 
   // Optimistically update a todo's status in the SWR cache and send the PATCH.

--- a/front/lib/project_todo/display_order.ts
+++ b/front/lib/project_todo/display_order.ts
@@ -1,0 +1,122 @@
+import type {
+  ProjectTodoAssigneeType,
+  ProjectTodoStatus,
+  ProjectTodoType,
+} from "@app/types/project_todo";
+
+const PROJECT_TODO_STATUS_SORT_RANK: Record<ProjectTodoStatus, number> = {
+  in_progress: 0,
+  todo: 1,
+  done: 2,
+};
+
+function projectTodoUpdatedAtMs(t: ProjectTodoType): number {
+  const u = t.updatedAt;
+  if (u instanceof Date) {
+    return u.getTime();
+  }
+  return new Date(String(u)).getTime();
+}
+
+/** In progress → Open → Done, then `updatedAt` descending. Used on first load per assignee group. */
+export function sortProjectTodosForInitialDisplay(
+  todos: ProjectTodoType[]
+): ProjectTodoType[] {
+  return [...todos].sort((a, b) => {
+    const rankDiff =
+      PROJECT_TODO_STATUS_SORT_RANK[a.status] -
+      PROJECT_TODO_STATUS_SORT_RANK[b.status];
+    if (rankDiff !== 0) {
+      return rankDiff;
+    }
+    return projectTodoUpdatedAtMs(b) - projectTodoUpdatedAtMs(a);
+  });
+}
+
+/**
+ * Preserves a previously shown order on revalidation; new items (not in `prevOrderedSIds`)
+ * are prepended, ordered among themselves with {@link sortProjectTodosForInitialDisplay}.
+ */
+export function mergeProjectTodoStableOrder(
+  prevOrderedSIds: string[] | undefined,
+  todos: ProjectTodoType[]
+): string[] {
+  const currentSet = new Set(todos.map((t) => t.sId));
+
+  if (!prevOrderedSIds || prevOrderedSIds.length === 0) {
+    return sortProjectTodosForInitialDisplay(todos).map((t) => t.sId);
+  }
+
+  const prevSet = new Set(prevOrderedSIds);
+  const kept = prevOrderedSIds.filter((id) => currentSet.has(id));
+  const brandNew = todos.filter((t) => !prevSet.has(t.sId));
+  const brandNewIds = sortProjectTodosForInitialDisplay(brandNew).map(
+    (t) => t.sId
+  );
+  return [...brandNewIds, ...kept];
+}
+
+export function orderProjectTodosBySIdList(
+  orderedSIds: string[],
+  todos: ProjectTodoType[]
+): ProjectTodoType[] {
+  const byId = new Map(todos.map((t) => [t.sId, t]));
+  return orderedSIds
+    .map((id) => byId.get(id))
+    .filter((t): t is ProjectTodoType => t !== undefined);
+}
+
+export function compareProjectTodoAssigneeGroups(
+  a: { user: ProjectTodoAssigneeType | null },
+  b: { user: ProjectTodoAssigneeType | null },
+  viewerUserId: string | null
+): number {
+  const aIsViewer = viewerUserId !== null && a.user?.sId === viewerUserId;
+  const bIsViewer = viewerUserId !== null && b.user?.sId === viewerUserId;
+  if (aIsViewer !== bIsViewer) {
+    return aIsViewer ? -1 : 1;
+  }
+  const aName = a.user?.fullName ?? "";
+  const bName = b.user?.fullName ?? "";
+  return aName.localeCompare(bName, undefined, { sensitivity: "base" });
+}
+
+/**
+ * Per-assignee stable order (initial sort, then stable across SWR revalidations), then
+ * flattened in the same assignee group order as the project to-dos UI.
+ */
+export function flattenProjectTodosWithStableAssigneeOrder(
+  rawTodos: ProjectTodoType[],
+  viewerUserId: string | null,
+  stableOrderByAssigneeKey: Map<string, string[]>
+): ProjectTodoType[] {
+  const groups = new Map<
+    string,
+    { user: ProjectTodoAssigneeType | null; todos: ProjectTodoType[] }
+  >();
+
+  for (const todo of rawTodos) {
+    const user = todo.user ?? null;
+    const key = user?.sId ?? `unknown-${todo.id}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.todos.push(todo);
+    } else {
+      groups.set(key, { user, todos: [todo] });
+    }
+  }
+
+  const sortedGroups = [...groups.values()].sort((a, b) =>
+    compareProjectTodoAssigneeGroups(a, b, viewerUserId)
+  );
+
+  const flattened: ProjectTodoType[] = [];
+  for (const group of sortedGroups) {
+    const key = group.user?.sId ?? `unknown-${group.todos[0]?.id}`;
+    const prev = stableOrderByAssigneeKey.get(key);
+    const mergedIds = mergeProjectTodoStableOrder(prev, group.todos);
+    stableOrderByAssigneeKey.set(key, mergedIds);
+    flattened.push(...orderProjectTodosBySIdList(mergedIds, group.todos));
+  }
+  return flattened;
+}

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -1,6 +1,7 @@
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import { flattenProjectTodosWithStableAssigneeOrder } from "@app/lib/project_todo/display_order";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -29,7 +30,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { type Fetcher, useSWRConfig } from "swr";
 
 export function useProjectContextAttachments({
@@ -344,6 +345,28 @@ export function useProjectTodos({
     todosFetcher
   );
 
+  const stableTodoOrderByAssigneeKeyRef = useRef<Map<string, string[]>>(
+    new Map()
+  );
+  const stableOrderScopeKeyRef = useRef(`${owner.sId}:${spaceId}`);
+  if (stableOrderScopeKeyRef.current !== `${owner.sId}:${spaceId}`) {
+    stableOrderScopeKeyRef.current = `${owner.sId}:${spaceId}`;
+    stableTodoOrderByAssigneeKeyRef.current = new Map();
+  }
+
+  const todos = useMemo(() => {
+    const raw = data?.todos ?? emptyArray<ProjectTodoType>();
+    const viewerUserId = data?.viewerUserId ?? null;
+    if (raw.length === 0) {
+      return raw;
+    }
+    return flattenProjectTodosWithStableAssigneeOrder(
+      raw,
+      viewerUserId,
+      stableTodoOrderByAssigneeKeyRef.current
+    );
+  }, [data?.todos, data?.viewerUserId]);
+
   const sortedUsers = useMemo(() => {
     const usersById = new Map<string, ProjectTodoAssigneeType>();
     for (const todo of data?.todos ?? emptyArray<ProjectTodoType>()) {
@@ -367,7 +390,7 @@ export function useProjectTodos({
   }, [data?.todos, data?.viewerUserId]);
 
   return {
-    todos: data?.todos ?? [],
+    todos,
     lastReadAt: data?.lastReadAt ?? null,
     viewerUserId: data?.viewerUserId ?? null,
     users: sortedUsers,


### PR DESCRIPTION
## Description

Todos were rendered in server response order. This PR introduces a stable display order that persists across revalidations (so things are ordered in a nice way on load but do not jump around when you add/edit/reassign).

## Tests

Local

## Risk

Low — order is stable after first load; worst case on SWR revalidation is an extra re-render with identical ordering

## Deploy Plan

Deploy `front`
