### PR TITLE
Add: popup when we click on the todo in a message.

### DIFF
--- a/front/components/actions/mcp/details/MCPDeepDiveActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDeepDiveActionDetails.tsx
@@ -5,7 +5,7 @@ import {
   getCiteDirective,
 } from "@app/components/markdown/CiteBlock";
 import {
-  TodoDirectiveBlock,
+  getTodoDirectiveBlock,
   todoDirective,
 } from "@app/components/markdown/TodoDirectiveBlock";
 import { isAgentPauseOutputResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
@@ -41,7 +41,7 @@ export function MCPDeepDiveActionDetails({
       sup: CiteBlock,
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: getAgentMentionPlugin(owner),
-      todo: TodoDirectiveBlock,
+      todo: getTodoDirectiveBlock(owner),
     }),
     [owner]
   );

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -13,7 +13,7 @@ import {
 } from "@app/components/markdown/CiteBlock";
 import type { MCPReferenceCitation } from "@app/components/markdown/MCPReferenceCitation";
 import {
-  TodoDirectiveBlock,
+  getTodoDirectiveBlock,
   todoDirective,
 } from "@app/components/markdown/TodoDirectiveBlock";
 import { getIcon } from "@app/components/resources/resources_icons";
@@ -262,7 +262,7 @@ function MCPRunAgentActionDetailsDisplay({
       sup: CiteBlock,
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: getAgentMentionPlugin(owner),
-      todo: TodoDirectiveBlock,
+      todo: getTodoDirectiveBlock(owner),
     }),
     [owner]
   );

--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -10,7 +10,7 @@ import {
 } from "@app/components/markdown/InstructionBlock";
 import { quickReplyDirective } from "@app/components/markdown/QuickReplyBlock";
 import {
-  TodoDirectiveBlock,
+  getTodoDirectiveBlock,
   todoDirective,
 } from "@app/components/markdown/TodoDirectiveBlock";
 import { toolDirective } from "@app/components/markdown/tool/tool";
