### PR TITLE
Add id of todo in tooltip and popup to ease debugging.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/TodoSubComponents.tsx
@@ -117,6 +117,11 @@ export function TodoMetadataTooltip({
           {todo.actorRationale}
         </div>
       )}
+      {todo.agentSuggestionStatus === "pending" ? (
+        <div className="break-all font-mono text-[11px] tabular-nums text-muted-foreground dark:text-muted-foreground-night">
+          ID: {todo.sId}
+        </div>
+      ) : null}
     </div>
   );
 

--- a/front/components/markdown/TodoDirectiveBlock.tsx
+++ b/front/components/markdown/TodoDirectiveBlock.tsx
@@ -159,6 +159,13 @@ function TodoDirectivePopoverBody({
           ) : null}
         </dd>
 
+        <dt className="text-muted-foreground dark:text-muted-foreground-night">
+          ID
+        </dt>
+        <dd className="min-w-0 text-right font-mono text-[11px] font-medium tabular-nums text-foreground dark:text-foreground-night">
+          <span className="break-all select-text">{todo.sId}</span>
+        </dd>
+
         {hasConversation && todo.conversationId && activityCaption ? (
           <>
             <dt className="text-muted-foreground dark:text-muted-foreground-night">


### PR DESCRIPTION
## Description

Todo sIds are not surfaced anywhere in the UI, making it hard to correlate what's on screen with DB records or logs during debugging.

- **`TodoMetadataTooltip`** — for pending agent suggestions, append `ID: {sId}` in small monospace below the rationale text
- **`TodoDirectivePopoverBody`** — add an "ID" row to the popover definition list

## Tests

Local
<img width="367" height="130" alt="image" src="https://github.com/user-attachments/assets/4480d951-f64d-49be-81ec-829340402e2b" />
<img width="365" height="316" alt="image" src="https://github.com/user-attachments/assets/fdad63e8-d20e-4c2d-a615-55035d984438" />


## Risk

Low — read-only display; no behavioral change

## Deploy Plan

Deploy `front`
