### PR TITLE
[sandbox] fix dsbx inheriting SSL_CERT_FILE before bundle exists

### DIFF
--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -196,8 +196,14 @@ export async function setupEgressForwarder(
       `--mitm-ca-path ${shellEscape(MITM_CA_PATH)} `
     : "";
 
+  // Strip SSL_CERT_FILE / CURL_CA_BUNDLE from dsbx's own env. The sandbox-wide
+  // env vars (set by buildSandboxEnvVars when MITM is enabled) point at
+  // /etc/dust/ca-bundle.pem, which is created by installMitmTrustBundle AFTER
+  // dsbx is healthy. If dsbx inherits those vars, rustls-native-certs honors
+  // SSL_CERT_FILE, fails to read the missing bundle, and dsbx exits before
+  // binding 9990, so the health check times out forever.
   const startForwarderCommand =
-    "nohup /opt/bin/dsbx forward " +
+    "nohup env -u SSL_CERT_FILE -u CURL_CA_BUNDLE /opt/bin/dsbx forward " +
     `--token-file ${shellEscape(EGRESS_TOKEN_PATH)} ` +
     `--proxy-addr ${shellEscape(`${proxyAddr}:${config.getEgressProxyPort()}`)} ` +
     `--proxy-tls-name ${shellEscape(getProxyTlsName())} ` +


### PR DESCRIPTION
## Description

dsbx forwarder fails to start in production. Health check fails for all 6 retries, returns \`Sandbox egress forwarder did not become healthy in time\`, every sandbox tool call breaks.

Cause: when the MITM experiment is enabled, \`buildSandboxEnvVars\` injects \`SSL_CERT_FILE=/etc/dust/ca-bundle.pem\` and \`CURL_CA_BUNDLE=/etc/dust/ca-bundle.pem\` at the sandbox env layer. That file is built by \`installMitmTrustBundle\`, which only runs **after** the forwarder is healthy. dsbx inherits both env vars at startup, \`rustls-native-certs\` honors \`SSL_CERT_FILE\`, fails to read the missing bundle, exits before binding 9990. Health check never sees a listener.

Fix: strip both vars from dsbx's own env via \`env -u\`. Agent processes still get them once the bundle is in place, so the curl trust path keeps working.

## Tests

Reproduced in a manually-spawned e2b sandbox (\`dust-base_0-8-2\`):
- without fix: dsbx logs \`failed to load any native root certificates\`, never binds 9990.
- with fix: dsbx binds 9990 within 1.5s, writes \`/etc/dust/egress-ca.pem\`, log shows clean startup.

## Risk

Low. One-line shell prefix that removes two env vars from dsbx's process. Falls back to system trust store, which is what dsbx 0.1.4 used in pre-MITM deploys.

## Deploy Plan

Merge and deploy front to all regions. No dsbx release, no image rebuild. Existing in-flight broken sandboxes will recover on their next \`setupEgressForwarder\` retry path; new spawns will be healthy from the first try.