### PR TITLE
[front] coupons: Metronome wrapper for coupon credits

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -208,6 +208,8 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
           endingBefore: startResult.value.expirationDate.toISOString(),
           name: `Free poke credit ($${originalAmount.toFixed(2)})`,
           idempotencyKey: `free-poke-${workspace.sId}-${startDate.getTime()}-${expirationDate.getTime()}`,
+          priority: 1,
+          applicableProductTags: ["usage"],
         });
 
         if (metronomeResult.isErr()) {

--- a/front/lib/metronome/client.test.ts
+++ b/front/lib/metronome/client.test.ts
@@ -1,0 +1,156 @@
+import { createMetronomeCredit } from "@app/lib/metronome/client";
+import type { Result } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function unwrapOk<T>(result: Result<T, Error>): T {
+  expect(result.isOk()).toBe(true);
+  if (!result.isOk()) {
+    throw new Error("Expected Ok");
+  }
+  return result.value;
+}
+
+function unwrapErr<T>(result: Result<T, Error>): Error {
+  expect(result.isErr()).toBe(true);
+  if (!result.isErr()) {
+    throw new Error("Expected Err");
+  }
+  return result.error;
+}
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockCreate, mockList, MockConflictError } = vi.hoisted(() => {
+  class MockConflictError extends Error {
+    status = 409;
+  }
+  return {
+    mockCreate: vi.fn(),
+    mockList: vi.fn(),
+    MockConflictError,
+  };
+});
+
+vi.mock("@metronome/sdk", () => {
+  // Must use a regular function (not an arrow) so it can be called with `new`.
+  function MockMetronome() {
+    return {
+      v1: {
+        customers: {
+          credits: { create: mockCreate, list: mockList },
+        },
+      },
+    };
+  }
+  return { default: MockMetronome, ConflictError: MockConflictError };
+});
+
+vi.mock("@app/lib/api/config", () => ({
+  default: { getMetronomeApiKey: () => "test-api-key" },
+}));
+
+vi.mock("@app/logger/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_PARAMS = {
+  metronomeCustomerId: "cust-1",
+  productId: "prod-1",
+  creditTypeId: "credit-type-usd",
+  amount: 10_000,
+  startingAt: "2026-04-01T00:00:00.000Z",
+  endingBefore: "2027-04-01T00:00:00.000Z",
+  name: "Test credit",
+  idempotencyKey: "key-1",
+  priority: 1,
+};
+
+beforeEach(() => {
+  mockCreate.mockReset();
+  mockList.mockReset();
+  mockCreate.mockResolvedValue({ data: { id: "credit-id-1" } });
+});
+
+// ---------------------------------------------------------------------------
+// createMetronomeCredit
+// ---------------------------------------------------------------------------
+
+describe("createMetronomeCredit", () => {
+  it("forwards priority to the API call", async () => {
+    await createMetronomeCredit({ ...BASE_PARAMS, priority: 0 });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ priority: 0 })
+    );
+  });
+
+  it("spreads applicableProductTags when provided", async () => {
+    await createMetronomeCredit({
+      ...BASE_PARAMS,
+      applicableProductTags: ["usage"],
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ applicable_product_tags: ["usage"] })
+    );
+  });
+
+  it("spreads applicableProductIds when provided", async () => {
+    await createMetronomeCredit({
+      ...BASE_PARAMS,
+      applicableProductIds: ["prod-seat"],
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ applicable_product_ids: ["prod-seat"] })
+    );
+  });
+
+  it("omits both applicable fields when neither is provided", async () => {
+    await createMetronomeCredit(BASE_PARAMS);
+
+    const call = mockCreate.mock.calls[0][0];
+    expect(call).not.toHaveProperty("applicable_product_tags");
+    expect(call).not.toHaveProperty("applicable_product_ids");
+  });
+
+  it("returns Ok with the credit id on success", async () => {
+    const result = await createMetronomeCredit(BASE_PARAMS);
+
+    expect(unwrapOk(result)).toEqual({ id: "credit-id-1" });
+  });
+
+  it("on ConflictError, looks up the existing credit and returns its id", async () => {
+    mockCreate.mockRejectedValueOnce(new MockConflictError("conflict"));
+    mockList.mockResolvedValue({
+      data: [{ id: "existing-id", uniqueness_key: BASE_PARAMS.idempotencyKey }],
+    });
+
+    const result = await createMetronomeCredit(BASE_PARAMS);
+
+    expect(unwrapOk(result)).toEqual({ id: "existing-id" });
+  });
+
+  it("on ConflictError with no matching credit in list, returns Ok(null)", async () => {
+    mockCreate.mockRejectedValueOnce(new MockConflictError("conflict"));
+    mockList.mockResolvedValue({ data: [] });
+
+    const result = await createMetronomeCredit(BASE_PARAMS);
+
+    expect(unwrapOk(result)).toBeNull();
+  });
+
+  it("returns Err on non-conflict API failure", async () => {
+    mockCreate.mockRejectedValueOnce(new Error("network error"));
+
+    const result = await createMetronomeCredit(BASE_PARAMS);
+
+    expect(unwrapErr(result).message).toMatch(/network error/);
+  });
+});

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -6,6 +6,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import Metronome, { ConflictError } from "@metronome/sdk";
 import type { Commit, ContractV2, Credit } from "@metronome/sdk/resources";
