### PR TITLE
[front] Heal poisoned X-Reload-Required cache entries via 304 merge

### DIFF
--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -200,6 +200,12 @@ export function withLogging<T>(
         // cleared in Redis at any time, but a cached "true" response would
         // keep the tab in a reload loop until it expires.
         res.setHeader("Cache-Control", "no-store");
+      } else {
+        // Always emit an explicit "false" so 304 revalidations can heal
+        // poisoned cache entries: per HTTP spec, the browser merges 304
+        // response headers into the stored entry. If we leave the header
+        // off, a cached "true" persists forever across revalidations.
+        res.setHeader("X-Reload-Required", "false");
       }
     }
 


### PR DESCRIPTION
## Description

Follow-up to #25115. Even after `Cache-Control: no-store` was deployed, idle clients keep emitting `[fetcher] Force client reload` logs hours later. Root cause: ETag-based 304 revalidations preserve the poisoned header.

### Why poisoned entries don't self-heal

For endpoints whose body is stable (`/api/user`, `/api/w/[wId]/auth-context`, `/api/app-status`, …):

1. The cached entry has `X-Reload-Required: true` from when the commit was flagged.
2. On focus / SWR revalidation, the browser sends a conditional request (`If-None-Match`).
3. Since the body hasn't changed, the server returns `304 Not Modified` — and the 304 carries no body and no `X-Reload-Required` header (the commit isn't flagged anymore).
4. Per HTTP spec (RFC 7234 §4.3.4), the browser **merges** the 304 headers into the stored entry, leaving fields the 304 doesn't mention untouched. So the original `X-Reload-Required: true` stays in the cached entry indefinitely, and the freshness clock just resets on every revalidation.

For endpoints whose body changes (conversations list, agent stats, …) the ETag rotates, the server returns 200, and the cache entry is replaced with a clean response — those self-heal. The long tail is entirely on stable-body endpoints.

## Fix

Emit `X-Reload-Required: false` on every non-flagged response. The next 304 then carries the header, the merge overwrites the stored `true` with `false`, and the entry heals on the very next revalidation.

```ts
if (await shouldForceClientReload(commitHash)) {
  res.setHeader("X-Reload-Required", "true");
  res.setHeader("Cache-Control", "no-store");
} else {
  res.setHeader("X-Reload-Required", "false");
}
```

The fetcher's check is `=== "true"`, so any non-`"true"` value is treated as "no reload needed" — `"false"` is just the most explicit choice.

## Tests

Manual.

## Risk

Low. Adds one response header on the non-flagged path. No behavioural change for clients (the JS check is unchanged).

## Deploy Plan

Standard deploy. Currently-poisoned entries heal on their next 304 revalidation, which happens on tab focus or SWR refresh. The volume of `Force client reload` logs should drop sharply within minutes once enough clients revalidate.