### PR TITLE
Hide todo settings based of ff

### DIFF
--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -5,6 +5,7 @@ import { SuggestedTodosGenerationTile } from "@app/components/assistant/conversa
 import { ConfirmContext } from "@app/components/Confirm";
 import { useSpaceConversationsSummary } from "@app/hooks/conversations";
 import { useArchiveProject } from "@app/hooks/useArchiveProject";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useCheckProjectName } from "@app/lib/swr/projects";
 import {
   useProjectMetadata,
@@ -55,6 +56,7 @@ export function SpaceAboutTab({
   space,
   onOpenMembersPanel,
 }: SpaceAboutTabProps) {
+  const { hasFeature } = useFeatureFlags();
   const {
     members: projectMembers,
     isEditor: isProjectEditor,
@@ -368,9 +370,11 @@ export function SpaceAboutTab({
                 )}
               </div>
             </div>
-            <div className="border-t border-border py-4">
-              <SuggestedTodosGenerationTile owner={owner} space={space} />
-            </div>
+            {hasFeature("project_todo") && (
+              <div className="border-t border-border py-4">
+                <SuggestedTodosGenerationTile owner={owner} space={space} />
+              </div>
+            )}
           </div>
         </div>
 

--- a/front/components/assistant/conversation/space/conversations/project_todos/SuggestedTodosGenerationTile.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_todos/SuggestedTodosGenerationTile.tsx
@@ -1,6 +1,7 @@
 import { ProjectSettingsOptionLabel } from "@app/components/assistant/conversation/space/about/ProjectSettingsOptionLabel";
 import { FirstSyncTodoLookbackForm } from "@app/components/assistant/conversation/space/FirstSyncTodoLookbackForm";
 import { ConfirmContext } from "@app/components/Confirm";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { InitialTodoSyncLookbackValue } from "@app/lib/project_todo/analyze_document/types";
 import { useUpdateProjectMetadata } from "@app/lib/swr/spaces";
 import { timeAgoFrom } from "@app/lib/utils";
@@ -41,6 +42,7 @@ export function SuggestedTodosGenerationTile({
   owner,
   space,
 }: SuggestedTodosGenerationTileProps) {
+  const { hasFeature } = useFeatureFlags();
   const confirm = useContext(ConfirmContext);
   const updateProjectMetadata = useUpdateProjectMetadata({
     owner,
@@ -131,6 +133,10 @@ export function SuggestedTodosGenerationTile({
   const onToggleClick = structurallyDisabled
     ? () => {}
     : handleTodoGenerationToggle;
+
+  if (!hasFeature("project_todo")) {
+    return null;
+  }
 
   return (
     <div className="flex items-center justify-between gap-4">


### PR DESCRIPTION
## Description

The "Suggested to-dos" settings row was visible in `SpaceAboutTab` for all project spaces, regardless of whether the workspace has the `project_todo` feature flag enabled. This was a leftover oversight from moving the tile into settings in #25200.

- Gate `SuggestedTodosGenerationTile` in `SpaceAboutTab` behind `hasFeature("project_todo")`
- Add the same guard as an early-return inside `SuggestedTodosGenerationTile` itself as a belt-and-suspenders check

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`
