### PR TITLE
feat: project onboarding card

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
@@ -1,9 +1,11 @@
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   BookOpenIcon,
   Card,
   CardGrid,
   ContactsUserIcon,
   Icon,
+  ListCheckIcon,
 } from "@dust-tt/sparkle";
 
 interface SpaceConversationsActionsProps {
@@ -15,31 +17,54 @@ export function SpaceConversationsActions({
   isEditor,
   onOpenMembersPanel,
 }: SpaceConversationsActionsProps) {
-  const suggestions = [
-    {
-      id: "add-context",
-      label: "Add knowledge",
-      icon: BookOpenIcon,
-      description:
-        "Add files, links, or data sources relevant to this project.",
-      onClick: () => {
-        window.location.hash = "context";
-      },
-    },
-    ...(isEditor
-      ? [
-          {
-            id: "manage-members",
-            label: "Manage members",
-            icon: ContactsUserIcon,
-            description: "Invite people to this project as members or editors.",
-            onClick: () => {
-              onOpenMembersPanel();
-            },
+  const { hasFeature } = useFeatureFlags();
+  const canShowTodosTab = hasFeature("project_todo");
+
+  const suggestions = canShowTodosTab
+    ? [
+        {
+          id: "onboarding-todos",
+          label: "Set up your project",
+          icon: ListCheckIcon,
+          description:
+            "New to projects? Add a description, bring in knowledge, invite your team, and create your first to-dos",
+          variant: "highlight" as const,
+          isPulsing: true,
+          onClick: () => {
+            window.location.hash = "todos";
           },
-        ]
-      : []),
-  ];
+        },
+      ]
+    : [
+        {
+          id: "add-context",
+          label: "Add knowledge",
+          icon: BookOpenIcon,
+          description:
+            "Add files, links, or data sources relevant to this project.",
+          variant: "primary" as const,
+          isPulsing: false,
+          onClick: () => {
+            window.location.hash = "context";
+          },
+        },
+        ...(isEditor
+          ? [
+              {
+                id: "manage-members",
+                label: "Manage members",
+                icon: ContactsUserIcon,
+                description:
+                  "Invite people to this project as members or editors.",
+                variant: "primary" as const,
+                isPulsing: false,
+                onClick: () => {
+                  onOpenMembersPanel();
+                },
+              },
+            ]
+          : []),
+      ];
 
   return (
     <div className="flex flex-col gap-3">
@@ -50,8 +75,9 @@ export function SpaceConversationsActions({
         {suggestions.map((suggestion) => (
           <Card
             key={suggestion.id}
-            variant="primary"
+            variant={suggestion.variant}
             size="lg"
+            isPulsing={suggestion.isPulsing}
             onClick={suggestion.onClick}
             className="cursor-pointer"
           >
@@ -60,11 +86,9 @@ export function SpaceConversationsActions({
                 <Icon visual={suggestion.icon} size="sm" />
                 <div className="w-full">{suggestion.label}</div>
               </div>
-              {suggestion.description && (
-                <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                  {suggestion.description}
-                </div>
-              )}
+              <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                {suggestion.description}
+              </div>
             </div>
           </Card>
         ))}

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
@@ -24,10 +24,10 @@ export function SpaceConversationsActions({
     ? [
         {
           id: "onboarding-todos",
-          label: "Set up your project",
+          label: "Get your project off the ground",
           icon: ListCheckIcon,
           description:
-            "New to projects? Add a description, bring in knowledge, invite your team, and create your first to-dos",
+            "Add context, connect your knowledge, and bring the right people in. Flying solo? It still keeps everything in one place.",
           variant: "highlight" as const,
           isPulsing: true,
           onClick: () => {

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
@@ -9,6 +9,7 @@ import {
 import {
   ADD_TODO_BAR_SHELL_CLASS,
   DELETE_TODO_CONFIRM_PREVIEW_MAX_CHARS,
+  isOnboardingTodo,
   SUMMARY_ITEM_TRANSITION_MS,
 } from "@app/components/assistant/conversation/space/conversations/project_todos/utils";
 import { ConfirmContext } from "@app/components/Confirm";
@@ -233,6 +234,19 @@ export function EditableProjectTodosPanel({
   }, [selectedUserSIds, todoOwnerFilter.assigneeScope, todos, viewerUserId]);
 
   const hasDoneItems = filteredTodos.some((todo) => todo.status === "done");
+
+  const getFirstOnboardingTodoId = (
+    todos: ProjectTodoType[]
+  ): string | null => {
+    for (const todo of todos) {
+      if (isOnboardingTodo(todo) && todo.status !== "done") {
+        return todo.sId;
+      }
+    }
+    return null;
+  };
+  const firstOnboardingTodoId = getFirstOnboardingTodoId(filteredTodos);
+
   const groupedTodosForAll = useMemo(() => {
     const groups = new Map<
       string,
@@ -705,6 +719,7 @@ export function EditableProjectTodosPanel({
                       isNewlyDone={doneFlashKeys.has(todo.sId)}
                       isStarting={startingTodoIds.has(todo.sId)}
                       isReadOnly={isReadOnly}
+                      isFirstOnboardingTodo={todo.sId === firstOnboardingTodoId}
                       projectMembers={projectMembers}
                       membersWithActiveTodoIds={membersWithActiveTodoIds}
                       onPatchTodo={patchTodoItem}

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -75,6 +75,7 @@ export interface EditableTodoItemProps {
   isNewlyDone: boolean;
   isStarting: boolean;
   isReadOnly?: boolean;
+  isFirstOnboardingTodo: boolean;
   projectMembers: SpaceUserType[];
   membersWithActiveTodoIds: Set<string>;
   onPatchTodo: (
@@ -98,6 +99,7 @@ export const EditableTodoItem = memo(function EditableTodoItem({
   isNewlyDone,
   isStarting,
   isReadOnly,
+  isFirstOnboardingTodo,
   projectMembers,
   membersWithActiveTodoIds,
   onPatchTodo,
@@ -483,11 +485,12 @@ export const EditableTodoItem = memo(function EditableTodoItem({
                   variant="outline"
                   isLoading={isStarting}
                   disabled={isStarting}
+                  isPulsing={isFirstOnboardingTodo && !startMenuOpen}
                   tooltip="Start working on to-do"
                 />
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-96 p-3">
-                <div className="flex flex-col gap-3">
+              <DropdownMenuContent align="end" className="w-96">
+                <div className="flex flex-col gap-3 p-3">
                   <TextArea
                     id={`todo-start-msg-${todo.sId}`}
                     aria-label="Additional instructions for the agent"
@@ -539,6 +542,7 @@ export const EditableTodoItem = memo(function EditableTodoItem({
                         size="sm"
                         isLoading={isStarting}
                         disabled={isStarting || !selectedStartAgent}
+                        isPulsing={isFirstOnboardingTodo}
                         onClick={() => void handleConfirmStart()}
                       />
                       <ButtonGroupDropdown

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -540,9 +540,10 @@ export const EditableTodoItem = memo(function EditableTodoItem({
                         label="Start working"
                         variant="outline"
                         size="sm"
+                        className={isFirstOnboardingTodo ? "z-10" : ""}
                         isLoading={isStarting}
-                        disabled={isStarting || !selectedStartAgent}
                         isPulsing={isFirstOnboardingTodo}
+                        disabled={isStarting || !selectedStartAgent}
                         onClick={() => void handleConfirmStart()}
                       />
                       <ButtonGroupDropdown

--- a/front/components/assistant/conversation/space/conversations/project_todos/utils.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/utils.ts
@@ -1,3 +1,4 @@
+import type { ProjectTodoType } from "@app/types/project_todo";
 import { cn } from "@dust-tt/sparkle";
 import type React from "react";
 import { useCallback, useLayoutEffect } from "react";
@@ -9,6 +10,12 @@ export const NEW_MANUAL_TODO_MAX_CHARS = 256;
 /** To-dos are visually multi-line (soft wrap) but must not contain newline characters. */
 export function stripNewlines(value: string): string {
   return value.replace(/\r\n|\r|\n/g, " ");
+}
+
+/** Onboarding to-dos are seeded with `agentInstructions` so a user can kick off
+ * a guided first conversation; manual user-created to-dos don't have them. */
+export function isOnboardingTodo(todo: ProjectTodoType): boolean {
+  return !!todo.agentInstructions;
 }
 
 export function useAutosizeTextArea(

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -164,6 +164,8 @@ const InnerCard = React.forwardRef<HTMLDivElement, InnerCardProps>(
       className
     );
 
+    const cardStyle = isPulsing ? { animationDuration: "3s", ...style } : style;
+
     if (href) {
       const linkContent = (
         <Link
@@ -182,7 +184,7 @@ const InnerCard = React.forwardRef<HTMLDivElement, InnerCardProps>(
       );
       if (isPulsing) {
         return (
-          <div className={cardButtonClassNames} style={style}>
+          <div className={cardButtonClassNames} style={cardStyle}>
             {linkContent}
           </div>
         );
@@ -194,7 +196,7 @@ const InnerCard = React.forwardRef<HTMLDivElement, InnerCardProps>(
       <div
         ref={ref}
         className={cardButtonClassNames}
-        style={style}
+        style={cardStyle}
         onClick={onClick}
         role={isInteractive ? "button" : undefined}
         aria-pressed={


### PR DESCRIPTION
## Description

This PR adds a project onboarding card with visual cues to guide new users through their first project setup when the `project_todo` feature flag is enabled.

- Introduces a new "Set up your project" card in the `SpaceConversationsActions`
- The onboarding card uses a `highlight` variant with a pulsing animation
- Adds logic to identify and highlight the first actionable onboarding todo by pulsing the start button


https://github.com/user-attachments/assets/fef693d8-0b45-4625-bd4b-b36aa3cd008b



## Tests

Manually

## Risks

Low

## Deploy Plan

Standard deployment - feature flag controls rollout
