### PR TITLE
feat(sandbox): validate approval flow for sandbox tool executions

### DIFF
--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -75,6 +75,20 @@ export function isUserQuestionResumeState(
   return UserQuestionResumeStateSchema.safeParse(value).success;
 }
 
+const SandboxResumeStateSchema = z.object({
+  type: z.literal("sandbox"),
+  childActionId: z.string(),
+  execId: z.string().optional(),
+});
+
+export type SandboxResumeState = z.infer<typeof SandboxResumeStateSchema>;
+
+export function isSandboxResumeState(
+  value: unknown
+): value is SandboxResumeState {
+  return SandboxResumeStateSchema.safeParse(value).success;
+}
+
 export type StepContext = {
   citationsCount: number;
   citationsOffset: number;

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -583,10 +583,7 @@ export const createAgentMessages = async (
   return { agentMessages, richMentions };
 };
 
-export async function getUserMessageIdFromMessageId(
-  auth: Authenticator,
-  { messageId }: { messageId: string }
-): Promise<{
+export type UserMessageInfoForAgentMessage = {
   agentMessageId: string;
   agentMessageVersion: number;
   userMessageId: string;
@@ -594,7 +591,12 @@ export async function getUserMessageIdFromMessageId(
   userMessageUserId: number | null;
   userMessageOrigin: UserMessageOrigin;
   branchId: string | null;
-}> {
+};
+
+export async function getUserMessageIdFromMessageId(
+  auth: Authenticator,
+  { messageId }: { messageId: string }
+): Promise<UserMessageInfoForAgentMessage> {
   // Query 1: Get the message and its parentId.
   const agentMessage = await MessageModel.findOne({
     where: {

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -10,6 +10,7 @@ import {
   extractArgRequiringApprovalValues,
   setUserAlwaysApprovedTool,
 } from "@app/lib/actions/tool_status";
+import type { UserMessageInfoForAgentMessage } from "@app/lib/api/assistant/conversation/messages";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
@@ -94,10 +95,6 @@ async function handleAlwaysApproved(
   }
 }
 
-type UserMessageInfo = Awaited<
-  ReturnType<typeof getUserMessageIdFromMessageId>
->;
-
 export async function validateAction(
   auth: Authenticator,
   conversation: ConversationResource,
@@ -167,7 +164,7 @@ async function handleMCPAction(
     actionId: string;
     approvalState: ActionApprovalStateType;
     messageId: string;
-    userMessageInfo: UserMessageInfo;
+    userMessageInfo: UserMessageInfoForAgentMessage;
   }
 ): Promise<Result<void, DustError>> {
   const owner = auth.getNonNullableWorkspace();

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -1,4 +1,7 @@
-import type { ActionApprovalStateType } from "@app/lib/actions/mcp";
+import type {
+  ActionApprovalStateType,
+  LightMCPToolConfigurationType,
+} from "@app/lib/actions/mcp";
 import {
   getMCPApprovalStateFromUserApprovalState,
   isMCPApproveExecutionEvent,
@@ -16,10 +19,84 @@ import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { isResourceSId } from "@app/lib/resources/string_ids";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+
+async function removeMCPApprovalEvent({
+  actionId,
+  messageId,
+}: {
+  actionId: string;
+  messageId: string;
+}): Promise<void> {
+  await getRedisHybridManager().removeEvent((event) => {
+    const payload = JSON.parse(event.message["payload"]);
+    return isMCPApproveExecutionEvent(payload)
+      ? payload.actionId === actionId
+      : false;
+  }, getMessageChannelId(messageId));
+}
+
+async function handleAlwaysApproved(
+  auth: Authenticator,
+  user: UserResource,
+  {
+    toolConfiguration,
+    functionCallName,
+    augmentedInputs,
+    agentMessageId,
+  }: {
+    toolConfiguration: LightMCPToolConfigurationType;
+    functionCallName: string;
+    augmentedInputs: Record<string, unknown>;
+    agentMessageId: ModelId;
+  }
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+  switch (toolConfiguration.permission) {
+    case "low":
+      await setUserAlwaysApprovedTool(auth, {
+        mcpServerId: toolConfiguration.toolServerId,
+        functionCallName,
+      });
+      break;
+    case "medium": {
+      const agentMessage = await AgentMessageModel.findOne({
+        where: {
+          workspaceId: owner.id,
+          id: agentMessageId,
+        },
+      });
+      if (agentMessage) {
+        const argumentsRequiringApproval =
+          toolConfiguration.argumentsRequiringApproval ?? [];
+        const argsAndValues = extractArgRequiringApprovalValues(
+          argumentsRequiringApproval,
+          augmentedInputs
+        );
+
+        await user.createToolApproval(auth, {
+          mcpServerId: toolConfiguration.toolServerId,
+          toolName: functionCallName,
+          agentId: agentMessage.agentConfigurationId,
+          argsAndValues,
+        });
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+type UserMessageInfo = Awaited<
+  ReturnType<typeof getUserMessageIdFromMessageId>
+>;
 
 export async function validateAction(
   auth: Authenticator,
@@ -36,33 +113,24 @@ export async function validateAction(
 ): Promise<Result<void, DustError>> {
   const owner = auth.getNonNullableWorkspace();
   const user = auth.user();
-  const { sId: conversationId, title: conversationTitle } = conversation;
 
   logger.info(
     {
       actionId,
       messageId,
       approvalState,
-      conversationId,
+      conversationId: conversation.sId,
       workspaceId: owner.sId,
       userId: user?.sId,
     },
     "Tool validation request"
   );
 
-  const {
-    agentMessageId,
-    agentMessageVersion,
-    userMessageId,
-    userMessageVersion,
-    userMessageUserId,
-    userMessageOrigin,
-    branchId,
-  } = await getUserMessageIdFromMessageId(auth, {
+  const userMessageInfo = await getUserMessageIdFromMessageId(auth, {
     messageId,
   });
 
-  if (userMessageUserId !== user?.id) {
+  if (userMessageInfo.userMessageUserId !== user?.id) {
     return new Err(
       new DustError(
         "unauthorized",
@@ -70,6 +138,40 @@ export async function validateAction(
       )
     );
   }
+
+  if (isResourceSId("sandbox_tool_execution", actionId)) {
+    return handleSandboxAction(auth, {
+      actionId,
+      approvalState,
+      messageId,
+    });
+  }
+
+  return handleMCPAction(auth, conversation, {
+    actionId,
+    approvalState,
+    messageId,
+    userMessageInfo,
+  });
+}
+
+async function handleMCPAction(
+  auth: Authenticator,
+  conversation: ConversationResource,
+  {
+    actionId,
+    approvalState,
+    messageId,
+    userMessageInfo,
+  }: {
+    actionId: string;
+    approvalState: ActionApprovalStateType;
+    messageId: string;
+    userMessageInfo: UserMessageInfo;
+  }
+): Promise<Result<void, DustError>> {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.user();
 
   const action = await AgentMCPActionResource.fetchById(auth, actionId);
   if (!action) {
@@ -106,39 +208,12 @@ export async function validateAction(
   );
 
   if (approvalState === "always_approved" && user) {
-    switch (action.toolConfiguration.permission) {
-      case "low":
-        await setUserAlwaysApprovedTool(auth, {
-          mcpServerId: action.toolConfiguration.toolServerId,
-          functionCallName: action.functionCallName,
-        });
-        break;
-      case "medium":
-        const agentMessage = await AgentMessageModel.findOne({
-          where: {
-            workspaceId: owner.id,
-            id: action.agentMessageId,
-          },
-        });
-        if (agentMessage) {
-          const argumentsRequiringApproval =
-            action.toolConfiguration.argumentsRequiringApproval ?? [];
-          const argsAndValues = extractArgRequiringApprovalValues(
-            argumentsRequiringApproval,
-            action.augmentedInputs
-          );
-
-          await user.createToolApproval(auth, {
-            mcpServerId: action.toolConfiguration.toolServerId,
-            toolName: action.functionCallName,
-            agentId: agentMessage.agentConfigurationId,
-            argsAndValues,
-          });
-        }
-        break;
-      default:
-        break;
-    }
+    await handleAlwaysApproved(auth, user, {
+      toolConfiguration: action.toolConfiguration,
+      functionCallName: action.functionCallName,
+      augmentedInputs: action.augmentedInputs,
+      agentMessageId: action.agentMessageId,
+    });
   }
 
   if (updatedCount === 0) {
@@ -152,17 +227,10 @@ export async function validateAction(
       },
       "Action already approved or rejected"
     );
-
     return new Ok(undefined);
   }
 
-  // Remove the tool approval request event from the message channel.
-  await getRedisHybridManager().removeEvent((event) => {
-    const payload = JSON.parse(event.message["payload"]);
-    return isMCPApproveExecutionEvent(payload)
-      ? payload.actionId === actionId
-      : false;
-  }, getMessageChannelId(messageId));
+  await removeMCPApprovalEvent({ actionId, messageId });
 
   // We only launch the agent loop if there are no remaining blocked actions.
   const blockedActions =
@@ -183,7 +251,7 @@ export async function validateAction(
       {
         blockedActions,
       },
-      "Skipping agent loop launch because there are remaining blocked actions"
+      "Skipping agent loop launch because there are remaining blocked actions for this message"
     );
     return new Ok(undefined);
   }
@@ -191,14 +259,14 @@ export async function validateAction(
   await launchAgentLoopWorkflow({
     auth,
     agentLoopArgs: {
-      agentMessageId,
-      agentMessageVersion,
-      conversationId,
-      conversationTitle,
-      conversationBranchId: branchId,
-      userMessageId,
-      userMessageVersion,
-      userMessageOrigin,
+      agentMessageId: userMessageInfo.agentMessageId,
+      agentMessageVersion: userMessageInfo.agentMessageVersion,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      conversationBranchId: userMessageInfo.branchId,
+      userMessageId: userMessageInfo.userMessageId,
+      userMessageVersion: userMessageInfo.userMessageVersion,
+      userMessageOrigin: userMessageInfo.userMessageOrigin,
     },
     // Resume from the step where the action was created.
     startStep: agentStepContent.step,
@@ -211,13 +279,81 @@ export async function validateAction(
 
   logger.info(
     {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      conversationId,
+      workspaceId: owner.id,
+      conversationId: conversation.sId,
       messageId,
       actionId,
     },
     `Action ${approvalState === "approved" ? "approved" : "rejected"} by user`
   );
+
+  return new Ok(undefined);
+}
+
+async function handleSandboxAction(
+  auth: Authenticator,
+  {
+    actionId,
+    approvalState,
+    messageId,
+  }: {
+    actionId: string;
+    approvalState: ActionApprovalStateType;
+    messageId: string;
+  }
+): Promise<Result<void, DustError>> {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.user();
+
+  const sandboxExecution =
+    await AgentMCPActionResource.fetchSandboxToolExecutionById(auth, actionId);
+  if (!sandboxExecution) {
+    return new Err(
+      new DustError("action_not_found", `Action not found: ${actionId}`)
+    );
+  }
+
+  if (sandboxExecution.status !== "blocked_validation_required") {
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        `Action is not blocked: ${sandboxExecution.status}`
+      )
+    );
+  }
+
+  const newStatus = getMCPApprovalStateFromUserApprovalState(approvalState);
+  const { updatedCount } =
+    await AgentMCPActionResource.updateSandboxToolExecutionStatus(
+      auth,
+      sandboxExecution.sId,
+      newStatus
+    );
+
+  if (approvalState === "always_approved" && user) {
+    await handleAlwaysApproved(auth, user, {
+      toolConfiguration: sandboxExecution.toolConfiguration,
+      functionCallName: sandboxExecution.functionCallName,
+      augmentedInputs: sandboxExecution.augmentedInputs,
+      agentMessageId: sandboxExecution.agentMessageId,
+    });
+  }
+
+  if (updatedCount === 0) {
+    logger.info(
+      {
+        actionId,
+        messageId,
+        approvalState,
+        workspaceId: owner.sId,
+        userId: user?.sId,
+      },
+      "Sandbox execution already approved or rejected"
+    );
+    return new Ok(undefined);
+  }
+
+  await removeMCPApprovalEvent({ actionId, messageId });
 
   return new Ok(undefined);
 }

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -18,6 +18,7 @@ import {
 import type { StepContext } from "@app/lib/actions/types";
 import {
   isFileAuthorizationInfo,
+  isSandboxResumeState,
   isUserQuestionResumeState,
 } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
@@ -59,6 +60,7 @@ import tracer from "@app/logger/tracer";
 import type {
   AgentMCPActionType,
   AgentMCPActionWithOutputType,
+  SandboxToolExecutionType,
 } from "@app/types/actions";
 import type { AgentFunctionCallContentType } from "@app/types/assistant/agent_message_content";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -519,7 +521,32 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           authorizationInfo: null,
         });
       } else if (action.status === "blocked_child_action_input_required") {
-        const conversationId = action.stepContext.resumeState?.conversationId;
+        const { resumeState } = action.stepContext;
+
+        if (isSandboxResumeState(resumeState)) {
+          const childBlockedActionsList =
+            await this.listBlockedSandboxToolExecutionsForAgentMessage(auth, {
+              agentMessageId: action.agentMessageId,
+              messageId: agentMessage.message.sId,
+              conversationId: conversation.sId,
+              agentConfiguration,
+              userId: parentUserMessage.userMessage?.user?.sId,
+            });
+
+          blockedActionsList.push({
+            ...baseActionParams,
+            status: action.status,
+            resumeState,
+            childBlockedActionsList,
+            metadata: {
+              ...baseActionParams.metadata,
+            },
+            authorizationInfo: null,
+          });
+          continue;
+        }
+
+        const conversationId = resumeState?.conversationId;
 
         // conversation was not created so we can skip it
         if (!conversationId || !isString(conversationId)) {
@@ -545,7 +572,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         blockedActionsList.push({
           ...baseActionParams,
           status: action.status,
-          resumeState: action.stepContext.resumeState,
+          resumeState,
           childBlockedActionsList,
           metadata: {
             ...baseActionParams.metadata,
@@ -564,6 +591,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       }
     }
 
+    // Sandbox children are surfaced under their parent's
+    // `childBlockedActionsList`.
     return blockedActionsList;
   }
 
@@ -1176,26 +1205,165 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     return this.stepContent.value.value.name;
   }
 
-  // Spawns a child sandbox tool execution under this agent action. The child
-  // lives in `sandbox_tool_executions` (separate table to dodge the
-  // `agent_step_contents` unique-index race) but is parented by this row, so
-  // the spawner is an instance method that fills in the FK from `this.id`.
-  // Returns the new execution's sId — read paths land with the approval flow.
+  // Sandbox tool executions live in their own table (split from
+  // `agent_mcp_actions` to dodge the `agent_step_contents` unique-index race).
+  // Helpers below stay on this resource so the model never escapes the file.
+
+  static sandboxToolExecutionModelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("sandbox_tool_execution", { id, workspaceId });
+  }
+
   async spawnChildSandboxToolExecution(
     blob: Omit<
       CreationAttributes<SandboxToolExecutionModel>,
       "workspaceId" | "agentMessageId" | "agentMCPActionId"
     >
-  ): Promise<string> {
+  ): Promise<SandboxToolExecutionType> {
     const model = await SandboxToolExecutionModel.create({
       ...blob,
       workspaceId: this.workspaceId,
       agentMessageId: this.agentMessageId,
       agentMCPActionId: this.id,
     });
-    return makeSId("sandbox_tool_execution", {
+    return sandboxToolExecutionFromModel(model);
+  }
+
+  static async fetchSandboxToolExecutionById(
+    auth: Authenticator,
+    sId: string
+  ): Promise<SandboxToolExecutionType | null> {
+    const modelId = getResourceIdFromSId(sId);
+    if (!modelId) {
+      return null;
+    }
+    const model = await SandboxToolExecutionModel.findOne({
+      where: {
+        id: modelId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    return model ? sandboxToolExecutionFromModel(model) : null;
+  }
+
+  static async updateSandboxToolExecutionStatus(
+    auth: Authenticator,
+    sId: string,
+    status: ToolExecutionStatus
+  ): Promise<{ updatedCount: number }> {
+    const modelId = getResourceIdFromSId(sId);
+    if (!modelId) {
+      return { updatedCount: 0 };
+    }
+    const [updatedCount] = await SandboxToolExecutionModel.update(
+      { status },
+      {
+        where: {
+          id: modelId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
+    return { updatedCount };
+  }
+
+  /**
+   * Resolves blocked sandbox tool executions for an agent message into the
+   * `BlockedToolExecution[]` shape consumed by the FE.
+   */
+  static async listBlockedSandboxToolExecutionsForAgentMessage(
+    auth: Authenticator,
+    {
+      agentMessageId,
+      messageId,
+      conversationId,
+      agentConfiguration,
+      userId,
+    }: {
+      agentMessageId: ModelId;
+      messageId: string;
+      conversationId: string;
+      agentConfiguration: { sId: string; name: string };
+      userId: string | undefined;
+    }
+  ): Promise<BlockedToolExecution[]> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const blockedExecutions = await SandboxToolExecutionModel.findAll({
+      where: {
+        workspaceId: owner.id,
+        agentMessageId,
+        status: "blocked_validation_required", // Only blocked validation required sandbox executions are surfaced to the FE.
+      },
+      order: [["createdAt", "ASC"]],
+    });
+
+    const result: BlockedToolExecution[] = [];
+    for (const execution of blockedExecutions) {
+      result.push({
+        messageId,
+        userId,
+        conversationId,
+        actionId: this.sandboxToolExecutionModelIdToSId({
+          id: execution.id,
+          workspaceId: owner.id,
+        }),
+        configurationId: isLightServerSideMCPToolConfiguration(
+          execution.toolConfiguration
+        )
+          ? execution.toolConfiguration.sId
+          : agentConfiguration.sId,
+        created: execution.createdAt.getTime(),
+        inputs: execution.augmentedInputs,
+        stake: execution.toolConfiguration.permission,
+        metadata: {
+          toolName: execution.toolConfiguration.originalName,
+          mcpServerName: execution.toolConfiguration.mcpServerName,
+          agentName: agentConfiguration.name,
+          icon: execution.toolConfiguration.icon,
+        },
+        argumentsRequiringApproval:
+          execution.toolConfiguration.argumentsRequiringApproval,
+        approvalArgsLabel: await getApprovalArgsLabel({
+          auth,
+          internalMCPServerName: execution.toolConfiguration.toolServerId
+            ? getInternalMCPServerNameFromSId(
+                execution.toolConfiguration.toolServerId
+              )
+            : null,
+          toolName: execution.toolConfiguration.originalName,
+          agentName: agentConfiguration.name,
+          inputs: execution.augmentedInputs,
+          argumentsRequiringApproval:
+            execution.toolConfiguration.argumentsRequiringApproval ?? [],
+        }),
+        status: "blocked_validation_required",
+        authorizationInfo: null,
+      });
+    }
+    return result;
+  }
+}
+
+function sandboxToolExecutionFromModel(
+  model: SandboxToolExecutionModel
+): SandboxToolExecutionType {
+  return {
+    sId: AgentMCPActionResource.sandboxToolExecutionModelIdToSId({
       id: model.id,
       workspaceId: model.workspaceId,
-    });
-  }
+    }),
+    workspaceId: model.workspaceId,
+    agentMessageId: model.agentMessageId,
+    agentMCPActionId: model.agentMCPActionId,
+    status: model.status,
+    toolConfiguration: model.toolConfiguration,
+    augmentedInputs: model.augmentedInputs,
+    functionCallName: model.toolConfiguration.originalName,
+  };
 }

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1298,13 +1298,20 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       where: {
         workspaceId: owner.id,
         agentMessageId,
-        status: "blocked_validation_required", // Only blocked validation required sandbox executions are surfaced to the FE.
+        status: { [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES },
       },
       order: [["createdAt", "ASC"]],
     });
 
     const result: BlockedToolExecution[] = [];
     for (const execution of blockedExecutions) {
+      // Sandbox tool executions can only ever be in `blocked_validation_required`
+      // today: the other blocked shapes (OAuth, file auth, user question, child
+      // action) don't apply to them.
+      assert(
+        execution.status === "blocked_validation_required",
+        `Unexpected sandbox tool execution status: ${execution.status}`
+      );
       result.push({
         messageId,
         userId,

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -1,3 +1,4 @@
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
@@ -33,4 +34,15 @@ export type AgentMCPActionWithOutputType = AgentMCPActionType & {
   generatedFiles: ActionGeneratedFileType[];
   output: CallToolResult["content"] | null;
   citations?: Record<string, CitationType> | null;
+};
+
+export type SandboxToolExecutionType = {
+  sId: string;
+  workspaceId: ModelId;
+  agentMessageId: ModelId;
+  agentMCPActionId: ModelId;
+  status: ToolExecutionStatus;
+  toolConfiguration: LightMCPToolConfigurationType;
+  augmentedInputs: Record<string, unknown>;
+  functionCallName: string;
 };


### PR DESCRIPTION
## Summary

User-side validation for sandbox tool executions. When the user approves or rejects a blocked sandbox tool call from the FE, this routes the request through `validateAction`, flips the child execution's status (`ready_allowed_*` / `denied`), persists the always-approved rule when applicable, and drops the pending approval event from redis.

`Follow up of #25162` (sandbox tool execution storage).

## What's in here

- `validateAction` becomes a thin dispatcher: shared setup (log, user message resolution, authz) at the top, then routes by sId prefix → `handleSandboxAction` for `ste_`-prefixed sIds, otherwise `handleMCPAction` (the existing flow, extracted for symmetry).
- Bubble-up branch in `listBlockedActionsForConversation`: when a parent bash action is in `blocked_child_action_input_required` with a sandbox `resumeState` (`type: "sandbox"`), surface its blocked sandbox children scoped to the parent's `agentMessageId`. Children share the parent's `agentConfiguration` and parent user message, so the caller's resolved values are passed through instead of refetched.
- Helpers on `AgentMCPActionResource` for sandbox tool executions: `fetchSandboxToolExecutionById`, `updateSandboxToolExecutionStatus`, `listBlockedSandboxToolExecutionsForAgentMessage`, `sandboxToolExecutionModelIdToSId`, plus a private converter to `SandboxToolExecutionType`. The model never escapes the resource file.
- `SandboxResumeState` schema + guard in `lib/actions/types`, next to `UserQuestionResumeState`. Discriminated by `type: "sandbox"`.

Sandbox executions only ever produce `blocked_validation_required`, so the formatter is narrower than the regular blocked-action one (no OAuth / file authorization / child actions / user questions).

## Next

The endpoint that creates these blocked rows (the merged `call_tool` POST) and the agent-loop wake-up on user decision land in follow-ups. Until the endpoint ships, no rows in `blocked_validation_required` are produced, so this path is dormant in prod.

## Risk

Worst case, dormant code with bugs in branches we never enter — no user impact. Safe to rollback.

## Tests

End-to-end tests will land with the call_tool endpoint, where rows can be set up through the natural entry point.