### PR TITLE
Add: slack formatter to remove dust custom markdown directives.

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -20,6 +20,7 @@ import {
 import { PlanMessageHandler } from "@connectors/connectors/slack/chat/plan_message_handler";
 import type { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
 import { isSlackWebAPIPlatformError } from "@connectors/connectors/slack/lib/errors";
+import { formatAgentMarkdownForSlack } from "@connectors/connectors/slack/lib/format_agent_markdown_for_slack";
 import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { apiConfig } from "@connectors/lib/api/config";
@@ -232,6 +233,13 @@ async function streamAgentAnswerToSlack(
 
   const { streamHandler } = conversationData;
 
+  const slackAgentMarkdownOptions = {
+    agentMentionLinkContext: {
+      workspaceId: connector.workspaceId,
+      conversationId: conversation.sId,
+    },
+  };
+
   for await (const event of streamRes.value.eventStream) {
     switch (event.type) {
       case "tool_params":
@@ -433,7 +441,9 @@ async function streamAgentAnswerToSlack(
         await streamHandler.stop();
         await planHandler.deletePlanMessage();
         const { formattedContent, footnotes } = annotateCitations(
-          answer,
+          // Do not log unsupported directives: `answer` may still be mid-generation
+          // when we stop only because the Slack length cap was hit.
+          formatAgentMarkdownForSlack(answer, slackAgentMarkdownOptions),
           actions
         );
 
@@ -463,7 +473,11 @@ async function streamAgentAnswerToSlack(
         const actions = event.message.actions;
         const messageId = event.message.sId; // Get the message ID
         const { formattedContent, footnotes } = annotateCitations(
-          finalAnswer,
+          formatAgentMarkdownForSlack(finalAnswer, {
+            ...slackAgentMarkdownOptions,
+            // Terminal agent payload from the API — safe to detect unknown directives.
+            logUnsupportedDirectives: true,
+          }),
           actions
         );
 
@@ -602,7 +616,14 @@ async function streamAgentAnswerToSlack(
         const {
           formattedContent: cancelledContent,
           footnotes: cancelledFootnotes,
-        } = annotateCitations(answer || cancelledMessage, actions);
+        } = annotateCitations(
+          // Do not log: `answer` is streaming buffer and may end mid-directive on cancel.
+          formatAgentMarkdownForSlack(
+            answer || cancelledMessage,
+            slackAgentMarkdownOptions
+          ),
+          actions
+        );
 
         await postSlackMessageUpdate({
           messageUpdate: {

--- a/connectors/src/connectors/slack/lib/format_agent_markdown_for_slack.test.ts
+++ b/connectors/src/connectors/slack/lib/format_agent_markdown_for_slack.test.ts
@@ -1,0 +1,92 @@
+import logger from "@connectors/logger/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockMakeAgentDetailsInConversationUrl = vi.hoisted(() =>
+  vi.fn(
+    (
+      workspaceId: string,
+      conversationId: string,
+      agentConfigurationId: string
+    ) =>
+      `https://dust.test/w/${workspaceId}/conversation/${conversationId}?agentDetails=${agentConfigurationId}`
+  )
+);
+
+vi.mock("@connectors/lib/bot/conversation_utils", () => ({
+  makeAgentDetailsInConversationUrl: mockMakeAgentDetailsInConversationUrl,
+}));
+
+import { formatAgentMarkdownForSlack } from "./format_agent_markdown_for_slack";
+
+describe("formatAgentMarkdownForSlack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("replaces project todos, mentions, and quickReply for Slack", () => {
+    const input =
+      'Hello :mention[Agent]{sId=a1} — :todo[Ship feature]{sId=todo_1} :quickReply[Go]{message="Do it"}';
+    expect(formatAgentMarkdownForSlack(input)).toBe(
+      "Hello @Agent — *Todo:* Ship feature _Go_ — _Do it_"
+    );
+  });
+
+  it("turns agent mentions into Slack links when workspace + conversation are provided", () => {
+    const input = "Ping :mention[My Agent]{sId=agent_conf_1} please";
+    const out = formatAgentMarkdownForSlack(input, {
+      agentMentionLinkContext: {
+        workspaceId: "ws_test",
+        conversationId: "conv_abc",
+      },
+    });
+    expect(out).toBe(
+      "Ping <https://dust.test/w/ws_test/conversation/conv_abc?agentDetails=agent_conf_1|@My Agent> please"
+    );
+    expect(mockMakeAgentDetailsInConversationUrl).toHaveBeenCalledWith(
+      "ws_test",
+      "conv_abc",
+      "agent_conf_1"
+    );
+  });
+
+  it("leaves cite markers for annotateCitations", () => {
+    const input = "See :cite[ab] and :todo[X]{sId=t}";
+    expect(formatAgentMarkdownForSlack(input)).toBe(
+      "See :cite[ab] and *Todo:* X"
+    );
+  });
+
+  it("replaces toolSetup and visualization blocks", () => {
+    const input = `Before\n:::visualization\n{"x":1}\n:::\nAfter :toolSetup[Connect Notion]{sId=notion}`;
+    expect(formatAgentMarkdownForSlack(input)).toBe(
+      "Before\n_Visualization_\n\nAfter _Connect Notion_"
+    );
+  });
+
+  it("does not log unsupported directives when option is off", () => {
+    const spy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    formatAgentMarkdownForSlack(":unknownDirective[hi]{x=1}", {
+      logUnsupportedDirectives: false,
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("logs when unsupported directives remain on full message", () => {
+    const spy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    formatAgentMarkdownForSlack("Text :unknownDirective[hi]{x=1} tail", {
+      logUnsupportedDirectives: true,
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]?.[0]).toMatchObject({
+      unsupportedDirectives: ["unknownDirective"],
+    });
+  });
+
+  it("does not log for cite-only remaining colon-directive syntax", () => {
+    const spy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    formatAgentMarkdownForSlack("Ref :cite[ab, cd] done", {
+      logUnsupportedDirectives: true,
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/connectors/src/connectors/slack/lib/format_agent_markdown_for_slack.ts
+++ b/connectors/src/connectors/slack/lib/format_agent_markdown_for_slack.ts
@@ -1,0 +1,203 @@
+import { makeAgentDetailsInConversationUrl } from "@connectors/lib/bot/conversation_utils";
+import logger from "@connectors/logger/logger";
+
+const AGENT_MENTION_REGEX = /:mention\[([^\]]+)]\{sId=([^}]+?)}/g;
+const USER_MENTION_REGEX = /:mention_user\[([^\]]+)]\{sId=([^}]+?)}/g;
+const PROJECT_TODO_REGEX = /:todo\[([^\]]+)]\{sId=([^}]+?)}/g;
+const TOOL_SETUP_REGEX = /:toolSetup\[([^\]]+)]\{sId=([^}]+?)}/g;
+const QUICK_REPLY_REGEX = /:quickReply\[([^\]]+)]\{([^}]*)\}/g;
+const CONTENT_NODE_REGEX = /:content_node_mention\[([^\]]+)](?:\{([^}]*)\})?/g;
+const PASTED_REGEX = /:pasted_(?:attachment|content)\[([^\]]+)]\{[^}]*\}/g;
+const VISUALIZATION_BLOCK_REGEX = /:::visualization\s*\n[\s\S]*?\n:::\s*/g;
+const INSTRUCTION_BLOCK_REGEX =
+  /:::instruction_block\[([^\]]*)]\s*\n([\s\S]*?)\n:::\s*/g;
+
+/** Text directives we intentionally leave for downstream (e.g. citation footnotes). */
+const DIRECTIVE_NAMES_ALLOWED_AFTER_FORMAT = new Set(["cite"]);
+
+function normalizeInlineLabel(label: string): string {
+  return label.replaceAll("\n", " ").replaceAll("\r", " ").trim();
+}
+
+/** Slack `<url|label>` breaks if the label contains `|`, `<`, or `>`. */
+function slackMrkdwnLinkLabel(label: string): string {
+  return label.replaceAll("|", "·").replaceAll("<", "‹").replaceAll(">", "›");
+}
+
+function replaceMentionsForSlack(
+  text: string,
+  agentMentionLinkContext?: { workspaceId: string; conversationId: string }
+): string {
+  const withAgents = text.replaceAll(
+    AGENT_MENTION_REGEX,
+    (_full, name: string, agentConfigurationId: string) => {
+      const display = slackMrkdwnLinkLabel(normalizeInlineLabel(name));
+      if (agentMentionLinkContext) {
+        const url = makeAgentDetailsInConversationUrl(
+          agentMentionLinkContext.workspaceId,
+          agentMentionLinkContext.conversationId,
+          agentConfigurationId
+        );
+        return `<${url}|@${display}>`;
+      }
+      return `@${display}`;
+    }
+  );
+  return withAgents.replaceAll(
+    USER_MENTION_REGEX,
+    (_, name: string) => `@${slackMrkdwnLinkLabel(normalizeInlineLabel(name))}`
+  );
+}
+
+function replaceProjectTodosForSlack(text: string): string {
+  return text.replaceAll(
+    PROJECT_TODO_REGEX,
+    (_, label: string) => `*Todo:* ${normalizeInlineLabel(label)}`
+  );
+}
+
+function replaceToolSetupForSlack(text: string): string {
+  return text.replaceAll(
+    TOOL_SETUP_REGEX,
+    (_, label: string) => `_${normalizeInlineLabel(label)}_`
+  );
+}
+
+function extractQuotedMessageAttr(attrs: string): string | null {
+  const m = attrs.match(/message=(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)')/);
+  if (!m) {
+    return null;
+  }
+  const raw = m[1] ?? m[2] ?? "";
+  return raw.replaceAll('\\"', '"').replaceAll("\\'", "'");
+}
+
+function replaceQuickRepliesForSlack(text: string): string {
+  return text.replaceAll(
+    QUICK_REPLY_REGEX,
+    (_full, label: string, attrs: string) => {
+      const cleanLabel = normalizeInlineLabel(label);
+      const message = extractQuotedMessageAttr(attrs);
+      const cleanMsg = message ? normalizeInlineLabel(message) : cleanLabel;
+      if (cleanMsg === cleanLabel) {
+        return `_${cleanLabel}_`;
+      }
+      return `_${cleanLabel}_ — _${cleanMsg}_`;
+    }
+  );
+}
+
+function replaceContentNodeMentionsForSlack(text: string): string {
+  return text.replaceAll(
+    CONTENT_NODE_REGEX,
+    (_full, title: string, attrs: string | undefined) => {
+      const cleanTitle = normalizeInlineLabel(title);
+      if (!attrs) {
+        return cleanTitle;
+      }
+      const urlMatch = attrs.match(/url=([^}\s]+)/);
+      if (urlMatch?.[1]) {
+        return `<${urlMatch[1]}|${cleanTitle}>`;
+      }
+      return cleanTitle;
+    }
+  );
+}
+
+function replacePastedAttachmentsForSlack(text: string): string {
+  return text.replaceAll(PASTED_REGEX, (_full, title: string) => {
+    return `📎 _${normalizeInlineLabel(title)}_`;
+  });
+}
+
+function replaceAgentSuggestionsForSlack(text: string): string {
+  return text
+    .replaceAll(/::agent_suggestion\[\]\{([^}]*)\}/g, () => "_Suggestion_")
+    .replaceAll(/:agent_suggestion\[\]\{([^}]*)\}/g, () => "_Suggestion_");
+}
+
+function replaceVisualizationBlocksForSlack(text: string): string {
+  return text.replaceAll(
+    VISUALIZATION_BLOCK_REGEX,
+    () => "_Visualization_\n\n"
+  );
+}
+
+function replaceInstructionBlocksForSlack(text: string): string {
+  return text.replaceAll(
+    INSTRUCTION_BLOCK_REGEX,
+    (_full, _tag: string, inner: string) => inner.trim()
+  );
+}
+
+function collectUnsupportedDirectiveSignals(text: string): string[] {
+  const found = new Set<string>();
+  for (const m of text.matchAll(/:([a-zA-Z_][a-zA-Z0-9_]*)\[/g)) {
+    const name = m[1];
+    if (name && !DIRECTIVE_NAMES_ALLOWED_AFTER_FORMAT.has(name)) {
+      found.add(name);
+    }
+  }
+  for (const m of text.matchAll(/^:::([a-zA-Z][a-zA-Z0-9_]*)/gm)) {
+    const name = m[1];
+    if (name) {
+      found.add(`:::${name}`);
+    }
+  }
+  return [...found].sort();
+}
+
+export type FormatAgentMarkdownForSlackOptions = {
+  /**
+   * When both fields are set, `:mention[…]{sId=…}` becomes a Slack
+   * `<url|@DisplayName>` link to the agent details view in that conversation
+   * (same URL as in-app `agentDetails` query).
+   */
+  agentMentionLinkContext?: {
+    workspaceId: string;
+    conversationId: string;
+  };
+  /**
+   * When true, log a warning if any Dust-only directive syntax remains after
+   * known transforms. Enable only for the **final** agent `message.content` from
+   * a successful generation (e.g. `agent_message_success`). Keep false for
+   * in-progress buffers (streaming, length fallback), cancelled runs, or any
+   * string that may truncate mid-directive — otherwise you get false positives.
+   */
+  logUnsupportedDirectives?: boolean;
+};
+
+/**
+ * Turns Dust-specific markdown directives into Slack-friendly text. Citations
+ * (`:cite[…]`) are left intact for {@link annotateCitations}.
+ */
+export function formatAgentMarkdownForSlack(
+  text: string,
+  options?: FormatAgentMarkdownForSlackOptions
+): string {
+  let out = text;
+  out = replaceVisualizationBlocksForSlack(out);
+  out = replaceInstructionBlocksForSlack(out);
+  out = replaceToolSetupForSlack(out);
+  out = replaceProjectTodosForSlack(out);
+  out = replaceQuickRepliesForSlack(out);
+  out = replaceContentNodeMentionsForSlack(out);
+  out = replacePastedAttachmentsForSlack(out);
+  out = replaceAgentSuggestionsForSlack(out);
+  out = replaceMentionsForSlack(out, options?.agentMentionLinkContext);
+
+  if (options?.logUnsupportedDirectives) {
+    const unsupported = collectUnsupportedDirectiveSignals(out);
+    if (unsupported.length > 0) {
+      logger.warn(
+        {
+          unsupportedDirectives: unsupported,
+          preview: out.length > 400 ? `${out.slice(0, 400)}…` : out,
+        },
+        "Slack agent markdown: unsupported Dust directive(s) after formatting"
+      );
+    }
+  }
+
+  return out;
+}

--- a/connectors/src/lib/bot/conversation_utils.ts
+++ b/connectors/src/lib/bot/conversation_utils.ts
@@ -13,3 +13,20 @@ export function makeConversationUrl(
   }
   return null;
 }
