### PR TITLE
Reinforcement: check that suggestions are made on skill being analysed

### DIFF
--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -340,6 +340,7 @@ export async function processSkillReinforcedEvents({
   operationType,
   contextId,
   conversation,
+  eligibleSkillIds,
 }: {
   auth: Authenticator;
   events: LLMEvent[];
@@ -347,6 +348,7 @@ export async function processSkillReinforcedEvents({
   operationType: ReinforcedSkillsOperationType;
   contextId: string;
   conversation?: ConversationResource;
+  eligibleSkillIds: string[];
 }): Promise<ProcessReinforcedSkillsEventsResult> {
   const errorEvents = events.filter((e) => e.type === "error");
   if (errorEvents.length > 0) {
@@ -402,6 +404,7 @@ export async function processSkillReinforcedEvents({
       operationType,
       contextId,
       conversation,
+      eligibleSkillIds,
     });
     switch (result.type) {
       case "created": {
@@ -457,6 +460,7 @@ async function createSkillSuggestionsFromToolCall({
   operationType,
   contextId,
   conversation,
+  eligibleSkillIds,
 }: {
   auth: Authenticator;
   toolName: string;
@@ -465,6 +469,7 @@ async function createSkillSuggestionsFromToolCall({
   operationType: ReinforcedSkillsOperationType;
   contextId: string;
   conversation?: ConversationResource;
+  eligibleSkillIds: string[];
 }): Promise<ToolCallResult> {
   switch (toolName) {
     case "edit_skill": {
@@ -487,6 +492,17 @@ async function createSkillSuggestionsFromToolCall({
           "ReinforcedSkills: skill not found for edit_skill"
         );
         return { type: "error", errorMessage: "Skill not found" };
+      }
+
+      if (!eligibleSkillIds.includes(parsed.data.skillId)) {
+        logger.warn(
+          { skillId: parsed.data.skillId, contextId },
+          "ReinforcedSkills: skill is not eligible for reinforcement suggestions"
+        );
+        return {
+          type: "error",
+          errorMessage: `Skill ${parsed.data.skillId} is not eligible for reinforcement suggestions`,
+        };
       }
 
       const hasInstructionEdits =

--- a/front/lib/reinforcement/selection.test.ts
+++ b/front/lib/reinforcement/selection.test.ts
@@ -1,12 +1,22 @@
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill";
 import {
   PER_SKILL_CONVERSATION_CAP,
   WEIGHT_FEEDBACK,
   WEIGHT_TOOL_ERRORS,
   WEIGHT_USER_ENGAGEMENT,
 } from "@app/lib/reinforcement/constants";
-import { scoreAndSelectConversations } from "@app/lib/reinforcement/selection";
+import {
+  findConversationsWithSkills,
+  scoreAndSelectConversations,
+} from "@app/lib/reinforcement/selection";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { ModelId } from "@app/types/shared/model_id";
-import { describe, expect, it } from "vitest";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
 
 function makeConversationSkillMap(
   entries: { convId: ModelId; skillIds: string[] }[]
@@ -287,6 +297,88 @@ describe("scoreAndSelectConversations", () => {
     //       = 0.45 + 0.30 + 0.25 = 1.0
     expect(WEIGHT_FEEDBACK + WEIGHT_TOOL_ERRORS + WEIGHT_USER_ENGAGEMENT).toBe(
       1.0
+    );
+  });
+});
+
+describe("findConversationsWithSkills", () => {
+  let auth: Authenticator;
+  let workspace: LightWorkspaceType;
+
+  beforeEach(async () => {
+    ({ authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    }));
+  });
+
+  it("excludes skills with reinforcement='off' and only returns conversations with at least one eligible skill", async () => {
+    // Create 3 skills: one per reinforcement mode.
+    const skillOn = await SkillFactory.create(auth, { name: "Skill On" });
+    await skillOn.updateReinforcement("on");
+    const skillAuto = await SkillFactory.create(auth, { name: "Skill Auto" });
+    // "auto" is the default, no update needed.
+    const skillOff = await SkillFactory.create(auth, { name: "Skill Off" });
+    await skillOff.updateReinforcement("off");
+
+    // Conversation A uses all 3 skills. Has 2 user messages to pass the scoring filter.
+    const convA = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [new Date(), new Date()],
+    });
+    const agentMessageA = await AgentMessageModel.create({
+      status: "created",
+      agentConfigurationId: "test-agent",
+      agentConfigurationVersion: 0,
+      workspaceId: workspace.id,
+      skipToolsValidation: false,
+    });
+    const skillLinksA = [skillOn, skillAuto, skillOff].map((skill) => ({
+      workspaceId: workspace.id,
+      agentMessageId: agentMessageA.id,
+      customSkillId: skill.id,
+      globalSkillId: null,
+      conversationId: convA.id,
+      source: "conversation" as const,
+      agentConfigurationId: null,
+      addedByUserId: null,
+    }));
+    await AgentMessageSkillModel.bulkCreate(skillLinksA);
+
+    // Conversation B uses only the "off" skill. Has 2 user messages.
+    const convB = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [new Date(), new Date()],
+    });
+    const agentMessageB = await AgentMessageModel.create({
+      status: "created",
+      agentConfigurationId: "test-agent",
+      agentConfigurationVersion: 0,
+      workspaceId: workspace.id,
+      skipToolsValidation: false,
+    });
+    const skillLinksB = [skillOff].map((skill) => ({
+      workspaceId: workspace.id,
+      agentMessageId: agentMessageB.id,
+      customSkillId: skill.id,
+      globalSkillId: null,
+      conversationId: convB.id,
+      source: "conversation" as const,
+      agentConfigurationId: null,
+      addedByUserId: null,
+    }));
+    await AgentMessageSkillModel.bulkCreate(skillLinksB);
+
+    const results = await findConversationsWithSkills(auth, {
+      cutoffDate: new Date(0), // Far past: all recent conversations qualify.
+    });
+
+    // Only conv A qualifies — conv B's only skill is "off".
+    expect(results).toHaveLength(1);
+    expect(results[0].conversationId).toBe(convA.sId);
+
+    // Only the enabled skills (on + auto) are included, not the "off" one.
+    expect(results[0].skillIds.sort()).toEqual(
+      [skillOn.sId, skillAuto.sId].sort()
     );
   });
 });

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -117,6 +117,9 @@ async function fetchEligibleSkillIds(
 /**
  * Stage 2: Discover conversations that used eligible custom skills,
  * filtering out conversations where skills were invoked by custom agents.
+ *
+ * The returned skill IDs per conversation contain only the eligible skills,
+ * not every skill used in the conversation.
  */
 async function discoverConversations(
   auth: Authenticator,

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -76,6 +76,7 @@ async function runReinforcedSkillsStep({
   contextId,
   source,
   conversation,
+  eligibleSkillIds,
 }: {
   auth: Authenticator;
   reinforcementConversationId: string;
@@ -84,6 +85,7 @@ async function runReinforcedSkillsStep({
   contextId: string;
   source: "synthetic" | "reinforcement";
   conversation?: ConversationResource;
+  eligibleSkillIds: string[];
 }): Promise<{
   isTerminal: boolean;
   suggestionsCreated: number;
@@ -184,6 +186,7 @@ async function runReinforcedSkillsStep({
       operationType,
       contextId,
       conversation,
+      eligibleSkillIds,
     });
 
     // Store results for all terminal tool calls so the conversation is complete.
@@ -369,6 +372,7 @@ export async function analyzeConversationStepActivity({
     contextId: conversationId,
     source: "synthetic",
     conversation,
+    eligibleSkillIds: skillIds,
   });
 }
 
@@ -467,6 +471,7 @@ export async function aggregateSuggestionsForSkillStepActivity({
     systemPrompt: buildSkillAggregationSystemPrompt(),
     contextId: skillId,
     source: "reinforcement",
+    eligibleSkillIds: [skillId],
   });
 }
 
@@ -709,10 +714,13 @@ export async function processSkillConversationAnalysisBatchResultActivity({
   workspaceId,
   batchId,
   reinforcementConversationMap,
+  conversationSkillMap,
 }: {
   workspaceId: string;
   batchId: string;
   reinforcementConversationMap: Record<string, string>;
+  // mapping from analysed conversation id to analysed skill ids
+  conversationSkillMap: Record<string, string[]>;
 }): Promise<ConversationContinuationInfo[]> {
   const auth = await getAuthForWorkspace(workspaceId);
 
@@ -773,6 +781,7 @@ export async function processSkillConversationAnalysisBatchResultActivity({
         operationType: "reinforcement_analyze_conversation",
         contextId: analysedConvId,
         conversation: conversationById.get(analysedConvId),
+        eligibleSkillIds: conversationSkillMap[analysedConvId] ?? [],
       });
       totalCreated += result.suggestionsCreated;
 
@@ -998,6 +1007,7 @@ export async function processSkillAggregationBatchResultActivity({
       source: "reinforcement",
       operationType: "reinforcement_aggregate_suggestions",
       contextId: skillId,
+      eligibleSkillIds: [skillId],
     });
 
     // Store results for all terminal tool calls.

--- a/front/temporal/reinforcement/workflows.ts
+++ b/front/temporal/reinforcement/workflows.ts
@@ -355,6 +355,9 @@ export async function reinforcementWorkspaceWorkflow({
           workspaceId,
           batchId: batchResult.batchId,
           reinforcementConversationMap,
+          conversationSkillMap: Object.fromEntries(
+            pendingConversations.map((c) => [c.conversationId, c.skillIds])
+          ),
         });
 
       if (continuations.length === 0) {


### PR DESCRIPTION
## Description

Add some safety to make sure we only do suggestions on skills where the reinforcement is enabled.

 - Add a test to make sure when we build the map (conversation -> skillIds) we only consider return skills where we want to do reinforcement, not all the skills used by the conv
 - Add a check that the suggestion made by the model is indeed on a skill being analysed. Only these skills are provided to the model in their context, but in theory nothing prevented the model from doing suggestion on other skills 🤷 

This is preliminary work for pricing so we can split the cost of the conversation among all the skills being analysed.

## Tests

- added one unit test
- tested that reinforcement still work locally

## Risk

low

## Deploy Plan

deploy front