### PR TITLE
feat(salesforce): make PDF attachments downloadable via read_attachment

### DIFF
--- a/front/lib/api/actions/servers/salesforce/api_helper.ts
+++ b/front/lib/api/actions/servers/salesforce/api_helper.ts
@@ -1,4 +1,3 @@
-import { extractTextFromBuffer } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import { SF_API_VERSION } from "@app/lib/api/actions/servers/salesforce/helpers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -224,24 +223,6 @@ export async function downloadSalesforceContent(
   } else {
     return downloadSalesforceAttachment(conn, attachmentId);
   }
-}
-
-export async function extractTextFromSalesforceAttachment(
-  conn: Connection,
-  attachmentId: string,
-  mimeType: string
-): Promise<Result<string, string>> {
-  if (!isValidSalesforceId(attachmentId)) {
-    return new Err("Invalid Salesforce ID format");
-  }
-
-  const downloadResult = await downloadSalesforceContent(conn, attachmentId);
-
-  if (downloadResult.isErr()) {
-    return downloadResult;
-  }
-
-  return extractTextFromBuffer(downloadResult.value, mimeType);
 }
 
 function getMimeType(fileType: string): string {

--- a/front/lib/api/actions/servers/salesforce/tools/index.ts
+++ b/front/lib/api/actions/servers/salesforce/tools/index.ts
@@ -5,10 +5,13 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { jsonToMarkdown } from "@app/lib/actions/mcp_internal_actions/utils";
-import { processAttachment } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
+import {
+  extractTextFromBuffer,
+  processAttachment,
+} from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
+import { sanitizeFilename } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import {
   downloadSalesforceContent,
-  extractTextFromSalesforceAttachment,
   getAllSalesforceAttachments,
 } from "@app/lib/api/actions/servers/salesforce/api_helper";
 import {
@@ -324,18 +327,54 @@ export function createSalesforceTools(auth: Authenticator): ToolDefinition[] {
           );
         }
 
-        return processAttachment({
-          mimeType: targetAttachment.mimeType,
-          filename: targetAttachment.filename || `attachment-${attachmentId}`,
-          extractText: async () =>
-            extractTextFromSalesforceAttachment(
-              conn,
-              attachmentId,
-              targetAttachment.mimeType
-            ),
-          downloadContent: async () =>
-            downloadSalesforceContent(conn, attachmentId),
+        const { mimeType, filename } = targetAttachment;
+        const safeFilename = filename || `attachment-${attachmentId}`;
+
+        // Download once upfront; reuse buffer for both text extraction and binary blob.
+        // Avoids a double network call to Salesforce (mirrors Microsoft Drive pattern).
+        const downloadResult = await downloadSalesforceContent(
+          conn,
+          attachmentId
+        );
+        if (downloadResult.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to download attachment: ${downloadResult.error}`
+            )
+          );
+        }
+        const buffer = downloadResult.value;
+
+        const result = await processAttachment({
+          mimeType,
+          filename: safeFilename,
+          extractText: async () => extractTextFromBuffer(buffer, mimeType),
+          downloadContent: async () => new Ok(buffer),
         });
+
+        if (result.isErr()) {
+          return new Err(result.error);
+        }
+
+        // Always include a raw binary resource block so the user receives a
+        // downloadable file, even when text extraction succeeded (PDFs).
+        if (result.value.some((c) => c.type === "resource")) {
+          return new Ok(result.value);
+        }
+
+        const sanitized = sanitizeFilename(safeFilename);
+        return new Ok([
+          ...result.value,
+          {
+            type: "resource" as const,
+            resource: {
+              blob: buffer.toString("base64"),
+              _meta: { text: `Attachment: ${sanitized}` },
+              mimeType,
+              uri: sanitized,
+            },
+          },
+        ]);
       });
     },
   };

--- a/front/lib/api/actions/servers/salesforce/tools/index.ts
+++ b/front/lib/api/actions/servers/salesforce/tools/index.ts
@@ -327,8 +327,18 @@ export function createSalesforceTools(auth: Authenticator): ToolDefinition[] {
           );
         }
 
-        const { mimeType, filename } = targetAttachment;
+        const { mimeType, filename, size } = targetAttachment;
         const safeFilename = filename || `attachment-${attachmentId}`;
+
+        // 50MB — matches the platform limit for data files (types/files.ts MAX_FILE_SIZES["data"]).
+        const MAX_ATTACHMENT_SIZE_BYTES = 50 * 1024 * 1024;
+        if (size !== undefined && size > MAX_ATTACHMENT_SIZE_BYTES) {
+          return new Err(
+            new MCPError(
+              `Attachment is too large to download (${(size / (1024 * 1024)).toFixed(1)}MB). Maximum supported size is 50MB.`
+            )
+          );
+        }
 
         // Download once upfront; reuse buffer for both text extraction and binary blob.
         // Avoids a double network call to Salesforce (mirrors Microsoft Drive pattern).


### PR DESCRIPTION
## Summary

When using `read_attachment` on a Salesforce record, PDFs are now returned as both extracted text (for the agent to reason about) and a downloadable file visible in the conversation UI.

Previously, only the extracted text was returned — the file itself was never surfaced, so users had no way to download or view the original PDF.

## How

- Download the attachment once upfront into a buffer
- Pass the same buffer to both text extraction and binary download callbacks (also eliminates a potential double network call)
- After processing, inject a binary resource block if none is present — which is always the case for readable PDFs where text extraction succeeds
- Dead code removed: `extractTextFromSalesforceAttachment` in `api_helper.ts` had exactly one caller and became unused after this refactor

## Reference

Same pattern already used by `get_file_content` in the Microsoft Drive MCP tool.

## Test plan

- [ ] PDF attached to a Salesforce record → agent response shows extracted text AND an inline downloadable PDF
- [ ] ContentVersion file (ID prefix `068`) → downloads correctly
- [ ] Legacy Attachment (ID prefix `00P`) → downloads correctly
- [ ] Non-PDF file (`.docx`, `.xlsx`) → behavior unchanged
- [ ] Corrupted PDF → fallback still works, no duplicate resource block injected