### PR TITLE
Stop inlining file attachments in conversation history when `new_file_explorer` FF is ON

### DIFF
--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -24,6 +24,7 @@ import {
 import { getConversationDataSourceViews } from "@app/lib/api/assistant/jit/utils";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
   CONTENT_OUTDATED_MSG,
@@ -88,7 +89,16 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
     }
 
     const conversation = agentLoopContext.runContext.conversation;
-    const attachments = await listAttachments(auth, { conversation });
+    const allAttachments = await listAttachments(auth, { conversation });
+
+    // When new_file_explorer is on, files are surfaced via the `files` server.
+    // Only list content nodes and queryable attachments (tables) here.
+    const isNewFileExplorer = await hasFeatureFlag(auth, "new_file_explorer");
+    const attachments = isNewFileExplorer
+      ? allAttachments.filter(
+          (a) => isContentNodeAttachmentType(a) || a.isQueryable
+        )
+      : allAttachments;
 
     if (attachments.length === 0) {
       return new Ok([

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -18,9 +18,7 @@ import {
   CONVERSATION_FILES_SERVER_NAME,
   CONVERSATION_SEARCH_FILES_ACTION_NAME,
 } from "@app/lib/api/actions/servers/conversation_files/metadata";
-import {
-  FILES_SERVER_NAME,
-} from "@app/lib/api/actions/servers/files/metadata";
+import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/global_agents";
 import type { EnabledSkill } from "@app/lib/api/assistant/skills_rendering";

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -18,6 +18,9 @@ import {
   CONVERSATION_FILES_SERVER_NAME,
   CONVERSATION_SEARCH_FILES_ACTION_NAME,
 } from "@app/lib/api/actions/servers/conversation_files/metadata";
+import {
+  FILES_SERVER_NAME,
+} from "@app/lib/api/actions/servers/files/metadata";
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/global_agents";
 import type { EnabledSkill } from "@app/lib/api/assistant/skills_rendering";
@@ -333,6 +336,7 @@ function constructSkillsSection({
   return skillsSection;
 }
 
+// TODO(20260504 FILE SYSTEM): Remove in favor of constructAttachmentsSectionNewFileExplorer.
 function constructAttachmentsSection(): string {
   return (
     "# ATTACHMENTS\n" +
@@ -345,6 +349,17 @@ function constructAttachmentsSection(): string {
     `- isSearchable: attachment contents are available for semantic search, i.e. when semantically searching conversation files' content, using \`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_SEARCH_FILES_ACTION_NAME)}\`,` +
     " contents of this attachment will be considered in the search.\n" +
     "Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files' types to decide which tool to use on which file.\n"
+  );
+}
+
+function constructAttachmentsSectionNewFileExplorer(): string {
+  return (
+    "# FILES\n" +
+    `Files attached to the conversation are accessible via the \`${FILES_SERVER_NAME}\` server.\n\n` +
+    "Some attachments remain visible in the conversation history as metadata tags:\n\n" +
+    "- Tabular files (CSV, spreadsheets) are queryable via the query tables tool;\n" +
+    "- Connected data references (content nodes with a `nodeId` and `sourceUrl`) appear as `<attachment>` tags; use the available search and retrieval tools to access their full content.\n\n" +
+    "Pasted content appears inline in `<pastedContent>` tags and already contains the full text, no tool call needed.\n"
   );
 }
 
@@ -466,6 +481,7 @@ export function constructPromptMultiActions(
     userContext,
     workspaceContext,
     projectContext,
+    isNewFileExplorer = false,
   }: {
     userMessage: UserMessageType;
     agentConfiguration: AgentConfigurationType;
@@ -485,6 +501,7 @@ export function constructPromptMultiActions(
     userContext?: string;
     workspaceContext?: string;
     projectContext?: string;
+    isNewFileExplorer?: boolean;
   }
 ): SystemPromptSections {
   const owner = auth.workspace();
@@ -529,7 +546,9 @@ export function constructPromptMultiActions(
         enabledSkills,
         equippedSkills,
       });
-  const attachmentsSection = constructAttachmentsSection();
+  const attachmentsSection = isNewFileExplorer
+    ? constructAttachmentsSectionNewFileExplorer()
+    : constructAttachmentsSection();
   const pastedContentSection = constructPastedContentSection();
   const guidelinesSection = constructGuidelinesSection({ agentConfiguration });
 

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -157,24 +157,32 @@ describe("renderLightContentFragmentForModel", () => {
       await FeatureFlagFactory.basic(authenticator, "new_file_explorer");
     });
 
-    it("skips a regular file attachment", async () => {
+    it("renders a slim file reference for a regular file attachment", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("application/pdf"),
         model,
         { excludeImages: false }
       );
-      expect(result).toBeNull();
+      expect(result).not.toBeNull();
+      expect(result?.content[0]).toMatchObject({
+        type: "text",
+        text: `<file name="file" path="conversation/file"/>`,
+      });
     });
 
-    it("skips a plain text file attachment", async () => {
+    it("renders a slim file reference for a plain text file attachment", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("text/plain"),
         model,
         { excludeImages: false }
       );
-      expect(result).toBeNull();
+      expect(result).not.toBeNull();
+      expect(result?.content[0]).toMatchObject({
+        type: "text",
+        text: `<file name="file" path="conversation/file"/>`,
+      });
     });
 
     it("still renders a queryable file attachment (CSV)", async () => {

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -1,4 +1,4 @@
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -111,7 +111,10 @@ describe("renderLightContentFragmentForModel", () => {
     it("renders a queryable file attachment (CSV)", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
-        makeFileFragment("text/csv", { generatedTables: ["table_1"], snippet: "" }),
+        makeFileFragment("text/csv", {
+          generatedTables: ["table_1"],
+          snippet: "",
+        }),
         model,
         { excludeImages: false }
       );
@@ -177,7 +180,10 @@ describe("renderLightContentFragmentForModel", () => {
     it("still renders a queryable file attachment (CSV)", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
-        makeFileFragment("text/csv", { generatedTables: ["table_1"], snippet: "" }),
+        makeFileFragment("text/csv", {
+          generatedTables: ["table_1"],
+          snippet: "",
+        }),
         model,
         { excludeImages: false }
       );

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -157,7 +157,7 @@ describe("renderLightContentFragmentForModel", () => {
       await FeatureFlagFactory.basic(authenticator, "new_file_explorer");
     });
 
-    it("renders a slim file reference for a regular file attachment", async () => {
+    it("renders a slim file reference without snippet", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("application/pdf"),
@@ -171,17 +171,17 @@ describe("renderLightContentFragmentForModel", () => {
       });
     });
 
-    it("renders a slim file reference for a plain text file attachment", async () => {
+    it("renders a slim file reference with snippet when available", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
-        makeFileFragment("text/plain"),
+        makeFileFragment("text/plain", { snippet: "First 256 chars..." }),
         model,
         { excludeImages: false }
       );
       expect(result).not.toBeNull();
       expect(result?.content[0]).toMatchObject({
         type: "text",
-        text: `<file name="file" path="conversation/file"/>`,
+        text: `<file name="file" path="conversation/file">First 256 chars...\n</file>`,
       });
     });
 

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -1,0 +1,217 @@
+import { Authenticator } from "@app/lib/auth";
+import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
+import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type {
+  ContentNodeContentFragmentType,
+  FileContentFragmentType,
+  SupportedContentFragmentType,
+} from "@app/types/content_fragment";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const BASE_CONTEXT = {
+  username: "user",
+  fullName: null,
+  email: null,
+  profilePictureUrl: null,
+};
+
+function makeFileFragment(
+  contentType: SupportedContentFragmentType,
+  {
+    generatedTables = [],
+    snippet = null,
+  }: {
+    generatedTables?: string[];
+    snippet?: string | null;
+  } = {}
+): FileContentFragmentType {
+  return {
+    type: "content_fragment",
+    id: 1,
+    sId: "cf_1",
+    created: Date.now(),
+    visibility: "visible",
+    version: 1,
+    rank: 0,
+    branchId: null,
+    sourceUrl: null,
+    title: "file",
+    contentType,
+    context: BASE_CONTEXT,
+    contentFragmentId: "cf_sId_1",
+    contentFragmentVersion: "latest",
+    expiredReason: null,
+    contentFragmentType: "file",
+    fileId: "fil_abc123",
+    snippet,
+    generatedTables,
+    textUrl: "https://example.com/file",
+    textBytes: null,
+    sourceProvider: null,
+    sourceIcon: null,
+    isInProjectContext: false,
+    hidden: false,
+  };
+}
+
+function makeContentNodeFragment(): ContentNodeContentFragmentType {
+  return {
+    type: "content_fragment",
+    id: 1,
+    sId: "cf_1",
+    created: Date.now(),
+    visibility: "visible",
+    version: 1,
+    rank: 0,
+    branchId: null,
+    sourceUrl: null,
+    title: "Notion page",
+    contentType: "text/plain",
+    context: BASE_CONTEXT,
+    contentFragmentId: "cf_sId_1",
+    contentFragmentVersion: "latest",
+    expiredReason: null,
+    contentFragmentType: "content_node",
+    nodeId: "node_1",
+    nodeDataSourceViewId: "dsv_1",
+    nodeType: "document",
+    contentNodeData: {
+      nodeId: "node_1",
+      nodeDataSourceViewId: "dsv_1",
+      nodeType: "document",
+      provider: null,
+      spaceName: "test",
+    },
+  };
+}
+
+const model = getSupportedModelConfigs().find((m) => m.supportsVision)!;
+
+describe("renderLightContentFragmentForModel", () => {
+  let authenticator: Authenticator;
+
+  beforeEach(async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    authenticator = auth;
+  });
+
+  describe("new_file_explorer FF off", () => {
+    it("renders a regular file attachment", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("application/pdf"),
+        model,
+        { excludeImages: false }
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it("renders a queryable file attachment (CSV)", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("text/csv", { generatedTables: ["table_1"], snippet: "" }),
+        model,
+        { excludeImages: false }
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it("renders pasted content", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("text/vnd.dust.attachment.pasted"),
+        model,
+        { excludeImages: false }
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it("renders an image", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("image/png"),
+        model,
+        { excludeImages: true }
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it("renders a content node", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeContentNodeFragment(),
+        model,
+        { excludeImages: false }
+      );
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("new_file_explorer FF on", () => {
+    beforeEach(async () => {
+      await FeatureFlagFactory.basic(authenticator, "new_file_explorer");
+    });
+
+    it("skips a regular file attachment", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("application/pdf"),
+        model,
+        { excludeImages: false }
+      );
+      expect(result).toBeNull();
+    });
+
+    it("skips a plain text file attachment", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("text/plain"),
+        model,
+        { excludeImages: false }
+      );
+      expect(result).toBeNull();
+    });
+
+    it("still renders a queryable file attachment (CSV)", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("text/csv", { generatedTables: ["table_1"], snippet: "" }),
+        model,
+        { excludeImages: false }
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it("still renders pasted content", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("text/vnd.dust.attachment.pasted"),
+        model,
+        { excludeImages: false }
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it("still renders an image", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("image/png"),
+        model,
+        { excludeImages: true }
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it("still renders a content node", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeContentNodeFragment(),
+        model,
+        { excludeImages: false }
+      );
+      expect(result).not.toBeNull();
+    });
+  });
+});

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -13,6 +13,7 @@ import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { MessageModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -1194,6 +1195,22 @@ export async function renderLightContentFragmentForModel(
   // Get fileId directly from the message based on content fragment type.
   const fileStringId =
     message.contentFragmentType === "file" ? message.fileId : null;
+
+  // When new_file_explorer is on, regular file attachments are accessible via the `files` server
+  // (path-based). Don't inline them in conversation history. Exceptions: pasted content (inlined
+  // by design), images (shown directly to vision models), and queryable tables (needed for
+  // query_tables_v2 which is pre-wired at JIT time).
+  if (
+    fileStringId &&
+    !isPastedFile(contentType) &&
+    !isLLMVisionSupportedImageContentType(contentType) &&
+    !attachment.isQueryable
+  ) {
+    const isNewFileExplorer = await hasFeatureFlag(auth, "new_file_explorer");
+    if (isNewFileExplorer) {
+      return null;
+    }
+  }
 
   // Check if this is pasted content - render with simplified format
   if (fileStringId && isPastedFile(contentType)) {

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -1196,20 +1196,21 @@ export async function renderLightContentFragmentForModel(
   const fileStringId =
     message.contentFragmentType === "file" ? message.fileId : null;
 
+  const isNewFileExplorer = fileStringId
+    ? await hasFeatureFlag(auth, "new_file_explorer")
+    : false;
+
   // When new_file_explorer is on, regular file attachments are accessible via the `files` server
   // (path-based). Don't inline them in conversation history. Exceptions: pasted content (inlined
   // by design), images (shown directly to vision models), and queryable tables (needed for
   // query_tables_v2 which is pre-wired at JIT time).
   if (
-    fileStringId &&
+    isNewFileExplorer &&
     !isPastedFile(contentType) &&
     !isLLMVisionSupportedImageContentType(contentType) &&
     !attachment.isQueryable
   ) {
-    const isNewFileExplorer = await hasFeatureFlag(auth, "new_file_explorer");
-    if (isNewFileExplorer) {
-      return null;
-    }
+    return null;
   }
 
   // Check if this is pasted content - render with simplified format
@@ -1270,12 +1271,14 @@ export async function renderLightContentFragmentForModel(
             url: signedUrl,
           },
         },
-        {
-          type: "text",
-          text: renderAttachmentXml({
-            attachment,
-          }),
-        },
+        ...(isNewFileExplorer
+          ? []
+          : [
+              {
+                type: "text" as const,
+                text: renderAttachmentXml({ attachment }),
+              },
+            ]),
       ],
     };
   }

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -6,11 +6,13 @@ import type {
 import {
   conversationAttachmentId,
   getAttachmentFromContentFragment,
+  isContentNodeAttachmentType,
   renderAttachmentXml,
   renderLargePasteXml,
 } from "@app/lib/api/assistant/conversation/attachments";
 import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
+
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
@@ -1201,16 +1203,27 @@ export async function renderLightContentFragmentForModel(
     : false;
 
   // When new_file_explorer is on, regular file attachments are accessible via the `files` server
-  // (path-based). Don't inline them in conversation history. Exceptions: pasted content (inlined
-  // by design), images (shown directly to vision models), and queryable tables (needed for
+  // (path-based). Don't inline them in conversation history, instead emit a slim notice so the
+  // model knows the file exists and how to reach it. Exceptions: pasted content (inlined by
+  // design), images (shown directly to vision models), queryable tables (needed for
   // query_tables_v2 which is pre-wired at JIT time).
   if (
     isNewFileExplorer &&
     !isPastedFile(contentType) &&
     !isLLMVisionSupportedImageContentType(contentType) &&
-    !attachment.isQueryable
+    !attachment.isQueryable &&
+    !isContentNodeAttachmentType(attachment)
   ) {
-    return null;
+    return {
+      role: "content_fragment",
+      name: `attach_${contentType}`,
+      content: [
+        {
+          type: "text",
+          text: `<file name="${attachment.title}" path="conversation/${attachment.title}"/>`,
+        },
+      ],
+    };
   }
 
   // Check if this is pasted content - render with simplified format

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -1214,15 +1214,14 @@ export async function renderLightContentFragmentForModel(
     !attachment.isQueryable &&
     !isContentNodeAttachmentType(attachment)
   ) {
+    const snippet = attachment.snippet;
+    const fileTag = snippet
+      ? `<file name="${attachment.title}" path="conversation/${attachment.title}">${snippet}\n</file>`
+      : `<file name="${attachment.title}" path="conversation/${attachment.title}"/>`;
     return {
       role: "content_fragment",
       name: `attach_${contentType}`,
-      content: [
-        {
-          type: "text",
-          text: `<file name="${attachment.title}" path="conversation/${attachment.title}"/>`,
-        },
-      ],
+      content: [{ type: "text", text: fileTag }],
     };
   }
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -1218,6 +1218,7 @@ export async function renderLightContentFragmentForModel(
     const fileTag = snippet
       ? `<file name="${attachment.title}" path="conversation/${attachment.title}">${snippet}\n</file>`
       : `<file name="${attachment.title}" path="conversation/${attachment.title}"/>`;
+
     return {
       role: "content_fragment",
       name: `attach_${contentType}`,

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -263,6 +263,8 @@ async function handler(
         conversation,
       });
 
+      const isNewFileExplorer = await hasFeatureFlag(auth, "new_file_explorer");
+
       const promptSections = constructPromptMultiActions(auth, {
         userMessage,
         agentConfiguration,
@@ -278,6 +280,7 @@ async function handler(
         equippedSkills,
         renderSkillsAsUserMessages,
         projectContext,
+        isNewFileExplorer,
       });
       const prompt = systemPromptToText(promptSections);
       const leadingMessages = renderSkillsAsUserMessages

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -386,6 +386,8 @@ export async function runModel(
     conversation,
   });
 
+  const isNewFileExplorer = await hasFeatureFlag(auth, "new_file_explorer");
+
   const prompt = constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
@@ -405,6 +407,7 @@ export async function runModel(
     userContext,
     workspaceContext,
     projectContext,
+    isNewFileExplorer,
   });
   const leadingMessages = renderSkillsAsUserMessages
     ? removeNulls([renderEquippedSkillsUserMessage(equippedSkills)])


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When files are attached to a conversation, they are currently rendered as `<attachment id="..." isIncludable="true" isSearchable="..." .../>` XML tags inline in every message context sent to the model. The model uses these tags to discover files and decide whether to call `conversation_files__cat` or `conversation_files__semantic_search` to read them. Those tools are not exposed anymore on the new file system when the FF is on since https://github.com/dust-tt/dust/pull/25143.

The new file explorer introduces a path-based files server that replaces this JIT tooling. Under the new model, files are not inlined in history. Instead the model calls `files__read` with a path.
This PR gates the transition behind the `new_file_explorer` feature flag.

## Main changes

The tool `conversation_files__list` :
- When FF is on, filter the list to only content nodes and queryable attachments (CSV/spreadsheets
pre-wired to query_tables_v2). Regular file attachments are no longer surfaced through a slim message to provide the path. Tables will be retired once each conversation can have access to a sandbox.

- Conversation history rendering:
  - When FF is on, skip inline rendering of regular file attachments (PDFs, plain text, etc.). Return null so they are omitted from the model context. Exceptions: pasted content (always inlined by design), images (must be passed as `image_url` to vision models), and queryable files (needed by query_tables_v2 which is pre-wired at JIT time).
- For images specifically, drop the `<attachment>` metadata tag alongside the `image_url`. The image speaks for itself and the flags (`isIncludable`, etc.) does not make ton of sense.

**Before:**

```
{
  "messages": [
    {
      "role": "user",
      "name": "Flavien David",
      "content": [
        {
          "type": "text",
          "text": "<attachment id=\"fil_Q8Ac4uf3P4\" type=\"application/json\" title=\"metrics.json\" version=\"latest\" isInProjectContext=\"false\" isIncludable=\"true\" isQueryable=\"false\" isSearchable=\"false\"/>"
        },
        {
          "type": "text",
          "text": "<dust_system>\n- Sender: Flavien David (:mention_user[Flavien David]{sId=WT9jdk2TVY}) <flavien@dust.tt>\n- Conversation: BOAAXYDOCA\n- Sent at: May 04, 2026, 17:26:57 GMT+2\n- Source: web\n</dust_system>\n\nCan you see this?"
        }
      ]
    },
    {
      "role": "user",
      "name": "dust",
      "content": [
        {
          "type": "text",
          "text": "<dust_system>\nThis is the output of another invoked agent: \"@dust\".\nYou are seeing the final response only, not the full reasoning or tool execution steps.\n</dust_system>\n\nYes! The file is accessible. It appears as `conversation/metrics.json` in the file system. Would you like me to open and analyze its contents?"
        }
      ]
    }
  ]
}
```

**After:**

```
{
  "messages": [
    {
      "role": "user",
      "name": "Flavien David",
      "content": [
        {
          "type": "text",
          "text": "<file name=\"metrics.json\" path=\"conversation/metrics.json\"/>"
        },
        {
          "type": "text",
          "text": "<dust_system>\n- Sender: Flavien David (:mention_user[Flavien David]{sId=WT9jdk2TVY}) <flavien@dust.tt>\n- Conversation: BOAAXYDOCA\n- Sent at: May 04, 2026, 17:26:57 GMT+2\n- Source: web\n</dust_system>\n\nCan you see this?"
        }
      ]
    },
    {
      "role": "user",
      "name": "dust",
      "content": [
        {
          "type": "text",
          "text": "<dust_system>\nThis is the output of another invoked agent: \"@dust\".\nYou are seeing the final response only, not the full reasoning or tool execution steps.\n</dust_system>\n\nYes! The file is accessible. It appears as `conversation/metrics.json` in the file system. Would you like me to open and analyze its contents?"
        }
      ]
    }
  ]
}
```

What still renders (FF on)

```
┌─────────────────────────────┬───────────────┬──────────────────────────────────────────┐
│        Fragment type        │   Renders?    │                   Why                    │
├─────────────────────────────┼───────────────┼──────────────────────────────────────────┤
│ Regular file (PDF, text, …) │ ❌            │ Accessible via files server              │
├─────────────────────────────┼───────────────┼──────────────────────────────────────────┤
│ Pasted content              │ ✅            │ Inlined by design                        │
├─────────────────────────────┼───────────────┼──────────────────────────────────────────┤
│ Image                       │ ✅ (URL only) │ Must be image_url for vision models      │
├─────────────────────────────┼───────────────┼──────────────────────────────────────────┤
│ Queryable file (CSV)        │ ✅            │ Pre-wired to query_tables_v2 at JIT time │
├─────────────────────────────┼───────────────┼──────────────────────────────────────────┤
│ Content node                │ ✅            │ Not affected by this change              │
└─────────────────────────────┴───────────────┴──────────────────────────────────────────┘
```

There are still meany references of `<attachment>` the goal is to kill most of those. More PRs to come.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
