### PR TITLE
Handle workspace rename

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/rename_workspace.ts
+++ b/front/lib/api/poke/plugins/workspaces/rename_workspace.ts
@@ -1,10 +1,8 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import { getWorkOS } from "@app/lib/api/workos/client";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renameWorkspace } from "@app/lib/api/workspace";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-export const renameWorkspace = createPlugin({
+export const renameWorkspacePlugin = createPlugin({
   manifest: {
     id: "rename-workspace",
     name: "Rename Workspace",
@@ -26,37 +24,14 @@ export const renameWorkspace = createPlugin({
       );
     }
 
-    const res = await WorkspaceResource.updateName(
-      auth.getNonNullableWorkspace().id,
-      newName
-    );
+    const res = await renameWorkspace(auth.getNonNullableWorkspace(), newName);
     if (res.isErr()) {
       return res;
     }
 
-    const organization_id = auth.getNonNullableWorkspace().workOSOrganizationId;
-    if (!organization_id) {
-      return new Ok({
-        display: "text",
-        value: `Workspace renamed to ${newName}.`,
-      });
-    }
-
-    try {
-      await getWorkOS().organizations.updateOrganization({
-        organization: organization_id,
-        name: newName,
-      });
-    } catch (error) {
-      const e = normalizeError(error);
-      return new Err(
-        new Error(`Failed to update WorkOS organization name: ${e.message}`)
-      );
-    }
-
     return new Ok({
       display: "text",
-      value: `Workspace renamed to ${newName}. It was renamed in WorkOS as well.`,
+      value: `Workspace renamed to ${newName} (DB, WorkOS, Metronome).`,
     });
   },
 });

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -168,7 +168,7 @@ export async function updateWorkOSOrganizationName(
       workspaceId: workspace.id,
       organizationId: organization.id,
     });
-    return new Ok(undefined);
+    return new Err(e);
   }
 
   return new Ok(undefined);

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -1,5 +1,7 @@
+import { updateWorkOSOrganizationName } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
+import { updateMetronomeCustomerName } from "@app/lib/metronome/client";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { getUsageToReportForSubscriptionItem } from "@app/lib/plans/usage";
@@ -56,6 +58,44 @@ export async function getWorkspaceInfos(
   }
 
   return renderLightWorkspaceType({ workspace });
+}
+
+/**
+ * Rename a workspace and propagate the new name to external systems
+ * (WorkOS organization, Metronome customer). All three updates must
+ * stay in sync — callers should always go through this helper.
+ */
+export async function renameWorkspace(
+  workspace: LightWorkspaceType,
+  newName: string
+): Promise<Result<void, Error>> {
+  const updateRes = await WorkspaceResource.updateName(workspace.id, newName);
+  if (updateRes.isErr()) {
+    return updateRes;
+  }
+
+  const renamedWorkspace = { ...workspace, name: newName };
+
+  const workOSRes = await updateWorkOSOrganizationName(renamedWorkspace);
+  const metronomeRes = await updateMetronomeCustomerName(renamedWorkspace);
+
+  if (workOSRes.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to update WorkOS organization name: ${workOSRes.error.message}`
+      )
+    );
+  }
+
+  if (metronomeRes.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to update Metronome customer name: ${metronomeRes.error.message}`
+      )
+    );
+  }
+
+  return new Ok(undefined);
 }
 
 export async function removeAllWorkspaceDomains(

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -3,6 +3,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
 import Metronome, { ConflictError } from "@metronome/sdk";
 import type { Commit, ContractV2, Credit } from "@metronome/sdk/resources";
 import type { Invoice } from "@metronome/sdk/resources/v1/customers";
@@ -159,6 +160,38 @@ export async function createMetronomeCustomer({
     logger.error(
       { error, workspaceId },
       "[Metronome] Failed to create customer"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Update the display name of an existing Metronome customer.
+ * Used to keep the Metronome customer name in sync when a workspace is renamed.
+ */
+export async function updateMetronomeCustomerName(
+  workspace: LightWorkspaceType
+): Promise<Result<void, Error>> {
+  const { metronomeCustomerId, name } = workspace;
+  if (!metronomeCustomerId) {
+    return new Ok(undefined);
+  }
+
+  try {
+    await getMetronomeClient().v1.customers.setName({
+      customer_id: metronomeCustomerId,
+      name,
+    });
+    logger.info(
+      { metronomeCustomerId, name },
+      "[Metronome] Customer name updated"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, name },
+      "[Metronome] Failed to update customer name"
     );
     return new Err(error);
   }

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -5,7 +5,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { updateWorkOSOrganizationName } from "@app/lib/api/workos/organization";
+import { renameWorkspace } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -179,21 +179,18 @@ async function handler(
       }
 
       if ("name" in body) {
-        await workspace.updateWorkspaceSettings({
-          name: escape(body.name),
-        });
-        owner.name = body.name;
-
-        const updateRes = await updateWorkOSOrganizationName(owner);
-        if (updateRes.isErr()) {
+        const newName = escape(body.name);
+        const renameRes = await renameWorkspace(owner, newName);
+        if (renameRes.isErr()) {
           return apiError(req, res, {
             status_code: 500,
             api_error: {
               type: "internal_server_error",
-              message: `Failed to update WorkOS organization name: ${updateRes.error.message}`,
+              message: renameRes.error.message,
             },
           });
         }
+        owner.name = newName;
       } else if ("ssoEnforced" in body) {
         await workspace.updateWorkspaceSettings({
           ssoEnforced: body.ssoEnforced,


### PR DESCRIPTION
## Description

Centralise workspace renames behind a single `renameWorkspace(workspace, newName)` helper in `lib/api/workspace.ts` so the DB row, WorkOS organization, and Metronome customer name stay in sync.

- New helper updates `WorkspaceResource.updateName`, then `updateWorkOSOrganizationName`, then (when a `metronomeCustomerId` is set) `updateMetronomeCustomerName`. Errors at any step are returned as `Err` and surface to the caller.
- Added `updateMetronomeCustomerName` to `lib/metronome/client.ts` (wraps `v1.customers.setName`).
- The settings API (`pages/api/w/[wId]/index.ts`) and the Poke "Rename Workspace" plugin both call the new helper instead of duplicating the WorkOS / Metronome updates inline.
- Renamed the Poke plugin export from `renameWorkspace` to `renameWorkspacePlugin` to free the name for the helper.

## Tests

- `npx tsgo --noEmit` clean.
- Manually exercise via Poke "Rename Workspace" and the workspace settings API on a workspace that has a Metronome customer; confirm the DB row, WorkOS org, and Metronome customer all reflect the new name.

## Risk

Low. Same three writes as before, just moved into one place. Failure modes unchanged: a partial-failure run (e.g., DB updated but WorkOS errors) returns an error to the caller — the Metronome update only runs after WorkOS succeeds, matching the prior order of effects. Workspaces without a Metronome customer skip that step silently.

## Deploy Plan

Standard deploy. No migration, no flag, no follow-up.
