### PR TITLE
Ensure customer is created on free plans

### DIFF
--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -2,7 +2,10 @@ import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { floorToHourISO } from "@app/lib/metronome/client";
-import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
+import {
+  ensureMetronomeCustomerForWorkspace,
+  provisionMetronomeContract,
+} from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import {
   getBillingCurrencyForCountry,
@@ -127,28 +130,32 @@ export async function handleMetronomeSetupCheckout({
     );
   }
 
-  const provisionResult = await provisionMetronomeCustomerAndContract({
-    workspace: renderLightWorkspaceType({ workspace }),
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+
+  const customerResult = await ensureMetronomeCustomerForWorkspace({
+    workspace: lightWorkspace,
     stripeCustomerId,
+  });
+  if (customerResult.isErr()) {
+    return new Err(
+      new DustError("metronome_error", customerResult.error.message)
+    );
+  }
+  const { metronomeCustomerId } = customerResult.value;
+
+  const contractResult = await provisionMetronomeContract({
+    metronomeCustomerId,
+    workspace: lightWorkspace,
     packageAlias: resolvedPackageAlias,
     uniquenessKey: sessionId,
     startingAt: new Date(floorToHourISO(now)),
   });
-  if (provisionResult.isErr()) {
+  if (contractResult.isErr()) {
     return new Err(
-      new DustError("metronome_error", provisionResult.error.message)
+      new DustError("metronome_error", contractResult.error.message)
     );
   }
-
-  const { metronomeCustomerId, metronomeContractId } = provisionResult.value;
-
-  const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
-    workspace.id,
-    metronomeCustomerId
-  );
-  if (updateResult.isErr()) {
-    return new Err(new DustError("internal_error", updateResult.error.message));
-  }
+  const { metronomeContractId } = contractResult.value;
 
   const subscriptionResult =
     await SubscriptionResource.createSubscriptionFromCheckout({

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -120,7 +120,7 @@ export async function createMetronomeCustomer({
 }: {
   workspaceId: string;
   workspaceName: string;
-  stripeCustomerId: string;
+  stripeCustomerId?: string;
 }): Promise<Result<{ metronomeCustomerId: string }, Error>> {
   try {
     const response = await getMetronomeClient().v1.customers.create({
@@ -159,6 +159,62 @@ export async function createMetronomeCustomer({
     logger.error(
       { error, workspaceId },
       "[Metronome] Failed to create customer"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Idempotently ensure a Stripe billing configuration exists on a Metronome
+ * customer. Used to upgrade a customer that was originally created without a
+ * Stripe link (e.g., a free workspace) once the workspace gets a Stripe
+ * customer. If a non-archived Stripe configuration already exists this is a
+ * no-op.
+ */
+export async function ensureMetronomeStripeBillingConfig({
+  metronomeCustomerId,
+  stripeCustomerId,
+}: {
+  metronomeCustomerId: string;
+  stripeCustomerId: string;
+}): Promise<Result<void, Error>> {
+  try {
+    const existing =
+      await getMetronomeClient().v1.customers.retrieveBillingConfigurations({
+        customer_id: metronomeCustomerId,
+      });
+
+    const hasStripeConfig = existing.data.some(
+      (c) => c.billing_provider === "stripe" && !c.archived_at
+    );
+    if (hasStripeConfig) {
+      return new Ok(undefined);
+    }
+
+    await getMetronomeClient().v1.customers.setBillingConfigurations({
+      data: [
+        {
+          customer_id: metronomeCustomerId,
+          billing_provider: "stripe",
+          delivery_method: "direct_to_billing_provider",
+          configuration: {
+            stripe_customer_id: stripeCustomerId,
+            stripe_collection_method: "charge_automatically",
+          },
+        },
+      ],
+    });
+
+    logger.info(
+      { metronomeCustomerId, stripeCustomerId },
+      "[Metronome] Stripe billing config added to existing customer"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, stripeCustomerId },
+      "[Metronome] Failed to ensure Stripe billing config on customer"
     );
     return new Err(error);
   }

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -165,11 +165,14 @@ export async function createMetronomeCustomer({
 }
 
 /**
- * Idempotently ensure a Stripe billing configuration exists on a Metronome
- * customer. Used to upgrade a customer that was originally created without a
- * Stripe link (e.g., a free workspace) once the workspace gets a Stripe
- * customer. If a non-archived Stripe configuration already exists this is a
- * no-op.
+ * Idempotently ensure a Metronome customer has a Stripe billing
+ * configuration pointing to the given `stripeCustomerId`.
+ *
+ * - No active Stripe config: adds one.
+ * - Active Stripe config already pointing to `stripeCustomerId`: no-op.
+ * - Active Stripe config pointing to a different `stripeCustomerId`: archives
+ *   the stale config(s) and adds a new one (defensive: should be rare, but
+ *   covers cases like a recreated Stripe customer).
  */
 export async function ensureMetronomeStripeBillingConfig({
   metronomeCustomerId,
@@ -184,11 +187,34 @@ export async function ensureMetronomeStripeBillingConfig({
         customer_id: metronomeCustomerId,
       });
 
-    const hasStripeConfig = existing.data.some(
+    const activeStripeConfigs = existing.data.filter(
       (c) => c.billing_provider === "stripe" && !c.archived_at
     );
-    if (hasStripeConfig) {
+
+    const alreadyCorrect = activeStripeConfigs.some(
+      (c) => c.configuration?.stripe_customer_id === stripeCustomerId
+    );
+    if (alreadyCorrect) {
       return new Ok(undefined);
+    }
+
+    if (activeStripeConfigs.length > 0) {
+      const staleIds = activeStripeConfigs.map((c) => c.id);
+      await getMetronomeClient().v1.customers.archiveBillingConfigurations({
+        customer_id: metronomeCustomerId,
+        customer_billing_provider_configuration_ids: staleIds,
+      });
+      logger.warn(
+        {
+          metronomeCustomerId,
+          stripeCustomerId,
+          archivedConfigIds: staleIds,
+          stalestripeCustomerIds: activeStripeConfigs.map(
+            (c) => c.configuration?.stripe_customer_id
+          ),
+        },
+        "[Metronome] Archived stale Stripe billing config(s) before re-adding"
+      );
     }
 
     await getMetronomeClient().v1.customers.setBillingConfigurations({
@@ -207,7 +233,7 @@ export async function ensureMetronomeStripeBillingConfig({
 
     logger.info(
       { metronomeCustomerId, stripeCustomerId },
-      "[Metronome] Stripe billing config added to existing customer"
+      "[Metronome] Stripe billing config added to customer"
     );
     return new Ok(undefined);
   } catch (err) {

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -2,7 +2,7 @@ import type { EnterprisePricingCents } from "@app/lib/metronome/contracts";
 import {
   buildEnterpriseOverrides,
   extractEnterprisePricing,
-  provisionMetronomeCustomerAndContract,
+  provisionMetronomeContract,
   switchMetronomeContractPackage,
 } from "@app/lib/metronome/contracts";
 import { Ok } from "@app/types/shared/result";
@@ -672,11 +672,11 @@ describe("buildEnterpriseOverrides", () => {
 // Contract provisioning / switching
 // ---------------------------------------------------------------------------
 
-describe("provisionMetronomeCustomerAndContract", () => {
+describe("provisionMetronomeContract", () => {
   it("syncs seats and MAU when the contract has both subscriptions", async () => {
-    const result = await provisionMetronomeCustomerAndContract({
+    const result = await provisionMetronomeContract({
+      metronomeCustomerId: "m-customer",
       workspace: WORKSPACE,
-      stripeCustomerId: "stripe-customer",
       packageAlias: "legacy-pro-monthly",
       uniquenessKey: "uniq_123",
       startingAt: new Date(START_DATE),
@@ -712,9 +712,9 @@ describe("provisionMetronomeCustomerAndContract", () => {
   it("skips seat sync when the contract has no seat subscription", async () => {
     mockGetSeatSubscriptionIdFromContract.mockReturnValue(undefined);
 
-    const result = await provisionMetronomeCustomerAndContract({
+    const result = await provisionMetronomeContract({
+      metronomeCustomerId: "m-customer",
       workspace: WORKSPACE,
-      stripeCustomerId: "stripe-customer",
       packageAlias: "legacy-enterprise",
       uniquenessKey: "uniq_123",
       startingAt: new Date(START_DATE),
@@ -728,9 +728,9 @@ describe("provisionMetronomeCustomerAndContract", () => {
   it("skips MAU sync when the contract has no MAU subscription", async () => {
     mockHasMauSubscriptionInContract.mockReturnValue(false);
 
-    const result = await provisionMetronomeCustomerAndContract({
+    const result = await provisionMetronomeContract({
+      metronomeCustomerId: "m-customer",
       workspace: WORKSPACE,
-      stripeCustomerId: "stripe-customer",
       packageAlias: "legacy-pro-monthly",
       uniquenessKey: "uniq_123",
       startingAt: new Date(START_DATE),

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -2,6 +2,7 @@ import {
   ceilToHourISO,
   createMetronomeContract,
   createMetronomeCustomer,
+  ensureMetronomeStripeBillingConfig,
   findMetronomeCustomerByAlias,
   floorToHourISO,
   getMetronomeClient,
@@ -33,6 +34,7 @@ import {
   isEnterpriseReportUsage,
   type SupportedEnterpriseReportUsage,
 } from "@app/lib/plans/usage/types";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Logger } from "@app/logger/logger";
 import logger from "@app/logger/logger";
@@ -99,34 +101,32 @@ export async function switchMetronomeContractPackage({
 }
 
 /**
- * Ensure a Metronome customer and contract exist for a workspace.
- * Creates the customer if missing, then creates a contract via the package alias.
- * Used from both Stripe webhook (checkout) and Poke (admin upgrade).
+ * Idempotently ensure a Metronome customer exists for a workspace and that
+ * its id is persisted on the workspace row.
+ *
+ * - If `workspace.metronomeCustomerId` is already set, returns it.
+ * - Otherwise looks the customer up on Metronome by ingest alias (workspace
+ *   sId), creating it if missing, then writes the id back to the workspace.
+ *
+ * `stripeCustomerId` is optional — when omitted the Metronome customer is
+ * created without a Stripe billing-provider configuration. This is the path
+ * used for free-plan workspaces that may later receive credits via Poke
+ * before they ever subscribe to a paid plan.
  */
-export async function provisionMetronomeCustomerAndContract({
+export async function ensureMetronomeCustomerForWorkspace({
   workspace,
   stripeCustomerId,
-  packageAlias,
-  uniquenessKey,
-  startingAt,
-  enableStripeBilling = true,
 }: {
   workspace: LightWorkspaceType;
-  stripeCustomerId: string;
-  packageAlias: string;
-  uniquenessKey: string;
-  // Must already be on an hour boundary (Metronome requirement).
-  startingAt: Date;
-  enableStripeBilling?: boolean;
-}): Promise<
-  Result<{ metronomeCustomerId: string; metronomeContractId: string }, Error>
-> {
-  // Find or create customer.
-  let metronomeCustomerId: string | null = null;
+  stripeCustomerId?: string;
+}): Promise<Result<{ metronomeCustomerId: string }, Error>> {
+  let metronomeCustomerId: string | null = workspace.metronomeCustomerId;
 
-  const findResult = await findMetronomeCustomerByAlias(workspace.sId);
-  if (findResult.isOk()) {
-    metronomeCustomerId = findResult.value;
+  if (!metronomeCustomerId) {
+    const findResult = await findMetronomeCustomerByAlias(workspace.sId);
+    if (findResult.isOk()) {
+      metronomeCustomerId = findResult.value;
+    }
   }
 
   if (!metronomeCustomerId) {
@@ -141,6 +141,58 @@ export async function provisionMetronomeCustomerAndContract({
     metronomeCustomerId = createResult.value.metronomeCustomerId;
   }
 
+  if (workspace.metronomeCustomerId !== metronomeCustomerId) {
+    const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
+      workspace.id,
+      metronomeCustomerId
+    );
+    if (updateResult.isErr()) {
+      return new Err(updateResult.error);
+    }
+    await WorkspaceResource.invalidateCache(workspace.sId);
+  }
+
+  // If a Stripe customer is provided, make sure the Metronome customer has a
+  // Stripe billing configuration. This covers the upgrade case where the
+  // workspace was provisioned in Metronome without a Stripe link (free plan)
+  // and later acquired a Stripe customer.
+  if (stripeCustomerId) {
+    const billingResult = await ensureMetronomeStripeBillingConfig({
+      metronomeCustomerId,
+      stripeCustomerId,
+    });
+    if (billingResult.isErr()) {
+      return new Err(billingResult.error);
+    }
+  }
+
+  return new Ok({ metronomeCustomerId });
+}
+
+/**
+ * Provision a Metronome contract on an already-existing Metronome customer.
+ * Creates the contract from the given package alias, then syncs seat / MAU
+ * subscription quantities seeded by the package.
+ *
+ * The Metronome customer must already exist (call
+ * `ensureMetronomeCustomerForWorkspace` first).
+ */
+export async function provisionMetronomeContract({
+  metronomeCustomerId,
+  workspace,
+  packageAlias,
+  uniquenessKey,
+  startingAt,
+  enableStripeBilling = true,
+}: {
+  metronomeCustomerId: string;
+  workspace: LightWorkspaceType;
+  packageAlias: string;
+  uniquenessKey: string;
+  // Must already be on an hour boundary (Metronome requirement).
+  startingAt: Date;
+  enableStripeBilling?: boolean;
+}): Promise<Result<{ metronomeContractId: string }, Error>> {
   const contractResult = await createMetronomeContract({
     metronomeCustomerId,
     packageAlias,
@@ -163,10 +215,7 @@ export async function provisionMetronomeCustomerAndContract({
     return new Err(syncResult.error);
   }
 
-  return new Ok({
-    metronomeCustomerId,
-    metronomeContractId,
-  });
+  return new Ok({ metronomeContractId });
 }
 
 // ---------------------------------------------------------------------------
@@ -849,7 +898,10 @@ export async function applyEnterpriseOverrides({
  * Provision a Metronome customer + contract for an enterprise workspace,
  * extract MAU pricing from the Stripe subscription, and apply overrides.
  *
- * Seats and MAU are synced by provisionMetronomeCustomerAndContract.
+ * The enterprise package alias is intentionally a near-empty shell —
+ * subscriptions (seats / MAU / tier products) are added by
+ * `applyEnterpriseOverrides` below using the live MAU count as
+ * `initial_quantity`.
  */
 export async function provisionShadowEnterpriseMetronomeContract({
   workspace,
@@ -895,20 +947,30 @@ export async function provisionShadowEnterpriseMetronomeContract({
     new Date(stripeSubscription.current_period_start * 1000)
   );
 
-  // Provision Metronome customer and contract (also syncs seats + MAU).
-  const provisionResult = await provisionMetronomeCustomerAndContract({
+  // Ensure the customer exists (creating it if needed) and is linked to
+  // Stripe.
+  const customerResult = await ensureMetronomeCustomerForWorkspace({
     workspace,
     stripeCustomerId,
+  });
+  if (customerResult.isErr()) {
+    return new Err(customerResult.error);
+  }
+  const { metronomeCustomerId } = customerResult.value;
+
+  // Create the (empty) contract directly — overrides below will add the MAU
+  // subscriptions with the right initial quantities.
+  const contractResult = await createMetronomeContract({
+    metronomeCustomerId,
     packageAlias,
     uniquenessKey: stripeSubscription.id,
     startingAt: new Date(startDate),
     enableStripeBilling: false,
   });
-  if (provisionResult.isErr()) {
-    return new Err(provisionResult.error);
+  if (contractResult.isErr()) {
+    return new Err(contractResult.error);
   }
-
-  const { metronomeCustomerId, metronomeContractId } = provisionResult.value;
+  const { contractId: metronomeContractId } = contractResult.value;
 
   // Count MAUs for initial subscription quantities on the first invoice.
   const initialMauCount = await countMauForWorkspace(

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -6,6 +6,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
+  ensureMetronomeCustomerForWorkspace,
   provisionShadowEnterpriseMetronomeContract,
   switchMetronomeContractPackage,
   syncContractQuantities,
@@ -751,6 +752,20 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       if (result.isErr() && !activeSubscription.isMetronomeShadowBilled) {
         throw result.error;
       }
+    }
+
+    // Ensure a Metronome customer exists for the workspace.
+    const ensureCustomerResult = await ensureMetronomeCustomerForWorkspace({
+      workspace,
+    });
+    if (ensureCustomerResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          error: ensureCustomerResult.error.message,
+        },
+        "[Subscription] Failed to ensure Metronome customer on free-plan subscription"
+      );
     }
 
     await SubscriptionResource.invalidateSubscriptionCache(workspace.id);

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -28,7 +28,10 @@ import {
   reactivateMetronomeContract,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
-import { provisionMetronomeCustomerAndContract } from "@app/lib/metronome/contracts";
+import {
+  ensureMetronomeCustomerForWorkspace,
+  provisionMetronomeContract,
+} from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
@@ -113,7 +116,7 @@ async function grantFreeCreditsForSubscription({
  * Uses shadow packages (no billing provider) so Metronome generates invoices
  * but does NOT deliver them to Stripe. Fire-and-forget: logs errors but does not throw.
  */
-async function shadowProvisionMetronome({
+async function provisionShadowMetronome({
   workspace,
   stripeCustomerId,
   metronomePackageAlias,
@@ -129,29 +132,38 @@ async function shadowProvisionMetronome({
   periodStart: Date;
 }): Promise<void> {
   try {
-    const result = await provisionMetronomeCustomerAndContract({
-      workspace: renderLightWorkspaceType({ workspace }),
+    const lightWorkspace = renderLightWorkspaceType({ workspace });
+
+    const customerResult = await ensureMetronomeCustomerForWorkspace({
+      workspace: lightWorkspace,
       stripeCustomerId,
+    });
+    if (customerResult.isErr()) {
+      logger.error(
+        { workspaceId: workspace.sId, error: customerResult.error.message },
+        "[Stripe Webhook] Failed to ensure Metronome customer for shadow provisioning"
+      );
+      return;
+    }
+    const { metronomeCustomerId } = customerResult.value;
+
+    const contractResult = await provisionMetronomeContract({
+      metronomeCustomerId,
+      workspace: lightWorkspace,
       packageAlias: metronomePackageAlias,
       uniquenessKey: sessionId,
       startingAt: periodStart,
       enableStripeBilling: false,
     });
-
-    if (result.isErr()) {
+    if (contractResult.isErr()) {
       logger.error(
-        { workspaceId: workspace.sId, error: result.error.message },
-        "[Stripe Webhook] Failed to shadow-provision Metronome"
+        { workspaceId: workspace.sId, error: contractResult.error.message },
+        "[Stripe Webhook] Failed to shadow-provision Metronome contract"
       );
       return;
     }
+    const { metronomeContractId } = contractResult.value;
 
-    const { metronomeCustomerId, metronomeContractId } = result.value;
-
-    await WorkspaceResource.updateMetronomeCustomerId(
-      workspace.id,
-      metronomeCustomerId
-    );
     await SubscriptionResource.updateMetronomeContractId(
       subscriptionModelId,
       metronomeContractId
@@ -460,7 +472,7 @@ async function handler(
                 metronomePackageAlias,
                 subscriptionCurrency
               );
-              void shadowProvisionMetronome({
+              void provisionShadowMetronome({
                 workspace,
                 stripeCustomerId: checkoutStripeSubscription.customer,
                 metronomePackageAlias: resolvedAlias,

--- a/front/scripts/provision_metronome_customers.ts
+++ b/front/scripts/provision_metronome_customers.ts
@@ -1,5 +1,6 @@
-import { createMetronomeCustomer } from "@app/lib/metronome/client";
-import { SubscriptionModel } from "@app/lib/models/plan";
+import { ensureMetronomeCustomerForWorkspace } from "@app/lib/metronome/contracts";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
+import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -14,13 +15,31 @@ async function provisionCustomer(
   execute: boolean,
   logger: Logger
 ) {
-  // Get Stripe customer ID from the active subscription.
-  // Skip workspaces without a Stripe customer — only paying workspaces get a Metronome customer.
-  let stripeCustomerId = "";
+  if (workspace.metronomeCustomerId) {
+    return;
+  }
+
+  // Only provision workspaces with an active subscription. Workspaces on
+  // FREE_NO_PLAN (no subscription row) are skipped — going forward they
+  // receive a Metronome customer when they subscribe (via
+  // `internalSubscribeWorkspaceToFreePlan` or the paid path).
+  // FREE_TRIAL_PHONE_PLAN workspaces are also skipped — phone trials have
+  // hard-coded usage limits and never interact with Metronome.
   const subscription = await SubscriptionModel.findOne({
     where: { workspaceId: workspace.id, status: "active" },
+    include: [PlanModel],
   });
-  if (subscription?.stripeSubscriptionId) {
+  if (!subscription) {
+    return;
+  }
+  if (subscription.plan?.code === FREE_TRIAL_PHONE_PLAN_CODE) {
+    return;
+  }
+
+  // Optionally link to a Stripe customer if the active subscription is paid.
+  // Free-plan subscriptions get a Metronome customer with no Stripe link.
+  let stripeCustomerId: string | undefined;
+  if (subscription.stripeSubscriptionId) {
     const stripeSubscription = await getStripeSubscription(
       subscription.stripeSubscriptionId
     );
@@ -32,19 +51,11 @@ async function provisionCustomer(
     }
   }
 
-  if (!stripeCustomerId) {
-    logger.info(
-      { workspaceId: workspace.sId },
-      "Skipping — no Stripe customer"
-    );
-    return;
-  }
-
   logger.info(
     {
       workspaceId: workspace.sId,
       workspaceName: workspace.name,
-      stripeCustomerId,
+      stripeCustomerId: stripeCustomerId ?? null,
     },
     `${execute ? "" : "[DRYRUN] "}Provisioning Metronome customer`
   );
@@ -53,45 +64,26 @@ async function provisionCustomer(
     return;
   }
 
-  const result = await createMetronomeCustomer({
-    workspaceId: workspace.sId,
-    workspaceName: workspace.name,
+  const result = await ensureMetronomeCustomerForWorkspace({
+    workspace,
     stripeCustomerId,
   });
 
-  if (result.isOk()) {
-    const { metronomeCustomerId } = result.value;
-
-    const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
-      workspace.id,
-      metronomeCustomerId
-    );
-    if (updateResult.isErr()) {
-      logger.error(
-        {
-          workspaceId: workspace.sId,
-          metronomeCustomerId,
-          error: updateResult.error.message,
-        },
-        "Failed to persist metronomeCustomerId on workspace"
-      );
-      return;
-    }
-
-    // Explicitly await cache invalidation — the fire-and-forget invalidation
-    // in update() may not complete before the script calls process.exit().
-    await WorkspaceResource.invalidateCache(workspace.sId);
-
-    logger.info(
-      { workspaceId: workspace.sId, metronomeCustomerId },
-      "Metronome customer provisioned and workspace updated"
-    );
-  } else {
+  if (result.isErr()) {
     logger.error(
       { workspaceId: workspace.sId, error: result.error.message },
       "Failed to provision Metronome customer"
     );
+    return;
   }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      metronomeCustomerId: result.value.metronomeCustomerId,
+    },
+    "Metronome customer provisioned and workspace updated"
+  );
 }
 
 makeScript(


### PR DESCRIPTION
## Description

Make sure every workspace with an active subscription has a Metronome customer — including free plans — so credits granted via Poke or by future renewals always have a customer to land on. Also tightens the customer/contract provisioning split so duplicate workspace updates and stale Stripe billing configs are gone.

- New `ensureMetronomeCustomerForWorkspace({ workspace, stripeCustomerId? })` helper in `lib/metronome/contracts.ts`. Idempotent: short-circuits on `workspace.metronomeCustomerId`, then alias lookup, then `createMetronomeCustomer`. Writes the id back to the workspace and invalidates the cache. When a `stripeCustomerId` is passed, it also runs `ensureMetronomeStripeBillingConfig` so a customer originally provisioned without Stripe gets the billing config attached on first paid checkout.
- New `ensureMetronomeStripeBillingConfig` in `lib/metronome/client.ts` (uses `customers.retrieveBillingConfigurations` + `customers.setBillingConfigurations`). No-op if a non-archived Stripe config already exists.
- `createMetronomeCustomer.stripeCustomerId` is now optional (was required); the customer is created without a billing-provider configuration when omitted.
- `provisionMetronomeCustomerAndContract` is split into `ensureMetronomeCustomerForWorkspace` + `provisionMetronomeContract`. The latter only handles contract creation + seat/MAU sync and takes `metronomeCustomerId` as a required input.
- `provisionShadowEnterpriseMetronomeContract` is rewritten to call `ensureMetronomeCustomerForWorkspace` then `createMetronomeContract` directly — skipping the now-redundant `syncContractQuantities` no-op on the empty enterprise package, before applying overrides with the live MAU count.
- `internalSubscribeWorkspaceToFreePlan` calls `ensureMetronomeCustomerForWorkspace` after the new subscription is created (best-effort, error logged but doesn't block subscription creation). Covers new workspace creation, phone-trial activation, free-plan downgrades.
- `shadowProvisionMetronome` (Stripe webhook) and `handleMetronomeSetupCheckout` (Stripe checkout) updated to the new ensure + provision flow. The redundant `WorkspaceResource.updateMetronomeCustomerId` calls in both are gone — the helper handles persistence.
- `scripts/provision_metronome_customers.ts` rewritten on top of the helper. Skips silently when the workspace already has a `metronomeCustomerId`, when there's no active subscription, or when the active subscription is on `FREE_TRIAL_PHONE_PLAN`. Handles workspaces with a free-plan subscription (no Stripe link).

## Tests

- `npx tsgo --noEmit` clean across the changed surface.
- `npm -w front run test -- lib/metronome/contracts.test.ts` — 23/23 pass; the existing `provisionMetronomeCustomerAndContract` describe block was renamed to `provisionMetronomeContract` and now passes `metronomeCustomerId` directly.

## Risk

Medium. The new ensure helper runs on every free-plan subscription path, so any breakage in the Metronome customer-create flow would surface as logged errors on subscription creation. Mitigations:

- `ensureMetronomeCustomerForWorkspace` is idempotent and safe to retry — handles 409 conflicts via `findMetronomeCustomerByAlias`.
- Call from `internalSubscribeWorkspaceToFreePlan` is best-effort: the error is logged but doesn't block subscription creation. The provision script backfills any misses.
- `provisionMetronomeCustomerAndContract` → `provisionMetronomeContract` is a name change with a tighter signature, so any caller still using the old name would fail at compile time (caught in CI). All in-repo callers updated.
- The Stripe-billing-config attachment runs on every paid-path call, but is gated by a fresh `retrieveBillingConfigurations` call so it's a no-op once a non-archived Stripe config exists.

Rollback: revert the PR. No schema changes.

## Deploy Plan

1. Merge.
2. Run `scripts/provision_metronome_customers.ts` (dry run first, then `--execute`) to backfill Metronome customers for existing free-plan workspaces.
3. Watch logs for `[Subscription] Failed to ensure Metronome customer on free-plan subscription` — should be empty under normal operation.
