### PR TITLE
[Google Drive] Fix manual folder sync metadata

### DIFF
--- a/connectors/src/connectors/google_drive/lib/cli.test.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.test.ts
@@ -140,6 +140,8 @@ describe("google drive admin cli", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    mocks.getFileParentsMemoized.mockReset();
+    mocks.getGoogleDriveObject.mockReset();
     mocks.getAuthObject.mockResolvedValue({});
     mocks.syncOneFile.mockResolvedValue(true);
     mocks.upsertDataSourceFolder.mockReset();
@@ -239,9 +241,7 @@ describe("google drive admin cli", () => {
     expect(result).toEqual({ success: true });
     expect(updatedFolder?.name).toBe("Current Folder Name");
     expect(updatedFolder?.parentId).toBe(parentId);
-    expect(updatedFolder?.lastSeenTs?.getTime()).toBeGreaterThan(
-      previousLastSeenTs.getTime()
-    );
+    expect(updatedFolder?.lastSeenTs).toEqual(previousLastSeenTs);
     expect(updatedParent?.name).toBe("Current Parent Name");
     expect(mocks.syncOneFile).not.toHaveBeenCalled();
     expect(mocks.upsertDataSourceFolder).toHaveBeenCalledWith(
@@ -256,5 +256,53 @@ describe("google drive admin cli", () => {
         title: "Current Folder Name",
       })
     );
+  });
+
+  it("does not upsert skipped folders into the datasource", async () => {
+    const suffix = randomUUID();
+    const folderId = `folder-${suffix}`;
+    const connector = await makeConnector(suffix);
+    const previousLastSeenTs = new Date("2025-01-01T00:00:00.000Z");
+
+    await GoogleDriveFilesModel.create({
+      connectorId: connector.id,
+      driveFileId: folderId,
+      dustFileId: `gdrive-${folderId}`,
+      lastSeenTs: previousLastSeenTs,
+      mimeType: FOLDER_MIME_TYPE,
+      name: "Stale Skipped Folder Name",
+      parentId: null,
+      skipReason: "blacklisted",
+    });
+
+    const folder = makeGoogleDriveFolder({
+      id: folderId,
+      name: "Current Skipped Folder Name",
+      parent: null,
+    });
+
+    mocks.getGoogleDriveObject.mockResolvedValue(folder);
+    mocks.getFileParentsMemoized.mockResolvedValue([folderId]);
+
+    await google_drive({
+      majorCommand: "google_drive",
+      command: "upsert-file",
+      args: {
+        connectorId: connector.id.toString(),
+        fileId: folderId,
+      },
+    });
+
+    const updatedFolder = await GoogleDriveFilesModel.findOne({
+      where: {
+        connectorId: connector.id,
+        driveFileId: folderId,
+      },
+    });
+
+    expect(updatedFolder?.name).toBe("Current Skipped Folder Name");
+    expect(updatedFolder?.lastSeenTs).toEqual(previousLastSeenTs);
+    expect(updatedFolder?.skipReason).toBe("blacklisted");
+    expect(mocks.upsertDataSourceFolder).not.toHaveBeenCalled();
   });
 });

