### PR TITLE
Add: local todos filtering.

### DIFF
--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -6,6 +6,7 @@ import { RenameFileDialog } from "@app/components/assistant/conversation/space/R
 import { ConfirmContext } from "@app/components/Confirm";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { FilePreviewSheet } from "@app/components/spaces/FilePreviewSheet";
+import { useDebounce } from "@app/hooks/useDebounce";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { ContextAttachmentItem } from "@app/lib/api/assistant/conversation/attachments";
 import {
@@ -41,6 +42,7 @@ import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import moment from "moment";
 import type React from "react";
 import {
+  memo,
   useCallback,
   useContext,
   useEffect,
@@ -106,6 +108,60 @@ function compareKnowledgeRowsByKindThenTitle(
   return a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
 }
 
+type KnowledgeFilteredDataTableProps = {
+  columns: ColumnDef<ProjectKnowledgeRow>[];
+  data: ProjectKnowledgeRow[];
+  filter: string;
+};
+
+const KnowledgeFilteredDataTable = memo(function KnowledgeFilteredDataTable({
+  columns,
+  data,
+  filter,
+}: KnowledgeFilteredDataTableProps) {
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      filter={filter}
+      filterColumn="title"
+      sorting={[{ id: "title", desc: false }]}
+    />
+  );
+});
+
+type KnowledgeSearchAndTableProps = {
+  columns: ColumnDef<ProjectKnowledgeRow>[];
+  data: ProjectKnowledgeRow[];
+};
+
+/** Debounced search lives here so typing does not rerender `SpaceKnowledgeTabContent`. */
+const KnowledgeSearchAndTable = memo(function KnowledgeSearchAndTable({
+  columns,
+  data,
+}: KnowledgeSearchAndTableProps) {
+  const { inputValue, debouncedValue, setValue } = useDebounce("", {
+    delay: 200,
+  });
+
+  return (
+    <>
+      <SearchInput
+        name="knowledge-search"
+        value={inputValue}
+        onChange={setValue}
+        placeholder="Filter knowledge..."
+        className="w-full"
+      />
+      <KnowledgeFilteredDataTable
+        columns={columns}
+        data={data}
+        filter={debouncedValue}
+      />
+    </>
+  );
+});
+
 export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
   const isArchived = !!space.archivedAt;
 
@@ -127,7 +183,6 @@ export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
 
 function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [searchText, setSearchText] = useState("");
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [fileToRename, setFileToRename] = useState<{
     sId: string;
@@ -569,22 +624,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
               action={isArchived ? null : attachButtonWithPolicyTooltip}
             />
           ) : (
-            <>
-              <SearchInput
-                name="knowledge-search"
-                value={searchText}
-                onChange={setSearchText}
-                placeholder="Filter knowledge..."
-                className="w-full"
-              />
-              <DataTable
-                columns={columns}
-                data={tableData}
-                filter={searchText}
-                filterColumn="title"
-                sorting={[{ id: "title", desc: false }]}
-              />
-            </>
+            <KnowledgeSearchAndTable columns={columns} data={tableData} />
           )}
         </div>
       </div>

