### PR TITLE
Add file preview dialog to the conversation file explorer

### DIFF
--- a/front/components/assistant/conversation/files_panel/FileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorer.tsx
@@ -5,10 +5,10 @@ import {
   FileExplorerFolderCard,
   type ViewMode,
 } from "@app/components/assistant/conversation/files_panel/FileExplorerItem";
+import { FilePreviewDialog } from "@app/components/assistant/conversation/files_panel/FilePreviewDialog";
 import { SandboxStatusChip } from "@app/components/assistant/conversation/files_panel/SandboxStatusChip";
 import type { SandboxTreeNode } from "@app/components/assistant/conversation/files_panel/types";
 import { buildSandboxTree } from "@app/components/assistant/conversation/files_panel/utils";
-import { FilePreviewDialog } from "@app/components/assistant/conversation/files_panel/FilePreviewDialog";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useSendNotification } from "@app/hooks/useNotification";

--- a/front/components/assistant/conversation/files_panel/FileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorer.tsx
@@ -8,10 +8,7 @@ import {
 import { SandboxStatusChip } from "@app/components/assistant/conversation/files_panel/SandboxStatusChip";
 import type { SandboxTreeNode } from "@app/components/assistant/conversation/files_panel/types";
 import { buildSandboxTree } from "@app/components/assistant/conversation/files_panel/utils";
-import {
-  FilePreviewSheet,
-  type MinimalFileForPreview,
-} from "@app/components/spaces/FilePreviewSheet";
+import { FilePreviewDialog } from "@app/components/assistant/conversation/files_panel/FilePreviewDialog";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -110,7 +107,7 @@ export function NewFileExplorer({
   const sendNotification = useSendNotification();
   const [folderStack, setFolderStack] = useState<SandboxTreeNode[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
-  const [previewFile, setPreviewFile] = useState<MinimalFileForPreview | null>(
+  const [previewFile, setPreviewFile] = useState<GCSMountFileEntry | null>(
     null
   );
   const [showPreviewSheet, setShowPreviewSheet] = useState(false);
@@ -187,17 +184,10 @@ export function NewFileExplorer({
 
   const handleOpen = useCallback(
     (entry: GCSMountFileEntry) => {
-      if (!entry.fileId) {
-        return;
-      }
-      if (isInteractiveContentType(entry.contentType)) {
+      if (isInteractiveContentType(entry.contentType) && entry.fileId) {
         openPanel({ type: "interactive_content", fileId: entry.fileId });
       } else {
-        setPreviewFile({
-          sId: entry.fileId,
-          fileName: entry.fileName,
-          contentType: entry.contentType,
-        });
+        setPreviewFile(entry);
         setShowPreviewSheet(true);
       }
     },
@@ -334,11 +324,13 @@ export function NewFileExplorer({
         </div>
       </div>
 
-      <FilePreviewSheet
+      <FilePreviewDialog
         owner={owner}
-        file={previewFile}
+        entry={previewFile}
+        conversationId={conversation.sId}
         isOpen={showPreviewSheet}
         onOpenChange={setShowPreviewSheet}
+        onDownload={handleDownload}
       />
     </>
   );

--- a/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
@@ -27,7 +27,7 @@ import {
   Spinner,
   cn,
 } from "@dust-tt/sparkle";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
 
 const MAX_CSV_ROWS = 200;
 const MAX_TEXT_CHARS = 100_000;
@@ -128,15 +128,14 @@ function DelimitedPreview({ content, mimeType }: DelimitedPreviewProps) {
   );
   const displayed = allRows.slice(0, MAX_CSV_ROWS);
 
+  type Row = Record<string, string>;
+
   const baseRatio = Math.floor(100 / headers.length);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const columns: ColumnDef<any>[] = headers.map((header, idx) => ({
+  const columns: ColumnDef<Row>[] = headers.map((header, idx) => ({
     id: header,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    accessorFn: (row: any) => row[header] ?? "",
+    accessorFn: (row: Row) => row[header] ?? "",
     header,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    cell: (info: any) => (
+    cell: (info: CellContext<Row, unknown>) => (
       <DataTable.BasicCellContent label={String(info.getValue() ?? "")} />
     ),
     meta: {
@@ -148,8 +147,7 @@ function DelimitedPreview({ content, mimeType }: DelimitedPreviewProps) {
     },
   }));
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const data: any[] = displayed.map((row) =>
+  const data: Row[] = displayed.map((row) =>
     Object.fromEntries(headers.map((h, i) => [h, row[i] ?? ""]))
   );
 

--- a/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
@@ -13,6 +13,7 @@ import {
   ArrowDownOnSquareIcon,
   Button,
   CodeBlock,
+  cn,
   DataTable,
   Dialog,
   DialogContent,
@@ -22,10 +23,9 @@ import {
   Icon,
   Markdown,
   ScrollArea,
-  ScrollBar,
   ScrollableDataTable,
+  ScrollBar,
   Spinner,
-  cn,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 
@@ -34,9 +34,15 @@ const MAX_TEXT_CHARS = 100_000;
 
 function getConversationFileUrl(
   owner: LightWorkspaceType,
-  conversationId: string,
-  filePath: string
+  {
+    conversationId,
+    filePath,
+  }: {
+    conversationId: string;
+    filePath: string;
+  }
 ): string {
+  // TODO(20260504 FILE SYSTEM): Align endpoint so it accepts the scoped version.
   // entry.path is scoped (e.g. "conversation/notes.txt") but [...rel].ts
   // expects the path relative to the conversation's /files/ base, so strip the scope prefix.
   // Use an absolute URL so iframe/audio src attributes resolve against the API origin, not the
@@ -104,6 +110,8 @@ interface DelimitedPreviewProps {
   mimeType: string;
 }
 
+type Row = Record<string, string>;
+
 function DelimitedPreview({ content, mimeType }: DelimitedPreviewProps) {
   const isTsv =
     mimeType === "text/tsv" || mimeType === "text/tab-separated-values";
@@ -127,8 +135,6 @@ function DelimitedPreview({ content, mimeType }: DelimitedPreviewProps) {
     line.split(delimiter).map((c) => c.trim().replace(/^"|"$/g, ""))
   );
   const displayed = allRows.slice(0, MAX_CSV_ROWS);
-
-  type Row = Record<string, string>;
 
   const baseRatio = Math.floor(100 / headers.length);
   const columns: ColumnDef<Row>[] = headers.map((header, idx) => ({
@@ -177,7 +183,10 @@ function FilePreviewDialogContent({
   owner,
   processedContent,
 }: FilePreviewDialogContentProps) {
-  const fileUrl = getConversationFileUrl(owner, conversationId, entry.path);
+  const fileUrl = getConversationFileUrl(owner, {
+    conversationId,
+    filePath: entry.path,
+  });
 
   if (isContentLoading) {
     return (

--- a/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
@@ -1,0 +1,420 @@
+import { getFilePreviewConfig } from "@app/components/spaces/FilePreviewSheet";
+import { useConversationFileContent } from "@app/hooks/conversations/useConversationFileContent";
+import config from "@app/lib/api/config";
+import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
+import type { ProcessedContent } from "@app/lib/file_content_utils";
+import { processFileContent } from "@app/lib/file_content_utils";
+import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
+import { stripMimeParameters } from "@app/types/files";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ArrowDownOnSquareIcon,
+  Button,
+  CodeBlock,
+  DataTable,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Icon,
+  Markdown,
+  ScrollArea,
+  ScrollBar,
+  ScrollableDataTable,
+  Spinner,
+  cn,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+
+const MAX_CSV_ROWS = 200;
+const MAX_TEXT_CHARS = 100_000;
+
+function getConversationFileUrl(
+  owner: LightWorkspaceType,
+  conversationId: string,
+  filePath: string
+): string {
+  // entry.path is scoped (e.g. "conversation/notes.txt") but [...rel].ts
+  // expects the path relative to the conversation's /files/ base, so strip the scope prefix.
+  // Use an absolute URL so iframe/audio src attributes resolve against the API origin, not the
+  // browser's current origin.
+  const scoped = parseScopedFilePath(filePath);
+  const rel = scoped ? scoped.rel : filePath;
+
+  return `${config.getClientFacingUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${rel}`;
+}
+
+const EXTENSION_TO_LANGUAGE: Record<string, string> = {
+  py: "python",
+  js: "javascript",
+  jsx: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  json: "json",
+  sh: "bash",
+  bash: "bash",
+  html: "html",
+  css: "css",
+  sql: "sql",
+  yaml: "yaml",
+  yml: "yaml",
+  rs: "rust",
+  go: "go",
+  rb: "ruby",
+  java: "java",
+  kt: "kotlin",
+  swift: "swift",
+  cpp: "cpp",
+  c: "c",
+  cs: "csharp",
+  php: "php",
+  r: "r",
+  md: "markdown",
+  xml: "xml",
+  toml: "toml",
+};
+
+function getCodeLanguage(fileName: string): string {
+  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+
+  return EXTENSION_TO_LANGUAGE[ext] ?? "text";
+}
+
+function getDelimitedRecordCount({
+  content,
+}: {
+  content: string;
+}): { displayed: number; total: number } | null {
+  const lines = content.split("\n").filter((l) => l.trim());
+  if (lines.length < 2) {
+    return null;
+  }
+
+  const [, ...dataLines] = lines;
+  const total = dataLines.length;
+
+  return { displayed: Math.min(total, MAX_CSV_ROWS), total };
+}
+
+interface DelimitedPreviewProps {
+  content: string;
+  mimeType: string;
+}
+
+function DelimitedPreview({ content, mimeType }: DelimitedPreviewProps) {
+  const isTsv =
+    mimeType === "text/tsv" || mimeType === "text/tab-separated-values";
+
+  const delimiter = isTsv ? "\t" : ",";
+  const lines = content.split("\n").filter((l) => l.trim());
+
+  if (lines.length < 2) {
+    return (
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        No data to preview.
+      </p>
+    );
+  }
+
+  const [headerLine, ...dataLines] = lines;
+  const headers = headerLine!
+    .split(delimiter)
+    .map((c) => c.trim().replace(/^"|"$/g, ""));
+  const allRows = dataLines.map((line) =>
+    line.split(delimiter).map((c) => c.trim().replace(/^"|"$/g, ""))
+  );
+  const displayed = allRows.slice(0, MAX_CSV_ROWS);
+
+  const baseRatio = Math.floor(100 / headers.length);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const columns: ColumnDef<any>[] = headers.map((header, idx) => ({
+    id: header,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    accessorFn: (row: any) => row[header] ?? "",
+    header,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    cell: (info: any) => (
+      <DataTable.BasicCellContent label={String(info.getValue() ?? "")} />
+    ),
+    meta: {
+      // Last column absorbs rounding remainder so ratios always sum to 100.
+      sizeRatio:
+        idx < headers.length - 1
+          ? baseRatio
+          : 100 - baseRatio * (headers.length - 1),
+    },
+  }));
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: any[] = displayed.map((row) =>
+    Object.fromEntries(headers.map((h, i) => [h, row[i] ?? ""]))
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <ScrollableDataTable data={data} columns={columns} maxHeight={true} />
+    </div>
+  );
+}
+
+interface FilePreviewDialogContentProps {
+  category: ReturnType<typeof getFilePreviewConfig>["category"];
+  conversationId: string;
+  entry: GCSMountFileEntry;
+  fileContent: string | null;
+  isContentLoading: boolean;
+  owner: LightWorkspaceType;
+  processedContent: ProcessedContent | null;
+}
+
+function FilePreviewDialogContent({
+  category,
+  conversationId,
+  entry,
+  fileContent,
+  isContentLoading,
+  owner,
+  processedContent,
+}: FilePreviewDialogContentProps) {
+  const fileUrl = getConversationFileUrl(owner, conversationId, entry.path);
+
+  if (isContentLoading) {
+    return (
+      <div className="flex h-48 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  switch (category) {
+    case "frame":
+      return null;
+
+    case "image":
+      return (
+        <img
+          src={entry.thumbnailUrl ?? fileUrl}
+          alt={entry.fileName}
+          className="w-full rounded-lg object-contain"
+        />
+      );
+
+    case "pdf":
+      return (
+        <iframe
+          src={`${fileUrl}#navpanes=0`}
+          className="h-[70vh] w-full rounded-lg border-0"
+          title={entry.fileName}
+        />
+      );
+
+    case "viewer":
+      // TODO(20260504 FILE_SYSTEM): add Office viewer preview support.
+      return (
+        <div className="flex h-48 items-center justify-center">
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Cannot preview this file type. You can download it instead.
+          </p>
+        </div>
+      );
+
+    case "audio":
+      return (
+        <div className="flex flex-col gap-4">
+          <audio controls className="w-full" src={fileUrl}>
+            Your browser does not support the audio element.
+          </audio>
+        </div>
+      );
+
+    case "delimited":
+      if (fileContent) {
+        return (
+          <DelimitedPreview
+            content={fileContent.slice(0, MAX_TEXT_CHARS)}
+            mimeType={stripMimeParameters(entry.contentType)}
+          />
+        );
+      }
+      return null;
+
+    case "markdown":
+    case "text":
+      if (processedContent) {
+        return (
+          <div className="rounded-lg bg-muted-background p-4 dark:bg-muted-background-night">
+            <Markdown content={processedContent.text} isStreaming={false} />
+          </div>
+        );
+      }
+      return null;
+
+    case "code": {
+      const lang = getCodeLanguage(entry.fileName);
+      const raw = fileContent?.slice(0, MAX_TEXT_CHARS) ?? "";
+      let displayContent = raw;
+      if (lang === "json") {
+        try {
+          displayContent = JSON.stringify(JSON.parse(raw), null, 2);
+        } catch {
+          // keep raw if not valid JSON
+        }
+      }
+      return (
+        <div className="rounded-lg bg-muted-background dark:bg-muted-background-night">
+          <CodeBlock className={`language-${lang}`} wrapLongLines={true}>
+            {displayContent}
+          </CodeBlock>
+        </div>
+      );
+    }
+
+    default:
+      assertNeverAndIgnore(category);
+      return null;
+  }
+}
+
+interface FilePreviewDialogProps {
+  conversationId: string;
+  entry: GCSMountFileEntry | null;
+  isOpen: boolean;
+  onDownload: (entry: GCSMountFileEntry) => void;
+  onOpenChange: (open: boolean) => void;
+  owner: LightWorkspaceType;
+}
+
+export function FilePreviewDialog({
+  entry,
+  conversationId,
+  isOpen,
+  onOpenChange,
+  owner,
+  onDownload,
+}: FilePreviewDialogProps) {
+  const mimeType = stripMimeParameters(entry?.contentType ?? "");
+  const { category } = getFilePreviewConfig(mimeType);
+
+  const needsTextContent =
+    category === "code" ||
+    category === "markdown" ||
+    category === "text" ||
+    category === "delimited";
+
+  const { fileContent, isFileContentLoading, fileContentError } =
+    useConversationFileContent({
+      owner,
+      conversationId,
+      filePath: entry?.path ?? null,
+      disabled: !isOpen || !entry || !needsTextContent,
+    });
+
+  const hasError = needsTextContent && !!fileContentError;
+  const isContentLoading =
+    isOpen && !!entry && !hasError && needsTextContent && isFileContentLoading;
+
+  const truncatedContent = fileContent?.slice(0, MAX_TEXT_CHARS) ?? null;
+
+  const processedContent =
+    (category === "markdown" || category === "text") && truncatedContent
+      ? processFileContent(truncatedContent, mimeType)
+      : null;
+
+  const FileIcon = entry
+    ? getFileTypeIcon(entry.contentType, entry.fileName)
+    : null;
+
+  const recordCounts =
+    category === "delimited" && truncatedContent
+      ? getDelimitedRecordCount({ content: truncatedContent })
+      : null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent size="xl" height="xl" className="gap-4">
+        <DialogHeader className="flex gap-4">
+          <DialogTitle>Preview Data</DialogTitle>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5 overflow-hidden">
+              {FileIcon && (
+                <Icon
+                  visual={FileIcon}
+                  size="xs"
+                  className="shrink-0 text-foreground dark:text-foreground-night"
+                />
+              )}
+              <span
+                className={cn(
+                  "line-clamp-1 text-sm font-medium leading-5",
+                  "text-foreground dark:text-foreground-night"
+                )}
+              >
+                {entry?.fileName ?? ""}
+              </span>
+            </div>
+            {recordCounts && (
+              <span
+                className={cn(
+                  "line-clamp-1 shrink-0 text-xs font-normal leading-4",
+                  "text-muted-foreground dark:text-muted-foreground-night"
+                )}
+              >
+                Showing {recordCounts.displayed} of {recordCounts.total} records
+                {recordCounts.total > MAX_CSV_ROWS && " (truncated)"}
+              </span>
+            )}
+          </div>
+        </DialogHeader>
+        {hasError ? (
+          <div className="flex h-48 items-center justify-center px-4">
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Unable to preview this file. You can download it instead.
+            </p>
+          </div>
+        ) : category === "delimited" ? (
+          <div className="flex min-h-0 flex-1 flex-col px-4">
+            {entry && (
+              <FilePreviewDialogContent
+                category={category}
+                conversationId={conversationId}
+                entry={entry}
+                fileContent={truncatedContent}
+                isContentLoading={isContentLoading}
+                owner={owner}
+                processedContent={processedContent}
+              />
+            )}
+          </div>
+        ) : (
+          <ScrollArea className="min-h-0 flex-1 overflow-x-hidden px-4">
+            {entry && (
+              <FilePreviewDialogContent
+                category={category}
+                conversationId={conversationId}
+                entry={entry}
+                fileContent={truncatedContent}
+                isContentLoading={isContentLoading}
+                owner={owner}
+                processedContent={processedContent}
+              />
+            )}
+            <ScrollBar />
+          </ScrollArea>
+        )}
+        <DialogFooter className="px-4">
+          <Button
+            variant="outline"
+            size="sm"
+            icon={ArrowDownOnSquareIcon}
+            label="Download"
+            onClick={() => entry && onDownload(entry)}
+            disabled={!entry}
+          />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/spaces/FilePreviewSheet.tsx
+++ b/front/components/spaces/FilePreviewSheet.tsx
@@ -302,6 +302,7 @@ interface FilePreviewSheetProps {
   onOpenChange: (open: boolean) => void;
 }
 
+// TODO(20260504 FILE SYSTEM) Replace this with FilePreviewDialog.
 export function FilePreviewSheet({
   file,
   owner,

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -23,6 +23,7 @@ export {
   useAddDeleteConversationSkill,
   useConversationSkills,
 } from "./useConversationSkills";
+export { useConversationFileContent } from "./useConversationFileContent";
 export { useConversations } from "./useConversations";
 export {
   useAddDeleteConversationTool,

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -7,6 +7,7 @@ export { useConversation } from "./useConversation";
 export { useConversationBranchActions } from "./useConversationBranchActions";
 export { useConversationContextUsage } from "./useConversationContextUsage";
 export { useConversationFeedbacks } from "./useConversationFeedbacks";
+export { useConversationFileContent } from "./useConversationFileContent";
 export { useConversationMarkAsRead } from "./useConversationMarkAsRead";
 export {
   useConversationMessage,
@@ -23,7 +24,6 @@ export {
   useAddDeleteConversationSkill,
   useConversationSkills,
 } from "./useConversationSkills";
-export { useConversationFileContent } from "./useConversationFileContent";
 export { useConversations } from "./useConversations";
 export {
   useAddDeleteConversationTool,

--- a/front/hooks/conversations/useConversationFileContent.ts
+++ b/front/hooks/conversations/useConversationFileContent.ts
@@ -1,8 +1,8 @@
 import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import { clientFetch } from "@app/lib/egress/client";
 import { useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { LightWorkspaceType } from "@app/types/user";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
 
 export function useConversationFileContent({
   owner,

--- a/front/hooks/conversations/useConversationFileContent.ts
+++ b/front/hooks/conversations/useConversationFileContent.ts
@@ -1,0 +1,42 @@
+import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
+import { clientFetch } from "@app/lib/egress/client";
+import { useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { LightWorkspaceType } from "@app/types/user";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export function useConversationFileContent({
+  owner,
+  conversationId,
+  filePath,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  conversationId: string;
+  filePath: string | null;
+  disabled?: boolean;
+}) {
+  const isDisabled = disabled || !filePath;
+  const scoped = filePath ? parseScopedFilePath(filePath) : null;
+  const rel = scoped ? scoped.rel : filePath;
+  const url = rel
+    ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${rel}`
+    : null;
+
+  const { data, error } = useSWRWithDefaults<string | null, string>(
+    url,
+    async (u: string) => {
+      const response = await clientFetch(u);
+      if (!response.ok) {
+        throw new Error("Failed to fetch file content");
+      }
+      return response.text();
+    },
+    { disabled: isDisabled }
+  );
+
+  return {
+    fileContent: data ?? null,
+    isFileContentLoading: !error && data === undefined && !isDisabled,
+    fileContentError: error ? normalizeError(error) : null,
+  };
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See Design [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=5649-52532&m=dev).

Clicking a file in the file explorer now opens a preview dialog instead of doing nothing.

Images show inline, PDFs load in an embedded viewer, audio files get a player, CSV and TSV files render as a scrollable table with a record count, and code files get syntax highlighting with JSON pretty-printing. Text and markdown files render normally. For file types we can't preview yet, there's a download button as fallback.

This will replace the existing `FilePreviewSheet` once it supports more content type.

<img width="1958" height="1480" alt="FilePreview" src="https://github.com/user-attachments/assets/8cbb523f-3a66-49c1-a524-47811d916131" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
