### PR TITLE
[Google Drive] Skip missing nodes in permissions list

### DIFF
--- a/connectors/src/api/get_connector_permissions.ts
+++ b/connectors/src/api/get_connector_permissions.ts
@@ -1,4 +1,6 @@
 import { getConnectorManager } from "@connectors/connectors";
+import { ContentNodeNotFoundError } from "@connectors/connectors/interface";
+import logger from "@connectors/logger/logger";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type {
@@ -85,10 +87,11 @@ const _getConnectorPermissions = async (
     });
   }
 
-  const pRes = await getConnectorManager({
+  const connectorManager = getConnectorManager({
     connectorProvider: connector.type,
     connectorId: connector.id,
-  }).retrievePermissions({
+  });
+  const pRes = await connectorManager.retrievePermissions({
     parentInternalId,
     filterPermission,
     viewType,
@@ -136,31 +139,33 @@ const _getConnectorPermissions = async (
 
   // Augment the resources with their parent internal ids.
   if (filterPermission === "read") {
-    const resourcesWithParentsResults: Result<ContentNodeWithParent, Error>[] =
-      await concurrentExecutor(
-        pRes.value,
-        async (resource) => {
-          const res = await getConnectorManager({
-            connectorProvider: connector.type,
-            connectorId: connector.id,
-          }).retrieveContentNodeParents({
-            internalId: resource.internalId,
-            memoizationKey: `${resource.internalId}-${resource.parentInternalId}`,
-          });
+    const resourcesWithParentsResults: Result<
+      ContentNodeWithParent | null,
+      Error
+    >[] = await concurrentExecutor(
+      pRes.value,
+      async (resource) => {
+        const res = await connectorManager.retrieveContentNodeParents({
+          internalId: resource.internalId,
+          memoizationKey: `${resource.internalId}-${resource.parentInternalId}`,
+        });
 
-          if (res.isErr()) {
-            return new Err(res.error);
+        if (res.isErr()) {
+          if (res.error instanceof ContentNodeNotFoundError) {
+            return new Ok(null);
           }
-
-          return new Ok({
-            ...resource,
-            parentInternalIds: res.value,
-          });
-        },
-        {
-          concurrency: 10,
+          return new Err(res.error);
         }
-      );
+
+        return new Ok({
+          ...resource,
+          parentInternalIds: res.value,
+        });
+      },
+      {
+        concurrency: 10,
+      }
+    );
 
     const hasErrors = resourcesWithParentsResults.some((r) => r.isErr());
     if (hasErrors) {
@@ -175,6 +180,20 @@ const _getConnectorPermissions = async (
           ).join(", ")}`,
         },
       });
+    }
+
+    const skippedNotFoundCount = resourcesWithParentsResults.filter(
+      (r) => r.isOk() && r.value === null
+    ).length;
+    if (skippedNotFoundCount > 0) {
+      logger.info(
+        {
+          connectorId: connector.id,
+          connectorProvider: connector.type,
+          skippedNotFoundCount,
+        },
+        "Skipped read-permission content nodes that no longer exist remotely"
+      );
     }
 
     return res.status(200).json({

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -65,11 +65,9 @@ import type {
 } from "@connectors/types";
 import {
   FILE_ATTRIBUTES_TO_FETCH,
-  getGoogleIdsFromSheetContentNodeInternalId,
   getGoogleSheetContentNodeInternalId,
   googleDriveIncrementalSyncWorkflowId,
   INTERNAL_MIME_TYPES,
-  isGoogleSheetContentNodeInternalId,
   normalizeError,
 } from "@connectors/types";
 import type { ConnectorProvider, Result } from "@dust-tt/client";
@@ -723,18 +721,12 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         return new Ok([]);
       }
 
-      const isGoogleSheetContentNode =
-        isGoogleSheetContentNodeInternalId(internalId);
-      const driveObjectId = isGoogleSheetContentNode
-        ? getGoogleIdsFromSheetContentNodeInternalId(internalId).googleFileId
-        : getDriveFileId(internalId);
-
       const authCredentials = await getAuthObject(connector.connectionId);
 
       const driveObject = await getGoogleDriveObject({
         connectorId: this.connectorId,
         authCredentials,
-        driveObjectId,
+        driveObjectId: getDriveFileId(internalId),
         cacheKey: { connectorId: this.connectorId, ts: memoizationKey },
       });
 
@@ -754,12 +746,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         { includeAllRemoteParents: true }
       );
 
-      const parentInternalIds = parents.map((p) => getInternalId(p));
-      return new Ok(
-        isGoogleSheetContentNode
-          ? [internalId, ...parentInternalIds]
-          : parentInternalIds
-      );
+      return new Ok(parents.map((p) => getInternalId(p)));
     } catch (err) {
       return new Err(normalizeError(err));
     }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -65,9 +65,11 @@ import type {
 } from "@connectors/types";
 import {
   FILE_ATTRIBUTES_TO_FETCH,
+  getGoogleIdsFromSheetContentNodeInternalId,
   getGoogleSheetContentNodeInternalId,
   googleDriveIncrementalSyncWorkflowId,
   INTERNAL_MIME_TYPES,
+  isGoogleSheetContentNodeInternalId,
   normalizeError,
 } from "@connectors/types";
 import type { ConnectorProvider, Result } from "@dust-tt/client";
@@ -721,12 +723,18 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         return new Ok([]);
       }
 
+      const isGoogleSheetContentNode =
+        isGoogleSheetContentNodeInternalId(internalId);
+      const driveObjectId = isGoogleSheetContentNode
+        ? getGoogleIdsFromSheetContentNodeInternalId(internalId).googleFileId
+        : getDriveFileId(internalId);
+
       const authCredentials = await getAuthObject(connector.connectionId);
 
       const driveObject = await getGoogleDriveObject({
         connectorId: this.connectorId,
         authCredentials,
-        driveObjectId: getDriveFileId(internalId),
+        driveObjectId,
         cacheKey: { connectorId: this.connectorId, ts: memoizationKey },
       });
 
@@ -746,7 +754,12 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         { includeAllRemoteParents: true }
       );
 
-      return new Ok(parents.map((p) => getInternalId(p)));
+      const parentInternalIds = parents.map((p) => getInternalId(p));
+      return new Ok(
+        isGoogleSheetContentNode
+          ? [internalId, ...parentInternalIds]
+          : parentInternalIds
+      );
     } catch (err) {
       return new Err(normalizeError(err));
     }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -39,6 +39,7 @@ import type {
 import {
   BaseConnectorManager,
   ConnectorManagerError,
+  ContentNodeNotFoundError,
 } from "@connectors/connectors/interface";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
@@ -731,7 +732,9 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
 
       if (!driveObject) {
         return new Err(
-          new Error(`Drive object not found with id ${internalId}`)
+          new ContentNodeNotFoundError(
+            `Drive object not found with id ${internalId}`
+          )
         );
       }
 

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -33,6 +33,13 @@ export class ConnectorManagerError<T extends string> extends Error {
   }
 }
 
+export class ContentNodeNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ContentNodeNotFoundError";
+  }
+}
+
 export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
   readonly connectorId: ModelId;
 


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/25169.

Read-permission listing now treats a missing remote content node as a skippable condition while retrieving parent paths. Google Drive returns that condition when a local row still exists but Drive no longer returns the object (deleted, or sharing removed), so the endpoint returns the remaining resources instead of a 500.

This fixes broken retrievePermissions e.g. when a file is removed but garbage collection / incremental sync hasn't run on this node yet.

## Risks
Blast radius: connector read-permission listing for resources whose parent path is augmented by connectors.
Risk: low

## Deploy Plan
- pmrr
- deploy connectors