### PR TITLE
[front] enh: add pptx skill with slide inspection tool

### DIFF
--- a/front/lib/api/sandbox/image/profile/anthropic.sh
+++ b/front/lib/api/sandbox/image/profile/anthropic.sh
@@ -9,4 +9,5 @@ grep_files()   { run_dust_tool --profile anthropic grep_files "$@"; }
 glob()         { run_dust_tool --profile anthropic glob "$@"; }
 list_dir()     { run_dust_tool --profile anthropic list_dir "$@"; }
 xlsx_inspect() { /opt/venv/bin/python3 "$SCRIPT_DIR/soffice/xlsx_inspect.py" "$@"; }
-export -f read_file write_file edit_file grep_files glob list_dir xlsx_inspect
+pptx_inspect() { /opt/venv/bin/python3 "$SCRIPT_DIR/soffice/pptx_inspect.py" "$@"; }
+export -f read_file write_file edit_file grep_files glob list_dir xlsx_inspect pptx_inspect

--- a/front/lib/api/sandbox/image/profile/gemini.sh
+++ b/front/lib/api/sandbox/image/profile/gemini.sh
@@ -9,4 +9,5 @@ grep_files()   { run_dust_tool --profile gemini grep_files "$@"; }
 glob()         { run_dust_tool --profile gemini glob "$@"; }
 list_dir()     { run_dust_tool --profile gemini list_dir "$@"; }
 xlsx_inspect() { /opt/venv/bin/python3 "$SCRIPT_DIR/soffice/xlsx_inspect.py" "$@"; }
-export -f read_file write_file edit_file grep_files glob list_dir xlsx_inspect
+pptx_inspect() { /opt/venv/bin/python3 "$SCRIPT_DIR/soffice/pptx_inspect.py" "$@"; }
+export -f read_file write_file edit_file grep_files glob list_dir xlsx_inspect pptx_inspect

--- a/front/lib/api/sandbox/image/profile/openai.sh
+++ b/front/lib/api/sandbox/image/profile/openai.sh
@@ -8,4 +8,5 @@ grep_files()   { run_dust_tool --profile openai grep_files "$@"; }
 glob()         { run_dust_tool --profile openai glob "$@"; }
 list_dir()     { run_dust_tool --profile openai list_dir "$@"; }
 xlsx_inspect() { /opt/venv/bin/python3 "$SCRIPT_DIR/soffice/xlsx_inspect.py" "$@"; }
-export -f read_file write_file grep_files glob list_dir xlsx_inspect
+pptx_inspect() { /opt/venv/bin/python3 "$SCRIPT_DIR/soffice/pptx_inspect.py" "$@"; }
+export -f read_file write_file grep_files glob list_dir xlsx_inspect pptx_inspect