--- a/connectors/src/connectors/google_drive/lib/cli.test.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.test.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from "node:crypto";
+
+import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { GoogleDriveObjectType } from "@connectors/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getAuthObject: vi.fn(),
+  getFileParentsMemoized: vi.fn(),
+  getGoogleDriveObject: vi.fn(),
+  syncOneFile: vi.fn(),
+  upsertDataSourceFolder: vi.fn(),
+}));
+
+vi.mock("@connectors/connectors/google_drive", () => ({
+  getSourceUrlForGoogleDriveFiles: (file: {
+    driveFileId?: string;
+    id?: string;
+  }) =>
+    `https://drive.google.com/drive/folders/${
+      "driveFileId" in file ? file.driveFileId : file.id
+    }`,
+}));
+
+vi.mock("@connectors/connectors/google_drive/lib/google_drive_api", () => ({
+  getGoogleDriveObject: mocks.getGoogleDriveObject,
+}));
+
+vi.mock("@connectors/connectors/google_drive/lib/hierarchy", () => ({
+  getFileParentsMemoized: mocks.getFileParentsMemoized,
+}));
+
+vi.mock("@connectors/connectors/google_drive/temporal/client", () => ({
+  launchGoogleDriveFullSyncWorkflow: vi.fn(),
+  launchGoogleDriveIncrementalSyncWorkflow: vi.fn(),
+  launchGoogleFixParentsConsistencyWorkflow: vi.fn(),
+}));
+
+vi.mock("@connectors/connectors/google_drive/temporal/file", () => ({
+  syncOneFile: mocks.syncOneFile,
+}));
+
+vi.mock(
+  "@connectors/connectors/google_drive/temporal/utils",
+  async (importOriginal) => {
+    const mod =
+      await importOriginal<
+        typeof import("@connectors/connectors/google_drive/temporal/utils")
+      >();
+
+    return {
+      ...mod,
+      getAuthObject: mocks.getAuthObject,
+    };
+  }
+);
+
+vi.mock("@connectors/lib/data_sources", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("@connectors/lib/data_sources")>();
+
+  return {
+    ...mod,
+    upsertDataSourceFolder: mocks.upsertDataSourceFolder,
+  };
+});
+
+vi.mock("@connectors/lib/temporal", () => ({
+  terminateWorkflow: vi.fn(),
+}));
+
+vi.mock("@connectors/logger/logger", () => ({
+  default: {
+    child: vi.fn(() => ({
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    })),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  getActivityLogger: vi.fn(() => ({
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  })),
+  getLoggerArgs: vi.fn(() => ({})),
+}));
+
+import { google_drive } from "./cli";
+
+const FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
+
+function makeGoogleDriveFolder({
+  id,
+  name,
+  parent,
+}: {
+  id: string;
+  name: string;
+  parent: string | null;
+}): GoogleDriveObjectType {
+  return {
+    capabilities: {
+      canDownload: false,
+    },
+    createdAtMs: Date.now(),
+    driveId: "drive-1",
+    id,
+    isInSharedDrive: false,
+    labels: [],
+    mimeType: FOLDER_MIME_TYPE,
+    name,
+    parent,
+    size: null,
+    trashed: false,
+  };
+}
+
+async function makeConnector(suffix: string) {
+  return ConnectorResource.makeNew(
+    "google_drive",
+    {
+      connectionId: `connection-${suffix}`,
+      dataSourceId: `data-source-${suffix}`,
+      workspaceAPIKey: `api-key-${suffix}`,
+      workspaceId: `workspace-${suffix}`,
+    },
+    {
+      csvEnabled: false,
+      largeFilesEnabled: false,
+      pdfEnabled: false,
+    }
+  );
+}
+
+describe("google drive admin cli", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.getAuthObject.mockResolvedValue({});
+    mocks.syncOneFile.mockResolvedValue(true);
+    mocks.upsertDataSourceFolder.mockReset();
+  });
+
+  it("refreshes stale folder metadata when upserting a folder", async () => {
+    const suffix = randomUUID();
+    const folderId = `folder-${suffix}`;
+    const parentId = `parent-${suffix}`;
+    const rootId = `root-${suffix}`;
+    const connector = await makeConnector(suffix);
+    const previousLastSeenTs = new Date("2025-01-01T00:00:00.000Z");
+
+    await GoogleDriveFilesModel.bulkCreate([
+      {
+        connectorId: connector.id,
+        driveFileId: folderId,
+        dustFileId: `gdrive-${folderId}`,
+        lastSeenTs: previousLastSeenTs,
+        mimeType: FOLDER_MIME_TYPE,
+        name: "Stale Folder Name",
+        parentId,
+      },
+      {
+        connectorId: connector.id,
+        driveFileId: parentId,
+        dustFileId: `gdrive-${parentId}`,
+        lastSeenTs: previousLastSeenTs,
+        mimeType: FOLDER_MIME_TYPE,
+        name: "Stale Parent Name",
+        parentId: rootId,
+      },
+    ]);
+
+    const folder = makeGoogleDriveFolder({
+      id: folderId,
+      name: "Current Folder Name",
+      parent: parentId,
+    });
+    const parent = makeGoogleDriveFolder({
+      id: parentId,
+      name: "Current Parent Name",
+      parent: rootId,
+    });
+    const root = makeGoogleDriveFolder({
+      id: rootId,
+      name: "Current Root Name",
+      parent: null,
+    });
+    const remoteFiles = new Map([
+      [folderId, folder],
+      [parentId, parent],
+      [rootId, root],
+    ]);
+
+    mocks.getGoogleDriveObject.mockImplementation(({ driveObjectId }) => {
+      return remoteFiles.get(driveObjectId) ?? null;
+    });
+    mocks.getFileParentsMemoized.mockImplementation(
+      (
+        _connectorId: number,
+        _authCredentials: unknown,
+        file: GoogleDriveObjectType
+      ) => {
+        if (file.id === folderId) {
+          return [folderId, parentId, rootId];
+        }
+        if (file.id === parentId) {
+          return [parentId, rootId];
+        }
+        return [rootId];
+      }
+    );
+
+    const result = await google_drive({
+      majorCommand: "google_drive",
+      command: "upsert-file",
+      args: {
+        connectorId: connector.id.toString(),
+        fileId: folderId,
+      },
+    });
+
+    const updatedFolder = await GoogleDriveFilesModel.findOne({
+      where: {
+        connectorId: connector.id,
+        driveFileId: folderId,
+      },
+    });
+    const updatedParent = await GoogleDriveFilesModel.findOne({
+      where: {
+        connectorId: connector.id,
+        driveFileId: parentId,
+      },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(updatedFolder?.name).toBe("Current Folder Name");
+    expect(updatedFolder?.parentId).toBe(parentId);
+    expect(updatedFolder?.lastSeenTs?.getTime()).toBeGreaterThan(
+      previousLastSeenTs.getTime()
+    );
+    expect(updatedParent?.name).toBe("Current Parent Name");
+    expect(mocks.syncOneFile).not.toHaveBeenCalled();
+    expect(mocks.upsertDataSourceFolder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        folderId: `gdrive-${folderId}`,
+        parentId: `gdrive-${parentId}`,
+        parents: [
+          `gdrive-${folderId}`,
+          `gdrive-${parentId}`,
+          `gdrive-${rootId}`,
+        ],
+        title: "Current Folder Name",
+      })
+    );
+  });
+});

