### PR TITLE
fix(projects): handle multiple source-linked todos per action item in merge flow

### DIFF
--- a/front/lib/project_todo/merge_into_project.test.ts
+++ b/front/lib/project_todo/merge_into_project.test.ts
@@ -1,17 +1,23 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
   actionItemBlob,
+  collectDocumentCandidates,
   updateTodoIfChanged,
 } from "@app/lib/project_todo/merge_into_project";
-import type { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import type { TakeawaysWithSource } from "@app/lib/resources/takeaways_resource";
+import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type {
   ProjectTodoActorType,
+  ProjectTodoSourceInfo,
   ProjectTodoStatus,
 } from "@app/types/project_todo";
 import type { TodoVersionedActionItem } from "@app/types/takeaways";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// ── Fixtures ──────────────────────────────────────────────────────────────────
+// ── Shared fixtures ───────────────────────────────────────────────────────────
 
 function makeActionItem(
   overrides: Partial<TodoVersionedActionItem> = {}
@@ -25,6 +31,18 @@ function makeActionItem(
     detectedDoneAt: null,
     detectedDoneRationale: null,
     detectedCreationRationale: null,
+    ...overrides,
+  };
+}
+
+function makeSource(
+  overrides: Partial<ProjectTodoSourceInfo> = {}
+): ProjectTodoSourceInfo {
+  return {
+    sourceType: "slack",
+    sourceId: "conv-test-1",
+    sourceTitle: "Test Conversation",
+    sourceUrl: null,
     ...overrides,
   };
 }
@@ -60,6 +78,211 @@ describe("actionItemBlob", () => {
       makeActionItem({ shortDescription: "Deploy to prod" })
     );
     expect(blob.text).toBe("Deploy to prod");
+  });
+});
+
+// ── collectDocumentCandidates ─────────────────────────────────────────────────
+
+describe("collectDocumentCandidates", () => {
+  let auth: Authenticator;
+  let user: UserResource;
+  let usersById: Map<string, UserResource>;
+  let takeawayBase: TakeawaysResource;
+  let source: ProjectTodoSourceInfo;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({ role: "user" });
+    auth = setup.authenticator;
+    user = setup.user;
+    usersById = new Map([[user.sId, user]]);
+    source = makeSource();
+    takeawayBase = await TakeawaysResource.makeNew(auth, {
+      spaceId: setup.globalSpace.id,
+      actionItems: [],
+    });
+  });
+
+  function makeTakeawayWithSource(
+    actionItems: TodoVersionedActionItem[]
+  ): TakeawaysWithSource {
+    // Reuse takeawayBase with a fresh actionItems list by spreading into a
+    // plain wrapper. collectDocumentCandidates reads `.takeaway.actionItems`
+    // and `.source`, nothing else.
+    return {
+      takeaway: Object.assign(Object.create(takeawayBase), {
+        actionItems,
+      }) as TakeawaysResource,
+      source,
+    };
+  }
+
+  it("returns the action item as a new candidate when no existing todo is linked", async () => {
+    const tws = makeTakeawayWithSource([
+      makeActionItem({
+        sId: "item-new",
+        assigneeUserId: user.sId,
+        status: "open",
+      }),
+    ]);
+
+    const { candidates, existingUpdated } = await collectDocumentCandidates(
+      auth,
+      { takeawayWithSource: tws, usersById }
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].itemId).toBe("item-new");
+    expect(existingUpdated).toBe(0);
+  });
+
+  it("updates the existing agent-created todo and returns no candidate when status changed", async () => {
+    const todo = await ProjectTodoResource.makeNew(auth, {
+      spaceId: takeawayBase.spaceId,
+      userId: user.id,
+      createdByType: "agent",
+      createdByUserId: null,
+      createdByAgentConfigurationId: "butler",
+      markedAsDoneByType: null,
+      markedAsDoneByUserId: null,
+      markedAsDoneByAgentConfigurationId: null,
+      text: "Write the report",
+      status: "todo",
+      doneAt: null,
+      actorRationale: null,
+      agentInstructions: null,
+    });
+    await todo.upsertSource(auth, { itemId: "item-existing", source });
+
+    const tws = makeTakeawayWithSource([
+      makeActionItem({
+        sId: "item-existing",
+        assigneeUserId: user.sId,
+        status: "done",
+        detectedDoneAt: "2026-05-01T10:00:00.000Z",
+      }),
+    ]);
+
+    const { candidates, existingUpdated } = await collectDocumentCandidates(
+      auth,
+      { takeawayWithSource: tws, usersById }
+    );
+
+    expect(candidates).toHaveLength(0);
+    expect(existingUpdated).toBe(1);
+    const refreshed = await ProjectTodoResource.fetchBySId(auth, todo.sId);
+    expect(refreshed?.status).toBe("done");
+  });
+
+  it("skips entirely when multiple existing todos are present and any is done", async () => {
+    const spaceId = takeawayBase.spaceId;
+    const agentBlob = {
+      spaceId,
+      userId: user.id,
+      createdByType: "agent" as const,
+      createdByUserId: null,
+      createdByAgentConfigurationId: "butler",
+      markedAsDoneByType: null,
+      markedAsDoneByUserId: null,
+      markedAsDoneByAgentConfigurationId: null,
+      text: "Multi item",
+      status: "todo" as const,
+      doneAt: null,
+      actorRationale: null,
+      agentInstructions: null,
+    };
+
+    const doneTodo = await ProjectTodoResource.makeNew(auth, {
+      ...agentBlob,
+      status: "done",
+      doneAt: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    await doneTodo.upsertSource(auth, {
+      itemId: "item-multi-done",
+      source: { ...source, sourceId: "src-done" },
+    });
+
+    const openTodo = await ProjectTodoResource.makeNew(auth, agentBlob);
+    await openTodo.upsertSource(auth, {
+      itemId: "item-multi-done",
+      source: { ...source, sourceId: "src-open" },
+    });
+
+    const tws = makeTakeawayWithSource([
+      makeActionItem({
+        sId: "item-multi-done",
+        assigneeUserId: user.sId,
+        status: "done",
+        detectedDoneAt: "2026-05-01T00:00:00.000Z",
+      }),
+    ]);
+
+    const { candidates, existingUpdated } = await collectDocumentCandidates(
+      auth,
+      { takeawayWithSource: tws, usersById }
+    );
+
+    expect(candidates).toHaveLength(0);
+    expect(existingUpdated).toBe(0);
+  });
+
+  it("updates only the most recently created todo when multiple exist and none is done", async () => {
+    const spaceId = takeawayBase.spaceId;
+    const agentBlob = {
+      spaceId,
+      userId: user.id,
+      createdByType: "agent" as const,
+      createdByUserId: null,
+      createdByAgentConfigurationId: "butler",
+      markedAsDoneByType: null,
+      markedAsDoneByUserId: null,
+      markedAsDoneByAgentConfigurationId: null,
+      text: "Multi open item",
+      status: "todo" as const,
+      doneAt: null,
+      actorRationale: null,
+      agentInstructions: null,
+    };
+
+    const olderTodo = await ProjectTodoResource.makeNew(auth, agentBlob);
+    await olderTodo.upsertSource(auth, {
+      itemId: "item-multi-open",
+      source: { ...source, sourceId: "src-older" },
+    });
+
+    const newerTodo = await ProjectTodoResource.makeNew(auth, agentBlob);
+    await newerTodo.upsertSource(auth, {
+      itemId: "item-multi-open",
+      source: { ...source, sourceId: "src-newer" },
+    });
+
+    const tws = makeTakeawayWithSource([
+      makeActionItem({
+        sId: "item-multi-open",
+        assigneeUserId: user.sId,
+        status: "done",
+        detectedDoneAt: "2026-05-01T00:00:00.000Z",
+      }),
+    ]);
+
+    const { candidates, existingUpdated } = await collectDocumentCandidates(
+      auth,
+      { takeawayWithSource: tws, usersById }
+    );
+
+    expect(candidates).toHaveLength(0);
+    expect(existingUpdated).toBe(1);
+
+    const olderRefreshed = await ProjectTodoResource.fetchBySId(
+      auth,
+      olderTodo.sId
+    );
+    const newerRefreshed = await ProjectTodoResource.fetchBySId(
+      auth,
+      newerTodo.sId
+    );
+    // The newer todo (higher createdAt) should have been updated to done.
+    expect(newerRefreshed?.status).toBe("done");
+    expect(olderRefreshed?.status).toBe("todo");
   });
 });
 

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -42,7 +42,10 @@ import {
   type DeduplicatedGroup,
   type ExistingTodosByUser,
 } from "@app/lib/project_todo/deduplicate_candidates";
