### PR TITLE
fix: honour URL hash on spaceId change to open correct tab

### DIFF
--- a/front/hooks/useSpaceProjectTabs.ts
+++ b/front/hooks/useSpaceProjectTabs.ts
@@ -54,7 +54,7 @@ interface UseSpaceProjectTabsParams {
 
 /**
  * Space page tabs: URL hash + `projectUI` scoped preferences (per space).
- * - On `spaceId` change: restore persisted tab and sync the hash.
+ * - On `spaceId` change: use the incoming URL hash if valid, else restore persisted tab.
  * - On `hashchange`: follow hash and persist.
  * - Empty hash: deferred `replaceState` so other layout hooks can observe an empty hash first.
  */
@@ -79,7 +79,10 @@ export function useSpaceProjectTabs({
       spaceId,
       DEFAULT_SPACE_PROJECT_UI_PREFERENCES
     );
-    const newTab = persisted.tab;
+    // Honour an incoming hash (e.g. a shared link with #todos) before falling
+    // back to the persisted tab. Without this the layout effect was overwriting
+    // the URL hash with the last-visited tab on every spaceId change.
+    const newTab = parseSpaceTabFromLocationHash(persisted.tab);
     setCurrentTab(newTab);
     replaceUrlHashWithTab(newTab);
   }, [spaceId]);


### PR DESCRIPTION
## Description

Fixes a bug where navigating to a space URL with a hash (e.g. `/w/xxx/spaces/yyy#todos`) would open the **last visited tab** instead of the tab specified by the hash.

### Root cause

In `useSpaceProjectTabs.ts`, the `useLayoutEffect` that runs on `spaceId` change was unconditionally restoring the persisted (last visited) tab and calling `replaceUrlHashWithTab(persisted.tab)`, which immediately overwrote any incoming hash.

```ts
// Before (bug): always uses the persisted tab, ignoring any incoming hash
const newTab = persisted.tab;
```

### Fix

Use `parseSpaceTabFromLocationHash(persisted.tab)` instead. This function already exists and handles the two cases correctly:
- If `window.location.hash` contains a valid tab name → use it (incoming navigation wins)
- If the hash is empty or unknown → fall back to `persisted.tab`

```ts
// After (fix): incoming hash wins; falls back to persisted tab when hash is absent/unknown
const newTab = parseSpaceTabFromLocationHash(persisted.tab);
```

### Behaviour preserved

- Navigating between spaces without a hash still restores the persisted tab
- The empty-hash deferred `replaceState` (third `useEffect`) is untouched
- The `hashchange` listener already used `parseSpaceTabFromLocationHash` correctly

## Tests

- Navigate to a project space while on a different tab → URL without hash → correct persisted tab restored ✓
- Open a direct link with `#todos` hash → todos tab opens ✓
- Open a direct link with `#knowledge` hash → knowledge tab opens ✓
- Open a direct link with an unknown hash → falls back to persisted tab ✓
- Switching tabs within a space still works and persists correctly ✓

## Risk

Low. One-line logic change in a hook. The `hashchange` path was already doing this correctly; this aligns the initial-load path with it. Easily rolled back.
