### PR TITLE
Include global agents in analytics exports

### DIFF
--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -1,8 +1,10 @@
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { WorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
 import { QueryTypes } from "sequelize";
 
@@ -58,9 +60,10 @@ export const AGENT_EXPORT_HEADERS: (keyof AgentExportRow)[] = [
 
 export async function fetchAgentExportRows(
   baseQuery: estypes.QueryDslQueryContainer,
-  owner: WorkspaceType,
+  auth: Authenticator,
   includeHiddenAgents: boolean
 ): Promise<Result<AgentExportRow[], Error>> {
+  const owner = auth.getNonNullableWorkspace();
   const esResult = await searchAnalytics<never, TopAgentsExportAggs>(
     {
       bool: {
@@ -152,6 +155,32 @@ export async function fetchAgentExportRows(
       lastEdit: agent.lastEdit,
     };
   });
+
+  const globalAgentIds = buckets
+    .map((b) => String(b.key))
+    .filter(isGlobalAgentId);
+  if (globalAgentIds.length > 0) {
+    const globalAgents = await getAgentConfigurations(auth, {
+      agentIds: globalAgentIds,
+      variant: "extra_light",
+    });
+    for (const agent of globalAgents) {
+      const metrics = esMetrics.get(agent.sId);
+      rows.push({
+        agentId: agent.sId,
+        name: agent.name,
+        description: agent.description,
+        settings: "global",
+        modelId: agent.model.modelId,
+        providerId: agent.model.providerId,
+        authorEmails: "",
+        messages: metrics?.messages ?? 0,
+        distinctUsersReached: metrics?.distinctUsersReached ?? 0,
+        distinctConversations: metrics?.distinctConversations ?? 0,
+        lastEdit: "",
+      });
+    }
+  }
 
   rows.sort((a, b) => b.messages - a.messages);
 

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -27,6 +27,7 @@ import {
 } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { formatUTCDateFromMillis } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -155,6 +156,7 @@ export type ExportTableData =
     };
 
 export async function exportTable({
+  auth,
   table,
   startDate,
   endDate,
@@ -162,6 +164,7 @@ export async function exportTable({
   owner,
   includeHiddenAgents,
 }: {
+  auth: Authenticator;
   table: AnalyticsExportTable;
   startDate: string;
   endDate: string;
@@ -177,7 +180,13 @@ export async function exportTable({
     case "source":
       return exportSource({ startDate, endDate, timezone, owner });
     case "agents":
-      return exportAgents({ startDate, endDate, owner, includeHiddenAgents });
+      return exportAgents({
+        auth,
+        startDate,
+        endDate,
+        owner,
+        includeHiddenAgents,
+      });
     case "users":
       return exportUsers({ startDate, endDate, timezone, owner });
     case "skill_usage":
@@ -351,11 +360,13 @@ async function exportSource({
 }
 
 async function exportAgents({
+  auth,
   startDate,
   endDate,
   owner,
   includeHiddenAgents,
 }: {
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   owner: WorkspaceType;
@@ -369,7 +380,7 @@ async function exportAgents({
 
   const result = await fetchAgentExportRows(
     baseQuery,
-    owner,
+    auth,
     includeHiddenAgents
   );
 

--- a/front/pages/api/v1/w/[wId]/analytics/export.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.ts
@@ -140,6 +140,7 @@ async function handler(
 
       const owner = auth.getNonNullableWorkspace();
       const result = await exportTable({
+        auth,
         table: q.data.table,
         startDate: q.data.startDate,
         endDate: q.data.endDate,

--- a/front/pages/api/w/[wId]/analytics/agents-export.ts
+++ b/front/pages/api/w/[wId]/analytics/agents-export.ts
@@ -53,7 +53,7 @@ async function handler(
         days: q.data.days,
       });
 
-      const result = await fetchAgentExportRows(baseQuery, owner, true);
+      const result = await fetchAgentExportRows(baseQuery, auth, true);
 
       if (result.isErr()) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

The /analytics/agents-export CSV and the public /api/v1/.../analytics/export?table=agents both excluded global agents like @Dust, @claude, @gpt-5-mini, etc. — even though those agents appear on the /analytics page in the UI.

The root cause: fetchAgentExportRows fetched agent metadata with a raw SQL query filtered by workspaceId, but global agents aren't stored per-workspace in agent_configurations. The workspace-scoped SQL returned nothing for them, so they were silently dropped from the CSV.

The UI's top-agents endpoint didn't have this bug because it used getAgentConfigurations, which delegates to getGlobalAgents for global IDs.

Fixes https://github.com/dust-tt/tasks/issues/7954

## Tests

Manual

## Risk

Low

## Deploy Plan

Front