### PR TITLE
feat: reopen current branch

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -37,6 +37,7 @@ import {
   useConversations,
 } from "@app/hooks/conversations";
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
+import { useOpenConversationBranch } from "@app/hooks/conversations/useOpenConversationBranch";
 import { planFileKey } from "@app/hooks/conversations/usePlanFile";
 import { useConversationEvents } from "@app/hooks/useConversationEvents";
 import { useEnableBrowserNotification } from "@app/hooks/useEnableBrowserNotification";
@@ -261,6 +262,9 @@ export const ConversationViewer = ({
     null
   );
 
+  const { openBranch } = useOpenConversationBranch({ owner, conversationId });
+  const hasInjectedOpenBranchRef = useRef(false);
+
   const {
     conversation,
     conversationError,
@@ -418,6 +422,31 @@ export const ConversationViewer = ({
     conversation?.unread,
     conversation?.lastReadMs,
   ]);
+
+  // Restore an open branch (and its messages) when the user reloads or
+  // navigates back to a conversation that has a pending open branch. The
+  // conversation fetch only returns the main thread, so without this the
+  // approval modal would never re-open.
+  useEffect(() => {
+    if (
+      !initialListData ||
+      !openBranch ||
+      !ref.current ||
+      hasInjectedOpenBranchRef.current
+    ) {
+      return;
+    }
+    hasInjectedOpenBranchRef.current = true;
+
+    const branchMessages = convertLightMessageTypeToVirtuosoMessages(
+      openBranch.messages
+    );
+    for (const msg of branchMessages) {
+      const insertIdx = getBranchedInsertIndex(ref.current.data.get(), msg);
+      ref.current.data.insert([msg], insertIdx);
+    }
+    setBranchIdToApprove(openBranch.branchId);
+  }, [initialListData, openBranch]);
 
   // Sync the virtuoso ref with the side panel context.
   const {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -244,7 +244,7 @@ export const ConversationViewer = ({
   setLimitReachedCode,
   clientSideMCPServerIds,
 }: ConversationViewerProps) => {
-  const ref =
+  const virtuosoMessageListRef =
     useRef<
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
@@ -431,7 +431,7 @@ export const ConversationViewer = ({
     if (
       !initialListData ||
       !openBranch ||
-      !ref.current ||
+      !virtuosoMessageListRef.current ||
       hasInjectedOpenBranchRef.current
     ) {
       return;
@@ -442,8 +442,11 @@ export const ConversationViewer = ({
       openBranch.messages
     );
     for (const msg of branchMessages) {
-      const insertIdx = getBranchedInsertIndex(ref.current.data.get(), msg);
-      ref.current.data.insert([msg], insertIdx);
+      const insertIdx = getBranchedInsertIndex(
+        virtuosoMessageListRef.current.data.get(),
+        msg
+      );
+      virtuosoMessageListRef.current.data.insert([msg], insertIdx);
     }
     setBranchIdToApprove(openBranch.branchId);
   }, [initialListData, openBranch]);
@@ -483,12 +486,15 @@ export const ConversationViewer = ({
   // This is to handle we just fetched more messages by scrolling up.
   useEffect(() => {
     // don't do anything until we have a first page of messages.
-    if (!ref.current || !ref.current.data.get().length) {
+    if (
+      !virtuosoMessageListRef.current ||
+      !virtuosoMessageListRef.current.data.get().length
+    ) {
       return;
     }
 
     // We use the messages ranks to know what is older and what is newer.
-    const ranks = ref.current.data.get().map((m) => m.rank);
+    const ranks = virtuosoMessageListRef.current.data.get().map((m) => m.rank);
 
     const minRank = Math.min(...ranks);
 
@@ -502,7 +508,7 @@ export const ConversationViewer = ({
       const renderedOlderMessages = convertLightMessageTypeToVirtuosoMessages(
         olderMessagesFromBackend
       );
-      ref.current.data.prepend(
+      virtuosoMessageListRef.current.data.prepend(
         addConversationForkNotices(
           renderedOlderMessages,
           conversation?.forkingData?.forkedChildren
@@ -520,7 +526,7 @@ export const ConversationViewer = ({
       const renderedRecentMessages = convertLightMessageTypeToVirtuosoMessages(
         recentMessagesFromBackend
       );
-      ref.current.data.append(
+      virtuosoMessageListRef.current.data.append(
         addConversationForkNotices(
           renderedRecentMessages,
           conversation?.forkingData?.forkedChildren
@@ -530,11 +536,14 @@ export const ConversationViewer = ({
   }, [conversation?.forkingData?.forkedChildren, messages]);
 
   useEffect(() => {
-    if (!ref.current || !ref.current.data.get().length) {
+    if (
+      !virtuosoMessageListRef.current ||
+      !virtuosoMessageListRef.current.data.get().length
+    ) {
       return;
     }
 
-    const currentData = ref.current.data.get();
+    const currentData = virtuosoMessageListRef.current.data.get();
     const reconciledData = addConversationForkNotices(
       currentData,
       conversation?.forkingData?.forkedChildren
@@ -549,8 +558,10 @@ export const ConversationViewer = ({
       return;
     }
 
-    while (ref.current.data.get().some(isConversationForkNotice)) {
-      ref.current.data.findAndDelete((message) =>
+    while (
+      virtuosoMessageListRef.current.data.get().some(isConversationForkNotice)
+    ) {
+      virtuosoMessageListRef.current.data.findAndDelete((message) =>
         isConversationForkNotice(message)
       );
     }
@@ -559,7 +570,7 @@ export const ConversationViewer = ({
 
     for (const message of reconciledData) {
       if (isConversationForkNotice(message)) {
-        ref.current.data.insert([message], index);
+        virtuosoMessageListRef.current.data.insert([message], index);
       }
       index += 1;
     }
@@ -606,30 +617,38 @@ export const ConversationViewer = ({
         eventIds.current.push(eventPayload.eventId);
         switch (event.type) {
           case "user_message_new":
-            if (ref.current) {
+            if (virtuosoMessageListRef.current) {
               const userMessage = event.message;
               const predicate = getPredicateForRankAndBranch(userMessage);
 
-              const exists = ref.current.data.find(predicate);
+              const exists =
+                virtuosoMessageListRef.current.data.find(predicate);
 
               if (!exists) {
                 // Do not scroll if the message is from the current user.
                 // Can happen with fake user messages (like handover messages).
                 const scroll = userMessage.user?.sId !== user.sId;
 
-                const currentData = ref.current.data.get();
+                const currentData = virtuosoMessageListRef.current.data.get();
                 const offset = getBranchedInsertIndex(currentData, userMessage);
 
                 if (offset < currentData.length) {
-                  ref.current.data.insert([userMessage], offset, scroll);
+                  virtuosoMessageListRef.current.data.insert(
+                    [userMessage],
+                    offset,
+                    scroll
+                  );
                 } else {
-                  ref.current.data.append([userMessage], scroll);
+                  virtuosoMessageListRef.current.data.append(
+                    [userMessage],
+                    scroll
+                  );
                 }
                 // Using else if with the type guard just to please the type checker as we already know it's a user message from the predicate.
               } else if (isUserMessage(exists)) {
                 // We only update if the version is greater or equals than the existing version.
                 if (exists.version <= event.message.version) {
-                  ref.current.data.map((m) =>
+                  virtuosoMessageListRef.current.data.map((m) =>
                     areSameRankAndBranch(m, userMessage) ? userMessage : m
                   );
                 }
@@ -662,8 +681,8 @@ export const ConversationViewer = ({
             break;
 
           case "user_message_promoted":
-            if (ref.current) {
-              ref.current.data.map((m) =>
+            if (virtuosoMessageListRef.current) {
+              virtuosoMessageListRef.current.data.map((m) =>
                 isUserMessage(m) && m.sId === event.messageId
                   ? { ...m, visibility: "visible" }
                   : m
@@ -672,28 +691,34 @@ export const ConversationViewer = ({
             break;
 
           case "agent_message_new":
-            if (ref.current) {
+            if (virtuosoMessageListRef.current) {
               const agentMessage = makeInitialMessageStreamState(
                 getLightAgentMessageFromAgentMessage(event.message)
               );
 
               // Replace the message in the exist list data, or append.
               const predicate = getPredicateForRankAndBranch(agentMessage);
-              const exists = ref.current.data.find(predicate);
+              const exists =
+                virtuosoMessageListRef.current.data.find(predicate);
 
               if (exists) {
-                ref.current.data.map((m) => (predicate(m) ? agentMessage : m));
+                virtuosoMessageListRef.current.data.map((m) =>
+                  predicate(m) ? agentMessage : m
+                );
               } else {
-                const currentData = ref.current.data.get();
+                const currentData = virtuosoMessageListRef.current.data.get();
                 const offset = getBranchedInsertIndex(
                   currentData,
                   agentMessage
                 );
 
                 if (offset < currentData.length) {
-                  ref.current.data.insert([agentMessage], offset);
+                  virtuosoMessageListRef.current.data.insert(
+                    [agentMessage],
+                    offset
+                  );
                 } else {
-                  ref.current.data.append([agentMessage]);
+                  virtuosoMessageListRef.current.data.append([agentMessage]);
                 }
               }
 
@@ -757,13 +782,14 @@ export const ConversationViewer = ({
             void mutateConversationAttachments();
             break;
           case "compaction_message_new":
-            if (ref.current) {
+            if (virtuosoMessageListRef.current) {
               const compactionMessage = event.message;
               const predicate = getPredicateForRankAndBranch(compactionMessage);
-              const exists = ref.current.data.find(predicate);
+              const exists =
+                virtuosoMessageListRef.current.data.find(predicate);
 
               if (!exists) {
-                const currentData = ref.current.data.get();
+                const currentData = virtuosoMessageListRef.current.data.get();
                 const offset = getBranchedInsertIndex(
                   currentData,
                   compactionMessage
@@ -777,13 +803,13 @@ export const ConversationViewer = ({
                     behavior: "smooth",
                   }) as const;
                 if (offset < currentData.length) {
-                  ref.current.data.insert(
+                  virtuosoMessageListRef.current.data.insert(
                     [compactionMessage],
                     offset,
                     scrollToCompaction
                   );
                 } else {
-                  ref.current.data.append(
+                  virtuosoMessageListRef.current.data.append(
                     [compactionMessage],
                     scrollToCompaction
                   );
@@ -796,9 +822,9 @@ export const ConversationViewer = ({
             break;
 
           case "compaction_message_done":
-            if (ref.current) {
+            if (virtuosoMessageListRef.current) {
               const doneMessage = event.message;
-              ref.current.data.map((m) =>
+              virtuosoMessageListRef.current.data.map((m) =>
                 isCompactionMessage(m) && m.sId === event.messageId
                   ? doneMessage
                   : m
@@ -859,7 +885,7 @@ export const ConversationViewer = ({
       mentions: RichMention[],
       contentFragments: ContentFragmentsType
     ): Promise<Result<undefined, DustError>> => {
-      if (!ref?.current) {
+      if (!virtuosoMessageListRef?.current) {
         return new Err({
           code: "internal_error",
           name: "NoRef",
@@ -889,7 +915,7 @@ export const ConversationViewer = ({
         };
 
         const lastMessageRank = Math.max(
-          ...ref.current.data.get().map((m) => m.rank)
+          ...virtuosoMessageListRef.current.data.get().map((m) => m.rank)
         );
 
         let rank =
@@ -914,7 +940,7 @@ export const ConversationViewer = ({
         // Skip placeholder agent messages if there's already a running agent in the conversation
         // (steering: the message will be pending, no new agent message is created until the running
         // one gracefully stops).
-        const hasRunningAgent = ref.current.data
+        const hasRunningAgent = virtuosoMessageListRef.current.data
           .get()
           .some((m) => m.type === "agent_message" && m.status === "created");
 
@@ -946,8 +972,8 @@ export const ConversationViewer = ({
         // agent message is created — stay at the current scroll position.
         const shouldScrollToUserMessage = isMentioningAgent && !hasRunningAgent;
 
-        const nbMessages = ref.current.data.get().length;
-        ref.current.data.append(
+        const nbMessages = virtuosoMessageListRef.current.data.get().length;
+        virtuosoMessageListRef.current.data.append(
           [placeholderUserMsg, ...placeholderAgentMessages],
           shouldScrollToUserMessage
             ? false // Skip append-time scroll; handled by scrollToItem below.
@@ -968,8 +994,8 @@ export const ConversationViewer = ({
         // Virtuoso's append callback clamps the scroll target before applying
         // the bottom padding needed for align:"start" near the end of the
         // list, causing the scroll to undershoot.
-        if (shouldScrollToUserMessage && ref.current) {
-          ref.current.scrollToItem({
+        if (shouldScrollToUserMessage && virtuosoMessageListRef.current) {
+          virtuosoMessageListRef.current.scrollToItem({
             index: nbMessages,
             align: "start",
             behavior: customSmoothScroll,
@@ -1011,13 +1037,13 @@ export const ConversationViewer = ({
             placeholderUserMsg.sId,
             ...placeholderAgentMessages.map((m) => m.sId),
           ];
-          ref.current.data.findAndDelete((m) =>
+          virtuosoMessageListRef.current.data.findAndDelete((m) =>
             placeHolderSids.includes(m.sId)
           );
         }
 
         // map() is how we update the state of virtuoso messages.
-        ref.current.data.map((m) =>
+        virtuosoMessageListRef.current.data.map((m) =>
           areSameRankAndBranch(m, placeholderUserMsg)
             ? {
                 ...messageFromBackend,
@@ -1194,7 +1220,7 @@ export const ConversationViewer = ({
               purgeItemSizes: true,
             },
           }}
-          ref={ref}
+          ref={virtuosoMessageListRef}
           ItemContent={MessageItem}
           StickyFooter={AgentInputBar}
           // Note: do NOT put any verticalpadding here as it will mess with the auto scroll to bottom.

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -29,6 +29,7 @@ export {
   useConversationTools,
 } from "./useConversationTools";
 export { useConversationUrlAccessMode } from "./useConversationUrlAccessMode";
+export { useOpenConversationBranch } from "./useOpenConversationBranch";
 export { usePostOnboardingFollowUp } from "./usePostOnboardingFollowUp";
 export { useSearchPrivateConversations } from "./useSearchPrivateConversations";
 export { useSearchProjectConversations } from "./useSearchProjectConversations";

--- a/front/hooks/conversations/useConversationBranchActions.ts
+++ b/front/hooks/conversations/useConversationBranchActions.ts
@@ -1,3 +1,4 @@
+import { useOpenConversationBranch } from "@app/hooks/conversations/useOpenConversationBranch";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -11,6 +12,12 @@ export function useConversationBranchActions({
   conversationId?: string | null;
 }) {
   const sendNotification = useSendNotification();
+
+  const { mutateOpenBranch } = useOpenConversationBranch({
+    owner,
+    conversationId: conversationId ?? "",
+    disabled: true,
+  });
 
   const [isMerging, setIsMerging] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
@@ -29,6 +36,7 @@ export function useConversationBranchActions({
         if (!res.ok) {
           throw new Error("Failed to merge branch");
         }
+        void mutateOpenBranch(undefined, { revalidate: false });
         return true;
       } catch {
         sendNotification({ type: "error", title: "Failed to publish branch" });
@@ -37,7 +45,7 @@ export function useConversationBranchActions({
         setIsMerging(false);
       }
     },
-    [conversationId, owner.sId, sendNotification]
+    [conversationId, owner.sId, sendNotification, mutateOpenBranch]
   );
 
   const closeBranch = useCallback(
@@ -54,6 +62,7 @@ export function useConversationBranchActions({
         if (!res.ok) {
           throw new Error("Failed to close branch");
         }
+        void mutateOpenBranch(undefined, { revalidate: false });
         return true;
       } catch {
         sendNotification({ type: "error", title: "Failed to reject branch" });
@@ -62,7 +71,7 @@ export function useConversationBranchActions({
         setIsClosing(false);
       }
     },
-    [conversationId, owner.sId, sendNotification]
+    [conversationId, owner.sId, sendNotification, mutateOpenBranch]
   );
 
   return {

--- a/front/hooks/conversations/useConversationBranchActions.ts
+++ b/front/hooks/conversations/useConversationBranchActions.ts
@@ -36,7 +36,7 @@ export function useConversationBranchActions({
         if (!res.ok) {
           throw new Error("Failed to merge branch");
         }
-        void mutateOpenBranch(undefined, { revalidate: false });
+        void mutateOpenBranch({ branch: null }, { revalidate: false });
         return true;
       } catch {
         sendNotification({ type: "error", title: "Failed to publish branch" });
@@ -62,7 +62,7 @@ export function useConversationBranchActions({
         if (!res.ok) {
           throw new Error("Failed to close branch");
         }
-        void mutateOpenBranch(undefined, { revalidate: false });
+        void mutateOpenBranch({ branch: null }, { revalidate: false });
         return true;
       } catch {
         sendNotification({ type: "error", title: "Failed to reject branch" });

--- a/front/hooks/conversations/useOpenConversationBranch.ts
+++ b/front/hooks/conversations/useOpenConversationBranch.ts
@@ -1,0 +1,33 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetConversationOpenBranchResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/branches";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useMemo } from "react";
+import type { Fetcher } from "swr";
+
+export function useOpenConversationBranch({
+  owner,
+  conversationId,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  conversationId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const branchFetcher: Fetcher<GetConversationOpenBranchResponse> = fetcher;
+
+  const { data, mutate: mutateOpenBranch } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/assistant/conversations/${conversationId}/branches`,
+    branchFetcher,
+    {
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      disabled,
+    }
+  );
+
+  const openBranch = useMemo(() => data?.branch ?? null, [data]);
+
+  return { openBranch, mutateOpenBranch };
+}

--- a/front/lib/api/assistant/conversation/branches.ts
+++ b/front/lib/api/assistant/conversation/branches.ts
@@ -22,6 +22,7 @@ import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   type CitationType,
   isUserMessageType,
+  type LightMessageType,
   type UserMessageContext,
 } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -431,4 +432,60 @@ export async function closeConversationBranch(
 
     return new Ok({ closedBranchId: branch.id });
   }, transaction);
+}
+
+export type RenderedOpenBranch = {
+  branchId: string;
+  messages: LightMessageType[];
+};
+
+export async function getMostRecentOpenBranchForConversation(
+  auth: Authenticator,
+  {
+    conversationId,
+  }: {
+    conversationId: string;
+  }
+): Promise<
+  Result<
+    RenderedOpenBranch | null,
+    DustError<"conversation_not_found" | "internal_error">
+  >
+> {
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return new Err(
+      new DustError("conversation_not_found", "Conversation not found.")
+    );
+  }
+
+  const openBranch =
+    await ConversationBranchResource.findMostRecentOpenBranchForUser(
+      auth,
+      conversation.id
+    );
+
+  if (!openBranch) {
+    return new Ok(null);
+  }
+
+  const branchMessages = await openBranch.fetchAllMessages(auth);
+
+  const renderedRes = await batchRenderMessages(
+    auth,
+    conversation,
+    branchMessages,
+    "light"
+  );
+  if (renderedRes.isErr()) {
+    return new Err(new DustError("internal_error", renderedRes.error.message));
+  }
+
+  return new Ok({
+    branchId: openBranch.sId,
+    messages: renderedRes.value,
+  });
 }

--- a/front/lib/resources/conversation_branch_resource.ts
+++ b/front/lib/resources/conversation_branch_resource.ts
@@ -137,6 +137,33 @@ export class ConversationBranchResource extends BaseResource<ConversationBranchM
     );
   }
 
+  /**
+   * Returns the most recent open branch owned by the authenticated user for
+   * a given conversation. There should only ever be one in practice, but we
+   * don't strictly enforce it at the DB level — fall back to the latest.
+   */
+  static async findMostRecentOpenBranchForUser(
+    auth: Authenticator,
+    conversationId: number
+  ): Promise<ConversationBranchResource | null> {
+    const workspace = auth.getNonNullableWorkspace();
+    const userId = auth.getNonNullableUser().id;
+
+    const branch = await this.model.findOne({
+      where: {
+        workspaceId: workspace.id,
+        conversationId,
+        state: "open",
+        userId,
+      },
+      order: [["createdAt", "DESC"]],
+    });
+
+    return branch
+      ? new this(ConversationBranchResource.model, branch.get())
+      : null;
+  }
+
   static async fetchById(
     auth: Authenticator,
     sId: string

--- a/front/lib/resources/conversation_branch_resource.ts
+++ b/front/lib/resources/conversation_branch_resource.ts
@@ -144,17 +144,17 @@ export class ConversationBranchResource extends BaseResource<ConversationBranchM
    */
   static async findMostRecentOpenBranchForUser(
     auth: Authenticator,
-    conversationId: number
+    conversationModelId: number
   ): Promise<ConversationBranchResource | null> {
     const workspace = auth.getNonNullableWorkspace();
-    const userId = auth.getNonNullableUser().id;
+    const userModelId = auth.getNonNullableUser().id;
 
     const branch = await this.model.findOne({
       where: {
         workspaceId: workspace.id,
-        conversationId,
+        conversationId: conversationModelId,
         state: "open",
-        userId,
+        userId: userModelId,
       },
       order: [["createdAt", "DESC"]],
     });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/branches/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/branches/index.ts
@@ -1,44 +1,5 @@
 /**
- * @swagger
- * /api/w/{wId}/assistant/conversations/{cId}/branches:
- *   get:
- *     summary: Get the most recent open branch for a conversation
- *     description: Returns the most recently opened branch for a specific conversation, or null if none exists.
- *     tags:
- *       - Private Conversations
- *     parameters:
- *       - in: path
- *         name: wId
- *         required: true
- *         description: ID of the workspace
- *         schema:
- *           type: string
- *       - in: path
- *         name: cId
- *         required: true
- *         description: ID of the conversation
- *         schema:
- *           type: string
- *     security:
- *       - BearerAuth: []
- *     responses:
- *       200:
- *         description: Successfully retrieved the open branch (or null if none)
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 branch:
- *                   nullable: true
- *                   type: object
- *                   description: The most recent open branch for the conversation, or null if none is open
- *       400:
- *         description: Invalid request parameters
- *       404:
- *         description: Conversation not found
- *       500:
- *         description: Internal server error
+ * @ignoreswagger
  */
 
 import {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/branches/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/branches/index.ts
@@ -1,3 +1,46 @@
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/conversations/{cId}/branches:
+ *   get:
+ *     summary: Get the most recent open branch for a conversation
+ *     description: Returns the most recently opened branch for a specific conversation, or null if none exists.
+ *     tags:
+ *       - Private Conversations
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: cId
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved the open branch (or null if none)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 branch:
+ *                   nullable: true
+ *                   type: object
+ *                   description: The most recent open branch for the conversation, or null if none is open
+ *       400:
+ *         description: Invalid request parameters
+ *       404:
+ *         description: Conversation not found
+ *       500:
+ *         description: Internal server error
+ */
+
 import {
   getMostRecentOpenBranchForConversation,
   type RenderedOpenBranch,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/branches/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/branches/index.ts
@@ -1,0 +1,75 @@
+import {
+  getMostRecentOpenBranchForConversation,
+  type RenderedOpenBranch,
+} from "@app/lib/api/assistant/conversation/branches";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetConversationOpenBranchResponse = {
+  branch: RenderedOpenBranch | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetConversationOpenBranchResponse>>,
+  auth: Authenticator
+): Promise<void> {
+  const { cId } = req.query;
+
+  if (!isString(cId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `cId` (string) is required.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const branchRes = await getMostRecentOpenBranchForConversation(auth, {
+    conversationId: cId,
+  });
+  if (branchRes.isErr()) {
+    switch (branchRes.error.code) {
+      case "conversation_not_found": {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: "Conversation not found.",
+          },
+        });
+      }
+      case "internal_error": {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Internal server error",
+          },
+        });
+      }
+      default:
+        assertNever(branchRes.error.code);
+    }
+  }
+
+  res.status(200).json({ branch: branchRes.value });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -6329,68 +6329,6 @@
         }
       }
     },
-    "/api/w/{wId}/assistant/conversations/{cId}/branches": {
-      "get": {
-        "summary": "Get the most recent open branch for a conversation",
-        "description": "Returns the most recently opened branch for a specific conversation, or null if none exists.",
-        "tags": [
-          "Private Conversations"
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "wId",
-            "required": true,
-            "description": "ID of the workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "cId",
-            "required": true,
-            "description": "ID of the conversation",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved the open branch (or null if none)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "branch": {
-                      "nullable": true,
-                      "type": "object",
-                      "description": "The most recent open branch for the conversation, or null if none is open"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request parameters"
-          },
-          "404": {
-            "description": "Conversation not found"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        }
-      }
-    },
     "/api/w/{wId}/assistant/conversations/{cId}/cancel": {
       "post": {
         "summary": "Cancel message generation",

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -6329,6 +6329,68 @@
         }
       }
     },
+    "/api/w/{wId}/assistant/conversations/{cId}/branches": {
+      "get": {
+        "summary": "Get the most recent open branch for a conversation",
+        "description": "Returns the most recently opened branch for a specific conversation, or null if none exists.",
+        "tags": [
+          "Private Conversations"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the open branch (or null if none)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "branch": {
+                      "nullable": true,
+                      "type": "object",
+                      "description": "The most recent open branch for the conversation, or null if none is open"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request parameters"
+          },
+          "404": {
+            "description": "Conversation not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/api/w/{wId}/assistant/conversations/{cId}/cancel": {
       "post": {
         "summary": "Cancel message generation",


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7879

This PR adds the ability to restore and reopen a conversation branch when the user reloads the page or navigates back to a conversation that has a pending open branch.

- Added new API endpoint `GET /api/w/[wId]/assistant/conversations/[cId]/branches` to fetch the most recent open branch for a conversation
- Added logic in `ConversationViewer` to restore branch messages and reopen the approval modal

## Tests

Manually

## Risks

Low - The changes are isolated to the branch approval flow and add a restoration mechanism that only triggers when an open branch exists in the database.

## Deploy Plan

Standard deployment - no special steps required.
