### PR TITLE
Migrate most of poke from io-ts to zod

### DIFF
--- a/front/components/poke/pages/PlansPage.tsx
+++ b/front/components/poke/pages/PlansPage.tsx
@@ -21,9 +21,9 @@ import {
   Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import type * as t from "io-ts";
 import React from "react";
 import { useSWRConfig } from "swr";
+import type { z } from "zod";
 
 export function PlansPage() {
   useDocumentTitle("Poke - Plans");
@@ -88,7 +88,7 @@ export function PlansPage() {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(
-        requestBody satisfies t.TypeOf<typeof PlanTypeSchema>
+        requestBody satisfies z.infer<typeof PlanTypeSchema>
       ),
     });
     if (!r.ok) {

--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -13,17 +13,17 @@ import {
 } from "@app/components/poke/shadcn/ui/form";
 import type { PokeGetPluginDetailsResponseBody } from "@app/pages/api/poke/plugins/[pluginId]/manifest";
 import type { AsyncEnumValues, EnumValues } from "@app/types/poke/plugins";
-import { createIoTsCodecFromArgs } from "@app/types/poke/plugins";
+import { createZodSchemaFromArgs } from "@app/types/poke/plugins";
 import { Button, Checkbox, SliderToggle } from "@dust-tt/sparkle";
-import { ioTsResolver } from "@hookform/resolvers/io-ts";
-import type * as t from "io-ts";
+import { zodResolver } from "@hookform/resolvers/zod";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React, { useMemo, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
+import type { z } from "zod";
 
 type FallbackArgs = Record<string, unknown>;
 
-type FormValues<T> = T extends t.TypeC<any> ? t.TypeOf<T> : FallbackArgs;
+type FormValues<T> = T extends z.ZodTypeAny ? z.infer<T> : FallbackArgs;
 
 interface PluginFormProps {
   asyncArgs?: Partial<
@@ -42,13 +42,13 @@ export function PluginForm({
 }: PluginFormProps) {
   const [isSubmitted, setIsSubmitted] = useState(false);
 
-  const argsCodec = useMemo(() => {
+  const argsSchema = useMemo(() => {
     if (!manifest) {
       return null;
     }
 
-    // Create codec from original manifest - async values are handled in rendering
-    return createIoTsCodecFromArgs(manifest.args);
+    // Create schema from original manifest - async values are handled in rendering
+    return createZodSchemaFromArgs(manifest.args);
   }, [manifest]);
 
   const defaultValues = useMemo(() => {
@@ -110,7 +110,7 @@ export function PluginForm({
   }, [manifest, asyncArgs]);
 
   const form = useForm({
-    resolver: argsCodec ? ioTsResolver(argsCodec) : undefined,
+    resolver: argsSchema ? zodResolver(argsSchema) : undefined,
     defaultValues,
   });
 
@@ -137,7 +137,7 @@ export function PluginForm({
     watchedValues[field] = watchedValuesArray[index];
   });
 
-  async function handleSubmit(values: FormValues<typeof argsCodec>) {
+  async function handleSubmit(values: FormValues<typeof argsSchema>) {
     // Lock the form to prevent multiple submissions.
     setIsSubmitted(true);
 

--- a/front/lib/api/poke/plugins/spaces/import_app.ts
+++ b/front/lib/api/poke/plugins/spaces/import_app.ts
@@ -3,9 +3,8 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { importApp } from "@app/lib/utils/apps";
 import { ImportAppBody } from "@app/pages/api/poke/workspaces/[wId]/apps/import";
 import { Err, Ok } from "@app/types/shared/result";
-import { isLeft } from "fp-ts/lib/Either";
 import { readFileSync } from "fs";
-import * as reporter from "io-ts-reporters";
+import { fromError } from "zod-validation-error";
 
 export const importAppPlugin = createPlugin({
   manifest: {
@@ -33,14 +32,16 @@ export const importAppPlugin = createPlugin({
     const { file } = args;
     const fileContent = readFileSync(file.filepath, "utf-8");
     const appData = JSON.parse(fileContent);
-    const contentValidation = ImportAppBody.decode(appData);
+    const contentValidation = ImportAppBody.safeParse(appData);
 
-    if (isLeft(contentValidation)) {
-      const pathError = reporter.formatValidationErrors(contentValidation.left);
-
-      return new Err(new Error(`Invalid content: ${pathError}`));
+    if (!contentValidation.success) {
+      return new Err(
+        new Error(
+          `Invalid content: ${fromError(contentValidation.error).toString()}`
+        )
+      );
     }
-    const { app } = contentValidation.right;
+    const { app } = contentValidation.data;
 
     const result = await importApp(auth, spaceResource, app);
     if (result.isErr()) {

--- a/front/pages/api/poke/kill.ts
+++ b/front/pages/api/poke/kill.ts
@@ -7,18 +7,17 @@ import { isKillSwitchType } from "@app/lib/poke/types";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export type GetKillSwitchesResponseBody = {
   killSwitches: KillSwitchType[];
 };
 
-const KillSwitchTypeSchema = t.type({
-  enabled: t.boolean,
-  type: t.string,
+const KillSwitchTypeSchema = z.object({
+  enabled: z.boolean(),
+  type: z.string(),
 });
 
 async function handler(
@@ -45,20 +44,17 @@ async function handler(
       const killSwitches = await KillSwitchResource.listEnabledKillSwitches();
       return res.status(200).json({ killSwitches });
     case "POST":
-      const payloadValidation = KillSwitchTypeSchema.decode(req.body);
-      if (isLeft(payloadValidation)) {
-        const pathError = reporter.formatValidationErrors(
-          payloadValidation.left
-        );
+      const payloadValidation = KillSwitchTypeSchema.safeParse(req.body);
+      if (!payloadValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `The request body is invalid: ${pathError}`,
+            message: `The request body is invalid: ${fromError(payloadValidation.error).toString()}`,
           },
         });
       }
-      const { enabled, type } = payloadValidation.right;
+      const { enabled, type } = payloadValidation.data;
       if (!isKillSwitchType(type)) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -9,56 +9,55 @@ import { apiError } from "@app/logger/withlogging";
 import { config as documentBodyParserConfig } from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PlanType } from "@app/types/plan";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-export const PlanTypeSchema = t.type({
-  code: t.string,
-  name: t.string,
-  limits: t.type({
-    assistant: t.type({
-      isSlackBotAllowed: t.boolean,
-      maxMessages: t.number,
-      maxMessagesTimeframe: t.union([t.literal("day"), t.literal("lifetime")]),
-      isDeepDiveAllowed: t.boolean,
+export const PlanTypeSchema = z.object({
+  code: z.string(),
+  name: z.string(),
+  limits: z.object({
+    assistant: z.object({
+      isSlackBotAllowed: z.boolean(),
+      maxMessages: z.number(),
+      maxMessagesTimeframe: z.enum(["day", "lifetime"]),
+      isDeepDiveAllowed: z.boolean(),
     }),
-    capabilities: t.type({
-      images: t.type({
-        maxImagesPerWeek: t.number,
+    capabilities: z.object({
+      images: z.object({
+        maxImagesPerWeek: z.number(),
       }),
     }),
-    connections: t.type({
-      isConfluenceAllowed: t.boolean,
-      isSlackAllowed: t.boolean,
-      isNotionAllowed: t.boolean,
-      isGoogleDriveAllowed: t.boolean,
-      isGithubAllowed: t.boolean,
-      isIntercomAllowed: t.boolean,
-      isWebCrawlerAllowed: t.boolean,
-      isSalesforceAllowed: t.boolean,
+    connections: z.object({
+      isConfluenceAllowed: z.boolean(),
+      isSlackAllowed: z.boolean(),
+      isNotionAllowed: z.boolean(),
+      isGoogleDriveAllowed: z.boolean(),
+      isGithubAllowed: z.boolean(),
+      isIntercomAllowed: z.boolean(),
+      isWebCrawlerAllowed: z.boolean(),
+      isSalesforceAllowed: z.boolean(),
     }),
-    dataSources: t.type({
-      count: t.number,
-      documents: t.type({
-        count: t.number,
-        sizeMb: t.number,
+    dataSources: z.object({
+      count: z.number(),
+      documents: z.object({
+        count: z.number(),
+        sizeMb: z.number(),
       }),
     }),
-    users: t.type({
-      maxUsers: t.number,
-      isSSOAllowed: t.boolean,
-      isSCIMAllowed: t.boolean,
+    users: z.object({
+      maxUsers: z.number(),
+      isSSOAllowed: z.boolean(),
+      isSCIMAllowed: z.boolean(),
     }),
-    vaults: t.type({
-      maxVaults: t.number,
+    vaults: z.object({
+      maxVaults: z.number(),
     }),
-    canUseProduct: t.boolean,
+    canUseProduct: z.boolean(),
   }),
-  trialPeriodDays: t.number,
-  isByok: t.boolean,
-  isAuditLogsAllowed: t.boolean,
+  trialPeriodDays: z.number(),
+  isByok: z.boolean(),
+  isAuditLogsAllowed: z.boolean(),
 });
 
 export type UpsertPokePlanResponseBody = {
@@ -103,18 +102,17 @@ async function handler(
       return;
 
     case "POST":
-      const bodyValidation = PlanTypeSchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      const bodyValidation = PlanTypeSchema.safeParse(req.body);
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `The request body is invalid: ${pathError}`,
+            message: `The request body is invalid: ${fromError(bodyValidation.error).toString()}`,
           },
         });
       }
-      const body = bodyValidation.right;
+      const body = bodyValidation.data;
 
       const { sizeLimit } = documentBodyParserConfig.api.bodyParser;
       const maxSizeMb = parseInt(sizeLimit.replace("mb", ""), 10);

--- a/front/pages/api/poke/plugins/[pluginId]/async-args.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/async-args.ts
@@ -11,10 +11,9 @@ import type {
   EnumValues,
   SupportedResourceType,
 } from "@app/types/poke/plugins";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export interface PokeGetPluginAsyncArgsResponseBody {
   asyncArgs: Record<
@@ -23,11 +22,11 @@ export interface PokeGetPluginAsyncArgsResponseBody {
   >;
 }
 
-const asyncArgsCodec = t.type({
-  pluginId: t.string,
-  resourceType: t.string,
-  resourceId: t.union([t.string, t.undefined]),
-  workspaceId: t.union([t.string, t.undefined]),
+const asyncArgsSchema = z.object({
+  pluginId: z.string(),
+  resourceType: z.string(),
+  resourceId: z.string().optional(),
+  workspaceId: z.string().optional(),
 });
 
 async function handler(
@@ -50,22 +49,20 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const queryValidation = asyncArgsCodec.decode(req.query);
+      const queryValidation = asyncArgsSchema.safeParse(req.query);
 
-      if (isLeft(queryValidation)) {
-        const pathError = reporter.formatValidationErrors(queryValidation.left);
-
+      if (!queryValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${fromError(queryValidation.error).toString()}`,
           },
         });
       }
 
       const { pluginId, resourceType, resourceId, workspaceId } =
-        queryValidation.right;
+        queryValidation.data;
 
       const plugin = pluginManager.getPluginById(pluginId);
       if (!plugin) {

--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -10,15 +10,14 @@ import { getClientIp } from "@app/lib/utils/request";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import {
-  createIoTsCodecFromArgs,
+  createZodSchemaFromArgs,
   supportedResourceTypes,
 } from "@app/types/poke/plugins";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { IncomingForm } from "formidable";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export const config = {
   api: {
@@ -26,23 +25,18 @@ export const config = {
   },
 };
 
-const [first, second, ...rest] = supportedResourceTypes;
-const SupportedResourceTypeCodec = t.union([
-  t.literal(first),
-  t.literal(second),
-  ...rest.map((value) => t.literal(value)),
-]);
+const SupportedResourceTypeSchema = z.enum(supportedResourceTypes);
 
-const RunPluginParamsCodec = t.union([
-  t.type({
-    pluginId: t.string,
-    resourceType: SupportedResourceTypeCodec,
+const RunPluginParamsSchema = z.union([
+  z.object({
+    pluginId: z.string(),
+    resourceType: SupportedResourceTypeSchema,
   }),
-  t.type({
-    pluginId: t.string,
-    resourceId: t.string,
-    resourceType: SupportedResourceTypeCodec,
-    workspaceId: t.string,
+  z.object({
+    pluginId: z.string(),
+    resourceId: z.string(),
+    resourceType: SupportedResourceTypeSchema,
+    workspaceId: z.string(),
   }),
 ]);
 
@@ -72,25 +66,21 @@ async function handler(
 
   switch (req.method) {
     case "POST": {
-      const pluginRunValidation = RunPluginParamsCodec.decode(req.query);
-      if (isLeft(pluginRunValidation)) {
-        const pathError = reporter.formatValidationErrors(
-          pluginRunValidation.left
-        );
-
+      const pluginRunValidation = RunPluginParamsSchema.safeParse(req.query);
+      if (!pluginRunValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `The query is invalid: ${pathError}`,
+            message: `The query is invalid: ${fromError(pluginRunValidation.error).toString()}`,
           },
         });
       }
 
-      const { pluginId, resourceType } = pluginRunValidation.right;
+      const { pluginId, resourceType } = pluginRunValidation.data;
       const { resourceId, workspaceId } =
-        "resourceId" in pluginRunValidation.right
-          ? pluginRunValidation.right
+        "resourceId" in pluginRunValidation.data
+          ? pluginRunValidation.data
           : {
               resourceId: undefined,
               workspaceId: undefined,
@@ -167,25 +157,21 @@ async function handler(
         });
       }
 
-      const pluginCodec = createIoTsCodecFromArgs(plugin.manifest.args);
-      const pluginArgsValidation = pluginCodec.decode(formData);
-      if (isLeft(pluginArgsValidation)) {
-        const pathError = reporter.formatValidationErrors(
-          pluginArgsValidation.left
-        );
-
+      const pluginSchema = createZodSchemaFromArgs(plugin.manifest.args);
+      const pluginArgsValidation = pluginSchema.safeParse(formData);
+      if (!pluginArgsValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `The request body is invalid: ${pathError}`,
+            message: `The request body is invalid: ${fromError(pluginArgsValidation.error).toString()}`,
           },
         });
       }
 
       const pluginRun = await PluginRunResource.makeNew(
         plugin,
-        pluginArgsValidation.right,
+        pluginArgsValidation.data,
         auth.getNonNullableUser(),
         workspaceId ? auth.getNonNullableWorkspace() : null,
         {
@@ -199,7 +185,7 @@ async function handler(
         runRes = await plugin.execute(
           auth,
           resource,
-          pluginArgsValidation.right
+          pluginArgsValidation.data
         );
       } catch (error) {
         const errorMessage = normalizeError(error).message;

--- a/front/pages/api/poke/production-checks/run.ts
+++ b/front/pages/api/poke/production-checks/run.ts
@@ -5,18 +5,17 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import { startManualCheckWorkflow } from "@app/temporal/production_checks/client";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export type RunProductionCheckResponseBody = {
   workflowId: string;
   checkName: string;
 };
 
-const RunCheckRequestSchema = t.type({
-  checkName: t.string,
+const RunCheckRequestSchema = z.object({
+  checkName: z.string(),
 });
 
 async function handler(
@@ -46,19 +45,18 @@ async function handler(
     });
   }
 
-  const bodyValidation = RunCheckRequestSchema.decode(req.body);
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+  const bodyValidation = RunCheckRequestSchema.safeParse(req.body);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request body: ${pathError}`,
+        message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
       },
     });
   }
 
-  const { checkName } = bodyValidation.right;
+  const { checkName } = bodyValidation.data;
 
   const result = await startManualCheckWorkflow(checkName);
   if (result.isErr()) {

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -8,10 +8,9 @@ import { apiError } from "@app/logger/withlogging";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { UserType } from "@app/types/user";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export type PokeAgentConfigurationType = LightAgentConfigurationType & {
   versionAuthor?: UserType | null;
@@ -21,8 +20,8 @@ export type PokeGetAgentConfigurationsResponseBody = {
   agentConfigurations: PokeAgentConfigurationType[];
 };
 
-const GetAgentConfigurationsQuerySchema = t.type({
-  view: t.union([t.literal("admin_internal"), t.literal("archived")]),
+const GetAgentConfigurationsQuerySchema = z.object({
+  view: z.enum(["admin_internal", "archived"]),
 });
 
 async function handler(
@@ -49,21 +48,20 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const queryValidation = GetAgentConfigurationsQuerySchema.decode(
+      const queryValidation = GetAgentConfigurationsQuerySchema.safeParse(
         req.query
       );
-      if (isLeft(queryValidation)) {
-        const pathError = reporter.formatValidationErrors(queryValidation.left);
+      if (!queryValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid query parameters: ${pathError}`,
+            message: `Invalid query parameters: ${fromError(queryValidation.error).toString()}`,
           },
         });
       }
 
-      const { view } = queryValidation.right;
+      const { view } = queryValidation.data;
       const viewParam = view;
 
       const agentConfigurations = await getAgentConfigurationsForView({

--- a/front/pages/api/poke/workspaces/[wId]/apps/import.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/import.ts
@@ -6,52 +6,39 @@ import { importApp } from "@app/lib/utils/apps";
 import { apiError } from "@app/logger/withlogging";
 import type { AppType } from "@app/types/app";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
-export const AppTypeSchema = t.type({
-  sId: t.string,
-  name: t.string,
-  description: t.union([t.string, t.null]),
-  savedSpecification: t.union([t.string, t.null]),
-  savedConfig: t.union([t.string, t.null]),
-  savedRun: t.union([t.string, t.null]),
-  dustAPIProjectId: t.string,
-  datasets: t.union([
-    t.array(
-      t.type({
-        name: t.string,
-        description: t.union([t.string, t.null]),
-        schema: t.union([
-          t.array(
-            t.type({
-              type: t.union([
-                t.literal("string"),
-                t.literal("number"),
-                t.literal("boolean"),
-                t.literal("json"),
-              ]),
-              description: t.union([t.string, t.null]),
-              key: t.string,
+export const AppTypeSchema = z.object({
+  sId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  savedSpecification: z.string().nullable(),
+  savedConfig: z.string().nullable(),
+  savedRun: z.string().nullable(),
+  dustAPIProjectId: z.string(),
+  datasets: z
+    .array(
+      z.object({
+        name: z.string(),
+        description: z.string().nullable(),
+        schema: z
+          .array(
+            z.object({
+              type: z.enum(["string", "number", "boolean", "json"]),
+              description: z.string().nullable(),
+              key: z.string(),
             })
-          ),
-          t.null,
-          t.undefined,
-        ]),
-        data: t.union([
-          t.array(t.record(t.string, t.any)),
-          t.null,
-          t.undefined,
-        ]),
+          )
+          .nullish(),
+        data: z.array(z.record(z.string(), z.any())).nullish(),
       })
-    ),
-    t.undefined,
-  ]),
-  coreSpecifications: t.union([t.record(t.string, t.string), t.undefined]),
+    )
+    .optional(),
+  coreSpecifications: z.record(z.string(), z.string()).optional(),
 });
 
-export const ImportAppBody = t.type({
+export const ImportAppBody = z.object({
   app: AppTypeSchema,
 });
 
@@ -104,8 +91,8 @@ async function handler(
     });
   }
 
-  const bodyValidation = ImportAppBody.decode(body);
-  if (isLeft(bodyValidation)) {
+  const bodyValidation = ImportAppBody.safeParse(body);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -115,7 +102,7 @@ async function handler(
     });
   }
 
-  const result = await importApp(auth, space, bodyValidation.right.app);
+  const result = await importApp(auth, space, bodyValidation.data.app);
 
   if (result.isErr()) {
     return apiError(req, res, {

--- a/front/pages/api/poke/workspaces/[wId]/invitations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/invitations/index.ts
@@ -5,13 +5,12 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-const PokeDeleteInvitationRequestBodySchema = t.type({
-  email: t.string,
+const PokeDeleteInvitationRequestBodySchema = z.object({
+  email: z.string(),
 });
 
 type PokePostInvitationResponseBody = {
@@ -44,21 +43,20 @@ async function handler(
 
   switch (req.method) {
     case "DELETE": {
-      const bodyValidation = PokeDeleteInvitationRequestBodySchema.decode(
+      const bodyValidation = PokeDeleteInvitationRequestBodySchema.safeParse(
         req.body
       );
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
           },
         });
       }
 
-      const { email } = bodyValidation.right;
+      const { email } = bodyValidation.data;
 
       // !! this is ok because we're in Poke as dust super user, do not copy paste
       // this mindlessly !!

--- a/front/pages/api/poke/workspaces/[wId]/roles.ts
+++ b/front/pages/api/poke/workspaces/[wId]/roles.ts
@@ -12,19 +12,18 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { ActiveRoleSchema } from "@app/types/user";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
+import { ACTIVE_ROLES } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export type PostRoleUserResponseBody = {
   success: true;
 };
 
-const PostRoleUserRequestBody = t.type({
-  userId: t.string,
-  role: ActiveRoleSchema,
+const PostRoleUserRequestBody = z.object({
+  userId: z.string(),
+  role: z.enum(ACTIVE_ROLES),
 });
 
 async function handler(
@@ -50,18 +49,17 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const bodyValidation = PostRoleUserRequestBody.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      const bodyValidation = PostRoleUserRequestBody.safeParse(req.body);
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `The request body is invalid: ${pathError}`,
+            message: `The request body is invalid: ${fromError(bodyValidation.error).toString()}`,
           },
         });
       }
-      const { userId, role } = bodyValidation.right;
+      const { userId, role } = bodyValidation.data;
 
       const user = await getUserForWorkspace(auth, { userId });
       if (!user) {

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -1,4 +1,4 @@
-import * as t from "io-ts";
+import { z } from "zod";
 
 import type { LightWorkspaceType } from "../user";
 
@@ -149,27 +149,27 @@ export type PluginResourceTarget =
   | PluginResourceScope
   | PluginWorkspaceResource;
 
-export function createIoTsCodecFromArgs(
+export function createZodSchemaFromArgs(
   args: PluginArgs
-): t.TypeC<Record<string, t.Mixed>> {
-  const codecProps: Record<string, t.Mixed> = {};
+): z.ZodObject<Record<string, z.ZodTypeAny>> {
+  const schemaProps: Record<string, z.ZodTypeAny> = {};
 
   for (const [key, arg] of Object.entries(args)) {
     switch (arg.type) {
       case "text":
-        codecProps[key] = t.string;
+        schemaProps[key] = z.string();
         break;
 
       case "string":
-        codecProps[key] = t.string;
+        schemaProps[key] = z.string();
         break;
 
       case "number":
-        codecProps[key] = t.number;
+        schemaProps[key] = z.number();
         break;
 
       case "boolean":
-        codecProps[key] = t.boolean;
+        schemaProps[key] = z.boolean();
         break;
 
       case "enum":
@@ -190,25 +190,25 @@ export function createIoTsCodecFromArgs(
 
         // Handle empty async enums
         if (enumValues.length === 0) {
-          codecProps[key] = t.array(t.string); // Allow any string for async enums initially.
+          schemaProps[key] = z.array(z.string()); // Allow any string for async enums initially.
         } else if (enumValues.length === 1) {
-          codecProps[key] = t.array(t.literal(enumValues[0]));
+          schemaProps[key] = z.array(z.literal(enumValues[0]));
         } else {
-          codecProps[key] = t.array(t.string);
+          schemaProps[key] = z.array(z.string());
         }
         break;
 
       case "file":
-        codecProps[key] = t.any;
+        schemaProps[key] = z.any();
         break;
 
       case "date":
-        codecProps[key] = t.string;
+        schemaProps[key] = z.string();
         break;
     }
   }
 
-  return t.type(codecProps);
+  return z.object(schemaProps);
 }
 
 export const supportedResourceTypes = [


### PR DESCRIPTION
## Description

Convert handlers under pages/api/poke from io-ts to zod.

Local schemas only:
- kill.ts — KillSwitchTypeSchema
- plans.ts — PlanTypeSchema (also updated PlansPage.tsx consumer: t.TypeOf → z.infer)
- plugins/[pluginId]/async-args.ts — asyncArgsSchema
- production-checks/run.ts — RunCheckRequestSchema
- workspaces/[wId]/agent_configurations/index.ts — query schema
- workspaces/[wId]/apps/import.ts — AppTypeSchema / ImportAppBody (also updated lib/api/poke/plugins/spaces/import_app.ts consumer)
- workspaces/[wId]/invitations/index.ts — body schema

Touched a small adjacent surface:
- workspaces/[wId]/roles.ts — replaced ActiveRoleSchema import with inline z.enum(ACTIVE_ROLES) using the existing const tuple
- plugins/[pluginId]/run.ts — local RunPluginParamsSchema, plus replaced createIoTsCodecFromArgs with createZodSchemaFromArgs in types/poke/plugins.ts (only used here and in PluginForm.tsx, which now uses zodResolver)

## Tests

Manually tested a subset of the scenarios in poke

## Risk

Low

## Deploy Plan

Front