### PR TITLE
[sandbox] bump dsbx CLI to 0.1.5

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [[bin]]

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -14,7 +14,7 @@ import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
 const DUST_BASE_IMAGE_VERSION = "0.8.2";
-const DSBX_CLI_VERSION = "0.1.4";
+const DSBX_CLI_VERSION = "0.1.5";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.


### PR DESCRIPTION
## Description

Bumps the dsbx Rust binary to 0.1.5 and points the sandbox image registry at the new release. Lands the Phase 0 MITM code from #25073 (TLS interception, byte-level header rewriter, ephemeral CA, leaf cache) into actual sandboxes. The 0.1.4 release on GitHub Releases predates the Phase 0 work, so until this bump merges + the release is cut, sandboxes still pull the pre-MITM binary.

## Tests

Cargo lock auto-updated via `cargo update -p dust-sandbox --offline`. CI will run the dsbx build + tests.

## Risk

Low. Two-line constant bump. The old 0.1.4 binary keeps working for any in-flight sandbox until it recycles. If the new binary regresses, revert the registry pin to 0.1.4 and ship.

## Deploy Plan

1. Merge this PR.
2. Trigger the **Release dsbx CLI** workflow on `main` to publish `dsbx-v0.1.5` to GitHub Releases.
3. Deploy `front` once the release artifact exists. New sandboxes will install the 0.1.5 binary; existing ones keep 0.1.4 until they recycle.

If `front` rolls before the release is published, sandbox provisioning will 404 on the binary fetch.