### PR TITLE
Hide suggested todos until you have completed the initial todos.

### DIFF
--- a/front/components/assistant/conversation/space/SpaceTodosTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTodosTab.tsx
@@ -3,23 +3,10 @@ import {
   ProjectTodosPanelMain,
   ProjectTodosPanelProvider,
 } from "@app/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel";
+import { SuggestedTodosGenerationTile } from "@app/components/assistant/conversation/space/conversations/project_todos/SuggestedTodosGenerationTile";
 import type { TodoOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents";
-import { FirstSyncTodoLookbackForm } from "@app/components/assistant/conversation/space/FirstSyncTodoLookbackForm";
-import { ConfirmContext } from "@app/components/Confirm";
-import type { InitialTodoSyncLookbackValue } from "@app/lib/project_todo/analyze_document/types";
-import { useUpdateProjectMetadata } from "@app/lib/swr/spaces";
-import { timeAgoFrom } from "@app/lib/utils";
 import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { WorkspaceType } from "@app/types/user";
-import {
-  Chip,
-  Icon,
-  InformationCircleIcon,
-  SliderToggle,
-  SparklesIcon,
-  Tooltip,
-} from "@dust-tt/sparkle";
-import { useCallback, useContext, useRef, useState } from "react";
 
 interface SpaceTodosTabProps {
   owner: WorkspaceType;
@@ -28,115 +15,12 @@ interface SpaceTodosTabProps {
   onTodoOwnerFilterChange: (value: TodoOwnerFilter) => void;
 }
 
-const SUGGEST_TO_DOS_TOOLTIP =
-  "When this is on, Dust periodically reviews this project’s conversations and connected sources and adds suggested to-dos. Turn it off if you only want to-dos you create yourself.";
-
-const SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR = `${SUGGEST_TO_DOS_TOOLTIP} Only project editors can change this.`;
-
-const LAST_SCAN_NEVER_TOOLTIP =
-  "Dust has not run an automatic scan for to-do suggestions for this project yet.";
-
-function lastScanTooltip(lastTodoAnalysisAt: number | null): string {
-  if (lastTodoAnalysisAt == null) {
-    return LAST_SCAN_NEVER_TOOLTIP;
-  }
-  const relative = timeAgoFrom(lastTodoAnalysisAt, { useLongFormat: true });
-  return `Last automatic scan for new to-do suggestions: ${relative} ago.`;
-}
-
 export function SpaceTodosTab({
   owner,
   spaceInfo,
   todoOwnerFilter,
   onTodoOwnerFilterChange,
 }: SpaceTodosTabProps) {
-  const confirm = useContext(ConfirmContext);
-  const updateProjectMetadata = useUpdateProjectMetadata({
-    owner,
-    spaceId: spaceInfo.sId,
-  });
-  const [isUpdatingTodoGeneration, setIsUpdatingTodoGeneration] =
-    useState(false);
-  const firstSyncLookbackRef = useRef<InitialTodoSyncLookbackValue>("last_24h");
-  const onFirstSyncLookbackChange = useCallback(
-    (v: InitialTodoSyncLookbackValue) => {
-      firstSyncLookbackRef.current = v;
-    },
-    []
-  );
-
-  const isProjectArchived = !!spaceInfo.archivedAt;
-  const structurallyDisabled =
-    !spaceInfo.isMember || isProjectArchived || !spaceInfo.isEditor;
-  const sliderDisabled = structurallyDisabled || isUpdatingTodoGeneration;
-
-  const toggleTooltip = isProjectArchived
-    ? "This project is archived; suggestion settings cannot be changed."
-    : !spaceInfo.isEditor && spaceInfo.isMember
-      ? SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR
-      : SUGGEST_TO_DOS_TOOLTIP;
-
-  const handleTodoGenerationToggle = useCallback(async () => {
-    if (structurallyDisabled) {
-      return;
-    }
-    if (spaceInfo.todoGenerationEnabled) {
-      setIsUpdatingTodoGeneration(true);
-      try {
-        await updateProjectMetadata({
-          todoGenerationEnabled: false,
-        });
-      } finally {
-        setIsUpdatingTodoGeneration(false);
-      }
-      return;
-    }
-
-    if (spaceInfo.lastTodoAnalysisAt === null) {
-      firstSyncLookbackRef.current = "last_24h";
-      const confirmed = await confirm({
-        title: "Turn on suggested to-dos?",
-        message: (
-          <FirstSyncTodoLookbackForm
-            onValueChange={onFirstSyncLookbackChange}
-          />
-        ),
-        validateLabel: "Turn on",
-        validateVariant: "primary",
-        cancelLabel: "Cancel",
-      });
-      if (!confirmed) {
-        return;
-      }
-      setIsUpdatingTodoGeneration(true);
-      try {
-        await updateProjectMetadata({
-          todoGenerationEnabled: true,
-          initialTodoAnalysisLookback: firstSyncLookbackRef.current,
-        });
-      } finally {
-        setIsUpdatingTodoGeneration(false);
-      }
-      return;
-    }
-
-    setIsUpdatingTodoGeneration(true);
-    try {
-      await updateProjectMetadata({
-        todoGenerationEnabled: true,
-      });
-    } finally {
-      setIsUpdatingTodoGeneration(false);
-    }
-  }, [
-    confirm,
-    onFirstSyncLookbackChange,
-    structurallyDisabled,
-    spaceInfo.lastTodoAnalysisAt,
-    spaceInfo.todoGenerationEnabled,
-    updateProjectMetadata,
-  ]);
-
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-3 py-8">
@@ -148,56 +32,7 @@ export function SpaceTodosTab({
           onTodoOwnerFilterChange={onTodoOwnerFilterChange}
         >
           <ProjectTodoScopeFilter />
-          <div className="flex flex-col gap-3 pb-4">
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex min-w-0 flex-col gap-0.5">
-                <div className="flex flex-wrap items-center gap-2">
-                  <SparklesIcon
-                    className="h-4 w-4 shrink-0 text-foreground dark:text-foreground-night"
-                    aria-hidden
-                  />
-                  <span className="heading-sm text-foreground dark:text-foreground-night">
-                    Suggested to-dos
-                  </span>
-                  <Chip color="golden" label="Beta" size="mini" />
-                </div>
-                <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                  Automatic to-do suggestions from project activity
-                </div>
-              </div>
-              <div className="flex shrink-0 items-center gap-2">
-                <Tooltip
-                  label={toggleTooltip}
-                  trigger={
-                    <div>
-                      <SliderToggle
-                        size="xs"
-                        selected={spaceInfo.todoGenerationEnabled}
-                        disabled={sliderDisabled}
-                        onClick={
-                          structurallyDisabled
-                            ? () => {}
-                            : handleTodoGenerationToggle
-                        }
-                      />
-                    </div>
-                  }
-                />
-                <Tooltip
-                  label={lastScanTooltip(spaceInfo.lastTodoAnalysisAt)}
-                  trigger={
-                    <button
-                      type="button"
-                      className="text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night inline-flex rounded-md p-1"
-                      aria-label="Last automatic to-do suggestion scan"
-                    >
-                      <Icon visual={InformationCircleIcon} size="sm" />
-                    </button>
-                  }
-                />
-              </div>
-            </div>
-          </div>
+          <SuggestedTodosGenerationTile owner={owner} spaceInfo={spaceInfo} />
           <ProjectTodosPanelMain />
         </ProjectTodosPanelProvider>
       </div>

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter.tsx
@@ -3,7 +3,6 @@ import {
   Avatar,
   Button,
   ChevronDownIcon,
-  cn,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -18,7 +17,6 @@ import {
 
 export function ProjectTodoScopeFilter() {
   const {
-    showSuggestedTodosTable,
     assigneeSearch,
     setAssigneeSearch,
     isAssigneeMenuOpen,
@@ -36,13 +34,7 @@ export function ProjectTodoScopeFilter() {
   } = useProjectTodosPanel();
 
   return (
-    <div
-      className={cn(
-        "border-b border-border pb-6 dark:border-border-night",
-        !showSuggestedTodosTable &&
-          "border-t border-border pt-6 dark:border-border-night"
-      )}
-    >
+    <div className="border-b border-border pb-6 dark:border-border-night">
       <div className="inline-flex w-full items-center gap-2">
         <DropdownMenu
           modal={false}

--- a/front/components/assistant/conversation/space/conversations/project_todos/SuggestedTodosGenerationTile.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/SuggestedTodosGenerationTile.tsx
@@ -1,0 +1,196 @@
+import { useProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
+import { isOnboardingTodo } from "@app/components/assistant/conversation/space/conversations/project_todos/utils";
+import { FirstSyncTodoLookbackForm } from "@app/components/assistant/conversation/space/FirstSyncTodoLookbackForm";
+import { ConfirmContext } from "@app/components/Confirm";
+import type { InitialTodoSyncLookbackValue } from "@app/lib/project_todo/analyze_document/types";
+import { useUpdateProjectMetadata } from "@app/lib/swr/spaces";
+import { timeAgoFrom } from "@app/lib/utils";
+import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Chip,
+  Icon,
+  InformationCircleIcon,
+  SliderToggle,
+  SparklesIcon,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import { useCallback, useContext, useMemo, useRef, useState } from "react";
+
+const SUGGEST_TO_DOS_TOOLTIP =
+  "When this is on, Dust periodically reviews this project’s conversations and connected sources and adds suggested to-dos. Turn it off if you only want to-dos you create yourself.";
+
+const SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR = `${SUGGEST_TO_DOS_TOOLTIP} Only project editors can change this.`;
+
+const LAST_SCAN_NEVER_TOOLTIP =
+  "Dust has not run an automatic scan for to-do suggestions for this project yet.";
+
+function lastScanTooltip(lastTodoAnalysisAt: number | null): string {
+  if (lastTodoAnalysisAt == null) {
+    return LAST_SCAN_NEVER_TOOLTIP;
+  }
+  const relative = timeAgoFrom(lastTodoAnalysisAt, { useLongFormat: true });
+  return `Last automatic scan for new to-do suggestions: ${relative} ago.`;
+}
+
+export type SuggestedTodosGenerationTileProps = {
+  owner: WorkspaceType;
+  spaceInfo: GetSpaceResponseBody["space"];
+};
+
+export function SuggestedTodosGenerationTile({
+  owner,
+  spaceInfo,
+}: SuggestedTodosGenerationTileProps) {
+  const { todos, isTodosLoading } = useProjectTodosPanel();
+  const confirm = useContext(ConfirmContext);
+  const updateProjectMetadata = useUpdateProjectMetadata({
+    owner,
+    spaceId: spaceInfo.sId,
+  });
+  const [isUpdatingTodoGeneration, setIsUpdatingTodoGeneration] =
+    useState(false);
+  const firstSyncLookbackRef = useRef<InitialTodoSyncLookbackValue>("last_24h");
+  const onFirstSyncLookbackChange = useCallback(
+    (v: InitialTodoSyncLookbackValue) => {
+      firstSyncLookbackRef.current = v;
+    },
+    []
+  );
+
+  const isProjectArchived = !!spaceInfo.archivedAt;
+  const structurallyDisabled =
+    !spaceInfo.isMember || isProjectArchived || !spaceInfo.isEditor;
+  const sliderDisabled = structurallyDisabled || isUpdatingTodoGeneration;
+
+  const toggleTooltip = isProjectArchived
+    ? "This project is archived; suggestion settings cannot be changed."
+    : !spaceInfo.isEditor && spaceInfo.isMember
+      ? SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR
+      : SUGGEST_TO_DOS_TOOLTIP;
+
+  const handleTodoGenerationToggle = useCallback(async () => {
+    if (structurallyDisabled) {
+      return;
+    }
+    if (spaceInfo.todoGenerationEnabled) {
+      setIsUpdatingTodoGeneration(true);
+      try {
+        await updateProjectMetadata({
+          todoGenerationEnabled: false,
+        });
+      } finally {
+        setIsUpdatingTodoGeneration(false);
+      }
+      return;
+    }
+
+    if (spaceInfo.lastTodoAnalysisAt === null) {
+      firstSyncLookbackRef.current = "last_24h";
+      const confirmed = await confirm({
+        title: "Turn on suggested to-dos?",
+        message: (
+          <FirstSyncTodoLookbackForm
+            onValueChange={onFirstSyncLookbackChange}
+          />
+        ),
+        validateLabel: "Turn on",
+        validateVariant: "primary",
+        cancelLabel: "Cancel",
+      });
+      if (!confirmed) {
+        return;
+      }
+      setIsUpdatingTodoGeneration(true);
+      try {
+        await updateProjectMetadata({
+          todoGenerationEnabled: true,
+          initialTodoAnalysisLookback: firstSyncLookbackRef.current,
+        });
+      } finally {
+        setIsUpdatingTodoGeneration(false);
+      }
+      return;
+    }
+
+    setIsUpdatingTodoGeneration(true);
+    try {
+      await updateProjectMetadata({
+        todoGenerationEnabled: true,
+      });
+    } finally {
+      setIsUpdatingTodoGeneration(false);
+    }
+  }, [
+    confirm,
+    onFirstSyncLookbackChange,
+    structurallyDisabled,
+    spaceInfo.lastTodoAnalysisAt,
+    spaceInfo.todoGenerationEnabled,
+    updateProjectMetadata,
+  ]);
+
+  const onToggleClick = structurallyDisabled
+    ? () => {}
+    : handleTodoGenerationToggle;
+
+  const hideWhileOnboardingTodoOpen = useMemo(
+    () =>
+      !isTodosLoading &&
+      todos.some((t) => isOnboardingTodo(t) && t.status !== "done"),
+    [isTodosLoading, todos]
+  );
+
+  if (hideWhileOnboardingTodoOpen) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-3 pb-4">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <SparklesIcon
+              className="h-4 w-4 shrink-0 text-foreground dark:text-foreground-night"
+              aria-hidden
+            />
+            <span className="heading-sm text-foreground dark:text-foreground-night">
+              Suggested to-dos
+            </span>
+            <Chip color="golden" label="Beta" size="mini" />
+          </div>
+          <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+            Automatic to-do suggestions from project activity
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Tooltip
+            label={toggleTooltip}
+            trigger={
+              <div>
+                <SliderToggle
+                  size="xs"
+                  selected={spaceInfo.todoGenerationEnabled}
+                  disabled={sliderDisabled}
+                  onClick={onToggleClick}
+                />
+              </div>
+            }
+          />
+          <Tooltip
+            label={lastScanTooltip(spaceInfo.lastTodoAnalysisAt)}
+            trigger={
+              <button
+                type="button"
+                className="inline-flex rounded-md p-1 text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
+                aria-label="Last automatic to-do suggestion scan"
+              >
+                <Icon visual={InformationCircleIcon} size="sm" />
+              </button>
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
@@ -66,6 +66,7 @@ export type ProjectTodosPanelData = {
   handleAddTodo: (text: string, assigneeSId: string) => Promise<boolean>;
   isTodosLoading: boolean;
   frozenLastReadAt: string | null | undefined;
+  todos: ProjectTodoType[];
   filteredTodos: ProjectTodoType[];
 };
 

--- a/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
@@ -627,6 +627,7 @@ export function useProjectTodosPanelState({
     handleAddTodo,
     isTodosLoading,
     frozenLastReadAt,
+    todos,
     filteredTodos,
   };
 }


### PR DESCRIPTION
## Description

Showing the "Suggested to-dos" section before users have worked through the seeded starter todos creates noise and dilutes the onboarding flow.

- Extract all suggestion toggle logic (slider, last-scan tooltip, first-sync lookback dialog) from `SpaceTodosTab` into a standalone `SuggestedTodosGenerationTile` component
- Gate the tile's visibility: it is hidden until all seeded todos (todos with `agentInstructions`) have been completed or deleted, signalling the user has engaged with the initial onboarding checklist
- `SpaceTodosTab` is now a thin composition of `ProjectTodosPanelProvider`, `ProjectTodoScopeFilter`, `ProjectTodoLocalSearch`, `SuggestedTodosGenerationTile`, and `ProjectTodosPanelMain`

## Tests

Local

## Risk

Low — the tile is still present in the DOM; it just starts hidden and appears once the condition is met

## Deploy Plan

Deploy `front`
