### PR TITLE
fix(projects): always show action buttons in Projects sidebar section, and display of "you"

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -701,22 +701,20 @@ export function AgentSidebarMenu({
           open={!isProjectsSectionCollapsed}
           onOpenChange={(open) => setProjectsSectionCollapsed(!open)}
           action={
-            summary.length > 0 ? (
-              <>
-                <Button
-                  size="xs"
-                  icon={PlusIcon}
-                  label="New"
-                  variant="ghost"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setIsCreateProjectModalOpen(true);
-                  }}
-                />
-                <ProjectsBrowsePopover owner={owner} />
-              </>
-            ) : null
+            <>
+              <Button
+                size="xs"
+                icon={PlusIcon}
+                label="New"
+                variant="ghost"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setIsCreateProjectModalOpen(true);
+                }}
+              />
+              <ProjectsBrowsePopover owner={owner} />
+            </>
           }
         >
           {isSummaryLoading ? (

--- a/front/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents.tsx
@@ -7,6 +7,7 @@ import {
 } from "@app/components/assistant/conversation/space/conversations/project_todos/utils";
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import { useUser } from "@app/lib/swr/user";
 import { timeAgoFrom } from "@app/lib/utils";
 import type {
   ProjectTodoActorType,
@@ -14,7 +15,11 @@ import type {
   ProjectTodoType,
 } from "@app/types/project_todo";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
+import type {
+  LightWorkspaceType,
+  SpaceUserType,
+  UserTypeWithWorkspaces,
+} from "@app/types/user";
 import {
   Avatar,
   BookOpenIcon,
@@ -286,7 +291,10 @@ export function AddTodoComposer({
 function formatActorLabel(
   type: ProjectTodoActorType | null,
   agentId: string | null,
-  agentNameById: Map<string, string>
+  userId: string | null,
+
+  agentNameById: Map<string, string>,
+  currentUser: UserTypeWithWorkspaces | null
 ): string {
   if (!type) {
     return "someone";
@@ -299,6 +307,9 @@ function formatActorLabel(
       const name = agentId ? agentNameById.get(agentId) : null;
       return name ? `@${name}` : "an agent";
     case "user":
+      if (userId === currentUser?.sId) {
+        return "you";
+      }
       return "a user";
     default:
       assertNeverAndIgnore(type);
@@ -321,16 +332,22 @@ export function TodoMetadataTooltip({
   agentNameById,
   children,
 }: TodoMetadataTooltipProps) {
+  const { user } = useUser();
+
   const creatorLabel = formatActorLabel(
     todo.createdByType,
     todo.createdByAgentConfigurationId,
-    agentNameById
+    todo.createdByUserId,
+    agentNameById,
+    user
   );
   const doneLabel = todo.markedAsDoneByType
     ? formatActorLabel(
         todo.markedAsDoneByType,
         todo.markedAsDoneByAgentConfigurationId,
-        agentNameById
+        todo.markedAsDoneByUserId,
+        agentNameById,
+        user
       )
     : null;
 

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -46,6 +46,8 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
   static model: ModelStaticWorkspaceAware<ProjectTodoModel> = ProjectTodoModel;
   private readonly assignee: ProjectTodoAssigneeType | null;
   private readonly conversationSId: string | null;
+  private readonly createdByUserSId: string | null;
+  private readonly markedAsDoneByUserSId: string | null;
 
   constructor(
     model: ModelStatic<ProjectTodoModel>,
@@ -53,14 +55,20 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     {
       assignee,
       conversationSId,
+      createdByUserSId,
+      markedAsDoneByUserSId,
     }: {
       assignee?: ProjectTodoAssigneeType | null;
       conversationSId?: string | null;
+      createdByUserSId?: string | null;
+      markedAsDoneByUserSId?: string | null;
     } = {}
   ) {
     super(ProjectTodoModel, blob);
     this.assignee = assignee ?? null;
     this.conversationSId = conversationSId ?? null;
+    this.createdByUserSId = createdByUserSId ?? null;
+    this.markedAsDoneByUserSId = markedAsDoneByUserSId ?? null;
   }
 
   // The stable string identifier for this todo, computed from the model's
@@ -203,10 +211,21 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
 
     const todoModelIds = todos.map((todo) => todo.id);
     const assigneeModelIds = [...new Set(todos.map((todo) => todo.userId))];
+    const actorModelIds = [
+      ...new Set([
+        ...todos
+          .map((todo) => todo.createdByUserId)
+          .filter((id): id is ModelId => id !== null),
+        ...todos
+          .map((todo) => todo.markedAsDoneByUserId)
+          .filter((id): id is ModelId => id !== null),
+      ]),
+    ];
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    const [assignees, conversationRows] = await Promise.all([
+    const [assignees, actors, conversationRows] = await Promise.all([
       UserResource.fetchByModelIds(assigneeModelIds, { transaction }),
+      UserResource.fetchByModelIds(actorModelIds, { transaction }),
       ProjectTodoConversationModel.findAll({
         where: {
           workspaceId,
@@ -236,6 +255,10 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       ])
     );
 
+    const actorSIdByModelId = new Map<ModelId, string>(
+      actors.map((actor) => [actor.id, actor.sId])
+    );
+
     const conversationIdByTodoModelId = new Map<ModelId, string>();
     for (const row of conversationRows) {
       const conversationId = row.conversation?.sId;
@@ -252,6 +275,14 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       return new this(ProjectTodoModel, todo.get(), {
         assignee: assigneeByModelId.get(todo.userId) ?? null,
         conversationSId: conversationIdByTodoModelId.get(todo.id) ?? null,
+        createdByUserSId:
+          todo.createdByUserId !== null
+            ? (actorSIdByModelId.get(todo.createdByUserId) ?? null)
+            : null,
+        markedAsDoneByUserSId:
+          todo.markedAsDoneByUserId !== null
+            ? (actorSIdByModelId.get(todo.markedAsDoneByUserId) ?? null)
+            : null,
       });
     });
   }
@@ -625,9 +656,11 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       agentInstructions: this.agentInstructions,
       createdByType: this.createdByType,
       createdByAgentConfigurationId: this.createdByAgentConfigurationId,
+      createdByUserId: this.createdByUserSId,
       markedAsDoneByType: this.markedAsDoneByType,
       markedAsDoneByAgentConfigurationId:
         this.markedAsDoneByAgentConfigurationId,
+      markedAsDoneByUserId: this.markedAsDoneByUserSId,
       sources: [],
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -50,8 +50,10 @@ export type ProjectTodoType = {
   actorRationale: string | null;
   createdByType: ProjectTodoActorType;
   createdByAgentConfigurationId: string | null;
+  createdByUserId: string | null;
   markedAsDoneByType: ProjectTodoActorType | null;
   markedAsDoneByAgentConfigurationId: string | null;
+  markedAsDoneByUserId: string | null;
   sources: ProjectTodoSourceInfo[];
   createdAt: Date;
   updatedAt: Date;


### PR DESCRIPTION
## Description

Always show the "New" button and browse popover (`...`) in the Projects sidebar section header, regardless of how many projects the user has. Previously these actions were conditionally hidden when `summary.length === 0`, making it impossible to discover or create a first project from the header.

This PR also includes improvements to project actor naming: resolves user `sId` for todo creators and completers, and displays "you" when the current user is the actor.

## Tests

Manually verified that the "New" and "..." buttons appear in the Projects section header when a user has zero projects.

## Risk

Low — UI-only change, no backend impact.

## Deploy Plan

Standard deploy, no special steps required.
