### PR TITLE
fix(projects): prevent re-extraction of already-tracked action items on repeated analysis

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/project_todo_details.ts
+++ b/front/lib/api/poke/plugins/workspaces/project_todo_details.ts
@@ -1,10 +1,7 @@
 import { createPlugin } from "@app/lib/api/poke/types";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
-import { ProjectTodoTakeawaySourcesModel } from "@app/lib/resources/storage/models/project_todo_takeaway_sources";
-import {
-  TakeawaySourcesModel,
-  TakeawaysModel,
-} from "@app/lib/resources/storage/models/takeaways";
+import { ProjectTodoSourceModel } from "@app/lib/resources/storage/models/project_todo";
+import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const projectTodoDetailsPlugin = createPlugin({
@@ -42,43 +39,18 @@ export const projectTodoDetailsPlugin = createPlugin({
     const todoSId = todo.sId;
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    const [sourcesMap, conversationsMap, takeawayLinks] = await Promise.all([
+    const [sourcesMap, conversationsMap, todoSources] = await Promise.all([
       ProjectTodoResource.fetchSourcesForTodoIds(auth, { sIds: [todoSId] }),
       ProjectTodoResource.fetchConversationIdsForTodoIds(auth, {
         sIds: [todoSId],
       }),
-      ProjectTodoTakeawaySourcesModel.findAll({
+      ProjectTodoSourceModel.findAll({
         where: { workspaceId, projectTodoId: todo.id },
-        include: [
-          {
-            model: TakeawaySourcesModel,
-            as: "takeawaySource",
-            required: true,
-          },
-        ],
       }),
     ]);
 
     const sources = sourcesMap.get(todoSId) ?? [];
     const conversationId = conversationsMap.get(todoSId) ?? null;
-
-    // Fetch the parent TakeawaysModel rows to retrieve actionItems.
-    const takeawaysIds = [
-      ...new Set(
-        takeawayLinks
-          .map((l) => l.takeawaySource?.takeawaysId)
-          .filter((id): id is number => id != null)
-      ),
-    ];
-    const takeawaysById = new Map(
-      takeawaysIds.length > 0
-        ? (
-            await TakeawaysModel.findAll({
-              where: { workspaceId, id: takeawaysIds },
-            })
-          ).map((t) => [t.id, t])
-        : []
-    );
 
     const statusEmoji: Record<string, string> = {
       todo: "⬜",
@@ -100,24 +72,34 @@ export const projectTodoDetailsPlugin = createPlugin({
       ? `\`${conversationId}\``
       : "_No linked conversation._";
 
-    const takeawaysSection =
-      takeawayLinks.length === 0
-        ? "_No takeaway sources._"
-        : takeawayLinks
-            .map((link) => {
-              const src = link.takeawaySource;
-              const takeaway = src ? takeawaysById.get(src.takeawaysId) : null;
-              const srcLink = src?.sourceUrl
-                ? ` ([link](${src.sourceUrl}))`
-                : "";
-              const label = `**${src?.sourceType}** — ${src?.sourceTitle ?? src?.sourceId}${srcLink}`;
+    const takeawayResults = await Promise.all(
+      todoSources.map(async (src) => {
+        const takeaway = await TakeawaysResource.fetchLatestBySourceIdAndType(
+          auth,
+          { sourceId: src.sourceId, sourceType: src.sourceType }
+        );
+        return { src, takeaway };
+      })
+    );
 
-              const matchingItem = takeaway?.actionItems?.find(
-                (item: { sId: string }) => item.sId === todoSId
+    const takeawaysSection =
+      takeawayResults.length === 0
+        ? "_No takeaway sources._"
+        : takeawayResults
+            .map(({ src, takeaway }) => {
+              const link = src.sourceUrl ? ` ([link](${src.sourceUrl}))` : "";
+              const label = `**${src.sourceType}** — ${src.sourceTitle ?? src.sourceId}${link}`;
+
+              if (!takeaway) {
+                return `- ${label} — _no takeaway found_`;
+              }
+
+              const actionItem = takeaway.actionItems.find(
+                (item) => item.sId === src.itemId
               );
-              const itemDetail = matchingItem
-                ? `\n  - _"${matchingItem.shortDescription}"_ (status: \`${matchingItem.status}\`)`
-                : "";
+              const itemDetail = actionItem
+                ? `\n  - _"${actionItem.shortDescription}"_ (status: \`${actionItem.status}\`)`
+                : `\n  - _item \`${src.itemId}\` not found in takeaway_`;
 
               return `- ${label}${itemDetail}`;
             })
@@ -128,7 +110,7 @@ export const projectTodoDetailsPlugin = createPlugin({
 
     return new Ok({
       display: "markdown",
-      value: `## ${statusEmoji[todo.status] ?? "❓"} Project TODO \`${todo.sId}\`
+      value: `## ${statusEmoji[todo.status] ?? "❓"} Project TODO \`${todo.id}\ \`${todo.sId}\` 
 
 **Text:** ${todo.text}
 
@@ -143,7 +125,7 @@ export const projectTodoDetailsPlugin = createPlugin({
 
 ${sourcesSection}
 
-## Takeaway Sources (${takeawayLinks.length})
+## Takeaways (${takeawayResults.length})
 
 ${takeawaysSection}
 

--- a/front/lib/project_todo/analyze_document/action_items.ts
+++ b/front/lib/project_todo/analyze_document/action_items.ts
@@ -107,9 +107,12 @@ export function buildPromptActionItems(
     "(birthday lunches, personal events, casual meetups) are not action items even if someone " +
     "commits to arranging them.\n\n" +
     "Output rules:\n" +
-    "- Place brand-new action items in `new_action_items`. They MUST have a clear assignee " +
-    "matching one of the project members; if you cannot identify a project member as assignee, " +
-    "do not extract the item.\n" +
+    "- Place brand-new action items (not already in the tracked list below) in `new_action_items`. " +
+    "They MUST have a clear assignee matching one of the project members; if you cannot identify " +
+    "a project member as assignee, do not extract the item.\n" +
+    "- **Never re-extract tracked items**: any item already listed under 'Previously tracked' below is " +
+    "already recorded. Do NOT put it in `new_action_items` even if you see it in the document — " +
+    "doing so creates a duplicate. If nothing changed, omit it entirely.\n" +
     "- Place changes to previously tracked items in `updated_action_items`, keyed by their sId. " +
     "Only include fields that materially changed in this document; omit unchanged fields. " +
     "Do not include items that have not changed at all.\n" +
@@ -121,8 +124,8 @@ export function buildPromptActionItems(
     "- Never include the assignee's name in the description — the assignee is tracked separately via assignee_user_id. Refer to the assignee with 'you'/'your' pronouns when needed.\n\n";
   if (previousActionItems.length > 0) {
     prompt +=
-      "Previously tracked action items (reference their sId in `updated_action_items` " +
-      "to record changes):\n";
+      "Previously tracked action items — ALREADY RECORDED, do NOT re-add to `new_action_items`. " +
+      "Only reference in `updated_action_items` if this document explicitly changes them:\n";
     for (const item of previousActionItems) {
       prompt += `<action_item sId="${item.sId}" status="${item.status}">`;
       prompt += `<short_description>${item.shortDescription}</short_description>`;

--- a/front/tests/takeaway-evals/test-suites/action-items.ts
+++ b/front/tests/takeaway-evals/test-suites/action-items.ts
@@ -309,6 +309,66 @@ Score 2 if Seb's items are extracted but Rcs's item is missing or wrongly assign
 Score 3 if Rcs's opt-in item and Seb's items 3/4/5 are correctly extracted, items 1 and 2 are not.`,
     },
 
+    // ── Re-analysis of same document must not duplicate items ─────────────────
+
+    {
+      scenarioId: "idempotent-re-analysis",
+      document: {
+        id: "doc-8",
+        title: "Sprint planning",
+        type: "slack",
+        text: [
+          "Alice: I'll write the migration script for the users table by Friday",
+          "Bob: I'll review it once it's ready",
+        ].join("\n"),
+        uri: "https://example.com/doc-8",
+      },
+      members: [
+        { sId: "user-alice", fullName: "Alice Martin", email: "alice@co.com" },
+        { sId: "user-bob", fullName: "Bob Chen", email: "bob@co.com" },
+      ],
+      previousVersion: {
+        actionItems: [
+          {
+            sId: "prev-migr-1",
+            shortDescription: "Write the migration script for the users table",
+            assigneeUserId: "user-alice",
+            assigneeName: "Alice Martin",
+            status: "open",
+            detectedDoneAt: null,
+            detectedDoneRationale: null,
+            detectedCreationRationale:
+              "Alice committed to writing the migration script by Friday",
+          },
+          {
+            sId: "prev-review-1",
+            shortDescription: "Review the migration PR once it's ready",
+            assigneeUserId: "user-bob",
+            assigneeName: "Bob Chen",
+            status: "open",
+            detectedDoneAt: null,
+            detectedDoneRationale: null,
+            detectedCreationRationale:
+              "Bob committed to reviewing the migration PR",
+          },
+        ],
+      },
+      expectedAssertions: [
+        shouldPreserveSId("actionItem", "prev-migr-1"),
+        shouldPreserveSId("actionItem", "prev-review-1"),
+        maxActionItems(2),
+      ],
+      judgeCriteria: `This document was already analyzed once and produced two action items (Alice:
+migration script, Bob: review PR). On this second pass, both items are already
+tracked in the 'Previously tracked' list. The document is unchanged, so nothing
+has changed.
+
+Score 0 if the same items are re-extracted as NEW action items (duplicates created).
+Score 1 if sIds from the previous version are not preserved.
+Score 2 if no duplicates but the output has extra spurious items.
+Score 3 if the two existing items are preserved with their original sIds and no new items are added.`,
+    },
+
     // ── No inline completion should be registered ──────────────────────────────
 
     {


### PR DESCRIPTION
## Description

Fixes a prompt stability bug where running the takeaway analysis twice on the same document would re-create already-tracked action items as new ones, producing duplicates.

Root cause: the prompt did not explicitly tell the model that previously listed items are already recorded and must not be emitted in `new_action_items`. The model would see the same content in the document and the "previously tracked" list, and still re-extract it.

Changes:
- Adds a `**Never re-extract tracked items**` rule to the output rules section that explicitly forbids placing any already-tracked item into `new_action_items`.
- Strengthens the "Previously tracked" section header with `ALREADY RECORDED, do NOT re-add to new_action_items`.
- Adds a unit test in `action_items.test.ts` asserting both instructions are present in the prompt when previous items exist.
- Adds an eval test case `idempotent-re-analysis` in `front/tests/takeaway-evals` that verifies no duplicate items are created when the same document is analyzed twice.

## Tests

- Unit test in `action_items.test.ts`: verifies both anti-duplication instructions are present in the generated prompt.
- Eval test case `idempotent-re-analysis`: same document re-analyzed with its own previously extracted items as context — expects no new items, original sIds preserved.
