### PR TITLE
[front] - fix: suppress lint warnings for legacy CSS important usage

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_todos/utils.ts
+++ b/front/components/assistant/conversation/space/conversations/project_todos/utils.ts
@@ -117,8 +117,10 @@ export const MANUAL_ADD_TODO_INPUT_FIELD_CLASS = cn(
   "shadow-none [box-shadow:none]",
   "outline-none ring-0 ring-offset-0",
   "focus:shadow-none focus:[box-shadow:none] focus:outline-none focus:ring-0 focus:ring-offset-0",
+  // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
   "focus:!ring-0 focus:!ring-offset-0",
   "focus-visible:shadow-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
+  // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
   "focus-visible:!ring-0",
   "placeholder:text-muted-foreground",
   "dark:text-foreground-night dark:placeholder:text-muted-foreground-night"


### PR DESCRIPTION
## Description

This PR adds biome-ignore comments to suppress lint/plugin/noCssImportant for lines using !important in CSS

## Tests

N/A

## Risk

N/A

## Deploy Plan

N/A