### PR TITLE
chore: linting CSS rule `!`

### DIFF
--- a/.grit/patterns/noCssImportant.grit
+++ b/.grit/patterns/noCssImportant.grit
@@ -1,0 +1,33 @@
+engine biome(1.0)
+language js
+
+// Disallows `!important` in CSS produced from JS/TS (CSS-in-JS, template
+// literals, inline style strings) and Tailwind v3's `!` important-prefix
+// utilities (e.g. `focus:!ring-0`, `!mt-0`). See CODING_RULES.md [GEN12].
+// Narrow exceptions for third-party library overrides and dev tooling are
+// scoped via biome.json overrides.
+pattern css_important_string() {
+    or {
+        // `!important` keyword anywhere in a string literal.
+        r"\"[^\"]*!important[^\"]*\"",
+        r"'[^']*!important[^']*'",
+        r"`[^`]*!important[^`]*`",
+        // Tailwind v3 modifier-prefixed important, e.g. `focus:!ring-0`.
+        r"\"[^\"]*:![a-z][^\"]*\"",
+        r"'[^']*:![a-z][^']*'",
+        r"`[^`]*:![a-z][^`]*`",
+        // Tailwind v3 leading important at start of a className string,
+        // e.g. `!ring-0`, `!mt-0`.
+        r"\"![a-z][^\"]*\"",
+        r"'![a-z][^']*'",
+        r"`![a-z][^`]*`"
+    }
+}
+
+css_important_string() as $val where {
+    register_diagnostic(
+        span = $val,
+        message = "Avoid `!important` in CSS (CODING_RULES.md [GEN12]). Fix the specificity issue instead. Narrow exceptions (third-party overrides, dev tooling) require a justifying comment and a biome.json scoping override.",
+        severity = "error"
+    )
+}

--- a/.grit/patterns/noCssImportant.grit
+++ b/.grit/patterns/noCssImportant.grit
@@ -6,21 +6,16 @@ language js
 // utilities (e.g. `focus:!ring-0`, `!mt-0`). See CODING_RULES.md [GEN12].
 // Narrow exceptions for third-party library overrides and dev tooling are
 // scoped via biome.json overrides.
+//
+// One regex per quote style; each covers all three flagged forms:
+//   - `!important` keyword (CSS-in-JS, template literals, inline styles)
+//   - Tailwind modifier-prefixed important: `:!<utility>` (e.g. `focus:!ring-0`)
+//   - Tailwind leading important: `"!<utility>"` (e.g. `!mt-0`)
 pattern css_important_string() {
     or {
-        // `!important` keyword anywhere in a string literal.
-        r"\"[^\"]*!important[^\"]*\"",
-        r"'[^']*!important[^']*'",
-        r"`[^`]*!important[^`]*`",
-        // Tailwind v3 modifier-prefixed important, e.g. `focus:!ring-0`.
-        r"\"[^\"]*:![a-z][^\"]*\"",
-        r"'[^']*:![a-z][^']*'",
-        r"`[^`]*:![a-z][^`]*`",
-        // Tailwind v3 leading important at start of a className string,
-        // e.g. `!ring-0`, `!mt-0`.
-        r"\"![a-z][^\"]*\"",
-        r"'![a-z][^']*'",
-        r"`![a-z][^`]*`"
+        r"\"(?:![a-z]|[^\"]*(?:!important|:![a-z]))[^\"]*\"",
+        r"'(?:![a-z]|[^']*(?:!important|:![a-z]))[^']*'",
+        r"`(?:![a-z]|[^`]*(?:!important|:![a-z]))[^`]*`"
     }
 }
 

