### PR TITLE
Todos : fix mobile tab buttons, fix missing padding at the bottom of the list.

### DIFF
--- a/front/components/assistant/conversation/space/SpaceTodosTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTodosTab.tsx
@@ -134,8 +134,8 @@ export function SpaceTodosTab({
   ]);
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-1 overflow-y-auto px-6">
-      <div className="mx-auto flex h-full w-full max-w-4xl flex-col py-8">
+    <div className="flex min-h-0 w-full flex-1 basis-0 flex-col overflow-y-auto overscroll-y-contain px-6">
+      <div className="mx-auto flex w-full max-w-4xl flex-col py-8">
         <div className="mb-6 flex flex-col gap-3 border-b border-border pb-6 dark:border-border-night">
           <div className="flex items-center justify-between gap-4">
             <div className="flex min-w-0 flex-col gap-0.5">

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -390,7 +390,7 @@ export const EditableTodoItem = memo(function EditableTodoItem({
           )}
         </div>
       )}
-      <div className="mt-0.5 flex shrink-0 items-center gap-1 opacity-100">
+      <div className="mt-0.5 flex shrink-0 flex-col items-end gap-1 opacity-100 md:flex-row md:items-center">
         {hasConversationLink ? (
           <Tooltip
             label="Open to-do conversation"
@@ -513,7 +513,7 @@ export const EditableTodoItem = memo(function EditableTodoItem({
               "transition-opacity",
               overflowMenuOpen
                 ? "opacity-100"
-                : "sm:opacity-0 sm:group-hover/todo:opacity-100"
+                : "md:opacity-0 md:group-hover/todo:opacity-100"
             )}
           >
             <DropdownMenu

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -28,6 +28,7 @@ import { useClientType } from "@app/lib/context/clientType";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
 import { useSpaceInfo, useSystemSpace } from "@app/lib/swr/spaces";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { LightConversationType } from "@app/types/assistant/conversation";
 import {
@@ -105,6 +106,7 @@ export function SpaceConversationsPage() {
   const [_planLimitReached, setPlanLimitReached] = useState(false);
   const [isInvitePanelOpen, setIsInvitePanelOpen] = useState(false);
   const canShowTodosTab = hasFeature("project_todo");
+  const compactProjectTabs = useIsMobile();
 
   const { currentTab, handleTabChange } = useSpaceProjectTabs({
     spaceId,
@@ -295,25 +297,32 @@ export function SpaceConversationsPage() {
   }
 
   return (
-    <div className="flex h-full w-full flex-col">
+    <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
       <Tabs
         value={currentTab}
         onValueChange={(value) => handleTabChange(value as SpaceProjectTab)}
-        className="flex min-h-0 flex-1 flex-col pt-3"
+        className="flex min-h-0 flex-1 flex-col overflow-hidden pt-3"
       >
-        <div className="flex items-start justify-between border-b border-separator pl-14 pr-6 lg:px-6 dark:border-separator-night">
+        <div className="flex shrink-0 items-start justify-between border-b border-separator pl-14 pr-6 lg:px-6 dark:border-separator-night">
           <TabsList border={false}>
             <TabsTrigger
               value="conversations"
-              label="Conversations"
+              label={compactProjectTabs ? undefined : "Conversations"}
+              tooltip={compactProjectTabs ? "Conversations" : undefined}
               icon={ChatBubbleLeftRightIcon}
             />
             {canShowTodosTab && (
-              <TabsTrigger value="todos" label="To-dos" icon={ListCheckIcon} />
+              <TabsTrigger
+                value="todos"
+                label={compactProjectTabs ? undefined : "To-dos"}
+                tooltip={compactProjectTabs ? "To-dos" : undefined}
+                icon={ListCheckIcon}
+              />
             )}
             <TabsTrigger
               value="knowledge"
-              label="Knowledge"
+              label={compactProjectTabs ? undefined : "Knowledge"}
+              tooltip={compactProjectTabs ? "Knowledge" : undefined}
               icon={BookOpenIcon}
             />
             <TabsTrigger
@@ -323,7 +332,8 @@ export function SpaceConversationsPage() {
             />
             <TabsTrigger
               value="alpha"
-              label="Alpha"
+              label={compactProjectTabs ? undefined : "Alpha"}
+              tooltip={compactProjectTabs ? "Alpha" : undefined}
               icon={TestTubeIcon}
               variant="warning-secondary"
             />


### PR DESCRIPTION
## Description

Two layout fixes for the todos tab on mobile.

**Tab buttons on mobile**

Project tab labels ("Conversations", "To-dos", "Knowledge", "Alpha") were too wide to fit on small screens. Add `useIsMobile()` in `SpaceConversationsPage`: when `compactProjectTabs` is true, render tabs with `icon` only and move the label text to a `tooltip` prop; on desktop the full label is shown as before.

**Missing bottom padding and scroll containment**

The `SpaceTodosTab` scroll container had `h-full` which prevented the inner content from growing beyond the viewport, cutting off the bottom of long lists. Replace with `flex-1 basis-0 flex-col overflow-y-auto overscroll-y-contain` so the tab fills available height, scrolls independently, and overscroll bounce stays contained. Remove the now-redundant `h-full` from the inner content wrapper.

## Tests

Local (mobile viewport)

<img width="384" height="781" alt="image" src="https://github.com/user-attachments/assets/9f076b37-f6d4-4047-880a-5449156b7e1c" />


## Risk

Low — layout-only changes; icon-only tabs on mobile are a common pattern already used elsewhere in the app

## Deploy Plan

Deploy `front`
