### PR TITLE
feat(project): add the possibility for TODOs to be unassigned

### DIFF
--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -336,6 +336,9 @@ async function buildDeduplicationGroups(
         userId,
       });
       for (const todo of todos) {
+        if (todo.userId === null) {
+          continue;
+        }
         const bucket = existingTodosByUser.get(todo.userId) ?? [];
         bucket.push(todo);
         existingTodosByUser.set(todo.userId, bucket);

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -210,7 +210,13 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     }
 
     const todoModelIds = todos.map((todo) => todo.id);
-    const assigneeModelIds = [...new Set(todos.map((todo) => todo.userId))];
+    const assigneeModelIds = [
+      ...new Set(
+        todos
+          .map((todo) => todo.userId)
+          .filter((id): id is ModelId => id !== null)
+      ),
+    ];
     const actorModelIds = [
       ...new Set([
         ...todos
@@ -273,7 +279,10 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
     return todos.map((todo) => {
       return new this(ProjectTodoModel, todo.get(), {
-        assignee: assigneeByModelId.get(todo.userId) ?? null,
+        assignee:
+          (todo.userId !== null
+            ? assigneeByModelId.get(todo.userId)
+            : undefined) ?? null,
         conversationSId: conversationIdByTodoModelId.get(todo.id) ?? null,
         createdByUserSId:
           todo.createdByUserId !== null
@@ -587,6 +596,12 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     },
     transaction?: Transaction
   ): Promise<void> {
+    if (this.userId === null) {
+      throw new Error(
+        "Cannot upsert source for a todo without an assigned user."
+      );
+    }
+
     const workspaceId = auth.getNonNullableWorkspace().id;
     // we want one link between one given TODO (that belongs to a user) for a given source
     const identity = {

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -33,8 +33,9 @@ const PROJECT_TODO_MODEL_ATTRIBUTES = {
   },
   userId: {
     type: DataTypes.BIGINT,
-    allowNull: false,
-    comment: "Owner of the todo — a todo is always assigned to a user.",
+    allowNull: true,
+    comment:
+      "Owner of the todo — null when the todo is not assigned to a specific user.",
   },
   createdByUserId: {
     type: DataTypes.BIGINT,
@@ -113,7 +114,7 @@ export class ProjectTodoModel extends WorkspaceAwareModel<ProjectTodoModel> {
   declare spaceId: ForeignKey<SpaceModel["id"]>;
 
   // Owner
-  declare userId: ForeignKey<UserModel["id"]>;
+  declare userId: ForeignKey<UserModel["id"]> | null;
 
   // Creator — user or agent (mutually exclusive FKs).
   declare createdByType: ProjectTodoActorType;
@@ -134,7 +135,7 @@ export class ProjectTodoModel extends WorkspaceAwareModel<ProjectTodoModel> {
   declare deletedAt: CreationOptional<Date | null>;
 
   declare space: NonAttribute<SpaceModel>;
-  declare user: NonAttribute<UserModel>;
+  declare user: NonAttribute<UserModel | null>;
   declare createdByUser: NonAttribute<UserModel | null>;
   declare markedAsDoneByUser: NonAttribute<UserModel | null>;
 }
@@ -269,7 +270,7 @@ ProjectTodoModel.belongsTo(SpaceModel, {
 });
 
 ProjectTodoModel.belongsTo(UserModel, {
-  foreignKey: { name: "userId", allowNull: false },
+  foreignKey: { name: "userId", allowNull: true },
   onDelete: "RESTRICT",
   as: "user",
 });

--- a/front/migrations/db/migration_619.sql
+++ b/front/migrations/db/migration_619.sql
@@ -1,0 +1,5 @@
+-- Migration created on May 4, 2026
+ALTER TABLE "public"."project_todos"
+    ALTER COLUMN "userId" DROP NOT NULL;
+ALTER TABLE "public"."project_todo_versions"
+    ALTER COLUMN "userId" DROP NOT NULL;


### PR DESCRIPTION
## Description

Makes `userId` nullable on `project_todos` so a TODO can exist without a specific assignee.

- `ProjectTodoModel.userId` becomes `allowNull: true`
- `baseFetch` filters null userIds before resolving assignees
- `buildDeduplicationGroups` skips todos without an assignee
- `upsertSource` guards against being called on an unassigned todo (throws)

## Tests

Existing tests cover the resource; null-userId paths are guarded at the code level.
