### PR TITLE
[front] coupons: Poke plugins apply_coupon + revoke_coupon

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/apply_coupon.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_coupon.test.ts
@@ -1,0 +1,305 @@
+import { applyCouponPlugin } from "@app/lib/api/poke/plugins/workspaces/apply_coupon";
+import { revokeCouponPlugin } from "@app/lib/api/poke/plugins/workspaces/revoke_coupon";
+import { Authenticator } from "@app/lib/auth";
+import { CREDIT_TYPE_USD_ID } from "@app/lib/metronome/constants";
+import { redeemCoupon } from "@app/lib/metronome/coupons";
+import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { CouponFactory } from "@app/tests/utils/CouponFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockCreateMetronomeCredit,
+  mockGetMetronomeRateCardById,
+  mockUpdateMetronomeCreditEndDate,
+  mockEmitAuditLogEvent,
+} = vi.hoisted(() => ({
+  mockCreateMetronomeCredit: vi.fn(),
+  mockGetMetronomeRateCardById: vi.fn(),
+  mockUpdateMetronomeCreditEndDate: vi.fn(),
+  mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/client")
+  >("@app/lib/metronome/client");
+  return {
+    ...actual,
+    createMetronomeCredit: mockCreateMetronomeCredit,
+    getMetronomeRateCardById: mockGetMetronomeRateCardById,
+    updateMetronomeCreditEndDate: mockUpdateMetronomeCreditEndDate,
+  };
+});
+
+vi.mock("@app/lib/metronome/plan_type", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/metronome/plan_type")>();
+  return {
+    ...actual,
+    getActiveContract: vi
+      .fn()
+      .mockResolvedValue({ rate_card_id: "rate-card-test-id" }),
+  };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
+});
+
+vi.mock("@app/lib/metronome/constants", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/constants")
+  >("@app/lib/metronome/constants");
+  return {
+    ...actual,
+    getProductSeatSubscriptionCreditsId: () => "seat-subscription-credits-prod",
+    getProductWorkspaceSeatId: () => "workspace-seat-prod",
+  };
+});
+
+vi.mock("@app/logger/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const METRONOME_CUSTOMER_ID = "metronome-test-customer-id";
+
+async function makeWorkspaceWithMetronome() {
+  const ws = await WorkspaceFactory.basic();
+  await WorkspaceResource.updateMetronomeCustomerId(
+    ws.id,
+    METRONOME_CUSTOMER_ID
+  );
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(ws, user, { role: "admin" });
+  // Fetch auth after metronomeCustomerId update so getNonNullableWorkspace reflects it.
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, ws.sId);
+  return { workspace: ws, auth };
+}
+
+async function makeWorkspaceNoMetronome() {
+  const ws = await WorkspaceFactory.basic();
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(ws, user, { role: "admin" });
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, ws.sId);
+  return { auth };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockCreateMetronomeCredit.mockReset();
+  mockGetMetronomeRateCardById.mockReset();
+  mockUpdateMetronomeCreditEndDate.mockReset();
+  mockEmitAuditLogEvent.mockReset();
+  mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "credit-id-1" }));
+  mockGetMetronomeRateCardById.mockResolvedValue(
+    new Ok({ fiat_credit_type: { id: CREDIT_TYPE_USD_ID } })
+  );
+  mockUpdateMetronomeCreditEndDate.mockResolvedValue(new Ok(undefined));
+  mockEmitAuditLogEvent.mockResolvedValue(undefined);
+});
+
+describe("applyCouponPlugin.execute", () => {
+  it("applies a valid coupon → redemption created with active status and audit event emitted", async () => {
+    const { auth } = await makeWorkspaceWithMetronome();
+    const coupon = await CouponFactory.create({ durationMonths: null });
+    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "credit-abc" }));
+
+    const result = await applyCouponPlugin.execute(auth, null, {
+      couponCode: coupon.code,
+      confirm: true,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.display).toBe("text");
+      expect(result.value.value).toContain(coupon.code);
+    }
+
+    const redemptions = await CouponRedemptionResource.listAllByCoupon(coupon);
+    expect(redemptions).toHaveLength(1);
+    expect(redemptions[0].status).toBe("active");
+
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "coupon.redeemed" })
+    );
+  });
+
+  it("returns Err when coupon code is not found", async () => {
+    const { auth } = await makeWorkspaceWithMetronome();
+
+    const result = await applyCouponPlugin.execute(auth, null, {
+      couponCode: "NONEXISTENT",
+      confirm: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("NONEXISTENT");
+    }
+  });
+
+  it("returns Err with workspace_not_on_metronome message when workspace has no Metronome customer ID", async () => {
+    const { auth } = await makeWorkspaceNoMetronome();
+    const coupon = await CouponFactory.create();
+
+    const result = await applyCouponPlugin.execute(auth, null, {
+      couponCode: coupon.code,
+      confirm: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(/Metronome/i);
+    }
+  });
+
+  it("returns Err when confirm is false", async () => {
+    const { auth } = await makeWorkspaceWithMetronome();
+    const coupon = await CouponFactory.create();
+
+    const result = await applyCouponPlugin.execute(auth, null, {
+      couponCode: coupon.code,
+      confirm: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(/confirm/i);
+    }
+  });
+});
+
+describe("revokeCouponPlugin.execute", () => {
+  it("revokes an active redemption → status revoked and audit event emitted", async () => {
+    const { auth } = await makeWorkspaceWithMetronome();
+    const coupon = await CouponFactory.create();
+
+    const redeemResult = await redeemCoupon(auth, { coupon });
+    expect(redeemResult.isOk()).toBe(true);
+    if (!redeemResult.isOk()) {
+      return;
+    }
+    const redemption = redeemResult.value;
+    mockEmitAuditLogEvent.mockClear();
+
+    const result = await revokeCouponPlugin.execute(auth, null, {
+      redemptionId: [redemption.sId],
+      confirm: true,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.display).toBe("text");
+      expect(result.value.value).toContain(redemption.sId);
+    }
+
+    const redemptions = await CouponRedemptionResource.listAllByCoupon(coupon);
+    expect(redemptions[0].status).toBe("revoked");
+
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "coupon.revoked" })
+    );
+  });
+
+  it("returns Err when redemption sId is not found", async () => {
+    const { auth } = await makeWorkspaceWithMetronome();
+
+    const result = await revokeCouponPlugin.execute(auth, null, {
+      redemptionId: ["nonexistent-sid"],
+      confirm: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("nonexistent-sid");
+    }
+  });
+
+  it("returns Err when redemption belongs to a different workspace", async () => {
+    const { auth: authA } = await makeWorkspaceWithMetronome();
+    const { auth: authB } = await makeWorkspaceWithMetronome();
+    const coupon = await CouponFactory.create();
+
+    const redeemResult = await redeemCoupon(authA, { coupon });
+    expect(redeemResult.isOk()).toBe(true);
+    if (!redeemResult.isOk()) {
+      return;
+    }
+    const redemptionOfA = redeemResult.value;
+
+    // Workspace B tries to revoke workspace A's redemption.
+    const result = await revokeCouponPlugin.execute(authB, null, {
+      redemptionId: [redemptionOfA.sId],
+      confirm: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("returns Err when Metronome fails to end the credit", async () => {
+    const { auth } = await makeWorkspaceWithMetronome();
+    const coupon = await CouponFactory.create();
+
+    const redeemResult = await redeemCoupon(auth, { coupon });
+    expect(redeemResult.isOk()).toBe(true);
+    if (!redeemResult.isOk()) {
+      return;
+    }
+    const redemption = redeemResult.value;
+
+    mockUpdateMetronomeCreditEndDate.mockResolvedValue(
+      new Err(new Error("Metronome unavailable"))
+    );
+
+    const result = await revokeCouponPlugin.execute(auth, null, {
+      redemptionId: [redemption.sId],
+      confirm: true,
+    });
+
+    expect(result.isErr()).toBe(true);
+
+    // Redemption should remain active (not revoked).
+    const redemptions = await CouponRedemptionResource.listAllByCoupon(coupon);
+    expect(redemptions[0].status).toBe("active");
+  });
+
+  it("returns Err when confirm is false", async () => {
+    const { auth } = await makeWorkspaceWithMetronome();
+    const coupon = await CouponFactory.create();
+
+    const redeemResult = await redeemCoupon(auth, { coupon });
+    expect(redeemResult.isOk()).toBe(true);
+    if (!redeemResult.isOk()) {
+      return;
+    }
+    const redemption = redeemResult.value;
+
+    const result = await revokeCouponPlugin.execute(auth, null, {
+      redemptionId: [redemption.sId],
+      confirm: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(/confirm/i);
+    }
+  });
+});

--- a/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_coupon.ts
@@ -1,0 +1,100 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { redeemCoupon } from "@app/lib/metronome/coupons";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+
+const ApplyCouponArgsSchema = z
+  .object({
+    couponCode: z.string().min(1, "Coupon code is required"),
+    confirm: z.boolean(),
+  })
+  .refine((data) => data.confirm === true, {
+    message: "Please confirm before applying the coupon",
+  });
+
+export const applyCouponPlugin = createPlugin({
+  manifest: {
+    id: "apply-coupon",
+    name: "Apply Coupon",
+    description:
+      "Apply a coupon to this workspace on behalf of the customer. The workspace must already be provisioned on Metronome.",
+    resourceTypes: ["workspaces"],
+    args: {
+      couponCode: {
+        type: "string",
+        label: "Coupon Code",
+        description: "The coupon code to apply to this workspace",
+      },
+      confirm: {
+        type: "boolean",
+        label: "Confirm",
+        description: "I confirm I want to apply this coupon to the workspace.",
+      },
+    },
+  },
+  execute: async (auth, _, args) => {
+    const validationResult = ApplyCouponArgsSchema.safeParse(args);
+    if (!validationResult.success) {
+      return new Err(new Error(fromZodError(validationResult.error).message));
+    }
+
+    const { couponCode } = validationResult.data;
+
+    const coupon = await CouponResource.findByCode(couponCode);
+    if (!coupon) {
+      return new Err(new Error(`Coupon not found: "${couponCode}".`));
+    }
+
+    const result = await redeemCoupon(auth, { coupon });
+    if (result.isErr()) {
+      const err = result.error;
+      if (err instanceof Error) {
+        return new Err(err);
+      }
+      switch (err.code) {
+        case "workspace_not_on_metronome":
+          return new Err(
+            new Error(
+              "Workspace is not provisioned on Metronome. Provision it first using the 'Switch to Metronome Billing' plugin."
+            )
+          );
+        case "coupon_validation_failed":
+          switch (err.reason.code) {
+            case "expired":
+              return new Err(
+                new Error(
+                  `Coupon "${couponCode}" expired on ${err.reason.expirationDate.toISOString()}.`
+                )
+              );
+            case "exhausted":
+              return new Err(
+                new Error(
+                  `Coupon "${couponCode}" has reached its limit of ${err.reason.maxRedemptions} redemption(s).`
+                )
+              );
+            case "archived":
+              return new Err(new Error(`Coupon "${couponCode}" is archived.`));
+            case "already_redeemed":
+              return new Err(
+                new Error(
+                  `Coupon "${couponCode}" has already been redeemed by this workspace.`
+                )
+              );
+            default:
+              return assertNever(err.reason);
+          }
+        default:
+          return assertNever(err);
+      }
+    }
+
+    const redemption = result.value;
+    return new Ok({
+      display: "text",
+      value: `Coupon "${couponCode}" applied successfully. Redemption ID: ${redemption.sId}.`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -1,4 +1,5 @@
 export * from "./add_user_to_workos_organization";
+export * from "./apply_coupon";
 export * from "./apply_group_roles";
 export * from "./buy_programmatic_usage_credits";
 export * from "./check_message_usage";
@@ -24,6 +25,7 @@ export * from "./rename_workspace";
 export * from "./reset_message_rate_limit";
 export * from "./reset_provisioned_members_not_in_directory";
 export * from "./restore_conversation";
+export * from "./revoke_coupon";
 export * from "./revoke_users";
 export * from "./run_reinforcement_workflow";
 export * from "./send_onboarding_conversation";

--- a/front/lib/api/poke/plugins/workspaces/revoke_coupon.ts
+++ b/front/lib/api/poke/plugins/workspaces/revoke_coupon.ts
@@ -1,0 +1,77 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { revokeCouponRedemption } from "@app/lib/metronome/coupons";
+import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+
+const RevokeCouponArgsSchema = z
+  .object({
+    redemptionId: z.array(z.string()).min(1, "Please select a redemption"),
+    confirm: z.boolean(),
+  })
+  .refine((data) => data.confirm === true, {
+    message: "Please confirm before revoking the coupon redemption",
+  });
+
+export const revokeCouponPlugin = createPlugin({
+  manifest: {
+    id: "revoke-coupon",
+    name: "Revoke Coupon Redemption",
+    description:
+      "Revoke an active coupon redemption for this workspace. This ends the Metronome credit and marks the redemption as revoked.",
+    resourceTypes: ["workspaces"],
+    args: {
+      redemptionId: {
+        type: "enum",
+        label: "Active Redemption",
+        description: "Select the active coupon redemption to revoke",
+        async: true,
+        values: [],
+        multiple: false,
+      },
+      confirm: {
+        type: "boolean",
+        label: "Confirm Revocation",
+        description:
+          "I confirm I want to revoke this coupon redemption. This will immediately stop the associated Metronome credit.",
+      },
+    },
+  },
+  populateAsyncArgs: async (auth) => {
+    const items = await CouponRedemptionResource.listActiveByWorkspace(auth);
+    return new Ok({
+      redemptionId: items.map(({ redemption, couponCode }) => ({
+        label: `Coupon ${couponCode} — redeemed ${redemption.redeemedAt.toISOString().slice(0, 10)} (${redemption.sId})`,
+        value: redemption.sId,
+      })),
+    });
+  },
+  execute: async (auth, _, args) => {
+    const validationResult = RevokeCouponArgsSchema.safeParse(args);
+    if (!validationResult.success) {
+      return new Err(new Error(fromZodError(validationResult.error).message));
+    }
+
+    const redemptionId = validationResult.data.redemptionId[0];
+    const redemption = await CouponRedemptionResource.fetchById(
+      auth,
+      redemptionId
+    );
+    if (!redemption) {
+      return new Err(
+        new Error(`Redemption "${redemptionId}" not found for this workspace.`)
+      );
+    }
+
+    const result = await revokeCouponRedemption(auth, { redemption });
+    if (result.isErr()) {
+      return result;
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Redemption ${redemptionId} revoked successfully.`,
+    });
+  },
+});

--- a/front/lib/resources/coupon_redemption_resource.ts
+++ b/front/lib/resources/coupon_redemption_resource.ts
@@ -1,11 +1,12 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { CouponResource } from "@app/lib/resources/coupon_resource";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { CouponRedemptionModel } from "@app/lib/resources/storage/models/coupon_redemptions";
+import { CouponModel } from "@app/lib/resources/storage/models/coupons";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { makeSId } from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type {
   CouponRedemptionStatus,
@@ -109,6 +110,53 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
       workspaceSId: workspace.sId,
       couponSId: coupon.sId,
       redeemedByUserSId: null,
+    });
+  }
+
+  static async listActiveByWorkspace(
+    auth: Authenticator
+  ): Promise<
+    Array<{ redemption: CouponRedemptionResource; couponCode: string }>
+  > {
+    const workspace = auth.getNonNullableWorkspace();
+    const rows = await this.model.findAll({
+      where: { workspaceId: workspace.id, status: "active" },
+      include: [
+        { model: CouponModel, as: "coupon", required: true },
+        { model: UserModel, as: "redeemedByUser", required: false },
+      ],
+      order: [["redeemedAt", "DESC"]],
+    });
+    return rows.map((r) => ({
+      redemption: new this(this.model, r.get(), {
+        workspaceSId: workspace.sId,
+        couponSId: CouponResource.modelIdToSId({ id: r.couponId }),
+        redeemedByUserSId: r.redeemedByUser?.sId ?? null,
+      }),
+      couponCode: r.coupon.code,
+    }));
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    redemptionId: string
+  ): Promise<CouponRedemptionResource | null> {
+    const workspace = auth.getNonNullableWorkspace();
+    const id = getResourceIdFromSId(redemptionId);
+    if (!id) {
+      return null;
+    }
+    const row = await this.model.findOne({
+      where: { id, workspaceId: workspace.id },
+      include: [{ model: UserModel, as: "redeemedByUser", required: false }],
+    });
+    if (!row) {
+      return null;
+    }
+    return new this(this.model, row.get(), {
+      workspaceSId: workspace.sId,
+      couponSId: CouponResource.modelIdToSId({ id: row.couponId }),
+      redeemedByUserSId: row.redeemedByUser?.sId ?? null,
     });
   }
 


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/7855
* Two operator-facing Poke plugins for the coupons feature
  * apply_coupon applies a coupon to a workspace by code
  * revoke_coupon lets operators pick and revoke an active redemption from a dropdown
* Both delegate to the existing redeemCoupon / revokeCouponRedemption business logic.
* Also adds listActiveByWorkspace and fetchById to CouponRedemptionResource to support the plugins.

## Tests

Tested locally with coupon creation, redemption and revocation

## Risk

Low, coupon page is not visible yet and hence coupons are not used in production yet

## Deploy Plan

Deploy front
