### PR TITLE
Clean do not affect pending todos.

### DIFF
--- a/front/lib/resources/project_todo_resource.test.ts
+++ b/front/lib/resources/project_todo_resource.test.ts
@@ -439,6 +439,57 @@ describe("ProjectTodoResource", () => {
     });
   });
 
+  describe("fetchBySpace", () => {
+    it("should hide done todos completed before lastCleanedAt", async () => {
+      const cutoff = new Date();
+      const beforeCutoff = new Date(cutoff.getTime() - 60_000);
+
+      const oldDone = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id, { text: "Hidden after clean" })
+      );
+      await oldDone.updateWithVersion(auth, {
+        status: "done",
+        doneAt: beforeCutoff,
+        markedAsDoneByType: "user",
+        markedAsDoneByUserId: user.id,
+        markedAsDoneByAgentConfigurationId: null,
+      });
+
+      const visible = await ProjectTodoResource.fetchBySpace(auth, {
+        spaceId: space.id,
+        lastCleanedAt: cutoff,
+      });
+
+      expect(visible.map((t) => t.sId)).not.toContain(oldDone.sId);
+    });
+
+    it("should still return todos with pending agentSuggestionStatus when done before lastCleanedAt", async () => {
+      const cutoff = new Date();
+      const beforeCutoff = new Date(cutoff.getTime() - 60_000);
+
+      const pending = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id, { text: "Pending suggestion" })
+      );
+      await pending.updateWithVersion(auth, {
+        status: "done",
+        doneAt: beforeCutoff,
+        markedAsDoneByType: "user",
+        markedAsDoneByUserId: user.id,
+        markedAsDoneByAgentConfigurationId: null,
+        agentSuggestionStatus: "pending",
+      });
+
+      const visible = await ProjectTodoResource.fetchBySpace(auth, {
+        spaceId: space.id,
+        lastCleanedAt: cutoff,
+      });
+
+      expect(visible.map((t) => t.sId)).toContain(pending.sId);
+    });
+  });
+
   describe("delete", () => {
     it("should delete the todo so fetchBySId returns null afterwards", async () => {
       const todo = await ProjectTodoResource.makeNew(

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -358,7 +358,8 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     let where: WhereOptions<ProjectTodoModel> = { spaceId };
 
     // Apply per-viewer "clean done" cutoff: hide done todos completed before
-    // lastCleanedAt, regardless of assignee.
+    // lastCleanedAt, regardless of assignee. Pending agent suggestions stay
+    // visible so users can still approve or reject after cleaning.
     if (lastCleanedAt) {
       where = {
         [Op.and]: [
@@ -368,6 +369,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
               { status: { [Op.ne]: "done" } },
               { doneAt: null },
               { doneAt: { [Op.gte]: lastCleanedAt } },
+              { agentSuggestionStatus: "pending" },
             ],
           },
         ],

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
@@ -159,6 +159,61 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_todos", () => {
     expect(texts).not.toContain("Other user's done");
   });
 
+  it("should still return pending agent suggestion todos completed before lastCleanedAt", async () => {
+    const { user, auth } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    const cutoff = new Date();
+    const beforeCutoff = new Date(cutoff.getTime() - 60_000);
+
+    const pendingDone = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Pending approval but done before clean",
+    });
+    await pendingDone.updateWithVersion(adminAuth, {
+      status: "done",
+      doneAt: beforeCutoff,
+      markedAsDoneByType: "user",
+      markedAsDoneByUserId: user.id,
+      markedAsDoneByAgentConfigurationId: null,
+      agentSuggestionStatus: "pending",
+    });
+
+    const normallyHiddenDone = await ProjectTodoFactory.create(
+      workspace,
+      project,
+      {
+        userId: user.id,
+        text: "Plain old done before clean",
+      }
+    );
+    await normallyHiddenDone.updateWithVersion(adminAuth, {
+      status: "done",
+      doneAt: beforeCutoff,
+      markedAsDoneByType: "user",
+      markedAsDoneByUserId: user.id,
+      markedAsDoneByAgentConfigurationId: null,
+    });
+
+    await ProjectTodoStateResource.upsertLastCleanedAtBySpace(auth, {
+      spaceId: project.id,
+      lastCleanedAt: cutoff,
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.assignee = "all";
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const texts = res._getJSONData().todos.map((t: { text: string }) => t.text);
+
+    expect(texts).toContain("Pending approval but done before clean");
+    expect(texts).not.toContain("Plain old done before clean");
+  });
+
   it("should return 400 for non-project spaces", async () => {
     const { user } = await setup();
     const adminAuth = await Authenticator.internalAdminForWorkspace(


### PR DESCRIPTION
## Description

The per-viewer "clean done" filter hides todos completed before `lastCleanedAt`. Without a carve-out, pending agent suggestions that were marked done before a clean would also disappear, preventing users from ever acting on them.

- Add `{ agentSuggestionStatus: "pending" }` as an OR condition in the `fetchBySpace` where clause so pending todos are always returned regardless of `lastCleanedAt`
- Add tests: confirm a plain-done todo is hidden after clean, and a pending-done todo remains visible

## Tests

Green (2 new test cases)

## Risk

Low — pending todos are already a small set; the OR clause adds no meaningful query overhead

## Deploy Plan

Deploy `front`
