### PR TITLE
refactor(sandbox): drop dead sandboxOrigin/sandboxPaused + widen stake check

### DIFF
--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -72,7 +72,6 @@ function makeStreamAction(
     generatedFiles: overrides.generatedFiles ?? [],
     output: overrides.output ?? null,
     citations: overrides.citations ?? null,
-    sandboxOrigin: overrides.sandboxOrigin,
   };
 }
 

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -10,11 +10,22 @@ export interface ToolInputContext {
   toolInputs: Record<string, unknown>;
 }
 
+type StakeCheckConfiguration = Pick<
+  MCPToolConfigurationType,
+  "permission" | "toolServerId" | "name" | "argumentsRequiringApproval"
+>;
+
 export async function getExecutionStatusFromConfig(
   auth: Authenticator,
-  actionConfiguration: MCPToolConfigurationType,
-  agentMessage: AgentMessageType,
-  context?: ToolInputContext
+  {
+    actionConfiguration,
+    agentMessage,
+    context,
+  }: {
+    actionConfiguration: StakeCheckConfiguration;
+    agentMessage: AgentMessageType;
+    context?: ToolInputContext;
+  }
 ): Promise<{
   stake?: MCPToolStakeLevelType;
   status: "ready_allowed_implicitly" | "blocked_validation_required";

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -81,8 +81,6 @@ export type StepContext = {
   fileAuthorizationInfo?: FileAuthorizationInfo;
   resumeState: Record<string, unknown> | null;
   retrievalTopK: number;
-  sandboxOrigin?: boolean;
-  sandboxPaused?: boolean;
   websearchResultCount: number;
 };
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1036,7 +1036,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       step: this.stepContent.step,
       executionDurationMs: this.executionDurationMs,
       displayLabels,
-      sandboxOrigin: this.stepContext.sandboxOrigin,
     };
   }
 

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -8,7 +8,6 @@ import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_act
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
-import type { ToolInputContext } from "@app/lib/actions/tool_status";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import type { StepContext } from "@app/lib/actions/types";
 import type { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
@@ -159,18 +158,14 @@ async function createActionForTool(
   const argumentsRequiringApproval =
     actionConfiguration.argumentsRequiringApproval ?? [];
 
-  // Build context for medium stake per-argument approval checks
-  const mediumStakeContext: ToolInputContext = {
-    agentId: agentConfiguration.sId,
-    toolInputs: rawInputs,
-  };
-
-  const { status } = await getExecutionStatusFromConfig(
-    auth,
+  const { status } = await getExecutionStatusFromConfig(auth, {
     actionConfiguration,
     agentMessage,
-    mediumStakeContext
-  );
+    context: {
+      agentId: agentConfiguration.sId,
+      toolInputs: rawInputs,
+    },
+  });
 
   const validateToolInputsResult = validateToolInputs(rawInputs);
   if (validateToolInputsResult.isErr()) {

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -27,7 +27,6 @@ export type AgentMCPActionType = {
     running: string;
     done: string;
   } | null;
-  sandboxOrigin?: boolean;
 };
 
 export type AgentMCPActionWithOutputType = AgentMCPActionType & {


### PR DESCRIPTION
## What

Two surgical cleanups ahead of the sandbox tool-call approval flow.

- **Drop `sandboxOrigin` and `sandboxPaused`** from `StepContext` (`lib/actions/types/index.ts`) and `AgentMCPActionType` (`types/actions.ts`).
  - `sandboxPaused` was declared and never read or set anywhere — pure dead flag.
  - `sandboxOrigin` was set in `AgentMCPActionResource.toJSON` and propagated on the wire but had zero non-test FE consumers. The approval flow PR will introduce a discriminated `resumeState.type === "sandbox"` for the same purpose, so the flag is redundant.
- **Widen `getExecutionStatusFromConfig` signature** from `MCPToolConfigurationType` to `Pick<..., "permission" | "toolServerId" | "name" | "argumentsRequiringApproval">`. All existing callers pass full configs that satisfy the narrower contract; the new sandbox `call_tool` path needs to call it with a `LightServerSideMCPToolConfigurationType`.

## Tests

No behavior change — `tsgo --noEmit` clean. 

## Risk

Safe to rollback.