+
+/**
+ * Opens the agent details sheet in the given conversation (same query as front
+ * `getConversationRoute(wId, conversationId, \`agentDetails=${agentConfigurationId}\`)`).
+ */
+export function makeAgentDetailsInConversationUrl(
+  workspaceId: string,
+  conversationId: string,
+  agentConfigurationId: string
+): string {
+  const q = new URLSearchParams({
+    agentDetails: agentConfigurationId,
+  });
+  return makeDustAppUrl(
+    `/w/${workspaceId}/conversation/${conversationId}?${q.toString()}`
+  );
+}


### PR DESCRIPTION
## Description

Agent messages sent to Slack were leaking raw Dust markdown directives (`:mention[…]`, `:todo[…]`, `:quickReply[…]`, `:::visualization`, `:toolSetup[…]`) as literal text, since Slack has no concept of these custom nodes.

`formatAgentMarkdownForSlack` is a pre-processing step applied to the agent answer before `annotateCitations` — it translates each known directive to a sensible Slack equivalent (e.g. `:mention` → `<url|@Name>` link, `:todo` → `*Todo:* text`, `:quickReply` → italic label + message, visualization/toolSetup blocks → italic placeholder) and leaves `:cite[…]` markers untouched for `annotateCitations` to handle. Unknown directives are stripped and optionally logged as a warning — logging is suppressed for mid-stream buffers (length cap hit, cancellation) where the text may be truncated mid-directive, and enabled for the terminal `generation_tokens` payload where the full message is available.

## Tests

Full unit test suite covering all directive types, link generation, cite passthrough, and the conditional logging behavior.

Tested in glitteryhelmet.

<img width="781" height="100" alt="image" src="https://github.com/user-attachments/assets/b7cc2470-e6a2-45c9-bbda-9ca9b4e76576" />
<img width="857" height="513" alt="image" src="https://github.com/user-attachments/assets/fe7a9fd1-e11b-4fa6-b0e4-9348c7821a8d" />


## Risk

Low — applied only in the Slack connector's stream handler; web/extension rendering is unaffected

## Deploy Plan

Deploy `connectors`
