### PR TITLE
Improve add to-do to make it more aligned with regular todos look.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/AddTodoComposer.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/AddTodoComposer.tsx
@@ -1,0 +1,290 @@
+import {
+  MANUAL_ADD_TODO_INPUT_FIELD_CLASS,
+  MANUAL_ADD_TODO_PLACEHOLDER,
+  NEW_MANUAL_TODO_MAX_CHARS,
+  PROJECT_TODO_EDIT_ACTION_CLUSTER_CLASS,
+  PROJECT_TODO_ITEM_ROW_FRAME_CLASS,
+  PROJECT_TODO_MANUAL_ADD_LEADING_ASSIGNEE_ANCHOR_CLASS,
+  PROJECT_TODO_MANUAL_ADD_LEADING_CLASS,
+  PROJECT_TODO_TABLE_ROW_INSET_CLASS,
+  stripNewlines,
+} from "@app/components/assistant/conversation/space/conversations/project_todos/utils";
+import { removeDiacritics } from "@app/lib/utils";
+import type { SpaceUserType } from "@app/types/user";
+import {
+  Avatar,
+  Button,
+  cn,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+function TodoRowAssigneeMenu({
+  ariaNamePrefix,
+  members,
+  viewerUserId,
+  selectedSId,
+  onSelect,
+  onMenuOpenChange,
+  disabled,
+}: {
+  ariaNamePrefix: string;
+  members: SpaceUserType[];
+  viewerUserId: string | null;
+  selectedSId: string | null;
+  onSelect: (userSId: string) => void;
+  onMenuOpenChange?: (open: boolean) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const filteredMembers = useMemo(() => {
+    const q = removeDiacritics(search.trim()).toLowerCase();
+    if (!q) {
+      return [...members];
+    }
+    return members.filter((m) =>
+      removeDiacritics(m.fullName).toLowerCase().includes(q)
+    );
+  }, [search, members]);
+  const selectedUser = members.find((m) => m.sId === selectedSId);
+  const assigneeTriggerVisual =
+    selectedUser?.image ?? "/static/humanavatar/anonymous.png";
+  const title = selectedUser
+    ? `Assign to ${selectedUser.fullName}${viewerUserId === selectedUser.sId ? " (you)" : ""} — click to change`
+    : "Choose assignee";
+  const ariaLabel = selectedUser
+    ? `Assign to ${selectedUser.fullName}${viewerUserId === selectedUser.sId ? " (you)" : ""}, open menu to change`
+    : "Choose assignee";
+
+  return (
+    <DropdownMenu
+      modal={false}
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        onMenuOpenChange?.(nextOpen);
+        if (nextOpen) {
+          setSearch("");
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          title={title}
+          aria-label={ariaLabel}
+          onMouseDown={(e) => e.preventDefault()}
+          className={cn(
+            "flex size-7 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-background p-0 ring-1 ring-border/60 ring-inset hover:brightness-105",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            "dark:bg-background-night dark:ring-border-night/55",
+            "disabled:pointer-events-none disabled:opacity-40"
+          )}
+        >
+          <Avatar size="xs" isRounded visual={assigneeTriggerVisual} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
+        align="start"
+      >
+        <DropdownMenuSearchbar
+          autoFocus
+          name={`${ariaNamePrefix}-assignee-search`}
+          placeholder="Search members"
+          value={search}
+          onChange={setSearch}
+        />
+        <DropdownMenuSeparator />
+        <div className="max-h-64 overflow-auto">
+          {filteredMembers.length > 0 ? (
+            filteredMembers.map((member) => (
+              <DropdownMenuCheckboxItem
+                key={`${ariaNamePrefix}-member-${member.sId}`}
+                icon={() => (
+                  <Avatar
+                    size="xxs"
+                    isRounded
+                    visual={member.image ?? "/static/humanavatar/anonymous.png"}
+                  />
+                )}
+                label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
+                checked={selectedSId === member.sId}
+                onClick={() => {
+                  onSelect(member.sId);
+                  setOpen(false);
+                  onMenuOpenChange?.(false);
+                }}
+                onSelect={(event) => {
+                  event.preventDefault();
+                }}
+              />
+            ))
+          ) : (
+            <div className="px-3 py-2 text-sm text-muted-foreground">
+              No members found
+            </div>
+          )}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function AddTodoComposer({
+  projectMembers,
+  viewerUserId,
+  defaultAssigneeSId,
+  onAdd,
+}: {
+  projectMembers: SpaceUserType[];
+  viewerUserId: string | null;
+  defaultAssigneeSId: string;
+  onAdd: (text: string, assigneeSId: string) => Promise<boolean>;
+}) {
+  const [text, setText] = useState("");
+  const [assigneeSId, setAssigneeSId] = useState<string | null>(null);
+  const [isAdding, setIsAdding] = useState(false);
+  const [inputFocused, setInputFocused] = useState(false);
+  const [assigneeMenuOpen, setAssigneeMenuOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedSId = assigneeSId ?? defaultAssigneeSId;
+
+  const isExpanded =
+    inputFocused || assigneeMenuOpen || stripNewlines(text).trim().length > 0;
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = stripNewlines(text).trim();
+    if (!trimmed || !selectedSId || isAdding) {
+      return;
+    }
+    setIsAdding(true);
+    const ok = await onAdd(trimmed, selectedSId);
+    setIsAdding(false);
+    if (ok) {
+      setText("");
+      // Re-assert focus after paint; `readOnly` keeps focus during `onAdd`, but
+      // some browsers / parent updates can still drop it.
+      queueMicrotask(() => {
+        const el = inputRef.current;
+        if (el) {
+          el.focus();
+          setInputFocused(true);
+        }
+      });
+    }
+  }, [text, selectedSId, isAdding, onAdd]);
+
+  const sideChromeToneClass = cn(
+    "transition-opacity duration-300 ease-in-out motion-reduce:transition-none motion-reduce:duration-75",
+    isExpanded ? "opacity-100" : "opacity-[0.4] hover:opacity-[0.88]"
+  );
+
+  const assigneeChromeToneClass = cn(
+    "transition-[opacity,filter] duration-300 ease-in-out motion-reduce:transition-none motion-reduce:duration-75",
+    isExpanded
+      ? "opacity-100 grayscale-0 brightness-100"
+      : "opacity-[0.42] grayscale brightness-[0.88] hover:opacity-[0.9] hover:grayscale-[0.12] hover:brightness-100"
+  );
+
+  return (
+    <div ref={containerRef} className={PROJECT_TODO_TABLE_ROW_INSET_CLASS}>
+      <div className={PROJECT_TODO_ITEM_ROW_FRAME_CLASS}>
+        <div className={PROJECT_TODO_MANUAL_ADD_LEADING_CLASS}>
+          <div
+            className={cn(
+              PROJECT_TODO_MANUAL_ADD_LEADING_ASSIGNEE_ANCHOR_CLASS,
+              assigneeChromeToneClass
+            )}
+          >
+            <TodoRowAssigneeMenu
+              ariaNamePrefix="add-todo"
+              members={projectMembers}
+              viewerUserId={viewerUserId}
+              selectedSId={selectedSId}
+              onSelect={setAssigneeSId}
+              onMenuOpenChange={setAssigneeMenuOpen}
+              disabled={isAdding}
+            />
+          </div>
+        </div>
+        <div className="flex min-w-0 flex-1 items-center gap-1">
+          <div
+            className={cn(
+              "box-border flex h-[2.375rem] min-h-[2.375rem] min-w-0 max-w-3xl flex-1 flex-col justify-center rounded-md",
+              "border border-border/55 bg-muted-background/70 px-2 py-1.5",
+              "cursor-text transition-colors hover:bg-muted-background/85 dark:border-border-night/55 dark:bg-muted-background-night/45 dark:hover:bg-muted-background-night/60",
+              "focus-within:border-border-highlight focus-within:ring-2 focus-within:ring-highlight/35 dark:focus-within:border-highlight-night"
+            )}
+          >
+            <input
+              ref={inputRef}
+              type="text"
+              name="new-manual-project-todo"
+              aria-label="New to-do"
+              autoComplete="off"
+              maxLength={NEW_MANUAL_TODO_MAX_CHARS}
+              placeholder={MANUAL_ADD_TODO_PLACEHOLDER}
+              value={text}
+              readOnly={isAdding}
+              aria-busy={isAdding}
+              className={cn(
+                MANUAL_ADD_TODO_INPUT_FIELD_CLASS,
+                isAdding && "cursor-wait opacity-60"
+              )}
+              onChange={(e) => setText(stripNewlines(e.target.value))}
+              onFocus={() => setInputFocused(true)}
+              onBlur={(e) => {
+                const next = e.relatedTarget;
+                if (
+                  next instanceof Node &&
+                  containerRef.current?.contains(next)
+                ) {
+                  return;
+                }
+                setInputFocused(false);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  inputRef.current?.blur();
+                  setInputFocused(false);
+                  return;
+                }
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleSubmit();
+                }
+              }}
+            />
+          </div>
+          <div
+            className={cn(
+              PROJECT_TODO_EDIT_ACTION_CLUSTER_CLASS,
+              sideChromeToneClass
+            )}
+          >
+            <Button
+              size="sm"
+              variant="highlight"
+              label="Add"
+              isLoading={isAdding}
+              disabled={isAdding || !stripNewlines(text).trim() || !selectedSId}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => void handleSubmit()}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -479,7 +479,7 @@ export const EditableTodoItem = memo(function EditableTodoItem({
             <div
               className={cn(
                 "flex shrink-0 items-center gap-1 transition-opacity",
-                startMenuKeepsActionsVisible
+                startMenuKeepsActionsVisible || isFirstOnboardingTodo
                   ? "opacity-100"
                   : "opacity-100 md:opacity-0 md:group-hover/todo:opacity-100 md:focus-within:opacity-100"
               )}

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain.tsx
@@ -1,8 +1,7 @@
+import { AddTodoComposer } from "@app/components/assistant/conversation/space/conversations/project_todos/AddTodoComposer";
 import { ProjectTodosDataTable } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTable";
 import { useProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
-import { AddTodoComposer } from "@app/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents";
-import { ADD_TODO_BAR_SHELL_CLASS } from "@app/components/assistant/conversation/space/conversations/project_todos/utils";
-import { cn, Icon, PlusIcon, Spinner } from "@dust-tt/sparkle";
+import { Spinner } from "@dust-tt/sparkle";
 
 export function ProjectTodosPanelMain() {
   const {
@@ -31,8 +30,6 @@ export function ProjectTodosPanelMain() {
     patchTodoItem,
     isSpaceInfoLoading,
     defaultNewAssigneeSId,
-    isAddTodoComposerOpen,
-    setIsAddTodoComposerOpen,
     handleAddTodo,
     isTodosLoading,
     frozenLastReadAt,
@@ -72,7 +69,7 @@ export function ProjectTodosPanelMain() {
         </div>
       )}
       <div className="flex flex-col gap-3">
-        {/* Manual add: discreet until opened; one row when expanded */}
+        {/* Manual add: single row; expands on focus / menu / typed text */}
         {!isReadOnly &&
           (isSpaceInfoLoading ? (
             <div className="flex h-7 items-center">
@@ -82,32 +79,13 @@ export function ProjectTodosPanelMain() {
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               No project members available to assign.
             </p>
-          ) : isAddTodoComposerOpen ? (
+          ) : (
             <AddTodoComposer
               projectMembers={projectMembers}
               viewerUserId={viewerUserId}
               defaultAssigneeSId={defaultNewAssigneeSId!}
               onAdd={handleAddTodo}
-              onClose={() => setIsAddTodoComposerOpen(false)}
             />
-          ) : (
-            <button
-              type="button"
-              onClick={() => setIsAddTodoComposerOpen(true)}
-              className={cn(
-                ADD_TODO_BAR_SHELL_CLASS,
-                "cursor-pointer text-left text-muted-foreground transition-colors",
-                "hover:bg-muted-background/80 dark:text-muted-foreground-night dark:hover:bg-muted-background-night/70"
-              )}
-            >
-              <span className="flex size-7 shrink-0 items-center justify-center">
-                <Icon visual={PlusIcon} size="xs" className="opacity-80" />
-              </span>
-              <span className="min-w-0 flex-1 text-base leading-6">
-                Add a to-do
-              </span>
-              <span className="size-7 shrink-0" aria-hidden />
-            </button>
           ))}
 
         {/* Body */}

--- a/front/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents.tsx
@@ -1,10 +1,3 @@
-import {
-  ADD_TODO_BAR_SHELL_CLASS,
-  NEW_MANUAL_TODO_MAX_CHARS,
-  stripNewlines,
-  TODO_TEXTAREA_FIELD_CLASS,
-  useAutosizeTextArea,
-} from "@app/components/assistant/conversation/space/conversations/project_todos/utils";
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useUser } from "@app/lib/swr/user";
@@ -17,274 +10,24 @@ import type {
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type {
   LightWorkspaceType,
-  SpaceUserType,
   UserTypeWithWorkspaces,
 } from "@app/types/user";
 import {
   Avatar,
   BookOpenIcon,
-  Button,
   ChatBubbleLeftRightIcon,
   ConfluenceLogo,
   cn,
   DriveLogo,
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuSearchbar,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
   GithubLogo,
   Icon,
   MicrosoftLogo,
   NotionLogo,
-  PlusIcon,
   SlackLogo,
   Tooltip,
 } from "@dust-tt/sparkle";
 import type React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-// ── Assignee menu ─────────────────────────────────────────────────────────────
-
-function TodoRowAssigneeMenu({
-  ariaNamePrefix,
-  members,
-  viewerUserId,
-  selectedSId,
-  onSelect,
-  disabled,
-}: {
-  ariaNamePrefix: string;
-  members: SpaceUserType[];
-  viewerUserId: string | null;
-  selectedSId: string | null;
-  onSelect: (userSId: string) => void;
-  disabled?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-  const filteredMembers = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) {
-      return members;
-    }
-    return members.filter((m) => m.fullName.toLowerCase().includes(q));
-  }, [search, members]);
-  const selectedUser = members.find((m) => m.sId === selectedSId);
-  const assigneeTriggerVisual =
-    selectedUser?.image ?? "/static/humanavatar/anonymous.png";
-  const AssigneeTriggerIcon = useMemo(
-    () =>
-      function AssigneeTriggerIconFn({ className }: { className?: string }) {
-        return (
-          <Avatar
-            className={className}
-            size="xxs"
-            isRounded
-            visual={assigneeTriggerVisual}
-          />
-        );
-      },
-    [assigneeTriggerVisual]
-  );
-
-  return (
-    <DropdownMenu
-      modal={false}
-      open={open}
-      onOpenChange={(nextOpen) => {
-        setOpen(nextOpen);
-        if (nextOpen) {
-          setSearch("");
-        }
-      }}
-    >
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          icon={AssigneeTriggerIcon}
-          disabled={disabled}
-          title={
-            selectedUser
-              ? `Assign to ${selectedUser.fullName}${viewerUserId === selectedUser.sId ? " (you)" : ""} — click to change`
-              : "Choose assignee"
-          }
-          aria-label={
-            selectedUser
-              ? `Assign to ${selectedUser.fullName}${viewerUserId === selectedUser.sId ? " (you)" : ""}, open menu to change`
-              : "Choose assignee"
-          }
-          className="shrink-0 focus-visible:ring-0 focus-visible:ring-offset-0 dark:focus-visible:ring-0 dark:focus-visible:ring-offset-0"
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
-        align="start"
-      >
-        <DropdownMenuSearchbar
-          autoFocus
-          name={`${ariaNamePrefix}-assignee-search`}
-          placeholder="Search members"
-          value={search}
-          onChange={setSearch}
-        />
-        <DropdownMenuSeparator />
-        <div className="max-h-64 overflow-auto">
-          {filteredMembers.length > 0 ? (
-            filteredMembers.map((member) => (
-              <DropdownMenuCheckboxItem
-                key={`${ariaNamePrefix}-member-${member.sId}`}
-                icon={() => (
-                  <Avatar
-                    size="xxs"
-                    isRounded
-                    visual={member.image ?? "/static/humanavatar/anonymous.png"}
-                  />
-                )}
-                label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
-                checked={selectedSId === member.sId}
-                onClick={() => {
-                  onSelect(member.sId);
-                  setOpen(false);
-                }}
-                onSelect={(event) => {
-                  event.preventDefault();
-                }}
-              />
-            ))
-          ) : (
-            <div className="px-3 py-2 text-sm text-muted-foreground">
-              No members found
-            </div>
-          )}
-        </div>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-// ── Add-todo composer ─────────────────────────────────────────────────────────
-
-export function AddTodoComposer({
-  projectMembers,
-  viewerUserId,
-  defaultAssigneeSId,
-  onAdd,
-  onClose,
-}: {
-  projectMembers: SpaceUserType[];
-  viewerUserId: string | null;
-  defaultAssigneeSId: string;
-  onAdd: (text: string, assigneeSId: string) => Promise<boolean>;
-  onClose: () => void;
-}) {
-  const [text, setText] = useState("");
-  const [assigneeSId, setAssigneeSId] = useState<string | null>(null);
-  const [isAdding, setIsAdding] = useState(false);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const selectedSId = assigneeSId ?? defaultAssigneeSId;
-
-  useAutosizeTextArea(inputRef, text, true);
-
-  useEffect(() => {
-    queueMicrotask(() => inputRef.current?.focus());
-  }, []);
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      const target = e.target as HTMLElement;
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(target) &&
-        !target.closest("[data-radix-popper-content-wrapper]") &&
-        !stripNewlines(text).trim()
-      ) {
-        onClose();
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [text, onClose]);
-
-  const handleSubmit = useCallback(async () => {
-    const trimmed = stripNewlines(text).trim();
-    if (!trimmed || !selectedSId || isAdding) {
-      return;
-    }
-    setIsAdding(true);
-    const ok = await onAdd(trimmed, selectedSId);
-    setIsAdding(false);
-    if (ok) {
-      setText("");
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => inputRef.current?.focus());
-      });
-    }
-  }, [text, selectedSId, isAdding, onAdd]);
-
-  return (
-    <div ref={containerRef} className={ADD_TODO_BAR_SHELL_CLASS}>
-      <TodoRowAssigneeMenu
-        ariaNamePrefix="add-todo"
-        members={projectMembers}
-        viewerUserId={viewerUserId}
-        selectedSId={selectedSId}
-        onSelect={setAssigneeSId}
-        disabled={isAdding}
-      />
-      <textarea
-        ref={inputRef}
-        name="new-manual-project-todo"
-        aria-label="New to-do"
-        autoComplete="off"
-        rows={1}
-        maxLength={NEW_MANUAL_TODO_MAX_CHARS}
-        placeholder="A new awesome task..."
-        value={text}
-        disabled={isAdding}
-        className={cn(
-          TODO_TEXTAREA_FIELD_CLASS,
-          "min-w-0 flex-1",
-          "disabled:opacity-60"
-        )}
-        onChange={(e) => setText(stripNewlines(e.target.value))}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            e.preventDefault();
-            onClose();
-            return;
-          }
-          if (e.key === "Enter") {
-            e.preventDefault();
-            if (!stripNewlines(text).trim()) {
-              onClose();
-            } else {
-              void handleSubmit();
-            }
-          }
-        }}
-      />
-      <Tooltip
-        label="Add to-do"
-        trigger={
-          <Button
-            size="xs"
-            variant="highlight"
-            icon={PlusIcon}
-            isLoading={isAdding}
-            disabled={isAdding || !stripNewlines(text).trim() || !selectedSId}
-            onClick={() => void handleSubmit()}
-          />
-        }
-      />
-    </div>
-  );
-}
+import { useMemo } from "react";
 
 // ── Metadata tooltip ──────────────────────────────────────────────────────────
 

--- a/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
@@ -63,8 +63,6 @@ export type ProjectTodosPanelData = {
   ) => Promise<void>;
   isSpaceInfoLoading: boolean;
   defaultNewAssigneeSId: string | null;
-  isAddTodoComposerOpen: boolean;
-  setIsAddTodoComposerOpen: Dispatch<SetStateAction<boolean>>;
   handleAddTodo: (text: string, assigneeSId: string) => Promise<boolean>;
   isTodosLoading: boolean;
   frozenLastReadAt: string | null | undefined;

--- a/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
@@ -141,8 +141,6 @@ export function useProjectTodosPanelState({
     return projectMembers[0]!.sId;
   }, [projectMembers, viewerUserId]);
 
-  const [isAddTodoComposerOpen, setIsAddTodoComposerOpen] = useState(false);
-
   // ── Diff animation state ────────────────────────────────────────────────────
 
   // Frozen snapshot of lastReadAt taken on first successful load. undefined =
@@ -626,8 +624,6 @@ export function useProjectTodosPanelState({
     patchTodoItem,
     isSpaceInfoLoading,
     defaultNewAssigneeSId,
-    isAddTodoComposerOpen,
-    setIsAddTodoComposerOpen,
     handleAddTodo,
     isTodosLoading,
     frozenLastReadAt,

--- a/front/components/assistant/conversation/space/conversations/project_todos/utils.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/utils.ts
@@ -6,6 +6,7 @@ import { useCallback, useLayoutEffect } from "react";
 export const SUMMARY_ITEM_TRANSITION_MS = 240;
 export const DELETE_TODO_CONFIRM_PREVIEW_MAX_CHARS = 200;
 export const NEW_MANUAL_TODO_MAX_CHARS = 256;
+export const MANUAL_ADD_TODO_PLACEHOLDER = "Add a to-do...";
 
 /** To-dos are visually multi-line (soft wrap) but must not contain newline characters. */
 export function stripNewlines(value: string): string {
@@ -40,9 +41,43 @@ export function useAutosizeTextArea(
   }, [active, adjustHeight]);
 }
 
-export const ADD_TODO_BAR_SHELL_CLASS = cn(
-  "flex min-h-9 w-full min-w-0 items-center gap-1.5 rounded-md border border-border/60 bg-background/80 px-1.5 py-0 shadow-sm",
-  "dark:border-border-night/60 dark:bg-background-night/50"
+/** Indents standalone rows (e.g. add block) to match `ProjectTodosDataTable` todo rows. */
+export const PROJECT_TODO_TABLE_ROW_INSET_CLASS = "pl-4 pr-0";
+
+/** Outer frame for the manual-add row (avatar · input · action). */
+export const PROJECT_TODO_ITEM_ROW_FRAME_CLASS =
+  "flex w-full min-w-0 items-center gap-3 rounded-md px-1 py-1";
+
+/**
+ * Manual-add gutter width: matches todo rows (`Checkbox` / leading icon = `size-4`)
+ * so the input lines up under task text.
+ */
+export const PROJECT_TODO_MANUAL_ADD_LEADING_CLASS =
+  "relative h-[2.375rem] w-4 shrink-0 flex-none overflow-visible";
+
+/** Centers `size-7` assignee control in the narrow gutter without affecting layout width */
+export const PROJECT_TODO_MANUAL_ADD_LEADING_ASSIGNEE_ANCHOR_CLASS =
+  "absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 shrink-0";
+
+/** Invisible spacer in the checkbox / sparkles column when that column is unused. */
+export const PROJECT_TODO_LEADING_GUTTER_CLASS =
+  "mt-0.5 flex size-4 shrink-0 items-center justify-center";
+
+/** Manual-add trailing actions: hugs the input (`w-auto`); height `2.375rem` matches shell. */
+export const PROJECT_TODO_EDIT_ACTION_CLUSTER_CLASS =
+  "flex h-[2.375rem] w-auto shrink-0 flex-none items-center justify-start gap-1";
+
+/** Single-line field inside the manual-add shell (paired with TODO_TEXTAREA styling). */
+export const MANUAL_ADD_TODO_INPUT_FIELD_CLASS = cn(
+  "m-0 block h-[1.5rem] w-full min-w-0 border-0 bg-transparent px-0 py-0 align-middle text-base leading-6 text-foreground",
+  "shadow-none [box-shadow:none]",
+  "outline-none ring-0 ring-offset-0",
+  "focus:shadow-none focus:[box-shadow:none] focus:outline-none focus:ring-0 focus:ring-offset-0",
+  "focus:!ring-0 focus:!ring-offset-0",
+  "focus-visible:shadow-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
+  "focus-visible:!ring-0",
+  "placeholder:text-muted-foreground",
+  "dark:text-foreground-night dark:placeholder:text-muted-foreground-night"
 );
 
 export const TODO_TEXTAREA_FIELD_CLASS = cn(


### PR DESCRIPTION
## Description

The "Add a to-do" composer looked visually disconnected from the todo rows above it. This PR redesigns it to use the same layout primitives as `EditableTodoItem`.

- Extract `AddTodoComposer` to its own file
- Share CSS class constants with `EditableTodoItem` via `utils.ts` (`PROJECT_TODO_ITEM_ROW_FRAME_CLASS`, `PROJECT_TODO_TABLE_ROW_INSET_CLASS`, `PROJECT_TODO_MANUAL_ADD_LEADING_CLASS`, `PROJECT_TODO_MANUAL_ADD_LEADING_ASSIGNEE_ANCHOR_CLASS`, `MANUAL_ADD_TODO_INPUT_FIELD_CLASS`, etc.)
- Extract `TodoRowAssigneeMenu` as a reusable avatar-trigger dropdown, shared between the composer and the reassign flow
- Composer now matches todo rows visually: same row height, leading assignee avatar position, same text input style and placeholder

## Tests

Local

## Risk

Low — UI redesign only; create logic unchanged

## Deploy Plan

Deploy `front`
