### PR TITLE
[Branching] Rename per-message branch action

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -794,7 +794,7 @@ export function AgentMessage({
 
     if (canBranchConversation) {
       dropdownItems.push({
-        label: "Branch conversation",
+        label: "Branch from here",
         icon: ActionGitBranchIcon,
         onSelect: () => {
           void branchConversation(agentMessage.sId);


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7787.
Context: https://dust4ai.slack.com/archives/C05BUSJQP5W/p1776962633625899?thread_ts=1776952384.283409&cid=C05BUSJQP5W

Renames the per-message branch menu action to "Branch from here" so the label reflects the clicked message as the branch point.

## Risks
Blast radius: conversation message dropdown for sessions branching.
Risk: low

## Deploy Plan
- pmrr (very small)
- deploy front