### PR TITLE
feat: autoscroll to validation card

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1108,6 +1108,22 @@ export const ConversationViewer = ({
             : m
         );
 
+        // When there are pending user mentions, MentionValidationRequired
+        // renders below the user message — scroll to the bottom so the action
+        // card is visible.
+        const hasPendingMentions = messageFromBackend.richMentions?.some(
+          (m) =>
+            m.status === "pending_conversation_access" ||
+            m.status === "pending_project_membership"
+        );
+        if (hasPendingMentions) {
+          virtuosoMessageListRef.current.scrollToItem({
+            index: "LAST",
+            align: "end",
+            behavior: customSmoothScroll,
+          });
+        }
+
         void mutateConversations(
           (currentData: ConversationListItemType[] | undefined) =>
             currentData?.map((c) =>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7923

This PR adds automatic scrolling to display validation cards when users mention someone requiring conversation access or project membership approval. 

https://github.com/user-attachments/assets/ca798219-055d-4bf5-b919-83ad53ccf93d


## Tests

Manually

## Risks

Low - isolated change that only affects scroll behavior when specific pending mention statuses are present.

## Deploy Plan

Standard deployment - no special steps required.
