### PR TITLE
Add: initial todos on project setup.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
@@ -17,6 +17,7 @@ import {
   useSpaceConversationsSummary,
 } from "@app/hooks/conversations";
 import { useTodoDiffAnimations } from "@app/hooks/useTodoDiffAnimations";
+import { useAppRouter } from "@app/lib/platform";
 import { compareProjectTodoAssigneeGroups } from "@app/lib/project_todo/display_order";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
@@ -31,6 +32,7 @@ import {
 } from "@app/lib/swr/projects";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { removeDiacritics } from "@app/lib/utils";
+import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetProjectTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import type {
@@ -101,6 +103,7 @@ export function EditableProjectTodosPanel({
     spaceId,
   });
   const confirm = useContext(ConfirmContext);
+  const router = useAppRouter();
 
   const { mutateConversations: mutateSpaceConversations } =
     useSpaceConversations({
@@ -443,6 +446,13 @@ export function EditableProjectTodosPanel({
       });
       if (result.isOk()) {
         const { conversationId } = result.value;
+        if (todo.agentInstructions?.trim() && conversationId) {
+          void router.push(
+            getConversationRoute(owner.sId, conversationId),
+            undefined,
+            { shallow: true }
+          );
+        }
         // Reflect the new todo state (conversationId set) immediately.
         // Only patch conversationId — the server-side toJSON doesn't rehydrate
         // sources, so replacing the whole todo would transiently drop them.
@@ -481,6 +491,8 @@ export function EditableProjectTodosPanel({
       mutateTodos,
       mutateSpaceConversations,
       mutateSpaceSummary,
+      owner.sId,
+      router,
       viewerUserId,
     ]
   );

--- a/front/lib/api/actions/servers/project_todos/tools/index.ts
+++ b/front/lib/api/actions/servers/project_todos/tools/index.ts
@@ -189,6 +189,7 @@ export function createProjectTodosTools(
             status: item.doneRationale ? "done" : "todo",
             doneAt: item.doneRationale ? new Date() : null,
             actorRationale: item.doneRationale ?? null,
+            agentInstructions: null,
           });
 
           // Record the conversation where the todo was created as a source so

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -5,6 +5,7 @@ import { getWorkspaceAdministrationVersionLock } from "@app/lib/api/workspace";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { seedInitialProjectTodosForProjectCreator } from "@app/lib/project_todo/seed_initial_project_todos";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -631,6 +632,7 @@ export async function createSpaceAndGroup(
 
       const featureFlags = await getFeatureFlags(auth);
       if (featureFlags.includes("project_todo")) {
+        await seedInitialProjectTodosForProjectCreator(auth, space);
         void launchOrSignalProjectTodoWorkflow({
           workspaceId: owner.sId,
           spaceId: space.sId,

--- a/front/lib/project_todo/initial_project_todos.ts
+++ b/front/lib/project_todo/initial_project_todos.ts
@@ -1,0 +1,28 @@
+/** Seeded when a project is created (UI/API via `createSpaceAndGroup`, or MCP `create_project`). */
+export const PROJECT_MANAGER_AGENT_SID = "project_manager" as const;
+
+export const INITIAL_PROJECT_TODOS: {
+  text: string;
+  agentInstructions: string;
+}[] = [
+  {
+    text: "Set up the project description and goals",
+    agentInstructions:
+      "Help the user refine a short project description and clear goals. Use project tools to read or update project metadata if available. Propose concrete edits; keep the tone practical and brief.",
+  },
+  {
+    text: "Bring in knowledge from company data",
+    agentInstructions:
+      "When it matches the project’s purpose, do a substantive pass over company data (search / retrieval across workspace sources and connected systems—not just a single quick lookup). Synthesize what matters, cite where it came from, then help store it in project knowledge using project tools (files, uploads, or structured notes). Skip deep dives when context isn’t needed yet.",
+  },
+  {
+    text: "Search for and add project members",
+    agentInstructions:
+      "Help the user invite the right collaborators. Use people search or directory capabilities when available; suggest candidates by role, team, or expertise relevant to the project. Guide them through adding those users as project members.",
+  },
+  {
+    text: "Build a list of initial todos",
+    agentInstructions:
+      "Partner with the user to produce a practical starter backlog for this project: concrete next steps, early milestones, dependencies, and risks to watch. Keep items actionable; offer wording they can turn into todos. This list shapes follow-on work—don’t recycle these seeded items verbatim.",
+  },
+];

--- a/front/lib/project_todo/seed_initial_project_todos.ts
+++ b/front/lib/project_todo/seed_initial_project_todos.ts
@@ -1,0 +1,55 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import {
+  INITIAL_PROJECT_TODOS,
+  PROJECT_MANAGER_AGENT_SID,
+} from "@app/lib/project_todo/initial_project_todos";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * Inserts starter todos for the user who created the project. No-ops when the
+ * space is not a project or the `project_todo` feature is off.
+ */
+export async function seedInitialProjectTodosForProjectCreator(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<void> {
+  if (!space.isProject()) {
+    return;
+  }
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("project_todo")) {
+    return;
+  }
+
+  const creator = auth.getNonNullableUser();
+  try {
+    // Insert in reverse array order so the first-defined todo is saved last and sorts
+    // to the top under default client ordering (`updatedAt` desc).
+    for (const seed of INITIAL_PROJECT_TODOS.slice().reverse()) {
+      await ProjectTodoResource.makeNew(auth, {
+        spaceId: space.id,
+        userId: creator.id,
+        createdByType: "agent",
+        createdByUserId: null,
+        createdByAgentConfigurationId: PROJECT_MANAGER_AGENT_SID,
+        markedAsDoneByType: null,
+        markedAsDoneByUserId: null,
+        markedAsDoneByAgentConfigurationId: null,
+        text: seed.text,
+        agentInstructions: seed.agentInstructions,
+        status: "todo",
+        doneAt: null,
+        actorRationale: null,
+      });
+    }
+  } catch (err) {
+    logger.error(
+      { err: normalizeError(err), spaceId: space.sId },
+      "Failed to seed initial project todos"
+    );
+  }
+}

--- a/front/lib/project_todo/start_agent.ts
+++ b/front/lib/project_todo/start_agent.ts
@@ -42,6 +42,18 @@ function linkLabelForUrlOnly(url: string): string {
   }
 }
 
+function mergeKickoffCustomMessage(
+  stored: string | null | undefined,
+  userProvided: string | undefined
+): string | undefined {
+  const s = stored?.trim();
+  const u = userProvided?.trim();
+  if (s && u) {
+    return `${s}\n\n${u}`;
+  }
+  return u ?? s ?? undefined;
+}
+
 function formatTodoSourcesMarkdown(sources: ProjectTodoSourceInfo[]): string {
   const lines = sources
     .map((s) => {
@@ -179,7 +191,10 @@ export async function startAgentForProjectTodo(
     todoId: todo.sId,
     todoText: todo.text,
     sources,
-    customMessage: customMessage?.trim() || undefined,
+    customMessage: mergeKickoffCustomMessage(
+      todo.agentInstructions,
+      customMessage
+    ),
   });
 
   let conversationId = await todo.getLatestConversationId(auth);

--- a/front/lib/resources/project_todo_resource.test.ts
+++ b/front/lib/resources/project_todo_resource.test.ts
@@ -29,6 +29,7 @@ function makeTodoBlob(
     status: "todo",
     doneAt: null,
     actorRationale: null,
+    agentInstructions: null,
   };
 }
 

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -120,6 +120,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
         | "status"
         | "doneAt"
         | "actorRationale"
+        | "agentInstructions"
         | "markedAsDoneByType"
         | "markedAsDoneByUserId"
         | "markedAsDoneByAgentConfigurationId"
@@ -167,6 +168,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       status: this.status,
       doneAt: this.doneAt ?? null,
       actorRationale: this.actorRationale ?? null,
+      agentInstructions: this.agentInstructions ?? null,
       markedAsDoneByType: this.markedAsDoneByType ?? null,
       markedAsDoneByUserId: this.markedAsDoneByUserId ?? null,
       markedAsDoneByAgentConfigurationId:
@@ -591,6 +593,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       status: this.status,
       doneAt: this.doneAt,
       actorRationale: this.actorRationale,
+      agentInstructions: this.agentInstructions,
       createdByType: this.createdByType,
       createdByAgentConfigurationId: this.createdByAgentConfigurationId,
       markedAsDoneByType: this.markedAsDoneByType,

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -89,6 +89,12 @@ const PROJECT_TODO_MODEL_ATTRIBUTES = {
     allowNull: true,
     comment: "Explanation for why the actor made a change.",
   },
+  agentInstructions: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+    comment:
+      "Optional kickoff instructions for the agent when this todo is started.",
+  },
   deletedAt: {
     type: DataTypes.DATE,
     allowNull: true,
@@ -124,6 +130,7 @@ export class ProjectTodoModel extends WorkspaceAwareModel<ProjectTodoModel> {
   declare status: ProjectTodoStatus;
   declare doneAt: Date | null;
   declare actorRationale: string | null;
+  declare agentInstructions: string | null;
   declare deletedAt: CreationOptional<Date | null>;
 
   declare space: NonAttribute<SpaceModel>;

--- a/front/migrations/db/migration_617.sql
+++ b/front/migrations/db/migration_617.sql
@@ -1,0 +1,6 @@
+-- Migration created on May 3, 2026
+ALTER TABLE "public"."project_todos"
+ADD COLUMN "agentInstructions" TEXT;
+
+ALTER TABLE "public"."project_todo_versions"
+ADD COLUMN "agentInstructions" TEXT;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
@@ -174,6 +174,7 @@ async function handler(
         status: "todo",
         doneAt: null,
         actorRationale: null,
+        agentInstructions: null,
       });
 
       const todoResource = await ProjectTodoResource.fetchBySId(

--- a/front/scripts/dev/seed_project_todos.ts
+++ b/front/scripts/dev/seed_project_todos.ts
@@ -134,6 +134,7 @@ makeScript(
         status: "todo",
         doneAt: null,
         actorRationale: null,
+        agentInstructions: null,
       });
 
       if (seed.deleted) {

--- a/front/tests/utils/ProjectTodoFactory.ts
+++ b/front/tests/utils/ProjectTodoFactory.ts
@@ -27,6 +27,7 @@ export class ProjectTodoFactory {
       status: "todo",
       doneAt: null,
       actorRationale: null,
+      agentInstructions: null,
     });
   }
 }

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -45,6 +45,8 @@ export type ProjectTodoType = {
   text: string;
   status: ProjectTodoStatus;
   doneAt: Date | null;
+  /** Optional persisted instructions merged into the kickoff prompt when the todo is started. */
+  agentInstructions: string | null;
   actorRationale: string | null;
   createdByType: ProjectTodoActorType;
   createdByAgentConfigurationId: string | null;


### PR DESCRIPTION
## Description

New projects started with an empty todos list and no guidance. This PR seeds a set of starter todos at project creation time, each carrying embedded agent instructions that enrich the kickoff prompt when the user clicks "Play".

**New `agentInstructions` field**

- Add `agentInstructions TEXT` to `project_todos` (`migration_617.sql`)
- Expose on `ProjectTodoModel`, `ProjectTodoResource.makeNew` / `toBlob` / `toJSON`, and `ProjectTodoType`

**Starter todos**

- `initial_project_todos.ts` — defines `INITIAL_PROJECT_TODOS`: 4 action-oriented todo templates with `text` + `agentInstructions`, attributed to `PROJECT_MANAGER_AGENT_SID = "project_manager"`:
  1. Set up the project description and goals
  2. Bring in knowledge from company data
  3. Search for and add project members
  4. Build a list of initial todos
- `seed_initial_project_todos.ts` — `seedInitialProjectTodosForProjectCreator`: inserts the 4 todos in reverse order so the first-defined item sorts to the top under default `updatedAt` desc ordering; assigned to the creator; no-ops when `project_todo` flag is off or space is not a project; logs on error without throwing
- Called in `createSpaceAndGroup`

**Kickoff prompt enrichment**

- Add `mergeKickoffCustomMessage` — merges `todo.agentInstructions` (stored at seed time) with the optional user `customMessage` (provided at click time); concatenates both when both are present
- `startAgentForProjectTodo` now calls `mergeKickoffCustomMessage` instead of using `customMessage` directly

**Auto-navigate to conversation**

- In `EditableProjectTodosPanel`: when a todo has `agentInstructions` and the start returns a `conversationId`, automatically `router.push` to the conversation (`shallow: true`) so the user lands there without an extra click

## Tests

Local + green (test fixture updated with `agentInstructions: null`)

## Risk

Low — `agentInstructions` is nullable; existing todos are unaffected; seeding failures are swallowed to avoid blocking project creation

## Deploy Plan

Run migration (`migration_617.sql`), deploy `front`