--- a/.grit/patterns/noCssImportant.md
+++ b/.grit/patterns/noCssImportant.md
@@ -1,0 +1,46 @@
+---
+tags: [lint, css]
+level: error
+---
+
+# No `!important` in CSS
+
+Disallows `!important` inside string literals and template literals produced
+from JS/TS, which covers CSS-in-JS, inline styles, and runtime-injected
+stylesheets. See [GEN12] in `CODING_RULES.md`.
+
+Narrow exceptions (third-party library overrides, dev tooling) are handled
+via per-file `includes` in `biome.json`, not by suppressing on a case-by-case
+basis.
+
+```grit
+language js
+
+css_important_string() => `"CSS_IMPORTANT_FORBIDDEN"`
+```
+
+## Should flag `!important` in a double-quoted string
+
+```typescript
+const css = "color: red !important";
+```
+
+```typescript
+const css = "CSS_IMPORTANT_FORBIDDEN";
+```
+
+## Should flag `!important` in a template literal
+
+```typescript
+const css = `color: red !important;`;
+```
+
+```typescript
+const css = "CSS_IMPORTANT_FORBIDDEN";
+```
+
+## Should not flag unrelated strings
+
+```typescript
+const message = "this is important";
+```

--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -262,6 +262,56 @@ const apiUrl = config.getApiUrl();
 const isProduction = config.getNodeEnv() === "production";
 ```
 
+### [GEN12] Avoid `!important` in CSS
+
+Do not use `!important` in stylesheets, CSS modules, Tailwind `@apply` blocks, CSS-in-JS, or
+template literals that produce CSS. This also covers Tailwind's `!` important-prefix utilities
+(e.g. `focus:!ring-0`, `!mt-0`) — they compile to `!important` and have the same downsides.
+`!important` breaks the cascade, makes specificity issues harder to debug, and tends to spread
+once introduced — every override forces the next one.
+
+Fix the underlying specificity issue instead: increase selector specificity, reorder rules, scope
+via a parent class, drop conflicting utilities, or restructure the component.
+
+Narrow exceptions are acceptable when:
+
+- Overriding styles from a third-party library that we do not control.
+- Dev-only tooling that injects inspection/debug styles at runtime.
+
+In those cases, add a brief comment on the same line or directly above explaining why
+`!important` is required.
+
+Reviewer: If you detect `!important` (including Tailwind's `!` prefix) without a justifying
+comment, ask the author to remove it and address the underlying specificity issue.
+
+Example:
+
+```
+/* BAD */
+.button {
+  color: red !important;
+}
+
+/* GOOD */
+.toolbar .button {
+  color: red;
+}
+
+/* GOOD — third-party library override */
+.allotment-pane {
+  /* allotment computes inline styles; only !important wins. */
+  cursor: default !important;
+}
+```
+
+```tsx
+// BAD — Tailwind important prefix
+<div className="focus:!ring-0 !mt-0" />
+
+// GOOD — drop the conflicting utility, or scope via a parent
+<div className="focus:ring-transparent mt-0" />
+```
+
 ## SECURITY
 
 ### [SEC1] No sensitive data outside of HTTP bodies or headers

--- a/biome.json
+++ b/biome.json
@@ -86,6 +86,14 @@
       "plugins": ["./.grit/patterns/noNextImports.grit"]
     },
     {
+      "includes": [
+        "**",
+        "!front/components/dev/devStyleOverrides.ts",
+        "!front/components/sparkle/ThemeContext.tsx"
+      ],
+      "plugins": ["./.grit/patterns/noCssImportant.grit"]
+    },
+    {
       "includes": ["front/**/*.tsx", "front-spa/**/*.tsx"],
       "plugins": ["./.grit/patterns/noSparkleClassInFront.grit"]
     },

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -513,6 +513,7 @@ export function ConversationMenu({
                         isRounded
                       />
                     }
+                    // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
                     className="!text-foreground dark:!text-foreground-night"
                   />
                 ))}

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -284,6 +284,7 @@ export function ProjectMenu({
                         isRounded
                       />
                     }
+                    // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
                     className="!text-foreground dark:!text-foreground-night"
                   />
                 ))}

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -668,6 +668,7 @@ export const InputBarAttachmentsPicker = ({
                 <LoadingBlock
                   // LoadingBlock defaults to dark:bg-muted-background-night, same as the menu
                   // surface, so skeletons read as invisible; match menu row hover contrast.
+                  // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
                   className="h-7 w-20 bg-muted-background dark:!bg-muted-night p-2 mt-2"
                 />
               )}
@@ -682,6 +683,7 @@ export const InputBarAttachmentsPicker = ({
                       key={i}
                       // LoadingBlock defaults to dark:bg-muted-background-night, same as the menu
                       // surface, so skeletons read as invisible; match menu row hover contrast.
+                      // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
                       className="h-11 w-full bg-muted-background dark:border-border-night dark:!bg-muted-night"
                     />
                   )

--- a/front/components/assistant/conversation/space/conversations/project_todos/utils.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/utils.ts
@@ -43,8 +43,10 @@ export const TODO_TEXTAREA_FIELD_CLASS = cn(
   "shadow-none [box-shadow:none]",
   "outline-none ring-0 ring-offset-0",
   "focus:shadow-none focus:[box-shadow:none] focus:outline-none focus:ring-0 focus:ring-offset-0",
+  // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
   "focus:!ring-0 focus:!ring-offset-0",
   "focus-visible:shadow-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
+  // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
   "focus-visible:!ring-0",
   "placeholder:text-muted-foreground",
   "dark:text-foreground-night dark:placeholder:text-muted-foreground-night"

--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -302,6 +302,7 @@ export function CreateWebhookSourceFormContent({
                           <Button
                             label={field.value}
                             variant="outline"
+                            // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
                             className="!mt-0"
                             icon={ChevronDownIcon}
                           />

--- a/sparkle/src/components/ButtonGroup.tsx
+++ b/sparkle/src/components/ButtonGroup.tsx
@@ -27,8 +27,10 @@ const buttonGroupVariants = cva("s-inline-flex s-w-fit s-items-stretch", {
       removeGaps: true,
       className: cn(
         "s-gap-0",
+        // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
         "[&>*:not(:first-child)]:!s-rounded-l-none",
         "[&>*:not(:first-child)]:s-border-l-0",
+        // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
         "[&>*:not(:last-child)]:!s-rounded-r-none"
       ),
     },
@@ -37,8 +39,10 @@ const buttonGroupVariants = cva("s-inline-flex s-w-fit s-items-stretch", {
       removeGaps: true,
       className: cn(
         "s-gap-0",
+        // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
         "[&>*:not(:first-child)]:!s-rounded-t-none",
         "[&>*:not(:first-child)]:s-border-t-0",
+        // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
         "[&>*:not(:last-child)]:!s-rounded-b-none"
       ),
     },

--- a/viz/components/ui/context-menu.tsx
+++ b/viz/components/ui/context-menu.tsx
@@ -125,6 +125,7 @@ function ContextMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
+        // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup (shadcn-derived)
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}

--- a/viz/components/ui/dropdown-menu.tsx
+++ b/viz/components/ui/dropdown-menu.tsx
@@ -73,6 +73,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
+        // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup (shadcn-derived)
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}

--- a/viz/components/ui/menubar.tsx
+++ b/viz/components/ui/menubar.tsx
@@ -100,6 +100,7 @@ function MenubarItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
+        // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup (shadcn-derived)
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}


### PR DESCRIPTION
## Description

Introduces a Grit linting rule to block `!important` in CSS-in-JS, template literals, and Tailwind's `!` prefix utilities (e.g. `focus:!ring-0`, `!mt-0`).

## Tests

Tested manually by running `npm run format:changed` to verify the linter flags new `!important` usage and passes on the biome-ignored legacy violations.

## Risk

Low. Existing code is unchanged (biome-ignore suppresses the rule for legacy violations). The rule only blocks new `!important` usage going forward.

## Deploy Plan

Deploy front