### PR TITLE
Add local search, new to-dos filtering. Nicer layout.

### DIFF
--- a/front/components/assistant/conversation/space/SpaceTodosTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTodosTab.tsx
@@ -1,11 +1,10 @@
 import {
-  ProjectTodoLocalSearch,
-  ProjectTodoScopeFilter,
   ProjectTodosPanelMain,
   ProjectTodosPanelProvider,
+  ProjectTodosToolbar,
 } from "@app/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel";
+import type { TodoOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
 import { SuggestedTodosGenerationTile } from "@app/components/assistant/conversation/space/conversations/project_todos/SuggestedTodosGenerationTile";
-import type { TodoOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents";
 import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { WorkspaceType } from "@app/types/user";
 
@@ -24,7 +23,12 @@ export function SpaceTodosTab({
 }: SpaceTodosTabProps) {
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-3 py-8">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 py-8">
+        <div className="flex gap-2">
+          <h3 className="heading-2xl flex-1 items-center">
+            {`${spaceInfo.name}'s To-dos`}
+          </h3>
+        </div>
         <ProjectTodosPanelProvider
           owner={owner}
           spaceId={spaceInfo.sId}
@@ -32,10 +36,11 @@ export function SpaceTodosTab({
           todoOwnerFilter={todoOwnerFilter}
           onTodoOwnerFilterChange={onTodoOwnerFilterChange}
         >
-          <ProjectTodoScopeFilter />
-          <ProjectTodoLocalSearch />
-          <SuggestedTodosGenerationTile owner={owner} spaceInfo={spaceInfo} />
-          <ProjectTodosPanelMain />
+          <div className="flex flex-col gap-3">
+            <ProjectTodosToolbar />
+            <SuggestedTodosGenerationTile owner={owner} spaceInfo={spaceInfo} />
+            <ProjectTodosPanelMain />
+          </div>
         </ProjectTodosPanelProvider>
       </div>
     </div>

--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel.tsx
@@ -1,9 +1,9 @@
-import { ProjectTodoLocalSearch } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoLocalSearch";
-import { ProjectTodoScopeFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter";
 import { ProjectTodosPanelProvider } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
 import { ProjectTodosPanelMain } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain";
+import { ProjectTodosToolbar } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosToolbar";
 import type { UseProjectTodosPanelArgs } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes";
 
+export { ProjectTodoCleanButton } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoCleanButton";
 export { ProjectTodoLocalSearch } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoLocalSearch";
 export { ProjectTodoScopeFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter";
 export {
@@ -11,6 +11,7 @@ export {
   useProjectTodosPanel,
 } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
 export { ProjectTodosPanelMain } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain";
+export { ProjectTodosToolbar } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosToolbar";
 export type {
   ProjectTodosPanelData,
   UseProjectTodosPanelArgs,
@@ -19,9 +20,10 @@ export type {
 export function EditableProjectTodosPanel(props: UseProjectTodosPanelArgs) {
   return (
     <ProjectTodosPanelProvider {...props}>
-      <ProjectTodoScopeFilter />
-      <ProjectTodoLocalSearch />
-      <ProjectTodosPanelMain />
+      <div className="flex flex-col gap-3">
+        <ProjectTodosToolbar />
+        <ProjectTodosPanelMain />
+      </div>
     </ProjectTodosPanelProvider>
   );
 }

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoCleanButton.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoCleanButton.tsx
@@ -1,0 +1,29 @@
+import { useProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import { Button, WindIcon } from "@dust-tt/sparkle";
+
+export function ProjectTodoCleanButton() {
+  const isMobile = useIsMobile();
+  const { todoOwnerFilter, isReadOnly, hasDoneItems, handleClean, isCleaning } =
+    useProjectTodosPanel();
+
+  const disabled =
+    isReadOnly ||
+    todoOwnerFilter.periodScope !== "active" ||
+    !hasDoneItems ||
+    isCleaning;
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      icon={WindIcon}
+      label={isMobile ? undefined : "Clean"}
+      tooltip={
+        isMobile ? "Clean — Hide all done to-dos" : "Hide all done to-dos"
+      }
+      onClick={handleClean}
+      disabled={disabled}
+    />
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter.tsx
@@ -1,173 +1,109 @@
 import { useProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
+import type {
+  ProjectTodoPeopleScope,
+  ProjectTodoPeriodScope,
+} from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
-  Avatar,
   Button,
-  ChevronDownIcon,
+  ClockIcon,
+  cn,
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuSearchbar,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  Icon,
-  UserGroupIcon,
-  UserIcon,
-  WindIcon,
 } from "@dust-tt/sparkle";
 
+const PERIOD_OPTIONS: Array<{
+  value: ProjectTodoPeriodScope;
+  label: string;
+}> = [
+  { value: "active", label: "Active" },
+  { value: "last_24h", label: "Last 24h" },
+  { value: "last_7d", label: "Last 7 days" },
+  { value: "last_30d", label: "Last 30 days" },
+];
+
+const PEOPLE_OPTIONS: Array<{
+  value: ProjectTodoPeopleScope;
+  label: string;
+}> = [
+  { value: "all_project", label: "All project's" },
+  { value: "just_mine", label: "Just mine" },
+];
+
 export function ProjectTodoScopeFilter() {
+  const isMobile = useIsMobile();
   const {
-    assigneeSearch,
-    setAssigneeSearch,
-    isAssigneeMenuOpen,
-    setIsAssigneeMenuOpen,
-    filteredUsers,
+    isScopeMenuOpen,
+    setIsScopeMenuOpen,
     todoOwnerFilter,
     onTodoOwnerFilterChange,
-    selectedUserSIds,
-    viewerUserId,
     todoScopeLabel,
-    isReadOnly,
-    hasDoneItems,
-    handleClean,
-    isCleaning,
-    isSoleProjectMember,
   } = useProjectTodosPanel();
 
   return (
-    <div className="mb-1">
-      <div className="inline-flex w-full items-center gap-2">
-        <DropdownMenu
-          modal={false}
-          open={isAssigneeMenuOpen}
-          onOpenChange={(open) => {
-            setIsAssigneeMenuOpen(open);
-            if (open) {
-              setAssigneeSearch("");
-            }
-          }}
-        >
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              className="inline-flex items-center gap-1 rounded-md px-0 py-0.5 hover:bg-muted/40 dark:hover:bg-muted-night/40"
-            >
-              <h3 className="heading-2xl text-foreground dark:text-foreground-night">
-                {todoScopeLabel}
-              </h3>
-              <Icon
-                visual={ChevronDownIcon}
-                size="sm"
-                className="text-muted-foreground dark:text-muted-foreground-night"
-              />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
-            align="start"
-          >
-            {!isSoleProjectMember && (
-              <>
-                <DropdownMenuSearchbar
-                  autoFocus
-                  name="assignee-filter"
-                  placeholder="Search members"
-                  value={assigneeSearch}
-                  onChange={setAssigneeSearch}
-                />
-                <DropdownMenuSeparator />
-              </>
-            )}
-            <DropdownMenuCheckboxItem
-              icon={UserIcon}
-              label="Your to-dos"
-              checked={todoOwnerFilter.assigneeScope === "mine"}
-              onClick={() => {
-                onTodoOwnerFilterChange({
-                  assigneeScope: "mine",
-                  selectedUserSIds: [],
-                });
-                setIsAssigneeMenuOpen(false);
-              }}
-              onSelect={(event) => {
-                event.preventDefault();
-              }}
-            />
-            <DropdownMenuCheckboxItem
-              icon={UserGroupIcon}
-              label="Project's to-dos"
-              checked={todoOwnerFilter.assigneeScope === "all"}
-              onClick={() => {
-                onTodoOwnerFilterChange({
-                  assigneeScope: "all",
-                  selectedUserSIds: [],
-                });
-                setIsAssigneeMenuOpen(false);
-              }}
-              onSelect={(event) => {
-                event.preventDefault();
-              }}
-            />
-            {!isSoleProjectMember && (
-              <>
-                <DropdownMenuSeparator />
-                <div className="max-h-64 overflow-auto">
-                  {filteredUsers.length > 0 ? (
-                    filteredUsers.map((user) => (
-                      <DropdownMenuCheckboxItem
-                        key={`todo-assignee-filter-${user.sId}`}
-                        icon={() => (
-                          <Avatar
-                            size="xxs"
-                            isRounded
-                            visual={
-                              user.image ?? "/static/humanavatar/anonymous.png"
-                            }
-                          />
-                        )}
-                        label={`${user.fullName}${viewerUserId === user.sId ? " (you)" : ""}`}
-                        checked={
-                          todoOwnerFilter.assigneeScope === "users" &&
-                          selectedUserSIds.has(user.sId)
-                        }
-                        onClick={() => {
-                          const next = new Set(selectedUserSIds);
-                          if (next.has(user.sId)) {
-                            next.delete(user.sId);
-                          } else {
-                            next.add(user.sId);
-                          }
-                          onTodoOwnerFilterChange({
-                            assigneeScope: next.size === 0 ? "all" : "users",
-                            selectedUserSIds: [...next],
-                          });
-                        }}
-                        onSelect={(event) => {
-                          event.preventDefault();
-                        }}
-                      />
-                    ))
-                  ) : (
-                    <div className="px-3 py-2 text-sm text-muted-foreground">
-                      No members found
-                    </div>
-                  )}
-                </div>
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <div className="flex-1" />
+    <DropdownMenu
+      modal={false}
+      open={isScopeMenuOpen}
+      onOpenChange={setIsScopeMenuOpen}
+    >
+      <DropdownMenuTrigger asChild>
         <Button
-          size="xs"
+          type="button"
           variant="outline"
-          icon={WindIcon}
-          label="Clean"
-          tooltip="Hide all done to-dos"
-          onClick={handleClean}
-          disabled={isReadOnly || !hasDoneItems || isCleaning}
+          size="sm"
+          isSelect
+          label={isMobile ? undefined : todoScopeLabel}
+          tooltip={isMobile ? todoScopeLabel : undefined}
+          icon={ClockIcon}
+          className={cn(!isMobile && "max-w-[min(100vw-3rem,24rem)]")}
         />
-      </div>
-    </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
+        align="start"
+      >
+        <DropdownMenuLabel label="Historic" />
+        <DropdownMenuRadioGroup
+          value={todoOwnerFilter.periodScope}
+          className="mb-2"
+        >
+          {PERIOD_OPTIONS.map(({ value, label }) => (
+            <DropdownMenuRadioItem
+              key={value}
+              value={value}
+              label={label}
+              onClick={() => {
+                onTodoOwnerFilterChange({
+                  ...todoOwnerFilter,
+                  periodScope: value,
+                });
+              }}
+            />
+          ))}
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel label="People" />
+        <DropdownMenuRadioGroup value={todoOwnerFilter.peopleScope}>
+          {PEOPLE_OPTIONS.map(({ value, label }) => (
+            <DropdownMenuRadioItem
+              key={value}
+              value={value}
+              label={label}
+              onClick={() => {
+                onTodoOwnerFilterChange({
+                  ...todoOwnerFilter,
+                  peopleScope: value,
+                });
+              }}
+            />
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosToolbar.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosToolbar.tsx
@@ -1,0 +1,20 @@
+import { ProjectTodoCleanButton } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoCleanButton";
+import { ProjectTodoLocalSearch } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoLocalSearch";
+import { ProjectTodoScopeFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodoScopeFilter";
+
+/** Single row: scope filter · search · clean (within `ProjectTodosPanelProvider`). */
+export function ProjectTodosToolbar() {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="shrink-0">
+        <ProjectTodoScopeFilter />
+      </div>
+      <div className="min-w-0 flex-1">
+        <ProjectTodoLocalSearch />
+      </div>
+      <div className="shrink-0">
+        <ProjectTodoCleanButton />
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents.tsx
@@ -265,54 +265,6 @@ export function TodoSources({
   );
 }
 
-// ── Filter types & helpers ────────────────────────────────────────────────────
-
-export type TodoAssigneeScope = "mine" | "all" | "users";
-
-export interface TodoOwnerFilter {
-  assigneeScope: TodoAssigneeScope;
-  selectedUserSIds: string[];
-}
-
-export function formatTodoScopeLabel({
-  scope,
-  selectedUserSIds,
-  usersBySId,
-  viewerUserId,
-}: {
-  scope: TodoAssigneeScope;
-  selectedUserSIds: Set<string>;
-  usersBySId: Map<string, ProjectTodoAssigneeType>;
-  viewerUserId: string | null;
-}) {
-  if (scope === "mine") {
-    return "Your to-dos";
-  }
-  if (scope === "all") {
-    return "Project's to-dos";
-  }
-
-  if (selectedUserSIds.size === 0) {
-    return "To-dos";
-  }
-
-  if (selectedUserSIds.size === 1) {
-    const [selectedUserSId] = selectedUserSIds;
-    const user = usersBySId.get(selectedUserSId);
-    if (!user) {
-      return "To-dos";
-    }
-
-    if (viewerUserId !== null && user.sId === viewerUserId) {
-      return "Your to-dos";
-    }
-
-    return `${user.fullName}'s to-dos`;
-  }
-
-  return `Selected to-dos (${selectedUserSIds.size})`;
-}
-
 export function TodoAssigneeHeader({
   user,
   viewerUserId,

--- a/front/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope.ts
@@ -1,0 +1,112 @@
+import { z } from "zod";
+
+export type ProjectTodoPeriodScope =
+  | "active"
+  | "last_24h"
+  | "last_7d"
+  | "last_30d";
+
+export type ProjectTodoPeopleScope = "all_project" | "just_mine";
+
+/** Filter for project todo list fetching + persisted project UI prefs. */
+export interface TodoOwnerFilter {
+  periodScope: ProjectTodoPeriodScope;
+  peopleScope: ProjectTodoPeopleScope;
+}
+
+export const DEFAULT_TODO_OWNER_FILTER: TodoOwnerFilter = {
+  periodScope: "active",
+  peopleScope: "all_project",
+};
+
+const PERIOD_SCOPE_LABELS: Record<ProjectTodoPeriodScope, string> = {
+  active: "Active",
+  last_24h: "Last 24h",
+  last_7d: "Last 7 days",
+  last_30d: "Last 30 days",
+};
+
+const PEOPLE_SCOPE_LABELS: Record<ProjectTodoPeopleScope, string> = {
+  all_project: "All project's",
+  just_mine: "Just mine",
+};
+
+export function formatTodoScopeLabel(filter: TodoOwnerFilter): string {
+  return `${PERIOD_SCOPE_LABELS[filter.periodScope]} · ${PEOPLE_SCOPE_LABELS[filter.peopleScope]}`;
+}
+
+const PERIOD_SCOPES: ProjectTodoPeriodScope[] = [
+  "active",
+  "last_24h",
+  "last_7d",
+  "last_30d",
+];
+
+function coercePeriodScope(raw: unknown): ProjectTodoPeriodScope {
+  if (
+    typeof raw === "string" &&
+    PERIOD_SCOPES.includes(raw as ProjectTodoPeriodScope)
+  ) {
+    return raw as ProjectTodoPeriodScope;
+  }
+  return "active";
+}
+
+const todosOwnerFilterPersistedBlobSchema = z
+  .object({
+    periodScope: z.string().optional(),
+    peopleScope: z.enum(["all_project", "just_mine"]).optional(),
+    assigneeScope: z.enum(["mine", "all", "users"]).optional(),
+    selectedUserSIds: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+export function normalizeTodosOwnerFilterFromPersistedBlob(
+  raw: unknown
+): TodoOwnerFilter {
+  const parsed = todosOwnerFilterPersistedBlobSchema.safeParse(raw);
+  if (!parsed.success) {
+    return DEFAULT_TODO_OWNER_FILTER;
+  }
+  const blob = parsed.data;
+
+  const peopleScope: ProjectTodoPeopleScope =
+    blob.peopleScope ??
+    (blob.assigneeScope === "mine" ? "just_mine" : "all_project");
+
+  return {
+    periodScope: coercePeriodScope(blob.periodScope),
+    peopleScope: peopleScope === "just_mine" ? "just_mine" : "all_project",
+  };
+}
+
+/** Query string for GET /spaces/:id/project_todos (canonical `period` + `people`). */
+export function todoOwnerFilterToSearchParams(
+  filter: TodoOwnerFilter
+): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("period", filter.periodScope);
+  params.set("people", filter.peopleScope === "just_mine" ? "mine" : "all");
+  return params;
+}
+
+export function buildProjectTodosListSwrKey(
+  workspaceSId: string,
+  spaceId: string,
+  filter: TodoOwnerFilter
+): string {
+  const base = `/api/w/${workspaceSId}/spaces/${spaceId}/project_todos`;
+  const qs = todoOwnerFilterToSearchParams(filter).toString();
+  return qs.length > 0 ? `${base}?${qs}` : base;
+}
+
+export function isProjectTodosListSwrKey(
+  key: unknown,
+  workspaceSId: string,
+  spaceId: string
+): boolean {
+  const prefix = `/api/w/${workspaceSId}/spaces/${spaceId}/project_todos`;
+  return (
+    typeof key === "string" && (key === prefix || key.startsWith(`${prefix}?`))
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
@@ -1,5 +1,5 @@
 import type { ProjectTodosDataTable } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTable";
-import type { TodoOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents";
+import type { TodoOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
 import type {
   ProjectTodoAssigneeType,
   ProjectTodoType,
@@ -15,14 +15,10 @@ export type GroupedTodosByAssignee = Array<{
 type ProjectTodosDataTableProps = ComponentProps<typeof ProjectTodosDataTable>;
 
 export type ProjectTodosPanelData = {
-  assigneeSearch: string;
-  setAssigneeSearch: Dispatch<SetStateAction<string>>;
-  isAssigneeMenuOpen: boolean;
-  setIsAssigneeMenuOpen: Dispatch<SetStateAction<boolean>>;
-  filteredUsers: ProjectTodoAssigneeType[];
+  isScopeMenuOpen: boolean;
+  setIsScopeMenuOpen: Dispatch<SetStateAction<boolean>>;
   todoOwnerFilter: TodoOwnerFilter;
   onTodoOwnerFilterChange: (value: TodoOwnerFilter) => void;
-  selectedUserSIds: Set<string>;
   viewerUserId: string | null;
   todoScopeLabel: string;
   isReadOnly?: boolean;
@@ -67,9 +63,9 @@ export type ProjectTodosPanelData = {
   isTodosLoading: boolean;
   frozenLastReadAt: string | null | undefined;
   todos: ProjectTodoType[];
-  /** After assignee scope; ignores description search — use for baseline empty counts. */
+  /** List returned for the current period & people filters (includes server-side filtering). */
   assigneeScopedTodos: ProjectTodoType[];
-  /** After assignee scope + debounced text filter (`debouncedTodoSearchQuery`). */
+  /** After debounced description search (`debouncedTodoSearchQuery`). */
   filteredTodos: ProjectTodoType[];
   /** Debounced query from ProjectTodoLocalSearch; tables filter on this. */
   debouncedTodoSearchQuery: string;

--- a/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
@@ -2,14 +2,12 @@ import {
   groupedTodosNonPendingSuggestions,
   groupedTodosPendingSuggestionsOnly,
 } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTable";
+import { formatTodoScopeLabel } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
 import type {
   ProjectTodosPanelData,
   UseProjectTodosPanelArgs,
 } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes";
-import {
-  formatTodoScopeLabel,
-  useAgentNameById,
-} from "@app/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents";
+import { useAgentNameById } from "@app/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents";
 import {
   DELETE_TODO_CONFIRM_PREVIEW_MAX_CHARS,
   isOnboardingTodo,
@@ -38,7 +36,6 @@ import {
   useUpdateProjectTodo,
 } from "@app/lib/swr/projects";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
-import { removeDiacritics } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetProjectTodosResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
@@ -56,20 +53,14 @@ export function useProjectTodosPanelState({
   todoOwnerFilter,
   onTodoOwnerFilterChange,
 }: UseProjectTodosPanelArgs): ProjectTodosPanelData {
-  const [assigneeSearch, setAssigneeSearch] = useState("");
   const [debouncedTodoSearchQuery, setDebouncedTodoSearchQuery] = useState("");
-  const [isAssigneeMenuOpen, setIsAssigneeMenuOpen] = useState(false);
-  const {
-    todos,
-    users,
-    viewerUserId,
-    lastReadAt,
-    isTodosLoading,
-    mutateTodos,
-  } = useProjectTodos({
-    owner,
-    spaceId,
-  });
+  const [isScopeMenuOpen, setIsScopeMenuOpen] = useState(false);
+  const { todos, viewerUserId, lastReadAt, isTodosLoading, mutateTodos } =
+    useProjectTodos({
+      owner,
+      spaceId,
+      todoOwnerFilter,
+    });
   const agentNameById = useAgentNameById(owner);
   const doUpdate = useUpdateProjectTodo({ owner, spaceId });
   const doBulkUpdateStatus = useBulkUpdateProjectTodoStatus({ owner, spaceId });
@@ -162,56 +153,16 @@ export function useProjectTodosPanelState({
   }, [isTodosLoading, frozenLastReadAt, lastReadAt]);
 
   const { newItemKeys, doneFlashKeys } = useTodoDiffAnimations({
-    ledgerScopeKey: `${owner.sId}:${spaceId}`,
+    ledgerScopeKey: `${owner.sId}:${spaceId}:${todoOwnerFilter.periodScope}:${todoOwnerFilter.peopleScope}`,
     todos,
     frozenLastReadAt,
     isTodosLoading,
     markRead,
   });
 
-  const usersBySId = useMemo(
-    () => new Map(users.map((user) => [user.sId, user])),
-    [users]
-  );
-  const selectedUserSIds = useMemo(
-    () => new Set(todoOwnerFilter.selectedUserSIds),
-    [todoOwnerFilter.selectedUserSIds]
-  );
-  const filteredUsers = useMemo(() => {
-    const q = removeDiacritics(assigneeSearch.trim()).toLowerCase();
-    if (!q) {
-      return users;
-    }
+  const todoScopeLabel = formatTodoScopeLabel(todoOwnerFilter);
 
-    return users.filter((user) =>
-      removeDiacritics(user.fullName).toLowerCase().includes(q)
-    );
-  }, [assigneeSearch, users]);
-  const todoScopeLabel = formatTodoScopeLabel({
-    scope: todoOwnerFilter.assigneeScope,
-    selectedUserSIds,
-    usersBySId,
-    viewerUserId,
-  });
-
-  const assigneeScopedTodos = useMemo(() => {
-    switch (todoOwnerFilter.assigneeScope) {
-      case "all":
-        return todos;
-      case "mine":
-        if (viewerUserId === null) {
-          return [];
-        }
-        return todos.filter((todo) => todo.user?.sId === viewerUserId);
-      case "users":
-        if (selectedUserSIds.size === 0) {
-          return todos;
-        }
-        return todos.filter(
-          (todo) => !!todo.user?.sId && selectedUserSIds.has(todo.user.sId)
-        );
-    }
-  }, [selectedUserSIds, todoOwnerFilter.assigneeScope, todos, viewerUserId]);
+  const assigneeScopedTodos = todos;
 
   const normalizedTodoSearchNeedle = useMemo(
     () => normalizeProjectTodoSearchNeedle(debouncedTodoSearchQuery),
@@ -618,14 +569,10 @@ export function useProjectTodosPanelState({
     groupedSuggestedTodosOnly.length > 0;
 
   return {
-    assigneeSearch,
-    setAssigneeSearch,
-    isAssigneeMenuOpen,
-    setIsAssigneeMenuOpen,
-    filteredUsers,
+    isScopeMenuOpen,
+    setIsScopeMenuOpen,
     todoOwnerFilter,
     onTodoOwnerFilterChange,
-    selectedUserSIds,
     viewerUserId,
     todoScopeLabel,
     isReadOnly,

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -1,5 +1,5 @@
 import { SpaceAboutTab } from "@app/components/assistant/conversation/space/about/SpaceAboutTab";
-import type { TodoOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents";
+import type { TodoOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
 import { SpaceConversationsTab } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsTab";
 import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
 import { ProjectHeaderActions } from "@app/components/assistant/conversation/space/ProjectHeaderActions";

--- a/front/hooks/useScopedUIPreferences.ts
+++ b/front/hooks/useScopedUIPreferences.ts
@@ -1,3 +1,4 @@
+import { normalizeTodosOwnerFilterFromPersistedBlob } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
 import { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { z } from "zod";
 
@@ -7,10 +8,9 @@ const scopedUIPreferencesSchemaByScope = {
   projectUI: z.object({
     tab: z.enum(["conversations", "todos", "knowledge", "settings", "alpha"]),
     conversationsFilter: z.enum(["all", "group", "with_me"]),
-    todosOwnerFilter: z.object({
-      assigneeScope: z.enum(["mine", "all", "users"]),
-      selectedUserSIds: z.array(z.string()),
-    }),
+    todosOwnerFilter: z
+      .unknown()
+      .transform(normalizeTodosOwnerFilterFromPersistedBlob),
   }),
 } as const;
 

--- a/front/hooks/useSpaceProjectTabs.ts
+++ b/front/hooks/useSpaceProjectTabs.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TODO_OWNER_FILTER } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
 import {
   type ProjectUIScopedPreferences,
   readScopedUIPreferencesValue,
@@ -10,10 +11,7 @@ export const DEFAULT_SPACE_PROJECT_UI_PREFERENCES: ProjectUIScopedPreferences =
   {
     tab: "conversations",
     conversationsFilter: "all",
-    todosOwnerFilter: {
-      assigneeScope: "all",
-      selectedUserSIds: [],
-    },
+    todosOwnerFilter: DEFAULT_TODO_OWNER_FILTER,
   };
 
 /** Hash segment → tab when the user navigates with the hash (same space). */

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -350,31 +350,54 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     {
       spaceId,
       lastCleanedAt,
+      timeScope = "active",
+      assigneeUserId = null,
     }: {
       spaceId: ModelId;
       lastCleanedAt?: Date | null;
+      timeScope?: "active" | "last_24h" | "last_7d" | "last_30d";
+      assigneeUserId?: ModelId | null;
     }
   ): Promise<ProjectTodoResource[]> {
-    let where: WhereOptions<ProjectTodoModel> = { spaceId };
+    const MS_PER_HOUR = 60 * 60 * 1000;
 
-    // Apply per-viewer "clean done" cutoff: hide done todos completed before
-    // lastCleanedAt, regardless of assignee. Pending agent suggestions stay
-    // visible so users can still approve or reject after cleaning.
-    if (lastCleanedAt) {
-      where = {
-        [Op.and]: [
-          { spaceId },
-          {
-            [Op.or]: [
-              { status: { [Op.ne]: "done" } },
-              { doneAt: null },
-              { doneAt: { [Op.gte]: lastCleanedAt } },
-              { agentSuggestionStatus: "pending" },
-            ],
-          },
-        ],
-      };
+    const historicUpdatedSince = (
+      scope: "last_24h" | "last_7d" | "last_30d"
+    ): Date => {
+      const now = Date.now();
+      switch (scope) {
+        case "last_24h":
+          return new Date(now - 24 * MS_PER_HOUR);
+        case "last_7d":
+          return new Date(now - 7 * 24 * MS_PER_HOUR);
+        case "last_30d":
+          return new Date(now - 30 * 24 * MS_PER_HOUR);
+      }
+    };
+
+    const clauses: WhereOptions<ProjectTodoModel>[] = [{ spaceId }];
+
+    if (assigneeUserId != null) {
+      clauses.push({ userId: assigneeUserId });
     }
+
+    if (timeScope !== "active") {
+      clauses.push({
+        updatedAt: { [Op.gte]: historicUpdatedSince(timeScope) },
+      });
+    } else if (lastCleanedAt) {
+      clauses.push({
+        [Op.or]: [
+          { status: { [Op.ne]: "done" } },
+          { doneAt: null },
+          { doneAt: { [Op.gte]: lastCleanedAt } },
+          { agentSuggestionStatus: "pending" },
+        ],
+      });
+    }
+
+    const where: WhereOptions<ProjectTodoModel> =
+      clauses.length === 1 ? clauses[0]! : { [Op.and]: clauses };
 
     return this.baseFetch(auth, { where, order: [["createdAt", "DESC"]] });
   }

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -1,3 +1,8 @@
+import {
+  buildProjectTodosListSwrKey,
+  isProjectTodosListSwrKey,
+  type TodoOwnerFilter,
+} from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
@@ -328,16 +333,21 @@ export function useProjectTodos({
   owner,
   spaceId,
   disabled,
+  todoOwnerFilter,
 }: {
   owner: LightWorkspaceType;
   spaceId: string;
   disabled?: boolean;
+  todoOwnerFilter: TodoOwnerFilter;
 }) {
   const { fetcher } = useFetcher();
   const todosFetcher: Fetcher<GetProjectTodosResponseBody> = fetcher;
   const todosUrl = useMemo(
-    () => `/api/w/${owner.sId}/spaces/${spaceId}/project_todos`,
-    [owner.sId, spaceId]
+    () =>
+      disabled
+        ? null
+        : buildProjectTodosListSwrKey(owner.sId, spaceId, todoOwnerFilter),
+    [disabled, owner.sId, spaceId, todoOwnerFilter]
   );
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -411,12 +421,11 @@ export function useMarkProjectTodosRead({
 
   return useCallback(async (): Promise<void> => {
     const immediateReadAt = new Date().toISOString();
-    const todosKey = `/api/w/${owner.sId}/spaces/${spaceId}/project_todos`;
 
     // Keep local UI state in sync immediately to avoid replaying new-item
     // animations when navigating away/back before the network round-trip ends.
     await mutate(
-      todosKey,
+      (key) => isProjectTodosListSwrKey(key, owner.sId, spaceId),
       (prev: GetProjectTodosResponseBody | undefined) => ({
         todos: prev?.todos ?? [],
         viewerUserId: prev?.viewerUserId ?? null,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.test.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { ProjectTodoFactory } from "@app/tests/utils/ProjectTodoFactory";
@@ -87,6 +88,65 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_todos", () => {
     expect(data.viewerUserId).toBe(user.sId);
     expect(data.todos[0].user).not.toBeNull();
     expect(data.todos[1].user).not.toBeNull();
+  });
+
+  it("should return only todos assigned to the viewer when assignee=mine", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const secondUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, secondUser, { role: "user" });
+
+    await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Mine only",
+    });
+    await ProjectTodoFactory.create(workspace, project, {
+      userId: secondUser.id,
+      text: "Not mine",
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.assignee = "mine";
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const texts = res._getJSONData().todos.map((t: { text: string }) => t.text);
+    expect(texts.sort()).toEqual(["Mine only"]);
+  });
+
+  it("should omit todos stale by updatedAt when period=last_24h", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+
+    await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Recent-ish",
+    });
+    const staleTodo = await ProjectTodoFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Stale update",
+    });
+    const stalePast = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    // biome-ignore lint/plugin/noRawSql: Sequelize/workspace hooks block reliable updatedAt backdating for this row
+    await frontSequelize.query(
+      `UPDATE project_todos SET "updatedAt" = :updatedAt WHERE id = :id AND "workspaceId" = :wid`,
+      {
+        replacements: {
+          updatedAt: stalePast,
+          id: staleTodo.id,
+          wid: staleTodo.workspaceId,
+        },
+      }
+    );
+
+    req.query.spaceId = project.sId;
+    req.query.period = "last_24h";
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const texts = res._getJSONData().todos.map((t: { text: string }) => t.text);
+    expect(texts).toContain("Recent-ish");
+    expect(texts).not.toContain("Stale update");
   });
 
   it("should hide cleaned done todos for all users", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_todos/index.ts
@@ -7,6 +7,44 @@ import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { ProjectTodoStateResource } from "@app/lib/resources/project_todo_state_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
+import type { ModelId } from "@app/types/shared/model_id";
+
+function parseSingleQueryValue(
+  value: NextApiRequest["query"][string] | undefined
+): string | undefined {
+  const v = Array.isArray(value) ? value[0] : value;
+  return typeof v === "string" && v.trim().length > 0 ? v.trim() : undefined;
+}
+
+const PROJECT_TODO_TIME_SCOPE_VALUES = [
+  "active",
+  "last_24h",
+  "last_7d",
+  "last_30d",
+] as const;
+
+type ProjectTodoFetchTimeScope =
+  (typeof PROJECT_TODO_TIME_SCOPE_VALUES)[number];
+
+function parseProjectTodoTimeScope(
+  req: NextApiRequest
+): ProjectTodoFetchTimeScope {
+  const raw =
+    parseSingleQueryValue(req.query.period)?.toLowerCase() ?? "active";
+  if ((PROJECT_TODO_TIME_SCOPE_VALUES as readonly string[]).includes(raw)) {
+    return raw as ProjectTodoFetchTimeScope;
+  }
+  return "active";
+}
+
+function parsePeopleMineOnly(req: NextApiRequest): boolean {
+  const legacy = parseSingleQueryValue(req.query.assignee)?.toLowerCase();
+  const explicit = parseSingleQueryValue(req.query.people)?.toLowerCase();
+
+  const token = explicit ?? legacy ?? "all";
+  return token === "mine";
+}
+
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ProjectTodoType } from "@app/types/project_todo";
@@ -58,10 +96,21 @@ async function handler(
       const state = await ProjectTodoStateResource.fetchBySpace(auth, {
         spaceId: space.id,
       });
+      const timeScope = parseProjectTodoTimeScope(req);
+      const viewerOnlyMine = parsePeopleMineOnly(req);
+      let assigneeUserId: ModelId | null = null;
+      if (viewerOnlyMine) {
+        assigneeUserId = currentUser.id;
+      }
+
+      const lastCleanedAtForFetch =
+        timeScope === "active" ? (state?.lastCleanedAt ?? null) : null;
 
       const todos = await ProjectTodoResource.fetchBySpace(auth, {
         spaceId: space.id,
-        lastCleanedAt: state?.lastCleanedAt ?? null,
+        lastCleanedAt: lastCleanedAtForFetch,
+        timeScope,
+        assigneeUserId,
       });
 
       const todoIds = todos.map((t) => t.sId);


### PR DESCRIPTION
## Description

Three small improvements bundled together.

**`ProjectTodosToolbar`**

Consolidates `ProjectTodoScopeFilter`, `ProjectTodoLocalSearch`, and `ProjectTodoCleanButton` into a single horizontal toolbar component. `SpaceTodosTab` and `EditableProjectTodosPanel` now both render `<ProjectTodosToolbar />` as a single slot instead of three separate components. `ProjectTodoCleanButton` is extracted to its own file, reads its state from `ProjectTodosPanelContext`, and adapts to mobile (icon-only via `useIsMobile`).

**"New" scope filter**

Adds a `"new"` option to the todo scope filter that shows only todos that haven't been actioned yet (pending agent suggestions + recently added items). `TodoOwnerFilter` type is moved to `projectTodosListScope.ts` to be co-located with the scope logic.

**Layout**

`SpaceTodosTab` gains a `heading-2xl` project name title (`{spaceInfo.name}'s To-dos`), consistent spacing (`gap-4` outer, `gap-3` inner), and a cleaner header row.

## Tests

Local

## Risk

Low — toolbar is a composition of existing components; layout change is visual only

## Deploy Plan

Deploy `front`
