### PR TITLE
Catch Graph API rate limiting and throttle

### DIFF
--- a/connectors/src/connectors/microsoft/lib/errors.ts
+++ b/connectors/src/connectors/microsoft/lib/errors.ts
@@ -1,0 +1,25 @@
+const DEFAULT_THROTTLE_RETRY_AFTER_MS = 60_000;
+
+export class MicrosoftThrottlingError extends Error {
+  constructor(
+    readonly endpoint: string,
+    readonly retryAfterMs: number
+  ) {
+    super(
+      `Microsoft Graph API throttled request to ${endpoint}. Retry after ${retryAfterMs}ms.`
+    );
+    this.name = "MicrosoftThrottlingError";
+  }
+}
+
+export function getMicrosoftThrottleRetryAfterMs(
+  retryAfterHeader: string | null | undefined
+): number {
+  if (retryAfterHeader) {
+    const seconds = parseInt(retryAfterHeader, 10);
+    if (!Number.isNaN(seconds)) {
+      return seconds * 1000;
+    }
+  }
+  return DEFAULT_THROTTLE_RETRY_AFTER_MS;
+}

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -1,3 +1,7 @@
+import {
+  getMicrosoftThrottleRetryAfterMs,
+  MicrosoftThrottlingError,
+} from "@connectors/connectors/microsoft/lib/errors";
 import type {
   DriveItem,
   MicrosoftNode,
@@ -34,6 +38,16 @@ export async function clientApiGet(
   try {
     return await client.api(endpoint).get();
   } catch (error) {
+    if (error instanceof GraphError && error.statusCode === 429) {
+      const retryAfterMs = getMicrosoftThrottleRetryAfterMs(
+        error.headers?.get("retry-after")
+      );
+      logger.warn(
+        { endpoint, retryAfterMs },
+        "Microsoft Graph API throttled (429). Will retry after delay."
+      );
+      throw new MicrosoftThrottlingError(endpoint, retryAfterMs);
+    }
     logger.error({ error, endpoint }, `Graph API call threw an error`);
     if (error instanceof GraphError && error.statusCode === 403) {
       throw new ExternalOAuthTokenError(error);
@@ -51,6 +65,16 @@ export async function clientApiPost(
   try {
     return await client.api(endpoint).post(content);
   } catch (error) {
+    if (error instanceof GraphError && error.statusCode === 429) {
+      const retryAfterMs = getMicrosoftThrottleRetryAfterMs(
+        error.headers?.get("retry-after")
+      );
+      logger.warn(
+        { endpoint, retryAfterMs },
+        "Microsoft Graph API throttled (429). Will retry after delay."
+      );
+      throw new MicrosoftThrottlingError(endpoint, retryAfterMs);
+    }
     logger.error({ error, endpoint }, `Graph API call threw an error`);
     if (error instanceof GraphError && error.statusCode === 403) {
       throw new ExternalOAuthTokenError(error);

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -1,5 +1,7 @@
+import { MicrosoftThrottlingError } from "@connectors/connectors/microsoft/lib/errors";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { GraphError } from "@microsoft/microsoft-graph-client";
+import { ApplicationFailure } from "@temporalio/common";
 import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
@@ -18,6 +20,12 @@ export function isMicrosoftSignInError(err: unknown): err is Error {
     ) &&
     knownMicrosoftSignInErrors.some((code) => err.message.includes(code))
   );
+}
+
+export function isThrottlingError(
+  err: unknown
+): err is MicrosoftThrottlingError {
+  return err instanceof MicrosoftThrottlingError;
 }
 
 export function isItemNotFoundError(err: unknown): err is GraphError {
@@ -91,6 +99,13 @@ export class MicrosoftCastKnownErrorsInterceptor
     try {
       return await next(input);
     } catch (err: unknown) {
+      if (isThrottlingError(err)) {
+        throw ApplicationFailure.create({
+          message: err.message,
+          nextRetryDelay: err.retryAfterMs,
+          cause: err,
+        });
+      }
       // See https://learn.microsoft.com/en-us/answers/questions/1339560/sign-in-error-code-50173
       // TODO(2025-02-12): add an error type for Microsoft client errors and catch them at strategic locations (e.g. API call to instantiate a client)
       if (isMicrosoftSignInError(err)) {


### PR DESCRIPTION
## Description

Fixes `GraphError: The request has been throttled` errors that crash the Microsoft connector when Graph API returns HTTP 429 responses. The connector was not handling 429s — they bubbled up unhandled causing Temporal to retry immediately, making throttling worse. This adds proper 429 detection and Temporal-aware backoff following the Confluence connector pattern. The fix reads the `Retry-After` header from Graph API responses, converts it to milliseconds, and throws a typed error that tells Temporal to pause before retrying instead of entering a retry storm.

## Risk

Low. Only changes behavior for HTTP 429 errors which are currently causing crashes. All other error paths remain unchanged. Temporal will now respect the Graph API's retry delay instead of retrying immediately.

## Deploy Plan

Deploy connectors. Once deployed, workflows currently stuck in retry storms will self-heal on the next retry when the 429 error is caught and converted to a proper backoff signal.