### PR TITLE
[front] Confirm X-Reload-Required with cache-busting refetch

### DIFF
--- a/front/lib/swr/fetcher.ts
+++ b/front/lib/swr/fetcher.ts
@@ -34,10 +34,10 @@ const makeResHandler =
             url: res.url,
             statusCode: res.status,
           },
-          "[fetcher] Force client reload"
+          "[fetcher] Force client reload - ignored"
         );
         sessionStorage.setItem(FORCE_RELOAD_SESSION_KEY, nowMs.toString());
-        window.location.reload();
+        // TODO - reenable once clients cache are cleaned - window.location.reload();
         // Return a never-resolving promise to prevent SWR from processing.
         return new Promise(() => {});
       }


### PR DESCRIPTION
## Description

Follow-up to #25115. The `Cache-Control: no-store` fix prevents future poisoning, but clients with cache entries already poisoned (from before #25115 was deployed) keep reload-looping until those entries expire (`max-age=120s`), and any new SWR fetch to the same URL hits the same poisoned entry.

Remove the reload code temporarly.

## Tests

Manual.

## Risk

Low. 

## Deploy Plan

Standard  SPA deploy. Already-poisoned clients pick up the fix on their next page load.