@@ -63,7 +63,7 @@ export const AgentMessageMarkdown = ({
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: getAgentMentionPlugin(owner),
       mention_user: getUserMentionPlugin(owner),
-      todo: TodoDirectiveBlock,
+      todo: getTodoDirectiveBlock(owner),
       dustimg: getImgPlugin(owner),
       instruction_block: InstructionBlock,
       ...additionalMarkdownComponents,

--- a/front/components/assistant/UserMessageMarkdown.tsx
+++ b/front/components/assistant/UserMessageMarkdown.tsx
@@ -11,7 +11,7 @@ import {
   pastedAttachmentDirective,
 } from "@app/components/markdown/PastedAttachmentBlock";
 import {
-  TodoDirectiveBlock,
+  getTodoDirectiveBlock,
   todoDirective,
 } from "@app/components/markdown/TodoDirectiveBlock";
 import {
@@ -47,7 +47,7 @@ export const UserMessageMarkdown = ({
       mention_user: getUserMentionPlugin(owner),
       content_node_mention: ContentNodeMentionBlock,
       pasted_attachment: PastedAttachmentBlock,
-      todo: TodoDirectiveBlock,
+      todo: getTodoDirectiveBlock(owner),
     }),
     [owner]
   );

--- a/front/components/markdown/TodoDirectiveBlock.test.tsx
+++ b/front/components/markdown/TodoDirectiveBlock.test.tsx
@@ -1,7 +1,10 @@
+import type { LightWorkspaceType } from "@app/types/user";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { TodoDirectiveBlock, todoDirective } from "./TodoDirectiveBlock";
+import { getTodoDirectiveBlock, todoDirective } from "./TodoDirectiveBlock";
+
+const mockOwner = { sId: "w_test_ws" } as LightWorkspaceType;
 
 describe("todoDirective", () => {
   it("transforms :todo textDirective nodes with hName and hProperties", () => {
@@ -36,9 +39,10 @@ describe("todoDirective", () => {
   });
 });
 
-describe("TodoDirectiveBlock", () => {
+describe("getTodoDirectiveBlock", () => {
   it("renders label and exposes sId on the wrapper", () => {
-    render(<TodoDirectiveBlock label="My task" sId="sid_1" />);
+    const TodoChip = getTodoDirectiveBlock(mockOwner);
+    render(<TodoChip label="My task" sId="sid_1" />);
 
     expect(screen.getByText("My task")).toBeInTheDocument();
     const wrap = document.querySelector("[data-project-todo-sid]");

--- a/front/components/markdown/TodoDirectiveBlock.tsx
+++ b/front/components/markdown/TodoDirectiveBlock.tsx
@@ -1,22 +1,266 @@
-import { AttachmentChip, ListCheckIcon } from "@dust-tt/sparkle";
+import { ConversationSidebarStatusDot } from "@app/components/assistant/conversation/ConversationSidebarStatusDot";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { timeAgoFrom } from "@app/lib/utils";
+import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
+import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
+import type { GetWorkspaceProjectTodoResponseBody } from "@app/pages/api/w/[wId]/project_todos/[todoSId]/index";
+import type { ProjectTodoStatus } from "@app/types/project_todo";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  AttachmentChip,
+  Avatar,
+  LinkWrapper,
+  ListCheckIcon,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  Separator,
+  Spinner,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+import type { Fetcher } from "swr";
 import { visit } from "unist-util-visit";
 
-export function TodoDirectiveBlock({
+function formatTodoStatusLabel(status: ProjectTodoStatus): string {
+  switch (status) {
+    case "todo":
+      return "To-do";
+    case "in_progress":
+      return "In progress";
+    case "done":
+      return "Done";
+    default:
+      assertNeverAndIgnore(status);
+      return status;
+  }
+}
+
+function formatRelativeAgo(value: Date | string): string {
+  return `${timeAgoFrom(new Date(value).getTime(), { useLongFormat: true })} ago`;
+}
+
+function conversationActivityCaption(
+  status: ConversationDotStatus,
+  hasConversation: boolean
+): string | null {
+  if (!hasConversation) {
+    return null;
+  }
+  switch (status) {
+    case "unread":
+      return "Unread activity";
+    case "blocked":
+      return "Needs attention";
+    case "idle":
+      return "Up to date";
+    default:
+      assertNeverAndIgnore(status);
+      return null;
+  }
+}
+
+function TodoDirectivePopoverBody({
+  owner,
+  todoSId,
+}: {
+  owner: LightWorkspaceType;
+  todoSId: string;
+}) {
+  const { fetcher } = useFetcher();
+  const url = `/api/w/${owner.sId}/project_todos/${encodeURIComponent(todoSId)}`;
+  const { data, error, isLoading } = useSWRWithDefaults(
+    url,
+    fetcher as Fetcher<GetWorkspaceProjectTodoResponseBody, string>
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[7rem] items-center justify-center p-3">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="p-3 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Could not load this to-do.
+      </div>
+    );
+  }
+
+  const { todo, space } = data;
+  const projectHref = getProjectRoute(owner.sId, space.sId);
+  const assignee = todo.user;
+  const dotStatus: ConversationDotStatus =
+    todo.conversationSidebarStatus ?? "idle";
+  const hasConversation = !!todo.conversationId;
+  const activityCaption = conversationActivityCaption(
+    dotStatus,
+    hasConversation
+  );
+
+  return (
+    <div className="flex flex-col p-3">
+      <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground dark:text-foreground-night">
+        {todo.text}
+      </p>
+
+      <Separator className="-mx-3 my-3 shrink-0 bg-border/60 dark:bg-border-night/60" />
+
+      <dl className="grid grid-cols-[minmax(0,7.5rem)_1fr] gap-x-3 gap-y-2.5 pb-2 text-xs">
+        <dt className="text-muted-foreground dark:text-muted-foreground-night">
+          Assignee
+        </dt>
+        <dd className="flex min-w-0 items-center justify-end">
+          {assignee ? (
+            <Tooltip
+              label={assignee.fullName}
+              tooltipTriggerAsChild
+              trigger={
+                <span className="inline-flex shrink-0">
+                  <Avatar
+                    size="xxs"
+                    isRounded
+                    name={assignee.fullName}
+                    visual={
+                      assignee.image ?? "/static/humanavatar/anonymous.png"
+                    }
+                    className="ring-1 ring-border/40 dark:ring-border-night/40"
+                  />
+                </span>
+              }
+            />
+          ) : (
+            <span className="text-muted-foreground dark:text-muted-foreground-night">
+              Unassigned
+            </span>
+          )}
+        </dd>
+
+        <dt className="text-muted-foreground dark:text-muted-foreground-night">
+          Created
+        </dt>
+        <dd className="text-right font-medium text-foreground dark:text-foreground-night">
+          {formatRelativeAgo(todo.createdAt)}
+        </dd>
+
+        <dt className="text-muted-foreground dark:text-muted-foreground-night">
+          Status
+        </dt>
+        <dd className="text-right font-medium text-foreground dark:text-foreground-night">
+          {formatTodoStatusLabel(todo.status)}
+          {todo.status === "done" && todo.doneAt ? (
+            <span className="block text-[11px] font-normal text-muted-foreground dark:text-muted-foreground-night">
+              Completed {formatRelativeAgo(todo.doneAt)}
+            </span>
+          ) : null}
+        </dd>
+
+        {hasConversation && todo.conversationId && activityCaption ? (
+          <>
+            <dt className="text-muted-foreground dark:text-muted-foreground-night">
+              Conversation
+            </dt>
+            <dd className="flex min-w-0 items-center justify-end gap-2 text-right">
+              <ConversationSidebarStatusDot
+                status={dotStatus}
+                className="m-0 shrink-0"
+              />
+              <LinkWrapper
+                href={getConversationRoute(owner.sId, todo.conversationId)}
+                shallow={false}
+                className="min-w-0 max-w-[11rem] truncate text-right text-xs font-medium text-highlight-700 underline-offset-2 hover:underline dark:text-highlight-400-night"
+              >
+                {activityCaption}
+              </LinkWrapper>
+            </dd>
+          </>
+        ) : null}
+      </dl>
+
+      <div className="-mx-3 -mb-3 mt-1 border-t border-border/60 bg-muted/25 px-3 py-2.5 dark:border-border-night/60 dark:bg-muted-night/15">
+        <LinkWrapper
+          href={projectHref}
+          shallow={false}
+          className="block w-full min-w-0 rounded-md outline-none ring-offset-background hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-highlight-300 focus-visible:ring-offset-1 dark:ring-offset-background-night dark:hover:bg-muted-night/25 dark:focus-visible:ring-highlight-300-night"
+        >
+          <div className="break-words text-sm font-semibold leading-snug text-highlight-700 underline-offset-2 hover:underline dark:text-highlight-400-night">
+            {space.name}
+          </div>
+        </LinkWrapper>
+        {space.description ? (
+          <p className="mt-1 w-full min-w-0 break-words text-xs leading-tight text-muted-foreground dark:text-muted-foreground-night">
+            {space.description}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function TodoDirectiveChipInner({
+  owner,
   label,
   sId,
 }: {
+  owner: LightWorkspaceType;
   label: string;
   sId: string;
 }) {
+  const [open, setOpen] = useState(false);
+  const displayLabel = label.replaceAll("\n", " ").replaceAll("\r", " ");
+
   return (
-    <span data-project-todo-sid={sId} className="inline-block">
-      <AttachmentChip
-        label={label.replaceAll("\n", " ").replaceAll("\r", " ")}
-        icon={{ visual: ListCheckIcon }}
-        color="green"
-      />
+    <span
+      data-project-todo-sid={sId}
+      className="inline-block max-w-[11rem] align-middle sm:max-w-[13rem]"
+    >
+      <PopoverRoot open={open} onOpenChange={setOpen} modal={false}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="group flex w-full min-w-0 max-w-full cursor-pointer rounded-md border-0 bg-transparent p-0 text-left outline-none ring-offset-background transition focus-visible:ring-2 focus-visible:ring-highlight-300 focus-visible:ring-offset-1 dark:focus-visible:ring-highlight-300-night dark:ring-offset-background-night"
+            aria-label={`To-do: ${displayLabel}. Open details.`}
+          >
+            <AttachmentChip
+              label={displayLabel}
+              icon={{ visual: ListCheckIcon }}
+              color="green"
+              className="min-w-0 max-w-full transition-opacity group-hover:opacity-90"
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          sideOffset={6}
+          collisionPadding={16}
+          className="w-[min(22rem,calc(100vw-1.5rem))] overflow-hidden rounded-xl border border-border/70 p-0 shadow-xl ring-1 ring-black/[0.04] dark:border-border-night/70 dark:ring-white/[0.06]"
+        >
+          {open ? (
+            <TodoDirectivePopoverBody owner={owner} todoSId={sId} />
+          ) : null}
+        </PopoverContent>
+      </PopoverRoot>
     </span>
   );
+}
+
+/**
+ * Markdown `todo` directive renderer with details popover (requires workspace context).
+ */
+export function getTodoDirectiveBlock(owner: LightWorkspaceType) {
+  return function TodoDirectiveBlockBound({
+    label,
+    sId,
+  }: {
+    label: string;
+    sId: string;
+  }) {
+    return <TodoDirectiveChipInner owner={owner} label={label} sId={sId} />;
+  };
 }
 
 /**


### PR DESCRIPTION
## Description

`:todo[…]` chips rendered in conversation messages were purely decorative — clicking one did nothing. This PR makes them interactive: clicking a chip fetches the full todo details and shows a popover with status, assignee, sources, a link to the project, and a button to open the linked conversation.

- Convert `TodoDirectiveBlock` from a plain component to a factory `getTodoDirectiveBlock(owner)` so the chip has access to workspace context for routing and API calls
- On click, the chip fires `useProjectTodoDetails` (SWR fetch to the new `GET /project_todos/[todoSId]` endpoint from #25153) and renders a `Popover` with:
  - Todo text, status badge, assignee avatar + name, elapsed time
  - Source links
  - "Open project" link (routes to the project's todos tab)
  - "Open conversation" button with `ConversationSidebarStatusDot` when a linked conversation exists
- While loading: spinner inside the chip; on error: graceful fallback (chip stays clickable, popover shows error state)
- All markdown renderers updated to use `getTodoDirectiveBlock(owner)` in place of the static `TodoDirectiveBlock`

## Tests

Local + existing unit tests updated for the new factory signature

<img width="392" height="347" alt="image" src="https://github.com/user-attachments/assets/dc6ec85a-f9aa-4469-9861-80a821546dbc" />
<img width="383" height="347" alt="image" src="https://github.com/user-attachments/assets/059e8869-c1ef-48ec-a5ee-710c5c3dc90f" />


## Risk

Low — chips that fail to load remain visible; popover is purely additive

## Deploy Plan

Deploy `front`
