### PR TITLE
Improve Google Drive tool descriptions to reduce unnecessary thinking

### DIFF
--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -344,7 +344,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
   copy_file: {
     description:
       "Copy an existing Google Drive file (Doc, Sheet, or Presentation). " +
-      "Creates a duplicate of the file with a new name in the same folder or a different location.",
+      "Creates a duplicate of the file with a new name in the same folder or a different location. " +
+      "Prefer this over creating a new document when you want to preserve the formatting or structure of an existing template.",
     schema: {
       fileId: z.string().describe("The ID of the file to copy."),
       name: z
@@ -411,8 +412,13 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       requests: GoogleDocsRequestsArraySchema.describe(
         "An array of batch update requests to apply to the document. Include multiple operations in a single call to minimize requests. " +
           "Each request is an object with optional properties for each request type (only one should be set per request). " +
-          "See https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/batchUpdate for request types. " +
-          "Common requests include replaceAllText (preserves formatting), insertText, deleteContentRange, insertTable, insertTableRow, updateTableCellStyle, updateTextStyle, etc."
+          "See https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/batchUpdate for all request types. " +
+          "Required fields for common requests: " +
+          "insertText: {text, location: {index}}; " +
+          "deleteContentRange: {range: {startIndex, endIndex}}; " +
+          "replaceAllText: {containsText: {text}, replaceText}; " +
+          "insertTable: {rows, columns, location: {index}}; " +
+          "updateTextStyle: {range: {startIndex, endIndex}, textStyle, fields}."
       ),
     },
     stake: "medium",


### PR DESCRIPTION
## Description

The update_document requests field now includes a quick reference of required parameters for the five most common request types (insertText, deleteContentRange, replaceAllText, insertTable, updateTextStyle). GoogleDocsRequestSchema exposes 30+ optional request types in a single object; without a cheat sheet the model tends to search through the full schema during thinking rather than calling the tool directly.

The copy_file description now mentions template use as the preferred scenario, so the model does not deliberate between copy and create from scratch when the intent is to reuse structure or formatting.

Comes from convo: Yv0QMuALRb

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 