### PR TITLE
[front] Route frontend stream hooks to SSE endpoints

### DIFF
--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -331,7 +331,7 @@ export function useAgentMessageStream({
 
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {
-      const esURL = `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${sId}/events`;
+      const esURL = `/api/sse/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${sId}/events`;
       let lastEventId = "";
       if (lastEvent) {
         const eventPayload: {

--- a/front/hooks/useChildAgentStream.ts
+++ b/front/hooks/useChildAgentStream.ts
@@ -108,7 +108,7 @@ export function useChildAgentStream({
         return null;
       }
       const { conversationId, agentMessageId } = childStreamIds;
-      const baseUrl = `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${agentMessageId}/events`;
+      const baseUrl = `/api/sse/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${agentMessageId}/events`;
       let lastEventId = "";
       if (lastEvent) {
         const eventPayload: { eventId: string } = JSON.parse(lastEvent);

--- a/front/hooks/useConversationEvents.ts
+++ b/front/hooks/useConversationEvents.ts
@@ -21,7 +21,7 @@ export function useConversationEvents({
         return null;
       }
 
-      const esURL = `/api/w/${owner.sId}/assistant/conversations/${conversationId}/events`;
+      const esURL = `/api/sse/w/${owner.sId}/assistant/conversations/${conversationId}/events`;
       let lastEventId = "";
       if (lastEvent) {
         const eventPayload: {


### PR DESCRIPTION
## Description

- Route frontend EventSource hooks directly through `/api/sse` instead of relying on middleware redirects from `/api/w`.
- Applies to conversation streams, agent message streams, and child agent streams.
- Follow up on https://github.com/dust-tt/dust/pull/21921

## Tests

## Risk

- Medium. Can be safely rolledback (would go back to relying on 307)

## Deploy Plan

- Deploy front
