### PR TITLE
Handle phases in enterprise migrations

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -447,6 +447,7 @@ export async function createMetronomeContract({
   packageId,
   uniquenessKey,
   startingAt,
+  endingBefore,
   enableStripeBilling,
 }: {
   metronomeCustomerId: string;
@@ -457,6 +458,9 @@ export async function createMetronomeContract({
   uniquenessKey?: string;
   // Must already be on an hour boundary (Metronome requirement).
   startingAt: Date;
+  // Optional. Must already be on an hour boundary. Used to bound a contract
+  // when chaining multiple per-phase contracts on the same customer.
+  endingBefore?: Date;
   enableStripeBilling: boolean;
 }): Promise<Result<{ contractId: string }, Error>> {
   if (!packageAlias === !packageId) {
@@ -467,6 +471,7 @@ export async function createMetronomeContract({
     );
   }
   const startingAtISO = startingAt.toISOString();
+  const endingBeforeISO = endingBefore?.toISOString();
   const packageLabel = packageAlias ?? packageId!;
 
   try {
@@ -475,6 +480,7 @@ export async function createMetronomeContract({
       ...(packageAlias ? { package_alias: packageAlias } : {}),
       ...(packageId ? { package_id: packageId } : {}),
       starting_at: startingAtISO,
+      ...(endingBeforeISO ? { ending_before: endingBeforeISO } : {}),
       ...(uniquenessKey ? { uniqueness_key: uniquenessKey } : {}),
     });
 

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -87,6 +87,13 @@ export const CREDIT_TYPE_EUR_ID = "58f0be15-cc47-4220-bdaf-072ab0e44f96";
 
 export const PLAN_CODE_CUSTOM_FIELD_KEY = "DUST_PLAN_CODE";
 
+// Marker custom field set on every contract that is part of a chain of
+// per-phase enterprise contracts (one Metronome contract per Stripe schedule
+// phase). Value is the Stripe subscription id — all contracts in the chain
+// share the same value, so the webhook can recognize phase activations and
+// rotate `subscription.metronomeContractId` without touching the plan.
+export const PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY = "DUST_PHASED_STRIPE_SUB";
+
 // AWU (Agentic Work Units) differs per environment.
 export const DEV_CREDIT_TYPE_AWU_ID = "eb003cc7-4935-467d-a41c-c1738c1c9dc2";
 export const PROD_CREDIT_TYPE_AWU_ID = "8dfc9846-a38e-44f8-a625-bd9372af681c";

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -397,7 +397,8 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      phases: [{ pricing, startDate: START_DATE }],
+      pricing,
+      startDate: START_DATE,
       initialMauCount: 0,
     });
 
@@ -423,7 +424,8 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      phases: [{ pricing, startDate: START_DATE }],
+      pricing,
+      startDate: START_DATE,
       initialMauCount: 0,
     });
 
@@ -465,7 +467,8 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      phases: [{ pricing, startDate: START_DATE }],
+      pricing,
+      startDate: START_DATE,
       initialMauCount: 0,
     });
 
@@ -491,7 +494,8 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      phases: [{ pricing, startDate: START_DATE }],
+      pricing,
+      startDate: START_DATE,
       initialMauCount: 0,
     });
 
@@ -520,7 +524,8 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      phases: [{ pricing, startDate: START_DATE }],
+      pricing,
+      startDate: START_DATE,
       initialMauCount: 0,
     });
 
@@ -553,7 +558,8 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      phases: [{ pricing, startDate: START_DATE }],
+      pricing,
+      startDate: START_DATE,
       initialMauCount: 0,
     });
 
@@ -584,7 +590,8 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      phases: [{ pricing, startDate: START_DATE }],
+      pricing,
+      startDate: START_DATE,
       initialMauCount: 0,
     });
 
@@ -612,7 +619,8 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      phases: [{ pricing, startDate: START_DATE }],
+      pricing,
+      startDate: START_DATE,
       initialMauCount: 0,
     });
 
@@ -641,7 +649,8 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      phases: [{ pricing, startDate: START_DATE }],
+      pricing,
+      startDate: START_DATE,
       initialMauCount: 0,
     });
 
@@ -656,128 +665,6 @@ describe("buildEnterpriseOverrides", () => {
 
     expect(result.recurring_commits![0].access_amount.unit_price).toBe(325000);
     expect(result.custom_fields?.MAU_TIERS).toBe("FLOOR-101-201");
-  });
-
-  it("multi-phase: emits dated overrides + per-phase commits", () => {
-    // 2-phase scheduled subscription:
-    //   Phase 1: floor 450k for 100 MAUs + overage 4500/MAU (= 4500 across all → simple mode)
-    //   Phase 2: floor 600k for 100 MAUs + overage 6000/MAU (= 6000 across all → simple mode)
-    const phase1Pricing: EnterprisePricingCents = {
-      currency: "usd",
-      billingMode: "MAU_1",
-      tiers: [
-        { upTo: 100, unitAmountCents: 0, flatAmountCents: 450000 },
-        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
-      ],
-      floorCents: 450000,
-    };
-    const phase2Pricing: EnterprisePricingCents = {
-      currency: "usd",
-      billingMode: "MAU_1",
-      tiers: [
-        { upTo: 100, unitAmountCents: 0, flatAmountCents: 600000 },
-        { upTo: undefined, unitAmountCents: 6000, flatAmountCents: 0 },
-      ],
-      floorCents: 600000,
-    };
-    const PHASE_BOUNDARY = "2026-07-01T00:00:00.000Z";
-
-    const result = buildEnterpriseOverrides({
-      phases: [
-        {
-          pricing: phase1Pricing,
-          startDate: START_DATE,
-          endDate: PHASE_BOUNDARY,
-        },
-        { pricing: phase2Pricing, startDate: PHASE_BOUNDARY },
-      ],
-      initialMauCount: 0,
-    });
-
-    // Two MAU price overrides (one per phase) + one disable for each tier product.
-    const mauOverrides = result.overrides.filter((o) =>
-      o.override_specifiers?.some((s) => s.product_id === "mau-product")
-    );
-    expect(mauOverrides).toHaveLength(2);
-    expect(mauOverrides[0].starting_at).toBe(START_DATE);
-    expect(mauOverrides[0].ending_before).toBe(PHASE_BOUNDARY);
-    expect(mauOverrides[0].overwrite_rate.price).toBe(4500);
-    expect(mauOverrides[1].starting_at).toBe(PHASE_BOUNDARY);
-    expect(mauOverrides[1].ending_before).toBeUndefined();
-    expect(mauOverrides[1].overwrite_rate.price).toBe(6000);
-
-    // One recurring commit per phase, each scoped to its date range.
-    expect(result.recurring_commits).toHaveLength(2);
-    expect(result.recurring_commits![0].starting_at).toBe(START_DATE);
-    expect(result.recurring_commits![0].ending_before).toBe(PHASE_BOUNDARY);
-    expect(result.recurring_commits![0].access_amount.unit_price).toBe(450000);
-    expect(result.recurring_commits![1].starting_at).toBe(PHASE_BOUNDARY);
-    expect(result.recurring_commits![1].ending_before).toBeUndefined();
-    expect(result.recurring_commits![1].access_amount.unit_price).toBe(600000);
-  });
-
-  it("multi-phase: rejects mismatched billing mode", () => {
-    const phase1: EnterprisePricingCents = {
-      currency: "usd",
-      billingMode: "MAU_1",
-      tiers: [{ upTo: undefined, unitAmountCents: 2000, flatAmountCents: 0 }],
-      floorCents: 0,
-    };
-    const phase2: EnterprisePricingCents = {
-      currency: "usd",
-      billingMode: "MAU_5",
-      tiers: [{ upTo: undefined, unitAmountCents: 2000, flatAmountCents: 0 }],
-      floorCents: 0,
-    };
-
-    expect(() =>
-      buildEnterpriseOverrides({
-        phases: [
-          {
-            pricing: phase1,
-            startDate: START_DATE,
-            endDate: "2026-07-01T00:00:00.000Z",
-          },
-          { pricing: phase2, startDate: "2026-07-01T00:00:00.000Z" },
-        ],
-        initialMauCount: 0,
-      })
-    ).toThrow(/billing mode/);
-  });
-
-  it("multi-phase: rejects mismatched tier boundaries", () => {
-    const phase1: EnterprisePricingCents = {
-      currency: "usd",
-      billingMode: "MAU_1",
-      tiers: [
-        { upTo: 100, unitAmountCents: 0, flatAmountCents: 450000 },
-        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
-      ],
-      floorCents: 450000,
-    };
-    const phase2: EnterprisePricingCents = {
-      currency: "usd",
-      billingMode: "MAU_1",
-      tiers: [
-        { upTo: 200, unitAmountCents: 0, flatAmountCents: 600000 },
-        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
-      ],
-      floorCents: 600000,
-    };
-
-    expect(() =>
-      buildEnterpriseOverrides({
-        phases: [
-          {
-            pricing: phase1,
-            startDate: START_DATE,
-            endDate: "2026-07-01T00:00:00.000Z",
-          },
-          { pricing: phase2, startDate: "2026-07-01T00:00:00.000Z" },
-        ],
-        initialMauCount: 0,
-      })
-    ).toThrow(/tier .* boundary/);
   });
 });
 

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -397,8 +397,7 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      pricing,
-      startDate: START_DATE,
+      phases: [{ pricing, startDate: START_DATE }],
       initialMauCount: 0,
     });
 
@@ -424,8 +423,7 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      pricing,
-      startDate: START_DATE,
+      phases: [{ pricing, startDate: START_DATE }],
       initialMauCount: 0,
     });
 
@@ -467,8 +465,7 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      pricing,
-      startDate: START_DATE,
+      phases: [{ pricing, startDate: START_DATE }],
       initialMauCount: 0,
     });
 
@@ -494,8 +491,7 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      pricing,
-      startDate: START_DATE,
+      phases: [{ pricing, startDate: START_DATE }],
       initialMauCount: 0,
     });
 
@@ -524,8 +520,7 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      pricing,
-      startDate: START_DATE,
+      phases: [{ pricing, startDate: START_DATE }],
       initialMauCount: 0,
     });
 
@@ -558,8 +553,7 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      pricing,
-      startDate: START_DATE,
+      phases: [{ pricing, startDate: START_DATE }],
       initialMauCount: 0,
     });
 
@@ -590,8 +584,7 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      pricing,
-      startDate: START_DATE,
+      phases: [{ pricing, startDate: START_DATE }],
       initialMauCount: 0,
     });
 
@@ -619,8 +612,7 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      pricing,
-      startDate: START_DATE,
+      phases: [{ pricing, startDate: START_DATE }],
       initialMauCount: 0,
     });
 
