### PR TITLE
feat(project_todo): include project description in takeaway extraction prompt

### DIFF
--- a/front/lib/project_todo/analyze_document/index.ts
+++ b/front/lib/project_todo/analyze_document/index.ts
@@ -11,6 +11,7 @@ import {
   ExtractTakeawaysInputSchema,
 } from "@app/lib/project_todo/analyze_document/types";
 import { buildSpec } from "@app/lib/project_todo/analyze_document/utils";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   type TakeawaySourceDocument,
@@ -124,6 +125,23 @@ async function callExtractActionItemsLLM(
 // Maps raw LLM-extracted items to typed action items, reusing sIds from the
 // previous version when the LLM echoes them back, generating new UUIDs otherwise.
 
+async function buildPromptProjectDescription(
+  auth: Authenticator,
+  { spaceId }: { spaceId: string }
+): Promise<string | null> {
+  const space = await SpaceResource.fetchById(auth, spaceId);
+  if (!space) {
+    return null;
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+  if (!metadata?.description) {
+    return null;
+  }
+
+  return `Project description: ${metadata.description}`;
+}
+
 export type ExtractedTakeawayStats = {
   actionItems: number;
   keyDecisions: number;
@@ -163,12 +181,20 @@ export async function extractDocumentTakeaways(
 
   const previousActionItems = previousVersion?.actionItems ?? [];
 
+  const [projectMembers, projectDescription] = await Promise.all([
+    buildPromptProjectMembers(auth, { spaceId }),
+    buildPromptProjectDescription(auth, { spaceId }),
+  ]);
+
   const prompt = [
-    await buildPromptProjectMembers(auth, { spaceId }),
+    projectMembers,
+    projectDescription,
     buildPromptForSourceType(document.type),
     buildPromptActionItems(previousActionItems),
     "You MUST call the tool. Always call it, even if there are no action items, notable facts, or key decisions (use empty arrays).",
-  ].join("\n\n");
+  ]
+    .filter(Boolean)
+    .join("\n\n");
   const specification = buildSpec();
 
   const extraction = await callExtractActionItemsLLM(auth, {


### PR DESCRIPTION
## Problem

The project description was stored (via `edit_description` tool / `ProjectMetadataResource`) but was never passed to the auto-suggested TODO generation flow. As confirmed in [#initiative-projects](https://dust4ai.slack.com/archives/C09T7N4S6GG/p1777878024624029), adding a description like "EXCLUDE any actions that don't mention animals" had no effect because the LLM never saw it.

## Fix

In `extractDocumentTakeaways` (`front/lib/project_todo/analyze_document/index.ts`), the prompt is built from:
1. Project members
2. Source type context
3. Previous action items

This PR adds **project description** as a second item in the prompt, injected right after the members list so the LLM sees it before source-type guidance and existing items.

### Implementation

- New `buildPromptProjectDescription` helper: fetches the space, then the `ProjectMetadataResource`, and returns `"Project description: <text>"` or `null` if unset.
- In `extractDocumentTakeaways`: the members fetch and the description fetch now run in `Promise.all` (parallel, no extra latency vs. before).
- The description entry is filtered out with `.filter(Boolean)` so projects without a description are unaffected.

## Testing

- Projects without a description: behavior unchanged (description block is simply absent from the prompt).
- Projects with a description: the LLM now receives it and can use it to filter or focus action item extraction.

No new tests needed — this is a pure prompt assembly change with no new DB writes or schema changes.