### PR TITLE
Skills: show enablement call output in UI

### DIFF
--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -1,11 +1,18 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import {
+  getOutputText,
+  isResourceContentWithText,
+  isTextContent,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isSkillEnableInputType } from "@app/lib/actions/mcp_internal_actions/types";
 import { SKILL_ICON } from "@app/lib/skill";
+import { ContentMessage } from "@dust-tt/sparkle";
 
 export function MCPSkillEnableActionDetails({
   displayContext,
   toolParams,
+  toolOutput,
 }: ToolExecutionDetailsProps) {
   const skillName = isSkillEnableInputType(toolParams)
     ? toolParams.skillName
@@ -15,11 +22,32 @@ export function MCPSkillEnableActionDetails({
     (displayContext === "conversation" ? "Enabling skill" : "Enable skill") +
     (skillName ? `: ${skillName}` : "");
 
+  const outputItems = toolOutput
+    ? toolOutput.filter((o) => isTextContent(o) || isResourceContentWithText(o))
+    : [];
+
   return (
     <ActionDetailsWrapper
       displayContext={displayContext}
       actionName={actionName}
       visual={SKILL_ICON}
-    />
+    >
+      {displayContext !== "conversation" && outputItems.length > 0 && (
+        <div className="dd-privacy-mask flex flex-col gap-4 py-4 pl-6">
+          <div>
+            <span className="font-medium text-foreground dark:text-foreground-night">
+              Output
+            </span>
+            <div className="my-2 flex flex-col gap-2">
+              {outputItems.map((o, index) => (
+                <ContentMessage key={index} variant="primary" size="lg">
+                  {getOutputText(o) ?? ""}
+                </ContentMessage>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </ActionDetailsWrapper>
   );
 }


### PR DESCRIPTION
## Description

Display the output in a similar way it is displayed for tool calls.
No need to display the input IMHO as it is already part of the tool call name

<img width="637" height="220" alt="Screenshot 2026-05-05 at 11 35 12" src="https://github.com/user-attachments/assets/d4e09f3d-9a23-438d-b4d1-80d6f91591c4" />

<br>

<img width="646" height="282" alt="Screenshot 2026-05-05 at 11 34 48" src="https://github.com/user-attachments/assets/545276d3-93cd-4824-8409-6e72e54149c2" />

<br>

<img width="640" height="219" alt="Screenshot 2026-05-05 at 11 34 58" src="https://github.com/user-attachments/assets/09c5479c-2a5f-4f0c-a1ee-00fd825ff107" />

<br>

<img width="640" height="241" alt="Screenshot 2026-05-05 at 11 35 06" src="https://github.com/user-attachments/assets/74307fb0-e939-4e18-8de4-ebcf4939e501" />



## Tests

tested locally

## Risk

low, it's just display

## Deploy Plan

deploy front