-import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
+import {
+  ProjectTodoResource,
+  type TodosByItemId,
+} from "@app/lib/resources/project_todo_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import {
   TakeawaysResource,
@@ -63,6 +66,9 @@ const BUTLER_AGENT_SID = "butler";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+// Outer key: userId (ModelId), inner key: itemId (action item sId).
+type PendingByUserId = Map<ModelId, Map<string, PendingCandidate>>;
+
 type TodoBlob = {
   text: string;
   status: "todo" | "done";
@@ -73,7 +79,7 @@ type TodoBlob = {
 
 // A candidate todo that has no existing source link yet and therefore needs to
 // go through the deduplication check before being created or linked.
-type PendingCandidate = {
+export type PendingCandidate = {
   itemId: string;
   userId: ModelId;
   blob: TodoBlob;
@@ -222,7 +228,7 @@ async function collectNewCandidates(
 
 // Processes one document's takeaway: updates todos whose source link already
 // exists and returns items that need to go through dedup + creation.
-async function collectDocumentCandidates(
+export async function collectDocumentCandidates(
   auth: Authenticator,
   {
     takeawayWithSource,
@@ -255,32 +261,42 @@ async function collectDocumentCandidates(
   // Batch-fetch existing todos by itemId. A hit means "this item is already
   // linked to a todo — skip dedup".
   const allActionItemIds = actionItems.map((t) => t.itemId);
-  const existingByKey = await ProjectTodoResource.fetchByItemIds(auth, {
-    itemIds: allActionItemIds,
-  });
+  const existingByItemId: TodosByItemId =
+    await ProjectTodoResource.fetchByItemIds(auth, {
+      itemIds: allActionItemIds,
+    });
 
   const candidates: PendingCandidate[] = [];
   let existingUpdated = 0;
   for (const { itemId, targetUserIds, blob: actionItemBlob } of actionItems) {
     for (const userId of targetUserIds) {
-      const existing = existingByKey.get(itemId) ?? null;
-      if (existing !== null) {
-        // Source link exists — update content if it has changed.
-        const updated = await updateTodoIfChanged(
-          existing,
-          auth,
-          actionItemBlob
-        );
-        if (updated) {
-          existingUpdated++;
-        }
-      } else {
+      const existing = existingByItemId.get(itemId)?.get(userId) ?? [];
+      if (existing.length === 0) {
         candidates.push({
           itemId,
           userId,
           blob: actionItemBlob,
           source: takeawayWithSource.source,
         });
+      } else if (
+        existing.length > 1 &&
+        existing.some((t) => t.status === "done")
+      ) {
+        // Multiple existing todos with at least one done — skip.
+      } else {
+        // Source link exists — update content if it has changed. When there
+        // are multiple undone todos, prefer the most recently created one.
+        const targetTodo = existing.reduce((a, b) =>
+          a.createdAt >= b.createdAt ? a : b
+        );
+        const updated = await updateTodoIfChanged(
+          targetTodo,
+          auth,
+          actionItemBlob
+        );
+        if (updated) {
+          existingUpdated++;
+        }
       }
     }
   }
@@ -305,20 +321,18 @@ async function buildDeduplicationGroups(
     spaceModelId: ModelId;
   }
 ): Promise<DeduplicatedGroup[]> {
-  const deduplicateCandidates: DeduplicateCandidate[] = newCandidates.map(
-    (c) => ({
-      itemId: c.itemId,
-      userId: c.userId,
-      text: c.blob.text,
-    })
-  );
+  const dedupInput: DeduplicateCandidate[] = newCandidates.map((c) => ({
+    itemId: c.itemId,
+    userId: c.userId,
+    text: c.blob.text,
+  }));
 
   const model = getSmallWhitelistedModel(auth);
   if (!model) {
     localLogger.warn(
       "Project todo merge: no whitelisted model, skipping deduplication"
     );
-    return deduplicateCandidates.map((c) => ({ kind: "new", candidates: [c] }));
+    return dedupInput.map((c) => ({ kind: "new", candidates: [c] }));
   }
 
   // Fetch all existing todos for each unique target user in a single pass,
@@ -348,7 +362,7 @@ async function buildDeduplicationGroups(
 
   return batchDeduplicateCandidates(auth, {
     model,
-    candidates: deduplicateCandidates,
+    candidates: dedupInput,
     existingTodosByUser,
   });
 }
@@ -376,16 +390,16 @@ async function createOrLinkTodos(
 
   // Dedup groups reference candidates by (userId, itemId); fetch the original
   // PendingCandidate (with blob + source) by that pair.
-  const pendingByUserItem = new Map<ModelId, Map<string, PendingCandidate>>();
+  const pendingByUserId: PendingByUserId = new Map();
   for (const c of newCandidates) {
     const inner =
-      pendingByUserItem.get(c.userId) ?? new Map<string, PendingCandidate>();
+      pendingByUserId.get(c.userId) ?? new Map<string, PendingCandidate>();
     inner.set(c.itemId, c);
-    pendingByUserItem.set(c.userId, inner);
+    pendingByUserId.set(c.userId, inner);
   }
 
   function lookupPending(c: DeduplicateCandidate): PendingCandidate | null {
-    return pendingByUserItem.get(c.userId)?.get(c.itemId) ?? null;
+    return pendingByUserId.get(c.userId)?.get(c.itemId) ?? null;
   }
 
   await concurrentExecutor(

--- a/front/lib/resources/project_todo_resource.test.ts
+++ b/front/lib/resources/project_todo_resource.test.ts
@@ -490,6 +490,145 @@ describe("ProjectTodoResource", () => {
     });
   });
 
+  describe("fetchByItemIds", () => {
+    it("returns an empty map when no itemIds are provided", async () => {
+      const result = await ProjectTodoResource.fetchByItemIds(auth, {
+        itemIds: [],
+      });
+      expect(result.size).toBe(0);
+    });
+
+    it("returns an empty map when none of the itemIds are linked", async () => {
+      const result = await ProjectTodoResource.fetchByItemIds(auth, {
+        itemIds: ["ghost-item-1", "ghost-item-2"],
+      });
+      expect(result.size).toBe(0);
+    });
+
+    it("returns a single-element array when one todo is linked to an itemId", async () => {
+      const todo = await ProjectTodoResource.makeNewWithSource(auth, {
+        blob: makeTodoBlob(space.id, user.id),
+        itemId: "item-single",
+        source: {
+          sourceType: "slack",
+          sourceId: "src-A",
+          sourceTitle: null,
+          sourceUrl: null,
+        },
+      });
+
+      const result = await ProjectTodoResource.fetchByItemIds(auth, {
+        itemIds: ["item-single"],
+      });
+
+      const todos = result.get("item-single")?.get(user.id);
+      expect(todos).toHaveLength(1);
+      expect(todos?.[0].sId).toBe(todo.sId);
+    });
+
+    it("wraps the linked todo in a single-element array", async () => {
+      const todo = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id)
+      );
+      await todo.upsertSource(auth, {
+        itemId: "item-array-check",
+        source: {
+          sourceType: "slack",
+          sourceId: "src-Z",
+          sourceTitle: null,
+          sourceUrl: null,
+        },
+      });
+
+      const result = await ProjectTodoResource.fetchByItemIds(auth, {
+        itemIds: ["item-array-check"],
+      });
+
+      const todos = result.get("item-array-check")?.get(user.id);
+      expect(Array.isArray(todos)).toBe(true);
+      expect(todos).toHaveLength(1);
+      expect(todos?.[0].sId).toBe(todo.sId);
+    });
+
+    it("returns an array with multiple todos when several todos are linked to the same itemId and userId", async () => {
+      const todo1 = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id, { text: "First" })
+      );
+      await todo1.upsertSource(auth, {
+        itemId: "item-multi",
+        source: {
+          sourceType: "slack",
+          sourceId: "src-A",
+          sourceTitle: null,
+          sourceUrl: null,
+        },
+      });
+
+      const todo2 = await ProjectTodoResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id, { text: "Second" })
+      );
+      await todo2.upsertSource(auth, {
+        itemId: "item-multi",
+        source: {
+          sourceType: "slack",
+          sourceId: "src-B",
+          sourceTitle: null,
+          sourceUrl: null,
+        },
+      });
+
+      const result = await ProjectTodoResource.fetchByItemIds(auth, {
+        itemIds: ["item-multi"],
+      });
+
+      const todos = result.get("item-multi")?.get(user.id) ?? [];
+      expect(todos).toHaveLength(2);
+      const sIds = todos.map((t) => t.sId).sort();
+      expect(sIds).toContain(todo1.sId);
+      expect(sIds).toContain(todo2.sId);
+    });
+
+    it("keeps todos from different users under separate keys in the inner map", async () => {
+      const otherSetup = await createResourceTest({ role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherSetup.user.sId,
+        workspace.sId
+      );
+
+      await ProjectTodoResource.makeNewWithSource(auth, {
+        blob: makeTodoBlob(space.id, user.id),
+        itemId: "item-two-users",
+        source: {
+          sourceType: "slack",
+          sourceId: "src-user1",
+          sourceTitle: null,
+          sourceUrl: null,
+        },
+      });
+      await ProjectTodoResource.makeNewWithSource(otherAuth, {
+        blob: makeTodoBlob(space.id, otherSetup.user.id),
+        itemId: "item-two-users",
+        source: {
+          sourceType: "slack",
+          sourceId: "src-user2",
+          sourceTitle: null,
+          sourceUrl: null,
+        },
+      });
+
+      const result = await ProjectTodoResource.fetchByItemIds(auth, {
+        itemIds: ["item-two-users"],
+      });
+
+      const byUser = result.get("item-two-users");
+      expect(byUser?.get(user.id)).toHaveLength(1);
+      expect(byUser?.get(otherSetup.user.id)).toHaveLength(1);
+    });
+  });
+
   describe("delete", () => {
     it("should delete the todo so fetchBySId returns null afterwards", async () => {
       const todo = await ProjectTodoResource.makeNew(

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -30,6 +30,10 @@ import {
   type Transaction,
 } from "sequelize";
 
+// Return type of fetchByItemIds: outer key is itemId (action item sId), inner
+// key is userId (ModelId).
+export type TodosByItemId = Map<string, Map<ModelId, ProjectTodoResource[]>>;
+
 type ProjectTodoVersionCreationAttributes =
   CreationAttributes<ProjectTodoModel> & {
     projectTodoId: ModelId;
@@ -432,7 +436,7 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
   static async fetchByItemIds(
     auth: Authenticator,
     { itemIds }: { itemIds: string[] }
-  ): Promise<Map<string, ProjectTodoResource>> {
+  ): Promise<Map<string, Map<ModelId, ProjectTodoResource[]>>> {
     if (itemIds.length === 0) {
       return new Map();
     }
@@ -458,13 +462,19 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
       linkedRows.map((t) => [t.id, t])
     );
 
-    const result = new Map<string, ProjectTodoResource>();
+    const result: TodosByItemId = new Map();
     for (const source of sources) {
       const todo = rowById.get(source.projectTodoId);
       if (!todo) {
         continue;
       }
-      result.set(source.itemId, todo);
+      const byUser =
+        result.get(source.itemId) ?? new Map<ModelId, ProjectTodoResource[]>();
+      const userId = todo.userId;
+      if (userId !== null) {
+        byUser.set(userId, [...(byUser.get(userId) ?? []), todo]);
+      }
+      result.set(source.itemId, byUser);
     }
 
     return result;


### PR DESCRIPTION
## Description

Two related fixes to the project-todo merge flow:

1. **`fetchByItemIds` bug**: The method was grouping todos by `source.userId`, but `ProjectTodoSourceModel` has no `userId` field — the user ID lives on the todo itself. Fixed to use `todo.userId`, which makes the `Map<itemId, Map<userId, todos[]>>` structure work correctly.

2. **`collectDocumentCandidates` multi-todo logic**: When an action item is linked to more than one existing todo (can happen when the same item appears across multiple sources), the function now applies a policy: if any of the linked todos is already done → skip the item entirely; if all are open → update only the most recently created one. Previously, `fetchByItemIds` was returning `ProjectTodoResource` (not an array), so this scenario was invisible.


## Tests

New integration tests added:
- `collectDocumentCandidates` 
- `fetchByItemIds`
