### PR TITLE
Use "sensitivity_labels" FF in MCP tools

### DIFF
--- a/front/lib/api/actions/servers/microsoft/utils.ts
+++ b/front/lib/api/actions/servers/microsoft/utils.ts
@@ -2,6 +2,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { untrustedFetch } from "@app/lib/egress/server";
 import { WorkspaceSensitivityLabelConfigResource } from "@app/lib/resources/workspace_sensitivity_label_config_resource";
 import logger from "@app/logger/logger";
@@ -137,6 +138,11 @@ export async function getAllowedLabelsForMCPServer(
       : null;
 
   if (!internalMCPServerId) {
+    return [];
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("sensitivity_labels")) {
     return [];
   }
 


### PR DESCRIPTION
## Description

Adds a feature flag check for `sensitivity_labels` before retrieving allowed labels for MCP servers. This ensures that the `getAllowedLabelsForMCPServer` function only fetches sensitivity label configurations when the feature is enabled for the workspace, returning an empty array otherwise.

## Tests

Manually tested with the feature flag enabled and disabled.

## Risk

None. This is an additive check that gates an existing feature behind a feature flag.

## Deploy Plan

Deploy front