--- a/front/components/assistant/conversation/space/SpaceTodosTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTodosTab.tsx
@@ -1,4 +1,5 @@
 import {
+  ProjectTodoLocalSearch,
   ProjectTodoScopeFilter,
   ProjectTodosPanelMain,
   ProjectTodosPanelProvider,
@@ -32,6 +33,7 @@ export function SpaceTodosTab({
           onTodoOwnerFilterChange={onTodoOwnerFilterChange}
         >
           <ProjectTodoScopeFilter />
+          <ProjectTodoLocalSearch />
           <SuggestedTodosGenerationTile owner={owner} spaceInfo={spaceInfo} />
           <ProjectTodosPanelMain />
         </ProjectTodosPanelProvider>

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -273,22 +273,22 @@ export function SpaceConversationsTab({
                     size="xs"
                   >
                     <ButtonsSwitch
-                      value="all"
-                      label="All"
-                      tooltip="Show every conversation in this project."
-                      onClick={() => onConversationFilterChange("all")}
-                    />
-                    <ButtonsSwitch
                       value="group"
-                      label="Group"
+                      label="Shared"
                       tooltip="Show only threads where at least two people have sent messages."
                       onClick={() => onConversationFilterChange("group")}
                     />
                     <ButtonsSwitch
                       value="with_me"
-                      label="Mine"
+                      label="Just mine"
                       tooltip="Show only conversations where you have sent a message."
                       onClick={() => onConversationFilterChange("with_me")}
+                    />
+                    <ButtonsSwitch
+                      value="all"
+                      label="All project's"
+                      tooltip="Show every conversation in this project."
+                      onClick={() => onConversationFilterChange("all")}
                     />
                   </ButtonsSwitchList>
                   <Button

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
@@ -1,10 +1,11 @@
+import { ProjectTodoLocalSearch } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoLocalSearch";
 import { ProjectTodoScopeFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter";
 import { ProjectTodosPanelProvider } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
 import { ProjectTodosPanelMain } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain";
 import type { UseProjectTodosPanelArgs } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes";
 
+export { ProjectTodoLocalSearch } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoLocalSearch";
 export { ProjectTodoScopeFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter";
-
 export {
   ProjectTodosPanelProvider,
   useProjectTodosPanel,
@@ -19,6 +20,7 @@ export function EditableProjectTodosPanel(props: UseProjectTodosPanelArgs) {
   return (
     <ProjectTodosPanelProvider {...props}>
       <ProjectTodoScopeFilter />
+      <ProjectTodoLocalSearch />
       <ProjectTodosPanelMain />
     </ProjectTodosPanelProvider>
   );

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoLocalSearch.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoLocalSearch.tsx
@@ -1,0 +1,27 @@
+import { useProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
+import { useDebounce } from "@app/hooks/useDebounce";
+import { SearchInput } from "@dust-tt/sparkle";
+import { useEffect } from "react";
+
+/** Keeps keystrokes out of panel context — only debounced updates reach the todo tables. */
+export function ProjectTodoLocalSearch() {
+  const { setDebouncedTodoSearchQuery } = useProjectTodosPanel();
+
+  const { inputValue, debouncedValue, setValue } = useDebounce("", {
+    delay: 200,
+  });
+
+  useEffect(() => {
+    setDebouncedTodoSearchQuery(debouncedValue);
+  }, [debouncedValue, setDebouncedTodoSearchQuery]);
+
+  return (
+    <SearchInput
+      name="project-todos-filter"
+      placeholder="Filter to-dos..."
+      value={inputValue}
+      onChange={setValue}
+      className="w-full"
+    />
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter.tsx
@@ -35,7 +35,7 @@ export function ProjectTodoScopeFilter() {
   } = useProjectTodosPanel();
 
   return (
-    <div className="border-b border-border pb-6 dark:border-border-night">
+    <div className="mb-1">
       <div className="inline-flex w-full items-center gap-2">
         <DropdownMenu
           modal={false}

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain.tsx
@@ -1,6 +1,7 @@
 import { AddTodoComposer } from "@app/components/assistant/conversation/space/conversations/project_todos/AddTodoComposer";
 import { ProjectTodosDataTable } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTable";
 import { useProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
+import { normalizeProjectTodoSearchNeedle } from "@app/components/assistant/conversation/space/conversations/project_todos/utils";
 import { Spinner } from "@dust-tt/sparkle";
 
 export function ProjectTodosPanelMain() {
@@ -35,9 +36,14 @@ export function ProjectTodosPanelMain() {
     frozenLastReadAt,
     groupedRegularTodosOnly,
     filteredTodos,
+    assigneeScopedTodos,
+    debouncedTodoSearchQuery,
     isSoleProjectMember,
     hideRegularTodoAssigneeHeaders,
   } = useProjectTodosPanel();
+
+  const hasActiveLocalSearch =
+    normalizeProjectTodoSearchNeedle(debouncedTodoSearchQuery) !== "";
 
   return (
     <>
@@ -129,7 +135,9 @@ export function ProjectTodosPanelMain() {
             {/* Empty state */}
             {filteredTodos.length === 0 && (
               <p className="text-base italic text-faint dark:text-faint-night">
-                You're all caught up!
+                {hasActiveLocalSearch && assigneeScopedTodos.length > 0
+                  ? "No to-dos match your filter."
+                  : "You're all caught up!"}
               </p>
             )}
           </>

--- a/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
@@ -67,7 +67,13 @@ export type ProjectTodosPanelData = {
   isTodosLoading: boolean;
   frozenLastReadAt: string | null | undefined;
   todos: ProjectTodoType[];
+  /** After assignee scope; ignores description search — use for baseline empty counts. */
+  assigneeScopedTodos: ProjectTodoType[];
+  /** After assignee scope + debounced text filter (`debouncedTodoSearchQuery`). */
   filteredTodos: ProjectTodoType[];
+  /** Debounced query from ProjectTodoLocalSearch; tables filter on this. */
+  debouncedTodoSearchQuery: string;
+  setDebouncedTodoSearchQuery: (value: string) => void;
   /** Single project member — hide member lists, reassign, and add-row assignee picker. */
   isSoleProjectMember: boolean;
   /** Solo project + every visible regular to-do is assigned to the viewer — flat list, no assignee headers. */

--- a/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
@@ -13,6 +13,8 @@ import {
 import {
   DELETE_TODO_CONFIRM_PREVIEW_MAX_CHARS,
   isOnboardingTodo,
+  normalizeProjectTodoSearchNeedle,
+  projectTodoMatchesLocalSearch,
   SUMMARY_ITEM_TRANSITION_MS,
 } from "@app/components/assistant/conversation/space/conversations/project_todos/utils";
 import { ConfirmContext } from "@app/components/Confirm";
@@ -55,6 +57,7 @@ export function useProjectTodosPanelState({
   onTodoOwnerFilterChange,
 }: UseProjectTodosPanelArgs): ProjectTodosPanelData {
   const [assigneeSearch, setAssigneeSearch] = useState("");
+  const [debouncedTodoSearchQuery, setDebouncedTodoSearchQuery] = useState("");
   const [isAssigneeMenuOpen, setIsAssigneeMenuOpen] = useState(false);
   const {
     todos,
@@ -191,7 +194,7 @@ export function useProjectTodosPanelState({
     viewerUserId,
   });
 
-  const filteredTodos = useMemo(() => {
+  const assigneeScopedTodos = useMemo(() => {
     switch (todoOwnerFilter.assigneeScope) {
       case "all":
         return todos;
@@ -210,7 +213,23 @@ export function useProjectTodosPanelState({
     }
   }, [selectedUserSIds, todoOwnerFilter.assigneeScope, todos, viewerUserId]);
 
-  const hasDoneItems = filteredTodos.some((todo) => todo.status === "done");
+  const normalizedTodoSearchNeedle = useMemo(
+    () => normalizeProjectTodoSearchNeedle(debouncedTodoSearchQuery),
+    [debouncedTodoSearchQuery]
+  );
+
+  const filteredTodos = useMemo(() => {
+    if (normalizedTodoSearchNeedle === "") {
+      return assigneeScopedTodos;
+    }
+    return assigneeScopedTodos.filter((todo) =>
+      projectTodoMatchesLocalSearch(todo, normalizedTodoSearchNeedle)
+    );
+  }, [assigneeScopedTodos, normalizedTodoSearchNeedle]);
+
+  const hasDoneItems = assigneeScopedTodos.some(
+    (todo) => todo.status === "done"
+  );
 
   const getFirstOnboardingTodoId = (
     todos: ProjectTodoType[]
@@ -642,6 +661,9 @@ export function useProjectTodosPanelState({
     frozenLastReadAt,
     todos,
     filteredTodos,
+    assigneeScopedTodos,
+    debouncedTodoSearchQuery,
+    setDebouncedTodoSearchQuery,
     isSoleProjectMember,
     hideRegularTodoAssigneeHeaders,
   };

--- a/front/components/assistant/conversation/space/conversations/project_todos/utils.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/utils.ts
@@ -1,3 +1,4 @@
+import { removeDiacritics } from "@app/lib/utils";
 import type { ProjectTodoType } from "@app/types/project_todo";
 import { cn } from "@dust-tt/sparkle";
 import type React from "react";
@@ -17,6 +18,49 @@ export function stripNewlines(value: string): string {
  * a guided first conversation; manual user-created to-dos don't have them. */
 export function isOnboardingTodo(todo: ProjectTodoType): boolean {
   return !!todo.agentInstructions;
+}
+
+/** Normalizes user input for accent-insensitive, case-insensitive matching. */
+export function normalizeProjectTodoSearchNeedle(raw: string): string {
+  return removeDiacritics(raw.trim()).toLowerCase();
+}
+
+function projectTodoHaystackNormalized(s: string | null | undefined): string {
+  return normalizeProjectTodoSearchNeedle(s ?? "");
+}
+
+/** `needle` must already be `{normalizeProjectTodoSearchNeedle}` output. Empty matches all. */
+export function projectTodoMatchesLocalSearch(
+  todo: ProjectTodoType,
+  needle: string
+): boolean {
+  if (needle === "") {
+    return true;
+  }
+  if (projectTodoHaystackNormalized(todo.text).includes(needle)) {
+    return true;
+  }
+  if (
+    todo.user?.fullName &&
+    projectTodoHaystackNormalized(todo.user.fullName).includes(needle)
+  ) {
+    return true;
+  }
+  if (
+    todo.actorRationale?.trim() &&
+    projectTodoHaystackNormalized(todo.actorRationale).includes(needle)
+  ) {
+    return true;
+  }
+  for (const src of todo.sources) {
+    if (
+      src.sourceTitle?.trim() &&
+      projectTodoHaystackNormalized(src.sourceTitle).includes(needle)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function useAutosizeTextArea(


### PR DESCRIPTION
## Description

Two local-filter improvements: a search bar for the todos list and a debounced search for the knowledge tab, both without server round-trips.

**Todos local search**

- Add `ProjectTodoLocalSearch` — a `SearchInput` with 200 ms debounce; filter string is stored in `ProjectTodosPanelContext` and applied in `ProjectTodosPanelMain` to hide non-matching rows client-side
- Placed in `SpaceTodosTab` between `ProjectTodoScopeFilter` and `SuggestedTodosGenerationTile`

**Knowledge tab search fix**

- Extract `KnowledgeSearchAndTable` + `KnowledgeFilteredDataTable` memo components from `SpaceKnowledgeTabContent` so debounce state lives in an isolated subtree; typing no longer rerenders the entire knowledge tab

## Tests

Local

## Risk

Low — all filtering is client-side; server behavior is unchanged

## Deploy Plan

Deploy `front`
