### PR TITLE
Allow Poke to view deleted convos

### DIFF
--- a/front/components/poke/conversation/agent_table.tsx
+++ b/front/components/poke/conversation/agent_table.tsx
@@ -1,11 +1,11 @@
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { PokeListConversationItem } from "@app/pages/api/poke/workspaces/[wId]/conversations";
 import type { PokeConversationsFetchProps } from "@app/poke/swr/conversation";
 import { usePokeConversations } from "@app/poke/swr/conversation";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
+import { Chip, IconButton, LinkWrapper } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -16,7 +16,7 @@ interface ConversationAgentDataTableProps {
 
 const makeColumnsForConversations = (
   owner: LightWorkspaceType
-): ColumnDef<ConversationWithoutContentType>[] => {
+): ColumnDef<PokeListConversationItem>[] => {
   return [
     {
       accessorKey: "sId",
@@ -82,6 +82,16 @@ const makeColumnsForConversations = (
         );
       },
     },
+    {
+      accessorKey: "visibility",
+      header: "Status",
+      cell: ({ row }) => {
+        if (row.original.visibility === "deleted") {
+          return <Chip color="warning" label="Deleted" size="xs" />;
+        }
+        return null;
+      },
+    },
   ];
 };
 
@@ -103,7 +113,7 @@ export function ConversationAgentDataTable({
         const columns = makeColumnsForConversations(owner);
 
         return (
-          <PokeDataTable<ConversationWithoutContentType, unknown>
+          <PokeDataTable<PokeListConversationItem, unknown>
             columns={columns}
             data={conversations}
           />

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -49,7 +49,8 @@ async function handler(
     case "GET":
       const cRes = await ConversationResource.fetchConversationWithoutContent(
         auth,
-        cId
+        cId,
+        { includeDeleted: true }
       );
       if (cRes.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -4,13 +4,20 @@ import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  ConversationVisibility,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+export type PokeListConversationItem = ConversationWithoutContentType & {
+  visibility?: ConversationVisibility;
+};
+
 export type PokeListConversations = {
-  conversations: ConversationWithoutContentType[];
+  conversations: PokeListConversationItem[];
 };
 
 async function handler(
@@ -37,7 +44,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      let conversations: ConversationWithoutContentType[];
+      let conversations: PokeListConversationItem[];
 
       if (isString(triggerId)) {
         // Get conversations for this trigger
@@ -63,7 +70,8 @@ async function handler(
             {
               agentConfigurationId: agentId,
               cutoffDate: new Date(), // Current time to get all conversations.
-            }
+            },
+            { includeDeleted: true }
           );
 
         conversations = conversationResources.map((c) => {


### PR DESCRIPTION
## Description

- Fix Poke conversation page failing to load for deleted conversations (the [cId]/config endpoint was filtering them out, blocking page render before the actual conversation endpoint was called).
- Include deleted conversations in the agent's conversation list in Poke.
- Add a "Status" column on that list showing a "Deleted" chip when applicable.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Poke only

## Deploy Plan

Front