### PR TITLE
Add default value for MCP server icon and name

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1339,6 +1339,9 @@ export function getInternalMCPServerIconByName(
   name: InternalMCPServerNameType
 ): InternalAllowedIconType {
   const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
+  if (!server) {
+    return "ActionRobotIcon";
+  }
 
   return server.metadata.serverInfo.icon;
 }
@@ -1351,6 +1354,9 @@ export function getInternalMCPServerDisplayedAs(
     return undefined;
   }
   const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
+  if (!server) {
+    return undefined;
+  }
   return server.metadata.serverInfo.displayedAs;
 }
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1338,7 +1338,7 @@ export function getInternalMCPServerNameFromSId(
 export function getInternalMCPServerIconByName(
   name: InternalMCPServerNameType
 ): InternalAllowedIconType {
-  const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
+  const server: InternalMCPServerEntry | undefined = INTERNAL_MCP_SERVERS[name];
   if (!server) {
     return "ActionRobotIcon";
   }
@@ -1353,7 +1353,7 @@ export function getInternalMCPServerDisplayedAs(
   if (!name) {
     return undefined;
   }
-  const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
+  const server: InternalMCPServerEntry | undefined = INTERNAL_MCP_SERVERS[name];
   if (!server) {
     return undefined;
   }


### PR DESCRIPTION
## Description

Adds defensive checks to `getInternalMCPServerIconByName` and `getInternalMCPServerDisplayedAs` to handle cases where the server name does not exist in `INTERNAL_MCP_SERVERS`. Returns a default icon (`ActionRobotIcon`) and `undefined` respectively when the server is not found, preventing crashes from accessing properties on undefined objects.

## Tests

Manually tested with invalid server names.

## Risk

Low. This is defensive programming to prevent crashes when accessing MCP server metadata with invalid names.

## Deploy Plan

Deploy front