### PR TITLE
[Branching] Add branch action to project conversation rows

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -1,3 +1,8 @@
+import {
+  ConversationMenu,
+  useConversationMenu,
+} from "@app/components/assistant/conversation/ConversationMenu";
+import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
 import {
@@ -12,7 +17,12 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { stripMarkdown } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import type { Avatar } from "@dust-tt/sparkle";
-import { ConversationListItem, ReplySection } from "@dust-tt/sparkle";
+import {
+  Button,
+  ConversationListItem,
+  MoreIcon,
+  ReplySection,
+} from "@dust-tt/sparkle";
 import uniqBy from "lodash/uniqBy";
 import moment from "moment";
 import { useMemo } from "react";
@@ -21,14 +31,19 @@ import { isMessageUnread } from "../../utils";
 
 interface SpaceConversationListItemProps {
   conversation: LightConversationType;
+  onConversationBranched?: () => Promise<void> | void;
   owner: WorkspaceType;
 }
 
 export function SpaceConversationListItem({
   conversation,
+  onConversationBranched,
   owner,
 }: SpaceConversationListItemProps) {
   const router = useAppRouter();
+  const activeConversationId = useActiveConversationId();
+  const { isMenuOpen, menuTriggerPosition, handleMenuOpenChange } =
+    useConversationMenu();
 
   const validMessages = conversation.content.filter((message) => {
     if (isCompactionMessageType(message)) {
@@ -132,6 +147,28 @@ export function SpaceConversationListItem({
               lastMessageBy={avatars[0]?.name ?? "Unknown"}
             />
           ) : null
+        }
+        moreMenu={
+          <ConversationMenu
+            activeConversationId={conversation.sId}
+            conversation={conversation}
+            onConversationBranched={onConversationBranched}
+            owner={owner}
+            trigger={({ isPendingAction }) => (
+              <Button
+                size="xmini"
+                icon={MoreIcon}
+                variant="ghost"
+                aria-label="Conversation menu"
+                isLoading={isPendingAction}
+                disabled={isPendingAction}
+              />
+            )}
+            isConversationDisplayed={activeConversationId === conversation.sId}
+            isOpen={isMenuOpen}
+            onOpenChange={handleMenuOpenChange}
+            triggerPosition={menuTriggerPosition}
+          />
         }
         onClick={async () => {
           await router.push(

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -65,6 +65,7 @@ interface SpaceConversationsTabProps {
     contentFragments: ContentFragmentsType,
     selectedMCPServerViewIds?: string[]
   ) => Promise<Result<undefined, any>>;
+  onConversationBranched?: () => Promise<void> | void;
   onOpenMembersPanel: () => void;
 }
 
@@ -81,6 +82,7 @@ export function SpaceConversationsTab({
   conversationFilter,
   onConversationFilterChange,
   onSubmit,
+  onConversationBranched,
   onOpenMembersPanel,
 }: SpaceConversationsTabProps) {
   const { isEditor: isProjectEditor } = spaceInfo;
@@ -338,6 +340,9 @@ export function SpaceConversationsTab({
                                 <SpaceConversationListItem
                                   key={conversation.sId}
                                   conversation={conversation}
+                                  onConversationBranched={
+                                    onConversationBranched
+                                  }
                                   owner={owner}
                                 />
                               ))}

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -125,6 +125,10 @@ export function SpaceConversationsPage() {
     [projectUIPreferences, setProjectUIPreferences]
   );
 
+  const handleConversationBranched = useCallback(() => {
+    void mutateConversations();
+  }, [mutateConversations]);
+
   const handleTodoOwnerFilterChange = useCallback(
     (todosOwnerFilter: TodoOwnerFilter) => {
       setProjectUIPreferences({
@@ -290,6 +294,7 @@ export function SpaceConversationsPage() {
           conversationFilter={conversationFilter}
           onConversationFilterChange={handleConversationFilterChange}
           onSubmit={handleConversationCreation}
+          onConversationBranched={handleConversationBranched}
           onOpenMembersPanel={() => setIsInvitePanelOpen(true)}
         />
       </div>
@@ -367,6 +372,7 @@ export function SpaceConversationsPage() {
             conversationFilter={conversationFilter}
             onConversationFilterChange={handleConversationFilterChange}
             onSubmit={handleConversationCreation}
+            onConversationBranched={handleConversationBranched}
             onOpenMembersPanel={() => setIsInvitePanelOpen(true)}
           />
         </TabsContent>

--- a/sparkle/src/components/ConversationListItem.tsx
+++ b/sparkle/src/components/ConversationListItem.tsx
@@ -103,6 +103,7 @@ export interface ConversationListItemProps {
   };
   time: string;
   replySection?: ReactNode;
+  moreMenu?: ReactNode;
   onClick?: () => void;
   showFocus?: boolean;
 }
@@ -113,6 +114,7 @@ export function ConversationListItem({
   creator,
   time,
   replySection,
+  moreMenu,
   onClick,
   showFocus = false,
 }: ConversationListItemProps) {
@@ -145,6 +147,7 @@ export function ConversationListItem({
     <ListItem
       onClick={onClick}
       groupName="conversation-item"
+      ignorePressSelector="[data-conversation-list-item-menu]"
       className={`s-transition-colors s-duration-500 ${
         isFocusVisible ? "s-bg-highlight-50 dark:s-bg-highlight-100-night" : ""
       }`}
@@ -178,6 +181,14 @@ export function ConversationListItem({
           </div>
           <div className="s-flex s-shrink-0 s-items-center s-gap-2 s-text-xs s-text-muted-foreground dark:s-text-muted-foreground-night">
             <span className="s-font-normal">{time}</span>
+            {moreMenu && (
+              <div
+                data-conversation-list-item-menu
+                className="s-pointer-events-none s-opacity-0 s-transition-opacity group-focus-within/conversation-item:s-pointer-events-auto group-focus-within/conversation-item:s-opacity-100 group-hover/conversation-item:s-pointer-events-auto group-hover/conversation-item:s-opacity-100"
+              >
+                {moreMenu}
+              </div>
+            )}
           </div>
         </div>
         {conversation.description && (


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7788.

Adds the shared conversation menu to project conversation rows so listed conversations expose the sessions branching action from their overflow menu.

## Risks
Blast radius: project conversation list rows and the shared Sparkle conversation list item component.
Risk: low

## Deploy Plan
- deploy sparkle
- deploy front