### PR TITLE
[front] feat: add prompt guidance for inline skill tags

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -219,19 +219,21 @@ function constructSkillsSectionForUserMessageRendering({
 }: {
   systemSkills: SkillResource[];
 }): string {
+  const toolDisplayName = `${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}`;
+
   let skillsSection =
     "\n## SKILLS\n" +
     "Skills are modular capabilities that extend your abilities for specific tasks. " +
     "Each skill includes specialized instructions and may provide additional tools.\n\n" +
     "Skills can be in two states:\n" +
-    "- **Available**: Shared with you in user messages but not active yet. Their instructions are not loaded. " +
-    `You can enable them using the \`${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}\` ` +
-    "tool when they become relevant to the conversation.\n" +
+    "- **Available**: Listed but not active yet. Their instructions are not loaded. " +
+    `You can enable them using the \`${toolDisplayName}\` tool when they become relevant to the conversation.\n` +
     "- **Enabled**: Fully active with instructions loaded.\n\n" +
     "Enable skills proactively when a user's request matches a skill's purpose.\n" +
-    `If a user message contains a \`<skill id=\"...\" name=\"...\" />\` tag, treat it as a strong signal that the referenced skill is relevant. ` +
-    `If that skill is not already enabled and it would help, enable it with \`${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}\`.\n` +
-    "Only enable skills you actually need—enabling a skill loads its full instructions into context.\n" +
+    `If a user message contains a \`<skill id=\"...\" name=\"...\" />\` tag, treat it as a strong hint that the ` +
+    "referenced skill is relevant. If that skill is not already enabled, and it would help, enable it with " +
+    `\`${toolDisplayName}\`.\n` +
+    "Only enable skills you actually need, enabling a skill loads its full instructions into context.\n" +
     "If you need to enable multiple skills, enable them in parallel.\n\n" +
     "When in doubt about enabling a skill, prefer enabling it as it may give you a new " +
     "perspective on the currently available context.\n";
@@ -273,8 +275,6 @@ function constructSkillsSection({
     "- **Enabled**: Fully active with instructions loaded. Once enabled, a skill remains active " +
     "for the rest of the conversation.\n\n" +
     "Enable skills proactively when a user's request matches a skill's purpose.\n" +
-    `If a user message contains a \`<skill id=\"...\" name=\"...\" />\` tag, treat it as a strong signal that the referenced skill is relevant. ` +
-    `If that skill is not already enabled and it would help, enable it with \`${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}\`.\n` +
     "Only enable skills you actually need—enabling a skill loads its full instructions into context.\n" +
     "If you need to enable multiple skills, enable them in parallel.\n\n" +
     "When in doubt about enabling a skill, prefer enabling it as it may give you a new " +

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -231,8 +231,8 @@ function constructSkillsSectionForUserMessageRendering({
     "- **Enabled**: Fully active with instructions loaded.\n\n" +
     "Enable skills proactively when a user's request matches a skill's purpose.\n" +
     `If a user message contains a \`<skill id=\"...\" name=\"...\" />\` tag, treat it as a strong hint that the ` +
-    "referenced skill is relevant. If that skill is not already enabled, and it would help, enable it with " +
-    `\`${toolDisplayName}\`.\n` +
+    "referenced skill is relevant: it means the user specifically mentioned this skill. If the skill is not already " +
+    `enabled, and it would help, enable it with \`${toolDisplayName}\`.\n` +
     "Only enable skills you actually need, enabling a skill loads its full instructions into context.\n" +
     "If you need to enable multiple skills, enable them in parallel.\n\n" +
     "When in doubt about enabling a skill, prefer enabling it as it may give you a new " +

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -229,6 +229,8 @@ function constructSkillsSectionForUserMessageRendering({
     "tool when they become relevant to the conversation.\n" +
     "- **Enabled**: Fully active with instructions loaded.\n\n" +
     "Enable skills proactively when a user's request matches a skill's purpose.\n" +
+    `If a user message contains a \`<skill id=\"...\" name=\"...\" />\` tag, treat it as a strong signal that the referenced skill is relevant. ` +
+    `If that skill is not already enabled and it would help, enable it with \`${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}\`.\n` +
     "Only enable skills you actually need—enabling a skill loads its full instructions into context.\n" +
     "If you need to enable multiple skills, enable them in parallel.\n\n" +
     "When in doubt about enabling a skill, prefer enabling it as it may give you a new " +
@@ -271,6 +273,8 @@ function constructSkillsSection({
     "- **Enabled**: Fully active with instructions loaded. Once enabled, a skill remains active " +
     "for the rest of the conversation.\n\n" +
     "Enable skills proactively when a user's request matches a skill's purpose.\n" +
+    `If a user message contains a \`<skill id=\"...\" name=\"...\" />\` tag, treat it as a strong signal that the referenced skill is relevant. ` +
+    `If that skill is not already enabled and it would help, enable it with \`${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}\`.\n` +
     "Only enable skills you actually need—enabling a skill loads its full instructions into context.\n" +
     "If you need to enable multiple skills, enable them in parallel.\n\n" +
     "When in doubt about enabling a skill, prefer enabling it as it may give you a new " +


### PR DESCRIPTION
## Description

- We are changing JIT skill references from side-channel UI state into explicit message content, so selected skills appear inline in user messages as `<skill ... />` references.
- This PR improves the prompting to account for these changes.
- When the model sees an explicit inline skill reference in a user message, it should treat that as a strong signal that the referenced skill may need to be enabled via `skill_management__enable_skill` if relevant.

## Tests

- Checked locally..

## Risk

- Low.

## Deploy Plan

- Deploy front
