### PR TITLE
Use native scroll in FilePreviewDialog for mobile touch support

### DIFF
--- a/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
@@ -22,9 +22,7 @@ import {
   DialogTitle,
   Icon,
   Markdown,
-  ScrollArea,
   ScrollableDataTable,
-  ScrollBar,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
@@ -396,7 +394,7 @@ export function FilePreviewDialog({
             )}
           </div>
         ) : (
-          <ScrollArea className="min-h-0 flex-1 overflow-x-hidden px-4">
+          <div className="min-h-0 flex-1 overflow-y-auto px-4">
             {entry && (
               <FilePreviewDialogContent
                 category={category}
@@ -408,8 +406,7 @@ export function FilePreviewDialog({
                 processedContent={processedContent}
               />
             )}
-            <ScrollBar />
-          </ScrollArea>
+          </div>
         )}
         <DialogFooter className="px-4">
           <Button


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR replaces Radix UI `ScrollArea` (custom JS-driven scrollbar) with a plain `div` `overflow-y-auto` in the file preview dialog to fix mobile touch scrolling.

<img width="378" height="670" alt="PreviewScroll" src="https://github.com/user-attachments/assets/f929db6e-4caa-4d4c-b004-b92c89abcf20" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
