### PR TITLE
Hide agent details button in extension

### DIFF
--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -1,4 +1,5 @@
 import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
+import { useClientType } from "@app/lib/context/clientType";
 import { filterAndSortAgents } from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -44,6 +45,7 @@ export function AgentPicker({
   isLoading = false,
   disabled = false,
 }: AgentPickerProps) {
+  const clientType = useClientType();
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
@@ -112,7 +114,7 @@ export function AgentPicker({
               truncateText
               className="group py-1"
               endComponent={
-                onAgentDetailsClick ? (
+                onAgentDetailsClick && clientType !== "extension" ? (
                   <Button
                     icon={MoreIcon}
                     variant="outline"


### PR DESCRIPTION
## Description

Hides the agent details button (More icon) in the AgentPicker component when running in the extension client. This button triggers the agent details sheet which is not applicable in the extension context where the UI is more constrained.

## Tests

Manually tested on extension client to confirm the details button no longer appears in the AgentPicker dropdown.

## Risk

None. This is a UI-only change that conditionally hides a button in the extension client.

## Deploy Plan

Deploy front