### PR TITLE
feat(sandbox): scaffold sandbox_tool_executions storage

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -12,6 +12,7 @@ import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_vie
 import { AgentProjectConfigurationModel } from "@app/lib/models/agent/actions/projects";
 import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
+import { SandboxToolExecutionModel } from "@app/lib/models/agent/actions/sandbox_tool_execution";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
 import {
   AgentConfigurationModel,
@@ -212,6 +213,7 @@ export function loadAllModels() {
     AgentStepContentModel,
     AgentMCPActionModel,
     AgentMCPActionOutputItemModel,
+    SandboxToolExecutionModel,
     AgentChildAgentConfigurationModel,
     FeatureFlagModel,
     GlobalFeatureFlagModel,

--- a/front/lib/models/agent/actions/sandbox_tool_execution.ts
+++ b/front/lib/models/agent/actions/sandbox_tool_execution.ts
@@ -1,0 +1,97 @@
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
+
+/**
+ * Stores MCP tool executions originating from inside the sandbox that require
+ * user approval. Unlike AgentMCPActionModel, this table has no stepContentId
+ * FK — sandbox tool executions are NOT agent reasoning steps and don't need a
+ * corresponding AgentStepContent record.
+ *
+ * Each row points to the parent `AgentMCPActionModel` (the agent's running
+ * sandbox bash tool) via `agentMCPActionId`, so we can scan blocked children
+ * directly under their parent without going through `agentMessageId`.
+ */
+export class SandboxToolExecutionModel extends WorkspaceAwareModel<SandboxToolExecutionModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
+  declare agentMCPActionId: ForeignKey<AgentMCPActionModel["id"]>;
+  declare status: ToolExecutionStatus;
+  declare mcpServerConfigurationId: string;
+  declare toolConfiguration: LightMCPToolConfigurationType;
+  declare augmentedInputs: Record<string, unknown>;
+}
+
+SandboxToolExecutionModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    mcpServerConfigurationId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    toolConfiguration: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
+    },
+    augmentedInputs: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
+    },
+  },
+  {
+    modelName: "sandbox_tool_execution",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["workspaceId", "agentMessageId", "status"],
+        name: "sandbox_tool_execution_ws_msg_status",
+        concurrently: true,
+      },
+      {
+        fields: ["workspaceId", "agentMCPActionId", "status"],
+        name: "sandbox_tool_execution_ws_action_status",
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+SandboxToolExecutionModel.belongsTo(AgentMessageModel, {
+  foreignKey: { name: "agentMessageId", allowNull: false },
+  as: "agentMessage",
+});
+
+AgentMessageModel.hasMany(SandboxToolExecutionModel, {
+  foreignKey: { name: "agentMessageId", allowNull: false },
+});
+
+SandboxToolExecutionModel.belongsTo(AgentMCPActionModel, {
+  foreignKey: { name: "agentMCPActionId", allowNull: false },
+  as: "agentMCPAction",
+});
+
+AgentMCPActionModel.hasMany(SandboxToolExecutionModel, {
+  foreignKey: { name: "agentMCPActionId", allowNull: false },
+});

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -29,6 +29,7 @@ import {
   AgentMCPActionModel,
   AgentMCPActionOutputItemModel,
 } from "@app/lib/models/agent/actions/mcp";
+import { SandboxToolExecutionModel } from "@app/lib/models/agent/actions/sandbox_tool_execution";
 import {
   AgentMessageModel,
   MessageModel,
@@ -1173,5 +1174,28 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
   get functionCallName(): string {
     return this.stepContent.value.value.name;
+  }
+
+  // Spawns a child sandbox tool execution under this agent action. The child
+  // lives in `sandbox_tool_executions` (separate table to dodge the
+  // `agent_step_contents` unique-index race) but is parented by this row, so
+  // the spawner is an instance method that fills in the FK from `this.id`.
+  // Returns the new execution's sId — read paths land with the approval flow.
+  async spawnChildSandboxToolExecution(
+    blob: Omit<
+      CreationAttributes<SandboxToolExecutionModel>,
+      "workspaceId" | "agentMessageId" | "agentMCPActionId"
+    >
+  ): Promise<string> {
+    const model = await SandboxToolExecutionModel.create({
+      ...blob,
+      workspaceId: this.workspaceId,
+      agentMessageId: this.agentMessageId,
+      agentMCPActionId: this.id,
+    });
+    return makeSId("sandbox_tool_execution", {
+      id: model.id,
+      workspaceId: model.workspaceId,
+    });
   }
 }

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -78,6 +78,7 @@ export const RESOURCES_PREFIX = {
   // Sandboxes.
   sandbox: "sbx",
   sandbox_env_var: "sev",
+  sandbox_tool_execution: "ste",
 
   // Project todos.
   project_todo_state: "pts",

--- a/front/migrations/db/migration_622.sql
+++ b/front/migrations/db/migration_622.sql
@@ -1,0 +1,24 @@
+-- Migration created on May 4, 2026
+-- Create sandbox_tool_executions table for sandbox-originated MCP tool
+-- executions that require user approval. Separates these from agent_mcp_actions
+-- to avoid the race condition on agent_step_contents unique index.
+
+CREATE TABLE IF NOT EXISTS "sandbox_tool_executions"
+(
+    "id"                       BIGSERIAL PRIMARY KEY,
+    "createdAt"                TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"                TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "workspaceId"              BIGINT                   NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "agentMessageId"           BIGINT                   NOT NULL REFERENCES "agent_messages" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "agentMCPActionId"         BIGINT                   NOT NULL REFERENCES "agent_mcp_actions" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "status"                   VARCHAR(255)             NOT NULL,
+    "mcpServerConfigurationId" VARCHAR(255)             NOT NULL,
+    "toolConfiguration"        JSONB                    NOT NULL DEFAULT '{}',
+    "augmentedInputs"          JSONB                    NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX CONCURRENTLY "sandbox_tool_execution_ws_msg_status"
+    ON "sandbox_tool_executions" ("workspaceId", "agentMessageId", "status");
+
+CREATE INDEX CONCURRENTLY "sandbox_tool_execution_ws_action_status"
+    ON "sandbox_tool_executions" ("workspaceId", "agentMCPActionId", "status");


### PR DESCRIPTION
## What

Storage layer for sandbox-originated MCP tool calls. The approval-flow PR will land on top of this, for now, nothing in production reads or writes the new table.

- New `sandbox_mcp_actions` table (migration #618)
- New `SandboxMCPActionModel` Sequelize model
- New `sma` sId prefix

## Why two tables

`agent_mcp_actions` carries regular agent tool calls, each backed by an `agent_step_contents` row with a `(agentMessageId, step, index)` unique index. Sandbox tool calls (e.g. `dsbx tools notion search_docs ...` from a bash command) aren't agent reasoning steps and don't need a step-content row. A separate table also dodges issues with unique-index race when several sandbox tools fire in one bash command.

`AgentMCPActionResource` is the conceptual home for both. The listing/blocked-shape methods (`listBlockedSandboxForAgentMessage`, `findSandboxActionForAgentMessage`) will land later in the approval-flow PR with their FE consumer.

## Tests

- `tsgo --noEmit` clean

## Risk

Worst case, an empty unused table. Nothing in production reads or writes it until the approval flow lands. Safe to rollback (drop the table).

## Deploy Plan

Apply migration 619 and deploy front