### PR TITLE
feat: skip new conversation notification for todo conversations

### DIFF
--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -94,6 +94,11 @@ const triggerProjectNewConversationNotifications = async (
     return new Ok(undefined);
   }
 
+  // Skip notification for conversations created from a todo.
+  if (conversation.metadata?.projectTodoId) {
+    return new Ok(undefined);
+  }
+
   const userThatCreatedConversation = auth.user();
 
   // If no user context (e.g., API call without specific user), skip notification.

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -445,6 +445,7 @@ export const CONVERSATION_METADATA_URL_ACCESS_MODE_KEY = "urlAccessMode";
 
 export type ConversationMetadata = Record<string, unknown> & {
   urlAccessMode?: ConversationUrlAccessMode;
+  projectTodoId?: string;
 };
 
 export function isConversationUrlAccessMode(


### PR DESCRIPTION
## Description

This PR prevents new conversation notifications from being sent when conversations are created from project todos.

- Added `projectTodoId` field to `ConversationMetadata` type definition for type safety
- Added early return in `triggerProjectNewConversationNotifications` to skip notification when `conversation.metadata.projectTodoId` is present

## Tests

Manually

## Risks

None

## Deploy Plan

Standard deployment
