### PR TITLE
Fixed script for contract credits + allow to force package on migrate

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1275,12 +1275,16 @@ export async function getMetronomeCommit({
  */
 export async function deductMetronomeCreditBalance({
   metronomeCustomerId,
+  contractId,
   creditId,
   segmentId,
   amount,
   reason,
 }: {
   metronomeCustomerId: string;
+  // Pass `contractId` for contract-level credits / commits. Customer-level
+  // entries (e.g., one-off poke credits) leave it undefined.
+  contractId?: string;
   creditId: string;
   segmentId: string;
   amount: number;
@@ -1293,17 +1297,17 @@ export async function deductMetronomeCreditBalance({
       amount: -amount, // negative to draw down the balance
       reason,
       segment_id: segmentId,
-      // contract_id omitted — applies to customer-level balance
+      ...(contractId ? { contract_id: contractId } : {}),
     });
     logger.info(
-      { metronomeCustomerId, creditId, segmentId, amount },
+      { metronomeCustomerId, contractId, creditId, segmentId, amount },
       "[Metronome] Manual credit deduction applied"
     );
     return new Ok(undefined);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
-      { error, metronomeCustomerId, creditId, segmentId, amount },
+      { error, metronomeCustomerId, contractId, creditId, segmentId, amount },
       "[Metronome] Failed to apply manual credit deduction"
     );
     return new Err(error);

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -284,6 +284,7 @@ async function migrateWorkspace(
     packageIdToAlias: Record<string, string>;
   },
   packageAliasFilter?: string,
+  forcePackageAlias?: string,
   enableBilling?: boolean
 ): Promise<void> {
   const client = getMetronomeClient();
@@ -304,9 +305,26 @@ async function migrateWorkspace(
     return;
   }
 
-  // Apply package alias filter if set.
+  // Apply package alias filter (matched against the *derived* target alias)
+  // before any override, so callers can scope a forced migration to e.g.
+  // "all monthly Pro contracts → some custom package".
   if (packageAliasFilter && subInfo.packageAlias !== packageAliasFilter) {
     return;
+  }
+
+  // Force-override the target alias when the operator passes one.
+  if (forcePackageAlias) {
+    if (subInfo.packageAlias !== forcePackageAlias) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          derivedAlias: subInfo.packageAlias,
+          forcedAlias: forcePackageAlias,
+        },
+        "Forcing target package alias (overriding derived value)"
+      );
+      subInfo.packageAlias = forcePackageAlias;
+    }
   }
 
   const targetPackageId = packageInfo.aliasToPackageId[subInfo.packageAlias];
@@ -523,6 +541,12 @@ makeScript(
         "Only migrate contracts targeting this package alias (e.g., 'legacy-pro-29'). Omit to migrate all.",
       type: "string" as const,
     },
+    forcePackageAlias: {
+      alias: "P",
+      describe:
+        "Override the derived target package alias and use this one instead. Useful for one-off migrations to a custom package; combine with --packageAlias to scope the override.",
+      type: "string" as const,
+    },
     force: {
       alias: "f",
       describe:
@@ -540,11 +564,18 @@ makeScript(
   },
   async (args, logger) => {
     const packageAliasFilter = args.packageAlias;
+    const forcePackageAlias = args.forcePackageAlias;
     const enableBilling = args.enableBilling;
     if (packageAliasFilter) {
       logger.info(
         { packageAlias: packageAliasFilter },
         "Filtering to contracts targeting this package alias"
+      );
+    }
+    if (forcePackageAlias) {
+      logger.info(
+        { forcePackageAlias },
+        "Forcing the target package alias for all migrated contracts"
       );
     }
     if (enableBilling) {
@@ -571,6 +602,7 @@ makeScript(
         logger,
         packageInfo,
         packageAliasFilter,
+        forcePackageAlias,
         enableBilling
       );
     } else {
@@ -583,6 +615,7 @@ makeScript(
             logger,
             packageInfo,
             packageAliasFilter,
+            forcePackageAlias,
             enableBilling
           ),
         { concurrency: 4 }

--- a/front/scripts/sync_metronome_credit_consumption.ts
+++ b/front/scripts/sync_metronome_credit_consumption.ts
@@ -288,8 +288,14 @@ async function syncCreditsOfType(
       continue;
     }
 
+    // Pass the parent contract id when present — contract-level
+    // commits / credits cannot be located by `addManualBalanceEntry`
+    // without it (Metronome returns "Unable to find commit ..." 404).
+    const entryContractId = metronomeEntry.contract?.id;
+
     const adjustResult = await deductMetronomeCreditBalance({
       metronomeCustomerId,
+      contractId: entryContractId,
       creditId: metronomeCreditId,
       segmentId,
       amount: adjustmentUsd,


### PR DESCRIPTION
## Description

Fixes the consumption-sync script for contract-level credits/commits and adds a force-override flag to the contract migration script.

- **`deductMetronomeCreditBalance` (`lib/metronome/client.ts`)** — accepts a new optional `contractId`. When passed, it forwards `contract_id` to `v1.contracts.addManualBalanceEntry`. Customer-level balance entries (e.g. one-off Poke credits) still leave it undefined.
- **`sync_metronome_credit_consumption.ts`** — reads `metronomeEntry.contract?.id` from the fetched commit/credit and threads it into `deductMetronomeCreditBalance`. Without this, Metronome rejects the call for contract-level commits/credits with a misleading `404 "Unable to find commit ..." on customer ...` because the API can't resolve the id without the parent contract. The fetch already includes contract-level entries by default; we just weren't carrying the contract id forward.
- **`migrate_metronome_contracts.ts`** — new `--forcePackageAlias` (`-P`) flag overrides the package alias derived from plan/billing-interval/currency. Combine with `--packageAlias` to scope (e.g. "all Pro-monthly contracts → custom package"), or use alone with `-w` for a single workspace. Logs the derived-vs-forced diff per workspace.

## Tests

- `npx tsgo --noEmit` clean.
- Manual: re-run `sync_metronome_credit_consumption.ts --execute` on the workspace that previously failed (`AirVtQzd2U` / commit `9d072807-…`); the manual ledger entry now applies to the contract-level commit successfully.
- Manual: dry-run `migrate_metronome_contracts.ts -w <wsId> -P <some-alias>` and verify the log shows the derived alias swapped to the forced one before contract creation.

## Risk

Low. The `contractId` parameter is opt-in and additive — pre-existing customer-level callers are unchanged. The migrate-contract flag is operator-only (no automatic callers), gated behind `--execute`, and validated against the live `aliasToPackageId` map (unknown aliases short-circuit with `Target package not found`).
