### PR TITLE
[Google Drive] Handle removed changes in incremental sync

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   changeList: vi.fn(),
+  deleteFile: vi.fn(),
   deleteOneFile: vi.fn(),
   driveObjectToDustType: vi.fn(),
   getAuthObject: vi.fn(),
@@ -46,6 +47,7 @@ vi.mock("@connectors/connectors/google_drive/lib/hierarchy", () => ({
 vi.mock(
   "@connectors/connectors/google_drive/temporal/activities/common/utils",
   () => ({
+    deleteFile: mocks.deleteFile,
     deleteOneFile: mocks.deleteOneFile,
     getSyncPageToken: mocks.getSyncPageToken,
     objectIsInFolderSelection: mocks.objectIsInFolderSelection,

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -4,6 +4,7 @@ import {
 } from "@connectors/connectors/google_drive/lib";
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
 import {
+  deleteFile,
   deleteOneFile,
   getSyncPageToken,
   objectIsInFolderSelection,
@@ -136,7 +137,24 @@ export async function incrementalSync(
     for (const change of changesRes.data.changes) {
       await heartbeat();
 
-      if (change.changeType !== "file" || !change.file) {
+      if (change.changeType !== "file") {
+        continue;
+      }
+
+      if (change.removed && change.fileId) {
+        const localFile = await GoogleDriveFilesModel.findOne({
+          where: {
+            connectorId: connectorId,
+            driveFileId: change.fileId,
+          },
+        });
+        if (localFile) {
+          await deleteFile(localFile);
+        }
+        continue;
+      }
+
+      if (!change.file) {
         continue;
       }
       if (


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/7601

Google Drive incremental sync now handles removed change tombstones before requiring a hydrated file payload. When Drive reports a removed file id, we delete the corresponding local Google Drive file through the existing connector deletion path.

This fixes issues where files for which we lost access (404) were not cleaned. Incremental sync does not garbage collection on single file access loss.

## Risks
Blast radius: Google Drive connector incremental sync deletion handling.
Risk: low

## Deploy Plan
- pmrr
- deploy connectors