### PR TITLE
[LLM] Add use_vertex_for_anthropic_models feature flag

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -8,6 +8,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
     stage: "dust_only",
   },
+  use_vertex_for_anthropic_models: {
+    description:
+      "Route Claude model LLM calls through Vertex AI instead of the direct Anthropic API",
+    stage: "dust_only",
+  },
   audit_logs: {
     description: "Enable audit log emission via WorkOS",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -757,6 +757,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "conversation_search_indexing"
   | "conversation_search_read"
   | "new_file_explorer"
+  | "use_vertex_for_anthropic_models"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Adds the `use_vertex_for_anthropic_models` feature flag (`dust_only` stage) to `front` and the JS SDK types. This is a prerequisite for an upcoming PR that routes Claude LLM calls through Vertex AI — we need the flag to test a feature on front-edge.

## Tests

No logic change — only adds a flag declaration. Verified the flag appears in `WHITELISTABLE_FEATURES_CONFIG` and `WhitelistableFeaturesSchema`.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`