### PR TITLE
Migrate members API to zod

### DIFF
--- a/front/lib/notifications/workflows/provider-credential-updated.ts
+++ b/front/lib/notifications/workflows/provider-credential-updated.ts
@@ -59,7 +59,6 @@ export const triggerProviderCredentialsHealthUpdatedNotifications = async (
   let paginationParams: MembershipsPaginationParams | undefined = {
     orderColumn: "createdAt",
     orderDirection: "asc",
-    lastValue: null,
     limit: NOVU_BULK_TRIGGER_LIMIT,
   };
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -49,7 +49,7 @@ type GetMembershipsOptions = RequireAtLeastOne<{
 export type MembershipsPaginationParams = {
   orderColumn: "createdAt";
   orderDirection: "asc" | "desc";
-  lastValue: number | null | undefined;
+  lastValue?: number;
   limit: number;
 };
 

--- a/front/pages/api/w/[wId]/members/index.test.ts
+++ b/front/pages/api/w/[wId]/members/index.test.ts
@@ -267,7 +267,10 @@ describe("GET /api/w/[wId]/members", () => {
       NextApiResponse
     >({
       method: "GET",
-      query: parseQueryString(firstPageData.nextPageUrl),
+      query: {
+        ...parseQueryString(firstPageData.nextPageUrl),
+        wId: workspace.sId,
+      },
       headers: {},
     });
 

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -6,10 +6,9 @@ import type { MembershipsPaginationParams } from "@app/lib/resources/membership_
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import { NumberFromString, withFallback } from "io-ts-types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export const DEFAULT_PAGE_LIMIT = 50;
 export const MAX_PAGE_LIMIT = 150;
@@ -20,24 +19,16 @@ export type GetMembersResponseBody = {
   nextPageUrl?: string;
 };
 
-const MembersPaginationCodec = t.type({
-  limit: withFallback(
-    t.refinement(
-      NumberFromString,
-      (n): n is number => n >= 0 && n <= MAX_PAGE_LIMIT,
-      `LimitWithRange`
-    ),
-    DEFAULT_PAGE_LIMIT
-  ),
-  orderColumn: withFallback(t.literal("createdAt"), "createdAt"),
-  orderDirection: withFallback(
-    t.union([t.literal("asc"), t.literal("desc")]),
-    "desc"
-  ),
-  lastValue: withFallback(
-    t.union([NumberFromString, t.null, t.undefined]),
-    undefined
-  ),
+const MembersPaginationSchema = z.object({
+  limit: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(MAX_PAGE_LIMIT)
+    .catch(DEFAULT_PAGE_LIMIT),
+  orderColumn: z.literal("createdAt").catch("createdAt"),
+  orderDirection: z.enum(["asc", "desc"]).catch("desc"),
+  lastValue: z.coerce.number().optional().catch(undefined),
 });
 
 const buildUrlWithParams = (
@@ -76,18 +67,18 @@ async function handler(
         });
       }
 
-      const paginationRes = MembersPaginationCodec.decode(req.query);
-      if (isLeft(paginationRes)) {
+      const paginationRes = MembersPaginationSchema.safeParse(req.query);
+      if (!paginationRes.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Invalid pagination parameters",
+            message: `Invalid pagination parameters: ${fromError(paginationRes.error).toString()}`,
           },
         });
       }
 
-      const paginationParams = paginationRes.right;
+      const paginationParams = paginationRes.data;
 
       if (req.query.role && req.query.role === "admin") {
         const { members, total, nextPageParams } = await getMembers(

--- a/front/pages/api/w/[wId]/members/lookup.ts
+++ b/front/pages/api/w/[wId]/members/lookup.ts
@@ -6,15 +6,13 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { UserType } from "@app/types/user";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import { NumberFromString } from "io-ts-types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 const MEMBERS_LOOKUP_MAX_IDS = 50;
 
-const MembersLookupQuery = t.type({
-  ids: t.union([NumberFromString, t.array(NumberFromString)]),
+const MembersLookupQuerySchema = z.object({
+  ids: z.union([z.coerce.number(), z.array(z.coerce.number())]),
 });
 
 export type MembersLookupResponseBody = {
@@ -28,8 +26,8 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET": {
-      const queryValidation = MembersLookupQuery.decode(req.query);
-      if (isLeft(queryValidation)) {
+      const queryValidation = MembersLookupQuerySchema.safeParse(req.query);
+      if (!queryValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -39,7 +37,7 @@ async function handler(
         });
       }
 
-      const rawIds = queryValidation.right.ids;
+      const rawIds = queryValidation.data.ids;
       const ids = Array.isArray(rawIds) ? rawIds : [rawIds];
 
       if (ids.length === 0) {

--- a/front/pages/api/w/[wId]/members/me/agent_favorite.ts
+++ b/front/pages/api/w/[wId]/members/me/agent_favorite.ts
@@ -5,22 +5,21 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export type PostAgentUserFavoriteResponseBody = {
   agentId: string;
   userFavorite: boolean;
 };
 
-export const PostAgentUserFavoriteRequestBodySchema = t.type({
-  agentId: t.string,
-  userFavorite: t.boolean,
+export const PostAgentUserFavoriteRequestBodySchema = z.object({
+  agentId: z.string(),
+  userFavorite: z.boolean(),
 });
 
-export type PostAgentUserFavoriteRequestBody = t.TypeOf<
+export type PostAgentUserFavoriteRequestBody = z.infer<
   typeof PostAgentUserFavoriteRequestBodySchema
 >;
 
@@ -31,22 +30,20 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "POST":
-      const bodyValidation = PostAgentUserFavoriteRequestBodySchema.decode(
+      const bodyValidation = PostAgentUserFavoriteRequestBodySchema.safeParse(
         req.body
       );
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
           },
         });
       }
 
-      const { agentId, userFavorite } = bodyValidation.right;
+      const { agentId, userFavorite } = bodyValidation.data;
 
       const agentConfiguration = await getAgentConfiguration(auth, {
         agentId,

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -5,37 +5,32 @@ import type { Authenticator } from "@app/lib/auth";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { GroupKind } from "@app/types/groups";
-import { GroupKindCodec } from "@app/types/groups";
+import { GROUP_KINDS } from "@app/types/groups";
 import type { UserTypeWithWorkspace } from "@app/types/user";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import { formatValidationErrors } from "io-ts-reporters";
-import { BooleanFromString, NumberFromString, withFallback } from "io-ts-types";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 const DEFAULT_PAGE_LIMIT = 25;
 
-const GroupKindWithoutSystemCodec = t.refinement(
-  GroupKindCodec,
-  (kind): kind is Exclude<GroupKind, "system"> => kind !== "system",
-  "GroupKindWithoutSystem"
-);
+const GROUP_KINDS_WITHOUT_SYSTEM = GROUP_KINDS.filter(
+  (kind): kind is Exclude<(typeof GROUP_KINDS)[number], "system"> =>
+    kind !== "system"
+) as [
+  Exclude<(typeof GROUP_KINDS)[number], "system">,
+  ...Exclude<(typeof GROUP_KINDS)[number], "system">[],
+];
 
-const SearchMembersQueryCodec = t.type({
-  offset: withFallback(NumberFromString, 0),
-  limit: withFallback(
-    t.refinement(
-      NumberFromString,
-      (n): n is number => n >= 0 && n <= 150,
-      `LimitWithRange`
-    ),
-    DEFAULT_PAGE_LIMIT
-  ),
-  searchTerm: t.union([t.string, t.undefined]),
-  searchEmails: t.union([t.string, t.undefined]),
-  groupKind: t.union([GroupKindWithoutSystemCodec, t.undefined]),
-  buildersOnly: t.union([BooleanFromString, t.undefined]),
+const SearchMembersQuerySchema = z.object({
+  offset: z.coerce.number().int().min(0).catch(0),
+  limit: z.coerce.number().int().min(0).max(150).catch(DEFAULT_PAGE_LIMIT),
+  searchTerm: z.string().optional(),
+  searchEmails: z.string().optional(),
+  groupKind: z.enum(GROUP_KINDS_WITHOUT_SYSTEM).optional(),
+  buildersOnly: z
+    .string()
+    .transform((v) => v === "true")
+    .optional(),
 });
 
 export type SearchMembersResponseBody = {
@@ -50,21 +45,19 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
-      const queryRes = SearchMembersQueryCodec.decode(req.query);
+      const queryRes = SearchMembersQuerySchema.safeParse(req.query);
 
-      if (isLeft(queryRes)) {
+      if (!queryRes.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message:
-              "Invalid query parameters: " +
-              formatValidationErrors(queryRes.left).join(", "),
+            message: `Invalid query parameters: ${fromError(queryRes.error).toString()}`,
           },
         });
       }
 
-      const query = queryRes.right;
+      const query = queryRes.data;
       const emails = query.searchEmails?.split(",");
       if (emails?.length && emails.length > MAX_SEARCH_EMAILS) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -13,20 +13,12 @@ import { fromError } from "zod-validation-error";
 
 const DEFAULT_PAGE_LIMIT = 25;
 
-const GROUP_KINDS_WITHOUT_SYSTEM = GROUP_KINDS.filter(
-  (kind): kind is Exclude<(typeof GROUP_KINDS)[number], "system"> =>
-    kind !== "system"
-) as [
-  Exclude<(typeof GROUP_KINDS)[number], "system">,
-  ...Exclude<(typeof GROUP_KINDS)[number], "system">[],
-];
-
 const SearchMembersQuerySchema = z.object({
   offset: z.coerce.number().int().min(0).catch(0),
   limit: z.coerce.number().int().min(0).max(150).catch(DEFAULT_PAGE_LIMIT),
   searchTerm: z.string().optional(),
   searchEmails: z.string().optional(),
-  groupKind: z.enum(GROUP_KINDS_WITHOUT_SYSTEM).optional(),
+  groupKind: z.enum(GROUP_KINDS).exclude(["system"]).optional(),
   buildersOnly: z
     .string()
     .transform((v) => v === "true")


### PR DESCRIPTION
## Description

Convert all handlers in pages/api/w/[wId]/members from io-ts to zod:

- index.ts — MembersPaginationCodec → MembersPaginationSchema using z.coerce.number() and .catch() for fallbacks
- lookup.ts — MembersLookupQuery → zod with z.union([z.coerce.number(), z.array(z.coerce.number())])
- me/agent_favorite.ts — request body t.type → z.object
- search.ts — SearchMembersQueryCodec → zod, including BooleanFromString → z.string().transform(v => v === "true") and GroupKindCodec → z.enum(GROUP_KINDS_WITHOUT_SYSTEM)

Drive-by cleanup

- MembershipsPaginationParams.lastValue changed from number | null | undefined (required) to number (optional). null was never used in practice — every consumer does if (lastValue). This also removes a lastValue: null in provider-credential-updated.ts that was equivalent to omitting the field.

Test change in members/index.test.ts

The "returns correct first and second pages" test needed wId: workspace.sId added to the second mock request. The test was previously passing by accident:

- io-ts's t.type preserves extra properties from the input object — so paginationRes.right carried wId through from req.query
- That wId got spread into nextPageParams inside MembershipResource, then iterated by buildUrlWithParams and written into the generated nextPageUrl as a query param
- parseQueryString(nextPageUrl) extracted it back, so the second createMocks call inherited wId for free

zod's z.object strips unknown keys (the correct behavior), so the leak is gone. In production this is a no-op — wId lives in the URL path (/api/w/[wId]/...) and Next.js injects it into req.query from the dynamic route. The test's createMocks skips that routing layer, so it now has to provide wId explicitly, just like Next.js would.

## Tests

Manually tested the membership API using the UI.

## Risk

Need to watch for any small behavior regression

## Deploy Plan

Front