### PR TITLE
[Google Drive] Resolve sheet node parents from spreadsheets

### DIFF
--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -64,9 +64,11 @@ import type {
 } from "@connectors/types";
 import {
   FILE_ATTRIBUTES_TO_FETCH,
+  getGoogleIdsFromSheetContentNodeInternalId,
   getGoogleSheetContentNodeInternalId,
   googleDriveIncrementalSyncWorkflowId,
   INTERNAL_MIME_TYPES,
+  isGoogleSheetContentNodeInternalId,
   normalizeError,
 } from "@connectors/types";
 import type { ConnectorProvider, Result } from "@dust-tt/client";
@@ -720,12 +722,18 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         return new Ok([]);
       }
 
+      const isGoogleSheetContentNode =
+        isGoogleSheetContentNodeInternalId(internalId);
+      const driveObjectId = isGoogleSheetContentNode
+        ? getGoogleIdsFromSheetContentNodeInternalId(internalId).googleFileId
+        : getDriveFileId(internalId);
+
       const authCredentials = await getAuthObject(connector.connectionId);
 
       const driveObject = await getGoogleDriveObject({
         connectorId: this.connectorId,
         authCredentials,
-        driveObjectId: getDriveFileId(internalId),
+        driveObjectId,
         cacheKey: { connectorId: this.connectorId, ts: memoizationKey },
       });
 
@@ -743,7 +751,12 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         { includeAllRemoteParents: true }
       );
 
-      return new Ok(parents.map((p) => getInternalId(p)));
+      const parentInternalIds = parents.map((p) => getInternalId(p));
+      return new Ok(
+        isGoogleSheetContentNode
+          ? [internalId, ...parentInternalIds]
+          : parentInternalIds
+      );
     } catch (err) {
       return new Err(normalizeError(err));
     }


### PR DESCRIPTION
## Description
Google Drive spreadsheets are represented as a spreadsheet content node plus one table content node per sheet. Sheet table nodes use synthetic internal ids (`google-spreadsheet-...-sheet-...`) that are not Google Drive file ids.

`retrieveContentNodeParents` is used by the connectors permissions API to attach parent paths to read resources. When called with a sheet table node, it previously tried to fetch a Drive object using the synthetic sheet id, which cannot exist in Google Drive. This resolves the parent path through the backing spreadsheet file id instead, while returning the same internal parent path shape used when syncing sheets: `[sheetId, spreadsheetId, ...]`.

This does not change the Google Drive managed permissions UI selection model; users still select folders there. It fixes correctness for the connectors permissions API table-resource path and prevents valid synced sheet table nodes from being treated as missing when that API asks for their parents.

## Risks
Blast radius: Google Drive table content-node parent path resolution through the connectors permissions API.
Risk: low

## Deploy Plan
- pmrr
- deploy connectors