### PR TITLE
[front] fix: Add ENT credit purchase self-healing path

### DIFF
--- a/front/lib/credits/committed.test.ts
+++ b/front/lib/credits/committed.test.ts
@@ -3,6 +3,7 @@ import {
   createEnterpriseCreditPurchase,
   createProCreditPurchase,
   deleteCreditFromVoidedInvoice,
+  startCreditFromEnterpriseOneOffInvoice,
   startCreditFromProOneOffInvoice,
   voidFailedProCreditPurchaseInvoice,
 } from "@app/lib/credits/committed";
@@ -182,6 +183,158 @@ describe("startCreditFromProOneOffInvoice", () => {
     });
 
     expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].startDate).not.toBeNull();
+  });
+});
+
+describe("startCreditFromEnterpriseOneOffInvoice", () => {
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    auth = authenticator;
+  });
+
+  it("should throw when invoice is not a credit purchase invoice", async () => {
+    vi.mocked(isCreditPurchaseInvoice).mockReturnValue(false);
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+
+    const invoice = makeCreditPurchaseInvoice();
+    const subscription = makeProSubscription();
+
+    await expect(
+      startCreditFromEnterpriseOneOffInvoice({
+        auth,
+        invoice,
+        stripeSubscription: subscription,
+      })
+    ).rejects.toThrow(
+      "Cannot process this invoice for enterprise credit purchase"
+    );
+  });
+
+  it("should throw when subscription is not enterprise", async () => {
+    vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
+
+    const invoice = makeCreditPurchaseInvoice();
+    const subscription = makeProSubscription();
+
+    await expect(
+      startCreditFromEnterpriseOneOffInvoice({
+        auth,
+        invoice,
+        stripeSubscription: subscription,
+      })
+    ).rejects.toThrow(
+      "Cannot process this invoice for enterprise credit purchase"
+    );
+  });
+
+  it("should return error when credit amount metadata is invalid", async () => {
+    vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+    vi.mocked(getCreditAmountFromInvoice).mockReturnValue(null);
+
+    const invoice = makeCreditPurchaseInvoice();
+    const subscription = makeProSubscription();
+
+    const result = await startCreditFromEnterpriseOneOffInvoice({
+      auth,
+      invoice,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe(
+        "Invalid credit amount in invoice metadata"
+      );
+    }
+  });
+
+  it("should return error when credit not found for invoice", async () => {
+    vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+    vi.mocked(getCreditAmountFromInvoice).mockReturnValue(10000);
+
+    const invoice = makeCreditPurchaseInvoice();
+    const subscription = makeProSubscription();
+
+    const result = await startCreditFromEnterpriseOneOffInvoice({
+      auth,
+      invoice,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Credit not found for invoice");
+    }
+  });
+
+  it("should be idempotent and return alreadyStarted:true when credit was started optimistically", async () => {
+    vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+    vi.mocked(getCreditAmountFromInvoice).mockReturnValue(10000);
+
+    const invoice = makeCreditPurchaseInvoice();
+    const subscription = makeProSubscription();
+
+    const credit = await CreditResource.makeNew(auth, {
+      type: "committed",
+      initialAmountMicroUsd: 100_000_000,
+      consumedAmountMicroUsd: 0,
+      invoiceOrLineItemId: invoice.id,
+    });
+    const optimisticStart = await credit.start(auth);
+    expect(optimisticStart.isOk()).toBe(true);
+    const startedAtBefore = optimisticStart.isOk()
+      ? optimisticStart.value.startDate
+      : null;
+
+    const result = await startCreditFromEnterpriseOneOffInvoice({
+      auth,
+      invoice,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.alreadyStarted).toBe(true);
+    }
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].startDate?.getTime()).toBe(startedAtBefore?.getTime());
+  });
+
+  it("should start credit and return alreadyStarted:false when credit was not started optimistically", async () => {
+    vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+    vi.mocked(getCreditAmountFromInvoice).mockReturnValue(10000);
+
+    const invoice = makeCreditPurchaseInvoice();
+    const subscription = makeProSubscription();
+
+    await CreditResource.makeNew(auth, {
+      type: "committed",
+      initialAmountMicroUsd: 100_000_000,
+      consumedAmountMicroUsd: 0,
+      invoiceOrLineItemId: invoice.id,
+    });
+
+    const result = await startCreditFromEnterpriseOneOffInvoice({
+      auth,
+      invoice,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.alreadyStarted).toBe(false);
+    }
     const credits = await CreditResource.listAll(auth);
     expect(credits[0].startDate).not.toBeNull();
   });

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -137,6 +137,135 @@ export async function startCreditFromProOneOffInvoice({
   return new Ok(undefined);
 }
 
+// We added this method because even though it's super rare, ENT customer
+// can self-serve credits, and if their plan/account was not correctly configured it can fail
+// with no path to recovery (other than manual eng intervention)
+export async function startCreditFromEnterpriseOneOffInvoice({
+  auth,
+  invoice,
+  stripeSubscription,
+}: {
+  auth: Authenticator;
+  invoice: Stripe.Invoice;
+  stripeSubscription: Stripe.Subscription;
+}): Promise<Result<{ alreadyStarted: boolean }, Error>> {
+  if (
+    !isCreditPurchaseInvoice(invoice) ||
+    !isEnterpriseSubscription(stripeSubscription)
+  ) {
+    throw new Error(
+      `Cannot process this invoice for enterprise credit purchase: ${invoice.id}\n` +
+        `isCreditPurchaseInvoice: ${isCreditPurchaseInvoice(invoice)}\n` +
+        `isEntrepriseSubscription: ${isEnterpriseSubscription(stripeSubscription)}`
+    );
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const creditAmountCents = getCreditAmountFromInvoice(invoice);
+
+  if (creditAmountCents === null) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+        creditAmountCents: invoice.metadata?.credit_amount_cents,
+      },
+      "[Credit Purchase] Invalid credit amount in invoice metadata"
+    );
+    getStatsDClient().increment("credits.top_up.error", 1, [
+      `workspace_id:${workspace.sId}`,
+      "type:committed",
+      "customer:enterprise",
+    ]);
+    return new Err(new Error("Invalid credit amount in invoice metadata"));
+  }
+
+  const credit = await CreditResource.fetchByInvoiceOrLineItemId(
+    auth,
+    invoice.id
+  );
+
+  if (!credit) {
+    logger.error(
+      {
+        panic: true,
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+      },
+      "[Credit Purchase] Credit not found for paid enterprise invoice"
+    );
+    getStatsDClient().increment("credits.top_up.error", 1, [
+      `workspace_id:${workspace.sId}`,
+      "type:committed",
+      "customer:enterprise",
+    ]);
+    return new Err(new Error("Credit not found for invoice"));
+  }
+
+  // For enterprise, the credit is normally started optimistically at invoice creation
+  // (see createEnterpriseCreditPurchase). The webhook firing later just
+  // confirms payment, so finding a started credit is the expected case.
+  if (credit.startDate !== null) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+        creditId: credit.id,
+      },
+      "[Credit Purchase] Enterprise credit already started, ack only"
+    );
+    return new Ok({ alreadyStarted: true });
+  }
+
+  // Edge case: optimistic start did not happen. Recover by starting the credit now.
+  const startResult = await credit.start(auth);
+  if (startResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        creditAmountCents,
+        invoiceId: invoice.id,
+        creditId: credit.id,
+        expirationDate: credit.expirationDate,
+      },
+      "[Credit Purchase] Error starting enterprise credit from webhook"
+    );
+    getStatsDClient().increment("credits.top_up.error", 1, [
+      `workspace_id:${workspace.sId}`,
+      "type:committed",
+      "customer:enterprise",
+    ]);
+    return new Err(startResult.error);
+  }
+  getStatsDClient().increment("credits.top_up.success", 1, [
+    `workspace_id:${workspace.sId}`,
+    "type:committed",
+    "customer:enterprise",
+  ]);
+
+  const metronomeResult = await addMetronomeCommitsForWorkspace({
+    auth,
+    credit,
+    amountCredits: creditAmountCents / 100,
+    startDate: startResult.value.startDate,
+    expirationDate: startResult.value.expirationDate,
+  });
+  if (metronomeResult.isErr()) {
+    return new Err(metronomeResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      creditAmountCents,
+      invoiceId: invoice.id,
+      creditId: credit.id,
+    },
+    "[Credit Purchase] Recovered and started enterprise credit from webhook"
+  );
+  return new Ok({ alreadyStarted: false });
+}
+
 export async function voidFailedProCreditPurchaseInvoice({
   auth,
   invoice,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -10,6 +10,7 @@ import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import {
   deleteCreditFromVoidedInvoice,
+  startCreditFromEnterpriseOneOffInvoice,
   startCreditFromProOneOffInvoice,
   voidFailedProCreditPurchaseInvoice,
 } from "@app/lib/credits/committed";
@@ -549,6 +550,10 @@ async function handler(
             isCreditPurchaseInvoice(invoice) &&
             !isEnterpriseSubscription(stripeSubscription);
 
+          const isEnterpriseCreditPurchaseInvoice =
+            isCreditPurchaseInvoice(invoice) &&
+            isEnterpriseSubscription(stripeSubscription);
+
           const workspace = await WorkspaceResource.fetchByModelId(
             subscription.workspaceId
           );
@@ -573,6 +578,24 @@ async function handler(
                   stripeSubscriptionId: invoice.subscription,
                 },
                 "[Stripe Webhook] Error processing credit purchase"
+              );
+            }
+          } else if (isEnterpriseCreditPurchaseInvoice) {
+            const creditPurchaseResult =
+              await startCreditFromEnterpriseOneOffInvoice({
+                auth,
+                invoice,
+                stripeSubscription,
+              });
+
+            if (creditPurchaseResult.isErr()) {
+              logger.error(
+                {
+                  error: creditPurchaseResult.error,
+                  invoiceId: invoice.id,
+                  stripeSubscriptionId: invoice.subscription,
+                },
+                "[Stripe Webhook] Error processing enterprise credit purchase"
               );
             }
           } else if (!isCreditPurchaseInvoice(invoice)) {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7943

Add a codepath to start ENT credits from a payment succeed event.
In 99% of cases we don't need it, but in rare cases, an ENT customer can be led to an unrecoverable state by purchasing credits from a misconfigured account (i.e from billing's POV).

Event if the account is properly configured and the invoice makes it to the customer and gets paid, there is currently no path to recovery other than manually updating the DB.

This PR adds a case in the webhook endpoint to fix it.

## Tests

Unit tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front