### PR TITLE
Add: endpoint to fetch a single todo details.

### DIFF
--- a/front/pages/api/w/[wId]/project_todos/[todoSId]/index.test.ts
+++ b/front/pages/api/w/[wId]/project_todos/[todoSId]/index.test.ts
@@ -1,0 +1,122 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { ProjectTodoFactory } from "@app/tests/utils/ProjectTodoFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { WorkspaceType } from "@app/types/user";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { MockRequest, MockResponse } from "node-mocks-http";
+import { describe, expect, it, vi } from "vitest";
+// After the helper module loads, `lib/auth` is mocked — import `getSession` second
+// so this binding is the vi.fn from that mock (same path as the mock target).
+import { getSession } from "../../../../../../lib/auth";
+
+import handler from ".";
+
+describe("GET /api/w/[wId]/project_todos/[todoSId]", () => {
+  let req: MockRequest<NextApiRequest>;
+  let res: MockResponse<NextApiResponse>;
+  let workspace: WorkspaceType;
+
+  async function setup() {
+    const result = await createPrivateApiMockRequest({ method: "GET" });
+    req = result.req;
+    res = result.res;
+    workspace = result.workspace;
+    return result;
+  }
+
+  it("returns the todo and project space id", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Ship the feature",
+    });
+
+    req.query.todoSId = todo.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const body = res._getJSONData();
+    expect(body.space.sId).toBe(project.sId);
+    expect(body.space.kind).toBe("project");
+    expect(body.space.name).toBe(project.name);
+    expect(body.todo.sId).toBe(todo.sId);
+    expect(body.todo.text).toBe("Ship the feature");
+    expect(body.todo.sources).toEqual([]);
+  });
+
+  it("returns 404 for an unknown todo sId", async () => {
+    await setup();
+    req.query.todoSId = "nonexistent_todo_sid";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("project_todo_not_found");
+  });
+
+  it("returns 400 when todoSId query param is missing", async () => {
+    await setup();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 when the user cannot read the todo's project space", async () => {
+    const { req, res, workspace, user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+    });
+
+    const outsider = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, outsider, { role: "user" });
+
+    vi.mocked(getSession).mockReturnValue(
+      Promise.resolve({
+        type: "workos",
+        sessionId: "outsider-session",
+        user: {
+          workOSUserId: outsider.workOSUserId!,
+          email: outsider.email!,
+          email_verified: true,
+          name: outsider.username!,
+          nickname: outsider.username!,
+          organizations: [],
+        },
+        authenticationMethod: "GoogleOAuth",
+        isSSO: false,
+        workspaceId: workspace.sId,
+        organizationId: workspace.workOSOrganizationId ?? undefined,
+        region: "us-central1",
+      })
+    );
+
+    req.query.todoSId = todo.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("project_todo_not_found");
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+    });
+    req.query.todoSId = todo.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+});

--- a/front/pages/api/w/[wId]/project_todos/[todoSId]/index.ts
+++ b/front/pages/api/w/[wId]/project_todos/[todoSId]/index.ts
@@ -1,0 +1,127 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
+import type { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ProjectTodoType } from "@app/types/project_todo";
+import { isString } from "@app/types/shared/utils/general";
+import type { ProjectType } from "@app/types/space";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export interface GetWorkspaceProjectTodoResponseBody {
+  todo: ProjectTodoType;
+  /** Project space (same shape as entries in `GET /api/w/{wId}/spaces` for projects). */
+  space: ProjectType;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetWorkspaceProjectTodoResponseBody>
+  >,
+  auth: Authenticator,
+  _session: SessionWithUser | null
+): Promise<void> {
+  const { todoSId } = req.query;
+  if (!isString(todoSId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid todo id.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const todo = await ProjectTodoResource.fetchBySId(auth, todoSId);
+      if (!todo) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "project_todo_not_found",
+            message: "Todo not found.",
+          },
+        });
+      }
+
+      const [space] = await SpaceResource.fetchByModelIds(auth, [todo.spaceId]);
+      if (!space || !space.canRead(auth) || !space.isProject()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "project_todo_not_found",
+            message: "Todo not found.",
+          },
+        });
+      }
+
+      const sourcesByTodoId = await ProjectTodoResource.fetchSourcesForTodoIds(
+        auth,
+        { sIds: [todo.sId] }
+      );
+      const conversationId = await todo.getLatestConversationId(auth);
+
+      const serializedBase = todo.toJSON();
+      let conversationSidebarStatus: ProjectTodoType["conversationSidebarStatus"] =
+        null;
+      if (conversationId) {
+        const listItemByConversationSId =
+          await ConversationResource.fetchListItemsBySIds(auth, [
+            conversationId,
+          ]);
+        const listItem = listItemByConversationSId.get(conversationId);
+        conversationSidebarStatus = listItem
+          ? getConversationDotStatus(listItem)
+          : "idle";
+      }
+
+      const sources = sourcesByTodoId.get(todo.sId) ?? [];
+      const todoPayload: ProjectTodoType = {
+        ...serializedBase,
+        conversationId,
+        conversationSidebarStatus,
+        sources: sources.map((s) => ({
+          sourceType: s.sourceType,
+          sourceId: s.sourceId,
+          sourceTitle: s.sourceTitle,
+          sourceUrl: s.sourceUrl,
+        })),
+      };
+
+      const [projectSpace] = await enrichProjectsWithMetadata(auth, [space]);
+      if (!projectSpace) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "project_todo_not_found",
+            message: "Todo not found.",
+          },
+        });
+      }
+
+      return res.status(200).json({
+        todo: todoPayload,
+        space: projectSpace,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Adds `GET /api/w/[wId]/project_todos/[todoSId]` — a workspace-scoped endpoint to fetch a single todo by sId regardless of which project space it belongs to. Returns the full `ProjectTodoType` (including sources, conversation link, and sidebar status dot) alongside the enriched `ProjectType` of its parent space. Access is gated on the caller being able to read the project space; non-members get a 404 identical to "not found" to avoid leaking existence.

Needed by the todo popup in #25154 to hydrate a chip on click from anywhere in the conversation UI.

## Tests

Full unit test suite: 200 with space + todo, 404 for unknown sId, 400 for missing param, 404 for non-member, 405 for wrong method.

## Risk

Low — read-only, gated behind existing space ACL

## Deploy Plan

Deploy `front`
