### PR TITLE
Add: approval / rejection support for pending todos.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
@@ -18,6 +18,7 @@ import {
   useSpaceConversationsSummary,
 } from "@app/hooks/conversations";
 import { useTodoDiffAnimations } from "@app/hooks/useTodoDiffAnimations";
+import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { compareProjectTodoAssigneeGroups } from "@app/lib/project_todo/display_order";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
@@ -300,6 +301,42 @@ export function EditableProjectTodosPanel({
       }
     },
     [handleSetStatus]
+  );
+
+  const onApproveAgentSuggestion = useCallback(
+    async (todo: ProjectTodoType) => {
+      await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/project_todos/bulk-actions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "approve_agent_suggestion",
+            todoIds: [todo.sId],
+          }),
+        }
+      );
+      await mutateTodos();
+    },
+    [owner.sId, spaceId, mutateTodos]
+  );
+
+  const onRejectAgentSuggestion = useCallback(
+    async (todo: ProjectTodoType) => {
+      await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/project_todos/bulk-actions`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "reject_agent_suggestion",
+            todoIds: [todo.sId],
+          }),
+        }
+      );
+      await mutateTodos();
+    },
+    [owner.sId, spaceId, mutateTodos]
   );
 
   const patchTodoItem = useCallback(
@@ -709,6 +746,8 @@ export function EditableProjectTodosPanel({
                       viewerUserId={viewerUserId}
                       onToggleDone={handleToggleDone}
                       onDelete={requestDelete}
+                      onApproveAgentSuggestion={onApproveAgentSuggestion}
+                      onRejectAgentSuggestion={onRejectAgentSuggestion}
                       onStartWorking={handleStartWorking}
                       owner={owner}
                       activeAgents={activeAgents}

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -44,11 +44,13 @@ import {
   MoreIcon,
   PlayIcon,
   RobotIcon,
+  SparklesIcon,
   TextArea,
   Tooltip,
   TrashIcon,
   TypingAnimation,
   UserIcon,
+  XMarkIcon,
 } from "@dust-tt/sparkle";
 import type React from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -58,6 +60,8 @@ export interface EditableTodoItemProps {
   viewerUserId: string | null;
   onToggleDone: (todo: ProjectTodoType) => void;
   onDelete: (todo: ProjectTodoType) => void | Promise<void>;
+  onApproveAgentSuggestion: (todo: ProjectTodoType) => void | Promise<void>;
+  onRejectAgentSuggestion: (todo: ProjectTodoType) => void | Promise<void>;
   onStartWorking: (
     todo: ProjectTodoType,
     options?: {
@@ -89,6 +93,8 @@ export const EditableTodoItem = memo(function EditableTodoItem({
   viewerUserId,
   onToggleDone,
   onDelete,
+  onApproveAgentSuggestion,
+  onRejectAgentSuggestion,
   onStartWorking,
   owner,
   activeAgents,
@@ -120,7 +126,9 @@ export const EditableTodoItem = memo(function EditableTodoItem({
   const conversationDotStatus: ConversationDotStatus =
     todo.conversationSidebarStatus ?? "idle";
   const isDoneWithoutConversation = isDone && !hasConversationLink;
-  const canEdit = viewerUserId !== null && !isReadOnly;
+  const isPendingApproval = todo.agentSuggestionStatus === "pending";
+  const canAct = viewerUserId !== null && !isReadOnly;
+  const canEdit = canAct && !isPendingApproval;
   const showInProgressTextAnimation = todo.status === "in_progress";
   const [isFlashing, setIsFlashing] = useState(isNewlyDone);
   const [showSavedPulse, setShowSavedPulse] = useState(false);
@@ -313,117 +321,61 @@ export const EditableTodoItem = memo(function EditableTodoItem({
       )}
     >
       <div className="mt-0.5 shrink-0">
-        <Checkbox
-          size="xs"
-          checked={isDone}
-          disabled={!canEdit}
-          isMutedAfterCheck
-          onCheckedChange={() => handleToggle()}
-        />
-      </div>
-      {isEditing ? (
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <textarea
-            ref={editInputRef}
-            aria-label="Edit to-do text"
-            autoComplete="off"
-            rows={1}
-            maxLength={NEW_MANUAL_TODO_MAX_CHARS}
-            value={draftText}
-            disabled={isStarting}
-            className={cn(
-              TODO_TEXTAREA_FIELD_CLASS,
-              isDone && "text-faint line-through dark:text-faint-night",
-              isFlashing &&
-                "rounded bg-warning-100/40 dark:bg-warning-100-night/30"
-            )}
-            onChange={(e) => setDraftText(stripNewlines(e.target.value))}
-            onFocus={() => {
-              if (blurCommitTimerRef.current) {
-                clearTimeout(blurCommitTimerRef.current);
-                blurCommitTimerRef.current = null;
-              }
-            }}
-            onBlur={() => {
-              blurCommitTimerRef.current = setTimeout(() => {
-                void commitEdit();
-              }, 150);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") {
-                e.preventDefault();
-                cancelEdit();
-                return;
-              }
-              if (e.key === "Enter") {
-                e.preventDefault();
-                void commitEdit();
-              }
-            }}
+        {isPendingApproval ? (
+          <span className="flex size-4 items-center justify-center text-muted-foreground dark:text-muted-foreground-night">
+            <SparklesIcon className="h-3.5 w-3.5" />
+          </span>
+        ) : (
+          <Checkbox
+            size="xs"
+            checked={isDone}
+            disabled={!canEdit}
+            isMutedAfterCheck
+            onCheckedChange={() => handleToggle()}
           />
-          <div className="ml-1">
-            <TodoSources sources={todo.sources} owner={owner} isDone={isDone} />
-          </div>
-        </div>
-      ) : (
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <div className="relative min-w-0 text-left">
-            {showTypingAnimation && (
-              <span
-                ref={measureRef}
-                aria-hidden
-                className="invisible block w-full min-w-0 break-words text-pretty text-base leading-6"
-              >
-                {displayText}
-              </span>
-            )}
-            <TodoMetadataTooltip todo={todo} agentNameById={agentNameById}>
-              <span
-                className={cn(
-                  "block min-h-6 w-full min-w-0 select-text break-words text-pretty text-left align-top text-base leading-6 transition-all duration-300",
-                  showTypingAnimation && "absolute inset-0",
-                  isDone
-                    ? "text-faint dark:text-faint-night line-through"
-                    : "text-foreground dark:text-foreground-night",
-                  isFlashing &&
-                    "rounded bg-warning-100/40 dark:bg-warning-100-night/30",
-                  showSavedPulse && "animate-saved-pulse",
-                  canEdit && "cursor-pointer"
-                )}
-                onAnimationEnd={() => setShowSavedPulse(false)}
-                onClick={() => {
-                  const sel = window.getSelection();
-                  const offset =
-                    sel?.rangeCount &&
-                    sel.getRangeAt(0).startContainer.nodeType === Node.TEXT_NODE
-                      ? sel.getRangeAt(0).startOffset
-                      : undefined;
-                  startEdit(offset);
-                }}
-                onKeyDown={(e) => {
-                  if (canEdit && (e.key === "Enter" || e.key === " ")) {
-                    e.preventDefault();
-                    startEdit();
-                  }
-                }}
-                role={canEdit ? "button" : undefined}
-                tabIndex={canEdit ? 0 : undefined}
-              >
-                {showTypingAnimation ? (
-                  <TypingAnimation
-                    text={displayText}
-                    duration={16}
-                    onComplete={() => setTypingDismissed(true)}
-                  />
-                ) : showInProgressTextAnimation ? (
-                  <AnimatedText variant="muted">{displayText}</AnimatedText>
-                ) : (
-                  displayText
-                )}
-              </span>
-            </TodoMetadataTooltip>
-          </div>
-          {!showTypingAnimation && (
+        )}
+      </div>
+      <div className="flex min-w-0 flex-1 items-start gap-2">
+        {isEditing ? (
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <textarea
+              ref={editInputRef}
+              aria-label="Edit to-do text"
+              autoComplete="off"
+              rows={1}
+              maxLength={NEW_MANUAL_TODO_MAX_CHARS}
+              value={draftText}
+              disabled={isStarting}
+              className={cn(
+                TODO_TEXTAREA_FIELD_CLASS,
+                isDone && "text-faint line-through dark:text-faint-night",
+                isFlashing &&
+                  "rounded bg-warning-100/40 dark:bg-warning-100-night/30"
+              )}
+              onChange={(e) => setDraftText(stripNewlines(e.target.value))}
+              onFocus={() => {
+                if (blurCommitTimerRef.current) {
+                  clearTimeout(blurCommitTimerRef.current);
+                  blurCommitTimerRef.current = null;
+                }
+              }}
+              onBlur={() => {
+                blurCommitTimerRef.current = setTimeout(() => {
+                  void commitEdit();
+                }, 150);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  cancelEdit();
+                  return;
+                }
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void commitEdit();
+                }
+              }}
+            />
             <div className="ml-1">
               <TodoSources
                 sources={todo.sources}
@@ -431,254 +383,370 @@ export const EditableTodoItem = memo(function EditableTodoItem({
                 isDone={isDone}
               />
             </div>
-          )}
-        </div>
-      )}
-      <div className="mt-0.5 flex shrink-0 flex-col items-end gap-1 opacity-100 md:flex-row md:items-center">
-        {hasConversationLink ? (
-          <Tooltip
-            label="Open to-do conversation"
-            trigger={
-              <span className="relative inline-flex shrink-0">
-                <Button
-                  icon={ChatBubbleLeftRightIcon}
-                  size="xs"
-                  variant="outline"
-                  onClick={() => {
-                    if (!todo.conversationId) {
-                      return;
-                    }
-                    void router.push(
-                      getConversationRoute(owner.sId, todo.conversationId),
-                      undefined,
-                      { shallow: true }
-                    );
-                  }}
-                />
-                <ConversationSidebarStatusDot
-                  status={conversationDotStatus}
-                  className="pointer-events-none absolute -right-0.5 -top-0.5 m-0 ring-2 ring-background dark:ring-background-night"
-                />
-              </span>
-            }
-          />
+          </div>
         ) : (
-          canEdit &&
-          !hasConversationLink &&
-          (isDoneWithoutConversation ? (
-            <Tooltip
-              label="Reopen this to-do before starting work."
-              trigger={
-                <Button icon={PlayIcon} size="xs" variant="outline" disabled />
-              }
-            />
-          ) : (
-            <DropdownMenu
-              modal={false}
-              open={startMenuOpen}
-              onOpenChange={handleStartMenuOpenChange}
-            >
-              <DropdownMenuTrigger asChild>
-                <Button
-                  icon={PlayIcon}
-                  size="xs"
-                  variant="outline"
-                  isLoading={isStarting}
-                  disabled={isStarting}
-                  isPulsing={isFirstOnboardingTodo && !startMenuOpen}
-                  tooltip="Start working on to-do"
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-96">
-                <div className="flex flex-col gap-3 p-3">
-                  <TextArea
-                    id={`todo-start-msg-${todo.sId}`}
-                    aria-label="Additional instructions for the agent"
-                    placeholder="(optional) Add a custom message for the agent..."
-                    value={startCustomMessage}
-                    rows={4}
-                    onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
-                      setStartCustomMessage(event.target.value)
-                    }
-                  />
-                  <div className="flex items-end justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <AgentPicker
-                        owner={owner}
-                        agents={activeAgents}
-                        disabled={agentsLoading}
-                        isLoading={agentsLoading}
-                        mountPortal
-                        showDropdownArrow
-                        showFooterButtons={false}
-                        side="bottom"
-                        size="xs"
-                        onItemClick={(agent) => setSelectedStartAgent(agent)}
-                        pickerButton={
-                          <Button
-                            variant="ghost-secondary"
-                            size="xs"
-                            isSelect
-                            icon={
-                              selectedStartAgent
-                                ? () => (
-                                    <Avatar
-                                      size="xxs"
-                                      visual={selectedStartAgent.pictureUrl}
-                                    />
-                                  )
-                                : RobotIcon
-                            }
-                            label={selectedStartAgent?.name ?? "Agent"}
-                            className="max-w-full min-w-0"
-                          />
-                        }
-                      />
-                    </div>
-                    <ButtonGroup className="shrink-0">
-                      <Button
-                        label="Start working"
-                        variant="outline"
-                        size="sm"
-                        className={isFirstOnboardingTodo ? "z-10" : ""}
-                        isLoading={isStarting}
-                        isPulsing={isFirstOnboardingTodo}
-                        disabled={isStarting || !selectedStartAgent}
-                        onClick={() => void handleConfirmStart()}
-                      />
-                      <ButtonGroupDropdown
-                        align="end"
-                        items={startRedirectMenuItems}
-                        trigger={
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            icon={ChevronDownIcon}
-                            disabled={isStarting || !selectedStartAgent}
-                            aria-label="After start: open conversation or stay on to-dos"
-                          />
-                        }
-                      />
-                    </ButtonGroup>
-                  </div>
-                </div>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ))
-        )}
-        {canEdit && (
-          <div
-            className={cn(
-              "transition-opacity",
-              overflowMenuOpen
-                ? "opacity-100"
-                : "md:opacity-0 md:group-hover/todo:opacity-100"
-            )}
-          >
-            <DropdownMenu
-              modal={false}
-              open={overflowMenuOpen}
-              onOpenChange={(open) => {
-                setOverflowMenuOpen(open);
-                if (open) {
-                  setReassignSearch("");
-                }
-              }}
-            >
-              <DropdownMenuTrigger asChild>
-                <Button
-                  aria-label="To-do actions"
-                  icon={MoreIcon}
-                  size="xs"
-                  variant="ghost"
-                  onClick={(e: React.MouseEvent) => {
-                    e.stopPropagation();
-                  }}
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                align="end"
-                className="z-[1000] w-56 shadow-2xl ring-1 ring-border/60"
-              >
-                <DropdownMenuSub
-                  onOpenChange={(subOpen) => {
-                    if (subOpen) {
-                      setReassignSearch("");
-                    }
-                  }}
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <div className="relative min-w-0 text-left">
+              {showTypingAnimation && (
+                <span
+                  ref={measureRef}
+                  aria-hidden
+                  className="invisible block w-full min-w-0 break-words text-pretty text-base leading-6"
                 >
-                  <DropdownMenuSubTrigger
-                    label="Reassign"
-                    icon={UserIcon}
-                    disabled={projectMembers.length === 0}
-                  />
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent
-                      alignOffset={-4}
-                      className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
-                    >
-                      <DropdownMenuSearchbar
-                        autoFocus
-                        name={`reassign-todo-${todo.sId}`}
-                        placeholder="Search members"
-                        value={reassignSearch}
-                        onChange={setReassignSearch}
-                      />
-                      <DropdownMenuSeparator />
-                      <div className="max-h-64 overflow-auto">
-                        {filteredReassignMembers.length > 0 ? (
-                          filteredReassignMembers.map((member) => (
-                            <DropdownMenuItem
-                              key={`reassign-${todo.sId}-${member.sId}`}
-                              label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
-                              disabled={member.sId === todo.user?.sId}
-                              icon={() => (
-                                <Avatar
-                                  size="xxs"
-                                  isRounded
-                                  visual={
-                                    member.image ??
-                                    "/static/humanavatar/anonymous.png"
-                                  }
-                                />
-                              )}
-                              onClick={() => {
-                                void (async () => {
-                                  try {
-                                    if (member.sId !== todo.user?.sId) {
-                                      await onPatchTodo(todo.sId, {
-                                        assigneeUserId: member.sId,
-                                      });
-                                    }
-                                  } finally {
-                                    setOverflowMenuOpen(false);
-                                  }
-                                })();
-                              }}
-                            />
-                          ))
-                        ) : (
-                          <div className="px-3 py-2 text-sm text-muted-foreground">
-                            No members found
-                          </div>
-                        )}
-                      </div>
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-                <DropdownMenuItem
-                  label="Delete"
-                  icon={TrashIcon}
-                  variant="warning"
+                  {displayText}
+                </span>
+              )}
+              <TodoMetadataTooltip todo={todo} agentNameById={agentNameById}>
+                <span
+                  className={cn(
+                    "block min-h-6 w-full min-w-0 select-text break-words text-pretty text-left align-top text-base leading-6 transition-all duration-300",
+                    showTypingAnimation && "absolute inset-0",
+                    isDone
+                      ? "text-faint dark:text-faint-night line-through"
+                      : "text-foreground dark:text-foreground-night",
+                    isFlashing &&
+                      "rounded bg-warning-100/40 dark:bg-warning-100-night/30",
+                    showSavedPulse && "animate-saved-pulse",
+                    canEdit && "cursor-pointer"
+                  )}
+                  onAnimationEnd={() => setShowSavedPulse(false)}
                   onClick={() => {
-                    setOverflowMenuOpen(false);
-                    void onDelete(todo);
+                    const sel = window.getSelection();
+                    const offset =
+                      sel?.rangeCount &&
+                      sel.getRangeAt(0).startContainer.nodeType ===
+                        Node.TEXT_NODE
+                        ? sel.getRangeAt(0).startOffset
+                        : undefined;
+                    startEdit(offset);
                   }}
+                  onKeyDown={(e) => {
+                    if (canEdit && (e.key === "Enter" || e.key === " ")) {
+                      e.preventDefault();
+                      startEdit();
+                    }
+                  }}
+                  role={canEdit ? "button" : undefined}
+                  tabIndex={canEdit ? 0 : undefined}
+                >
+                  {showTypingAnimation ? (
+                    <TypingAnimation
+                      text={displayText}
+                      duration={16}
+                      onComplete={() => setTypingDismissed(true)}
+                    />
+                  ) : showInProgressTextAnimation ? (
+                    <AnimatedText variant="muted">{displayText}</AnimatedText>
+                  ) : (
+                    displayText
+                  )}
+                </span>
+              </TodoMetadataTooltip>
+            </div>
+            {isPendingApproval && !showTypingAnimation && (
+              <p className="min-w-0 text-pretty text-xs leading-relaxed text-muted-foreground dark:text-muted-foreground-night">
+                {todo.actorRationale?.trim() ||
+                  "Suggested from your project takeaways."}
+              </p>
+            )}
+            {!showTypingAnimation && (
+              <div className="ml-1">
+                <TodoSources
+                  sources={todo.sources}
+                  owner={owner}
+                  isDone={isDone}
                 />
-              </DropdownMenuContent>
-            </DropdownMenu>
+              </div>
+            )}
           </div>
         )}
+        <div className="mt-0.5 flex shrink-0 items-center gap-1 opacity-100">
+          {isPendingApproval && canAct && !isEditing ? (
+            <>
+              <Button
+                icon={CheckIcon}
+                size="xs"
+                variant="outline"
+                tooltip="Keep this suggestion"
+                className="text-success-500 hover:text-success-600 dark:text-success-500-night dark:hover:text-success-600-night"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void onApproveAgentSuggestion(todo);
+                }}
+              />
+              <Button
+                icon={XMarkIcon}
+                size="xs"
+                variant="outline"
+                tooltip="Reject suggestion"
+                className="text-warning-500 hover:text-warning-600 dark:text-warning-500-night dark:hover:text-warning-600-night"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void onRejectAgentSuggestion(todo);
+                }}
+              />
+            </>
+          ) : (
+            <>
+              {hasConversationLink ? (
+                <Tooltip
+                  label="Open to-do conversation"
+                  trigger={
+                    <span className="relative inline-flex shrink-0">
+                      <Button
+                        icon={ChatBubbleLeftRightIcon}
+                        size="xs"
+                        variant="outline"
+                        onClick={() => {
+                          if (!todo.conversationId) {
+                            return;
+                          }
+                          void router.push(
+                            getConversationRoute(
+                              owner.sId,
+                              todo.conversationId
+                            ),
+                            undefined,
+                            { shallow: true }
+                          );
+                        }}
+                      />
+                      <ConversationSidebarStatusDot
+                        status={conversationDotStatus}
+                        className="pointer-events-none absolute -right-0.5 -top-0.5 m-0 ring-2 ring-background dark:ring-background-night"
+                      />
+                    </span>
+                  }
+                />
+              ) : (
+                canEdit &&
+                !hasConversationLink &&
+                (isDoneWithoutConversation ? (
+                  <Tooltip
+                    label="Reopen this to-do before starting work."
+                    trigger={
+                      <Button
+                        icon={PlayIcon}
+                        size="xs"
+                        variant="outline"
+                        disabled
+                      />
+                    }
+                  />
+                ) : (
+                  <DropdownMenu
+                    modal={false}
+                    open={startMenuOpen}
+                    onOpenChange={handleStartMenuOpenChange}
+                  >
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        icon={PlayIcon}
+                        size="xs"
+                        variant="outline"
+                        isLoading={isStarting}
+                        disabled={isStarting}
+                        isPulsing={isFirstOnboardingTodo && !startMenuOpen}
+                        tooltip="Start working on to-do"
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-96">
+                      <div className="flex flex-col gap-3 p-3">
+                        <TextArea
+                          id={`todo-start-msg-${todo.sId}`}
+                          aria-label="Additional instructions for the agent"
+                          placeholder="(optional) Add a custom message for the agent..."
+                          value={startCustomMessage}
+                          rows={4}
+                          onChange={(
+                            event: React.ChangeEvent<HTMLTextAreaElement>
+                          ) => setStartCustomMessage(event.target.value)}
+                        />
+                        <div className="flex items-end justify-between gap-2">
+                          <div className="min-w-0 flex-1">
+                            <AgentPicker
+                              owner={owner}
+                              agents={activeAgents}
+                              disabled={agentsLoading}
+                              isLoading={agentsLoading}
+                              mountPortal
+                              showDropdownArrow
+                              showFooterButtons={false}
+                              side="bottom"
+                              size="xs"
+                              onItemClick={(agent) =>
+                                setSelectedStartAgent(agent)
+                              }
+                              pickerButton={
+                                <Button
+                                  variant="ghost-secondary"
+                                  size="xs"
+                                  isSelect
+                                  icon={
+                                    selectedStartAgent
+                                      ? () => (
+                                          <Avatar
+                                            size="xxs"
+                                            visual={
+                                              selectedStartAgent.pictureUrl
+                                            }
+                                          />
+                                        )
+                                      : RobotIcon
+                                  }
+                                  label={selectedStartAgent?.name ?? "Agent"}
+                                  className="max-w-full min-w-0"
+                                />
+                              }
+                            />
+                          </div>
+                          <ButtonGroup className="shrink-0">
+                            <Button
+                              label="Start working"
+                              variant="outline"
+                              size="sm"
+                              className={isFirstOnboardingTodo ? "z-10" : ""}
+                              isLoading={isStarting}
+                              isPulsing={isFirstOnboardingTodo}
+                              disabled={isStarting || !selectedStartAgent}
+                              onClick={() => void handleConfirmStart()}
+                            />
+                            <ButtonGroupDropdown
+                              align="end"
+                              items={startRedirectMenuItems}
+                              trigger={
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  icon={ChevronDownIcon}
+                                  disabled={isStarting || !selectedStartAgent}
+                                  aria-label="After start: open conversation or stay on to-dos"
+                                />
+                              }
+                            />
+                          </ButtonGroup>
+                        </div>
+                      </div>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ))
+              )}
+              {canEdit && (
+                <div
+                  className={cn(
+                    "transition-opacity",
+                    overflowMenuOpen
+                      ? "opacity-100"
+                      : "md:opacity-0 md:group-hover/todo:opacity-100"
+                  )}
+                >
+                  <DropdownMenu
+                    modal={false}
+                    open={overflowMenuOpen}
+                    onOpenChange={(open) => {
+                      setOverflowMenuOpen(open);
+                      if (open) {
+                        setReassignSearch("");
+                      }
+                    }}
+                  >
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        aria-label="To-do actions"
+                        icon={MoreIcon}
+                        size="xs"
+                        variant="ghost"
+                        onClick={(e: React.MouseEvent) => {
+                          e.stopPropagation();
+                        }}
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="end"
+                      className="z-[1000] w-56 shadow-2xl ring-1 ring-border/60"
+                    >
+                      <DropdownMenuSub
+                        onOpenChange={(subOpen) => {
+                          if (subOpen) {
+                            setReassignSearch("");
+                          }
+                        }}
+                      >
+                        <DropdownMenuSubTrigger
+                          label="Reassign"
+                          icon={UserIcon}
+                          disabled={projectMembers.length === 0}
+                        />
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent
+                            alignOffset={-4}
+                            className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
+                          >
+                            <DropdownMenuSearchbar
+                              autoFocus
+                              name={`reassign-todo-${todo.sId}`}
+                              placeholder="Search members"
+                              value={reassignSearch}
+                              onChange={setReassignSearch}
+                            />
+                            <DropdownMenuSeparator />
+                            <div className="max-h-64 overflow-auto">
+                              {filteredReassignMembers.length > 0 ? (
+                                filteredReassignMembers.map((member) => (
+                                  <DropdownMenuItem
+                                    key={`reassign-${todo.sId}-${member.sId}`}
+                                    label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
+                                    disabled={member.sId === todo.user?.sId}
+                                    icon={() => (
+                                      <Avatar
+                                        size="xxs"
+                                        isRounded
+                                        visual={
+                                          member.image ??
+                                          "/static/humanavatar/anonymous.png"
+                                        }
+                                      />
+                                    )}
+                                    onClick={() => {
+                                      void (async () => {
+                                        try {
+                                          if (member.sId !== todo.user?.sId) {
+                                            await onPatchTodo(todo.sId, {
+                                              assigneeUserId: member.sId,
+                                            });
+                                          }
+                                        } finally {
+                                          setOverflowMenuOpen(false);
+                                        }
+                                      })();
+                                    }}
+                                  />
+                                ))
+                              ) : (
+                                <div className="px-3 py-2 text-sm text-muted-foreground">
+                                  No members found
+                                </div>
+                              )}
+                            </div>
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+                      <DropdownMenuItem
+                        label="Delete"
+                        icon={TrashIcon}
+                        variant="warning"
+                        onClick={() => {
+                          setOverflowMenuOpen(false);
+                          void onDelete(todo);
+                        }}
+                      />
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              )}
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -438,6 +438,7 @@ async function createOrLinkTodos(
           createdByType: "agent",
           createdByUserId: null,
           createdByAgentConfigurationId: BUTLER_AGENT_SID,
+          agentSuggestionStatus: "pending",
           text: primary.blob.text,
           status: primary.blob.status,
           doneAt: primary.blob.doneAt,
@@ -519,11 +520,8 @@ export async function updateTodoIfChanged(
   }
 
   const statusChanged = todo.status !== blob.status;
-  const doneAtChanged =
-    todo.doneAt?.toISOString() !== blob.doneAt?.toISOString();
-  const actorRationaleAtChanged = todo.actorRationale !== blob.reasoningDoneAt;
 
-  if (statusChanged || doneAtChanged || actorRationaleAtChanged) {
+  if (statusChanged) {
     await todo.updateWithVersion(auth, {
       text: todo.text,
       status: blob.status,

--- a/front/lib/resources/project_todo_resource.test.ts
+++ b/front/lib/resources/project_todo_resource.test.ts
@@ -30,6 +30,9 @@ function makeTodoBlob(
     doneAt: null,
     actorRationale: null,
     agentInstructions: null,
+    agentSuggestionStatus: null,
+    agentSuggestionReviewedAt: null,
+    agentSuggestionReviewedByUserId: null,
   };
 }
 

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -133,6 +133,9 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
         | "markedAsDoneByUserId"
         | "markedAsDoneByAgentConfigurationId"
         | "deletedAt"
+        | "agentSuggestionStatus"
+        | "agentSuggestionReviewedAt"
+        | "agentSuggestionReviewedByUserId"
       >
     >,
     transaction?: Transaction
@@ -182,6 +185,10 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       markedAsDoneByAgentConfigurationId:
         this.markedAsDoneByAgentConfigurationId ?? null,
       deletedAt: this.deletedAt ?? null,
+      agentSuggestionStatus: this.agentSuggestionStatus ?? null,
+      agentSuggestionReviewedAt: this.agentSuggestionReviewedAt ?? null,
+      agentSuggestionReviewedByUserId:
+        this.agentSuggestionReviewedByUserId ?? null,
     };
     await ProjectTodoVersionModel.create(versionData, { transaction });
   }
@@ -658,6 +665,8 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       createdByType: this.createdByType,
       createdByAgentConfigurationId: this.createdByAgentConfigurationId,
       createdByUserId: this.createdByUserSId,
+      agentSuggestionStatus: this.agentSuggestionStatus,
+      agentSuggestionReviewedAt: this.agentSuggestionReviewedAt,
       markedAsDoneByType: this.markedAsDoneByType,
       markedAsDoneByAgentConfigurationId:
         this.markedAsDoneByAgentConfigurationId,
@@ -745,6 +754,29 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     });
 
     return new Ok({ updatedCount: todos.length });
+  }
+
+  async approveAgentSuggestion(
+    auth: Authenticator,
+    { reviewedByUserId }: { reviewedByUserId: ModelId }
+  ): Promise<void> {
+    await this.updateWithVersion(auth, {
+      agentSuggestionStatus: "approved",
+      agentSuggestionReviewedAt: new Date(),
+      agentSuggestionReviewedByUserId: reviewedByUserId,
+    });
+  }
+
+  async rejectAgentSuggestion(
+    auth: Authenticator,
+    { reviewedByUserId }: { reviewedByUserId: ModelId }
+  ): Promise<void> {
+    await this.updateWithVersion(auth, {
+      agentSuggestionStatus: "rejected",
+      agentSuggestionReviewedAt: new Date(),
+      agentSuggestionReviewedByUserId: reviewedByUserId,
+      deletedAt: new Date(),
+    });
   }
 
   async softDelete(auth: Authenticator): Promise<Result<undefined, Error>> {

--- a/front/lib/resources/storage/models/project_todo.ts
+++ b/front/lib/resources/storage/models/project_todo.ts
@@ -4,6 +4,7 @@ import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
+  AgentSuggestionStatus,
   ProjectTodoActorType,
   ProjectTodoSourceType,
   ProjectTodoStatus,
@@ -101,6 +102,20 @@ const PROJECT_TODO_MODEL_ATTRIBUTES = {
     allowNull: true,
     defaultValue: null,
   },
+  agentSuggestionStatus: {
+    type: DataTypes.STRING,
+    allowNull: true,
+    defaultValue: null,
+  },
+  agentSuggestionReviewedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    defaultValue: null,
+  },
+  agentSuggestionReviewedByUserId: {
+    type: DataTypes.BIGINT,
+    allowNull: true,
+  },
 } as const;
 
 // ── Main model ──────────────────────────────────────────────────────────────
@@ -133,6 +148,9 @@ export class ProjectTodoModel extends WorkspaceAwareModel<ProjectTodoModel> {
   declare actorRationale: string | null;
   declare agentInstructions: string | null;
   declare deletedAt: CreationOptional<Date | null>;
+  declare agentSuggestionStatus: AgentSuggestionStatus | null;
+  declare agentSuggestionReviewedAt: Date | null;
+  declare agentSuggestionReviewedByUserId: ForeignKey<UserModel["id"]> | null;
 
   declare space: NonAttribute<SpaceModel>;
   declare user: NonAttribute<UserModel | null>;
@@ -285,6 +303,15 @@ ProjectTodoModel.belongsTo(UserModel, {
   foreignKey: { name: "markedAsDoneByUserId", allowNull: true },
   onDelete: "RESTRICT",
   as: "markedAsDoneByUser",
+});
+
+ProjectTodoModel.belongsTo(UserModel, {
+  foreignKey: {
+    name: "agentSuggestionReviewedByUserId",
+    allowNull: true,
+  },
+  onDelete: "RESTRICT",
+  as: "agentSuggestionReviewedByUser",
 });
 
 // ── Join table: ProjectTodo → Conversation (output direction only) ──────────

--- a/front/migrations/db/migration_621.sql
+++ b/front/migrations/db/migration_621.sql
@@ -1,0 +1,11 @@
+-- Migration created on May 04, 2026
+-- Butler / agent todo suggestion review (approve or reject from UI)
+ALTER TABLE "project_todos"
+ADD COLUMN IF NOT EXISTS "agentSuggestionStatus" VARCHAR NULL,
+ADD COLUMN IF NOT EXISTS "agentSuggestionReviewedAt" TIMESTAMPTZ NULL,
+ADD COLUMN IF NOT EXISTS "agentSuggestionReviewedByUserId" BIGINT NULL;
+
+ALTER TABLE "project_todo_versions"
+ADD COLUMN IF NOT EXISTS "agentSuggestionStatus" VARCHAR NULL,
+ADD COLUMN IF NOT EXISTS "agentSuggestionReviewedAt" TIMESTAMPTZ NULL,
+ADD COLUMN IF NOT EXISTS "agentSuggestionReviewedByUserId" BIGINT NULL;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/bulk-actions.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/bulk-actions.test.ts
@@ -190,6 +190,65 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_todos/bulk-actions", () => 
     expect(visibleSIds.has(openTodo.sId)).toBe(true);
   });
 
+  it("should approve pending agent suggestions in the space", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+    });
+    await todo.updateWithVersion(auth, {
+      agentSuggestionStatus: "pending",
+    });
+
+    req.query.spaceId = project.sId;
+    req.body = {
+      action: "approve_agent_suggestion",
+      todoIds: [todo.sId],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+
+    const refreshed = await ProjectTodoResource.fetchBySId(auth, todo.sId);
+    expect(refreshed?.agentSuggestionStatus).toBe("approved");
+    expect(refreshed?.agentSuggestionReviewedAt).not.toBeNull();
+    expect(refreshed?.agentSuggestionReviewedByUserId).toBe(user.id);
+  });
+
+  it("should reject pending agent suggestions and soft-delete", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const todo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+    });
+    await todo.updateWithVersion(auth, {
+      agentSuggestionStatus: "pending",
+    });
+
+    req.query.spaceId = project.sId;
+    req.body = {
+      action: "reject_agent_suggestion",
+      todoIds: [todo.sId],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+
+    const refreshed = await ProjectTodoResource.fetchBySIdWithDeleted(
+      auth,
+      todo.sId
+    );
+    expect(refreshed?.agentSuggestionStatus).toBe("rejected");
+    expect(refreshed?.deletedAt).not.toBeNull();
+    expect(refreshed?.agentSuggestionReviewedByUserId).toBe(user.id);
+  });
+
   it("should return 400 when the body is invalid", async () => {
     const { user } = await setup();
     const project = await SpaceFactory.project(workspace, user.id);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/bulk-actions.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/bulk-actions.ts
@@ -26,6 +26,14 @@ export const BulkActionsBodySchema = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("clean_done"),
   }),
+  z.object({
+    action: z.literal("approve_agent_suggestion"),
+    todoIds: z.array(z.string().min(1)).min(1).max(200),
+  }),
+  z.object({
+    action: z.literal("reject_agent_suggestion"),
+    todoIds: z.array(z.string().min(1)).min(1).max(200),
+  }),
 ]);
 
 async function handler(
@@ -123,6 +131,38 @@ async function handler(
       return res
         .status(200)
         .json({ success: true, cleanedCount: result.value.cleanedCount });
+    }
+
+    case "approve_agent_suggestion": {
+      const user = auth.getNonNullableUser();
+      for (const sId of body.todoIds) {
+        const todo = await ProjectTodoResource.fetchBySId(auth, sId);
+        if (
+          !todo ||
+          todo.spaceId !== space.id ||
+          todo.agentSuggestionStatus !== "pending"
+        ) {
+          continue;
+        }
+        await todo.approveAgentSuggestion(auth, { reviewedByUserId: user.id });
+      }
+      return res.status(200).json({ success: true });
+    }
+
+    case "reject_agent_suggestion": {
+      const user = auth.getNonNullableUser();
+      for (const sId of body.todoIds) {
+        const todo = await ProjectTodoResource.fetchBySId(auth, sId);
+        if (
+          !todo ||
+          todo.spaceId !== space.id ||
+          todo.agentSuggestionStatus !== "pending"
+        ) {
+          continue;
+        }
+        await todo.rejectAgentSuggestion(auth, { reviewedByUserId: user.id });
+      }
+      return res.status(200).json({ success: true });
     }
 
     default:

--- a/front/tests/utils/ProjectTodoFactory.ts
+++ b/front/tests/utils/ProjectTodoFactory.ts
@@ -28,6 +28,9 @@ export class ProjectTodoFactory {
       doneAt: null,
       actorRationale: null,
       agentInstructions: null,
+      agentSuggestionStatus: null,
+      agentSuggestionReviewedAt: null,
+      agentSuggestionReviewedByUserId: null,
     });
   }
 }

--- a/front/types/project_todo.ts
+++ b/front/types/project_todo.ts
@@ -22,6 +22,13 @@ export const PROJECT_TODO_SOURCE_TYPES = [
 
 export type ProjectTodoSourceType = (typeof PROJECT_TODO_SOURCE_TYPES)[number];
 
+export const AGENT_SUGGESTION_STATUSES = [
+  "pending",
+  "approved",
+  "rejected",
+] as const;
+export type AgentSuggestionStatus = (typeof AGENT_SUGGESTION_STATUSES)[number];
+
 export type ProjectTodoSourceInfo = {
   sourceType: ProjectTodoSourceType;
   sourceId: string;
@@ -51,6 +58,8 @@ export type ProjectTodoType = {
   createdByType: ProjectTodoActorType;
   createdByAgentConfigurationId: string | null;
   createdByUserId: string | null;
+  agentSuggestionStatus: AgentSuggestionStatus | null;
+  agentSuggestionReviewedAt: Date | null;
   markedAsDoneByType: ProjectTodoActorType | null;
   markedAsDoneByAgentConfigurationId: string | null;
   markedAsDoneByUserId: string | null;


### PR DESCRIPTION
## Description

Agent-suggested todos appeared in the list with no way for project members to act on them. This PR adds explicit approve and reject actions so users are in control of what enters their backlog.

- Add `approve_agent_suggestion` and `reject_agent_suggestion` actions to the `bulk-actions` endpoint; both transition `agentSuggestionStatus` from `pending` to `approved` / `rejected` and revalidate the todo list
- In `EditableTodoItem`: when `isPendingApproval`, swap the checkbox for a `SparklesIcon` marker, lock editing (`canEdit = canAct && !isPendingApproval`), show the `actorRationale` below the text, and replace the action cluster with approve (`CheckIcon`) and reject (`XMarkIcon`) icon buttons that track their own loading state
- Pass `onApproveAgentSuggestion` and `onRejectAgentSuggestion` callbacks from `EditableProjectTodosPanel` down to `EditableTodoItem`

## Tests

Local

## Risk

Low — pending todos were already visible but inert; the new actions are additive

## Deploy Plan

Deploy `front`