--- a/front/lib/api/sandbox/image/profile/soffice/pptx_inspect.py
+++ b/front/lib/api/sandbox/image/profile/soffice/pptx_inspect.py
@@ -1,0 +1,1210 @@
+#!/opt/venv/bin/python3
+"""pptx_inspect — paginated structural inspection of .pptx decks.
+
+Backed by python-pptx for slide/shape/placeholder/text traversal; the
+shared `ooxml` helpers and stdlib `zipfile` are used for chart titles
+and embedded media listing where python-pptx is awkward or silent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple
+
+import ooxml
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+from pptx.presentation import Presentation as PresentationType
+from pptx.shapes.base import BaseShape
+from pptx.slide import Slide
+
+A_NS = ooxml.NS["a"]
+P_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+THEME_NS = {"a": A_NS, "p": P_NS}
+
+MAX_OUTPUT_BYTES = 48_000
+DEFAULT_MAX_SHAPES = 200
+TEXT_PREVIEW_LIMIT = 80
+EMU_PER_INCH = 914_400
+EDGE_EPSILON_EMU = 45_720  # 0.05" tolerance before flagging edge overflow.
+
+# Glyphs commonly typed as manual bullets at the start of a paragraph. When
+# they appear inside a placeholder whose layout already renders a bullet,
+# the result is a doubled marker ("● • text"); see the bullet-glyph lint.
+BULLET_PREFIXES = ("•", "·", "*", "-", "–")
+
+
+class SlideContext(NamedTuple):
+    width_emu: int
+    height_emu: int
+
+USAGE = (
+    "pptx_inspect <file> [--slide N] [--layouts] [--text] [--media] "
+    "[--render] [--max-shapes N] [--offset N]"
+)
+
+HELP_TEXT = (
+    "pptx_inspect - Inspect .pptx deck structure\n"
+    "\n"
+    f"Usage: {USAGE}\n"
+    "\n"
+    "Arguments:\n"
+    "  file              Path to .pptx deck (required)\n"
+    "\n"
+    "Options:\n"
+    "  --slide N         Show one slide's shapes (1-indexed): kind, position,\n"
+    "                    size, text, formatting, placeholder type.\n"
+    "  --layouts         List slide masters and their layouts with placeholder slots,\n"
+    "                    including each placeholder's resolved default typeface,\n"
+    "                    size, weight, color, and alignment (from layout / master /\n"
+    "                    theme inheritance).\n"
+    "  --text            Extract readable text per slide (preserves slide/shape boundaries).\n"
+    "  --media           List embedded media (images, audio, video) with file sizes.\n"
+    "  --render          Rasterize slides to JPEG (100 dpi) via LibreOffice + pdftoppm.\n"
+    "                    Outputs to /tmp/pptx_render/<deck>/slide-NNN.jpg and prints\n"
+    "                    one absolute path per slide. Combine with --slide N to\n"
+    "                    render just one slide for fast post-fix re-checks.\n"
+    "  --max-shapes N    Maximum shapes to print in slide view (default 200).\n"
+    "  --offset N        Skip first N shapes in slide view (default 0).\n"
+    "\n"
+    "Output (slide view, one shape per line, paragraphs indented):\n"
+    "  <id>  <kind>  <left,top inWxinH>  [ph=<type>]  <summary>\n"
+    "    p<level>: <text>  [<font hints>]\n"
+    "Empty shapes are skipped; long text is ellipsized."
+)
+
+
+def ellipsize(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def pad(text: str, width: int) -> str:
+    if len(text) >= width:
+        return text
+    return text + " " * (width - len(text))
+
+
+def format_size(num_bytes: int) -> str:
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+    if num_bytes < 1024 * 1024:
+        return f"{num_bytes / 1024:.1f} KB"
+    return f"{num_bytes / (1024 * 1024):.1f} MB"
+
+
+def emu_to_inches(emu: Optional[int]) -> Optional[float]:
+    if emu is None:
+        return None
+    return emu / EMU_PER_INCH
+
+
+def format_box(shape: BaseShape) -> str:
+    left = emu_to_inches(shape.left)
+    top = emu_to_inches(shape.top)
+    width = emu_to_inches(shape.width)
+    height = emu_to_inches(shape.height)
+    if None in (left, top, width, height):
+        return "(?,?)"
+    return f"({left:.1f},{top:.1f}) {width:.1f}x{height:.1f}\""
+
+
+def shape_kind(shape: BaseShape) -> str:
+    if shape.has_chart:
+        return "chart"
+    if shape.has_table:
+        return "table"
+    st = shape.shape_type
+    if st == MSO_SHAPE_TYPE.PICTURE:
+        return "pic"
+    if st == MSO_SHAPE_TYPE.GROUP:
+        return "group"
+    if st == MSO_SHAPE_TYPE.TEXT_BOX:
+        return "text"
+    if st == MSO_SHAPE_TYPE.PLACEHOLDER:
+        return "ph"
+    if st == MSO_SHAPE_TYPE.AUTO_SHAPE:
+        return "auto"
+    if st == MSO_SHAPE_TYPE.LINE:
+        return "line"
+    if st == MSO_SHAPE_TYPE.FREEFORM:
+        return "free"
+    if st == MSO_SHAPE_TYPE.MEDIA:
+        return "media"
+    name = getattr(st, "name", None)
+    return name.lower() if name else "shape"
+
+
+def placeholder_type(shape: BaseShape) -> Optional[str]:
+    if not getattr(shape, "is_placeholder", False):
+        return None
+    # `placeholder_format` raises ValueError on non-placeholder shapes,
+    # which we already filtered out above.
+    pf = shape.placeholder_format
+    t = getattr(pf, "type", None)
+    if t is None:
+        return None
+    name = getattr(t, "name", None)
+    return name.lower() if name else None
+
+
+def font_argb(run) -> Optional[str]:
+    font = getattr(run, "font", None)
+    if font is None:
+        return None
+    color = getattr(font, "color", None)
+    if color is None:
+        return None
+    # color.rgb raises AttributeError when the color is theme-based
+    # rather than explicit RGB; we treat both as "not set".
+    try:
+        rgb = color.rgb
+    except (AttributeError, TypeError, ValueError):
+        return None
+    if rgb is None:
+        return None
+    return str(rgb).upper()
+
+
+# ---------------------------------------------------------------------------
+# Theme / placeholder default resolution.
+#
+# python-pptx does not surface the effective typography of an empty layout
+# placeholder — that information lives in the layout's <a:lstStyle>, falling
+# back to the master's matching placeholder, the master's titleStyle /
+# bodyStyle / otherStyle, and finally the theme's major/minor font + color
+# scheme. The helpers below walk that chain directly off the zip so we can
+# print "this title placeholder defaults to Lexend 28pt bold #F8FAFC".
+# ---------------------------------------------------------------------------
+
+
+def _q(local: str) -> str:
+    return f"{{{A_NS}}}{local}"
+
+
+def _qp(local: str) -> str:
+    return f"{{{P_NS}}}{local}"
+
+
+def _read_clr_map(master_xml) -> Dict[str, str]:
+    """Map placeholder color tokens (bg1, tx1, accent1...) to theme tokens
+    (lt1/dk1/accent1...) via the master's <p:clrMap>."""
+    if master_xml is None:
+        return {}
+    clr_map = master_xml.find(_qp("clrMap"))
+    if clr_map is None:
+        return {}
+    return {k: v for k, v in clr_map.attrib.items() if not k.startswith("{")}
+
+
+def _theme_color_table(theme_xml) -> Dict[str, str]:
+    """Return {scheme-token: 6-hex} for the theme's color scheme."""
+    if theme_xml is None:
+        return {}
+    out: Dict[str, str] = {}
+    scheme = theme_xml.find(f"{_q('themeElements')}/{_q('clrScheme')}")
+    if scheme is None:
+        return out
+    for child in scheme:
+        token = child.tag.split("}", 1)[-1]
+        srgb = child.find(_q("srgbClr"))
+        if srgb is not None:
+            out[token] = srgb.attrib.get("val", "").upper()
+            continue
+        sysclr = child.find(_q("sysClr"))
+        if sysclr is not None:
+            # lastClr is the resolved value the system color uses.
+            out[token] = sysclr.attrib.get("lastClr", "").upper()
+    return out
+
+
+def _resolve_scheme_color(
+    scheme_token: str,
+    clr_map: Dict[str, str],
+    theme_colors: Dict[str, str],
+) -> Optional[str]:
+    target = clr_map.get(scheme_token, scheme_token)
+    hex_val = theme_colors.get(target)
+    return hex_val or None
+
+
+def _solid_fill_hex(
+    elem,
+    clr_map: Dict[str, str],
+    theme_colors: Dict[str, str],
+) -> Optional[str]:
+    """Resolve <a:solidFill> on a defRPr-like element to a 6-hex color."""
+    if elem is None:
+        return None
+    fill = elem.find(_q("solidFill"))
+    if fill is None:
+        return None
+    srgb = fill.find(_q("srgbClr"))
+    if srgb is not None:
+        return srgb.attrib.get("val", "").upper() or None
+    scheme = fill.find(_q("schemeClr"))
+    if scheme is not None:
+        return _resolve_scheme_color(scheme.attrib.get("val", ""), clr_map, theme_colors)
+    return None
+
+
+def _theme_font(theme_xml, kind: str) -> Optional[str]:
+    """kind is 'major' or 'minor'. Returns the latin typeface."""
+    if theme_xml is None:
+        return None
+    latin = theme_xml.find(
+        f"{_q('themeElements')}/{_q('fontScheme')
+                                 }/{_q(kind + 'Font')}/{_q('latin')}"
+    )
+    if latin is None:
+        return None
+    return latin.attrib.get("typeface") or None
+
+
+def _ph_type_default_kind(ph_type: Optional[str]) -> str:
+    """Pick which master *Style block applies when nothing else matches."""
+    if ph_type in ("title", "ctrtitle", "ctr_title", "center_title"):
+        return "title"
+    if ph_type in ("body", "subtitle", "subTitle", "obj"):
+        return "body"
+    return "other"
+
+
+def _find_ph_sp(parent, ph_idx: Optional[int], ph_type: Optional[str]):
+    """Find a <p:sp> in `parent` whose <p:ph> matches the given idx/type."""
+    if parent is None:
+        return None
+    for sp in parent.iter(_qp("sp")):
+        ph = sp.find(f"{_qp('nvSpPr')}/{_qp('nvPr')}/{_qp('ph')}")
+        if ph is None:
+            continue
+        sp_idx_raw = ph.attrib.get("idx")
+        sp_idx = int(sp_idx_raw) if sp_idx_raw and sp_idx_raw.isdigit() else 0
+        sp_type = (ph.attrib.get("type") or "").lower()
+        if ph_idx is not None and sp_idx == ph_idx:
+            return sp
+        if ph_type and sp_type == ph_type:
+            return sp
+    return None
+
+
+def _lvl1_defrpr(sp):
+    """Return (lvl1pPr_element, defRPr_element) from the <a:lstStyle> of a
+    placeholder shape. Either may be None."""
+    if sp is None:
+        return None, None
+    lst = sp.find(f"{_qp('txBody')}/{_q('lstStyle')}")
+    if lst is None:
+        return None, None
+    lvl1 = lst.find(_q("lvl1pPr"))
+    if lvl1 is None:
+        return None, None
+    def_rpr = lvl1.find(_q("defRPr"))
+    return lvl1, def_rpr
+
+
+def _master_style_defrpr(master_xml, kind: str):
+    """Pull <a:lvl1pPr>/<a:defRPr> from <p:titleStyle> / <p:bodyStyle> /
+    <p:otherStyle> on the master."""
+    if master_xml is None:
+        return None, None
+    style_name = {
+        "title": "titleStyle",
+        "body": "bodyStyle",
+        "other": "otherStyle",
+    }[kind]
+    style = master_xml.find(f"{_qp('txStyles')}/{_qp(style_name)}")
+    if style is None:
+        return None, None
+    lvl1 = style.find(_q("lvl1pPr"))
+    if lvl1 is None:
+        return None, None
+    def_rpr = lvl1.find(_q("defRPr"))
+    return lvl1, def_rpr
+
+
+def resolve_placeholder_defaults(
+    layout_xml,
+    master_xml,
+    theme_xml,
+    clr_map: Dict[str, str],
+    theme_colors: Dict[str, str],
+    ph_idx: Optional[int],
+    ph_type: Optional[str],
+) -> Dict[str, Optional[str]]:
+    """Walk layout placeholder -> master placeholder -> master *Style ->
+    theme to compute the effective default typography of a placeholder."""
+    kind = _ph_type_default_kind(ph_type)
+
+    chain = []
+    chain.append(_lvl1_defrpr(_find_ph_sp(layout_xml, ph_idx, ph_type)))
+    chain.append(_lvl1_defrpr(_find_ph_sp(master_xml, ph_idx, ph_type)))
+    chain.append(_master_style_defrpr(master_xml, kind))
+
+    typeface: Optional[str] = None
+    size_pt: Optional[float] = None
+    bold: Optional[bool] = None
+    color_hex: Optional[str] = None
+    align: Optional[str] = None
+
+    for lvl1, def_rpr in chain:
+        if lvl1 is not None and align is None:
+            algn = lvl1.attrib.get("algn")
+            if algn:
+                align = algn
+        if def_rpr is None:
+            continue
+        if typeface is None:
+            latin = def_rpr.find(_q("latin"))
+            if latin is not None:
+                typeface = latin.attrib.get("typeface") or None
+        if size_pt is None:
+            sz = def_rpr.attrib.get("sz")
+            if sz and sz.isdigit():
+                size_pt = int(sz) / 100.0
+        if bold is None:
+            b = def_rpr.attrib.get("b")
+            if b in ("1", "true"):
+                bold = True
+            elif b in ("0", "false"):
+                bold = False
+        if color_hex is None:
+            color_hex = _solid_fill_hex(def_rpr, clr_map, theme_colors)
+
+    if typeface is None:
+        typeface = _theme_font(
+            theme_xml, "major" if kind == "title" else "minor")
+
+    return {
+        "typeface": typeface,
+        "size_pt": size_pt,
+        "bold": bold,
+        "color": color_hex,
+        "align": align,
+    }
+
+
+def format_placeholder_defaults(defaults: Dict[str, Optional[str]]) -> str:
+    parts: List[str] = []
+    if defaults.get("typeface"):
+        parts.append(str(defaults["typeface"]))
+    size_pt = defaults.get("size_pt")
+    if size_pt is not None:
+        if float(size_pt).is_integer():
+            parts.append(f"{int(size_pt)}pt")
+        else:
+            parts.append(f"{size_pt:.1f}pt")
+    if defaults.get("bold"):
+        parts.append("bold")
+    color = defaults.get("color")
+    if color:
+        parts.append(f"#{color}")
+    align = defaults.get("align")
+    if align:
+        parts.append(f"algn={align}")
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Package-level XML access (lazy: most code paths don't need it).
+# ---------------------------------------------------------------------------
+
+
+def _slide_master_rel_target(zf: zipfile.ZipFile, master_path: str, rel_type_tail: str) -> Optional[str]:
+    rels = ooxml.parse_rels(zf, ooxml.rels_path_for(master_path))
+    if not rels:
+        return None
+    rels_xml = ooxml.read_xml(zf, ooxml.rels_path_for(master_path))
+    if rels_xml is None:
+        return None
+    for rel in rels_xml.findall("pr:Relationship", ooxml.NS):
+        rtype = rel.attrib.get("Type", "")
+        if rtype.endswith(rel_type_tail):
+            return ooxml.resolve_rel_target(ooxml.rels_path_for(master_path), rel.attrib["Target"])
+    return None
+
+
+def _read_theme_for_master(zf: zipfile.ZipFile, master_path: str):
+    theme_path = _slide_master_rel_target(zf, master_path, "/theme")
+    if not theme_path:
+        return None, None
+    return theme_path, ooxml.read_xml(zf, theme_path)
+
+
+def _layout_master_path(zf: zipfile.ZipFile, layout_path: str) -> Optional[str]:
+    return _slide_master_rel_target(zf, layout_path, "/slideMaster")
+
+
+def _read_layout_chain(
+    zf: zipfile.ZipFile, layout_path: str
+) -> Tuple[Optional[object], Optional[object], Optional[object], Dict[str, str], Dict[str, str]]:
+    layout_xml = ooxml.read_xml(zf, layout_path)
+    master_path = _layout_master_path(zf, layout_path)
+    master_xml = ooxml.read_xml(zf, master_path) if master_path else None
+    theme_xml = None
+    if master_path:
+        _, theme_xml = _read_theme_for_master(zf, master_path)
+    clr_map = _read_clr_map(master_xml)
+    theme_colors = _theme_color_table(theme_xml)
+    return layout_xml, master_xml, theme_xml, clr_map, theme_colors
+
+
+def font_hints(run) -> str:
+    font = getattr(run, "font", None)
+    if font is None:
+        return ""
+    parts: List[str] = []
+    name = getattr(font, "name", None)
+    if name:
+        parts.append(name)
+    size = getattr(font, "size", None)
+    if size is not None:
+        parts.append(f"{int(size.pt)}pt")
+    if getattr(font, "bold", None):
+        parts.append("bold")
+    if getattr(font, "italic", None):
+        parts.append("italic")
+    if getattr(font, "underline", None):
+        parts.append("underline")
+    argb = font_argb(run)
+    if argb and argb not in ("000000", "FF000000"):
+        parts.append(f"color:{argb}")
+    return ", ".join(parts)
+
+
+def paragraph_runs_summary(paragraph) -> str:
+    """First run's font hints, as a stand-in for paragraph formatting."""
+    for run in paragraph.runs:
+        hints = font_hints(run)
+        if hints:
+            return hints
+    return ""
+
+
+def paragraph_alignment(paragraph) -> Optional[str]:
+    alignment = getattr(paragraph, "alignment", None)
+    if alignment is None:
+        return None
+    name = getattr(alignment, "name", None)
+    return name.lower() if name else None
+
+
+def text_frame_lines(shape: BaseShape, indent: str = "  ") -> List[str]:
+    if not shape.has_text_frame:
+        return []
+    is_placeholder = placeholder_type(shape) is not None
+    lines: List[str] = []
+    for paragraph in shape.text_frame.paragraphs:
+        text = (paragraph.text or "").strip()
+        if not text:
+            continue
+        level = paragraph.level or 0
+        attrs: List[str] = []
+        hints = paragraph_runs_summary(paragraph)
+        if hints:
+            attrs.append(hints)
+        algn = paragraph_alignment(paragraph)
+        if algn:
+            attrs.append(f"algn={algn}")
+        if is_placeholder and _starts_with_bullet_glyph(text):
+            attrs.append("[!] manual bullet glyph in placeholder — remove")
+        line = f"{indent}p{level}: {ellipsize(text, TEXT_PREVIEW_LIMIT)}"
+        if attrs:
+            line += f"  [{', '.join(attrs)}]"
+        lines.append(line)
+    return lines
+
+
+def picture_summary(shape: BaseShape) -> str:
+    image = getattr(shape, "image", None)
+    if image is None:
+        return ""
+    parts: List[str] = []
+    filename = getattr(image, "filename", None)
+    if filename:
+        parts.append(filename)
+    size = getattr(image, "size", None)
+    if isinstance(size, tuple) and len(size) == 2:
+        parts.append(f"{size[0]}x{size[1]}px")
+    content_type = getattr(image, "content_type", None)
+    if content_type:
+        parts.append(content_type)
+    return "  ".join(parts)
+
+
+def chart_summary(shape: BaseShape) -> str:
+    chart = shape.chart
+    parts: List[str] = []
+    chart_type = getattr(chart, "chart_type", None)
+    if chart_type is not None:
+        type_name = getattr(chart_type, "name", str(chart_type))
+        parts.append(type_name.lower())
+    series_count = sum(1 for _ in chart.series)
+    parts.append(f"series:{series_count}")
+    title = ""
+    if getattr(chart, "has_title", False):
+        try:
+            title = (chart.chart_title.text_frame.text or "").strip()
+        except (AttributeError, ValueError):
+            title = ""
+    if not title:
+        title = chart_title_via_zip(shape)
+    if title:
+        parts.append(f'title:"{ellipsize(title, TEXT_PREVIEW_LIMIT)}"')
+    return "  ".join(parts)
+
+
+def chart_title_via_zip(shape: BaseShape) -> str:
+    """Fallback: resolve the chart part via the slide's rels and parse the
+    DrawingML title with the shared ooxml helper."""
+    chart = getattr(shape, "chart", None)
+    if chart is None:
+        return ""
+    part = getattr(chart, "part", None)
+    partname = getattr(part, "partname", None)
+    if not partname:
+        return ""
+    chart_path = str(partname).lstrip("/")
+    pkg = getattr(part, "package", None)
+    pkg_path = getattr(pkg, "_path", None) or getattr(pkg, "path", None)
+    if not pkg_path:
+        return ""
+    try:
+        zf = zipfile.ZipFile(pkg_path)
+    except (zipfile.BadZipFile, OSError):
+        return ""
+    with zf:
+        return ooxml.parse_chart_title(zf, chart_path) or ""
+
+
+def table_summary(shape: BaseShape) -> Tuple[str, List[str]]:
+    table = shape.table
+    rows = list(table.rows)
+    nrows = len(rows)
+    ncols = len(rows[0].cells) if rows else 0
+    summary = f"{nrows}x{ncols}"
+    cell_lines: List[str] = []
+    for r, row in enumerate(rows):
+        for c, cell in enumerate(row.cells):
+            text = (cell.text or "").strip().replace("\n", " ")
+            if not text:
+                continue
+            cell_lines.append(
+                f"  ({r + 1},{c + 1}) {ellipsize(text, TEXT_PREVIEW_LIMIT)}"
+            )
+    return summary, cell_lines
+
+
+def slide_title(slide: Slide) -> str:
+    title_shape = slide.shapes.title
+    if title_shape is None or not title_shape.has_text_frame:
+        return ""
+    return (title_shape.text_frame.text or "").strip().replace("\n", " ")
+
+
+def slide_is_hidden(slide: Slide) -> bool:
+    return slide.element.get("show") == "0"
+
+
+def _shape_text_iter(shape: BaseShape) -> Iterable[str]:
+    kind = shape_kind(shape)
+    if kind == "group":
+        for inner in shape.shapes:
+            yield from _shape_text_iter(inner)
+        return
+    if kind == "table":
+        for row in shape.table.rows:
+            for cell in row.cells:
+                yield cell.text or ""
+        return
+    if shape.has_text_frame:
+        for paragraph in shape.text_frame.paragraphs:
+            yield paragraph.text or ""
+
+
+def slide_word_count(slide: Slide) -> int:
+    count = 0
+    for shape in slide.shapes:
+        for text in _shape_text_iter(shape):
+            count += len(text.split())
+    return count
+
+
+def _starts_with_bullet_glyph(text: str) -> bool:
+    if len(text) < 2:
+        return False
+    if text[0] not in BULLET_PREFIXES:
+        return False
+    return text[1].isspace()
+
+
+def count_shapes_by_kind(shapes: Iterable[BaseShape]) -> dict:
+    counts = {"text": 0, "pic": 0, "chart": 0, "table": 0, "other": 0}
+    for shape in shapes:
+        if shape.has_chart:
+            counts["chart"] += 1
+        elif shape.has_table:
+            counts["table"] += 1
+        elif shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+            counts["pic"] += 1
+        elif shape.has_text_frame and (shape.text_frame.text or "").strip():
+            counts["text"] += 1
+        else:
+            counts["other"] += 1
+    return counts
+
+
+def describe_shape(
+    shape: BaseShape,
+    *,
+    ctx: Optional[SlideContext] = None,
+    indent: str = "",
+) -> List[str]:
+    kind = shape_kind(shape)
+    box = format_box(shape)
+    parts = [pad(f"#{shape.shape_id}", 6), pad(kind, 6), pad(box, 24)]
+    ph = placeholder_type(shape)
+    if ph:
+        parts.append(pad(f"ph={ph}", 14))
+
+    sub_lines: List[str] = []
+    summary = ""
+    if kind == "chart":
+        summary = chart_summary(shape)
+    elif kind == "pic":
+        summary = picture_summary(shape)
+    elif kind == "table":
+        ts, cell_lines = table_summary(shape)
+        summary = ts
+        sub_lines.extend(cell_lines)
+    elif kind == "group":
+        nested = list(shape.shapes)
+        summary = f"shapes:{len(nested)}"
+        for inner in nested:
+            sub_lines.extend(describe_shape(inner, ctx=ctx, indent="    "))
+        if shape.has_text_frame:
+            sub_lines.extend(text_frame_lines(shape, indent="  "))
+    else:
+        text_lines = text_frame_lines(shape, indent="  ")
+        if text_lines:
+            sub_lines.extend(text_lines)
+        else:
+            name = (shape.name or "").strip()
+            if name:
+                summary = f'name:"{ellipsize(name, 40)}"'
+
+    if summary:
+        parts.append(summary)
+    for marker in _shape_warning_markers(shape, ph, ctx):
+        parts.append(marker)
+
+    head = indent + "  ".join(parts).rstrip()
+    return [head] + [indent + line for line in sub_lines]
+
+
+def _shape_warning_markers(
+    shape: BaseShape,
+    ph: Optional[str],
+    ctx: Optional[SlideContext],
+) -> List[str]:
+    markers: List[str] = []
+    if ctx is not None:
+        left, top, width, height = (
+            shape.left,
+            shape.top,
+            shape.width,
+            shape.height,
+        )
+        if None not in (left, top, width, height):
+            if (
+                left + width > ctx.width_emu + EDGE_EPSILON_EMU
+                or top + height > ctx.height_emu + EDGE_EPSILON_EMU
+            ):
+                markers.append("[!] extends past slide edge")
+    if ph and shape.has_text_frame:
+        has_text = any(
+            (p.text or "").strip() for p in shape.text_frame.paragraphs
+        )
+        if not has_text:
+            markers.append(
+                "[!] EMPTY PLACEHOLDER — will render layout prompt text"
+            )
+    return markers
+
+
+def _theme_summary_line(file_path: str) -> Optional[str]:
+    """One-line theme summary for the overview: name, major/minor font,
+    bg/text/accent colors. Returns None if the package isn't readable."""
+    try:
+        zf = zipfile.ZipFile(file_path)
+    except (zipfile.BadZipFile, OSError):
+        return None
+    try:
+        with zf:
+            pres_rels = ooxml.read_xml(
+                zf, ooxml.rels_path_for("ppt/presentation.xml"))
+            if pres_rels is None:
+                return None
+            master_path: Optional[str] = None
+            for rel in pres_rels.findall("pr:Relationship", ooxml.NS):
+                if rel.attrib.get("Type", "").endswith("/slideMaster"):
+                    master_path = ooxml.resolve_rel_target(
+                        ooxml.rels_path_for("ppt/presentation.xml"),
+                        rel.attrib["Target"],
+                    )
+                    break
+            if not master_path:
+                return None
+            master_xml = ooxml.read_xml(zf, master_path)
+            theme_path, theme_xml = _read_theme_for_master(zf, master_path)
+            if theme_xml is None:
+                return None
+            clr_map = _read_clr_map(master_xml)
+            theme_colors = _theme_color_table(theme_xml)
+            major = _theme_font(theme_xml, "major")
+            minor = _theme_font(theme_xml, "minor")
+            theme_name = theme_xml.attrib.get("name") or "?"
+
+            def _resolved(token: str) -> str:
+                hx = _resolve_scheme_color(token, clr_map, theme_colors)
+                return f"#{hx}" if hx else "—"
+
+            accents = " ".join(_resolved(f"accent{i}") for i in range(1, 7))
+            parts = [
+                f"theme:{theme_name}",
+                f"major:{major or '—'}",
+                f"minor:{minor or '—'}",
+                f"bg1:{_resolved('bg1')}",
+                f"tx1:{_resolved('tx1')}",
+                f"accents:{accents}",
+            ]
+            return "[" + " | ".join(parts) + "]"
+    except Exception:
+        return None
+
+
+def print_overview(prs: PresentationType, file_path: str) -> str:
+    width = emu_to_inches(prs.slide_width) or 0.0
+    height = emu_to_inches(prs.slide_height) or 0.0
+    slide_count = len(prs.slides)
+    layout_count = sum(len(m.slide_layouts) for m in prs.slide_masters)
+
+    word_counts = [slide_word_count(slide) for slide in prs.slides]
+    avg_words = sum(word_counts) // len(word_counts) if word_counts else 0
+    max_words = max(word_counts) if word_counts else 0
+
+    lines = [
+        f"[Slides: {slide_count} | "
+        f"size: {width:.1f}x{height:.1f}\" | "
+        f"masters: {len(prs.slide_masters)} | "
+        f"layouts: {layout_count} | "
+        f"words/slide: avg={avg_words} max={max_words}]"
+    ]
+    theme_line = _theme_summary_line(file_path)
+    if theme_line:
+        lines.append(theme_line)
+    for idx, slide in enumerate(prs.slides, start=1):
+        layout = slide.slide_layout.name or "?"
+        title = slide_title(slide)
+        counts = count_shapes_by_kind(slide.shapes)
+        words = word_counts[idx - 1]
+        flags: List[str] = []
+        if slide.has_notes_slide and slide.notes_slide.notes_text_frame.text.strip():
+            flags.append("notes")
+        if slide_is_hidden(slide):
+            flags.append("hidden")
+
+        title_str = f'"{ellipsize(title, 40)}"' if title else ""
+        counts_str = (
+            f"shapes:{sum(counts.values())}  "
+            f"text:{counts['text']}  pic:{counts['pic']}  "
+            f"chart:{counts['chart']}  table:{counts['table']}  "
+            f"words:{words}"
+        )
+        flags_str = f"  [{','.join(flags)}]" if flags else ""
+        lines.append(
+            f"  {pad(str(idx), 3)} {pad(ellipsize(layout, 24), 26)}"
+            f"{pad(title_str, 42)}  {counts_str}{flags_str}"
+        )
+    return "\n".join(lines)
+
+
+def find_slide(prs: PresentationType, idx: int) -> Slide:
+    if idx < 1 or idx > len(prs.slides):
+        raise ValueError(
+            f"slide index out of range: {
+                idx} (deck has {len(prs.slides)} slides)"
+        )
+    return prs.slides[idx - 1]
+
+
+def print_slide(
+    prs: PresentationType,
+    idx: int,
+    offset: int,
+    max_shapes: int,
+) -> str:
+    slide = find_slide(prs, idx)
+    shapes = list(slide.shapes)
+    total = len(shapes)
+    layout = slide.slide_layout.name or "?"
+    title = slide_title(slide)
+    title_str = f' | "{ellipsize(title, 60)}"' if title else ""
+    flags: List[str] = []
+    if slide_is_hidden(slide):
+        flags.append("hidden")
+    flags_str = f" | {','.join(flags)}" if flags else ""
+
+    header = (
+        f"[Slide {idx}/{len(prs.slides)} | layout: {layout}"
+        f"{title_str}{flags_str} | shapes: {total}]"
+    )
+    lines = [header]
+
+    ctx = SlideContext(
+        width_emu=prs.slide_width or 0,
+        height_emu=prs.slide_height or 0,
+    )
+    end = min(total, offset + max_shapes)
+    for shape in shapes[offset:end]:
+        lines.extend(describe_shape(shape, ctx=ctx))
+
+    if end < total:
+        lines.append("")
+        lines.append(
+            f"[Showing shapes {offset + 1}-{end} of {total}. "
+            f"Use --offset {end} for the next page.]"
+        )
+
+    if slide.has_notes_slide:
+        notes = (slide.notes_slide.notes_text_frame.text or "").strip()
+        if notes:
+            lines.append("")
+            lines.append("[Notes]")
+            for paragraph in notes.split("\n"):
+                paragraph = paragraph.strip()
+                if paragraph:
+                    lines.append(
+                        f"  {ellipsize(paragraph, TEXT_PREVIEW_LIMIT)}")
+    return "\n".join(lines)
+
+
+def _layout_part_path(layout) -> Optional[str]:
+    """Layout XML path inside the .pptx zip, e.g. 'ppt/slideLayouts/slideLayout3.xml'."""
+    partname = getattr(getattr(layout, "part", None), "partname", None)
+    if partname is None:
+        return None
+    return str(partname).lstrip("/")
+
+
+def print_layouts(prs: PresentationType, file_path: str) -> str:
+    lines = [f"[Masters: {len(prs.slide_masters)}]"]
+    try:
+        zf: Optional[zipfile.ZipFile] = zipfile.ZipFile(file_path)
+    except (zipfile.BadZipFile, OSError):
+        zf = None
+    try:
+        for mi, master in enumerate(prs.slide_masters, start=1):
+            master_name = (master.name or "").strip() or f"master{mi}"
+            lines.append("")
+            lines.append(
+                f"# Master {mi}: {master_name}  layouts: {
+                    len(master.slide_layouts)}"
+            )
+            for layout in master.slide_layouts:
+                placeholders = list(layout.placeholders)
+                lines.append(
+                    f"- {pad(layout.name or '?', 28)
+                         } placeholders: {len(placeholders)}"
+                )
+
+                layout_path = _layout_part_path(layout)
+                layout_xml = master_xml = theme_xml = None
+                clr_map: Dict[str, str] = {}
+                theme_colors: Dict[str, str] = {}
+                if zf is not None and layout_path:
+                    (
+                        layout_xml,
+                        master_xml,
+                        theme_xml,
+                        clr_map,
+                        theme_colors,
+                    ) = _read_layout_chain(zf, layout_path)
+
+                for ph in placeholders:
+                    ph_name = placeholder_type(ph) or "unknown"
+                    pf = ph.placeholder_format
+                    idx = pf.idx if pf else None
+                    idx_str = str(idx) if idx is not None else "?"
+                    box = format_box(ph)
+                    head = f"    [{idx_str}] {pad(ph_name, 14)} {pad(box, 24)}"
+                    if layout_xml is not None:
+                        defaults = resolve_placeholder_defaults(
+                            layout_xml,
+                            master_xml,
+                            theme_xml,
+                            clr_map,
+                            theme_colors,
+                            ph_idx=idx,
+                            ph_type=ph_name,
+                        )
+                        defaults_str = format_placeholder_defaults(defaults)
+                        if defaults_str:
+                            head = f"{head}  {defaults_str}"
+                    lines.append(head.rstrip())
+    finally:
+        if zf is not None:
+            zf.close()
+    return "\n".join(lines)
+
+
+def print_text(prs: PresentationType) -> str:
+    blocks: List[str] = []
+    total_chars = 0
+    for idx, slide in enumerate(prs.slides, start=1):
+        slide_lines: List[str] = []
+        for shape in slide.shapes:
+            slide_lines.extend(_collect_text(shape))
+        if slide.has_notes_slide:
+            notes = (slide.notes_slide.notes_text_frame.text or "").strip()
+            if notes:
+                slide_lines.append(
+                    f"  [notes] {ellipsize(notes, TEXT_PREVIEW_LIMIT)}")
+        if slide_lines:
+            title = slide_title(slide)
+            header = f"# Slide {idx}"
+            if title:
+                header += f': "{ellipsize(title, 60)}"'
+            blocks.append(header)
+            blocks.extend(slide_lines)
+            blocks.append("")
+            total_chars += sum(len(line) for line in slide_lines)
+    if not blocks:
+        return "[No text in deck]"
+    if blocks and blocks[-1] == "":
+        blocks.pop()
+    return f"[Text: {total_chars} chars across {len(prs.slides)} slides]\n\n" + "\n".join(blocks)
+
+
+def _collect_text(shape: BaseShape, indent: str = "  ") -> List[str]:
+    lines: List[str] = []
+    kind = shape_kind(shape)
+    if kind == "group":
+        for inner in shape.shapes:
+            lines.extend(_collect_text(inner, indent))
+        return lines
+    if kind == "table":
+        _, cell_lines = table_summary(shape)
+        lines.extend(cell_lines)
+        return lines
+    if shape.has_text_frame:
+        for paragraph in shape.text_frame.paragraphs:
+            text = (paragraph.text or "").strip()
+            if not text:
+                continue
+            level = paragraph.level or 0
+            lines.append(f"{indent}p{level}: {
+                         ellipsize(text, TEXT_PREVIEW_LIMIT)}")
+    return lines
+
+
+def print_media(path: str) -> str:
+    try:
+        zf = zipfile.ZipFile(path)
+    except zipfile.BadZipFile:
+        return "[Not a valid zip / .pptx package]"
+    media_entries: List[Tuple[str, int]] = []
+    with zf:
+        for info in zf.infolist():
+            if info.filename.startswith("ppt/media/"):
+                media_entries.append((info.filename, info.file_size))
+    if not media_entries:
+        return "[No embedded media]"
+    media_entries.sort()
+    lines = [f"[Media: {len(media_entries)}]"]
+    for name, size in media_entries:
+        short = name[len("ppt/media/"):]
+        lines.append(f"- {pad(short, 32)} {format_size(size)}")
+    return "\n".join(lines)
+
+
+def print_render(
+    file_path: str,
+    prs: PresentationType,
+    slide_idx: Optional[int],
+) -> str:
+    total_slides = len(prs.slides)
+    if slide_idx is not None and (slide_idx < 1 or slide_idx > total_slides):
+        raise ValueError(
+            f"slide index out of range: {slide_idx} "
+            f"(deck has {total_slides} slides)"
+        )
+
+    deck_basename = os.path.splitext(os.path.basename(file_path))[0]
+    out_dir = Path("/tmp/pptx_render") / deck_basename
+
+    if slide_idx is None and out_dir.exists():
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pdf_path = out_dir / f"{deck_basename}.pdf"
+    soffice = subprocess.run(
+        [
+            "soffice",
+            "--headless",
+            "--convert-to", "pdf",
+            "--outdir", str(out_dir),
+            file_path,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    if soffice.returncode != 0 or not pdf_path.exists():
+        tail = (soffice.stderr or soffice.stdout or "").strip().splitlines()
+        msg = tail[-1] if tail else "soffice produced no output"
+        raise ValueError(f"pdf conversion failed: {msg}")
+
+    pdftoppm_args = ["pdftoppm", "-jpeg", "-r", "100"]
+    if slide_idx is not None:
+        pdftoppm_args.extend(["-f", str(slide_idx), "-l", str(slide_idx)])
+    pdftoppm_args.extend([str(pdf_path), str(out_dir / "slide")])
+    pdftoppm = subprocess.run(
+        pdftoppm_args,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    if pdftoppm.returncode != 0:
+        tail = (pdftoppm.stderr or pdftoppm.stdout or "").strip().splitlines()
+        msg = tail[-1] if tail else "pdftoppm produced no output"
+        raise ValueError(f"page rasterization failed: {msg}")
+
+    # pdftoppm zero-pads to the width of the total page count, so a 5-page
+    # deck yields slide-1.jpg..slide-5.jpg and a 50-page deck yields
+    # slide-01.jpg..slide-50.jpg. Normalize everything we just produced to
+    # 3-digit padding so paths sort lexically and stay stable across runs.
+    width = max(1, len(str(total_slides)))
+    nums = [slide_idx] if slide_idx is not None else list(
+        range(1, total_slides + 1))
+    rendered: List[Path] = []
+    for n in nums:
+        src = out_dir / f"slide-{n:0{width}d}.jpg"
+        target = out_dir / f"slide-{n:03d}.jpg"
+        if src != target and src.exists():
+            src.rename(target)
+        if not target.exists():
+            raise ValueError(
+                f"expected rendered slide missing: {target.name}"
+            )
+        rendered.append(target)
+
+    plural = "" if len(rendered) == 1 else "s"
+    lines = [
+        f"[Rendered: {len(rendered)} slide{
+            plural} | jpeg @ 100 dpi | {out_dir}]"
+    ]
+    for p in rendered:
+        lines.append(str(p))
+    return "\n".join(lines)
+
+
+def safe_output(text: str) -> Tuple[str, bool]:
+    if len(text.encode("utf-8")) <= MAX_OUTPUT_BYTES:
+        return text, False
+    out_lines: List[str] = []
+    out_bytes = 0
+    for line in text.split("\n"):
+        line_bytes = len((line + "\n").encode("utf-8"))
+        if out_bytes + line_bytes > MAX_OUTPUT_BYTES:
+            return "\n".join(out_lines), True
+        out_lines.append(line)
+        out_bytes += line_bytes
+    return "\n".join(out_lines), False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="pptx_inspect",
+        usage=USAGE,
+        add_help=False,
+    )
+    parser.add_argument("file", nargs="?")
+    parser.add_argument("--slide", type=int)
+    parser.add_argument("--layouts", action="store_true")
+    parser.add_argument("--text", action="store_true")
+    parser.add_argument("--media", action="store_true")
+    parser.add_argument("--render", action="store_true")
+    parser.add_argument("--max-shapes", type=int, default=DEFAULT_MAX_SHAPES)
+    parser.add_argument("--offset", type=int, default=0)
+    parser.add_argument("--help", "-h", action="store_true", dest="help_flag")
+
+    args = parser.parse_args()
+
+    if args.help_flag:
+        sys.stdout.write(HELP_TEXT + "\n")
+        return 0
+
+    if not args.file:
+        sys.stderr.write(f"Error: file is required\nUsage: {USAGE}\n")
+        return 1
+
+    if not os.path.isfile(args.file):
+        sys.stderr.write(f"Error: file not found: {args.file}\n")
+        return 1
+
+    if args.max_shapes < 1:
+        sys.stderr.write("Error: --max-shapes must be >= 1\n")
+        return 1
+    if args.offset < 0:
+        sys.stderr.write("Error: --offset must be >= 0\n")
+        return 1
+
+    file_header = (
+        f"[File: {os.path.basename(args.file)} | "
+        f"{format_size(os.path.getsize(args.file))}]"
+    )
+
+    if args.media:
+        body = print_media(args.file)
+    else:
+        prs = Presentation(args.file)
+        if args.render:
+            body = print_render(args.file, prs, args.slide)
+        elif args.layouts:
+            body = print_layouts(prs, args.file)
+        elif args.text:
+            body = print_text(prs)
+        elif args.slide is not None:
+            body = print_slide(prs, args.slide, args.offset, args.max_shapes)
+        else:
+            body = print_overview(prs, args.file)
+
+    full = file_header + "\n" + body
+    text, truncated = safe_output(full)
+    sys.stdout.write(text)
+    sys.stdout.write("\n")
+    if truncated:
+        sys.stdout.write(
+            "[Output truncated; narrow with --slide or paginate with "
+            "--offset / --max-shapes]\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (ValueError, KeyError) as exc:
+        sys.stderr.write(f"Error: {exc}\n")
+        sys.exit(1)
+    except Exception as exc:
+        sys.stderr.write(f"Error: {type(exc).__name__}: {exc}\n")
+        sys.exit(1)

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -287,6 +287,12 @@ SHELLEOF`,
     { user: "root" }
   )
   .runCmd(`chmod +x ${PROFILE_DIR}/soffice/xlsx_inspect.py`, { user: "root" })
+  .copy(
+    getLocalContent(PROFILE_LOCAL_DIR, "soffice/pptx_inspect.py"),
+    `${PROFILE_DIR}/soffice/pptx_inspect.py`,
+    { user: "root" }
+  )
+  .runCmd(`chmod +x ${PROFILE_DIR}/soffice/pptx_inspect.py`, { user: "root" })
   // Telemetry configs for fluent-bit
   .copy(
     getLocalContent(TELEMETRY_LOCAL_DIR, "fluent-bit.conf"),
@@ -422,6 +428,17 @@ SHELLEOF`,
       "xlsx_inspect <file> [--sheet NAME] [--range A1:Z50] [--grep PATTERN [--regex] [--meta]] [--names] [--limit N] [--offset N]",
     returns:
       "Workbook overview, or one cell per line: '<address>  <formula or value>  [cached result]  numFmt: <fmt>  [font: <color>]  [fill: <color>]'. Empty cells skipped",
+    runtime: "system",
+  })
+  // --- pptx_inspect: structural inspection of .pptx decks ---
+  .registerTool({
+    name: "pptx_inspect",
+    description:
+      "Inspect .pptx structure: slides, layouts, shapes, text, charts, tables, embedded media. Use before editing a deck to map layouts and shape positions without rendering to PDF/images",
+    usage:
+      "pptx_inspect <file> [--slide N] [--layouts] [--text] [--media] [--max-shapes N] [--offset N]",
+    returns:
+      "Deck overview, or one shape per line in slide view: '<id>  <kind>  <left,top WxH>  [ph=<type>]  <summary>' with paragraphs indented. Layouts/text/media views emit format-specific listings",
     runtime: "system",
   })
   .withCapability("gcsfuse")

