### PR TITLE
[front] gate sandbox workspace admin surface behind sandbox_workspace_admin flag

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -323,7 +323,7 @@ export const subNavigationAdmin = ({
           icon: GlobeAltIcon,
           href: `/w/${owner.sId}/developers/sandbox`,
           current: isCurrent("sandbox"),
-          featureFlag: "sandbox_tools",
+          featureFlag: "sandbox_workspace_admin",
         },
       ],
     });

--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -1,7 +1,6 @@
 import { EnvironmentSection } from "@app/components/pages/workspace/developers/sections/EnvironmentSection";
 import { NetworkSection } from "@app/components/pages/workspace/developers/sections/NetworkSection";
-import { useAuth } from "@app/lib/auth/AuthContext";
-import { useHasSandboxWorkspaceAdmin } from "@app/lib/swr/sandbox";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   CommandLineIcon,
   ContentMessage,
@@ -11,7 +10,10 @@ import {
 
 export function SandboxPage() {
   const { isAdmin } = useAuth();
-  const hasSandboxAdmin = useHasSandboxWorkspaceAdmin();
+  const { featureFlags } = useFeatureFlags();
+  const hasSandboxAdmin =
+    featureFlags.includes("sandbox_tools") &&
+    featureFlags.includes("sandbox_workspace_admin");
 
   const renderBody = () => {
     if (!isAdmin) {

--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -1,6 +1,7 @@
 import { EnvironmentSection } from "@app/components/pages/workspace/developers/sections/EnvironmentSection";
 import { NetworkSection } from "@app/components/pages/workspace/developers/sections/NetworkSection";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useHasSandboxWorkspaceAdmin } from "@app/lib/swr/sandbox";
 import {
   CommandLineIcon,
   ContentMessage,
@@ -10,8 +11,7 @@ import {
 
 export function SandboxPage() {
   const { isAdmin } = useAuth();
-  const { featureFlags } = useFeatureFlags();
-  const hasSandboxTools = featureFlags.includes("sandbox_tools");
+  const hasSandboxAdmin = useHasSandboxWorkspaceAdmin();
 
   const renderBody = () => {
     if (!isAdmin) {
@@ -22,10 +22,10 @@ export function SandboxPage() {
       );
     }
 
-    if (!hasSandboxTools) {
+    if (!hasSandboxAdmin) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Sandbox tools are not enabled for this workspace.
+          Sandbox workspace administration is not enabled for this workspace.
         </ContentMessage>
       );
     }

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -3,10 +3,13 @@ import {
   MAX_VALUE_BYTES,
   SANDBOX_ENV_VAR_PREFIX,
 } from "@app/lib/api/sandbox/env_vars";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import {
   useDeleteWorkspaceSandboxEnvVar,
-  useHasSandboxWorkspaceAdmin,
   useUpsertWorkspaceSandboxEnvVar,
   useWorkspaceSandboxEnvVars,
 } from "@app/lib/swr/sandbox";
@@ -68,7 +71,10 @@ const DEFAULT_FORM_VALUES: FormValues = { name: "", value: "" };
 export function EnvironmentSection() {
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
-  const hasSandboxAdmin = useHasSandboxWorkspaceAdmin();
+  const { featureFlags } = useFeatureFlags();
+  const hasSandboxAdmin =
+    featureFlags.includes("sandbox_tools") &&
+    featureFlags.includes("sandbox_workspace_admin");
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isNameLocked, setIsNameLocked] = useState(false);
   const [envVarToDelete, setEnvVarToDelete] =

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -3,13 +3,10 @@ import {
   MAX_VALUE_BYTES,
   SANDBOX_ENV_VAR_PREFIX,
 } from "@app/lib/api/sandbox/env_vars";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   useDeleteWorkspaceSandboxEnvVar,
+  useHasSandboxWorkspaceAdmin,
   useUpsertWorkspaceSandboxEnvVar,
   useWorkspaceSandboxEnvVars,
 } from "@app/lib/swr/sandbox";
@@ -71,8 +68,7 @@ const DEFAULT_FORM_VALUES: FormValues = { name: "", value: "" };
 export function EnvironmentSection() {
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
-  const { featureFlags } = useFeatureFlags();
-  const hasSandboxTools = featureFlags.includes("sandbox_tools");
+  const hasSandboxAdmin = useHasSandboxWorkspaceAdmin();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isNameLocked, setIsNameLocked] = useState(false);
   const [envVarToDelete, setEnvVarToDelete] =
@@ -84,7 +80,7 @@ export function EnvironmentSection() {
     isWorkspaceSandboxEnvVarsError,
   } = useWorkspaceSandboxEnvVars({
     owner,
-    disabled: !hasSandboxTools || !isAdmin,
+    disabled: !hasSandboxAdmin || !isAdmin,
   });
   const { upsertWorkspaceSandboxEnvVar, isUpsertingWorkspaceSandboxEnvVar } =
     useUpsertWorkspaceSandboxEnvVar({ owner });
@@ -193,10 +189,10 @@ export function EnvironmentSection() {
         </ContentMessage>
       );
     }
-    if (!hasSandboxTools) {
+    if (!hasSandboxAdmin) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Sandbox tools are not enabled for this workspace.
+          Sandbox workspace administration is not enabled for this workspace.
         </ContentMessage>
       );
     }

--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -1,9 +1,6 @@
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
-import {
+  useHasSandboxWorkspaceAdmin,
   useUpdateWorkspaceEgressPolicy,
   useUpdateWorkspaceSandboxAgentEgressRequests,
   useWorkspaceEgressPolicy,
@@ -31,8 +28,7 @@ import { useState } from "react";
 export function NetworkSection() {
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
-  const { featureFlags } = useFeatureFlags();
-  const hasSandboxTools = featureFlags.includes("sandbox_tools");
+  const hasSandboxAdmin = useHasSandboxWorkspaceAdmin();
   const [domainInput, setDomainInput] = useState("");
   const [isEnableAgentRequestsDialogOpen, setIsEnableAgentRequestsDialogOpen] =
     useState(false);
@@ -43,7 +39,7 @@ export function NetworkSection() {
     isWorkspaceEgressPolicyError,
   } = useWorkspaceEgressPolicy({
     owner,
-    disabled: !hasSandboxTools || !isAdmin,
+    disabled: !hasSandboxAdmin || !isAdmin,
   });
   const { updateWorkspaceEgressPolicy, isUpdatingWorkspaceEgressPolicy } =
     useUpdateWorkspaceEgressPolicy({ owner });
@@ -123,10 +119,10 @@ export function NetworkSection() {
         </ContentMessage>
       );
     }
-    if (!hasSandboxTools) {
+    if (!hasSandboxAdmin) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Sandbox tools are not enabled for this workspace.
+          Sandbox workspace administration is not enabled for this workspace.
         </ContentMessage>
       );
     }

--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -1,6 +1,9 @@
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
-  useHasSandboxWorkspaceAdmin,
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
+import {
   useUpdateWorkspaceEgressPolicy,
   useUpdateWorkspaceSandboxAgentEgressRequests,
   useWorkspaceEgressPolicy,
@@ -28,7 +31,10 @@ import { useState } from "react";
 export function NetworkSection() {
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
-  const hasSandboxAdmin = useHasSandboxWorkspaceAdmin();
+  const { featureFlags } = useFeatureFlags();
+  const hasSandboxAdmin =
+    featureFlags.includes("sandbox_tools") &&
+    featureFlags.includes("sandbox_workspace_admin");
   const [domainInput, setDomainInput] = useState("");
   const [isEnableAgentRequestsDialogOpen, setIsEnableAgentRequestsDialogOpen] =
     useState(false);

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -157,7 +157,23 @@ describe("createSandboxTools", () => {
     expect(tools.map((tool) => tool.name)).not.toContain("add_egress_domain");
   });
 
-  it("includes add_egress_domain when agent egress requests are enabled", async () => {
+  it("includes add_egress_domain when both flag and metadata are set", async () => {
+    const { workspace, user } = await createResourceTest({});
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      sandboxAllowAgentEgressRequests: true,
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "sandbox_workspace_admin");
+
+    const tools = await createSandboxTools(auth);
+
+    expect(tools.map((tool) => tool.name)).toContain("add_egress_domain");
+  });
+
+  it("omits add_egress_domain when flag is off, even if metadata is set", async () => {
     const { workspace, user } = await createResourceTest({});
     await WorkspaceResource.updateMetadata(workspace.id, {
       sandboxAllowAgentEgressRequests: true,
@@ -169,7 +185,7 @@ describe("createSandboxTools", () => {
 
     const tools = await createSandboxTools(auth);
 
-    expect(tools.map((tool) => tool.name)).toContain("add_egress_domain");
+    expect(tools.map((tool) => tool.name)).not.toContain("add_egress_domain");
   });
 });
 

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -186,7 +186,15 @@ export async function createSandboxTools(
   };
 
   const tools = buildTools(SANDBOX_TOOLS_METADATA, handlers);
-  if (isSandboxAgentEgressRequestsAllowed(auth)) {
+
+  // The add_egress_domain tool requires both the workspace admin flag
+  // (gates the whole agent-egress-requests configuration) and the
+  // per-workspace setting that admins toggle on top of it.
+  const flags = await getFeatureFlags(auth);
+  if (
+    flags.includes("sandbox_workspace_admin") &&
+    isSandboxAgentEgressRequestsAllowed(auth)
+  ) {
     return tools;
   }
 
@@ -399,6 +407,9 @@ export async function addEgressDomainTool(
   { domain, reason }: { domain: string; reason: string },
   { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<Result<Array<{ type: "text"; text: string }>, MCPError>> {
+  // Defense-in-depth: createSandboxTools already filters this tool out when the
+  // sandbox_workspace_admin flag is off, so this metadata-only check is enough
+  // to reject any caller that bypasses tool-list filtering.
   if (!isSandboxAgentEgressRequestsAllowed(auth)) {
     return new Err(
       new MCPError(

--- a/front/lib/resources/skill/code_defined/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.test.ts
@@ -53,6 +53,7 @@ describe("sandboxSkill", () => {
       user.sId,
       workspace.sId
     );
+    await FeatureFlagFactory.basic(refreshedAuth, "sandbox_workspace_admin");
 
     const permissiveInstructions = await sandboxSkill.fetchInstructions(
       refreshedAuth,

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -49,9 +49,12 @@ function formatWorkspaceAllowlist(domains: string[]): string {
 }
 
 async function buildNetworkAccessSection(auth: Authenticator): Promise<string> {
+  const flags = await getFeatureFlags(auth);
+  const hasWorkspaceAdmin = flags.includes("sandbox_workspace_admin");
   const allowAgentRequests =
+    hasWorkspaceAdmin &&
     auth.getNonNullableWorkspace().metadata?.sandboxAllowAgentEgressRequests ===
-    true;
+      true;
   const policyResult = await readWorkspacePolicy(auth);
   let workspaceDomains: string[] = [];
   if (policyResult.isErr()) {

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -1,5 +1,4 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -25,14 +24,6 @@ import type { Fetcher } from "swr";
 
 function workspaceEgressPolicyUrl(workspaceId: string) {
   return `/api/w/${workspaceId}/sandbox/egress-policy`;
-}
-
-export function useHasSandboxWorkspaceAdmin(): boolean {
-  const { featureFlags } = useFeatureFlags();
-  return (
-    featureFlags.includes("sandbox_tools") &&
-    featureFlags.includes("sandbox_workspace_admin")
-  );
 }
 
 function workspaceSandboxEnvVarsUrl(workspaceId: string) {

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -1,4 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -24,6 +25,14 @@ import type { Fetcher } from "swr";
 
 function workspaceEgressPolicyUrl(workspaceId: string) {
   return `/api/w/${workspaceId}/sandbox/egress-policy`;
+}
+
+export function useHasSandboxWorkspaceAdmin(): boolean {
+  const { featureFlags } = useFeatureFlags();
+  return (
+    featureFlags.includes("sandbox_tools") &&
+    featureFlags.includes("sandbox_workspace_admin")
+  );
 }
 
 function workspaceSandboxEnvVarsUrl(workspaceId: string) {

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -6,7 +6,7 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { renameWorkspace } from "@app/lib/api/workspace";
-import { hasFeatureFlag, type Authenticator } from "@app/lib/auth";
+import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -6,7 +6,7 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { renameWorkspace } from "@app/lib/api/workspace";
-import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag, type Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -305,6 +305,17 @@ async function handler(
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;
       } else if ("sandboxAllowAgentEgressRequests" in body) {
+        if (!(await hasFeatureFlag(auth, "sandbox_workspace_admin"))) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "feature_flag_not_found",
+              message:
+                "Sandbox workspace admin configuration is not enabled for this workspace.",
+            },
+          });
+        }
+
         const previousMetadata = owner.metadata ?? {};
         const newMetadata = {
           ...previousMetadata,

--- a/front/pages/api/w/[wId]/sandbox/egress-policy.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/egress-policy.test.ts
@@ -53,6 +53,7 @@ describe("GET/PUT /api/w/[wId]/sandbox/egress-policy", () => {
       role: "admin",
     });
     await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    await FeatureFlagFactory.basic(auth, "sandbox_workspace_admin");
 
     await handler(req, res);
 
@@ -69,6 +70,7 @@ describe("GET/PUT /api/w/[wId]/sandbox/egress-policy", () => {
       role: "admin",
     });
     await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    await FeatureFlagFactory.basic(auth, "sandbox_workspace_admin");
     req.body = {
       allowedDomains: ["API.GitHub.COM", "*.GitHub.COM"],
     };
@@ -118,6 +120,7 @@ describe("GET/PUT /api/w/[wId]/sandbox/egress-policy", () => {
       role: "admin",
     });
     await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    await FeatureFlagFactory.basic(auth, "sandbox_workspace_admin");
     req.body = {
       allowedDomains: ["127.0.0.1"],
     };
@@ -151,6 +154,7 @@ describe("GET/PUT /api/w/[wId]/sandbox/egress-policy", () => {
       role: "user",
     });
     await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    await FeatureFlagFactory.basic(auth, "sandbox_workspace_admin");
 
     await handler(req, res);
 
@@ -168,6 +172,7 @@ describe("GET/PUT /api/w/[wId]/sandbox/egress-policy", () => {
       role: "admin",
     });
     await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    await FeatureFlagFactory.basic(auth, "sandbox_workspace_admin");
     mockReadWorkspacePolicy.mockResolvedValue(new Err(new Error("GCS failed")));
 
     await handler(req, res);

--- a/front/pages/api/w/[wId]/sandbox/egress-policy.ts
+++ b/front/pages/api/w/[wId]/sandbox/egress-policy.ts
@@ -57,6 +57,17 @@ async function handler(
     });
   }
 
+  if (!(await hasFeatureFlag(auth, "sandbox_workspace_admin"))) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message:
+          "Sandbox workspace admin configuration is not enabled for this workspace.",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET": {
       const result = await readWorkspacePolicy(auth);

--- a/front/pages/api/w/[wId]/sandbox/env-vars/[id].ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/[id].ts
@@ -45,6 +45,17 @@ async function handler(
     });
   }
 
+  if (!(await hasFeatureFlag(auth, "sandbox_workspace_admin"))) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message:
+          "Sandbox workspace admin configuration is not enabled for this workspace.",
+      },
+    });
+  }
+
   const { id } = req.query;
 
   const envVarModelId =

--- a/front/pages/api/w/[wId]/sandbox/env-vars/delete.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/delete.test.ts
@@ -18,6 +18,7 @@ async function createDeleteRequest({
     role,
   });
   await FeatureFlagFactory.basic(request.auth, "sandbox_tools");
+  await FeatureFlagFactory.basic(request.auth, "sandbox_workspace_admin");
   return request;
 }
 

--- a/front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts
@@ -33,6 +33,7 @@ async function createEnvVarRequest({
 }) {
   const request = await createPrivateApiMockRequest({ method, role });
   await FeatureFlagFactory.basic(request.auth, "sandbox_tools");
+  await FeatureFlagFactory.basic(request.auth, "sandbox_workspace_admin");
   request.req.body = body;
   return request;
 }

--- a/front/pages/api/w/[wId]/sandbox/env-vars/index.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/index.ts
@@ -69,6 +69,17 @@ async function handler(
     });
   }
 
+  if (!(await hasFeatureFlag(auth, "sandbox_workspace_admin"))) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "feature_flag_not_found",
+        message:
+          "Sandbox workspace admin configuration is not enabled for this workspace.",
+      },
+    });
+  }
+
   switch (req.method) {
     case "GET": {
       const envVars =

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -212,6 +212,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Programmatic access to MCP tools from inside the sandbox via the dsbx CLI",
     stage: "dust_only",
   },
+  sandbox_workspace_admin: {
+    description:
+      "Workspace admin configuration for the sandbox: whitelisted domains, environment variables, and the agent egress request setting/tool",
+    stage: "dust_only",
+  },
   skills_as_user_messages: {
     description:
       "Render skills in assistant conversations as synthetic user messages instead of in the system prompt",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -736,6 +736,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_tool"
   | "sandbox_dsbx_tools"
   | "sandbox_tools"
+  | "sandbox_workspace_admin"
   | "self_created_slack_app_connector_rollout"
   | "show_debug_tools"
   | "slack_bot_mcp"


### PR DESCRIPTION
## Description

New `sandbox_workspace_admin` feature flag (dust_only) stacked on top of the existing `sandbox_tools` flag. When off, the whole workspace-admin sandbox surface is unavailable:

- `/w/[wId]/developers/sandbox` page and its nav entry
- `GET/PUT /api/w/[wId]/sandbox/egress-policy`
- `GET/POST/DELETE /api/w/[wId]/sandbox/env-vars[/[id]]`
- The `sandboxAllowAgentEgressRequests` branch of `PATCH /api/w/[wId]`
- The system-prompt section that tells the agent it can request egress domains
- The `add_egress_domain` MCP tool (filtered out of `createSandboxTools`)

UI uses a shared `useHasSandboxWorkspaceAdmin` hook so the FE predicate lives in one place.

## Tests

Added two unit tests around `createSandboxTools`: tool exposed only when both flag and metadata are set, omitted when flag is off even if metadata is true. Existing positive case updated to set the flag.

## Risk

Low. Existing `sandbox_tools` workspaces keep all their access until we also enable `sandbox_workspace_admin` for them. Worst case, flip the flag back off. Safe to rollback.

## Deploy Plan

Standard deploy.