### PR TITLE
feat(projects): make initial todos opt-in in create_project tool

### DIFF
--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -283,6 +283,12 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional list of user ids to add as project members after project creation."
         ),
+      seedInitialTodos: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether to seed the project with a set of starter todos. Defaults to false when creating via the tool."
+        ),
     },
     stake: "low",
     displayLabels: {

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -842,13 +842,17 @@ export function createProjectManagerTools(
           );
         }
 
-        const createSpaceRes = await createSpaceAndGroup(auth, {
-          name: params.title,
-          isRestricted: params.visibility !== "open",
-          spaceKind: "project",
-          managementMode: "manual",
-          memberIds: [],
-        });
+        const createSpaceRes = await createSpaceAndGroup(
+          auth,
+          {
+            name: params.title,
+            isRestricted: params.visibility !== "open",
+            spaceKind: "project",
+            managementMode: "manual",
+            memberIds: [],
+          },
+          { seedInitialTodos: params.seedInitialTodos ?? false }
+        );
 
         if (createSpaceRes.isErr()) {
           const error = createSpaceRes.error;

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -392,7 +392,7 @@ export async function createSpaceAndGroup(
     | { memberIds: string[]; managementMode: "manual" }
     | { groupIds: string[]; managementMode: "group" }
   ),
-  { ignoreWorkspaceLimit = false }: { ignoreWorkspaceLimit?: boolean } = {}
+  { ignoreWorkspaceLimit = false, seedInitialTodos = true }: { ignoreWorkspaceLimit?: boolean; seedInitialTodos?: boolean } = {}
 ): Promise<
   Result<
     SpaceResource,
@@ -632,7 +632,9 @@ export async function createSpaceAndGroup(
 
       const featureFlags = await getFeatureFlags(auth);
       if (featureFlags.includes("project_todo")) {
-        await seedInitialProjectTodosForProjectCreator(auth, space);
+        if (seedInitialTodos) {
+          await seedInitialProjectTodosForProjectCreator(auth, space);
+        }
         void launchOrSignalProjectTodoWorkflow({
           workspaceId: owner.sId,
           spaceId: space.sId,

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -392,7 +392,13 @@ export async function createSpaceAndGroup(
     | { memberIds: string[]; managementMode: "manual" }
     | { groupIds: string[]; managementMode: "group" }
   ),
-  { ignoreWorkspaceLimit = false, seedInitialTodos = true }: { ignoreWorkspaceLimit?: boolean; seedInitialTodos?: boolean } = {}
+  {
+    ignoreWorkspaceLimit = false,
+    seedInitialTodos = true,
+  }: {
+    ignoreWorkspaceLimit?: boolean;
+    seedInitialTodos?: boolean;
+  } = {}
 ): Promise<
   Result<
     SpaceResource,


### PR DESCRIPTION
## Summary

Follow-up to #25128 (initial todos seeding). The seeding was unconditionally triggered for every project creation path. When creating a project via the `create_project` MCP tool, initial todos should be **opt-in**, not default.

## Changes

### `front/lib/api/spaces.ts`
- Add `seedInitialTodos?: boolean` (default `true`) to `createSpaceAndGroup`'s third-argument options.
- Gate the `seedInitialProjectTodosForProjectCreator` call with this flag.
- The `launchOrSignalProjectTodoWorkflow` call is **not** gated — the butler workflow still starts regardless (it manages ongoing todos, not just seeding).
- **UI / other callers are unaffected** since the default is `true`.

### `front/lib/api/actions/servers/project_manager/metadata.ts`
- Add `seedInitialTodos?: boolean` to the `create_project` tool schema with a description making it clear the default is `false` for the tool.

### `front/lib/api/actions/servers/project_manager/tools/index.ts`
- Pass `{ seedInitialTodos: params.seedInitialTodos ?? false }` to `createSpaceAndGroup` from the tool handler, so the tool default is **false**.

## Behaviour

| Creation path | Before | After |
|---|---|---|
| UI (new project button) | Seeded | Still seeded (default `true`) |
| `create_project` tool (no arg) | Seeded | **Not seeded** |
| `create_project` tool (`seedInitialTodos: true`) | Seeded | Seeded |