@@ -649,8 +641,7 @@ describe("buildEnterpriseOverrides", () => {
     };
 
     const result = buildEnterpriseOverrides({
-      pricing,
-      startDate: START_DATE,
+      phases: [{ pricing, startDate: START_DATE }],
       initialMauCount: 0,
     });
 
@@ -665,6 +656,128 @@ describe("buildEnterpriseOverrides", () => {
 
     expect(result.recurring_commits![0].access_amount.unit_price).toBe(325000);
     expect(result.custom_fields?.MAU_TIERS).toBe("FLOOR-101-201");
+  });
+
+  it("multi-phase: emits dated overrides + per-phase commits", () => {
+    // 2-phase scheduled subscription:
+    //   Phase 1: floor 450k for 100 MAUs + overage 4500/MAU (= 4500 across all → simple mode)
+    //   Phase 2: floor 600k for 100 MAUs + overage 6000/MAU (= 6000 across all → simple mode)
+    const phase1Pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 100, unitAmountCents: 0, flatAmountCents: 450000 },
+        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
+      ],
+      floorCents: 450000,
+    };
+    const phase2Pricing: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 100, unitAmountCents: 0, flatAmountCents: 600000 },
+        { upTo: undefined, unitAmountCents: 6000, flatAmountCents: 0 },
+      ],
+      floorCents: 600000,
+    };
+    const PHASE_BOUNDARY = "2026-07-01T00:00:00.000Z";
+
+    const result = buildEnterpriseOverrides({
+      phases: [
+        {
+          pricing: phase1Pricing,
+          startDate: START_DATE,
+          endDate: PHASE_BOUNDARY,
+        },
+        { pricing: phase2Pricing, startDate: PHASE_BOUNDARY },
+      ],
+      initialMauCount: 0,
+    });
+
+    // Two MAU price overrides (one per phase) + one disable for each tier product.
+    const mauOverrides = result.overrides.filter((o) =>
+      o.override_specifiers?.some((s) => s.product_id === "mau-product")
+    );
+    expect(mauOverrides).toHaveLength(2);
+    expect(mauOverrides[0].starting_at).toBe(START_DATE);
+    expect(mauOverrides[0].ending_before).toBe(PHASE_BOUNDARY);
+    expect(mauOverrides[0].overwrite_rate.price).toBe(4500);
+    expect(mauOverrides[1].starting_at).toBe(PHASE_BOUNDARY);
+    expect(mauOverrides[1].ending_before).toBeUndefined();
+    expect(mauOverrides[1].overwrite_rate.price).toBe(6000);
+
+    // One recurring commit per phase, each scoped to its date range.
+    expect(result.recurring_commits).toHaveLength(2);
+    expect(result.recurring_commits![0].starting_at).toBe(START_DATE);
+    expect(result.recurring_commits![0].ending_before).toBe(PHASE_BOUNDARY);
+    expect(result.recurring_commits![0].access_amount.unit_price).toBe(450000);
+    expect(result.recurring_commits![1].starting_at).toBe(PHASE_BOUNDARY);
+    expect(result.recurring_commits![1].ending_before).toBeUndefined();
+    expect(result.recurring_commits![1].access_amount.unit_price).toBe(600000);
+  });
+
+  it("multi-phase: rejects mismatched billing mode", () => {
+    const phase1: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [{ upTo: undefined, unitAmountCents: 2000, flatAmountCents: 0 }],
+      floorCents: 0,
+    };
+    const phase2: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_5",
+      tiers: [{ upTo: undefined, unitAmountCents: 2000, flatAmountCents: 0 }],
+      floorCents: 0,
+    };
+
+    expect(() =>
+      buildEnterpriseOverrides({
+        phases: [
+          {
+            pricing: phase1,
+            startDate: START_DATE,
+            endDate: "2026-07-01T00:00:00.000Z",
+          },
+          { pricing: phase2, startDate: "2026-07-01T00:00:00.000Z" },
+        ],
+        initialMauCount: 0,
+      })
+    ).toThrow(/billing mode/);
+  });
+
+  it("multi-phase: rejects mismatched tier boundaries", () => {
+    const phase1: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 100, unitAmountCents: 0, flatAmountCents: 450000 },
+        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
+      ],
+      floorCents: 450000,
+    };
+    const phase2: EnterprisePricingCents = {
+      currency: "usd",
+      billingMode: "MAU_1",
+      tiers: [
+        { upTo: 200, unitAmountCents: 0, flatAmountCents: 600000 },
+        { upTo: undefined, unitAmountCents: 4500, flatAmountCents: 0 },
+      ],
+      floorCents: 600000,
+    };
+
+    expect(() =>
+      buildEnterpriseOverrides({
+        phases: [
+          {
+            pricing: phase1,
+            startDate: START_DATE,
+            endDate: "2026-07-01T00:00:00.000Z",
+          },
+          { pricing: phase2, startDate: "2026-07-01T00:00:00.000Z" },
+        ],
+        initialMauCount: 0,
+      })
+    ).toThrow(/tier .* boundary/);
   });
 });
 

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -15,6 +15,7 @@ import {
   getProductMauId,
   getProductMauTierIds,
   MAX_MAU_TIERS,
+  PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import {
   computeTierQuantity,
@@ -600,7 +601,6 @@ export async function extractEnterprisePricingPhases(
 
 interface OverrideEntry {
   starting_at: string;
-  ending_before?: string;
   type: "OVERWRITE";
   entitled: boolean;
   product_id?: string;
@@ -633,7 +633,6 @@ interface RecurringCommitEntry {
   product_id: string;
   name: string;
   starting_at: string;
-  ending_before?: string;
   rate_type: "LIST_RATE";
   priority: number;
   access_amount: {
@@ -726,75 +725,8 @@ function deriveTierPrices(
 }
 
 /**
- * Determine whether a phase uses "simple mode" (single MAU product with a
- * uniform per-MAU rate) versus "tiered mode" (one MAU Tier product per Stripe
- * tier). Simple mode kicks in when all derived per-tier prices collapse to a
- * single value — the floor (if any) is still handled by a recurring commit.
- */
-function isSimplePhaseMode(pricing: EnterprisePricingCents): boolean {
-  if (pricing.tiers.length === 0) {
-    return false;
-  }
-  const tierPrices = deriveTierPrices(pricing.tiers, pricing.currency);
-  return tierPrices.length > 0 && tierPrices.every((p) => p === tierPrices[0]);
-}
-
-/**
- * Validate that all phases share the same contract-wide structure:
- * billing mode, currency, tier-boundary layout, and simple-vs-tiered shape.
- *
- * These dimensions cannot vary inside a single Metronome contract — they
- * determine which products the overrides target and what value is stored in
- * the contract-level MAU_TIERS / MAU_THRESHOLD custom fields. Only prices and
- * floor amounts are allowed to differ across phases.
- */
-function assertPhasesAreConsistent(phases: EnterprisePricingPhase[]): void {
-  if (phases.length <= 1) {
-    return;
-  }
-  const first = phases[0].pricing;
-
-  for (let i = 1; i < phases.length; i++) {
-    const p = phases[i].pricing;
-    if (p.currency !== first.currency) {
-      throw new Error(
-        `Phase ${i} currency (${p.currency}) differs from phase 0 (${first.currency}) — currency cannot change within a single Metronome contract.`
-      );
-    }
-    if (p.billingMode !== first.billingMode) {
-      throw new Error(
-        `Phase ${i} billing mode (${p.billingMode}) differs from phase 0 (${first.billingMode}) — billing mode cannot change within a single Metronome contract.`
-      );
-    }
-    if (first.billingMode === "FIXED") {
-      continue;
-    }
-    if (p.tiers.length !== first.tiers.length) {
-      throw new Error(
-        `Phase ${i} has ${p.tiers.length} tiers, phase 0 has ${first.tiers.length} — tier layout must match across phases.`
-      );
-    }
-    for (let t = 0; t < first.tiers.length; t++) {
-      if (p.tiers[t].upTo !== first.tiers[t].upTo) {
-        throw new Error(
-          `Phase ${i} tier ${t} boundary (${p.tiers[t].upTo}) differs from phase 0 (${first.tiers[t].upTo}) — tier boundaries must match across phases.`
-        );
-      }
-    }
-    if (isSimplePhaseMode(p) !== isSimplePhaseMode(first)) {
-      throw new Error(
-        `Phase ${i} switches between simple and tiered mode vs phase 0 — all phases must use the same shape.`
-      );
-    }
-  }
-}
-
-/**
- * Build the Metronome contract edit payload for enterprise pricing overrides.
- *
- * Each phase in `phases` produces its own time-bounded set of rate overrides
- * (and a recurring commit, if it has a floor). Subscriptions and custom
- * fields are contract-scoped and emitted once, derived from the first phase.
+ * Build the Metronome contract edit payload for enterprise pricing overrides
+ * for a SINGLE phase / contract.
  *
  * For MAU-based plans (MAU_1/5/10):
  * - Uses MAU Tier products (one per Stripe tier) with FLAT rate overrides.
@@ -804,21 +736,23 @@ function assertPhasesAreConsistent(phases: EnterprisePricingPhase[]): void {
  *
  * For FIXED plans:
  * - Disables all MAU products (billing is a flat Stripe fee).
+ *
+ * When a Stripe SubscriptionSchedule has multiple phases, each phase becomes
+ * its own Metronome contract (chained on the same customer). Per-phase
+ * overrides are simpler than time-multiplexed overrides — a contract carries
+ * its own MAU_TIERS / MAU_THRESHOLD / billing mode / tier layout, so phases
+ * can change any of those without coordination.
  */
 export function buildEnterpriseOverrides({
-  phases,
+  pricing,
+  startDate,
   initialMauCount,
 }: {
-  phases: EnterprisePricingPhase[];
+  pricing: EnterprisePricingCents;
+  startDate: string;
   initialMauCount: number;
 }): EnterpriseOverridesPayload {
-  if (phases.length === 0) {
-    throw new Error("buildEnterpriseOverrides requires at least one phase");
-  }
-  assertPhasesAreConsistent(phases);
-
-  const firstPhase = phases[0];
-  const { currency, billingMode } = firstPhase.pricing;
+  const { currency, billingMode } = pricing;
   const creditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[currency];
   if (!creditTypeId) {
     throw new Error(
@@ -826,10 +760,8 @@ export function buildEnterpriseOverrides({
     );
   }
 
-  // Disable a product for the full contract lifetime — these are products
-  // we're never going to bill on, regardless of phase.
-  const disableOverrideForContract = (productId: string): OverrideEntry => ({
-    starting_at: firstPhase.startDate,
+  const disableOverride = (productId: string): OverrideEntry => ({
+    starting_at: startDate,
     type: "OVERWRITE" as const,
     entitled: false,
     override_specifiers: [
@@ -846,97 +778,71 @@ export function buildEnterpriseOverrides({
   if (billingMode === "FIXED") {
     return {
       overrides: [
-        disableOverrideForContract(getProductMauId()),
-        ...getProductMauTierIds().map(disableOverrideForContract),
+        disableOverride(getProductMauId()),
+        ...getProductMauTierIds().map(disableOverride),
       ],
     };
   }
 
-  if (firstPhase.pricing.tiers.length > MAX_MAU_TIERS) {
+  if (pricing.tiers.length > MAX_MAU_TIERS) {
     throw new Error(
-      `Too many tiers (${firstPhase.pricing.tiers.length}) — max ${MAX_MAU_TIERS} supported`
+      `Too many tiers (${pricing.tiers.length}) — max ${MAX_MAU_TIERS} supported`
     );
   }
 
+  const tierPrices = deriveTierPrices(pricing.tiers, currency);
   const tierProductIds = getProductMauTierIds();
   const mauThreshold = String(billingModeToMauThreshold(billingMode));
-  const useSimpleMode = isSimplePhaseMode(firstPhase.pricing);
 
-  // Helper: build a price override for one product, scoped to a single phase.
-  const phasePriceOverride = (
-    phase: EnterprisePricingPhase,
-    productId: string,
-    price: number
-  ): OverrideEntry => ({
-    starting_at: phase.startDate,
-    ...(phase.endDate ? { ending_before: phase.endDate } : {}),
-    type: "OVERWRITE" as const,
-    entitled: true,
-    override_specifiers: [
-      { product_id: productId, billing_frequency: "MONTHLY" as const },
-    ],
-    overwrite_rate: {
-      rate_type: "FLAT" as const,
-      price,
+  const floorMetronome = metronomeAmount(pricing.floorCents, currency);
+  const recurringCommit = (
+    applicableProductId: string
+  ): RecurringCommitEntry => ({
+    product_id: getProductMauCommitId(),
+    name: "MAU Commit",
+    starting_at: startDate,
+    rate_type: "LIST_RATE" as const,
+    priority: 100,
+    access_amount: {
       credit_type_id: creditTypeId,
+      unit_price: floorMetronome,
+      quantity: 1,
     },
+    invoice_amount: {
+      credit_type_id: creditTypeId,
+      unit_price: floorMetronome,
+      quantity: 1,
+    },
+    commit_duration: { value: 1, unit: "PERIODS" as const },
+    recurrence_frequency: "MONTHLY" as const,
+    applicable_product_ids: [applicableProductId],
   });
 
-  // Helper: build a recurring commit for a phase's floor, scoped to that phase.
-  const phaseFloorCommit = (
-    phase: EnterprisePricingPhase,
-    applicableProductId: string
-  ): RecurringCommitEntry | undefined => {
-    if (phase.pricing.floorCents <= 0) {
-      return undefined;
-    }
-    const floorMetronome = metronomeAmount(
-      phase.pricing.floorCents,
-      phase.pricing.currency
-    );
-    return {
-      product_id: getProductMauCommitId(),
-      name: "MAU Commit",
-      starting_at: phase.startDate,
-      ...(phase.endDate ? { ending_before: phase.endDate } : {}),
-      rate_type: "LIST_RATE" as const,
-      priority: 100,
-      access_amount: {
-        credit_type_id: creditTypeId,
-        unit_price: floorMetronome,
-        quantity: 1,
-      },
-      invoice_amount: {
-        credit_type_id: creditTypeId,
-        unit_price: floorMetronome,
-        quantity: 1,
-      },
-      commit_duration: { value: 1, unit: "PERIODS" as const },
-      recurrence_frequency: "MONTHLY" as const,
-      applicable_product_ids: [applicableProductId],
-    };
-  };
+  // Simple mode kicks in when all derived per-tier prices collapse to a single
+  // value — the floor (if any) is still handled by a recurring commit.
+  const allSamePrice =
+    tierPrices.length > 0 && tierPrices.every((p) => p === tierPrices[0]);
 
-  if (useSimpleMode) {
-    const overrides: OverrideEntry[] = [];
-    const recurringCommits: RecurringCommitEntry[] = [];
-
-    for (const phase of phases) {
-      const tierPrices = deriveTierPrices(
-        phase.pricing.tiers,
-        phase.pricing.currency
-      );
-      overrides.push(
-        phasePriceOverride(phase, getProductMauId(), tierPrices[0])
-      );
-      const commit = phaseFloorCommit(phase, getProductMauId());
-      if (commit) {
-        recurringCommits.push(commit);
-      }
-    }
-    // Tier products stay disabled for the entire contract — simple mode only
-    // bills the MAU product.
-    overrides.push(...tierProductIds.map(disableOverrideForContract));
+  if (allSamePrice) {
+    const overrides: OverrideEntry[] = [
+      {
+        starting_at: startDate,
+        type: "OVERWRITE" as const,
+        entitled: true,
+        override_specifiers: [
+          {
+            product_id: getProductMauId(),
+            billing_frequency: "MONTHLY" as const,
+          },
+        ],
+        overwrite_rate: {
+          rate_type: "FLAT" as const,
+          price: tierPrices[0],
+          credit_type_id: creditTypeId,
+        },
+      },
+      ...tierProductIds.map(disableOverride),
+    ];
 
     return {
       overrides,
@@ -955,8 +861,8 @@ export function buildEnterpriseOverrides({
           },
         },
       ],
-      ...(recurringCommits.length > 0
-        ? { recurring_commits: recurringCommits }
+      ...(pricing.floorCents > 0
+        ? { recurring_commits: [recurringCommit(getProductMauId())] }
         : {}),
       custom_fields: {
         MAU_THRESHOLD: mauThreshold,
@@ -966,42 +872,41 @@ export function buildEnterpriseOverrides({
 
   // Multi-tier: use MAU Tier products with per-tier FLAT prices.
   const overrides: OverrideEntry[] = [];
-  const recurringCommits: RecurringCommitEntry[] = [];
 
-  // Disable the default MAU product for the contract — tiered contracts bill
-  // through the MAU Tier products instead.
-  overrides.push(disableOverrideForContract(getProductMauId()));
+  // Disable the default MAU product (tiered contracts use MAU Tier products instead).
+  overrides.push(disableOverride(getProductMauId()));
 
-  for (const phase of phases) {
-    const tierPrices = deriveTierPrices(
-      phase.pricing.tiers,
-      phase.pricing.currency
-    );
-    for (let i = 0; i < phase.pricing.tiers.length; i++) {
-      overrides.push(
-        phasePriceOverride(phase, tierProductIds[i], tierPrices[i])
-      );
-    }
-    const commit = phaseFloorCommit(phase, tierProductIds[0]);
-    if (commit) {
-      recurringCommits.push(commit);
-    }
+  // Enable MAU Tier products with per-tier FLAT prices.
+  for (let i = 0; i < pricing.tiers.length; i++) {
+    overrides.push({
+      starting_at: startDate,
+      type: "OVERWRITE" as const,
+      entitled: true,
+      override_specifiers: [
+        {
+          product_id: tierProductIds[i],
+          billing_frequency: "MONTHLY" as const,
+        },
+      ],
+      overwrite_rate: {
+        rate_type: "FLAT" as const,
+        price: tierPrices[i],
+        credit_type_id: creditTypeId,
+      },
+    });
   }
 
-  // Disable unused tier products for the entire contract (these don't change
-  // across phases — tier count is invariant per assertPhasesAreConsistent).
-  for (let i = firstPhase.pricing.tiers.length; i < MAX_MAU_TIERS; i++) {
-    overrides.push(disableOverrideForContract(tierProductIds[i]));
+  // Disable unused tier products.
+  for (let i = pricing.tiers.length; i < MAX_MAU_TIERS; i++) {
+    overrides.push(disableOverride(tierProductIds[i]));
   }
 
-  // Add subscriptions for each enabled tier (so syncMauCount can set
-  // quantities). Distribute the initial MAU count across tiers for the first
-  // invoice, using the first phase's tier boundaries — tier layout is
-  // invariant across phases per assertPhasesAreConsistent.
-  const mauTiersField = buildMauTiersField(firstPhase.pricing.tiers);
+  // Add subscriptions for each enabled tier (so syncMauCount can set quantities).
+  // Distribute initialMauCount across tiers for the first invoice.
+  const mauTiersField = buildMauTiersField(pricing.tiers);
   const tierBoundaries = parseMauTiers(mauTiersField) ?? [];
   const addSubscriptions: SubscriptionEntry[] = [];
-  for (let i = 0; i < firstPhase.pricing.tiers.length; i++) {
+  for (let i = 0; i < pricing.tiers.length; i++) {
     const tierQuantity = tierBoundaries[i]
       ? computeTierQuantity(initialMauCount, tierBoundaries[i])
       : 0;
@@ -1024,8 +929,8 @@ export function buildEnterpriseOverrides({
   return {
     overrides,
     add_subscriptions: addSubscriptions,
-    ...(recurringCommits.length > 0
-      ? { recurring_commits: recurringCommits }
+    ...(pricing.floorCents > 0
+      ? { recurring_commits: [recurringCommit(tierProductIds[0])] }
       : {}),
     custom_fields: {
       MAU_TIERS: mauTiersField,
@@ -1037,37 +942,33 @@ export function buildEnterpriseOverrides({
 /**
  * Apply enterprise pricing overrides on a Metronome contract.
  * Uses buildEnterpriseOverrides to construct the payload, then sends it.
- *
- * Pass `phases` to express scheduled rate changes (Stripe SubscriptionSchedule
- * phases). Each phase emits its own dated rate overrides + recurring commit.
  */
 export async function applyEnterpriseOverrides({
   metronomeCustomerId,
   contractId,
-  phases,
+  pricing,
+  startDate,
   overrideLogger,
   workspaceId,
   initialMauCount,
 }: {
   metronomeCustomerId: string;
   contractId: string;
-  phases: EnterprisePricingPhase[];
+  pricing: EnterprisePricingCents;
+  startDate: string;
   overrideLogger: Logger;
   workspaceId: string;
   initialMauCount: number;
 }): Promise<void> {
-  if (phases.length === 0) {
-    throw new Error("applyEnterpriseOverrides requires at least one phase");
-  }
   const payload = buildEnterpriseOverrides({
-    phases,
+    pricing,
+    startDate,
     initialMauCount,
   });
 
-  const billingMode = phases[0].pricing.billingMode;
   overrideLogger.info(
-    { workspaceId, contractId, phaseCount: phases.length, ...payload },
-    `Applying enterprise overrides (${billingMode}, ${phases.length} phase${phases.length === 1 ? "" : "s"})`
+    { workspaceId, contractId, ...payload },
+    `Applying enterprise overrides (${pricing.billingMode})`
   );
 
   const client = getMetronomeClient();
@@ -1131,19 +1032,127 @@ export async function applyEnterpriseOverrides({
   }
 
   overrideLogger.info(
-    { workspaceId, contractId, billingMode },
+    { workspaceId, contractId, billingMode: pricing.billingMode },
     "Enterprise overrides applied"
   );
 }
 
 /**
- * Provision a Metronome customer + contract for an enterprise workspace,
- * extract MAU pricing from the Stripe subscription, and apply overrides.
+ * Provision one Metronome contract per Stripe SubscriptionSchedule phase
+ * (chained on the same customer).
+ *
+ * Each phase contract carries its own pricing, custom fields (MAU_TIERS /
+ * MAU_THRESHOLD), and floor commit. Per-phase contracts are bounded by
+ * `starting_at` / `ending_before` so Metronome activates them in turn — the
+ * `contract.start` webhook then rotates `subscription.metronomeContractId` to
+ * the newly-active contract.
+ *
+ * All contracts in the chain share the same `PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY`
+ * value (the Stripe subscription id) so the webhook can recognize a phase
+ * activation versus an unrelated `contract.start` event.
+ */
+export async function provisionEnterpriseContractsForPhases({
+  metronomeCustomerId,
+  workspace,
+  phases,
+  packageAlias,
+  uniquenessKeyPrefix,
+  enableStripeBilling,
+  initialMauCount,
+  phaseGroupId,
+  contractsLogger,
+}: {
+  metronomeCustomerId: string;
+  workspace: LightWorkspaceType;
+  phases: EnterprisePricingPhase[];
+  packageAlias: string;
+  /** Combined with the phase index to form a stable uniquenessKey per phase. */
+  uniquenessKeyPrefix: string;
+  enableStripeBilling: boolean;
+  initialMauCount: number;
+  /**
+   * Stable group identifier shared across every contract in the chain (so the
+   * webhook can recognize them as siblings). Typically the Stripe subscription
+   * id.
+   */
+  phaseGroupId: string;
+  contractsLogger: Logger;
+}): Promise<Result<{ contractIds: string[] }, Error>> {
+  if (phases.length === 0) {
+    return new Err(
+      new Error("provisionEnterpriseContractsForPhases requires ≥1 phase")
+    );
+  }
+
+  const contractIds: string[] = [];
+
+  for (let i = 0; i < phases.length; i++) {
+    const phase = phases[i];
+
+    const contractResult = await createMetronomeContract({
+      metronomeCustomerId,
+      packageAlias,
+      uniquenessKey: `${uniquenessKeyPrefix}_phase_${i}`,
+      startingAt: new Date(phase.startDate),
+      endingBefore: phase.endDate ? new Date(phase.endDate) : undefined,
+      enableStripeBilling,
+    });
+    if (contractResult.isErr()) {
+      return new Err(contractResult.error);
+    }
+    const { contractId } = contractResult.value;
+    contractIds.push(contractId);
+
+    contractsLogger.info(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        contractId,
+        phaseIndex: i,
+        phaseStart: phase.startDate,
+        phaseEnd: phase.endDate,
+        billingMode: phase.pricing.billingMode,
+      },
+      "[Metronome] Created per-phase enterprise contract"
+    );
+
+    await applyEnterpriseOverrides({
+      metronomeCustomerId,
+      contractId,
+      pricing: phase.pricing,
+      startDate: phase.startDate,
+      overrideLogger: contractsLogger,
+      workspaceId: workspace.sId,
+      initialMauCount,
+    });
+
+    // Tag every contract in the chain with the same group id so the
+    // contract.start webhook can recognize phase activations.
+    await getMetronomeClient().v1.customFields.setValues({
+      entity: "contract",
+      entity_id: contractId,
+      custom_fields: {
+        [PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY]: phaseGroupId,
+      },
+    });
+  }
+
+  return new Ok({ contractIds });
+}
+
+/**
+ * Provision a Metronome customer + per-phase contracts for an enterprise
+ * workspace, extract MAU pricing from the Stripe subscription, and apply
+ * overrides on each contract.
  *
  * The enterprise package alias is intentionally a near-empty shell —
  * subscriptions (seats / MAU / tier products) are added by
  * `applyEnterpriseOverrides` below using the live MAU count as
  * `initial_quantity`.
+ *
+ * Returns the FIRST contract id (the one currently active). Subsequent phase
+ * contracts coexist on the customer and the `contract.start` webhook rotates
+ * `subscription.metronomeContractId` when each later phase activates.
  */
 export async function provisionShadowEnterpriseMetronomeContract({
   workspace,
@@ -1185,8 +1194,7 @@ export async function provisionShadowEnterpriseMetronomeContract({
     );
   }
 
-  // Resolve the package alias based on the subscription currency (consistent
-  // across phases per assertPhasesAreConsistent).
+  // Resolve the package alias based on the active phase's currency.
   const packageAlias = resolvePackageAliasForCurrency(
     LEGACY_ENTERPRISE_PACKAGE_ALIAS,
     phases[0].pricing.currency
@@ -1203,35 +1211,30 @@ export async function provisionShadowEnterpriseMetronomeContract({
   }
   const { metronomeCustomerId } = customerResult.value;
 
-  // Create the (empty) contract directly — overrides below will add the MAU
-  // subscriptions with the right initial quantities.
-  const contractResult = await createMetronomeContract({
-    metronomeCustomerId,
-    packageAlias,
-    uniquenessKey: stripeSubscription.id,
-    startingAt: new Date(startDate),
-    enableStripeBilling: false,
-  });
-  if (contractResult.isErr()) {
-    return new Err(contractResult.error);
-  }
-  const { contractId: metronomeContractId } = contractResult.value;
-
   // Count MAUs for initial subscription quantities on the first invoice.
+  // Reuse the same count for every phase contract (each contract's first
+  // invoice gets the live MAU count; later usage is reported via events).
   const initialMauCount = await countMauForWorkspace(
     workspace,
     phases[0].pricing.billingMode
   );
 
-  // Apply MAU rate overrides + floor commit (per phase).
-  await applyEnterpriseOverrides({
+  const provisionResult = await provisionEnterpriseContractsForPhases({
     metronomeCustomerId,
-    contractId: metronomeContractId,
+    workspace,
     phases,
-    overrideLogger: logger,
-    workspaceId: workspace.sId,
+    packageAlias,
+    uniquenessKeyPrefix: stripeSubscription.id,
+    enableStripeBilling: false,
     initialMauCount,
+    phaseGroupId: stripeSubscription.id,
+    contractsLogger: logger,
   });
+  if (provisionResult.isErr()) {
+    return new Err(provisionResult.error);
+  }
+
+  const metronomeContractId = provisionResult.value.contractIds[0];
 
   return new Ok({ metronomeCustomerId, metronomeContractId });
 }

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -249,6 +249,24 @@ export interface EnterprisePricingCents {
   floorCents: number;
 }
 
+/**
+ * One pricing phase of an enterprise contract.
+ *
+ * Stripe Subscription Schedules split a subscription's lifetime into phases,
+ * each with its own pricing and date range. We mirror that on the Metronome
+ * side by emitting time-bounded rate overrides (and a recurring commit per
+ * phase if the floor amount changes).
+ *
+ * `endDate` is omitted on the final phase to keep the override open-ended —
+ * matching Stripe's default `end_behavior: "release"` where the last phase's
+ * pricing carries forward indefinitely.
+ */
+export interface EnterprisePricingPhase {
+  pricing: EnterprisePricingCents;
+  startDate: string;
+  endDate?: string;
+}
+
 export async function syncContractQuantities(
   metronomeCustomerId: string,
   metronomeContractId: string,
@@ -337,7 +355,26 @@ export async function countMauForWorkspace(
 }
 
 /**
- * Extract enterprise pricing from a Stripe subscription.
+ * A normalized view of a Stripe pricing item — the fields we actually need to
+ * decide whether the item carries enterprise pricing and to extract it.
+ *
+ * Expressed this way so we can build it from both `Stripe.SubscriptionItem`
+ * (where `price` is already a full object) and `SubscriptionSchedule.Phase.Item`
+ * (where `price` is typically a string ID and we need to retrieve it first).
+ */
+interface EnterprisePricingItem {
+  priceId: string;
+  metadata: Stripe.Metadata | null | undefined;
+  currency: string;
+  unitAmountCents: number | null;
+}
+
+/**
+ * Extract enterprise pricing from a normalized list of items.
+ *
+ * Walks the items, returning the first one tagged with an enterprise
+ * `REPORT_USAGE` metadata. Tiers are fetched via `expand: ["tiers"]` since
+ * neither Subscription items nor Schedule phase items include them by default.
  *
  * Supports two enterprise billing modes:
  * - MAU-based (REPORT_USAGE=MAU_1/5/10): metered, tiered price with floor + per-MAU overage.
@@ -347,39 +384,39 @@ export async function countMauForWorkspace(
  *
  * Returns undefined if no enterprise pricing item is found.
  */
-export async function extractEnterprisePricing(
-  stripeSubscription: Stripe.Subscription,
+async function extractEnterprisePricingFromItems(
+  items: EnterprisePricingItem[],
   pricingLogger: Logger
 ): Promise<EnterprisePricingCents | undefined> {
   const stripe = getStripeClient();
 
-  for (const item of stripeSubscription.items.data) {
-    const reportUsage = item.price.metadata?.REPORT_USAGE;
+  for (const item of items) {
+    const reportUsage = item.metadata?.REPORT_USAGE;
     if (!isEnterpriseReportUsage(reportUsage)) {
       continue;
     }
 
-    // FIXED pricing: flat monthly fee, no MAU.
-    if (!isSupportedCurrency(item.price.currency)) {
+    if (!isSupportedCurrency(item.currency)) {
       pricingLogger.warn(
-        { priceId: item.price.id, currency: item.price.currency },
+        { priceId: item.priceId, currency: item.currency },
         "Unsupported enterprise price currency"
       );
       return undefined;
     }
 
+    // FIXED pricing: flat monthly fee, no MAU.
     if (reportUsage === "FIXED") {
       return {
-        currency: item.price.currency,
+        currency: item.currency,
         billingMode: reportUsage,
         tiers: [],
-        floorCents: item.price.unit_amount ?? 0,
+        floorCents: item.unitAmountCents ?? 0,
       };
     }
 
     // MAU-based pricing: graduated tiered price.
-    // Stripe doesn't include tiers in the subscription item by default.
-    const price = await stripe.prices.retrieve(item.price.id, {
+    // Stripe doesn't include tiers in the subscription / phase item by default.
+    const price = await stripe.prices.retrieve(item.priceId, {
       expand: ["tiers"],
     });
 
@@ -433,8 +470,133 @@ export async function extractEnterprisePricing(
   return undefined;
 }
 
+/**
+ * Extract enterprise pricing from the *current* items of a Stripe subscription.
+ *
+ * This ignores SubscriptionSchedule phases — use `extractEnterprisePricingPhases`
+ * when you need pricing across the full lifetime of a scheduled subscription.
+ */
+export async function extractEnterprisePricing(
+  stripeSubscription: Stripe.Subscription,
+  pricingLogger: Logger
+): Promise<EnterprisePricingCents | undefined> {
+  return extractEnterprisePricingFromItems(
+    stripeSubscription.items.data.map((item) => ({
+      priceId: item.price.id,
+      metadata: item.price.metadata,
+      currency: item.price.currency,
+      unitAmountCents: item.price.unit_amount,
+    })),
+    pricingLogger
+  );
+}
+
+/**
+ * Resolve a `SubscriptionSchedule.Phase.Item` (where `price` is typically a
+ * string ID) into our normalized item shape, fetching the price if needed.
+ */
+async function normalizePhaseItem(
+  item: Stripe.SubscriptionSchedule.Phase.Item
+): Promise<EnterprisePricingItem> {
+  const stripe = getStripeClient();
+  const priceId = typeof item.price === "string" ? item.price : item.price.id;
+  // Always retrieve to get a non-deleted Price with metadata + currency +
+  // unit_amount populated. Phase items are commonly returned unexpanded.
+  const price = await stripe.prices.retrieve(priceId);
+  return {
+    priceId: price.id,
+    metadata: price.metadata,
+    currency: price.currency,
+    unitAmountCents: price.unit_amount ?? null,
+  };
+}
+
+/**
+ * Extract enterprise pricing across all current and future phases of a Stripe
+ * subscription.
+ *
+ * If the subscription is not part of a SubscriptionSchedule, returns a single
+ * phase from the current items, anchored at `contractStartDate`.
+ *
+ * Otherwise fetches the schedule, drops phases that ended before
+ * `contractStartDate`, and clamps the first kept phase's start to that date so
+ * the resulting overrides line up with the new Metronome contract start. The
+ * final phase has no `endDate` (open-ended override) — Stripe schedules
+ * default to `end_behavior: "release"`, where the last phase's pricing carries
+ * forward indefinitely.
+ *
+ * Returns an empty array if the subscription has no enterprise pricing.
+ */
+export async function extractEnterprisePricingPhases(
+  stripeSubscription: Stripe.Subscription,
+  contractStartDate: string,
+  pricingLogger: Logger
+): Promise<EnterprisePricingPhase[]> {
+  const scheduleId =
+    typeof stripeSubscription.schedule === "string"
+      ? stripeSubscription.schedule
+      : (stripeSubscription.schedule?.id ?? null);
+
+  if (!scheduleId) {
+    const pricing = await extractEnterprisePricing(
+      stripeSubscription,
+      pricingLogger
+    );
+    if (!pricing) {
+      return [];
+    }
+    return [{ pricing, startDate: contractStartDate }];
+  }
+
+  const stripe = getStripeClient();
+  const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
+
+  const contractStartMs = new Date(contractStartDate).getTime();
+  const phases: EnterprisePricingPhase[] = [];
+
+  for (let i = 0; i < schedule.phases.length; i++) {
+    const phase = schedule.phases[i];
+    const phaseEndMs = phase.end_date * 1000;
+    const phaseStartMs = phase.start_date * 1000;
+
+    // Drop phases that have already ended by the time the contract starts.
+    if (phaseEndMs <= contractStartMs) {
+      continue;
+    }
+
+    const normalizedItems: EnterprisePricingItem[] = [];
+    for (const item of phase.items) {
+      normalizedItems.push(await normalizePhaseItem(item));
+    }
+    const pricing = await extractEnterprisePricingFromItems(
+      normalizedItems,
+      pricingLogger
+    );
+    if (!pricing) {
+      continue;
+    }
+
+    // Clamp the first kept phase to the contract start so the override doesn't
+    // try to begin in the past.
+    const startDate =
+      phaseStartMs < contractStartMs
+        ? contractStartDate
+        : floorToHourISO(new Date(phaseStartMs));
+
+    const isLastPhase = i === schedule.phases.length - 1;
+    const endDate = isLastPhase
+      ? undefined
+      : ceilToHourISO(new Date(phaseEndMs));
+
+    phases.push({ pricing, startDate, endDate });
+  }
+
+  return phases;
+}
+
 interface OverrideEntry {
   starting_at: string;
+  ending_before?: string;
   type: "OVERWRITE";
   entitled: boolean;
   product_id?: string;
@@ -463,29 +625,32 @@ interface SubscriptionEntry {
   };
 }
 
+interface RecurringCommitEntry {
+  product_id: string;
+  name: string;
+  starting_at: string;
+  ending_before?: string;
+  rate_type: "LIST_RATE";
+  priority: number;
+  access_amount: {
+    credit_type_id: string;
+    unit_price: number;
+    quantity: number;
+  };
+  invoice_amount: {
+    credit_type_id: string;
+    unit_price: number;
+    quantity: number;
+  };
+  commit_duration: { value: number; unit: "PERIODS" };
+  recurrence_frequency: "MONTHLY";
+  applicable_product_ids: string[];
+}
+
 export interface EnterpriseOverridesPayload {
   overrides: OverrideEntry[];
   add_subscriptions?: SubscriptionEntry[];
-  recurring_commits?: Array<{
-    product_id: string;
-    name: string;
-    starting_at: string;
-    rate_type: "LIST_RATE";
-    priority: number;
-    access_amount: {
-      credit_type_id: string;
-      unit_price: number;
-      quantity: number;
-    };
-    invoice_amount: {
-      credit_type_id: string;
-      unit_price: number;
-      quantity: number;
-    };
-    commit_duration: { value: number; unit: "PERIODS" };
-    recurrence_frequency: "MONTHLY";
-    applicable_product_ids: string[];
-  }>;
+  recurring_commits?: RecurringCommitEntry[];
   /** Custom fields to set on the contract (MAU_TIERS, MAU_THRESHOLD). */
   custom_fields?: Record<string, string>;
 }
@@ -557,11 +722,79 @@ function deriveTierPrices(
 }
 
 /**
+ * Determine whether a phase uses "simple mode" (single MAU product with a
+ * uniform per-MAU rate) versus "tiered mode" (one MAU Tier product per Stripe
+ * tier). Simple mode kicks in when all derived per-tier prices collapse to a
+ * single value — the floor (if any) is still handled by a recurring commit.
+ */
+function isSimplePhaseMode(pricing: EnterprisePricingCents): boolean {
+  if (pricing.tiers.length === 0) {
+    return false;
+  }
+  const tierPrices = deriveTierPrices(pricing.tiers, pricing.currency);
+  return tierPrices.length > 0 && tierPrices.every((p) => p === tierPrices[0]);
+}
+
+/**
+ * Validate that all phases share the same contract-wide structure:
+ * billing mode, currency, tier-boundary layout, and simple-vs-tiered shape.
+ *
+ * These dimensions cannot vary inside a single Metronome contract — they
+ * determine which products the overrides target and what value is stored in
+ * the contract-level MAU_TIERS / MAU_THRESHOLD custom fields. Only prices and
+ * floor amounts are allowed to differ across phases.
+ */
+function assertPhasesAreConsistent(phases: EnterprisePricingPhase[]): void {
+  if (phases.length <= 1) {
+    return;
+  }
+  const first = phases[0].pricing;
+
+  for (let i = 1; i < phases.length; i++) {
+    const p = phases[i].pricing;
+    if (p.currency !== first.currency) {
+      throw new Error(
+        `Phase ${i} currency (${p.currency}) differs from phase 0 (${first.currency}) — currency cannot change within a single Metronome contract.`
+      );
+    }
+    if (p.billingMode !== first.billingMode) {
+      throw new Error(
+        `Phase ${i} billing mode (${p.billingMode}) differs from phase 0 (${first.billingMode}) — billing mode cannot change within a single Metronome contract.`
+      );
+    }
+    if (first.billingMode === "FIXED") {
+      continue;
+    }
+    if (p.tiers.length !== first.tiers.length) {
+      throw new Error(
+        `Phase ${i} has ${p.tiers.length} tiers, phase 0 has ${first.tiers.length} — tier layout must match across phases.`
+      );
+    }
+    for (let t = 0; t < first.tiers.length; t++) {
+      if (p.tiers[t].upTo !== first.tiers[t].upTo) {
+        throw new Error(
+          `Phase ${i} tier ${t} boundary (${p.tiers[t].upTo}) differs from phase 0 (${first.tiers[t].upTo}) — tier boundaries must match across phases.`
+        );
+      }
+    }
+    if (isSimplePhaseMode(p) !== isSimplePhaseMode(first)) {
+      throw new Error(
+        `Phase ${i} switches between simple and tiered mode vs phase 0 — all phases must use the same shape.`
+      );
+    }
+  }
+}
+
+/**
  * Build the Metronome contract edit payload for enterprise pricing overrides.
+ *
+ * Each phase in `phases` produces its own time-bounded set of rate overrides
+ * (and a recurring commit, if it has a floor). Subscriptions and custom
+ * fields are contract-scoped and emitted once, derived from the first phase.
  *
  * For MAU-based plans (MAU_1/5/10):
  * - Uses MAU Tier products (one per Stripe tier) with FLAT rate overrides.
- * - Disables the default MAU product.
+ * - Disables the default MAU product (or, in simple mode, the tier products).
  * - Sets MAU_TIERS and MAU_THRESHOLD custom fields for syncMauCount.
  * - Recurring prepaid commit for the floor (if any), applicable to MAU Tier 1.
  *
@@ -569,23 +802,30 @@ function deriveTierPrices(
  * - Disables all MAU products (billing is a flat Stripe fee).
  */
 export function buildEnterpriseOverrides({
-  pricing,
-  startDate,
+  phases,
   initialMauCount,
 }: {
-  pricing: EnterprisePricingCents;
-  startDate: string;
+  phases: EnterprisePricingPhase[];
   initialMauCount: number;
 }): EnterpriseOverridesPayload {
-  const creditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[pricing.currency];
+  if (phases.length === 0) {
+    throw new Error("buildEnterpriseOverrides requires at least one phase");
+  }
+  assertPhasesAreConsistent(phases);
+
+  const firstPhase = phases[0];
+  const { currency, billingMode } = firstPhase.pricing;
+  const creditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[currency];
   if (!creditTypeId) {
     throw new Error(
-      `Unsupported currency "${pricing.currency}" for enterprise pricing — add it to CURRENCY_TO_CREDIT_TYPE_ID`
+      `Unsupported currency "${currency}" for enterprise pricing — add it to CURRENCY_TO_CREDIT_TYPE_ID`
     );
   }
 
-  const disableOverride = (productId: string): OverrideEntry => ({
-    starting_at: startDate,
+  // Disable a product for the full contract lifetime — these are products
+  // we're never going to bill on, regardless of phase.
+  const disableOverrideForContract = (productId: string): OverrideEntry => ({
+    starting_at: firstPhase.startDate,
     type: "OVERWRITE" as const,
     entitled: false,
     override_specifiers: [
@@ -599,82 +839,100 @@ export function buildEnterpriseOverrides({
   });
 
   // FIXED: disable all MAU products — billing is a flat Stripe fee.
-  if (pricing.billingMode === "FIXED") {
+  if (billingMode === "FIXED") {
     return {
       overrides: [
-        disableOverride(getProductMauId()),
-        ...getProductMauTierIds().map(disableOverride),
+        disableOverrideForContract(getProductMauId()),
+        ...getProductMauTierIds().map(disableOverrideForContract),
       ],
     };
   }
 
-  if (pricing.tiers.length > MAX_MAU_TIERS) {
+  if (firstPhase.pricing.tiers.length > MAX_MAU_TIERS) {
     throw new Error(
-      `Too many tiers (${pricing.tiers.length}) — max ${MAX_MAU_TIERS} supported`
+      `Too many tiers (${firstPhase.pricing.tiers.length}) — max ${MAX_MAU_TIERS} supported`
     );
   }
 
-  const tierPrices = deriveTierPrices(pricing.tiers, pricing.currency);
   const tierProductIds = getProductMauTierIds();
-  const mauThreshold = String(billingModeToMauThreshold(pricing.billingMode));
+  const mauThreshold = String(billingModeToMauThreshold(billingMode));
+  const useSimpleMode = isSimplePhaseMode(firstPhase.pricing);
 
-  // If all tiers have the same effective price, use the simple MAU product
-  // instead of tier products. The floor (if any) is still handled by a commit.
-  const allSamePrice =
-    tierPrices.length > 0 && tierPrices.every((p) => p === tierPrices[0]);
+  // Helper: build a price override for one product, scoped to a single phase.
+  const phasePriceOverride = (
+    phase: EnterprisePricingPhase,
+    productId: string,
+    price: number
+  ): OverrideEntry => ({
+    starting_at: phase.startDate,
+    ...(phase.endDate ? { ending_before: phase.endDate } : {}),
+    type: "OVERWRITE" as const,
+    entitled: true,
+    override_specifiers: [
+      { product_id: productId, billing_frequency: "MONTHLY" as const },
+    ],
+    overwrite_rate: {
+      rate_type: "FLAT" as const,
+      price,
+      credit_type_id: creditTypeId,
+    },
+  });
 
-  if (allSamePrice) {
-    const overrides: OverrideEntry[] = [
-      // Set the MAU product price.
-      {
-        starting_at: startDate,
-        type: "OVERWRITE" as const,
-        entitled: true,
-        override_specifiers: [
-          {
-            product_id: getProductMauId(),
-            billing_frequency: "MONTHLY" as const,
-          },
-        ],
-        overwrite_rate: {
-          rate_type: "FLAT" as const,
-          price: tierPrices[0],
-          credit_type_id: creditTypeId,
-        },
-      },
-      // Disable all tier products.
-      ...tierProductIds.map(disableOverride),
-    ];
-
+  // Helper: build a recurring commit for a phase's floor, scoped to that phase.
+  const phaseFloorCommit = (
+    phase: EnterprisePricingPhase,
+    applicableProductId: string
+  ): RecurringCommitEntry | undefined => {
+    if (phase.pricing.floorCents <= 0) {
+      return undefined;
+    }
     const floorMetronome = metronomeAmount(
-      pricing.floorCents,
-      pricing.currency
+      phase.pricing.floorCents,
+      phase.pricing.currency
     );
-    const recurringCommits =
-      pricing.floorCents > 0
-        ? [
-            {
-              product_id: getProductMauCommitId(),
-              name: "MAU Commit",
-              starting_at: startDate,
-              rate_type: "LIST_RATE" as const,
-              priority: 100,
-              access_amount: {
-                credit_type_id: creditTypeId,
-                unit_price: floorMetronome,
-                quantity: 1,
-              },
-              invoice_amount: {
-                credit_type_id: creditTypeId,
-                unit_price: floorMetronome,
-                quantity: 1,
-              },
-              commit_duration: { value: 1, unit: "PERIODS" as const },
-              recurrence_frequency: "MONTHLY" as const,
-              applicable_product_ids: [getProductMauId()],
-            },
-          ]
-        : undefined;
+    return {
+      product_id: getProductMauCommitId(),
+      name: "MAU Commit",
+      starting_at: phase.startDate,
+      ...(phase.endDate ? { ending_before: phase.endDate } : {}),
+      rate_type: "LIST_RATE" as const,
+      priority: 100,
+      access_amount: {
+        credit_type_id: creditTypeId,
+        unit_price: floorMetronome,
+        quantity: 1,
+      },
+      invoice_amount: {
+        credit_type_id: creditTypeId,
+        unit_price: floorMetronome,
+        quantity: 1,
+      },
+      commit_duration: { value: 1, unit: "PERIODS" as const },
+      recurrence_frequency: "MONTHLY" as const,
+      applicable_product_ids: [applicableProductId],
+    };
+  };
+
+  if (useSimpleMode) {
+    const overrides: OverrideEntry[] = [];
+    const recurringCommits: RecurringCommitEntry[] = [];
+
+    for (const phase of phases) {
+      const tierPrices = deriveTierPrices(
+        phase.pricing.tiers,
+        phase.pricing.currency
+      );
+      overrides.push(
+        phasePriceOverride(phase, getProductMauId(), tierPrices[0])
+      );
+      const commit = phaseFloorCommit(phase, getProductMauId());
+      if (commit) {
+        recurringCommits.push(commit);
+      }
+    }
+    // Tier products stay disabled for the entire contract — simple mode only
+    // bills the MAU product.
+    overrides.push(...tierProductIds.map(disableOverrideForContract));
 
     return {
       overrides,
@@ -693,7 +951,9 @@ export function buildEnterpriseOverrides({
           },
         },
       ],
-      ...(recurringCommits ? { recurring_commits: recurringCommits } : {}),
+      ...(recurringCommits.length > 0
+        ? { recurring_commits: recurringCommits }
+        : {}),
       custom_fields: {
         MAU_THRESHOLD: mauThreshold,
       },
@@ -702,70 +962,42 @@ export function buildEnterpriseOverrides({
 
   // Multi-tier: use MAU Tier products with per-tier FLAT prices.
   const overrides: OverrideEntry[] = [];
+  const recurringCommits: RecurringCommitEntry[] = [];
 
-  // Disable the default MAU product (tiered contracts use MAU Tier products instead).
-  overrides.push(disableOverride(getProductMauId()));
+  // Disable the default MAU product for the contract — tiered contracts bill
+  // through the MAU Tier products instead.
+  overrides.push(disableOverrideForContract(getProductMauId()));
 
-  // Enable MAU Tier products with per-tier FLAT prices.
-  for (let i = 0; i < pricing.tiers.length; i++) {
-    overrides.push({
-      starting_at: startDate,
-      type: "OVERWRITE" as const,
-      entitled: true,
-      override_specifiers: [
-        {
-          product_id: tierProductIds[i],
-          billing_frequency: "MONTHLY" as const,
-        },
-      ],
-      overwrite_rate: {
-        rate_type: "FLAT" as const,
-        price: tierPrices[i],
-        credit_type_id: creditTypeId,
-      },
-    });
+  for (const phase of phases) {
+    const tierPrices = deriveTierPrices(
+      phase.pricing.tiers,
+      phase.pricing.currency
+    );
+    for (let i = 0; i < phase.pricing.tiers.length; i++) {
+      overrides.push(
+        phasePriceOverride(phase, tierProductIds[i], tierPrices[i])
+      );
+    }
+    const commit = phaseFloorCommit(phase, tierProductIds[0]);
+    if (commit) {
+      recurringCommits.push(commit);
+    }
   }
 
-  // Disable unused tier products.
-  for (let i = pricing.tiers.length; i < MAX_MAU_TIERS; i++) {
-    overrides.push(disableOverride(tierProductIds[i]));
+  // Disable unused tier products for the entire contract (these don't change
+  // across phases — tier count is invariant per assertPhasesAreConsistent).
+  for (let i = firstPhase.pricing.tiers.length; i < MAX_MAU_TIERS; i++) {
+    overrides.push(disableOverrideForContract(tierProductIds[i]));
   }
 
-  // Recurring commit for the floor (flat_amount on first tier).
-  // Applicable to MAU Tier 1 so the commit draws down at tier 1's rate.
-  const floorMetronome = metronomeAmount(pricing.floorCents, pricing.currency);
-  const recurringCommits =
-    pricing.floorCents > 0
-      ? [
-          {
-            product_id: getProductMauCommitId(),
-            name: "MAU Commit",
-            starting_at: startDate,
-            rate_type: "LIST_RATE" as const,
-            priority: 100,
-            access_amount: {
-              credit_type_id: creditTypeId,
-              unit_price: floorMetronome,
-              quantity: 1,
-            },
-            invoice_amount: {
-              credit_type_id: creditTypeId,
-              unit_price: floorMetronome,
-              quantity: 1,
-            },
-            commit_duration: { value: 1, unit: "PERIODS" as const },
-            recurrence_frequency: "MONTHLY" as const,
-            applicable_product_ids: [tierProductIds[0]],
-          },
-        ]
-      : undefined;
-
-  // Add subscriptions for each enabled tier (so syncMauCount can set quantities).
-  // Distribute initialMauCount across tiers for the first invoice.
-  const mauTiersField = buildMauTiersField(pricing.tiers);
+  // Add subscriptions for each enabled tier (so syncMauCount can set
+  // quantities). Distribute the initial MAU count across tiers for the first
+  // invoice, using the first phase's tier boundaries — tier layout is
+  // invariant across phases per assertPhasesAreConsistent.
+  const mauTiersField = buildMauTiersField(firstPhase.pricing.tiers);
   const tierBoundaries = parseMauTiers(mauTiersField) ?? [];
   const addSubscriptions: SubscriptionEntry[] = [];
-  for (let i = 0; i < pricing.tiers.length; i++) {
+  for (let i = 0; i < firstPhase.pricing.tiers.length; i++) {
     const tierQuantity = tierBoundaries[i]
       ? computeTierQuantity(initialMauCount, tierBoundaries[i])
       : 0;
@@ -788,7 +1020,9 @@ export function buildEnterpriseOverrides({
   return {
     overrides,
     add_subscriptions: addSubscriptions,
-    ...(recurringCommits ? { recurring_commits: recurringCommits } : {}),
+    ...(recurringCommits.length > 0
+      ? { recurring_commits: recurringCommits }
+      : {}),
     custom_fields: {
       MAU_TIERS: mauTiersField,
       MAU_THRESHOLD: mauThreshold,
@@ -799,33 +1033,37 @@ export function buildEnterpriseOverrides({
 /**
  * Apply enterprise pricing overrides on a Metronome contract.
  * Uses buildEnterpriseOverrides to construct the payload, then sends it.
+ *
+ * Pass `phases` to express scheduled rate changes (Stripe SubscriptionSchedule
+ * phases). Each phase emits its own dated rate overrides + recurring commit.
  */
 export async function applyEnterpriseOverrides({
   metronomeCustomerId,
   contractId,
-  pricing,
-  startDate,
+  phases,
   overrideLogger,
   workspaceId,
   initialMauCount,
 }: {
   metronomeCustomerId: string;
   contractId: string;
-  pricing: EnterprisePricingCents;
-  startDate: string;
+  phases: EnterprisePricingPhase[];
   overrideLogger: Logger;
   workspaceId: string;
   initialMauCount: number;
 }): Promise<void> {
+  if (phases.length === 0) {
+    throw new Error("applyEnterpriseOverrides requires at least one phase");
+  }
   const payload = buildEnterpriseOverrides({
-    pricing,
-    startDate,
+    phases,
     initialMauCount,
   });
 
+  const billingMode = phases[0].pricing.billingMode;
   overrideLogger.info(
-    { workspaceId, contractId, ...payload },
-    `Applying enterprise overrides (${pricing.billingMode})`
+    { workspaceId, contractId, phaseCount: phases.length, ...payload },
+    `Applying enterprise overrides (${billingMode}, ${phases.length} phase${phases.length === 1 ? "" : "s"})`
   );
 
   const client = getMetronomeClient();
@@ -889,7 +1127,7 @@ export async function applyEnterpriseOverrides({
   }
 
   overrideLogger.info(
-    { workspaceId, contractId, billingMode: pricing.billingMode },
+    { workspaceId, contractId, billingMode },
     "Enterprise overrides applied"
   );
 }
@@ -921,12 +1159,21 @@ export async function provisionShadowEnterpriseMetronomeContract({
     );
   }
 
-  // Extract MAU pricing from the Stripe subscription tiers.
-  const enterprisePricing = await extractEnterprisePricing(
+  // Anchor the Metronome contract to the Stripe billing period start so the
+  // recurring commit (which uses the same date) cannot start before the
+  // contract — Metronome rejects that as a 400.
+  const startDate = floorToHourISO(
+    new Date(stripeSubscription.current_period_start * 1000)
+  );
+
+  // Extract MAU pricing across all current/future schedule phases (or a single
+  // phase from the current items if the subscription has no schedule).
+  const phases = await extractEnterprisePricingPhases(
     stripeSubscription,
+    startDate,
     logger
   );
-  if (!enterprisePricing) {
+  if (phases.length === 0) {
     return new Err(
       new Error(
         `No MAU pricing found in Stripe subscription ${stripeSubscription.id}`
@@ -934,17 +1181,11 @@ export async function provisionShadowEnterpriseMetronomeContract({
     );
   }
 
-  // Resolve the package alias based on the subscription currency.
+  // Resolve the package alias based on the subscription currency (consistent
+  // across phases per assertPhasesAreConsistent).
   const packageAlias = resolvePackageAliasForCurrency(
     LEGACY_ENTERPRISE_PACKAGE_ALIAS,
-    enterprisePricing.currency
-  );
-
-  // Anchor the Metronome contract to the Stripe billing period start so the
-  // recurring commit (which uses the same date) cannot start before the
-  // contract — Metronome rejects that as a 400.
-  const startDate = floorToHourISO(
-    new Date(stripeSubscription.current_period_start * 1000)
+    phases[0].pricing.currency
   );
 
   // Ensure the customer exists (creating it if needed) and is linked to
@@ -975,15 +1216,14 @@ export async function provisionShadowEnterpriseMetronomeContract({
   // Count MAUs for initial subscription quantities on the first invoice.
   const initialMauCount = await countMauForWorkspace(
     workspace,
-    enterprisePricing.billingMode
+    phases[0].pricing.billingMode
   );
 
-  // Apply MAU rate overrides + floor commit.
+  // Apply MAU rate overrides + floor commit (per phase).
   await applyEnterpriseOverrides({
     metronomeCustomerId,
     contractId: metronomeContractId,
-    pricing: enterprisePricing,
-    startDate,
+    phases,
     overrideLogger: logger,
     workspaceId: workspace.sId,
     initialMauCount,

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -518,12 +518,12 @@ async function normalizePhaseItem(
  * If the subscription is not part of a SubscriptionSchedule, returns a single
  * phase from the current items, anchored at `contractStartDate`.
  *
- * Otherwise fetches the schedule, drops phases that ended before
- * `contractStartDate`, and clamps the first kept phase's start to that date so
- * the resulting overrides line up with the new Metronome contract start. The
- * final phase has no `endDate` (open-ended override) — Stripe schedules
- * default to `end_behavior: "release"`, where the last phase's pricing carries
- * forward indefinitely.
+ * Otherwise fetches the schedule, drops phases that have already ended (relative
+ * to `now` or the contract start, whichever is later), and clamps the first
+ * kept phase's start to the contract start so the resulting overrides line up
+ * with the new Metronome contract start. The final phase has no `endDate`
+ * (open-ended override) — Stripe schedules default to `end_behavior: "release"`,
+ * where the last phase's pricing carries forward indefinitely.
  *
  * Returns an empty array if the subscription has no enterprise pricing.
  */
@@ -552,6 +552,10 @@ export async function extractEnterprisePricingPhases(
   const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
 
   const contractStartMs = new Date(contractStartDate).getTime();
+  // Cutoff for dropping past phases. The contract anchor is typically
+  // `current_period_start` which is itself in the past, so a phase that ended
+  // mid-period is still in the past today — filter relative to `now` as well.
+  const cutoffMs = Math.max(contractStartMs, Date.now());
   const phases: EnterprisePricingPhase[] = [];
 
   for (let i = 0; i < schedule.phases.length; i++) {
@@ -559,8 +563,8 @@ export async function extractEnterprisePricingPhases(
     const phaseEndMs = phase.end_date * 1000;
     const phaseStartMs = phase.start_date * 1000;
 
-    // Drop phases that have already ended by the time the contract starts.
-    if (phaseEndMs <= contractStartMs) {
+    // Drop phases that have already ended.
+    if (phaseEndMs <= cutoffMs) {
       continue;
     }
 

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -17,6 +17,7 @@ import {
 import {
   getCreditTypeProgrammaticUsdId,
   getProductFreeCreditId,
+  PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY,
   PLAN_CODE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
@@ -413,6 +414,55 @@ async function handler(
                 message: `Error fetching contract: ${contractResult.error.message}`,
               },
             });
+          }
+
+          // Phase rotation: when a contract is part of a chain of per-phase
+          // enterprise contracts (PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY set),
+          // just point subscription.metronomeContractId at the newly-active
+          // contract. Plan code does not change across phases.
+          const phaseGroupId =
+            contractResult.value.custom_fields?.[
+              PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY
+            ];
+          if (phaseGroupId) {
+            const activeSubscription =
+              await SubscriptionResource.fetchActiveByWorkspaceModelId(
+                workspace.id
+              );
+            if (!activeSubscription) {
+              logger.warn(
+                { contractId, customerId, workspaceId: workspace.sId },
+                "[Metronome Webhook] contract.start: phase activation but no active subscription"
+              );
+              break;
+            }
+
+            // Idempotency: re-deliveries land here with the subscription
+            // already pointing at the new contract.
+            if (activeSubscription.metronomeContractId === contractId) {
+              logger.info(
+                { contractId, workspaceId: workspace.sId },
+                "[Metronome Webhook] contract.start: phase already active, skipping"
+              );
+              break;
+            }
+
+            await SubscriptionResource.updateMetronomeContractId(
+              activeSubscription.id,
+              contractId
+            );
+            await invalidateContractCache(workspace.sId);
+
+            logger.info(
+              {
+                contractId,
+                phaseGroupId,
+                previousContractId: activeSubscription.metronomeContractId,
+                workspaceId: workspace.sId,
+              },
+              "[Metronome Webhook] contract.start: rotated subscription to new phase contract"
+            );
+            break;
           }
 
           const targetPlanCode =

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -18,6 +18,7 @@ import {
   CREDIT_TYPE_USD_ID,
   DEV_CREDIT_TYPE_AWU_ID,
   DEV_CREDIT_TYPE_PROG_USD_ID,
+  PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY,
   PLAN_CODE_CUSTOM_FIELD_KEY,
   PROD_CREDIT_TYPE_AWU_ID,
   PROD_CREDIT_TYPE_PROG_USD_ID,
@@ -2042,6 +2043,7 @@ const CUSTOM_FIELD_KEYS: Array<{
   { entity: "contract", key: "MAU_TIERS" },
   { entity: "contract", key: "MAU_THRESHOLD" },
   { entity: "contract", key: PLAN_CODE_CUSTOM_FIELD_KEY },
+  { entity: "contract", key: PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY },
 ];
 
 async function syncCustomFields(): Promise<void> {

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -25,8 +25,8 @@ import {
   applyEnterpriseOverrides,
   buildEnterpriseOverrides,
   countMauForWorkspace,
-  type EnterprisePricingCents,
-  extractEnterprisePricing,
+  type EnterprisePricingPhase,
+  extractEnterprisePricingPhases,
 } from "@app/lib/metronome/contracts";
 import { syncMauCount } from "@app/lib/metronome/mau_sync";
 import { syncSeatCount } from "@app/lib/metronome/seats";
@@ -131,7 +131,8 @@ async function getPackageInfo(): Promise<{
  * Returns undefined if no active paid subscription.
  *
  * For enterprise plans, also extracts the per-MAU pricing from the Stripe subscription
- * so it can be applied as a rate override on the Metronome contract.
+ * — including all SubscriptionSchedule phases — so each phase can be applied as a
+ * dated rate override on the Metronome contract.
  */
 async function getSubscriptionInfo(
   workspace: LightWorkspaceType,
@@ -141,7 +142,7 @@ async function getSubscriptionInfo(
       packageAlias: string;
       startDate: string;
       subscriptionModelId: number;
-      enterprisePricing?: EnterprisePricingCents;
+      enterprisePhases?: EnterprisePricingPhase[];
     }
   | undefined
 > {
@@ -176,17 +177,18 @@ async function getSubscriptionInfo(
 
   const planCode = subscription.getPlan().code;
 
-  // Enterprise plans: extract MAU pricing from Stripe tiers.
+  // Enterprise plans: extract MAU pricing per schedule phase from Stripe.
   if (isEntreprisePlanPrefix(planCode)) {
     if (!stripeSubscription) {
       return undefined;
     }
 
-    const enterprisePricing = await extractEnterprisePricing(
+    const enterprisePhases = await extractEnterprisePricingPhases(
       stripeSubscription,
+      startDate,
       logger
     );
-    if (!enterprisePricing) {
+    if (enterprisePhases.length === 0) {
       logger.warn(
         { workspaceId: workspace.sId, planCode },
         "Enterprise plan but no MAU pricing found in Stripe — skipping"
@@ -194,16 +196,15 @@ async function getSubscriptionInfo(
       return undefined;
     }
 
+    const phaseCurrency = enterprisePhases[0].pricing.currency;
     return {
       packageAlias: resolvePackageAliasForCurrency(
         LEGACY_ENTERPRISE_PACKAGE_ALIAS,
-        isSupportedCurrency(enterprisePricing.currency)
-          ? enterprisePricing.currency
-          : "usd"
+        isSupportedCurrency(phaseCurrency) ? phaseCurrency : "usd"
       ),
       startDate,
       subscriptionModelId: subscription.id,
-      enterprisePricing,
+      enterprisePhases,
     };
   }
 
@@ -380,19 +381,20 @@ async function migrateWorkspace(
   }
 
   // Count MAUs for initial subscription quantities.
-  const initialMauCount = isEnterprise
-    ? await countMauForWorkspace(
-        workspace,
-        subInfo.enterprisePricing!.billingMode
-      )
-    : 0;
+  const enterprisePhases = subInfo.enterprisePhases;
+  const initialMauCount =
+    isEnterprise && enterprisePhases
+      ? await countMauForWorkspace(
+          workspace,
+          enterprisePhases[0].pricing.billingMode
+        )
+      : 0;
 
   // Build enterprise overrides for both logging and contract creation.
   const enterpriseOverrides =
-    isEnterprise && subInfo.enterprisePricing
+    isEnterprise && enterprisePhases
       ? buildEnterpriseOverrides({
-          pricing: subInfo.enterprisePricing,
-          startDate: subInfo.startDate,
+          phases: enterprisePhases,
           initialMauCount,
         })
       : undefined;
@@ -405,6 +407,19 @@ async function migrateWorkspace(
       targetAlias,
       targetPackageId,
       startDate: subInfo.startDate,
+      ...(enterprisePhases
+        ? {
+            phaseCount: enterprisePhases.length,
+            phases: enterprisePhases.map((p) => ({
+              startDate: p.startDate,
+              endDate: p.endDate,
+              billingMode: p.pricing.billingMode,
+              currency: p.pricing.currency,
+              floorCents: p.pricing.floorCents,
+              tiers: p.pricing.tiers,
+            })),
+          }
+        : {}),
       ...(oldContractId
         ? { oldContractId, oldAlias, action: "MIGRATE" }
         : { action: "CREATE_NEW" }),
@@ -451,12 +466,11 @@ async function migrateWorkspace(
     "New contract created"
   );
 
-  if (enterpriseOverrides) {
+  if (enterpriseOverrides && enterprisePhases) {
     await applyEnterpriseOverrides({
       metronomeCustomerId,
       contractId: newContractId,
-      pricing: subInfo.enterprisePricing!,
-      startDate: subInfo.startDate,
+      phases: enterprisePhases,
       overrideLogger: logger,
       workspaceId: workspace.sId,
       initialMauCount,

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -22,11 +22,11 @@ import {
   getMetronomeClient,
 } from "@app/lib/metronome/client";
 import {
-  applyEnterpriseOverrides,
   buildEnterpriseOverrides,
   countMauForWorkspace,
   type EnterprisePricingPhase,
   extractEnterprisePricingPhases,
+  provisionEnterpriseContractsForPhases,
 } from "@app/lib/metronome/contracts";
 import { syncMauCount } from "@app/lib/metronome/mau_sync";
 import { syncSeatCount } from "@app/lib/metronome/seats";
@@ -142,6 +142,7 @@ async function getSubscriptionInfo(
       packageAlias: string;
       startDate: string;
       subscriptionModelId: number;
+      stripeSubscriptionId: string;
       enterprisePhases?: EnterprisePricingPhase[];
     }
   | undefined
@@ -204,6 +205,7 @@ async function getSubscriptionInfo(
       ),
       startDate,
       subscriptionModelId: subscription.id,
+      stripeSubscriptionId: subscription.stripeSubscriptionId,
       enterprisePhases,
     };
   }
@@ -232,6 +234,7 @@ async function getSubscriptionInfo(
     packageAlias,
     startDate,
     subscriptionModelId: subscription.id,
+    stripeSubscriptionId: subscription.stripeSubscriptionId,
   };
 }
 
@@ -390,13 +393,17 @@ async function migrateWorkspace(
         )
       : 0;
 
-  // Build enterprise overrides for both logging and contract creation.
+  // Build per-phase override payloads for logging only — actual contract
+  // creation goes through provisionEnterpriseContractsForPhases below.
   const enterpriseOverrides =
     isEnterprise && enterprisePhases
-      ? buildEnterpriseOverrides({
-          phases: enterprisePhases,
-          initialMauCount,
-        })
+      ? enterprisePhases.map((phase) =>
+          buildEnterpriseOverrides({
+            pricing: phase.pricing,
+            startDate: phase.startDate,
+            initialMauCount,
+          })
+        )
       : undefined;
 
   logger.info(
@@ -452,29 +459,54 @@ async function migrateWorkspace(
     );
   }
 
-  // Create new contract, then apply enterprise overrides if needed.
-  // Metronome does not allow overrides in v1.contracts.create when using a package.
-  const newContract = await client.v1.contracts.create({
-    customer_id: metronomeCustomerId,
-    package_alias: targetAlias,
-    starting_at: subInfo.startDate,
-  });
-  const newContractId = newContract.data.id;
-
-  logger.info(
-    { workspaceId: workspace.sId, contractId: newContractId, targetAlias },
-    "New contract created"
-  );
-
-  if (enterpriseOverrides && enterprisePhases) {
-    await applyEnterpriseOverrides({
+  // Enterprise: create one contract per Stripe schedule phase (chained on the
+  // same customer). The contract.start webhook rotates
+  // subscription.metronomeContractId when later phases activate.
+  // Non-enterprise: a single contract from the package alias.
+  let newContractId: string;
+  if (isEnterprise && enterprisePhases) {
+    const provisionResult = await provisionEnterpriseContractsForPhases({
       metronomeCustomerId,
-      contractId: newContractId,
+      workspace,
       phases: enterprisePhases,
-      overrideLogger: logger,
-      workspaceId: workspace.sId,
+      packageAlias: targetAlias,
+      // Phase contracts are scoped to a re-migration cycle; include the start
+      // date so re-runs after a force migration don't collide.
+      uniquenessKeyPrefix: `migrate_${subInfo.startDate}`,
+      enableStripeBilling: enableBilling ?? false,
       initialMauCount,
+      phaseGroupId: subInfo.stripeSubscriptionId,
+      contractsLogger: logger,
     });
+    if (provisionResult.isErr()) {
+      logger.error(
+        { workspaceId: workspace.sId, error: provisionResult.error.message },
+        "Failed to provision per-phase enterprise contracts"
+      );
+      return;
+    }
+    newContractId = provisionResult.value.contractIds[0];
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        contractIds: provisionResult.value.contractIds,
+        phaseCount: enterprisePhases.length,
+      },
+      "Per-phase enterprise contracts created"
+    );
+  } else {
+    // Metronome does not allow overrides in v1.contracts.create when using a package.
+    const newContract = await client.v1.contracts.create({
+      customer_id: metronomeCustomerId,
+      package_alias: targetAlias,
+      starting_at: subInfo.startDate,
+    });
+    newContractId = newContract.data.id;
+
+    logger.info(
+      { workspaceId: workspace.sId, contractId: newContractId, targetAlias },
+      "New contract created"
+    );
   }
 
   // Update metronomeContractId on the subscription first so that the contract


### PR DESCRIPTION
## Description

When migrating Stripe enterprise subscriptions to Metronome, we were only reading the *current* subscription items — so any pricing scheduled via Stripe Subscription Schedule phases (ramp deals, year-2 price bumps) was silently dropped and the resulting Metronome contract billed the wrong rate as soon as the next phase kicked in.

**Approach: one Metronome contract per Stripe schedule phase, chained on the customer.** Each phase contract carries its own pricing, custom fields (`MAU_TIERS`, `MAU_THRESHOLD`), and floor commit. This is simpler than time-multiplexed overrides on a single contract — phases can change billing mode, tier count, MAU threshold, or tier boundaries without coordination — and lets Metronome handle activation timing for us.

Changes:

- **`extractEnterprisePricingPhases(subscription, contractStartDate, logger)`** reads `subscription.schedule`, walks each phase, drops phases that have already ended (relative to `max(contractStart, now)`), and clamps the first kept phase's start to the contract start. The final phase has no `endDate` (open-ended) — matching Stripe's default `end_behavior: \"release\"`. Falls back to a single phase derived from the current items when no schedule is attached.
- **`provisionEnterpriseContractsForPhases(...)`** creates N Metronome contracts (one per phase), each bounded by `starting_at` / `ending_before`, applies per-phase overrides via `applyEnterpriseOverrides`, and tags every contract with a new `PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY = <stripe sub id>` custom field so the webhook can recognize phase activations.
- **`createMetronomeContract`** gained an optional `endingBefore` parameter.
- **`contract.start` webhook**: when the activating contract carries `PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY`, rotate `subscription.metronomeContractId` to the new contract id (no plan-code change). Idempotent on redelivery. The existing Poke-scheduled enterprise upgrade flow (driven by `PLAN_CODE_CUSTOM_FIELD_KEY`) is unchanged — phase rotation is checked first since it's more specific.
- **`provisionShadowEnterpriseMetronomeContract`** and **`scripts/migrate_metronome_contracts.ts`** switched to the per-phase helper. The first contract id is stored on the subscription; subsequent phase contracts coexist on the customer and rotate via the webhook.
- **`metronome_setup`** registers the new `PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY` so phase-tagging won't 400 in fresh environments.
- **`buildEnterpriseOverrides`** stays single-phase (`{ pricing, startDate, initialMauCount }`) — no cross-phase consistency assertion needed.

## Tests

- `contracts.test.ts` — 23 tests covering `extractEnterprisePricing` and all `buildEnterpriseOverrides` patterns (FIXED, simple mode, no-floor, multi-tier, EUR conversion). All passing.
- `npx tsgo --noEmit` clean.

## Risk

- **New enterprise sign-ups via `provisionShadowEnterpriseMetronomeContract`**: subscriptions without a schedule continue to produce a single Metronome contract (single-phase fallback) — no behavior change. Subscriptions with a schedule now produce N contracts; the active one is stored on the subscription as before.
- **Webhook**: the new phase-rotation branch only fires when a contract carries `PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY`. No existing contracts have it set, so the path is dormant for everyone until per-phase contracts are created.
- **Migration script**: dry-run by default (`--execute` to apply), so the per-phase contract list can be inspected via logs before committing.
- **Webhook ordering** — when a phase boundary fires both `contract.end` (phase N) and `contract.start` (phase N+1), the existing `contract.end` handler already tolerates a swapped subscription pointer: shadow contracts log and break; non-shadow contracts find a successor contract via `listMetronomeContracts(coveringDate: now)` and skip the scrub.

## Deploy Plan

1. Standard deploy. Phase rotation is dormant until contracts are tagged with `PHASED_SUBSCRIPTION_CUSTOM_FIELD_KEY`.
2. Run `scripts/metronome_setup.ts --execute` in sandbox + production to register the new custom-field key.
3. For the legacy enterprise migration: dry-run `scripts/migrate_metronome_contracts.ts`, validate per-phase contract log lines for any scheduled customer, then re-run with `--execute`.