### PR TITLE
Support scoped file paths in MCP tool servers

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -1,6 +1,6 @@
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { createConversation } from "@app/lib/api/assistant/conversation";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -232,7 +232,7 @@ describe("resolveConversationFileRef", () => {
   });
 
   it("returns the signed URL and metadata for a legacy fileId", async () => {
-    const { authenticator: auth, workspace } = await createResourceTest({
+    const { authenticator: auth } = await createResourceTest({
       role: "admin",
     });
 

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -1,0 +1,309 @@
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import { Err, Ok } from "@app/types/shared/result";
+import { Readable } from "stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getFileFromConversationAttachment,
+  resolveConversationFileRef,
+} from "./file_utils";
+
+const { mockResolveConversationFile } = vi.hoisted(() => ({
+  mockResolveConversationFile: vi.fn(),
+}));
+
+vi.mock(
+  "@app/lib/api/actions/servers/files/tools/utils",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/api/actions/servers/files/tools/utils")
+      >();
+    return {
+      ...actual,
+      resolveConversationFile: mockResolveConversationFile,
+    };
+  }
+);
+
+function makeAgentLoopContext(
+  conversation: ConversationType
+): AgentLoopContextType {
+  return {
+    runContext: { conversation },
+  } as unknown as AgentLoopContextType;
+}
+
+function makeReadableStream(content: string): Readable {
+  return new Readable({
+    read() {
+      this.push(content);
+      this.push(null);
+    },
+  });
+}
+
+describe("getFileFromConversationAttachment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("legacy fileId path", () => {
+    it("reads the file content for an attached content fragment", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+        contentType: "application/pdf",
+        fileName: "report.pdf",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      await ConversationFactory.createContentFragmentMessage({
+        auth,
+        workspace,
+        conversationId: conversation.id,
+        rank: 0,
+        fileId: file.id,
+        title: "Report",
+        contentType: "application/pdf",
+        fileName: "report.pdf",
+      });
+
+      const conversationResult = await getConversation(auth, conversation.sId);
+      if (conversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const fullConversation = conversationResult.value;
+
+      const expectedContent = "pdf bytes";
+      vi.spyOn(FileResource.prototype, "getReadStream").mockReturnValue(
+        makeReadableStream(expectedContent)
+      );
+
+      const result = await getFileFromConversationAttachment(
+        auth,
+        file.sId,
+        makeAgentLoopContext(fullConversation)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.buffer.toString()).toBe(expectedContent);
+      expect(result.value.contentType).toBe("application/pdf");
+      // title is overridden by fileResource.fileName during conversation rendering
+      expect(result.value.filename).toBe("report.pdf");
+    });
+
+    it("returns Err when the fileId is not in the conversation", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const conversationResult = await getConversation(auth, conversation.sId);
+      if (conversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+
+      const result = await getFileFromConversationAttachment(
+        auth,
+        "fil_notfound",
+        makeAgentLoopContext(conversationResult.value)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error).toContain("not found in conversation");
+    });
+  });
+
+  describe("scoped path (conversation/...)", () => {
+    it("reads the file content from GCS via resolveConversationFile", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const expectedContent = "gcs bytes";
+      mockResolveConversationFile.mockResolvedValue(
+        new Ok({
+          file: { createReadStream: () => makeReadableStream(expectedContent) },
+          mimeType: "text/plain",
+          sizeBytes: 9,
+        })
+      );
+
+      const result = await getFileFromConversationAttachment(
+        auth,
+        "conversation/notes.txt",
+        makeAgentLoopContext({ ...conversation, content: [] })
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.buffer.toString()).toBe(expectedContent);
+      expect(result.value.contentType).toBe("text/plain");
+      expect(result.value.filename).toBe("notes.txt");
+    });
+
+    it("returns Err when resolveConversationFile fails", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      mockResolveConversationFile.mockResolvedValue(
+        new Err({ message: "GCS object not found" })
+      );
+
+      const result = await getFileFromConversationAttachment(
+        auth,
+        "conversation/missing.pdf",
+        makeAgentLoopContext({ ...conversation, content: [] })
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error).toContain("GCS object not found");
+    });
+  });
+});
+
+describe("resolveConversationFileRef", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns Err when agentLoopContext has no runContext", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const result = await resolveConversationFileRef(
+      auth,
+      "conversation/file.pdf",
+      undefined
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      return;
+    }
+    expect(result.error).toContain("No conversation context");
+  });
+
+  it("returns the signed URL and metadata for a legacy fileId", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+      contentType: "image/png",
+      fileName: "photo.png",
+      fileSize: 512,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const result = await resolveConversationFileRef(
+      auth,
+      file.sId,
+      makeAgentLoopContext({ ...conversation, content: [] })
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.contentType).toBe("image/png");
+    expect(result.value.fileName).toBe("photo.png");
+    expect(result.value.sizeBytes).toBe(512);
+    expect(typeof result.value.getSignedUrl).toBe("function");
+    expect(typeof result.value.createReadStream).toBe("function");
+  });
+
+  it("returns Err when the legacy file does not belong to the conversation", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const conversationA = await createConversation(auth, {
+      title: "A",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const conversationB = await createConversation(auth, {
+      title: "B",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    // File belongs to conversation A.
+    const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+      contentType: "image/png",
+      fileName: "photo.png",
+      fileSize: 512,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversationA.sId },
+    });
+
+    // But agentLoopContext points to conversation B.
+    const result = await resolveConversationFileRef(
+      auth,
+      file.sId,
+      makeAgentLoopContext({ ...conversationB, content: [] })
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      return;
+    }
+    expect(result.error).toContain("does not belong to this conversation");
+  });
+});

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -7,10 +7,7 @@ import {
   makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { resolveConversationFile } from "@app/lib/api/actions/servers/files/tools/utils";
-import {
-  getConversationFilesBasePath,
-  parseScopedFilePath,
-} from "@app/lib/api/files/mount_path";
+import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { streamToBuffer } from "@app/lib/utils/streams";
@@ -28,47 +25,6 @@ export function sanitizeFilename(filename: string): string {
     .substring(0, 255);
 }
 
-// TODO(20260504 FILE SYSTEM): Replace with file path.
-/**
- * Resolve a scoped file path (e.g. "conversation/report.pdf") to a FileResource
- * by computing the full GCS mount path and looking it up in the database.
- * Returns an error if no DB record exists — callers that require a FileResource
- * (e.g. image generation) should use this and propagate the error.
- */
-export async function getFileResourceFromScopedPath(
-  auth: Authenticator,
-  scopedPath: string,
-  agentLoopContext: AgentLoopContextType | undefined
-): Promise<Result<FileResource, string>> {
-  if (!agentLoopContext?.runContext) {
-    return new Err("No conversation context available");
-  }
-
-  const parsed = parseScopedFilePath(scopedPath);
-  if (!parsed) {
-    return new Err(`Invalid scoped path: ${scopedPath}`);
-  }
-
-  const owner = auth.getNonNullableWorkspace();
-  const conversation = agentLoopContext.runContext.conversation;
-
-  const gcsPath =
-    getConversationFilesBasePath({
-      workspaceId: owner.sId,
-      conversationId: conversation.sId,
-    }) + parsed.rel;
-
-  const [fileResource] = await FileResource.fetchByMountFilePaths(auth, [
-    gcsPath,
-  ]);
-  if (!fileResource) {
-    return new Err(
-      `No file record found for path: ${scopedPath}. Only tracked files (uploads, agent-generated) can be used here.`
-    );
-  }
-
-  return new Ok(fileResource);
-}
 
 /**
  * Get file data from a conversation attachment, including images.

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,4 +1,5 @@
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { resolveConversationFile } from "@app/lib/api/actions/servers/files/tools/utils";
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   conversationAttachmentId,
@@ -6,7 +7,6 @@ import {
   isFileAttachmentType,
   makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
-import { resolveConversationFile } from "@app/lib/api/actions/servers/files/tools/utils";
 import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -25,7 +25,6 @@ export function sanitizeFilename(filename: string): string {
     .replace(/[^\w\-._]/g, "_")
     .substring(0, 255);
 }
-
 
 export type ConversationFileRef = {
   contentType: string;
@@ -54,7 +53,11 @@ export async function resolveConversationFileRef(
   const parsed = parseScopedFilePath(fileId);
   if (parsed) {
     const conversation = agentLoopContext.runContext.conversation;
-    const resolvedRes = await resolveConversationFile(auth, conversation, fileId);
+    const resolvedRes = await resolveConversationFile(
+      auth,
+      conversation,
+      fileId
+    );
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
     }
@@ -84,7 +87,8 @@ export async function resolveConversationFileRef(
     sizeBytes: fileResource.fileSize,
     fileName: sanitizeFilename(fileResource.fileName),
     getSignedUrl: () => fileResource.getSignedUrlForDownload(auth, "original"),
-    createReadStream: () => fileResource.getReadStream({ auth, version: "original" }),
+    createReadStream: () =>
+      fileResource.getReadStream({ auth, version: "original" }),
   });
 }
 

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -9,6 +9,7 @@ import {
 import { resolveConversationFile } from "@app/lib/api/actions/servers/files/tools/utils";
 import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { streamToBuffer } from "@app/lib/utils/streams";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
@@ -25,6 +26,67 @@ export function sanitizeFilename(filename: string): string {
     .substring(0, 255);
 }
 
+
+export type ConversationFileRef = {
+  contentType: string;
+  sizeBytes: number;
+  fileName: string;
+  getSignedUrl: () => Promise<string>;
+  createReadStream: () => NodeJS.ReadableStream;
+};
+
+/**
+ * Resolve a conversation file (scoped path or legacy fileId) to its metadata
+ * and lazy GCS accessors, without reading its content.
+ *
+ * Scoped paths are resolved via GCS mount path.
+ * Legacy fileIds are resolved via FileResource with a conversation ownership check.
+ */
+export async function resolveConversationFileRef(
+  auth: Authenticator,
+  fileId: string,
+  agentLoopContext: AgentLoopContextType | undefined
+): Promise<Result<ConversationFileRef, string>> {
+  if (!agentLoopContext?.runContext) {
+    return new Err("No conversation context available");
+  }
+
+  const parsed = parseScopedFilePath(fileId);
+  if (parsed) {
+    const conversation = agentLoopContext.runContext.conversation;
+    const resolvedRes = await resolveConversationFile(auth, conversation, fileId);
+    if (resolvedRes.isErr()) {
+      return new Err(resolvedRes.error.message);
+    }
+    const { file: gcsFile, mimeType, sizeBytes } = resolvedRes.value;
+    return new Ok({
+      contentType: mimeType,
+      sizeBytes,
+      fileName: sanitizeFilename(parsed.rel.split("/").pop() ?? parsed.rel),
+      getSignedUrl: () => getPrivateUploadBucket().getSignedUrl(gcsFile.name),
+      createReadStream: () => gcsFile.createReadStream(),
+    });
+  }
+
+  const conversation = agentLoopContext.runContext.conversation;
+  const fileResource = await FileResource.fetchById(auth, fileId);
+  if (!fileResource) {
+    return new Err(`File resource not found for fileId ${fileId}`);
+  }
+
+  const belongsResult = fileResource.belongsToConversation(conversation.sId);
+  if (belongsResult.isErr() || !belongsResult.value) {
+    return new Err(`File ${fileId} does not belong to this conversation`);
+  }
+
+  return new Ok({
+    contentType: fileResource.contentType,
+    sizeBytes: fileResource.fileSize,
+    fileName: sanitizeFilename(fileResource.fileName),
+    getSignedUrl: () => fileResource.getSignedUrlForDownload(auth, "original"),
+    createReadStream: () => fileResource.getReadStream({ auth, version: "original" }),
+  });
+}
 
 /**
  * Get file data from a conversation attachment, including images.

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -6,6 +6,11 @@ import {
   isFileAttachmentType,
   makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
+import { resolveConversationFile } from "@app/lib/api/actions/servers/files/tools/utils";
+import {
+  getConversationFilesBasePath,
+  parseScopedFilePath,
+} from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { streamToBuffer } from "@app/lib/utils/streams";
@@ -23,9 +28,58 @@ export function sanitizeFilename(filename: string): string {
     .substring(0, 255);
 }
 
+// TODO(20260504 FILE SYSTEM): Replace with file path.
 /**
- * Get file data from a conversation attachment, including images
- * This is a more comprehensive version than listAttachments() which excludes images
+ * Resolve a scoped file path (e.g. "conversation/report.pdf") to a FileResource
+ * by computing the full GCS mount path and looking it up in the database.
+ * Returns an error if no DB record exists — callers that require a FileResource
+ * (e.g. image generation) should use this and propagate the error.
+ */
+export async function getFileResourceFromScopedPath(
+  auth: Authenticator,
+  scopedPath: string,
+  agentLoopContext: AgentLoopContextType | undefined
+): Promise<Result<FileResource, string>> {
+  if (!agentLoopContext?.runContext) {
+    return new Err("No conversation context available");
+  }
+
+  const parsed = parseScopedFilePath(scopedPath);
+  if (!parsed) {
+    return new Err(`Invalid scoped path: ${scopedPath}`);
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const conversation = agentLoopContext.runContext.conversation;
+
+  const gcsPath =
+    getConversationFilesBasePath({
+      workspaceId: owner.sId,
+      conversationId: conversation.sId,
+    }) + parsed.rel;
+
+  const [fileResource] = await FileResource.fetchByMountFilePaths(auth, [
+    gcsPath,
+  ]);
+  if (!fileResource) {
+    return new Err(
+      `No file record found for path: ${scopedPath}. Only tracked files (uploads, agent-generated) can be used here.`
+    );
+  }
+
+  return new Ok(fileResource);
+}
+
+/**
+ * Get file data from a conversation attachment, including images.
+ * Accepts either a scoped file path (e.g. "conversation/report.pdf") or a
+ * legacy fileId (e.g. "fil_xxx").
+ *
+ * Scoped paths are resolved via GCS mount path (workspace + conversation scoped).
+ * When no FileResource record exists for the GCS path (e.g. tool-written outputs),
+ * content is read directly from GCS.
+ *
+ * Legacy fileIds are resolved by scanning conversation content.
  */
 export async function getFileFromConversationAttachment(
   auth: Authenticator,
@@ -37,7 +91,6 @@ export async function getFileFromConversationAttachment(
       buffer: Buffer;
       filename: string;
       contentType: string;
-      fileResource: FileResource;
     },
     string
   >
@@ -46,6 +99,33 @@ export async function getFileFromConversationAttachment(
     return new Err("No conversation context available");
   }
 
+  // Scoped paths resolve through mount path.
+  const parsed = parseScopedFilePath(fileId);
+  if (parsed) {
+    const conversation = agentLoopContext.runContext.conversation;
+    const resolvedRes = await resolveConversationFile(
+      auth,
+      conversation,
+      fileId
+    );
+    if (resolvedRes.isErr()) {
+      return new Err(resolvedRes.error.message);
+    }
+    const { file: gcsFile, mimeType } = resolvedRes.value;
+
+    const bufferResult = await streamToBuffer(gcsFile.createReadStream());
+    if (bufferResult.isErr()) {
+      return new Err(bufferResult.error);
+    }
+
+    return new Ok({
+      buffer: bufferResult.value,
+      filename: sanitizeFilename(parsed.rel.split("/").pop() ?? parsed.rel),
+      contentType: mimeType,
+    });
+  }
+
+  // Legacy fileId path: scan the conversation to find the attachment.
   const conversation = agentLoopContext.runContext.conversation;
   let attachment: ConversationAttachmentType | null = null;
 
@@ -117,8 +197,6 @@ export async function getFileFromConversationAttachment(
   return new Ok({
     buffer: bufferResult.value,
     filename: sanitizeFilename(attachment.title || `attachment-${fileId}`),
-
     contentType: attachment.contentType || "application/octet-stream",
-    fileResource,
   });
 }

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -3,8 +3,10 @@ import type {
   MCPProgressNotificationType,
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { getFileResourceFromScopedPath } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
+import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -276,31 +278,49 @@ async function processSingleImageFile(
     maxImageSize,
     supportedContentTypes,
     providerId,
+    agentLoopContext,
   }: {
     imageFileId: string;
     conversationId: string;
     maxImageSize: number;
     supportedContentTypes: string[];
     providerId: ModelProviderIdType;
+    agentLoopContext: AgentLoopContextType | undefined;
   }
 ): Promise<Ok<FileResource> | Err<MCPError>> {
   const workspace = auth.getNonNullableWorkspace();
-  const fileResource = await FileResource.fetchById(auth, imageFileId);
-  if (!fileResource) {
-    return new Err(
-      new MCPError(`File not found: ${imageFileId}`, {
-        tracked: false,
-      })
-    );
-  }
+  let fileResource: FileResource;
 
-  const belongsResult = fileResource.belongsToConversation(conversationId);
-  if (belongsResult.isErr() || !belongsResult.value) {
-    return new Err(
-      new MCPError(`File ${imageFileId} does not belong to this conversation`, {
-        tracked: false,
-      })
+  if (parseScopedFilePath(imageFileId)) {
+    const fileResult = await getFileResourceFromScopedPath(
+      auth,
+      imageFileId,
+      agentLoopContext
     );
+    if (fileResult.isErr()) {
+      return new Err(
+        new MCPError(`File not found: ${imageFileId}`, { tracked: false })
+      );
+    }
+    fileResource = fileResult.value;
+  } else {
+    const fetchedFile = await FileResource.fetchById(auth, imageFileId);
+    if (!fetchedFile) {
+      return new Err(
+        new MCPError(`File not found: ${imageFileId}`, { tracked: false })
+      );
+    }
+    fileResource = fetchedFile;
+
+    const belongsResult = fileResource.belongsToConversation(conversationId);
+    if (belongsResult.isErr() || !belongsResult.value) {
+      return new Err(
+        new MCPError(
+          `File ${imageFileId} does not belong to this conversation`,
+          { tracked: false }
+        )
+      );
+    }
   }
 
   // TODO(@jd) JIT resize over 20MB once imagemagick is available.
@@ -381,6 +401,7 @@ export async function processImageFileIds(
         maxImageSize,
         supportedContentTypes,
         providerId,
+        agentLoopContext,
       }),
     { concurrency: 8 }
   );

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -4,13 +4,10 @@ import type {
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
-import { resolveConversationFile } from "@app/lib/api/actions/servers/files/tools/utils";
-import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { FileResource } from "@app/lib/resources/file_resource";
 import type { ReferenceImageFile } from "@app/lib/api/llm/imageGeneration";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
@@ -276,14 +273,12 @@ async function processSingleImageFile(
   auth: Authenticator,
   {
     imageFileId,
-    conversationId,
     maxImageSize,
     supportedContentTypes,
     providerId,
     agentLoopContext,
   }: {
     imageFileId: string;
-    conversationId: string;
     maxImageSize: number;
     supportedContentTypes: string[];
     providerId: ModelProviderIdType;
@@ -292,53 +287,14 @@ async function processSingleImageFile(
 ): Promise<Ok<ReferenceImageFile> | Err<MCPError>> {
   const workspace = auth.getNonNullableWorkspace();
 
-  let sizeBytes: number;
-  let contentType: string;
-  let signedUrl: string;
-  let fileName: string;
-
-  const parsed = parseScopedFilePath(imageFileId);
-  if (parsed) {
-    const conversation = agentLoopContext?.runContext?.conversation;
-    const resolvedRes = await resolveConversationFile(
-      auth,
-      conversation,
-      imageFileId
+  const refResult = await resolveConversationFileRef(auth, imageFileId, agentLoopContext);
+  if (refResult.isErr()) {
+    return new Err(
+      new MCPError(`File not found: ${imageFileId}`, { tracked: false })
     );
-    if (resolvedRes.isErr()) {
-      return new Err(
-        new MCPError(`File not found: ${imageFileId}`, { tracked: false })
-      );
-    }
-    sizeBytes = resolvedRes.value.sizeBytes;
-    contentType = resolvedRes.value.mimeType;
-    signedUrl = await getPrivateUploadBucket().getSignedUrl(
-      resolvedRes.value.file.name
-    );
-    fileName = parsed.rel.split("/").pop() ?? parsed.rel;
-  } else {
-    const fileResource = await FileResource.fetchById(auth, imageFileId);
-    if (!fileResource) {
-      return new Err(
-        new MCPError(`File not found: ${imageFileId}`, { tracked: false })
-      );
-    }
-
-    const belongsResult = fileResource.belongsToConversation(conversationId);
-    if (belongsResult.isErr() || !belongsResult.value) {
-      return new Err(
-        new MCPError(
-          `File ${imageFileId} does not belong to this conversation`,
-          { tracked: false }
-        )
-      );
-    }
-
-    sizeBytes = fileResource.fileSize;
-    contentType = fileResource.contentType;
-    signedUrl = await fileResource.getSignedUrlForDownload(auth, "original");
-    fileName = fileResource.fileName;
   }
+
+  const { contentType, sizeBytes, fileName, getSignedUrl } = refResult.value;
 
   // TODO(@jd) JIT resize over 20MB once imagemagick is available.
   if (sizeBytes > maxImageSize) {
@@ -377,6 +333,7 @@ async function processSingleImageFile(
     );
   }
 
+  const signedUrl = await getSignedUrl();
   return new Ok({ signedUrl, fileName, contentType });
 }
 
@@ -402,7 +359,6 @@ export async function processImageFileIds(
     );
   }
 
-  const conversationId = agentLoopContext.runContext.conversation.sId;
   const maxImageSize = MAX_FILE_SIZES.image;
 
   const results = await concurrentExecutor(
@@ -410,7 +366,6 @@ export async function processImageFileIds(
     (imageFileId) =>
       processSingleImageFile(auth, {
         imageFileId,
-        conversationId,
         maxImageSize,
         supportedContentTypes,
         providerId,

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -3,13 +3,15 @@ import type {
   MCPProgressNotificationType,
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { getFileResourceFromScopedPath } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
+import { resolveConversationFile } from "@app/lib/api/actions/servers/files/tools/utils";
 import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
+import type { ReferenceImageFile } from "@app/lib/api/llm/imageGeneration";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -287,30 +289,40 @@ async function processSingleImageFile(
     providerId: ModelProviderIdType;
     agentLoopContext: AgentLoopContextType | undefined;
   }
-): Promise<Ok<FileResource> | Err<MCPError>> {
+): Promise<Ok<ReferenceImageFile> | Err<MCPError>> {
   const workspace = auth.getNonNullableWorkspace();
-  let fileResource: FileResource;
 
-  if (parseScopedFilePath(imageFileId)) {
-    const fileResult = await getFileResourceFromScopedPath(
+  let sizeBytes: number;
+  let contentType: string;
+  let signedUrl: string;
+  let fileName: string;
+
+  const parsed = parseScopedFilePath(imageFileId);
+  if (parsed) {
+    const conversation = agentLoopContext?.runContext?.conversation;
+    const resolvedRes = await resolveConversationFile(
       auth,
-      imageFileId,
-      agentLoopContext
+      conversation,
+      imageFileId
     );
-    if (fileResult.isErr()) {
+    if (resolvedRes.isErr()) {
       return new Err(
         new MCPError(`File not found: ${imageFileId}`, { tracked: false })
       );
     }
-    fileResource = fileResult.value;
+    sizeBytes = resolvedRes.value.sizeBytes;
+    contentType = resolvedRes.value.mimeType;
+    signedUrl = await getPrivateUploadBucket().getSignedUrl(
+      resolvedRes.value.file.name
+    );
+    fileName = parsed.rel.split("/").pop() ?? parsed.rel;
   } else {
-    const fetchedFile = await FileResource.fetchById(auth, imageFileId);
-    if (!fetchedFile) {
+    const fileResource = await FileResource.fetchById(auth, imageFileId);
+    if (!fileResource) {
       return new Err(
         new MCPError(`File not found: ${imageFileId}`, { tracked: false })
       );
     }
-    fileResource = fetchedFile;
 
     const belongsResult = fileResource.belongsToConversation(conversationId);
     if (belongsResult.isErr() || !belongsResult.value) {
@@ -321,14 +333,19 @@ async function processSingleImageFile(
         )
       );
     }
+
+    sizeBytes = fileResource.fileSize;
+    contentType = fileResource.contentType;
+    signedUrl = await fileResource.getSignedUrlForDownload(auth, "original");
+    fileName = fileResource.fileName;
   }
 
   // TODO(@jd) JIT resize over 20MB once imagemagick is available.
-  if (fileResource.fileSize > maxImageSize) {
+  if (sizeBytes > maxImageSize) {
     logger.warn(
       {
-        fileId: fileResource.sId,
-        fileSize: fileResource.fileSize,
+        imageFileId,
+        fileSize: sizeBytes,
         maxFileSize: maxImageSize,
         workspaceId: workspace.sId,
       },
@@ -343,28 +360,24 @@ async function processSingleImageFile(
 
     return new Err(
       new MCPError(
-        `Image file ${imageFileId} too large. Maximum allowed size is ${fileSizeToHumanReadable(maxImageSize, 0)}, but file is ${fileSizeToHumanReadable(fileResource.fileSize, 0)}.`,
-        {
-          tracked: false,
-        }
+        `Image file ${imageFileId} too large. Maximum allowed size is ${fileSizeToHumanReadable(maxImageSize, 0)}, but file is ${fileSizeToHumanReadable(sizeBytes, 0)}.`,
+        { tracked: false }
       )
     );
   }
 
-  if (!supportedContentTypes.includes(fileResource.contentType)) {
+  if (!supportedContentTypes.includes(contentType)) {
     return new Err(
       new MCPError(
-        `File ${imageFileId} is not a supported image type. Got: ${fileResource.contentType}. Supported types: ${supportedContentTypes
+        `File ${imageFileId} is not a supported image type. Got: ${contentType}. Supported types: ${supportedContentTypes
           .map((t) => t.replace("image/", "").toUpperCase())
           .join(", ")}.`,
-        {
-          tracked: false,
-        }
+        { tracked: false }
       )
     );
   }
 
-  return new Ok(fileResource);
+  return new Ok({ signedUrl, fileName, contentType });
 }
 
 export async function processImageFileIds(
@@ -380,7 +393,7 @@ export async function processImageFileIds(
     supportedContentTypes: string[];
     providerId: ModelProviderIdType;
   }
-): Promise<Ok<FileResource[]> | Err<MCPError>> {
+): Promise<Ok<ReferenceImageFile[]> | Err<MCPError>> {
   if (!agentLoopContext?.runContext) {
     return new Err(
       new MCPError("No conversation context available for file access", {
@@ -411,9 +424,9 @@ export async function processImageFileIds(
     return firstError;
   }
 
-  const fileResources = results
-    .filter((r): r is Ok<FileResource> => r.isOk())
-    .map((r) => r.value);
-
-  return new Ok(fileResources);
+  return new Ok(
+    results
+      .filter((r): r is Ok<ReferenceImageFile> => r.isOk())
+      .map((r) => r.value)
+  );
 }

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -3,12 +3,12 @@ import type {
   MCPProgressNotificationType,
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { resolveConversationFileRef } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
-import type { Authenticator } from "@app/lib/auth";
 import type { ReferenceImageFile } from "@app/lib/api/llm/imageGeneration";
+import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -287,7 +287,11 @@ async function processSingleImageFile(
 ): Promise<Ok<ReferenceImageFile> | Err<MCPError>> {
   const workspace = auth.getNonNullableWorkspace();
 
-  const refResult = await resolveConversationFileRef(auth, imageFileId, agentLoopContext);
+  const refResult = await resolveConversationFileRef(
+    auth,
+    imageFileId,
+    agentLoopContext
+  );
   if (refResult.isErr()) {
     return new Err(
       new MCPError(`File not found: ${imageFileId}`, { tracked: false })

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -22,7 +22,7 @@ export const imageGenerationToolInputSchema = z.object({
     .max(14)
     .optional()
     .describe(
-      "Optional file IDs of reference images from conversation attachments. Up to 14 reference images."
+      "Optional reference images from the conversation. Accepts scoped file paths (e.g. 'conversation/photo.png') or legacy file sIds. Up to 14 reference images."
     ),
   aspectRatio: z
     .enum([

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -17,7 +17,7 @@ import { IMAGE_GENERATION_TOOLS_METADATA } from "@app/lib/api/actions/servers/im
 import { getImageGenerationLLM } from "@app/lib/api/llm/getImageGenerationLLM";
 import type { ImageGenerationInput } from "@app/lib/api/llm/imageGeneration";
 import type { Authenticator } from "@app/lib/auth";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import type { ReferenceImageFile } from "@app/lib/api/llm/imageGeneration";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { Err } from "@app/types/shared/result";
@@ -68,7 +68,7 @@ export function createImageGenerationTools(
         return rateLimitResult;
       }
 
-      let referenceFileResources: FileResource[] = [];
+      let referenceFiles: ReferenceImageFile[] = [];
 
       if (referenceImages && referenceImages.length > 0) {
         const processResult = await processImageFileIds(auth, {
@@ -80,13 +80,13 @@ export function createImageGenerationTools(
         if (processResult.isErr()) {
           return processResult;
         }
-        referenceFileResources = processResult.value;
+        referenceFiles = processResult.value;
       }
 
       const generationInput = {
         prompt,
         aspectRatio,
-        fileResources: referenceFileResources,
+        referenceFiles,
         quality,
       } satisfies ImageGenerationInput;
 

--- a/front/lib/api/actions/servers/image_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/image_generation/tools/index.ts
@@ -15,9 +15,11 @@ import {
 } from "@app/lib/api/actions/servers/image_generation/helpers";
 import { IMAGE_GENERATION_TOOLS_METADATA } from "@app/lib/api/actions/servers/image_generation/metadata";
 import { getImageGenerationLLM } from "@app/lib/api/llm/getImageGenerationLLM";
-import type { ImageGenerationInput } from "@app/lib/api/llm/imageGeneration";
+import type {
+  ImageGenerationInput,
+  ReferenceImageFile,
+} from "@app/lib/api/llm/imageGeneration";
 import type { Authenticator } from "@app/lib/auth";
-import type { ReferenceImageFile } from "@app/lib/api/llm/imageGeneration";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { Err } from "@app/types/shared/result";

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -356,7 +356,7 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
           fileId: z
             .string()
             .describe(
-              "The fileId from conversation attachments (use conversation_list_files to get available files)"
+              "The file reference from the conversation. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
             ),
         }),
         z.object({

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -804,7 +804,11 @@ export async function executePostMessage(
         new MCPError(`File not found: ${fileId}`, { tracked: false })
       );
     }
-    const { buffer: fileBuffer, filename, contentType: filetype } = fileResult.value;
+    const {
+      buffer: fileBuffer,
+      filename,
+      contentType: filetype,
+    } = fileResult.value;
 
     // Resolve channel id using the shared helper function.
     const channelId = await resolveChannelId({

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -2,9 +2,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
-import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
-import { FileResource } from "@app/lib/resources/file_resource";
 import { removeDiacritics } from "@app/lib/utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -796,44 +794,17 @@ export async function executePostMessage(
 
   // If a file is provided, upload it as attachment of the original message.
   if (fileId) {
-    let fileBuffer: Buffer;
-    let filename: string;
-    let filetype: string;
-
-    if (parseScopedFilePath(fileId)) {
-      // Scoped path: read bytes directly (handles both tracked and untracked
-      // GCS files such as tool outputs without a DB record).
-      const fileResult = await getFileFromConversationAttachment(
-        auth,
-        fileId,
-        agentLoopContext
+    const fileResult = await getFileFromConversationAttachment(
+      auth,
+      fileId,
+      agentLoopContext
+    );
+    if (fileResult.isErr()) {
+      return new Err(
+        new MCPError(`File not found: ${fileId}`, { tracked: false })
       );
-      if (fileResult.isErr()) {
-        return new Err(
-          new MCPError(`File not found: ${fileId}`, { tracked: false })
-        );
-      }
-      fileBuffer = fileResult.value.buffer;
-      filename = fileResult.value.filename;
-      filetype = fileResult.value.contentType;
-    } else {
-      // Legacy fileId: fetch FileResource and download via signed URL.
-      const file = await FileResource.fetchById(auth, fileId);
-      if (!file) {
-        return new Err(new MCPError("File not found", { tracked: false }));
-      }
-      const signedUrl = await file.getSignedUrlForDownload(auth, "original");
-      // eslint-disable-next-line no-restricted-globals
-      const fileResp = await fetch(signedUrl);
-      if (!fileResp.ok) {
-        return new Err(
-          new MCPError(`Failed to fetch file (HTTP ${fileResp.status})`)
-        );
-      }
-      fileBuffer = Buffer.from(await fileResp.arrayBuffer());
-      filename = file.fileName ?? `upload_${file.sId}`;
-      filetype = file.contentType;
     }
+    const { buffer: fileBuffer, filename, contentType: filetype } = fileResult.value;
 
     // Resolve channel id using the shared helper function.
     const channelId = await resolveChannelId({

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -1,6 +1,8 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
+import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { removeDiacritics } from "@app/lib/utils";
@@ -794,13 +796,43 @@ export async function executePostMessage(
 
   // If a file is provided, upload it as attachment of the original message.
   if (fileId) {
-    const file = await FileResource.fetchById(auth, fileId);
-    if (!file) {
-      return new Err(
-        new MCPError("File not found", {
-          tracked: false,
-        })
+    let fileBuffer: Buffer;
+    let filename: string;
+    let filetype: string;
+
+    if (parseScopedFilePath(fileId)) {
+      // Scoped path: read bytes directly (handles both tracked and untracked
+      // GCS files such as tool outputs without a DB record).
+      const fileResult = await getFileFromConversationAttachment(
+        auth,
+        fileId,
+        agentLoopContext
       );
+      if (fileResult.isErr()) {
+        return new Err(
+          new MCPError(`File not found: ${fileId}`, { tracked: false })
+        );
+      }
+      fileBuffer = fileResult.value.buffer;
+      filename = fileResult.value.filename;
+      filetype = fileResult.value.contentType;
+    } else {
+      // Legacy fileId: fetch FileResource and download via signed URL.
+      const file = await FileResource.fetchById(auth, fileId);
+      if (!file) {
+        return new Err(new MCPError("File not found", { tracked: false }));
+      }
+      const signedUrl = await file.getSignedUrlForDownload(auth, "original");
+      // eslint-disable-next-line no-restricted-globals
+      const fileResp = await fetch(signedUrl);
+      if (!fileResp.ok) {
+        return new Err(
+          new MCPError(`Failed to fetch file (HTTP ${fileResp.status})`)
+        );
+      }
+      fileBuffer = Buffer.from(await fileResp.arrayBuffer());
+      filename = file.fileName ?? `upload_${file.sId}`;
+      filetype = file.contentType;
     }
 
     // Resolve channel id using the shared helper function.
@@ -819,24 +851,11 @@ export async function executePostMessage(
       );
     }
 
-    const signedUrl = await file.getSignedUrlForDownload(auth, "original");
-    // eslint-disable-next-line no-restricted-globals
-    const fileResp = await fetch(signedUrl);
-    if (!fileResp.ok) {
-      return new Err(
-        new MCPError(`Failed to fetch file (HTTP ${fileResp.status})`)
-      );
-    }
-    const arrayBuf = await fileResp.arrayBuffer();
-    const fileBuffer = Buffer.from(arrayBuf);
-
-    const filename = file.fileName ?? `upload_${file.sId}`;
-
     const baseArgs = {
       channel_id: channelId,
       file: fileBuffer,
       filename,
-      filetype: file.contentType,
+      filetype,
       initial_comment: message,
     };
     const uploadResp = threadTs

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -29,7 +29,7 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "Optional file id (sId) of a file in Dust to attach to the Slack message."
+          "Optional file to attach to the Slack message. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
         ),
     },
     stake: "low",

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -113,7 +113,9 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       fileId: z
         .string()
         .optional()
-        .describe("The file id of the file to attach to the message."),
+        .describe(
+          "Optional file to attach to the message. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
+        ),
     },
     stake: "medium",
     displayLabels: {

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -63,7 +63,6 @@ export type ContentNodeAttachmentType = BaseConversationAttachmentType & {
 };
 
 export type LargePasteType = {
-  fileId: string;
   title: string;
 };
 

--- a/front/lib/api/llm/clients/google/imageGeneration.ts
+++ b/front/lib/api/llm/clients/google/imageGeneration.ts
@@ -69,20 +69,15 @@ export class ImageGenerationGoogleLLM extends ImageGenerationLLM {
   async generateImage(
     params: ImageGenerationInput
   ): Promise<Result<ImageGenerationOutput, ImageGenerationError>> {
-    const { prompt, aspectRatio, fileResources, quality } = params;
+    const { prompt, aspectRatio, referenceFiles, quality } = params;
 
     let imageParts: Part[] = [];
 
-    if (fileResources && fileResources.length > 0) {
+    if (referenceFiles && referenceFiles.length > 0) {
       imageParts = await concurrentExecutor(
-        fileResources,
-        async (fileResource) => {
-          const signedUrl = await fileResource.getSignedUrlForDownload(
-            this.auth,
-            "original"
-          );
-          return createPartFromUri(signedUrl, fileResource.contentType);
-        },
+        referenceFiles,
+        async (referenceFile) =>
+          createPartFromUri(referenceFile.signedUrl, referenceFile.contentType),
         { concurrency: 8 }
       );
     }

--- a/front/lib/api/llm/clients/openai/imageGeneration.ts
+++ b/front/lib/api/llm/clients/openai/imageGeneration.ts
@@ -7,11 +7,11 @@ import {
   type ImageGenerationInput,
   ImageGenerationLLM,
   type ImageGenerationOutput,
+  type ReferenceImageFile,
   type TokenCountDetails,
 } from "@app/lib/api/llm/imageGeneration";
 import type { Authenticator } from "@app/lib/auth";
 import { trustedFetch } from "@app/lib/egress/server";
-import type { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/temporal/workflow_utils";
 import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import { GPT_IMAGE_2_MODEL_ID } from "@app/types/assistant/models/openai";
@@ -88,14 +88,14 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
   async generateImage(
     params: ImageGenerationInput
   ): Promise<Result<ImageGenerationOutput, ImageGenerationError>> {
-    const { prompt, aspectRatio, fileResources, quality } = params;
+    const { prompt, aspectRatio, referenceFiles, quality } = params;
 
     const size = ASPECT_RATIO_TO_IMAGE_SIZE[aspectRatio];
 
     let response: ImagesResponse;
     try {
-      if (fileResources && fileResources.length > 0) {
-        const uploadables = await this.toUploadableFiles(fileResources);
+      if (referenceFiles && referenceFiles.length > 0) {
+        const uploadables = await this.toUploadableFiles(referenceFiles);
 
         response = await this.client.images.edit({
           model: this.modelId,
@@ -202,18 +202,14 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
     };
   }
 
-  private async toUploadableFiles(fileResources: FileResource[]) {
+  private async toUploadableFiles(referenceFiles: ReferenceImageFile[]) {
     return concurrentExecutor(
-      fileResources,
-      async (fileResource) => {
-        const signedUrl = await fileResource.getSignedUrlForDownload(
-          this.auth,
-          "original"
-        );
-        const res = await trustedFetch(signedUrl);
+      referenceFiles,
+      async (referenceFile) => {
+        const res = await trustedFetch(referenceFile.signedUrl);
         const arrayBuffer = await res.arrayBuffer();
-        return toFile(Buffer.from(arrayBuffer), fileResource.fileName, {
-          type: fileResource.contentType,
+        return toFile(Buffer.from(arrayBuffer), referenceFile.fileName, {
+          type: referenceFile.contentType,
         });
       },
       { concurrency: 8 }

--- a/front/lib/api/llm/imageGeneration.ts
+++ b/front/lib/api/llm/imageGeneration.ts
@@ -4,7 +4,6 @@ import type {
 } from "@app/lib/api/actions/servers/image_generation/helpers";
 import type { ImageGenerationToolInput } from "@app/lib/api/actions/servers/image_generation/metadata";
 import type { Authenticator } from "@app/lib/auth";
-import type { FileResource } from "@app/lib/resources/file_resource";
 import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import type { LLMCredentialsType } from "@app/types/provider_credential";
@@ -16,11 +15,17 @@ export type TokenCountDetails = {
   totalTokens: number;
 };
 
+export type ReferenceImageFile = {
+  signedUrl: string;
+  fileName: string;
+  contentType: string;
+};
+
 export type ImageGenerationInput = Omit<
   ImageGenerationToolInput,
   "referenceImages" | "outputName"
 > & {
-  fileResources?: FileResource[];
+  referenceFiles?: ReferenceImageFile[];
 };
 
 export type ImageGenerationOutput = {

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -1120,7 +1120,6 @@ export async function getContentFragmentFromAttachmentFile(
     // Check if this is a pasted content (large paste) - use simplified XML format
     if (isPastedFile(attachment.contentType)) {
       const largePaste: LargePasteType = {
-        fileId: fileStringId,
         title: attachment.title,
       };
 
@@ -1198,7 +1197,6 @@ export async function renderLightContentFragmentForModel(
   // Check if this is pasted content - render with simplified format
   if (fileStringId && isPastedFile(contentType)) {
     const largePaste: LargePasteType = {
-      fileId: fileStringId,
       title: attachment.title,
     };
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
MCP tool servers that accept file inputs (Slack, Jira, image generation) previously only handled legacy file IDs (`fil_xxx`). With the new file explorer, agents can now reference files using scoped paths like `conversation/report.pdf` which resolve directly against the GCS mount without requiring a database record. For example, files written as tool outputs.

The core change is a new `resolveConversationFileRef` helper that centralises the dispatch logic: scoped paths go through `resolveConversationFile`, while legacy fileIds fall back to a `FileResource` database lookup with conversation ownership
verification.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
