### PR TITLE
fix: enterprise pricing copy

### DIFF
--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -130,7 +130,7 @@ function getSeatBasedPlanItems(
       plans: ["business"],
     },
     {
-      label: "Advanced models (GPT-5, Claude, Gemini, Mistral\u2026)",
+      label: "Advanced models (GPT-5, Claude, Gemini, Mistral…)",
       variant: "check",
       display: ["landing", "subscribe"],
       plans: ["pro", "business"],

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -130,7 +130,7 @@ function getSeatBasedPlanItems(
       plans: ["business"],
     },
     {
-      label: "Advanced models (GPT-5, Claude, Gemini, Mistral…)",
+      label: "Advanced models (GPT-5, Claude, Gemini, Mistral\u2026)",
       variant: "check",
       display: ["landing", "subscribe"],
       plans: ["pro", "business"],
@@ -378,7 +378,7 @@ function EnterprisePriceTable({
       title="Enterprise"
       price="Custom"
       size={size}
-      priceLabel=" pay-per-use, 100+ users"
+      priceLabel=" based on active users"
       magnified={false}
     >
       <PriceTable.ActionContainer position="top">

--- a/front/components/plans/SubscriptionPlanCards.tsx
+++ b/front/components/plans/SubscriptionPlanCards.tsx
@@ -123,7 +123,7 @@ export function SubscriptionPlanCards({
               Custom
             </span>
             <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              pay-per-use, from 100+ users
+              based on active users
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Description

Fix enterprise pricing descriptor copy on plan cards.

- `PlansTables.tsx`: `priceLabel=" pay-per-use, 100+ users"` → `priceLabel=" based on active users"`
- `SubscriptionPlanCards.tsx`: `pay-per-use, from 100+ users` → `based on active users`

Context: https://dust4ai.slack.com/archives/C09QQ87AAER/p1777510046849019?thread_ts=1777510046.849019&cid=C09QQ87AAER

## Tests

No

## Risk

Low

## Deploy Plan

Deploy front