### PR TITLE
Fixed wording in subscribe page

### DIFF
--- a/front/components/pages/onboarding/SubscribePage.tsx
+++ b/front/components/pages/onboarding/SubscribePage.tsx
@@ -87,9 +87,9 @@ export function SubscribePage() {
 
   // We treat user as being in free trial if they don't have any non free subs,
   // regardless of whether they're active or not.
-  const isInFreePhoneTrial = !subscriptions.some(
-    (sub) => !isFreeTrialPhonePlan(sub.plan.code)
-  );
+  const isInFreePhoneTrial =
+    subscriptions.length > 0 &&
+    !subscriptions.some((sub) => !isFreeTrialPhonePlan(sub.plan.code));
 
   // If you had another subscription before, you will not get the free trial again: we use this to show the correct message.
   // Current plan is either FREE_NO_PLAN or FREE_TEST_PLAN if you're on this paywall.
@@ -138,7 +138,7 @@ export function SubscribePage() {
                     isInFreePhoneTrial
                       ? "Subscribe to a paid plan"
                       : noPreviousSubscription
-                        ? "Start your free trial"
+                        ? "Start your subscription"
                         : "Resume your subscription"
                   }
                 />
@@ -174,12 +174,11 @@ export function SubscribePage() {
                   <>
                     <Page.P>
                       <span className="font-bold">
-                        Try the Pro plan for free for two weeks.
+                        Subscribe to the Pro plan.
                       </span>
                     </Page.P>
                     <Page.P>
-                      You will be charged after your trial ends. You can cancel
-                      at any time during your trial.
+                      You'll be charged immediately. You can cancel at any time.
                     </Page.P>
                   </>
                 )}
@@ -218,7 +217,7 @@ export function SubscribePage() {
                       ? isInFreePhoneTrial
                         ? `Subscribe with ${billingPeriod} billing`
                         : `Resume with ${billingPeriod} billing`
-                      : `Start your trial with ${billingPeriod} billing`
+                      : `Start your subscription with ${billingPeriod} billing`
                   }
                   icon={CreditCardIcon}
                   size="sm"


### PR DESCRIPTION
## Description

Update onboarding `SubscribePage` to reflect the actual flow: there is no free trial when subscribing — the customer is charged immediately. Replaces the misleading "Try the Pro plan for free for two weeks" / "Start your free trial" copy with subscription wording, and tightens the `isInFreePhoneTrial` guard so an empty subscription list no longer reports as "in trial".

- "Start your free trial" → "Start your subscription" (page header).
- "Try the Pro plan for free for two weeks." → "Subscribe to the Pro plan." (lead).
- "You will be charged after your trial ends. You can cancel at any time during your trial." → "You'll be charged immediately. You can cancel at any time."
- "Start your trial with X billing" → "Start your subscription with X billing" (CTA).
- `isInFreePhoneTrial` now requires at least one subscription before considering the user trialing — previously a workspace with zero subscriptions evaluated as "in trial" through `!subscriptions.some(...)`.

## Tests

Manual: open the subscribe page in three states — no prior subscription, currently on `FREE_TRIAL_PHONE_PLAN`, and returning customer with a previously-cancelled paid subscription — and verify the right header / lead / CTA show.

## Risk

Low. Copy-only changes plus a tighter `isInFreePhoneTrial` predicate that closes a small false-positive in the empty-subscription case.
