### PR TITLE
Fix streaming issue

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -922,8 +922,17 @@ export const ConversationViewer = ({
     owner,
     conversationId,
     onEvent: onEventCallback,
+    // Also gate on initialListData being set: that only happens after the
+    // Virtuoso init effect runs, which itself waits for !isValidating (fresh
+    // SWR data). Without this gate, the conversation SSE starts as soon as
+    // cached data exists (isLoadingInitialData = false) while Virtuoso is still
+    // empty — so agent_message_new fires against an empty list, bypasses the
+    // terminal-status guard, and re-opens the message-events stream.
     isReadyToConsumeStream:
-      !isConversationLoading && !isLoadingInitialData && messages.length !== 0,
+      !isConversationLoading &&
+      !isLoadingInitialData &&
+      messages.length !== 0 &&
+      initialListData !== undefined,
   });
 
   const handleSubmit = useCallback(

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -59,6 +59,8 @@ import logger from "@app/logger/logger";
 import {
   type ConversationForkedChildType,
   type ConversationListItemType,
+  isLightAgentMessageType,
+  isTerminalAgentMessageStatus,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
@@ -315,6 +317,7 @@ export const ConversationViewer = ({
     isMessagesError,
     isValidating,
     messages,
+    mutateMessages,
     setSize,
     size,
   } = useConversationMessages({
@@ -702,9 +705,25 @@ export const ConversationViewer = ({
                 virtuosoMessageListRef.current.data.find(predicate);
 
               if (exists) {
-                virtuosoMessageListRef.current.data.map((m) =>
-                  predicate(m) ? agentMessage : m
-                );
+                // On replay (e.g. after navigating away and coming back), the
+                // existing message may already reflect the final state from
+                // the SWR snapshot. The replayed event always carries the
+                // initial "created" payload, so replacing would downgrade the
+                // status (re-activating shouldStream and the message-events
+                // stream) and wipe inlineActivitySteps. Skip the replace only
+                // when the existing message is the same logical message (same
+                // sId) and already terminal. A retry creates a new sId at the
+                // same rank/branch, so it must still go through the replace.
+                const isReplayOfTerminalMessage =
+                  isAgentMessageWithStreaming(exists) &&
+                  exists.sId === agentMessage.sId &&
+                  isTerminalAgentMessageStatus(exists.status);
+
+                if (!isReplayOfTerminalMessage) {
+                  virtuosoMessageListRef.current.data.map((m) =>
+                    predicate(m) ? agentMessage : m
+                  );
+                }
               } else {
                 const currentData = virtuosoMessageListRef.current.data.get();
                 const offset = getBranchedInsertIndex(
@@ -766,6 +785,33 @@ export const ConversationViewer = ({
 
             // Re-fetch context usage after the agent finishes so the indicator is up-to-date.
             void mutateContextUsage();
+
+            // Update the messages SWR cache in place so a future remount
+            // of this conversation (e.g. navigating away and back) sees the
+            // message as terminal instead of the stale "created" snapshot
+            // (which would otherwise re-open an SSE replay). We only flip
+            // status here to avoid a network refetch on every termination,
+            // which on prod was slow enough to delay retry feedback. The
+            // richer final state (activitySteps, content, gracefully_stopped
+            // vs cancelled) is restored by the next real fetch when needed.
+            void mutateMessages(
+              (pages) =>
+                pages?.map((page) => ({
+                  ...page,
+                  messages: page.messages.map((m) =>
+                    isLightAgentMessageType(m) && m.sId === event.messageId
+                      ? {
+                          ...m,
+                          status:
+                            event.status === "error"
+                              ? ("failed" as const)
+                              : ("succeeded" as const),
+                        }
+                      : m
+                  ),
+                })),
+              { revalidate: false }
+            );
 
             // Update the conversation hasError state in the local cache without making a network request.
             void mutateConversations(
@@ -865,6 +911,7 @@ export const ConversationViewer = ({
       mutateConversationAttachments,
       mutateConversationParticipants,
       mutateConversations,
+      mutateMessages,
       openPanel,
       owner.sId,
       user.sId,

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -303,6 +303,17 @@ export function useAgentMessageStream({
     []
   );
 
+  // Short-circuit replays of events we've already processed in this hook
+  // instance. The hook is mounted per agent message (via AgentMessage.tsx),
+  // so the ref is scoped to a single message and resets on remount or when a
+  // retry creates a new agentMessage.sId. Within a single mount,
+  // `useEventSource` reconnects on every server-side "done" frame and on
+  // network errors using `lastEventId`; if the server replays an event we
+  // already saw (e.g. just past the cursor boundary), the handlers downstream
+  // are not idempotent — inline activity step IDs are built from `Date.now()`
+  // and same-millisecond re-processing produces duplicate React keys.
+  const seenEventIds = useRef<Set<string>>(new Set());
+
   useEffect(() => {
     return () => {
       updateMessageThrottled.cancel();
@@ -353,6 +364,12 @@ export function useAgentMessageStream({
         eventId: string;
         data: AgentMessageStateWithControlEvent;
       } = JSON.parse(eventStr);
+      if (eventPayload.eventId) {
+        if (seenEventIds.current.has(eventPayload.eventId)) {
+          return;
+        }
+        seenEventIds.current.add(eventPayload.eventId);
+      }
       const eventType = eventPayload.data.type;
       switch (eventType) {
         case "end-of-stream":

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -8,6 +8,7 @@ import moment from "moment";
 import type { ContentFragmentType } from "../content_fragment";
 import type { AllSupportedWithDustSpecificFileContentType } from "../files";
 import type { ModelId } from "../shared/model_id";
+import { assertNeverAndIgnore } from "../shared/utils/assert_never";
 import type { UserType, WorkspaceType } from "../user";
 import type {
   AgentConfigurationStatus,
@@ -245,6 +246,23 @@ export const AGENT_MESSAGE_STATUSES_TO_TRACK: AgentMessageStatus[] = [
   "cancelled",
   "gracefully_stopped",
 ];
+
+export function isTerminalAgentMessageStatus(
+  status: AgentMessageStatus
+): boolean {
+  switch (status) {
+    case "succeeded":
+    case "failed":
+    case "cancelled":
+    case "gracefully_stopped":
+      return true;
+    case "created":
+      return false;
+    default:
+      assertNeverAndIgnore(status);
+      return false;
+  }
+}
 
 export interface CitationType {
   description?: string;


### PR DESCRIPTION
## Description

### Context

This is a revised version of #24991, which was rolled back because the bug persisted in production even after a hard refresh.

### Root cause

When navigating to a completed conversation, the conversation SSE endpoint replays `agent_message_new` with `status: "created"` from Redis history (10-minute TTL).

This is expected behavior: it lets live conversations resume mid-stream. The problem is that it also fires for already-completed conversations, causing `useAgentMessageStream` to re-activate and replay the entire tool execution.

### Why the original fix was insufficient

PR #24991 added a terminal-status guard in the `agent_message_new` handler: skip the replace if the existing message already has a terminal status. This works **only if Virtuoso is already populated** when the SSE event arrives.

The race that breaks it:

1. `isReadyToConsumeStream` becomes `true` as soon as `isLoadingInitialData = false` (SWR cache hit on SPA nav, or first fetch returning on hard refresh)
2. SSE starts connecting (async)
3. Virtuoso init runs in the same render — but `setInitialListData` is a React state update, so Virtuoso doesn't actually receive the data until the **next** render
4. SSE `agent_message_new` arrives in this window: Virtuoso is empty, the terminal-status guard never fires, the message is appended as `created`, and `useAgentMessageStream` activates

On SPA navigation the window is wide (SWR revalidation takes 100–300ms in production). On hard refresh it is narrower but still present, which is why a refresh didn't
reliably fix it.

### This fix

Gate `isReadyToConsumeStream` on `initialListData !== undefined`:

```ts
isReadyToConsumeStream:
  !isConversationLoading &&
  !isLoadingInitialData &&
  messages.length !== 0 &&
  initialListData !== undefined,
```

initialListData is the React state value passed as the Virtuoso data prop. It is set by setInitialListData, which only runs after SWR revalidation completes (!isValidating). Because isReadyToConsumeStream now depends on this state, it only becomes true in the render where Virtuoso already has its data,  making it impossible for agent_message_new to arrive against an empty list.

This closes the race on both SPA navigation and hard refresh.
All four layers:

| Layer | What it does | Closes which path |
|---|---|---|
| `initialListData !== undefined` gate | SSE only starts after Virtuoso is populated | race on SPA nav and hard refresh |
| Terminal-status guard in `agent_message_new` | Skip replace if existing message is terminal | any residual replay that gets through |
| `mutateMessages` on `agent_message_done` | Updates SWR cache to terminal status | stale-cache path (no revalidation) |
| `seenEventIds` dedup in `useAgentMessageStream` | Drops events already processed in this mount | duplicate events from per-message SSE replay |

Verification

Tested with Playwright on a local hive. A tool-using conversation navigated away and back (within the 10-minute Redis TTL):
- Without fix: per-message SSE (/messages/{id}/events) reconnects after navigation back — visible in network tab as additional [200] OK requests
- With fix: per-message SSE only connects during initial streaming; no reconnection after navigation back

## Risk

Can be rolled back.

## Deploy Plan

Deploy front. 
