### PR TITLE
Add user limits based on spend alert

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -56,8 +56,8 @@ import { isModelAvailable, isProviderWhitelisted } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
-import { hasCredits } from "@app/lib/metronome/credit_balance";
 import { isLegacyPlan } from "@app/lib/metronome/plan_type";
+import { isUserBlocked } from "@app/lib/metronome/user_block";
 import {
   AgentMCPActionModel,
   AgentMCPActionOutputItemModel,
@@ -2395,20 +2395,17 @@ async function checkMessagesLimit(
     return new Ok(undefined);
   }
 
-  // Check Metronome credits.
+  // Block users flagged by the Metronome `alerts.spend_threshold_reached`
+  // webhook. The flag is set per (workspace, user) in Redis and is only
+  // checked for non-legacy Metronome plans.
   const owner = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(auth);
-  if (featureFlags.includes("metronome_billing") && owner.metronomeCustomerId) {
+  if (owner.metronomeCustomerId) {
     const onLegacyPlan = await isLegacyPlan(owner.sId);
     if (!onLegacyPlan) {
       const user = auth.user();
       if (user) {
-        const hasCreds = await hasCredits(
-          owner.sId,
-          user.sId,
-          owner.metronomeCustomerId
-        );
-        if (!hasCreds) {
+        const blocked = await isUserBlocked(owner.sId, user.sId);
+        if (blocked) {
           return new Err({
             status_code: 403,
             api_error: {

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -54,6 +54,7 @@ export type RedisUsageTagsType =
   | "mcp_client_side_results"
   | "mentions_count"
   | "metronome_credit_cache"
+  | "metronome_limit"
   | "message_events"
   | "notion_url_sync"
   | "poke_cache_invalidation"

--- a/front/lib/metronome/plan_type.ts
+++ b/front/lib/metronome/plan_type.ts
@@ -1,5 +1,5 @@
 import { getMetronomeClient } from "@app/lib/metronome/client";
-import { getProductAiUsageUserId } from "@app/lib/metronome/constants";
+import { getProductRegularSeatId } from "@app/lib/metronome/constants";
 import { SubscriptionModel } from "@app/lib/models/plan";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
@@ -86,8 +86,10 @@ export async function getActiveContract(
 
 /**
  * Returns true if the workspace is on a legacy Metronome plan.
- * Legacy plans are billed by seat and do not enforce AWU credit limits.
- * Fails open (returns true) when the plan cannot be determined.
+ * Non-legacy plans use the `Regular Seat` SUBSCRIPTION product on the contract;
+ * legacy plans use `Workspace Seat` (or no subscription at all for MAU-billed
+ * legacy enterprise contracts). Fails open (returns true) when the plan cannot
+ * be determined.
  */
 export async function isLegacyPlan(workspaceId: string): Promise<boolean> {
   const contract = await getActiveContract(workspaceId);
@@ -95,9 +97,9 @@ export async function isLegacyPlan(workspaceId: string): Promise<boolean> {
     return true;
   }
   const subscriptions = contract.subscriptions ?? [];
-  const aiUsageUserId = getProductAiUsageUserId();
+  const regularSeatId = getProductRegularSeatId();
   return !subscriptions.some(
-    (s) => s.subscription_rate.product.id === aiUsageUserId
+    (s) => s.subscription_rate.product.id === regularSeatId
   );
 }
 

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -1,0 +1,35 @@
+import { runOnRedis } from "@app/lib/api/redis";
+
+const REDIS_ORIGIN = "metronome_limit" as const;
+
+function buildKey(workspaceId: string, userId: string): string {
+  return `metronome:user_block:${workspaceId}:${userId}`;
+}
+
+export async function setUserBlocked(
+  workspaceId: string,
+  userId: string
+): Promise<void> {
+  await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
+    await client.set(buildKey(workspaceId, userId), "1");
+  });
+}
+
+export async function isUserBlocked(
+  workspaceId: string,
+  userId: string
+): Promise<boolean> {
+  return runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
+    const value = await client.get(buildKey(workspaceId, userId));
+    return value === "1";
+  });
+}
+
+export async function clearUserBlocked(
+  workspaceId: string,
+  userId: string
+): Promise<void> {
+  await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
+    await client.del(buildKey(workspaceId, userId));
+  });
+}

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -17,6 +17,7 @@ import {
 import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
+import { setUserBlocked } from "@app/lib/metronome/user_block";
 import {
   getCustomerIdFromEvent,
   MetronomeWebhookEventSchema,
@@ -145,12 +146,42 @@ async function handler(
       }
 
       switch (event.type) {
+        case "alerts.spend_threshold_reached": {
+          // Block the user that triggered the threshold. Metronome attaches
+          // the presentation group values that scoped the alert under
+          // `group_values` — extract `user_id` from there.
+          const userId = event.properties.group_values?.find(
+            (g) => g.key === "user_id"
+          )?.value;
+          if (!userId) {
+            logger.warn(
+              { eventId: event.id, workspaceId: workspace.sId },
+              "[Metronome Webhook] spend_threshold_reached: no user_id in group_values, skipping"
+            );
+            break;
+          }
+
+          const currentSpend = event.properties.current_spend;
+
+          // TODO: Check user seat and spend limit and block if needed, don't block on every spend threshold reached.
+          await setUserBlocked(workspace.sId, userId);
+          logger.info(
+            {
+              eventId: event.id,
+              workspaceId: workspace.sId,
+              userId,
+              currentSpend,
+            },
+            "[Metronome Webhook] spend_threshold_reached: user blocked"
+          );
+          break;
+        }
+
         case "alerts.invoice_total_reached":
         case "alerts.low_remaining_commit_balance_reached":
         case "alerts.low_remaining_contract_credit_balance_reached":
         case "alerts.low_remaining_credit_balance_reached":
         case "alerts.low_remaining_seat_balance_reached":
-        case "alerts.spend_threshold_reached":
         case "alerts.usage_threshold_reached":
         case "commit.archive":
         case "commit.create":


### PR DESCRIPTION
## Description

Add simple user block when a spend usage is reached. Gated to enterprise plan.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low - gated

## Deploy Plan

deploy front
