### PR TITLE
refactor(project_todo): drop userId from project_todo_source

### DIFF
--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -7,7 +7,7 @@
 //
 //   Phase 1 — Collect new candidates.
 //     For every (takeaway, item, targetUser) triple:
-//       - fetchBySourceId(itemId, userId):
+//       - fetchByItemId(itemId):
 //           found     → update status/doneAt if changed (no new row, text
 //                       always preserved from the first version)
 //           not found → push to newCandidates[]
@@ -252,9 +252,8 @@ async function collectDocumentCandidates(
     blob: actionItemBlob(item),
   }));
 
-  // Batch-fetch existing todos by itemId. The result map is keyed by
-  // `${itemId}:${userId}`, matching the lookup below so a hit means
-  // "this (item, user) pair is already linked to a todo — skip dedup".
+  // Batch-fetch existing todos by itemId. A hit means "this item is already
+  // linked to a todo — skip dedup".
   const allActionItemIds = actionItems.map((t) => t.itemId);
   const existingByKey = await ProjectTodoResource.fetchByItemIds(auth, {
     itemIds: allActionItemIds,
@@ -264,7 +263,7 @@ async function collectDocumentCandidates(
   let existingUpdated = 0;
   for (const { itemId, targetUserIds, blob: actionItemBlob } of actionItems) {
     for (const userId of targetUserIds) {
-      const existing = existingByKey.get(itemId)?.get(userId) ?? null;
+      const existing = existingByKey.get(itemId) ?? null;
       if (existing !== null) {
         // Source link exists — update content if it has changed.
         const updated = await updateTodoIfChanged(

--- a/front/lib/resources/project_todo_resource.test.ts
+++ b/front/lib/resources/project_todo_resource.test.ts
@@ -280,7 +280,7 @@ describe("ProjectTodoResource", () => {
   });
 
   describe("upsertSource", () => {
-    it("should not create a new source when called twice with the same (workspaceId, sourceType, sourceId, userId)", async () => {
+    it("should not create a new source when called twice with the same itemId", async () => {
       const todo = await ProjectTodoResource.makeNew(
         auth,
         makeTodoBlob(space.id, user.id)
@@ -396,7 +396,7 @@ describe("ProjectTodoResource", () => {
       ]);
     });
 
-    it("should create a separate source for a different user with the same (sourceType, sourceId)", async () => {
+    it("should create separate sources for different itemIds even with the same (sourceType, sourceId)", async () => {
       const otherSetup = await createResourceTest({ role: "user" });
       const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
         otherSetup.user.sId,

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -395,15 +395,12 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
   }
 
   // Batch variant: fetches the current todo row for each itemId in one pass.
-  // Returns a map from `${itemId}:${userId}` to the matching ProjectTodoResource
-  // — missing entries mean no todo yet exists for that (item, user) pair.
-  //
-  // This is the identity lookup used by the merge workflow's Phase 1 to detect
-  // items that are already linked to a todo and can therefore skip dedup.
+  // Returns a map from itemId to the matching ProjectTodoResource — missing
+  // entries mean no todo yet exists for that item.
   static async fetchByItemIds(
     auth: Authenticator,
     { itemIds }: { itemIds: string[] }
-  ): Promise<Map<string, Map<ModelId, ProjectTodoResource>>> {
+  ): Promise<Map<string, ProjectTodoResource>> {
     if (itemIds.length === 0) {
       return new Map();
     }
@@ -429,16 +426,13 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       linkedRows.map((t) => [t.id, t])
     );
 
-    const result = new Map<string, Map<ModelId, ProjectTodoResource>>();
+    const result = new Map<string, ProjectTodoResource>();
     for (const source of sources) {
       const todo = rowById.get(source.projectTodoId);
       if (!todo) {
         continue;
       }
-      const byUser =
-        result.get(source.itemId) ?? new Map<ModelId, ProjectTodoResource>();
-      byUser.set(source.userId, todo);
-      result.set(source.itemId, byUser);
+      result.set(source.itemId, todo);
     }
 
     return result;
@@ -581,10 +575,9 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
   // ── Source links (* => todo) ─────────────────────────────────────────────
 
   // Links the given takeaway item + source document to this todo. Idempotent
-  // by (workspaceId, sourceType, sourceId, userId, projectTodoId): if a row already exists for this,\
-  // its fields are updated to point at this todo and
-  // source — so a Temporal activity retry after a partial success converges
-  // to the same state instead of creating a duplicate.
+  // by (workspaceId, itemId): if a row already exists for this itemId its
+  // title and URL are updated so Temporal activity retries converge instead
+  // of creating a duplicate.
   async upsertSource(
     auth: Authenticator,
     {
@@ -596,19 +589,12 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     },
     transaction?: Transaction
   ): Promise<void> {
-    if (this.userId === null) {
-      throw new Error(
-        "Cannot upsert source for a todo without an assigned user."
-      );
-    }
-
     const workspaceId = auth.getNonNullableWorkspace().id;
-    // we want one link between one given TODO (that belongs to a user) for a given source
+    // we want one link between one given TODO for a given source
     const identity = {
       workspaceId,
       sourceType: source.sourceType,
       sourceId: source.sourceId,
-      userId: this.userId,
       projectTodoId: this.id,
     };
     const payload = {

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -370,13 +370,9 @@ export class ProjectTodoSourceModel extends WorkspaceAwareModel<ProjectTodoSourc
   declare createdAt: CreationOptional<Date>;
 
   declare projectTodoId: ForeignKey<ProjectTodoModel["id"]>;
-  // Owner of the todo this source links to. Denormalized from the parent
-  // project_todo row so the (workspaceId, itemId, userId) uniqueness can be
-  // enforced at the DB level. Always equal to projectTodo.userId.
-  declare userId: ForeignKey<UserModel["id"]>;
   // sId of the takeaway item that produced this link. At most one row per
-  // (workspaceId, itemId, userId) — if the same item reappears later (same
-  // sId echoed by the LLM) the row is upserted, not duplicated.
+  // (workspaceId, itemId) — if the same item reappears later the row is
+  // upserted, not duplicated.
   declare itemId: string;
   declare sourceType: ProjectTodoSourceType;
   declare sourceId: string;
@@ -384,7 +380,6 @@ export class ProjectTodoSourceModel extends WorkspaceAwareModel<ProjectTodoSourc
   declare sourceUrl: string | null;
 
   declare projectTodo: NonAttribute<ProjectTodoModel>;
-  declare user: NonAttribute<UserModel>;
 }
 
 ProjectTodoSourceModel.init(
@@ -397,12 +392,6 @@ ProjectTodoSourceModel.init(
     projectTodoId: {
       type: DataTypes.BIGINT,
       allowNull: false,
-    },
-    userId: {
-      type: DataTypes.BIGINT,
-      allowNull: false,
-      comment:
-        "Owner of the linked todo, denormalized for uniqueness enforcement.",
     },
     itemId: {
       type: DataTypes.STRING,
@@ -449,19 +438,8 @@ ProjectTodoSourceModel.init(
         concurrently: true,
       },
       {
-        name: "project_todo_sources_userId_idx",
-        fields: ["userId"],
-        concurrently: true,
-      },
-      {
-        name: "project_todo_sources_ws_todo_source_user_unique_idx",
-        fields: [
-          "workspaceId",
-          "projectTodoId",
-          "sourceType",
-          "sourceId",
-          "userId",
-        ],
+        name: "project_todo_sources_ws_todo_source_unique_idx",
+        fields: ["workspaceId", "projectTodoId", "sourceType", "sourceId"],
         unique: true,
         concurrently: true,
       },
@@ -478,10 +456,4 @@ ProjectTodoSourceModel.belongsTo(ProjectTodoModel, {
 ProjectTodoModel.hasMany(ProjectTodoSourceModel, {
   foreignKey: { name: "projectTodoId", allowNull: false },
   as: "sources",
-});
-
-ProjectTodoSourceModel.belongsTo(UserModel, {
-  foreignKey: { name: "userId", allowNull: false },
-  onDelete: "RESTRICT",
-  as: "user",
 });

--- a/front/migrations/db/migration_620.sql
+++ b/front/migrations/db/migration_620.sql
@@ -1,0 +1,13 @@
+-- Migration created on May 4, 2026
+-- Drop userId from project_todo_sources: identity is now (workspaceId, itemId)
+-- alone. One itemId maps to exactly one action item which maps to one user, so
+-- the column was redundant with the todo's own userId.
+
+DROP INDEX CONCURRENTLY IF EXISTS "project_todo_sources_ws_item_user_unique_idx";
+DROP INDEX CONCURRENTLY IF EXISTS "project_todo_sources_userId_idx";
+
+ALTER TABLE "project_todo_sources"
+    DROP COLUMN IF EXISTS "userId";
+
+CREATE UNIQUE INDEX CONCURRENTLY "project_todo_sources_ws_todo_source_unique_idx"
+    ON "project_todo_sources" ("workspaceId", "projectTodoId", "sourceType", "sourceId");


### PR DESCRIPTION
## Description

Drops the denormalized `userId` column from `project_todo_sources`. The column existed solely to enforce a composite unique constraint `(workspaceId, itemId, userId)` at the DB level, but since one `itemId` maps to exactly one action item (and therefore one user), `userId` was redundant.

Changes:
- Removes `userId` field and FK from `ProjectTodoSourceModel`
- New unique constraint: `(workspaceId, projectTodoId, sourceType, sourceId)`
- `upsertSource` identity simplified — no more `userId` in the where clause
- `fetchByItemIds` return type flattened from `Map<string, Map<ModelId, ProjectTodoResource>>` to `Map<string, ProjectTodoResource>`
- Updated test descriptions to reflect the new uniqueness key

## Deploy Plan

Run `migration_620.sql` (drops `userId` column + old indexes, creates new unique index `CONCURRENTLY`). Safe to roll back: adding the column back and recreating the old index restores the previous state.
