### PR TITLE
Do not expose conversation files tools when new file explorer FF is on

### DIFF
--- a/front/components/home/content/Integration/utils/integrationRegistry.ts
+++ b/front/components/home/content/Integration/utils/integrationRegistry.ts
@@ -25,6 +25,7 @@ const EXCLUDED_MCP_SERVERS = new Set([
   "schedules_management",
   "common_utilities",
   "project_context_management",
+  "files",
   // Debug/dev only
   "primitive_types_debugger",
   "jit_testing",

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -1,22 +1,39 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { CONVERSATION_FILES_SERVER_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
+import {
+  CONVERSATION_CAT_FILE_ACTION_NAME,
+  CONVERSATION_FILES_SERVER_NAME,
+  CONVERSATION_SEARCH_FILES_ACTION_NAME,
+} from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/conversation_files/tools";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-function createServer(
+const NEW_FILE_EXPLORER_HIDDEN_TOOLS = new Set([
+  CONVERSATION_CAT_FILE_ACTION_NAME,
+  CONVERSATION_SEARCH_FILES_ACTION_NAME,
+]);
+
+async function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer {
+): Promise<McpServer> {
   const server = makeInternalMCPServer("conversation_files");
 
+  const isNewFileExplorer = await hasFeatureFlag(auth, "new_file_explorer");
+
   for (const tool of TOOLS) {
+    if (isNewFileExplorer && NEW_FILE_EXPLORER_HIDDEN_TOOLS.has(tool.name)) {
+      continue;
+    }
+
     registerTool(auth, agentLoopContext, server, tool, {
       monitoringName: CONVERSATION_FILES_SERVER_NAME,
     });
   }
+
   return server;
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When the FF `new_file_explorer` is on, do not expose the legacy conversation cat and search tools. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
