### PR TITLE
[CONVERSATIONS] Register creator as participant on conversation creation

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -295,6 +295,15 @@ async function handler(
         metadata,
       });
 
+      // Register the creator as a participant immediately so that access checks
+      // relying on participation (e.g. "private conversation URLs by default") pass
+      // before the first message is posted.
+      await ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "subscribed",
+        user: user.toJSON() ?? null,
+      });
+
       const newContentFragments: ContentFragmentType[] = [];
       let newMessage: UserMessageType | null = null;
 


### PR DESCRIPTION
## Description

fixes https://github.com/orgs/dust-tt/projects/2/views/1?pane=issue&itemId=183830903&issue=dust-tt%7Ctasks%7C7967

When a conversation is created, immediately register the creator as a participant (subscribed) so that participation-based access checks pass before any message is posted.

## Tests

Tested manually by creating a conversation and verifying access is granted without needing to post a first message.

## Risk

Low — additive call only; `upsertParticipation` is idempotent and already called on message post, so this is a no-op for existing flows where a message follows immediately.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`