--- a/front/lib/resources/skill/code_defined/global_registry.ts
+++ b/front/lib/resources/skill/code_defined/global_registry.ts
@@ -2,6 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { framesSkill } from "@app/lib/resources/skill/code_defined/frames";
 import { goDeepSkill } from "@app/lib/resources/skill/code_defined/go_deep";
 import { mentionUsersSkill } from "@app/lib/resources/skill/code_defined/mention_users";
+import { pptxSkill } from "@app/lib/resources/skill/code_defined/pptx";
 import { projectsSkill } from "@app/lib/resources/skill/code_defined/projects";
 import {
   ensureUniqueSIds,
@@ -16,6 +17,7 @@ const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
   framesSkill,
   goDeepSkill,
   mentionUsersSkill,
+  pptxSkill,
   projectsSkill,
   xlsxSkill,
 ] as const);

--- a/front/lib/resources/skill/code_defined/pptx.ts
+++ b/front/lib/resources/skill/code_defined/pptx.ts
@@ -1,0 +1,338 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+
+const PPTX_SKILL_INSTRUCTIONS = `# Slide decks (.pptx)
+
+## 1. Pick the workflow first
+
+Two workflows. Decide which one applies **before** writing any code:
+
+- **Template-as-shell** — user hands you a deck whose role is "use this
+  look": a template, a sample deck, a starter, a style reference. The
+  template's own slides are *exemplars*, not content to keep. Your output
+  is a **new file** that inherits the template's masters, layouts, theme,
+  and embedded media (logos, footers) but contains *only* your generated
+  slides. This is the default whenever a deck is provided without an
+  explicit edit verb.
+- **Edit-in-place** — user explicitly used a verb like *edit, update,
+  modify, fix, change, tweak, adjust, revise* against a deck whose existing
+  slides have content the user wants kept. Modify the file at its existing
+  path.
+
+**When in doubt, choose template-as-shell.** Keeping all template
+exemplars and appending new slides at the end (the most common failure
+mode) is strictly worse than the inverse: the user has to delete by hand,
+whereas regenerating when edit was wanted is recoverable from the original
+file the user still has.
+
+## 2. Inspect before you touch
+
+Whichever workflow you're in, the **very first** action is \`pptx_inspect\`
+— never \`markitdown\` blind (markitdown drops layouts, placeholders,
+positioning, charts, and embedded media; you'd silently rebuild a broken
+deck) and never go straight to PDF rendering (soffice + pdftoppm is slow
+and burns vision tokens).
+
+\`\`\`bash
+pptx_inspect /files/conversation/deck.pptx                 # overview + theme + word density
+pptx_inspect /files/conversation/deck.pptx --slide 3       # one slide's shapes
+pptx_inspect /files/conversation/deck.pptx --layouts       # masters & layout placeholders
+pptx_inspect /files/conversation/deck.pptx --text          # all readable text per slide
+pptx_inspect /files/conversation/deck.pptx --media         # embedded images / audio / video
+\`\`\`
+
+The overview reports the deck's **theme** on its own line (theme name,
+major/minor fallback typefaces, background, main text color, six accent
+colors) and the **word-density envelope** the template uses:
+\`words/slide: avg=X max=Y\` at the deck level and \`words:N\` per slide.
+You'll use those numbers as your density ceiling in section 4.
+
+\`--layouts\` reports, for every placeholder of every layout, the resolved
+typeface, size, weight, color, and alignment. This is what tells you the
+template wants Lexend 28pt bold for titles, not Calibri 18pt.
+
+The \`--slide\` view shows each shape with its position and size in inches,
+placeholder type, and per-paragraph text with typography. It also emits
+explicit warnings prefixed with \`[!]\`:
+
+- \`[!] EMPTY PLACEHOLDER — will render layout prompt text\` — the
+  placeholder exists but is empty; PowerPoint will draw "Click to add
+  title" / "Click to add Text" on top of your slide. Populate it
+  (section 3) before moving on.
+- \`[!] manual bullet glyph in placeholder — remove\` — you typed
+  \`•\`, \`·\`, \`-\`, \`–\`, or \`*\` at the start of a paragraph in a
+  placeholder whose layout already renders bullets. The result is a
+  doubled marker ("● • text"). Remove the glyph; use \`paragraph.level\`
+  (section 3).
+- \`[!] extends past slide edge\` — the shape's right or bottom edge is
+  off the slide. Resize or reposition.
+
+**Every \`[!]\` line is a blocker.** Structural QA is not done until they
+are all gone (section 6.1).
+
+Render slides to images **only** for final visual QA (section 6.2), not
+for exploratory reading.
+
+## 3. Author against the template
+
+### Template-as-shell: strip the existing slides, then add yours
+
+\`python-pptx\` has no first-class slide-delete API. The standard recipe
+pops entries from the package's \`sldIdLst\` and drops their relationships,
+leaving masters, layouts, theme, and media intact:
+
+\`\`\`python
+from pptx import Presentation
+from pptx.oxml.ns import qn
+
+prs = Presentation("/files/conversation/template.pptx")
+sld_id_lst = prs.slides._sldIdLst
+rels = prs.part.rels
+for sld_id in list(sld_id_lst):
+    rId = sld_id.get(qn("r:id"))
+    rels.pop(rId, None)
+    sld_id_lst.remove(sld_id)
+prs.save("/files/conversation/output.pptx")  # never overwrite the template
+\`\`\`
+
+Re-open the empty shell and add slides via \`prs.slide_layouts[...]\`:
+
+\`\`\`python
+prs = Presentation("/files/conversation/output.pptx")
+layout = next(l for l in prs.slide_layouts if l.name == "TITLE_AND_BODY")
+slide = prs.slides.add_slide(layout)
+slide.shapes.title.text = "Q4 results"
+slide.placeholders[1].text_frame.text = "Highlights"
+prs.save("/files/conversation/output.pptx")
+\`\`\`
+
+### Edit-in-place: open and save to the original path
+
+\`\`\`python
+prs = Presentation("/files/conversation/deck.pptx")
+# ... mutate ...
+prs.save("/files/conversation/deck.pptx")
+\`\`\`
+
+### Always populate the layout's placeholders
+
+Layouts ship with empty title / body / subtitle placeholders. **You must
+fill them.** An empty placeholder renders as "Click to add …" in
+PowerPoint — the prompt text is not stored in the file, it's generated by
+the renderer whenever the placeholder is empty, so adding a parallel text
+box on top does **not** suppress it. The \`[!] EMPTY PLACEHOLDER\` warning
+in \`--slide\` output is your safety net.
+
+- Title: \`slide.shapes.title.text = "Q4 results"\` (works for both \`title\`
+  and \`center_title\`).
+- Other placeholders: \`slide.placeholders[idx].text_frame.text = "..."\`
+  where \`idx\` is the value reported by \`pptx_inspect --layouts\`.
+
+### Never type bullet glyphs in body placeholders
+
+Body placeholders render bullets *from the layout* based on paragraph
+level. Typing \`•\`, \`·\`, \`-\`, \`–\`, or \`*\` at the start of a
+paragraph stacks your glyph on top of the layout's, producing "● • text".
+Use \`paragraph.level\` instead:
+
+\`\`\`python
+# BAD — produces double bullets ("● • Revenue Model")
+tf.text = "• Revenue Model"
+tf.add_paragraph().text = "• MRR end of month"
+
+# GOOD — let the layout draw the bullets
+tf = slide.placeholders[1].text_frame
+tf.text = "Revenue Model"                    # level 0, layout draws the bullet
+sub = tf.add_paragraph()
+sub.text = "MRR end of month"
+sub.level = 1                                 # nested bullet style from layout
+\`\`\`
+
+If you need bullet-shaped content in a *non-placeholder* text box, you
+have to draw the bullets manually (no inherited list style) — but that's
+a fallback, not the default; prefer the body placeholder.
+
+### Defer to placeholder defaults for typography
+
+The layout already defines typeface, size, color, weight, and alignment
+for each placeholder — exactly what \`--layouts\` prints. Write the text
+and leave \`font.name\`, \`font.size\`, \`font.color\` unset on runs; they
+inherit from the layout. Override only when you intentionally want a
+different style for a specific run.
+
+If you must add a custom shape outside a placeholder (a callout, a
+sidebar, a label), copy the typeface and color from the matching
+placeholder in \`--layouts\`. Otherwise the run falls back to the theme's
+major/minor latin font (commonly Arial or Calibri) and the slide looks
+foreign next to the rest of the deck.
+
+### Recommended order
+
+1. \`pptx_inspect template.pptx\` — read the theme header, note
+   \`words/slide: avg=… max=…\`, skim the per-slide layout choices.
+2. \`pptx_inspect template.pptx --layouts\` — record, for each layout
+   you'll use, the placeholder \`idx\`, type, and resolved
+   typeface / size / color.
+3. \`pptx_inspect template.pptx --text\` — read the existing slides as
+   exemplars: tone, density, structure.
+4. Strip slides (template-as-shell) or open existing (edit-in-place),
+   author with \`python-pptx\`, save to the output path.
+
+## 4. Design guidance
+
+### Match the template's information density
+
+The overview reports \`words/slide: avg=X max=Y\` for the template. **Treat
+\`max\` as a hard ceiling for every slide you generate.** If the template
+averages ~25 words per slide, your slides should too. The template *is*
+the design contract — exceeding its density is the single most common way
+to produce a slide that "doesn't look like the template" even when fonts
+and colors match.
+
+If your content needs more text than the template's max allows, the
+overflow goes into **speaker notes**, not the slide:
+
+\`\`\`python
+slide.notes_slide.notes_text_frame.text = "Detailed talking points here…"
+\`\`\`
+
+Notes are visible in presenter view and don't bloat the rendered slide.
+Use them liberally for context the audience hears but doesn't read.
+
+### Charts and embedded images must match the template
+
+A matplotlib chart with default styling on a navy slide reads as a
+mismatched screenshot, no matter how good the data is. Two rules:
+
+1. **Prefer native python-pptx charts** (\`XL_CHART_TYPE.BAR_CLUSTERED\`,
+   \`LINE\`, etc.) when the data is tabular. They inherit the theme palette
+   and typography automatically. Drop down to matplotlib only when the
+   chart type isn't natively supported (combo charts, complex annotations).
+
+2. **If you must use matplotlib**, pull background and series colors from
+   the theme (the bracketed line in \`pptx_inspect\` overview reports
+   \`bg1\`, \`tx1\`, and six accent colors):
+
+   \`\`\`python
+   import matplotlib.pyplot as plt
+
+   BG = "#0F1A2E"            # bg1 from theme overview
+   FG = "#F8FAFC"            # tx1 from theme overview
+   ACCENTS = ["#3B82F6", "#10B981", "#F59E0B"]  # accent1..N from theme overview
+
+   fig, ax = plt.subplots(facecolor=BG)
+   ax.set_facecolor(BG)
+   for spine in ax.spines.values():
+       spine.set_color(FG)
+   ax.tick_params(colors=FG)
+   ax.title.set_color(FG)
+   ax.xaxis.label.set_color(FG)
+   ax.yaxis.label.set_color(FG)
+   for bar, color in zip(bars, ACCENTS):
+       bar.set_color(color)
+   fig.savefig("/tmp/chart.png", facecolor=BG, dpi=150, bbox_inches="tight")
+   \`\`\`
+
+   Then insert the PNG via \`slide.shapes.add_picture(...)\`.
+
+### Slide-level rules
+
+- Pick a content-informed accent palette from the theme's six accents; do
+  not pull colors from outside the theme.
+- Every slide needs a visual element (image, chart, icon, shape). Text-only
+  slides are forgettable.
+- Title 36–44pt bold, body 14–16pt. Left-align body text, center only titles.
+- Keep ≥0.5" page margins. The bottom 0.5" of the slide is typically where
+  the template's logo/footer sits on the master — **any content shape
+  extending into that region is overflow, not layout**. Move it up or split
+  the slide.
+- Vary layouts across slides; do not repeat the same template.
+- Never draw thin accent lines under titles.
+Use whitespace or background color for hierarchy instead.
+
+
+## 5. QA (mandatory before delivery)
+
+Two passes. Both are required — never ship after only the structural pass.
+The visual pass is where text overflow, off-center elements, and uneven
+gaps actually surface; structural inspection alone cannot catch them.
+
+### 5.1 Structural
+
+Run \`pptx_inspect output.pptx\`, \`pptx_inspect output.pptx --text\`, and
+\`pptx_inspect output.pptx --slide N\` for every authored slide. Confirm:
+
+- The deck contains **only your generated slides** — no template
+  exemplars left over. Template-as-shell deliveries that ship with the
+  template's original slides still attached are a hard fail.
+- Every slide uses the layout you intended.
+- **Zero \`[!]\` warnings remain** in \`--slide\` output. Specifically:
+  - No \`[!] EMPTY PLACEHOLDER\` — populate via
+    \`slide.shapes.title.text\` or \`slide.placeholders[idx]\`.
+  - No \`[!] manual bullet glyph in placeholder\` — remove the glyph; use
+    \`paragraph.level\` for nesting.
+  - No \`[!] extends past slide edge\` — resize or reposition.
+- Per-slide \`words:N\` ≤ the template's \`max\` reported in the overview.
+- Typography on populated runs matches \`--layouts\` (or is an intentional
+  override).
+- No template leftovers (\`xxxx\`, \`lorem ipsum\`, draft titles).
+
+### 5.2 Visual
+
+Render every slide and \`Read\` each image:
+
+\`\`\`bash
+pptx_inspect /files/conversation/output.pptx --render
+\`\`\`
+
+This prints one absolute path per slide
+(\`/tmp/pptx_render/<deck>/slide-001.jpg\`, …). For **every** path printed,
+load the image with the \`Read\` tool. Do not stop after one or two —
+every slide must be inspected before delivery.
+
+For each rendered slide, run through this checklist explicitly in your
+response (one short line per slide naming what you checked and what you
+saw — silent "looks fine" is not acceptable):
+
+- text running outside its placeholder or off the slide
+- text overlapping the template's logo/footer region (bottom 0.5")
+- "strikethrough"-shaped lines through numbers or text — almost always
+  two overlapping shapes, not intentional formatting
+- elements not centered / not aligned with their column
+- low-contrast text (light on light, dark on dark)
+- uneven gaps between content blocks
+- content closer than ~0.5" to the slide edges
+- placeholder leftovers visible in the rendering ("Click to add …")
+- chart background / palette clashing with the slide background
+
+When you find an issue, fix the slide via \`python-pptx\`, then re-render
+just that slide for a fast loop:
+
+\`\`\`bash
+pptx_inspect /files/conversation/output.pptx --render --slide 3
+\`\`\`
+
+\`Read\` only that one image, confirm the fix, move on. Do not declare the
+deck done until every slide has been \`Read\` clean.
+`;
+
+export const pptxSkill = {
+  sId: "pptx",
+  name: "Slide decks",
+  userFacingDescription: "Read, edit, and create slide presentations (.pptx)",
+  agentFacingDescription:
+    "Work with .pptx files in the sandbox. Includes the pptx_inspect tool " +
+    "for paginated structural inspection of decks (slides, layouts, shapes, " +
+    "text, charts, tables, media) so existing decks can be adapted in place " +
+    "via python-pptx rather than rebuilt from scratch with pptxgenjs.",
+  instructions: PPTX_SKILL_INSTRUCTIONS,
+  mcpServers: [{ name: "sandbox" }],
+  version: 1,
+  icon: "ActionSlideshowIcon",
+  isRestricted: async (auth: Authenticator) => {
+    const flags = await getFeatureFlags(auth);
+
+    return !flags.includes("sandbox_tools");
+  },
+} as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/xlsx.ts
+++ b/front/lib/resources/skill/code_defined/xlsx.ts
@@ -124,8 +124,7 @@ Also verify zero formula errors. \`#REF!\`, \`#DIV/0!\`, \`#VALUE!\`, \`#N/A\`,
 export const xlsxSkill = {
   sId: "xlsx",
   name: "Spreadsheets",
-  userFacingDescription:
-    "Read, edit, and create spreadsheets (.xlsx, .csv) in the sandbox.",
+  userFacingDescription: "Read, edit, and create spreadsheets (.xlsx, .csv)",
   agentFacingDescription:
     "Work with .xlsx, .xlsm, .csv, and .tsv files in the sandbox. Includes " +
     "the xlsx_inspect tool for paginated structural inspection of workbooks " +


### PR DESCRIPTION
## Description

Add pptx skill + tool to inspect slides and get informations about templating, layout, conventions in the files passed to the agent.
Also add a shortcut to render slides to images to make agent's self-QA more consistent.


## Tests

Tested locally

## Risk

Low

## Deploy Plan

- [ ] Deploy front