--- a/connectors/src/connectors/google_drive/lib/cli.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.ts
@@ -6,7 +6,7 @@ import {
 } from "@connectors/connectors/google_drive/lib";
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
-import { markFolderAsVisited } from "@connectors/connectors/google_drive/temporal/activities";
+import { upsertGoogleDriveFolderMetadata } from "@connectors/connectors/google_drive/temporal/activities/mark_folder_as_visited";
 import {
   launchGoogleDriveFullSyncWorkflow,
   launchGoogleDriveIncrementalSyncWorkflow,
@@ -15,6 +15,7 @@ import {
 import { syncOneFile } from "@connectors/connectors/google_drive/temporal/file";
 import {
   getMimeTypesToSync,
+  isGoogleDriveFolder,
   MIME_TYPES_TO_EXPORT,
 } from "@connectors/connectors/google_drive/temporal/mime_types";
 import {
@@ -179,27 +180,35 @@ export const google_drive = async ({
       const reversedParents = parents.reverse();
       const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-      // Upsert parents if missing
+      // Refresh parent metadata as manual sync is often used to repair stale names.
       for (const parent of reversedParents) {
-        const file = await GoogleDriveFilesModel.findOne({
-          where: {
-            connectorId: connector.id,
-            driveFileId: parent,
-          },
+        const parentDriveObject = await getGoogleDriveObject({
+          connectorId: connector.id,
+          authCredentials,
+          driveObjectId: getDriveFileId(parent),
+          cacheKey: { connectorId: connector.id, ts: now },
         });
-        if (!file) {
-          const parentDriveObject = await getGoogleDriveObject({
-            connectorId: connector.id,
-            authCredentials,
-            driveObjectId: getDriveFileId(parent),
-            cacheKey: { connectorId: connector.id, ts: now },
-          });
-          if (!parentDriveObject) {
-            throw new Error(`Can't find google drive object: ${parent}`);
-          }
-
-          await markFolderAsVisited(connector.id, parent, now);
+        if (!parentDriveObject) {
+          throw new Error(`Can't find google drive object: ${parent}`);
         }
+
+        await upsertGoogleDriveFolderMetadata({
+          connector,
+          authCredentials,
+          file: parentDriveObject,
+          startSyncTs: now,
+        });
+      }
+
+      if (isGoogleDriveFolder(driveObject)) {
+        await upsertGoogleDriveFolderMetadata({
+          connector,
+          authCredentials,
+          file: driveObject,
+          startSyncTs: now,
+        });
+
+        return { success: true };
       }
 
       await syncOneFile(

--- a/connectors/src/connectors/google_drive/temporal/activities/mark_folder_as_visited.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/mark_folder_as_visited.ts
@@ -11,8 +11,52 @@ import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ModelId } from "@connectors/types";
+import type { GoogleDriveObjectType, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES, stripNullBytes } from "@connectors/types";
+import type { OAuth2Client } from "googleapis-common";
+
+export async function upsertGoogleDriveFolderMetadata({
+  connector,
+  authCredentials,
+  file,
+  startSyncTs,
+}: {
+  connector: ConnectorResource;
+  authCredentials: OAuth2Client;
+  file: GoogleDriveObjectType;
+  startSyncTs: number;
+}) {
+  const parentGoogleIds = await getFileParentsMemoized(
+    connector.id,
+    authCredentials,
+    file,
+    startSyncTs
+  );
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+  const parents = parentGoogleIds.map((parent) => getInternalId(parent));
+  const name = stripNullBytes(file.name) ?? "";
+
+  await upsertDataSourceFolder({
+    dataSourceConfig,
+    folderId: getInternalId(file.id),
+    parents,
+    parentId: parents[1] || null,
+    title: name,
+    mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
+    sourceUrl: getSourceUrlForGoogleDriveFiles(file),
+  });
+
+  await GoogleDriveFilesModel.upsert({
+    connectorId: connector.id,
+    dustFileId: getInternalId(file.id),
+    driveFileId: file.id,
+    name,
+    mimeType: file.mimeType,
+    parentId: parents[1] ? getDriveFileId(parents[1]) : null,
+    lastSeenTs: new Date(),
+  });
+}
 
 export async function markFolderAsVisited(
   connectorId: ModelId,
@@ -40,34 +84,10 @@ export async function markFolderAsVisited(
     return;
   }
 
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const parentGoogleIds = await getFileParentsMemoized(
-    connectorId,
+  await upsertGoogleDriveFolderMetadata({
+    connector,
     authCredentials,
     file,
-    startSyncTs
-  );
-
-  const parents = parentGoogleIds.map((parent) => getInternalId(parent));
-  const name = stripNullBytes(file.name) ?? "";
-
-  await upsertDataSourceFolder({
-    dataSourceConfig,
-    folderId: getInternalId(file.id),
-    parents,
-    parentId: parents[1] || null,
-    title: name,
-    mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
-    sourceUrl: getSourceUrlForGoogleDriveFiles(file),
-  });
-
-  await GoogleDriveFilesModel.upsert({
-    connectorId: connectorId,
-    dustFileId: getInternalId(driveFileId),
-    driveFileId: file.id,
-    name,
-    mimeType: file.mimeType,
-    parentId: parents[1] ? getDriveFileId(parents[1]) : null,
-    lastSeenTs: new Date(),
+    startSyncTs,
   });
 }

--- a/connectors/src/connectors/google_drive/temporal/activities/mark_folder_as_visited.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/mark_folder_as_visited.ts
@@ -14,17 +14,22 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { GoogleDriveObjectType, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES, stripNullBytes } from "@connectors/types";
 import type { OAuth2Client } from "googleapis-common";
+import type { CreationAttributes } from "sequelize";
 
 export async function upsertGoogleDriveFolderMetadata({
   connector,
   authCredentials,
   file,
   startSyncTs,
+  updateLastSeenTs = false,
+  upsertDataSourceFolderForSkipped = false,
 }: {
   connector: ConnectorResource;
   authCredentials: OAuth2Client;
   file: GoogleDriveObjectType;
   startSyncTs: number;
+  updateLastSeenTs?: boolean;
+  upsertDataSourceFolderForSkipped?: boolean;
 }) {
   const parentGoogleIds = await getFileParentsMemoized(
     connector.id,
@@ -37,25 +42,39 @@ export async function upsertGoogleDriveFolderMetadata({
   const parents = parentGoogleIds.map((parent) => getInternalId(parent));
   const name = stripNullBytes(file.name) ?? "";
 
-  await upsertDataSourceFolder({
-    dataSourceConfig,
-    folderId: getInternalId(file.id),
-    parents,
-    parentId: parents[1] || null,
-    title: name,
-    mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
-    sourceUrl: getSourceUrlForGoogleDriveFiles(file),
+  const existingFolder = await GoogleDriveFilesModel.findOne({
+    where: {
+      connectorId: connector.id,
+      driveFileId: file.id,
+    },
   });
 
-  await GoogleDriveFilesModel.upsert({
+  if (!existingFolder?.skipReason || upsertDataSourceFolderForSkipped) {
+    await upsertDataSourceFolder({
+      dataSourceConfig,
+      folderId: getInternalId(file.id),
+      parents,
+      parentId: parents[1] || null,
+      title: name,
+      mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
+      sourceUrl: getSourceUrlForGoogleDriveFiles(file),
+    });
+  }
+
+  const googleDriveFileParams: CreationAttributes<GoogleDriveFilesModel> = {
     connectorId: connector.id,
     dustFileId: getInternalId(file.id),
     driveFileId: file.id,
     name,
     mimeType: file.mimeType,
     parentId: parents[1] ? getDriveFileId(parents[1]) : null,
-    lastSeenTs: new Date(),
-  });
+  };
+
+  if (updateLastSeenTs) {
+    googleDriveFileParams.lastSeenTs = new Date();
+  }
+
+  await GoogleDriveFilesModel.upsert(googleDriveFileParams);
 }
 
 export async function markFolderAsVisited(
@@ -89,5 +108,7 @@ export async function markFolderAsVisited(
     authCredentials,
     file,
     startSyncTs,
+    updateLastSeenTs: true,
+    upsertDataSourceFolderForSkipped: true,
   });
 }

--- a/front/lib/api/poke/plugins/data_sources/google_drive_sync_file.test.ts
+++ b/front/lib/api/poke/plugins/data_sources/google_drive_sync_file.test.ts
@@ -1,0 +1,18 @@
+import { extractGoogleDriveFileId } from "@app/lib/api/poke/plugins/data_sources/google_drive_sync_file";
+import { describe, expect, it } from "vitest";
+
+describe("extractGoogleDriveFileId", () => {
+  it("extracts IDs from Google Drive folder URLs", () => {
+    expect(
+      extractGoogleDriveFileId(
+        "https://drive.google.com/drive/folders/1P8oP_Ro7P97xvc--x6bU9wZdL-s6xoCd"
+      )
+    ).toBe("1P8oP_Ro7P97xvc--x6bU9wZdL-s6xoCd");
+
+    expect(
+      extractGoogleDriveFileId(
+        "https://drive.google.com/drive/u/0/folders/1P8oP_Ro7P97xvc--x6bU9wZdL-s6xoCd"
+      )
+    ).toBe("1P8oP_Ro7P97xvc--x6bU9wZdL-s6xoCd");
+  });
+});

--- a/front/lib/api/poke/plugins/data_sources/google_drive_sync_file.ts
+++ b/front/lib/api/poke/plugins/data_sources/google_drive_sync_file.ts
@@ -4,7 +4,7 @@ import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { Err, Ok } from "@app/types/shared/result";
 
-function extractGoogleDriveFileId(input: string): string | null {
+export function extractGoogleDriveFileId(input: string): string | null {
   const trimmedInput = input.trim();
 
   // If it's already a file ID (alphanumeric, hyphens, underscores), return it
@@ -23,10 +23,17 @@ function extractGoogleDriveFileId(input: string): string | null {
       return docsMatch[2];
     }
 
-    // Handle drive.google.com URLs: /file/d/FILE_ID/, /open?id=FILE_ID
+    // Handle drive.google.com URLs: /file/d/FILE_ID/, /drive/folders/FILE_ID, /open?id=FILE_ID
     const driveMatch = url.pathname.match(/^\/file\/d\/([a-zA-Z0-9_-]+)/);
     if (driveMatch) {
       return driveMatch[1];
+    }
+
+    const folderMatch = url.pathname.match(
+      /^\/drive(?:\/u\/\d+)?\/folders\/([a-zA-Z0-9_-]+)/
+    );
+    if (folderMatch) {
+      return folderMatch[1];
     }
 
     // Handle drive.google.com/open?id=FILE_ID
@@ -47,14 +54,14 @@ export const googleDriveSyncFilePlugin = createPlugin({
     id: "google-drive-sync-file",
     name: "Sync Google Drive File",
     description:
-      "Force sync a single Google Drive file by its file ID. This will upsert the file and all its parent folders if needed.",
+      "Force sync a single Google Drive file or folder by its ID. This will upsert the file or folder and all its parent folders.",
     resourceTypes: ["data_sources"],
     args: {
       fileId: {
         type: "string",
-        label: "File ID",
+        label: "File or Folder ID",
         description:
-          "Google Drive file ID (e.g., 1a2b3c4d5e6f7g8h9i0j or the full URL)",
+          "Google Drive file or folder ID (e.g., 1a2b3c4d5e6f7g8h9i0j or the full URL)",
       },
     },
   },
@@ -84,7 +91,7 @@ export const googleDriveSyncFilePlugin = createPlugin({
     if (!extractedFileId) {
       return new Err(
         new Error(
-          "Invalid Google Drive file ID or URL. Please provide a valid file ID or URL."
+          "Invalid Google Drive file or folder ID or URL. Please provide a valid file or folder ID or URL."
         )
       );
     }
@@ -112,7 +119,7 @@ export const googleDriveSyncFilePlugin = createPlugin({
 
     return new Ok({
       display: "text",
-      value: `Successfully synced Google Drive file: ${extractedFileId}`,
+      value: `Successfully synced Google Drive file or folder: ${extractedFileId}`,
     });
   },
 });


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7601

Manual Google Drive upsert now refreshes folder metadata for requested folders and ancestors instead of routing folders through `syncOneFile`, which skips non-downloadable objects. Poke also accepts `drive.google.com/drive/folders/<id>` URLs.

## Risks
Blast radius: Google Drive poke/admin manual file/folder sync.
Risk: low

## Deploy Plan
- deploy connectors
- deploy front

## Test
- [x] `NODE_ENV=test CONNECTORS_DATABASE_URI=postgres://dev:dev@localhost:5432/dust_connectors_test npx vitest run ./src/connectors/google_drive/lib/cli.test.ts`
- [x] `NODE_ENV=test CONNECTORS_DATABASE_URI=postgres://dev:dev@localhost:5432/dust_connectors_test npx vitest run ./src/connectors/google_drive/temporal/activities/incremental_sync.test.ts`
- [x] `NODE_ENV=test FRONT_DATABASE_URI=postgres://dev:dev@localhost:5432/dust_front_test_gdrive_sync REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run ./lib/api/poke/plugins/data_sources/google_drive_sync_file.test.ts`