### PR TITLE
Polish when you are sole member of a project.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/AddTodoComposer.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/AddTodoComposer.tsx
@@ -142,11 +142,14 @@ export function AddTodoComposer({
   projectMembers,
   viewerUserId,
   defaultAssigneeSId,
+  hideAssigneePicker = false,
   onAdd,
 }: {
   projectMembers: SpaceUserType[];
   viewerUserId: string | null;
   defaultAssigneeSId: string;
+  /** When true, assignee is implicit (e.g. sole project member); no avatar control. */
+  hideAssigneePicker?: boolean;
   onAdd: (text: string, assigneeSId: string) => Promise<boolean>;
 }) {
   const [text, setText] = useState("");
@@ -160,7 +163,9 @@ export function AddTodoComposer({
   const selectedSId = assigneeSId ?? defaultAssigneeSId;
 
   const isExpanded =
-    inputFocused || assigneeMenuOpen || stripNewlines(text).trim().length > 0;
+    inputFocused ||
+    (!hideAssigneePicker && assigneeMenuOpen) ||
+    stripNewlines(text).trim().length > 0;
 
   const handleSubmit = useCallback(async () => {
     const trimmed = stripNewlines(text).trim();
@@ -199,24 +204,28 @@ export function AddTodoComposer({
   return (
     <div ref={containerRef} className={PROJECT_TODO_TABLE_ROW_INSET_CLASS}>
       <div className={PROJECT_TODO_ITEM_ROW_FRAME_CLASS}>
-        <div className={PROJECT_TODO_MANUAL_ADD_LEADING_CLASS}>
-          <div
-            className={cn(
-              PROJECT_TODO_MANUAL_ADD_LEADING_ASSIGNEE_ANCHOR_CLASS,
-              assigneeChromeToneClass
-            )}
-          >
-            <TodoRowAssigneeMenu
-              ariaNamePrefix="add-todo"
-              members={projectMembers}
-              viewerUserId={viewerUserId}
-              selectedSId={selectedSId}
-              onSelect={setAssigneeSId}
-              onMenuOpenChange={setAssigneeMenuOpen}
-              disabled={isAdding}
-            />
+        {hideAssigneePicker ? (
+          <div className={PROJECT_TODO_MANUAL_ADD_LEADING_CLASS} aria-hidden />
+        ) : (
+          <div className={PROJECT_TODO_MANUAL_ADD_LEADING_CLASS}>
+            <div
+              className={cn(
+                PROJECT_TODO_MANUAL_ADD_LEADING_ASSIGNEE_ANCHOR_CLASS,
+                assigneeChromeToneClass
+              )}
+            >
+              <TodoRowAssigneeMenu
+                ariaNamePrefix="add-todo"
+                members={projectMembers}
+                viewerUserId={viewerUserId}
+                selectedSId={selectedSId}
+                onSelect={setAssigneeSId}
+                onMenuOpenChange={setAssigneeMenuOpen}
+                disabled={isAdding}
+              />
+            </div>
           </div>
-        </div>
+        )}
         <div className="flex min-w-0 flex-1 items-center gap-1">
           <div
             className={cn(

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -82,6 +82,7 @@ export interface EditableTodoItemProps {
     todoId: string,
     updates: { text?: string; assigneeUserId?: string }
   ) => Promise<void>;
+  allowAssigneeReassign?: boolean;
 }
 
 export const EditableTodoItem = memo(function EditableTodoItem({
@@ -103,6 +104,7 @@ export const EditableTodoItem = memo(function EditableTodoItem({
   projectMembers,
   membersWithActiveTodoIds,
   onPatchTodo,
+  allowAssigneeReassign = true,
 }: EditableTodoItemProps) {
   const router = useAppRouter();
   const [startMenuOpen, setStartMenuOpen] = useState(false);
@@ -627,72 +629,74 @@ export const EditableTodoItem = memo(function EditableTodoItem({
                   align="end"
                   className="z-[1000] w-56 shadow-2xl ring-1 ring-border/60"
                 >
-                  <DropdownMenuSub
-                    onOpenChange={(subOpen) => {
-                      if (subOpen) {
-                        setReassignSearch("");
-                      }
-                    }}
-                  >
-                    <DropdownMenuSubTrigger
-                      label="Reassign"
-                      icon={UserIcon}
-                      disabled={projectMembers.length === 0}
-                    />
-                    <DropdownMenuPortal>
-                      <DropdownMenuSubContent
-                        alignOffset={-4}
-                        className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
-                      >
-                        <DropdownMenuSearchbar
-                          autoFocus
-                          name={`reassign-todo-${todo.sId}`}
-                          placeholder="Search members"
-                          value={reassignSearch}
-                          onChange={setReassignSearch}
-                        />
-                        <DropdownMenuSeparator />
-                        <div className="max-h-64 overflow-auto">
-                          {filteredReassignMembers.length > 0 ? (
-                            filteredReassignMembers.map((member) => (
-                              <DropdownMenuItem
-                                key={`reassign-${todo.sId}-${member.sId}`}
-                                label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
-                                disabled={member.sId === todo.user?.sId}
-                                icon={() => (
-                                  <Avatar
-                                    size="xxs"
-                                    isRounded
-                                    visual={
-                                      member.image ??
-                                      "/static/humanavatar/anonymous.png"
-                                    }
-                                  />
-                                )}
-                                onClick={() => {
-                                  void (async () => {
-                                    try {
-                                      if (member.sId !== todo.user?.sId) {
-                                        await onPatchTodo(todo.sId, {
-                                          assigneeUserId: member.sId,
-                                        });
+                  {allowAssigneeReassign && (
+                    <DropdownMenuSub
+                      onOpenChange={(subOpen) => {
+                        if (subOpen) {
+                          setReassignSearch("");
+                        }
+                      }}
+                    >
+                      <DropdownMenuSubTrigger
+                        label="Reassign"
+                        icon={UserIcon}
+                        disabled={projectMembers.length === 0}
+                      />
+                      <DropdownMenuPortal>
+                        <DropdownMenuSubContent
+                          alignOffset={-4}
+                          className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
+                        >
+                          <DropdownMenuSearchbar
+                            autoFocus
+                            name={`reassign-todo-${todo.sId}`}
+                            placeholder="Search members"
+                            value={reassignSearch}
+                            onChange={setReassignSearch}
+                          />
+                          <DropdownMenuSeparator />
+                          <div className="max-h-64 overflow-auto">
+                            {filteredReassignMembers.length > 0 ? (
+                              filteredReassignMembers.map((member) => (
+                                <DropdownMenuItem
+                                  key={`reassign-${todo.sId}-${member.sId}`}
+                                  label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
+                                  disabled={member.sId === todo.user?.sId}
+                                  icon={() => (
+                                    <Avatar
+                                      size="xxs"
+                                      isRounded
+                                      visual={
+                                        member.image ??
+                                        "/static/humanavatar/anonymous.png"
                                       }
-                                    } finally {
-                                      setOverflowMenuOpen(false);
-                                    }
-                                  })();
-                                }}
-                              />
-                            ))
-                          ) : (
-                            <div className="px-3 py-2 text-sm text-muted-foreground">
-                              No members found
-                            </div>
-                          )}
-                        </div>
-                      </DropdownMenuSubContent>
-                    </DropdownMenuPortal>
-                  </DropdownMenuSub>
+                                    />
+                                  )}
+                                  onClick={() => {
+                                    void (async () => {
+                                      try {
+                                        if (member.sId !== todo.user?.sId) {
+                                          await onPatchTodo(todo.sId, {
+                                            assigneeUserId: member.sId,
+                                          });
+                                        }
+                                      } finally {
+                                        setOverflowMenuOpen(false);
+                                      }
+                                    })();
+                                  }}
+                                />
+                              ))
+                            ) : (
+                              <div className="px-3 py-2 text-sm text-muted-foreground">
+                                No members found
+                              </div>
+                            )}
+                          </div>
+                        </DropdownMenuSubContent>
+                      </DropdownMenuPortal>
+                    </DropdownMenuSub>
+                  )}
                   <DropdownMenuItem
                     label="Delete"
                     icon={TrashIcon}

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter.tsx
@@ -31,6 +31,7 @@ export function ProjectTodoScopeFilter() {
     hasDoneItems,
     handleClean,
     isCleaning,
+    isSoleProjectMember,
   } = useProjectTodosPanel();
 
   return (
@@ -65,14 +66,18 @@ export function ProjectTodoScopeFilter() {
             className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
             align="start"
           >
-            <DropdownMenuSearchbar
-              autoFocus
-              name="assignee-filter"
-              placeholder="Search members"
-              value={assigneeSearch}
-              onChange={setAssigneeSearch}
-            />
-            <DropdownMenuSeparator />
+            {!isSoleProjectMember && (
+              <>
+                <DropdownMenuSearchbar
+                  autoFocus
+                  name="assignee-filter"
+                  placeholder="Search members"
+                  value={assigneeSearch}
+                  onChange={setAssigneeSearch}
+                />
+                <DropdownMenuSeparator />
+              </>
+            )}
             <DropdownMenuCheckboxItem
               icon={UserIcon}
               label="Your to-dos"
@@ -103,63 +108,65 @@ export function ProjectTodoScopeFilter() {
                 event.preventDefault();
               }}
             />
-            <DropdownMenuSeparator />
-            <div className="max-h-64 overflow-auto">
-              {filteredUsers.length > 0 ? (
-                filteredUsers.map((user) => (
-                  <DropdownMenuCheckboxItem
-                    key={`todo-assignee-filter-${user.sId}`}
-                    icon={() => (
-                      <Avatar
-                        size="xxs"
-                        isRounded
-                        visual={
-                          user.image ?? "/static/humanavatar/anonymous.png"
+            {!isSoleProjectMember && (
+              <>
+                <DropdownMenuSeparator />
+                <div className="max-h-64 overflow-auto">
+                  {filteredUsers.length > 0 ? (
+                    filteredUsers.map((user) => (
+                      <DropdownMenuCheckboxItem
+                        key={`todo-assignee-filter-${user.sId}`}
+                        icon={() => (
+                          <Avatar
+                            size="xxs"
+                            isRounded
+                            visual={
+                              user.image ?? "/static/humanavatar/anonymous.png"
+                            }
+                          />
+                        )}
+                        label={`${user.fullName}${viewerUserId === user.sId ? " (you)" : ""}`}
+                        checked={
+                          todoOwnerFilter.assigneeScope === "users" &&
+                          selectedUserSIds.has(user.sId)
                         }
+                        onClick={() => {
+                          const next = new Set(selectedUserSIds);
+                          if (next.has(user.sId)) {
+                            next.delete(user.sId);
+                          } else {
+                            next.add(user.sId);
+                          }
+                          onTodoOwnerFilterChange({
+                            assigneeScope: next.size === 0 ? "all" : "users",
+                            selectedUserSIds: [...next],
+                          });
+                        }}
+                        onSelect={(event) => {
+                          event.preventDefault();
+                        }}
                       />
-                    )}
-                    label={`${user.fullName}${viewerUserId === user.sId ? " (you)" : ""}`}
-                    checked={
-                      todoOwnerFilter.assigneeScope === "users" &&
-                      selectedUserSIds.has(user.sId)
-                    }
-                    onClick={() => {
-                      const next = new Set(selectedUserSIds);
-                      if (next.has(user.sId)) {
-                        next.delete(user.sId);
-                      } else {
-                        next.add(user.sId);
-                      }
-                      onTodoOwnerFilterChange({
-                        assigneeScope: next.size === 0 ? "all" : "users",
-                        selectedUserSIds: [...next],
-                      });
-                    }}
-                    onSelect={(event) => {
-                      event.preventDefault();
-                    }}
-                  />
-                ))
-              ) : (
-                <div className="px-3 py-2 text-sm text-muted-foreground">
-                  No members found
+                    ))
+                  ) : (
+                    <div className="px-3 py-2 text-sm text-muted-foreground">
+                      No members found
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
+              </>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
         <div className="flex-1" />
-        {!isReadOnly && hasDoneItems && (
-          <Button
-            size="xs"
-            variant="outline"
-            icon={WindIcon}
-            label="Clean"
-            tooltip="Hide all done to-dos"
-            onClick={handleClean}
-            disabled={isCleaning}
-          />
-        )}
+        <Button
+          size="xs"
+          variant="outline"
+          icon={WindIcon}
+          label="Clean"
+          tooltip="Hide all done to-dos"
+          onClick={handleClean}
+          disabled={isReadOnly || !hasDoneItems || isCleaning}
+        />
       </div>
     </div>
   );

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTable.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTable.tsx
@@ -138,6 +138,10 @@ export type ProjectTodosDataTableProps = {
   onRejectAllSuggestedForAssignee?: (todoIds: string[]) => void | Promise<void>;
   onStartWorking: EditableTodoItemProps["onStartWorking"];
   onPatchTodo: EditableTodoItemProps["onPatchTodo"];
+  /** Regular table: omit per-assignee header rows (flat list). */
+  hideAssigneeGroupHeaders?: boolean;
+  /** When false, hides the overflow "Reassign" submenu (e.g. sole project member). */
+  allowAssigneeReassign?: boolean;
 };
 
 export function ProjectTodosDataTable({
@@ -164,6 +168,8 @@ export function ProjectTodosDataTable({
   onRejectAllSuggestedForAssignee,
   onStartWorking,
   onPatchTodo,
+  hideAssigneeGroupHeaders = false,
+  allowAssigneeReassign = true,
 }: ProjectTodosDataTableProps) {
   const [bulkAssigneeAction, setBulkAssigneeAction] =
     useState<BulkAssigneeActionState>(null);
@@ -198,10 +204,18 @@ export function ProjectTodosDataTable({
     [onRejectAllSuggestedForAssignee]
   );
 
-  const data = useMemo(
-    () => flattenGroupedTodos(groupedTodosForAll, variant),
-    [groupedTodosForAll, variant]
-  );
+  const data = useMemo(() => {
+    if (
+      variant === "regular" &&
+      hideAssigneeGroupHeaders &&
+      groupedTodosForAll.length > 0
+    ) {
+      return groupedTodosForAll.flatMap((group) =>
+        group.todos.map((todo) => ({ kind: "todo" as const, todo }))
+      );
+    }
+    return flattenGroupedTodos(groupedTodosForAll, variant);
+  }, [groupedTodosForAll, variant, hideAssigneeGroupHeaders]);
 
   const columns = useMemo<ColumnDef<ProjectTodoTableRow>[]>(
     () => [
@@ -317,6 +331,7 @@ export function ProjectTodosDataTable({
                   projectMembers={projectMembers}
                   membersWithActiveTodoIds={membersWithActiveTodoIds}
                   onPatchTodo={onPatchTodo}
+                  allowAssigneeReassign={allowAssigneeReassign}
                 />
               )}
             </div>
@@ -350,6 +365,7 @@ export function ProjectTodosDataTable({
       runBulkRejectForGroup,
       onApproveAllSuggestedForAssignee,
       onRejectAllSuggestedForAssignee,
+      allowAssigneeReassign,
     ]
   );
 

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain.tsx
@@ -35,6 +35,8 @@ export function ProjectTodosPanelMain() {
     frozenLastReadAt,
     groupedRegularTodosOnly,
     filteredTodos,
+    isSoleProjectMember,
+    hideRegularTodoAssigneeHeaders,
   } = useProjectTodosPanel();
 
   return (
@@ -84,6 +86,7 @@ export function ProjectTodosPanelMain() {
               projectMembers={projectMembers}
               viewerUserId={viewerUserId}
               defaultAssigneeSId={defaultNewAssigneeSId!}
+              hideAssigneePicker={isSoleProjectMember}
               onAdd={handleAddTodo}
             />
           ))}
@@ -118,6 +121,8 @@ export function ProjectTodosPanelMain() {
                 onRejectAgentSuggestion={onRejectAgentSuggestion}
                 onStartWorking={handleStartWorking}
                 onPatchTodo={patchTodoItem}
+                hideAssigneeGroupHeaders={hideRegularTodoAssigneeHeaders}
+                allowAssigneeReassign={!isSoleProjectMember}
               />
             )}
 

--- a/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
@@ -68,6 +68,10 @@ export type ProjectTodosPanelData = {
   frozenLastReadAt: string | null | undefined;
   todos: ProjectTodoType[];
   filteredTodos: ProjectTodoType[];
+  /** Single project member — hide member lists, reassign, and add-row assignee picker. */
+  isSoleProjectMember: boolean;
+  /** Solo project + every visible regular to-do is assigned to the viewer — flat list, no assignee headers. */
+  hideRegularTodoAssigneeHeaders: boolean;
 };
 
 export type UseProjectTodosPanelArgs = {

--- a/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
@@ -256,6 +256,19 @@ export function useProjectTodosPanelState({
     [groupedTodosForAll]
   );
 
+  const isSoleProjectMember = projectMembers.length === 1;
+
+  const hideRegularTodoAssigneeHeaders = useMemo(() => {
+    if (!isSoleProjectMember || viewerUserId === null) {
+      return false;
+    }
+    const regularTodos = groupedRegularTodosOnly.flatMap((g) => g.todos);
+    if (regularTodos.length === 0) {
+      return false;
+    }
+    return regularTodos.every((t) => t.user?.sId === viewerUserId);
+  }, [groupedRegularTodosOnly, isSoleProjectMember, viewerUserId]);
+
   // Optimistically update a todo's status in the SWR cache and send the PATCH.
   // On failure the cache is revalidated from the server.
   const handleSetStatus = useCallback(
@@ -629,5 +642,7 @@ export function useProjectTodosPanelState({
     frozenLastReadAt,
     todos,
     filteredTodos,
+    isSoleProjectMember,
+    hideRegularTodoAssigneeHeaders,
   };
 }


### PR DESCRIPTION
## Description

When a project has only one member, the assignee picker and reassign menu are unnecessary UI noise — everything is implicitly assigned to the sole member.

- Add `hideAssigneePicker` prop to `AddTodoComposer` — replaces the avatar control with an invisible spacer; the assignee is always `defaultAssigneeSId`; also prevents the assignee menu open state from keeping the composer expanded
- Add `allowAssigneeReassign` prop (default `true`) to `EditableTodoItem` — when `false`, removes the "Reassign" submenu from the overflow menu
- Both props are set to their restricted values in `EditableProjectTodosPanel` / `ProjectTodosPanelMain` when `projectMembers.length <= 1`

## Tests

Local

## Risk

Low — defaults preserve existing behavior for multi-member projects

## Deploy Plan

Deploy `front`
