### PR TITLE
Fix todos on mobile: hide sources, tweak actions buttons.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents.tsx
@@ -239,7 +239,7 @@ export function AddTodoComposer({
         autoComplete="off"
         rows={1}
         maxLength={NEW_MANUAL_TODO_MAX_CHARS}
-        placeholder="Add a to-do — Enter to add · Esc to cancel"
+        placeholder="A new awesome task..."
         value={text}
         disabled={isAdding}
         className={cn(
@@ -427,7 +427,7 @@ export function TodoSources({
   return (
     <span
       className={cn(
-        "text-xs",
+        "hidden text-xs md:block",
         isDone
           ? "text-faint dark:text-faint-night line-through"
           : "text-muted-foreground dark:text-muted-foreground-night"


### PR DESCRIPTION
## Description

Two small mobile fixes for the todos panel.

- **Hide sources on mobile** — `TodoSources` gains `hidden md:block` so source links are not rendered on small screens where they push the text into a cramped layout
- **Stack action buttons vertically on mobile** — the action button container in `EditableTodoItem` changes from `flex-row items-center` to `flex-col items-end md:flex-row md:items-center`; on small screens buttons stack vertically (right-aligned) instead of overflowing horizontally
- **Hover-only delete at `md` breakpoint** — the overflow menu opacity transition switches from `sm:opacity-0 sm:group-hover/todo:opacity-100` to `md:opacity-0 md:group-hover/todo:opacity-100` to match the new mobile/desktop boundary
- **Update `AddTodoComposer` placeholder** — "Add a to-do — Enter to add · Esc to cancel" → "A new awesome task..." (shorter, fits on small screens)

## Tests

Local (mobile viewport)

## Risk

Low — CSS-only changes

## Deploy Plan

Deploy `front`
