### PR TITLE
Move suggested todos toggle in settings.

### DIFF
--- a/front/components/assistant/conversation/space/SpaceTodosTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTodosTab.tsx
@@ -4,7 +4,6 @@ import {
   ProjectTodosToolbar,
 } from "@app/components/assistant/conversation/space/conversations/project_todos/EditableProjectTodosPanel";
 import type { TodoOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_todos/projectTodosListScope";
-import { SuggestedTodosGenerationTile } from "@app/components/assistant/conversation/space/conversations/project_todos/SuggestedTodosGenerationTile";
 import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { WorkspaceType } from "@app/types/user";
 
@@ -38,7 +37,6 @@ export function SpaceTodosTab({
         >
           <div className="flex flex-col gap-3">
             <ProjectTodosToolbar />
-            <SuggestedTodosGenerationTile owner={owner} spaceInfo={spaceInfo} />
             <ProjectTodosPanelMain />
           </div>
         </ProjectTodosPanelProvider>

--- a/front/components/assistant/conversation/space/about/ProjectSettingsOptionLabel.tsx
+++ b/front/components/assistant/conversation/space/about/ProjectSettingsOptionLabel.tsx
@@ -1,0 +1,36 @@
+import type { ComponentType, ReactNode } from "react";
+
+type IconProps = {
+  className?: string;
+  "aria-hidden"?: boolean;
+};
+
+export function ProjectSettingsOptionLabel({
+  icon: Icon,
+  title,
+  description,
+  trailingInTitle,
+}: {
+  icon: ComponentType<IconProps>;
+  title: string;
+  description: string;
+  trailingInTitle?: ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <Icon
+          className="h-4 w-4 shrink-0 text-foreground dark:text-foreground-night"
+          aria-hidden
+        />
+        <span className="heading-sm text-foreground dark:text-foreground-night">
+          {title}
+        </span>
+        {trailingInTitle}
+      </div>
+      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {description}
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -1,5 +1,7 @@
 import { DeleteSpaceDialog } from "@app/components/assistant/conversation/space/about/DeleteSpaceDialog";
 import { MembersTable } from "@app/components/assistant/conversation/space/about/MembersTable";
+import { ProjectSettingsOptionLabel } from "@app/components/assistant/conversation/space/about/ProjectSettingsOptionLabel";
+import { SuggestedTodosGenerationTile } from "@app/components/assistant/conversation/space/conversations/project_todos/SuggestedTodosGenerationTile";
 import { ConfirmContext } from "@app/components/Confirm";
 import { useSpaceConversationsSummary } from "@app/hooks/conversations";
 import { useArchiveProject } from "@app/hooks/useArchiveProject";
@@ -25,6 +27,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  GlobeAltIcon,
   Input,
   MoreIcon,
   ScrollArea,
@@ -333,38 +336,41 @@ export function SpaceAboutTab({
         </div>
 
         <div className="flex w-full flex-col gap-2">
-          <h3 className="heading-lg">Visibility</h3>
-          <div className="flex items-center justify-between gap-4 border-y border-border py-4">
-            <div className="flex flex-col">
-              <div className="heading-sm text-foreground dark:text-foreground-night">
-                Open to everyone
-              </div>
-              <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                Anyone in the workspace can find and join the project.
+          <div className="flex flex-col border-y border-border">
+            <div className="flex items-center justify-between gap-4 py-4">
+              <ProjectSettingsOptionLabel
+                icon={GlobeAltIcon}
+                title="Open to everyone"
+                description="Anyone in the workspace can find and join the project."
+              />
+              <div className="flex shrink-0 items-center gap-2">
+                {isVisibilityToggleDisabled ? (
+                  <Tooltip
+                    label={OPEN_PROJECTS_DISABLED_TOOLTIP}
+                    trigger={
+                      <div>
+                        <SliderToggle
+                          size="xs"
+                          selected={isPublic}
+                          onClick={handleVisibilityToggle}
+                          disabled
+                        />
+                      </div>
+                    }
+                  />
+                ) : (
+                  <SliderToggle
+                    size="xs"
+                    selected={isPublic}
+                    onClick={handleVisibilityToggle}
+                    disabled={isVisibilityToggleDisabled}
+                  />
+                )}
               </div>
             </div>
-            {isVisibilityToggleDisabled ? (
-              <Tooltip
-                label={OPEN_PROJECTS_DISABLED_TOOLTIP}
-                trigger={
-                  <div>
-                    <SliderToggle
-                      size="xs"
-                      selected={isPublic}
-                      onClick={handleVisibilityToggle}
-                      disabled
-                    />
-                  </div>
-                }
-              />
-            ) : (
-              <SliderToggle
-                size="xs"
-                selected={isPublic}
-                onClick={handleVisibilityToggle}
-                disabled={isVisibilityToggleDisabled}
-              />
-            )}
+            <div className="border-t border-border py-4">
+              <SuggestedTodosGenerationTile owner={owner} space={space} />
+            </div>
           </div>
         </div>
 

--- a/front/components/assistant/conversation/space/conversations/project_todos/SuggestedTodosGenerationTile.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/SuggestedTodosGenerationTile.tsx
@@ -1,12 +1,11 @@
-import { useProjectTodosPanel } from "@app/components/assistant/conversation/space/conversations/project_todos/ProjectTodosPanelContext";
-import { isOnboardingTodo } from "@app/components/assistant/conversation/space/conversations/project_todos/utils";
+import { ProjectSettingsOptionLabel } from "@app/components/assistant/conversation/space/about/ProjectSettingsOptionLabel";
 import { FirstSyncTodoLookbackForm } from "@app/components/assistant/conversation/space/FirstSyncTodoLookbackForm";
 import { ConfirmContext } from "@app/components/Confirm";
 import type { InitialTodoSyncLookbackValue } from "@app/lib/project_todo/analyze_document/types";
 import { useUpdateProjectMetadata } from "@app/lib/swr/spaces";
 import { timeAgoFrom } from "@app/lib/utils";
-import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
-import type { WorkspaceType } from "@app/types/user";
+import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Chip,
   Icon,
@@ -15,7 +14,7 @@ import {
   SparklesIcon,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { useCallback, useContext, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useRef, useState } from "react";
 
 const SUGGEST_TO_DOS_TOOLTIP =
   "When this is on, Dust periodically reviews this project’s conversations and connected sources and adds suggested to-dos. Turn it off if you only want to-dos you create yourself.";
@@ -34,19 +33,18 @@ function lastScanTooltip(lastTodoAnalysisAt: number | null): string {
 }
 
 export type SuggestedTodosGenerationTileProps = {
-  owner: WorkspaceType;
-  spaceInfo: GetSpaceResponseBody["space"];
+  owner: LightWorkspaceType;
+  space: RichSpaceType;
 };
 
 export function SuggestedTodosGenerationTile({
   owner,
-  spaceInfo,
+  space,
 }: SuggestedTodosGenerationTileProps) {
-  const { todos, isTodosLoading } = useProjectTodosPanel();
   const confirm = useContext(ConfirmContext);
   const updateProjectMetadata = useUpdateProjectMetadata({
     owner,
-    spaceId: spaceInfo.sId,
+    spaceId: space.sId,
   });
   const [isUpdatingTodoGeneration, setIsUpdatingTodoGeneration] =
     useState(false);
@@ -58,14 +56,14 @@ export function SuggestedTodosGenerationTile({
     []
   );
 
-  const isProjectArchived = !!spaceInfo.archivedAt;
+  const isProjectArchived = !!space.archivedAt;
   const structurallyDisabled =
-    !spaceInfo.isMember || isProjectArchived || !spaceInfo.isEditor;
+    !space.isMember || isProjectArchived || !space.isEditor;
   const sliderDisabled = structurallyDisabled || isUpdatingTodoGeneration;
 
   const toggleTooltip = isProjectArchived
     ? "This project is archived; suggestion settings cannot be changed."
-    : !spaceInfo.isEditor && spaceInfo.isMember
+    : !space.isEditor && space.isMember
       ? SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR
       : SUGGEST_TO_DOS_TOOLTIP;
 
@@ -73,7 +71,7 @@ export function SuggestedTodosGenerationTile({
     if (structurallyDisabled) {
       return;
     }
-    if (spaceInfo.todoGenerationEnabled) {
+    if (space.todoGenerationEnabled) {
       setIsUpdatingTodoGeneration(true);
       try {
         await updateProjectMetadata({
@@ -85,7 +83,7 @@ export function SuggestedTodosGenerationTile({
       return;
     }
 
-    if (spaceInfo.lastTodoAnalysisAt === null) {
+    if (space.lastTodoAnalysisAt === null) {
       firstSyncLookbackRef.current = "last_24h";
       const confirmed = await confirm({
         title: "Turn on suggested to-dos?",
@@ -125,8 +123,8 @@ export function SuggestedTodosGenerationTile({
     confirm,
     onFirstSyncLookbackChange,
     structurallyDisabled,
-    spaceInfo.lastTodoAnalysisAt,
-    spaceInfo.todoGenerationEnabled,
+    space.lastTodoAnalysisAt,
+    space.todoGenerationEnabled,
     updateProjectMetadata,
   ]);
 
@@ -134,62 +132,42 @@ export function SuggestedTodosGenerationTile({
     ? () => {}
     : handleTodoGenerationToggle;
 
-  const hideWhileOnboardingTodoOpen = useMemo(
-    () =>
-      !isTodosLoading &&
-      todos.some((t) => isOnboardingTodo(t) && t.status !== "done"),
-    [isTodosLoading, todos]
-  );
-
-  if (hideWhileOnboardingTodoOpen) {
-    return null;
-  }
-
   return (
-    <div className="flex flex-col gap-3 pb-4">
-      <div className="flex items-center justify-between gap-4">
-        <div className="flex min-w-0 flex-col gap-0.5">
-          <div className="flex flex-wrap items-center gap-2">
-            <SparklesIcon
-              className="h-4 w-4 shrink-0 text-foreground dark:text-foreground-night"
-              aria-hidden
-            />
-            <span className="heading-sm text-foreground dark:text-foreground-night">
-              Suggested to-dos
-            </span>
-            <Chip color="golden" label="Beta" size="mini" />
-          </div>
-          <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-            Automatic to-do suggestions from project activity
-          </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <Tooltip
-            label={toggleTooltip}
-            trigger={
-              <div>
-                <SliderToggle
-                  size="xs"
-                  selected={spaceInfo.todoGenerationEnabled}
-                  disabled={sliderDisabled}
-                  onClick={onToggleClick}
-                />
-              </div>
-            }
-          />
-          <Tooltip
-            label={lastScanTooltip(spaceInfo.lastTodoAnalysisAt)}
-            trigger={
-              <button
-                type="button"
-                className="inline-flex rounded-md p-1 text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
-                aria-label="Last automatic to-do suggestion scan"
-              >
-                <Icon visual={InformationCircleIcon} size="sm" />
-              </button>
-            }
-          />
-        </div>
+    <div className="flex items-center justify-between gap-4">
+      <ProjectSettingsOptionLabel
+        icon={SparklesIcon}
+        title="Suggest to-dos"
+        description="Automatic to-do suggestions from project activity"
+        trailingInTitle={
+          <Chip color="golden" label="Experimental" size="mini" />
+        }
+      />
+      <div className="flex shrink-0 items-center gap-2">
+        <Tooltip
+          label={lastScanTooltip(space.lastTodoAnalysisAt)}
+          trigger={
+            <button
+              type="button"
+              className="inline-flex rounded-md p-1 text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
+              aria-label="Last automatic to-do suggestion scan"
+            >
+              <Icon visual={InformationCircleIcon} size="sm" />
+            </button>
+          }
+        />
+        <Tooltip
+          label={toggleTooltip}
+          trigger={
+            <div>
+              <SliderToggle
+                size="xs"
+                selected={space.todoGenerationEnabled}
+                disabled={sliderDisabled}
+                onClick={onToggleClick}
+              />
+            </div>
+          }
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

The "Suggested to-dos" toggle was sitting in the todos tab, mixing a configuration concern into the content view. Moving it to the project settings tab (`SpaceAboutTab`) is a better fit — it sits alongside the existing visibility toggle as a project-level option.

- Remove `SuggestedTodosGenerationTile` from `SpaceTodosTab`
- Add it to `SpaceAboutTab` as a new settings row, below the visibility toggle
- Extract `ProjectSettingsOptionLabel` — a reusable `icon + title + description + optional trailing` label component; used to unify the layout of both the visibility row and the new suggested-todos row

## Tests

Local
<img width="933" height="190" alt="image" src="https://github.com/user-attachments/assets/fdd0993c-b9d2-466c-8b9b-08426cfb25ea" />

## Risk

Low — pure relocation; no logic change

## Deploy Plan

Deploy `front`
