### PR TITLE
Fix todos datatable unstable columns leading to re-triggering diff animations.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem.tsx
@@ -137,9 +137,31 @@ export const EditableTodoItem = memo(function EditableTodoItem({
   const clickOffsetRef = useRef<number | null>(null);
   const [typingDismissed, setTypingDismissed] = useState(false);
   const measureRef = useRef<HTMLSpanElement>(null);
+  const typingAnimationLockedTextRef = useRef<string | null>(null);
 
   const displayText = stripNewlines(todo.text);
   const showTypingAnimation = isNew && !typingDismissed;
+
+  useEffect(() => {
+    if (!isNew) {
+      typingAnimationLockedTextRef.current = null;
+    }
+  }, [isNew]);
+
+  useEffect(() => {
+    if (!showTypingAnimation) {
+      typingAnimationLockedTextRef.current = null;
+    }
+  }, [showTypingAnimation]);
+
+  let typingAnimationSourceText = displayText;
+  if (showTypingAnimation) {
+    if (typingAnimationLockedTextRef.current === null) {
+      typingAnimationLockedTextRef.current = displayText;
+    }
+    typingAnimationSourceText = typingAnimationLockedTextRef.current;
+  }
+
   useAutosizeTextArea(editInputRef, draftText, isEditing);
 
   const filteredReassignMembers = useMemo(() => {
@@ -387,7 +409,7 @@ export const EditableTodoItem = memo(function EditableTodoItem({
                   aria-hidden
                   className="invisible block w-full min-w-0 break-words text-pretty text-base leading-6"
                 >
-                  {displayText}
+                  {typingAnimationSourceText}
                 </span>
               )}
               <TodoMetadataTooltip todo={todo} agentNameById={agentNameById}>
@@ -425,7 +447,7 @@ export const EditableTodoItem = memo(function EditableTodoItem({
                 >
                   {showTypingAnimation ? (
                     <TypingAnimation
-                      text={displayText}
+                      text={typingAnimationSourceText}
                       duration={16}
                       onComplete={() => setTypingDismissed(true)}
                     />

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTable.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTable.tsx
@@ -1,58 +1,17 @@
-import type { EditableTodoItemProps } from "@app/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem";
-import { EditableTodoItem } from "@app/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem";
-import { SuggestedTodoItem } from "@app/components/assistant/conversation/space/conversations/project_todos/SuggestedTodoItem";
-import { TodoAssigneeHeader } from "@app/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import {
+  ProjectTodosDataTableCell,
+  ProjectTodosDataTableHeaderTitle,
+  ProjectTodosDataTableUiProvider,
+} from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTableCell";
 import type {
   ProjectTodoAssigneeType,
   ProjectTodoType,
 } from "@app/types/project_todo";
-import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
-import {
-  Button,
-  CheckIcon,
-  cn,
-  DataTable,
-  type MenuItem,
-  XMarkIcon,
-} from "@dust-tt/sparkle";
+import { DataTable, type MenuItem } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo } from "react";
 
-type BulkAssigneeActionState = {
-  groupKey: string;
-  kind: "approve" | "reject";
-} | null;
-
-/** Split full assignee groups into pending-suggestion todos only (for the top table). */
-export function groupedTodosPendingSuggestionsOnly(
-  groups: Array<{
-    user: ProjectTodoAssigneeType | null;
-    todos: ProjectTodoType[];
-  }>
-): Array<{ user: ProjectTodoAssigneeType | null; todos: ProjectTodoType[] }> {
-  return groups
-    .map((g) => ({
-      user: g.user,
-      todos: g.todos.filter((t) => t.agentSuggestionStatus === "pending"),
-    }))
-    .filter((g) => g.todos.length > 0);
-}
-
-/** Split full assignee groups into non-pending todos (for the bottom table). */
-export function groupedTodosNonPendingSuggestions(
-  groups: Array<{
-    user: ProjectTodoAssigneeType | null;
-    todos: ProjectTodoType[];
-  }>
-): Array<{ user: ProjectTodoAssigneeType | null; todos: ProjectTodoType[] }> {
-  return groups
-    .map((g) => ({
-      user: g.user,
-      todos: g.todos.filter((t) => t.agentSuggestionStatus !== "pending"),
-    }))
-    .filter((g) => g.todos.length > 0);
-}
+export type ProjectTodosDataTableVariant = "suggested" | "regular";
 
 const SUGGESTED_TABLE_SHELL_CLASS =
   "mx-auto w-full max-w-[52rem] rounded-lg border border-border bg-muted-background/50 p-2 dark:border-border-night dark:bg-muted-background-night/35";
@@ -62,8 +21,6 @@ type SparkleTodoTableExtras = {
   onDoubleClick?: () => void;
   menuItems?: MenuItem[];
 };
-
-export type ProjectTodosDataTableVariant = "suggested" | "regular";
 
 export type ProjectTodoTableRow = SparkleTodoTableExtras &
   (
@@ -108,102 +65,41 @@ function flattenGroupedTodos(
   return rows;
 }
 
+/**
+ * Stable TanStack column defs. Sparkle `DataTable` does not expose an option to
+ * freeze column instances; TanStack expects a stable `columns` reference. Row
+ * cells read live props from `useProjectTodosPanel` instead of closing over
+ * parent render state.
+ */
+const PROJECT_TODOS_DATA_TABLE_COLUMNS: ColumnDef<ProjectTodoTableRow>[] = [
+  {
+    id: "content",
+    header: () => <ProjectTodosDataTableHeaderTitle />,
+    accessorFn: (row) => row,
+    enableSorting: false,
+    meta: {
+      className:
+        "h-auto min-h-0 max-h-none align-top whitespace-normal overflow-visible py-0 px-1",
+    },
+    cell: ({ row }) => <ProjectTodosDataTableCell original={row.original} />,
+  },
+];
+
 export type ProjectTodosDataTableProps = {
   variant: ProjectTodosDataTableVariant;
   groupedTodosForAll: Array<{
     user: ProjectTodoAssigneeType | null;
     todos: ProjectTodoType[];
   }>;
-  viewerUserId: string | null;
-  owner: LightWorkspaceType;
-  activeAgents: LightAgentConfigurationType[];
-  agentsLoading: boolean;
-  agentNameById: Map<string, string>;
-  pendingRemovalIds: Set<string>;
-  newItemKeys: Set<string>;
-  doneFlashKeys: Set<string>;
-  startingTodoIds: Set<string>;
-  isReadOnly?: boolean;
-  firstOnboardingTodoId: string | null;
-  projectMembers: SpaceUserType[];
-  membersWithActiveTodoIds: Set<string>;
-  onToggleDone: (todo: ProjectTodoType) => void;
-  onDelete: (todo: ProjectTodoType) => void | Promise<void>;
-  onApproveAgentSuggestion: (todo: ProjectTodoType) => void | Promise<void>;
-  onRejectAgentSuggestion: (todo: ProjectTodoType) => void | Promise<void>;
-  /** Suggested table: approve every pending suggestion listed under this assignee */
-  onApproveAllSuggestedForAssignee?: (
-    todoIds: string[]
-  ) => void | Promise<void>;
-  onRejectAllSuggestedForAssignee?: (todoIds: string[]) => void | Promise<void>;
-  onStartWorking: EditableTodoItemProps["onStartWorking"];
-  onPatchTodo: EditableTodoItemProps["onPatchTodo"];
   /** Regular table: omit per-assignee header rows (flat list). */
   hideAssigneeGroupHeaders?: boolean;
-  /** When false, hides the overflow "Reassign" submenu (e.g. sole project member). */
-  allowAssigneeReassign?: boolean;
 };
 
 export function ProjectTodosDataTable({
   variant,
   groupedTodosForAll,
-  viewerUserId,
-  owner,
-  activeAgents,
-  agentsLoading,
-  agentNameById,
-  pendingRemovalIds,
-  newItemKeys,
-  doneFlashKeys,
-  startingTodoIds,
-  isReadOnly,
-  firstOnboardingTodoId,
-  projectMembers,
-  membersWithActiveTodoIds,
-  onToggleDone,
-  onDelete,
-  onApproveAgentSuggestion,
-  onRejectAgentSuggestion,
-  onApproveAllSuggestedForAssignee,
-  onRejectAllSuggestedForAssignee,
-  onStartWorking,
-  onPatchTodo,
   hideAssigneeGroupHeaders = false,
-  allowAssigneeReassign = true,
 }: ProjectTodosDataTableProps) {
-  const [bulkAssigneeAction, setBulkAssigneeAction] =
-    useState<BulkAssigneeActionState>(null);
-
-  const runBulkApproveForGroup = useCallback(
-    async (groupKey: string, todoIds: string[]) => {
-      if (!onApproveAllSuggestedForAssignee || todoIds.length === 0) {
-        return;
-      }
-      setBulkAssigneeAction({ groupKey, kind: "approve" });
-      try {
-        await onApproveAllSuggestedForAssignee(todoIds);
-      } finally {
-        setBulkAssigneeAction(null);
-      }
-    },
-    [onApproveAllSuggestedForAssignee]
-  );
-
-  const runBulkRejectForGroup = useCallback(
-    async (groupKey: string, todoIds: string[]) => {
-      if (!onRejectAllSuggestedForAssignee || todoIds.length === 0) {
-        return;
-      }
-      setBulkAssigneeAction({ groupKey, kind: "reject" });
-      try {
-        await onRejectAllSuggestedForAssignee(todoIds);
-      } finally {
-        setBulkAssigneeAction(null);
-      }
-    },
-    [onRejectAllSuggestedForAssignee]
-  );
-
   const data = useMemo(() => {
     if (
       variant === "regular" &&
@@ -217,175 +113,25 @@ export function ProjectTodosDataTable({
     return flattenGroupedTodos(groupedTodosForAll, variant);
   }, [groupedTodosForAll, variant, hideAssigneeGroupHeaders]);
 
-  const columns = useMemo<ColumnDef<ProjectTodoTableRow>[]>(
-    () => [
-      {
-        id: "content",
-        header: variant === "suggested" ? "Suggested" : "To-do",
-        accessorFn: (row) => row,
-        enableSorting: false,
-        meta: {
-          className:
-            "h-auto min-h-0 max-h-none align-top whitespace-normal overflow-visible py-0 px-1",
-        },
-        cell: ({ row }) => {
-          const original = row.original;
-          if (original.kind === "assignee_header") {
-            const bulkIds = original.pendingSuggestionTodoIds ?? [];
-            const showBulkActions =
-              variant === "suggested" &&
-              bulkIds.length > 0 &&
-              viewerUserId !== null &&
-              !isReadOnly &&
-              onApproveAllSuggestedForAssignee &&
-              onRejectAllSuggestedForAssignee;
-
-            const rowBusy = bulkAssigneeAction?.groupKey === original.groupKey;
-            const approveBulkLoading =
-              rowBusy && bulkAssigneeAction?.kind === "approve";
-            const rejectBulkLoading =
-              rowBusy && bulkAssigneeAction?.kind === "reject";
-
-            return (
-              <div
-                className={cn(
-                  "flex min-w-0 items-center gap-2",
-                  !original.isFirstGroup && "mt-4"
-                )}
-              >
-                <div className="min-w-0 flex-1">
-                  <TodoAssigneeHeader
-                    user={original.user}
-                    viewerUserId={viewerUserId}
-                    className="mb-0 mt-0"
-                  />
-                </div>
-                {showBulkActions ? (
-                  <div className="flex shrink-0 items-center gap-0.5">
-                    <Button
-                      icon={CheckIcon}
-                      size="mini"
-                      variant="outline"
-                      tooltip="Accept all suggested to-dos for this assignee"
-                      isLoading={approveBulkLoading}
-                      disabled={rowBusy}
-                      className="text-success-500 hover:text-success-600 dark:text-success-500-night dark:hover:text-success-600-night"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void runBulkApproveForGroup(original.groupKey, bulkIds);
-                      }}
-                    />
-                    <Button
-                      icon={XMarkIcon}
-                      size="mini"
-                      variant="outline"
-                      tooltip="Reject all suggested to-dos for this assignee"
-                      isLoading={rejectBulkLoading}
-                      disabled={rowBusy}
-                      className="text-warning-500 hover:text-warning-600 dark:text-warning-500-night dark:hover:text-warning-600-night"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void runBulkRejectForGroup(original.groupKey, bulkIds);
-                      }}
-                    />
-                  </div>
-                ) : null}
-              </div>
-            );
-          }
-          if (original.kind !== "todo") {
-            return null;
-          }
-          const todo = original.todo;
-          return (
-            <div className="py-0.5 pl-4 pr-0">
-              {variant === "suggested" ? (
-                <SuggestedTodoItem
-                  todo={todo}
-                  viewerUserId={viewerUserId}
-                  onApproveAgentSuggestion={onApproveAgentSuggestion}
-                  onRejectAgentSuggestion={onRejectAgentSuggestion}
-                  owner={owner}
-                  agentNameById={agentNameById}
-                  isExiting={pendingRemovalIds.has(todo.sId)}
-                  isNew={newItemKeys.has(todo.sId)}
-                  isReadOnly={isReadOnly}
-                />
-              ) : (
-                <EditableTodoItem
-                  todo={todo}
-                  viewerUserId={viewerUserId}
-                  onToggleDone={onToggleDone}
-                  onDelete={onDelete}
-                  onStartWorking={onStartWorking}
-                  owner={owner}
-                  activeAgents={activeAgents}
-                  agentsLoading={agentsLoading}
-                  agentNameById={agentNameById}
-                  isExiting={pendingRemovalIds.has(todo.sId)}
-                  isNew={newItemKeys.has(todo.sId)}
-                  isNewlyDone={doneFlashKeys.has(todo.sId)}
-                  isStarting={startingTodoIds.has(todo.sId)}
-                  isReadOnly={isReadOnly}
-                  isFirstOnboardingTodo={todo.sId === firstOnboardingTodoId}
-                  projectMembers={projectMembers}
-                  membersWithActiveTodoIds={membersWithActiveTodoIds}
-                  onPatchTodo={onPatchTodo}
-                  allowAssigneeReassign={allowAssigneeReassign}
-                />
-              )}
-            </div>
-          );
-        },
-      },
-    ],
-    [
-      variant,
-      viewerUserId,
-      owner,
-      activeAgents,
-      agentsLoading,
-      agentNameById,
-      pendingRemovalIds,
-      newItemKeys,
-      doneFlashKeys,
-      startingTodoIds,
-      isReadOnly,
-      firstOnboardingTodoId,
-      projectMembers,
-      membersWithActiveTodoIds,
-      onToggleDone,
-      onDelete,
-      onApproveAgentSuggestion,
-      onRejectAgentSuggestion,
-      onStartWorking,
-      onPatchTodo,
-      bulkAssigneeAction,
-      runBulkApproveForGroup,
-      runBulkRejectForGroup,
-      onApproveAllSuggestedForAssignee,
-      onRejectAllSuggestedForAssignee,
-      allowAssigneeReassign,
-    ]
-  );
-
   if (groupedTodosForAll.length === 0) {
     return null;
   }
 
   const table = (
-    <DataTable<ProjectTodoTableRow>
-      data={data}
-      columns={columns}
-      widthClassName="w-full"
-      hideRowDivider
-      className="[&_thead]:hidden"
-      getRowId={(row) =>
-        row.kind === "assignee_header"
-          ? `${variant}-assignee-${row.groupKey}`
-          : row.todo.sId
-      }
-    />
+    <ProjectTodosDataTableUiProvider variant={variant}>
+      <DataTable<ProjectTodoTableRow>
+        data={data}
+        columns={PROJECT_TODOS_DATA_TABLE_COLUMNS}
+        widthClassName="w-full"
+        hideRowDivider
+        className="[&_thead]:hidden"
+        getRowId={(row) =>
+          row.kind === "assignee_header"
+            ? `${variant}-assignee-${row.groupKey}`
+            : row.todo.sId
+        }
+      />
+    </ProjectTodosDataTableUiProvider>
   );
 
   if (variant === "suggested") {

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTableCell.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTableCell.tsx
@@ -1,0 +1,258 @@
+import { EditableTodoItem } from "@app/components/assistant/conversation/space/conversations/project_todos/EditableTodoItem";
+import { useProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
+import { SuggestedTodoItem } from "@app/components/assistant/conversation/space/conversations/project_todos/SuggestedTodoItem";
+import { TodoAssigneeHeader } from "@app/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents";
+import { Button, CheckIcon, cn, XMarkIcon } from "@dust-tt/sparkle";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import type {
+  ProjectTodosDataTableVariant,
+  ProjectTodoTableRow,
+} from "./ProjectTodosDataTable";
+
+export type BulkAssigneeActionState = {
+  groupKey: string;
+  kind: "approve" | "reject";
+} | null;
+
+type ProjectTodosDataTableUiContextValue = {
+  variant: ProjectTodosDataTableVariant;
+  bulkAssigneeAction: BulkAssigneeActionState;
+  runBulkApproveForGroup: (groupKey: string, todoIds: string[]) => void;
+  runBulkRejectForGroup: (groupKey: string, todoIds: string[]) => void;
+};
+
+export const ProjectTodosDataTableUiContext =
+  createContext<ProjectTodosDataTableUiContextValue | null>(null);
+
+function useProjectTodosDataTableUi(): ProjectTodosDataTableUiContextValue {
+  const ctx = useContext(ProjectTodosDataTableUiContext);
+  if (!ctx) {
+    throw new Error(
+      "Project todos table UI components require ProjectTodosDataTableUiContext.Provider"
+    );
+  }
+  return ctx;
+}
+
+export function ProjectTodosDataTableHeaderTitle() {
+  const { variant } = useProjectTodosDataTableUi();
+  return <>{variant === "suggested" ? "Suggested" : "To-do"}</>;
+}
+
+export function ProjectTodosDataTableCell({
+  original,
+}: {
+  original: ProjectTodoTableRow;
+}) {
+  const {
+    viewerUserId,
+    owner,
+    activeAgents,
+    isAgentsLoading,
+    agentNameById,
+    pendingRemovalIds,
+    newItemKeys,
+    doneFlashKeys,
+    startingTodoIds,
+    isReadOnly,
+    firstOnboardingTodoId,
+    projectMembers,
+    membersWithActiveTodoIds,
+    handleToggleDone,
+    requestDelete,
+    onApproveAgentSuggestion,
+    onRejectAgentSuggestion,
+    handleStartWorking,
+    patchTodoItem,
+    isSoleProjectMember,
+  } = useProjectTodosPanel();
+
+  const {
+    variant,
+    bulkAssigneeAction,
+    runBulkApproveForGroup,
+    runBulkRejectForGroup,
+  } = useProjectTodosDataTableUi();
+
+  const allowAssigneeReassign = !isSoleProjectMember;
+
+  if (original.kind === "assignee_header") {
+    const bulkIds = original.pendingSuggestionTodoIds ?? [];
+    const showBulkActions =
+      variant === "suggested" &&
+      bulkIds.length > 0 &&
+      viewerUserId !== null &&
+      !isReadOnly;
+
+    const rowBusy = bulkAssigneeAction?.groupKey === original.groupKey;
+    const approveBulkLoading =
+      rowBusy && bulkAssigneeAction?.kind === "approve";
+    const rejectBulkLoading = rowBusy && bulkAssigneeAction?.kind === "reject";
+
+    return (
+      <div
+        className={cn(
+          "flex min-w-0 items-center gap-2",
+          !original.isFirstGroup && "mt-4"
+        )}
+      >
+        <div className="min-w-0 flex-1">
+          <TodoAssigneeHeader
+            user={original.user}
+            viewerUserId={viewerUserId}
+            className="mb-0 mt-0"
+          />
+        </div>
+        {showBulkActions ? (
+          <div className="flex shrink-0 items-center gap-0.5">
+            <Button
+              icon={CheckIcon}
+              size="mini"
+              variant="outline"
+              tooltip="Accept all suggested to-dos for this assignee"
+              isLoading={approveBulkLoading}
+              disabled={rowBusy}
+              className="text-success-500 hover:text-success-600 dark:text-success-500-night dark:hover:text-success-600-night"
+              onClick={(e) => {
+                e.stopPropagation();
+                void runBulkApproveForGroup(original.groupKey, bulkIds);
+              }}
+            />
+            <Button
+              icon={XMarkIcon}
+              size="mini"
+              variant="outline"
+              tooltip="Reject all suggested to-dos for this assignee"
+              isLoading={rejectBulkLoading}
+              disabled={rowBusy}
+              className="text-warning-500 hover:text-warning-600 dark:text-warning-500-night dark:hover:text-warning-600-night"
+              onClick={(e) => {
+                e.stopPropagation();
+                void runBulkRejectForGroup(original.groupKey, bulkIds);
+              }}
+            />
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (original.kind !== "todo") {
+    return null;
+  }
+
+  const todo = original.todo;
+
+  return (
+    <div className="py-0.5 pl-4 pr-0">
+      {variant === "suggested" ? (
+        <SuggestedTodoItem
+          key={todo.sId}
+          todo={todo}
+          viewerUserId={viewerUserId}
+          onApproveAgentSuggestion={onApproveAgentSuggestion}
+          onRejectAgentSuggestion={onRejectAgentSuggestion}
+          owner={owner}
+          agentNameById={agentNameById}
+          isExiting={pendingRemovalIds.has(todo.sId)}
+          isNew={newItemKeys.has(todo.sId)}
+          isReadOnly={isReadOnly}
+        />
+      ) : (
+        <EditableTodoItem
+          key={todo.sId}
+          todo={todo}
+          viewerUserId={viewerUserId}
+          onToggleDone={handleToggleDone}
+          onDelete={requestDelete}
+          onStartWorking={handleStartWorking}
+          owner={owner}
+          activeAgents={activeAgents}
+          agentsLoading={isAgentsLoading}
+          agentNameById={agentNameById}
+          isExiting={pendingRemovalIds.has(todo.sId)}
+          isNew={newItemKeys.has(todo.sId)}
+          isNewlyDone={doneFlashKeys.has(todo.sId)}
+          isStarting={startingTodoIds.has(todo.sId)}
+          isReadOnly={isReadOnly}
+          isFirstOnboardingTodo={todo.sId === firstOnboardingTodoId}
+          projectMembers={projectMembers}
+          membersWithActiveTodoIds={membersWithActiveTodoIds}
+          onPatchTodo={patchTodoItem}
+          allowAssigneeReassign={allowAssigneeReassign}
+        />
+      )}
+    </div>
+  );
+}
+
+export function ProjectTodosDataTableUiProvider({
+  variant,
+  children,
+}: {
+  variant: ProjectTodosDataTableVariant;
+  children: ReactNode;
+}) {
+  const { onApproveAllSuggestedForAssignee, onRejectAllSuggestedForAssignee } =
+    useProjectTodosPanel();
+
+  const [bulkAssigneeAction, setBulkAssigneeAction] =
+    useState<BulkAssigneeActionState>(null);
+
+  const runBulkApproveForGroup = useCallback(
+    (groupKey: string, todoIds: string[]) => {
+      if (!onApproveAllSuggestedForAssignee || todoIds.length === 0) {
+        return;
+      }
+      setBulkAssigneeAction({ groupKey, kind: "approve" });
+      void (async () => {
+        try {
+          await onApproveAllSuggestedForAssignee(todoIds);
+        } finally {
+          setBulkAssigneeAction(null);
+        }
+      })();
+    },
+    [onApproveAllSuggestedForAssignee]
+  );
+
+  const runBulkRejectForGroup = useCallback(
+    (groupKey: string, todoIds: string[]) => {
+      if (!onRejectAllSuggestedForAssignee || todoIds.length === 0) {
+        return;
+      }
+      setBulkAssigneeAction({ groupKey, kind: "reject" });
+      void (async () => {
+        try {
+          await onRejectAllSuggestedForAssignee(todoIds);
+        } finally {
+          setBulkAssigneeAction(null);
+        }
+      })();
+    },
+    [onRejectAllSuggestedForAssignee]
+  );
+
+  const value = useMemo(
+    () => ({
+      variant,
+      bulkAssigneeAction,
+      runBulkApproveForGroup,
+      runBulkRejectForGroup,
+    }),
+    [variant, bulkAssigneeAction, runBulkApproveForGroup, runBulkRejectForGroup]
+  );
+
+  return (
+    <ProjectTodosDataTableUiContext.Provider value={value}>
+      {children}
+    </ProjectTodosDataTableUiContext.Provider>
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelMain.tsx
@@ -9,26 +9,8 @@ export function ProjectTodosPanelMain() {
     showSuggestedTodosTable,
     groupedSuggestedTodosOnly,
     viewerUserId,
-    owner,
-    activeAgents,
-    isAgentsLoading,
-    agentNameById,
-    pendingRemovalIds,
-    newItemKeys,
-    doneFlashKeys,
-    startingTodoIds,
-    isReadOnly,
-    firstOnboardingTodoId,
     projectMembers,
-    membersWithActiveTodoIds,
-    handleToggleDone,
-    requestDelete,
-    onApproveAgentSuggestion,
-    onRejectAgentSuggestion,
-    onApproveAllSuggestedForAssignee,
-    onRejectAllSuggestedForAssignee,
-    handleStartWorking,
-    patchTodoItem,
+    isReadOnly,
     isSpaceInfoLoading,
     defaultNewAssigneeSId,
     handleAddTodo,
@@ -52,27 +34,6 @@ export function ProjectTodosPanelMain() {
           <ProjectTodosDataTable
             variant="suggested"
             groupedTodosForAll={groupedSuggestedTodosOnly}
-            viewerUserId={viewerUserId}
-            owner={owner}
-            activeAgents={activeAgents}
-            agentsLoading={isAgentsLoading}
-            agentNameById={agentNameById}
-            pendingRemovalIds={pendingRemovalIds}
-            newItemKeys={newItemKeys}
-            doneFlashKeys={doneFlashKeys}
-            startingTodoIds={startingTodoIds}
-            isReadOnly={isReadOnly}
-            firstOnboardingTodoId={firstOnboardingTodoId}
-            projectMembers={projectMembers}
-            membersWithActiveTodoIds={membersWithActiveTodoIds}
-            onToggleDone={handleToggleDone}
-            onDelete={requestDelete}
-            onApproveAgentSuggestion={onApproveAgentSuggestion}
-            onRejectAgentSuggestion={onRejectAgentSuggestion}
-            onApproveAllSuggestedForAssignee={onApproveAllSuggestedForAssignee}
-            onRejectAllSuggestedForAssignee={onRejectAllSuggestedForAssignee}
-            onStartWorking={handleStartWorking}
-            onPatchTodo={patchTodoItem}
           />
         </div>
       )}
@@ -108,27 +69,7 @@ export function ProjectTodosPanelMain() {
               <ProjectTodosDataTable
                 variant="regular"
                 groupedTodosForAll={groupedRegularTodosOnly}
-                viewerUserId={viewerUserId}
-                owner={owner}
-                activeAgents={activeAgents}
-                agentsLoading={isAgentsLoading}
-                agentNameById={agentNameById}
-                pendingRemovalIds={pendingRemovalIds}
-                newItemKeys={newItemKeys}
-                doneFlashKeys={doneFlashKeys}
-                startingTodoIds={startingTodoIds}
-                isReadOnly={isReadOnly}
-                firstOnboardingTodoId={firstOnboardingTodoId}
-                projectMembers={projectMembers}
-                membersWithActiveTodoIds={membersWithActiveTodoIds}
-                onToggleDone={handleToggleDone}
-                onDelete={requestDelete}
-                onApproveAgentSuggestion={onApproveAgentSuggestion}
-                onRejectAgentSuggestion={onRejectAgentSuggestion}
-                onStartWorking={handleStartWorking}
-                onPatchTodo={patchTodoItem}
                 hideAssigneeGroupHeaders={hideRegularTodoAssigneeHeaders}
-                allowAssigneeReassign={!isSoleProjectMember}
               />
             )}
 

--- a/front/components/assistant/conversation/space/conversations/project_todos/SuggestedTodoItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/SuggestedTodoItem.tsx
@@ -14,7 +14,7 @@ import {
   TypingAnimation,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { memo, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 
 export interface SuggestedTodoItemProps {
   todo: ProjectTodoType;
@@ -44,9 +44,31 @@ export const SuggestedTodoItem = memo(function SuggestedTodoItem({
     "approve" | "reject" | null
   >(null);
   const measureRef = useRef<HTMLSpanElement>(null);
+  const typingAnimationLockedTextRef = useRef<string | null>(null);
 
   const displayText = stripNewlines(todo.text);
   const showTypingAnimation = isNew && !typingDismissed;
+
+  useEffect(() => {
+    if (!isNew) {
+      typingAnimationLockedTextRef.current = null;
+    }
+  }, [isNew]);
+
+  useEffect(() => {
+    if (!showTypingAnimation) {
+      typingAnimationLockedTextRef.current = null;
+    }
+  }, [showTypingAnimation]);
+
+  let typingAnimationSourceText = displayText;
+  if (showTypingAnimation) {
+    if (typingAnimationLockedTextRef.current === null) {
+      typingAnimationLockedTextRef.current = displayText;
+    }
+    typingAnimationSourceText = typingAnimationLockedTextRef.current;
+  }
+
   const showInProgressTextAnimation = todo.status === "in_progress";
 
   const canAct = viewerUserId !== null && !isReadOnly;
@@ -77,7 +99,7 @@ export const SuggestedTodoItem = memo(function SuggestedTodoItem({
                 aria-hidden
                 className="invisible block w-full min-w-0 break-words text-pretty text-base leading-6"
               >
-                {displayText}
+                {typingAnimationSourceText}
               </span>
             )}
             <TodoMetadataTooltip todo={todo} agentNameById={agentNameById}>
@@ -90,7 +112,7 @@ export const SuggestedTodoItem = memo(function SuggestedTodoItem({
               >
                 {showTypingAnimation ? (
                   <TypingAnimation
-                    text={displayText}
+                    text={typingAnimationSourceText}
                     duration={16}
                     onComplete={() => setTypingDismissed(true)}
                   />

--- a/front/components/assistant/conversation/space/conversations/project_todos/projectTodosGrouping.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/projectTodosGrouping.ts
@@ -1,0 +1,34 @@
+import type {
+  ProjectTodoAssigneeType,
+  ProjectTodoType,
+} from "@app/types/project_todo";
+
+/** Split full assignee groups into pending-suggestion todos only (for the top table). */
+export function groupedTodosPendingSuggestionsOnly(
+  groups: Array<{
+    user: ProjectTodoAssigneeType | null;
+    todos: ProjectTodoType[];
+  }>
+): Array<{ user: ProjectTodoAssigneeType | null; todos: ProjectTodoType[] }> {
+  return groups
+    .map((g) => ({
+      user: g.user,
+      todos: g.todos.filter((t) => t.agentSuggestionStatus === "pending"),
+    }))
+    .filter((g) => g.todos.length > 0);
+}
+
+/** Split full assignee groups into non-pending todos (for the bottom table). */
+export function groupedTodosNonPendingSuggestions(
+  groups: Array<{
+    user: ProjectTodoAssigneeType | null;
+    todos: ProjectTodoType[];
+  }>
+): Array<{ user: ProjectTodoAssigneeType | null; todos: ProjectTodoType[] }> {
+  return groups
+    .map((g) => ({
+      user: g.user,
+      todos: g.todos.filter((t) => t.agentSuggestionStatus !== "pending"),
+    }))
+    .filter((g) => g.todos.length > 0);
+}

--- a/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/projectTodosPanelTypes.ts
@@ -1,18 +1,16 @@
-import type { ProjectTodosDataTable } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTable";
 import type { TodoOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ProjectTodoAssigneeType,
   ProjectTodoType,
 } from "@app/types/project_todo";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
-import type { ComponentProps, Dispatch, SetStateAction } from "react";
+import type { Dispatch, SetStateAction } from "react";
 
 export type GroupedTodosByAssignee = Array<{
   user: ProjectTodoAssigneeType | null;
   todos: ProjectTodoType[];
 }>;
-
-type ProjectTodosDataTableProps = ComponentProps<typeof ProjectTodosDataTable>;
 
 export type ProjectTodosPanelData = {
   isScopeMenuOpen: boolean;
@@ -29,7 +27,7 @@ export type ProjectTodosPanelData = {
   owner: LightWorkspaceType;
   groupedSuggestedTodosOnly: GroupedTodosByAssignee;
   groupedRegularTodosOnly: GroupedTodosByAssignee;
-  activeAgents: ProjectTodosDataTableProps["activeAgents"];
+  activeAgents: LightAgentConfigurationType[];
   isAgentsLoading: boolean;
   agentNameById: Map<string, string>;
   pendingRemovalIds: Set<string>;

--- a/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/useProjectTodosPanelState.ts
@@ -1,7 +1,7 @@
 import {
   groupedTodosNonPendingSuggestions,
   groupedTodosPendingSuggestionsOnly,
-} from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosDataTable";
+} from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosGrouping";
 import { formatTodoScopeLabel } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
 import type {
   ProjectTodosPanelData,


### PR DESCRIPTION
## Description

Two separate animation bugs, one root cause: column defs and text props changing identity on every render.

**Stable column defs**

TanStack Table re-mounts rows when column definitions change identity, which re-set the `isNew` flag and re-fired the entry animation for already-seen todos on every SWR revalidation. Fix: extract column defs as module-level stable constants via a new `ProjectTodosDataTableCell` component and a `ProjectTodosDataTableUiProvider` context. Callbacks (approve, reject, start, delete, …) are injected via context rather than captured in closures, so column objects never change identity between renders.

**Locked typing animation text**

If a SWR revalidation updated `todo.text` while `TypingAnimation` was mid-play, the new string restarted the animation from the beginning. Fix: `typingAnimationLockedTextRef` captures `displayText` the moment `showTypingAnimation` first becomes `true`; both `TypingAnimation` and the invisible sizing `<span>` use the locked text for the duration of the animation. The lock is released when `isNew` or `showTypingAnimation` goes `false`.

## Tests

Local

## Risk

Low — purely internal rendering correctness; no behavior change visible to users once animations fire correctly

## Deploy Plan

Deploy `front`