+import type { RateCardRetrieveResponse } from "@metronome/sdk/resources/v1/contracts/rate-cards";
 import type { Invoice } from "@metronome/sdk/resources/v1/customers";
 import type {
   MetronomeBalance,
@@ -465,34 +466,26 @@ export async function getMetronomeActiveContract(
 }
 
 /**
- * Retrieve a specific Metronome contract by customer + contract ID.
+ * Retrieve a specific Metronomome rate card by ID.
  */
 export async function getMetronomeRateCardById({
   rateCardId,
 }: {
   rateCardId: string;
-}): Promise<
-  Result<
-    {
-      fiat_credit_type_id: string | undefined;
-      fiat_credit_type_name: string | undefined;
-    },
-    Error
-  >
-> {
+}): Promise<Result<RateCardRetrieveResponse.Data, Error>> {
   try {
     const response = await getMetronomeClient().v1.contracts.rateCards.retrieve(
       { id: rateCardId }
     );
-    return new Ok({
-      fiat_credit_type_id: response.data.fiat_credit_type?.id,
-      fiat_credit_type_name: response.data.fiat_credit_type?.name,
-    });
+    return new Ok(response.data);
   } catch (err) {
     return new Err(normalizeError(err));
   }
 }
 
+/**
+ * Retrieve a specific Metronome contract by customer + contract ID.
+ */
 export async function getMetronomeContractById({
   metronomeCustomerId,
   metronomeContractId,

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -467,6 +467,32 @@ export async function getMetronomeActiveContract(
 /**
  * Retrieve a specific Metronome contract by customer + contract ID.
  */
+export async function getMetronomeRateCardById({
+  rateCardId,
+}: {
+  rateCardId: string;
+}): Promise<
+  Result<
+    {
+      fiat_credit_type_id: string | undefined;
+      fiat_credit_type_name: string | undefined;
+    },
+    Error
+  >
+> {
+  try {
+    const response = await getMetronomeClient().v1.contracts.rateCards.retrieve(
+      { id: rateCardId }
+    );
+    return new Ok({
+      fiat_credit_type_id: response.data.fiat_credit_type?.id,
+      fiat_credit_type_name: response.data.fiat_credit_type?.name,
+    });
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
 export async function getMetronomeContractById({
   metronomeCustomerId,
   metronomeContractId,
@@ -1048,6 +1074,9 @@ export async function createMetronomeCredit({
   endingBefore,
   name,
   idempotencyKey,
+  applicableProductTags,
+  applicableProductIds,
+  priority,
 }: {
   metronomeCustomerId: string;
   productId: string;
@@ -1057,6 +1086,9 @@ export async function createMetronomeCredit({
   endingBefore: string;
   name: string;
   idempotencyKey: string;
+  applicableProductTags?: string[];
+  applicableProductIds?: string[];
+  priority: number;
 }): Promise<Result<{ id: string } | null, Error>> {
   // Metronome requires dates on hour boundaries — round down start, round up end.
   const roundedStartingAt = floorToHourISO(new Date(startingAt));
@@ -1067,8 +1099,13 @@ export async function createMetronomeCredit({
       customer_id: metronomeCustomerId,
       product_id: productId,
       name,
-      priority: 1, // Apply credits before any prepaid commits
-      applicable_product_tags: ["usage"],
+      priority,
+      ...(applicableProductTags
+        ? { applicable_product_tags: applicableProductTags }
+        : {}),
+      ...(applicableProductIds
+        ? { applicable_product_ids: applicableProductIds }
+        : {}),
       access_schedule: {
         credit_type_id: creditTypeId,
         schedule_items: [
@@ -1266,6 +1303,40 @@ export async function getMetronomeCommit({
     return result;
   }
   return new Ok(result.value[0] ?? null);
+}
+
+/**
+ * Update the access end date on a customer-level credit.
+ * Used when revoking a coupon to cut off the credit early.
+ */
+export async function updateMetronomeCreditEndDate({
+  metronomeCustomerId,
+  creditId,
+  accessEndingBefore,
+}: {
+  metronomeCustomerId: string;
+  creditId: string;
+  accessEndingBefore: string;
+}): Promise<Result<void, Error>> {
+  try {
+    await getMetronomeClient().v1.customers.credits.updateEndDate({
+      customer_id: metronomeCustomerId,
+      credit_id: creditId,
+      access_ending_before: accessEndingBefore,
+    });
+    logger.info(
+      { metronomeCustomerId, creditId, accessEndingBefore },
+      "[Metronome] Credit end date updated"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, creditId, accessEndingBefore },
+      "[Metronome] Failed to update credit end date"
+    );
+    return new Err(error);
+  }
 }
 
 /**

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -34,6 +34,8 @@ const DEV_PRODUCT_MAU_COMMIT = "ababd7de-376d-41c6-a7da-40088af94433";
 const DEV_PRODUCT_FREE_MONTHLY_CREDITS = "04f41dd1-ba27-42e3-93d5-6121712a4b67";
 const DEV_PRODUCT_PREPAID_COMMIT = "5f4331b7-4bf6-488b-9a0c-51bd139ac91c";
 const DEV_PRODUCT_PAYG_OVERAGE = "f4583c77-d226-48bb-97a3-46a8087b97fe";
+const DEV_PRODUCT_SEAT_SUBSCRIPTION_CREDITS =
+  "92f3466b-2423-4f2a-a8d1-0f6e9f7f0140";
 
 // --- PROD (production) — TODO: update after running setup script in production ---
 
@@ -68,6 +70,8 @@ const PROD_PRODUCT_FREE_MONTHLY_CREDITS =
   "7379999c-5492-4e68-968f-345a26f6da63";
 const PROD_PRODUCT_PREPAID_COMMIT = "1408c9fc-dea1-4269-bd6d-1bc0aa1f1218";
 const PROD_PRODUCT_PAYG_OVERAGE = "f6b27a6e-86fc-4964-8076-371a912cee09";
+const PROD_PRODUCT_SEAT_SUBSCRIPTION_CREDITS =
+  "TODO_PROD_SEAT_SUBSCRIPTION_CREDITS_ID";
 
 // --- Credit type IDs (stable across envs unless noted) ---
 
@@ -157,6 +161,11 @@ export const getProductPrepaidCommitId = () =>
   devOrProd(DEV_PRODUCT_PREPAID_COMMIT, PROD_PRODUCT_PREPAID_COMMIT);
 export const getProductPaygOverageId = () =>
   devOrProd(DEV_PRODUCT_PAYG_OVERAGE, PROD_PRODUCT_PAYG_OVERAGE);
+export const getProductSeatSubscriptionCreditsId = () =>
+  devOrProd(
+    DEV_PRODUCT_SEAT_SUBSCRIPTION_CREDITS,
+    PROD_PRODUCT_SEAT_SUBSCRIPTION_CREDITS
+  );
 
 // MAU tier product accessors — ordered array for indexed access.
 export const MAX_MAU_TIERS = 6;

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -1,0 +1,145 @@
+import { metronomeAmount } from "@app/lib/metronome/amounts";
+import {
+  ceilToHourISO,
+  createMetronomeCredit,
+  floorToHourISO,
+  getMetronomeRateCardById,
+  updateMetronomeCreditEndDate,
+} from "@app/lib/metronome/client";
+import {
+  CURRENCY_TO_CREDIT_TYPE_ID,
+  getProductSeatSubscriptionCreditsId,
+  getProductWorkspaceSeatId,
+} from "@app/lib/metronome/constants";
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import type { CouponResource } from "@app/lib/resources/coupon_resource";
+import type { CouponDiscountType } from "@app/types/coupon";
+import type { SupportedCurrency } from "@app/types/currency";
+import { isSupportedCurrency } from "@app/types/currency";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { addMonths } from "date-fns";
+
+export async function getCreditTypeFromContract(
+  contract: CachedContract
+): Promise<
+  Result<{ creditTypeId: string; currency: SupportedCurrency }, Error>
+> {
+  if (!contract.rate_card_id) {
+    return new Err(new Error("Contract has no rate_card_id"));
+  }
+  const result = await getMetronomeRateCardById({
+    rateCardId: contract.rate_card_id,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+
+  const { fiat_credit_type_id } = result.value;
+  if (!fiat_credit_type_id) {
+    return new Err(new Error("Rate card has no fiat_credit_type_id"));
+  }
+  const creditTypeIdToCurrency = Object.fromEntries(
+    Object.entries(CURRENCY_TO_CREDIT_TYPE_ID).map(([c, id]) => [id, c])
+  );
+  const currency = creditTypeIdToCurrency[fiat_credit_type_id];
+  if (!isSupportedCurrency(currency)) {
+    return new Err(
+      new Error(
+        `Unsupported currency for credit type id: ${fiat_credit_type_id}`
+      )
+    );
+  }
+  return new Ok({ creditTypeId: fiat_credit_type_id, currency });
+}
+
+function getApplicableProductIdsForDiscountType(
+  discountType: CouponDiscountType
+): string[] {
+  switch (discountType) {
+    case "seat":
+      return [getProductWorkspaceSeatId()];
+    default:
+      return assertNever(discountType);
+  }
+}
+
+export async function createCouponCredit({
+  metronomeCustomerId,
+  coupon,
+  redemptionId,
+  redeemedAt,
+  creditTypeId,
+  currency,
+}: {
+  metronomeCustomerId: string;
+  coupon: CouponResource;
+  redemptionId: string;
+  redeemedAt: Date;
+  creditTypeId: string;
+  currency: SupportedCurrency;
+}): Promise<Result<string[], Error>> {
+  const scheduleItems =
+    coupon.durationMonths === null
+      ? [{ startingAt: redeemedAt, endingBefore: addMonths(redeemedAt, 1) }]
+      : Array.from({ length: coupon.durationMonths }, (_, i) => ({
+          startingAt: addMonths(redeemedAt, i),
+          endingBefore: addMonths(redeemedAt, i + 1),
+        }));
+
+  const creditIds: string[] = [];
+
+  for (let i = 0; i < scheduleItems.length; i++) {
+    const item = scheduleItems[i];
+    const result = await createMetronomeCredit({
+      metronomeCustomerId,
+      productId: getProductSeatSubscriptionCreditsId(),
+      creditTypeId,
+      amount: metronomeAmount(coupon.amount * 100, currency),
+      startingAt: floorToHourISO(item.startingAt),
+      endingBefore: ceilToHourISO(item.endingBefore),
+      name: `Coupon: ${coupon.code}`,
+      idempotencyKey: `coupon-${redemptionId}-${i}`,
+      priority: 0,
+      applicableProductIds: getApplicableProductIdsForDiscountType(
+        coupon.discountType
+      ),
+    });
+
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    if (result.value !== null) {
+      creditIds.push(result.value.id);
+    }
+  }
+
+  return new Ok(creditIds);
+}
+
+export async function endCouponCredit({
+  metronomeCustomerId,
+  metronomeCreditIds,
+  endAt,
+}: {
+  metronomeCustomerId: string;
+  metronomeCreditIds: string[];
+  endAt: Date;
+}): Promise<Result<void, Error>> {
+  const accessEndingBefore = ceilToHourISO(endAt);
+
+  for (const creditId of metronomeCreditIds) {
+    const result = await updateMetronomeCreditEndDate({
+      metronomeCustomerId,
+      creditId,
+      accessEndingBefore,
+    });
+    if (result.isErr()) {
+      return result;
+    }
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -36,7 +36,7 @@ export async function getCreditTypeFromContract(
     return result;
   }
 
-  const { fiat_credit_type_id } = result.value;
+  const fiat_credit_type_id = result.value.fiat_credit_type?.id;
   if (!fiat_credit_type_id) {
     return new Err(new Error("Rate card has no fiat_credit_type_id"));
   }

--- a/front/scripts/backfill_metronome_credits.ts
+++ b/front/scripts/backfill_metronome_credits.ts
@@ -213,6 +213,8 @@ async function backfillCreditsOfType(
             endingBefore: endingBefore.toISOString(),
             name: `Free poke credit backfill (${startingAt.toISOString().split("T")[0]})`,
             idempotencyKey: `createCredit-${workspace.sId}-${startingAt.getTime()}-${endingBefore.getTime()}`,
+            priority: 1,
+            applicableProductTags: ["usage"],
           });
         }
         break;

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -343,6 +343,10 @@ const PRODUCTS: ProductDef[] = [
     name: "PAYG Overage",
     type: "FIXED",
   },
+  {
+    name: "Seat Subscription Credits",
+    type: "FIXED",
+  },
 ];
 
 // MAU tier rate definitions for enterprise rate cards.


### PR DESCRIPTION
## Description

Closes  https://github.com/dust-tt/tasks/issues/7853
* Implements the Metronome layer for coupon credits (ticket 2.1). Makes createMetronomeCredit fully configurable by replacing hardcoded priority and product tag defaults with explicit caller-owned parameters
* creates front/lib/metronome/coupons.ts with helpers to derive the credit type from a workspace contract, schedule one-time or recurring monthly credits with priority: 0, and terminate them early on revocation.
* adds the Seat Subscription Credits product constant

Note: the PROD constant (PROD_PRODUCT_SEAT_SUBSCRIPTION_CREDITS) is still "TODO_PROD_SEAT_SUBSCRIPTION_CREDITS_ID" and must be filled after running metronome_setup in production

## Tests

Tested locally with Metronome Sandbox

## Risk

None, coupons still not used

## Deploy Plan

Deploy front