### PR TITLE
Add: Splitbutton to go to the conversation when starting a todo.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
@@ -437,7 +437,11 @@ export function EditableProjectTodosPanel({
   const handleStartWorking = useCallback(
     async (
       todo: ProjectTodoType,
-      options?: { customMessage?: string; agentConfigurationId?: string }
+      options?: {
+        customMessage?: string;
+        agentConfigurationId?: string;
+        goToConversation?: boolean;
+      }
     ) => {
       setStartingTodoIds((prev) => new Set([...prev, todo.sId]));
       const result = await doStartConversation(todo.sId, {
@@ -446,7 +450,7 @@ export function EditableProjectTodosPanel({
       });
       if (result.isOk()) {
         const { conversationId } = result.value;
-        if (todo.agentInstructions?.trim() && conversationId) {
+        if (options?.goToConversation && conversationId) {
           void router.push(
             getConversationRoute(owner.sId, conversationId),
             undefined,

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -22,12 +22,17 @@ import {
   AnimatedText,
   Avatar,
   Button,
+  ButtonGroup,
+  ButtonGroupDropdown,
   ChatBubbleLeftRightIcon,
   Checkbox,
+  CheckIcon,
+  ChevronDownIcon,
   cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  type DropdownMenuItemProps,
   DropdownMenuPortal,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
@@ -35,6 +40,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  Icon,
   MoreIcon,
   PlayIcon,
   RobotIcon,
@@ -54,7 +60,11 @@ export interface EditableTodoItemProps {
   onDelete: (todo: ProjectTodoType) => void | Promise<void>;
   onStartWorking: (
     todo: ProjectTodoType,
-    options?: { customMessage?: string; agentConfigurationId?: string }
+    options?: {
+      customMessage?: string;
+      agentConfigurationId?: string;
+      goToConversation?: boolean;
+    }
   ) => Promise<void>;
   owner: LightWorkspaceType;
   activeAgents: LightAgentConfigurationType[];
@@ -95,6 +105,9 @@ export const EditableTodoItem = memo(function EditableTodoItem({
   const router = useAppRouter();
   const [startMenuOpen, setStartMenuOpen] = useState(false);
   const [startCustomMessage, setStartCustomMessage] = useState("");
+  const [goToConversationAfterStart, setGoToConversationAfterStart] = useState(
+    () => !!todo.agentInstructions?.trim()
+  );
   const [selectedStartAgent, setSelectedStartAgent] =
     useState<LightAgentConfigurationType | null>(null);
 
@@ -256,8 +269,37 @@ export const EditableTodoItem = memo(function EditableTodoItem({
     await onStartWorking(todo, {
       customMessage: startCustomMessage.trim() || undefined,
       agentConfigurationId,
+      goToConversation: goToConversationAfterStart,
     });
   };
+
+  const startRedirectMenuItems = useMemo((): DropdownMenuItemProps[] => {
+    const check = (
+      <Icon
+        size="xs"
+        visual={CheckIcon}
+        className="text-muted-foreground dark:text-muted-foreground-night"
+      />
+    );
+    return [
+      {
+        label: "Redirect to conversation",
+        onSelect: (e) => {
+          e.preventDefault();
+          setGoToConversationAfterStart(true);
+        },
+        endComponent: goToConversationAfterStart ? check : undefined,
+      },
+      {
+        label: "Stay on to-dos",
+        onSelect: (e) => {
+          e.preventDefault();
+          setGoToConversationAfterStart(false);
+        },
+        endComponent: !goToConversationAfterStart ? check : undefined,
+      },
+    ];
+  }, [goToConversationAfterStart]);
 
   return (
     <div
@@ -456,8 +498,8 @@ export const EditableTodoItem = memo(function EditableTodoItem({
                       setStartCustomMessage(event.target.value)
                     }
                   />
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="w-[200px] min-w-0 shrink-0">
+                  <div className="flex items-end justify-between gap-2">
+                    <div className="min-w-0 flex-1">
                       <AgentPicker
                         owner={owner}
                         agents={activeAgents}
@@ -490,17 +532,29 @@ export const EditableTodoItem = memo(function EditableTodoItem({
                         }
                       />
                     </div>
-                    <div className="w-[92px] shrink-0">
+                    <ButtonGroup className="shrink-0">
                       <Button
-                        label="Go!"
-                        variant="highlight"
+                        label="Start working"
+                        variant="outline"
                         size="sm"
-                        className="w-full"
                         isLoading={isStarting}
                         disabled={isStarting || !selectedStartAgent}
                         onClick={() => void handleConfirmStart()}
                       />
-                    </div>
+                      <ButtonGroupDropdown
+                        align="end"
+                        items={startRedirectMenuItems}
+                        trigger={
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            icon={ChevronDownIcon}
+                            disabled={isStarting || !selectedStartAgent}
+                            aria-label="After start: open conversation or stay on to-dos"
+                          />
+                        }
+                      />
+                    </ButtonGroup>
                   </div>
                 </div>
               </DropdownMenuContent>


### PR DESCRIPTION
## Description

Auto-navigating to the new conversation on every todo start (introduced in #25128 for seeded todos) was too aggressive — users starting a todo while browsing the project would be yanked out of context unexpectedly.

- Replace the `agentInstructions`-based auto-redirect with an explicit opt-in `goToConversation` flag threaded through `onStartWorking` → `handleStartWorking`
- Replace the single "Go!" button with a `ButtonGroup` split button: the main "Start working" action (outline) + a `ButtonGroupDropdown` chevron that lets the user pick between "Redirect to conversation" and "Stay on to-dos" (active option shown with a checkmark)
- Default selection: redirect when the todo has `agentInstructions` (seeded todos), stay otherwise
- Widen the agent picker to `flex-1` so the layout adapts to different label lengths

## Tests

Local
<img width="397" height="192" alt="image" src="https://github.com/user-attachments/assets/f1227fea-a768-4e38-a5c1-505b96f710df" />


## Risk

Low — purely additive UI change; default behavior matches previous intent for seeded todos

## Deploy Plan

Deploy `front`
