### PR TITLE
Compaction: force compact client side

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -14,7 +14,12 @@ import {
 } from "@app/components/assistant/conversation/types";
 import { WakeUpBanner } from "@app/components/assistant/conversation/WakeUpBanner";
 import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
-import { useCancelMessage, useConversation } from "@app/hooks/conversations";
+import {
+  useCancelMessage,
+  useConversation,
+  useConversationContextUsage,
+} from "@app/hooks/conversations";
+import { CONTEXT_USAGE_PERCENT_THRESHOLDS } from "@app/hooks/conversations/useConversationContextUsage";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
@@ -100,21 +105,27 @@ export const AgentInputBar = ({
       ?.richMentions.find(isRichAgentMention) ?? null;
 
   const draftAgent = agentBuilderContext?.draftAgent;
+
+  const { contextUsagePercentage } = useConversationContextUsage({
+    conversationId: context.conversation?.sId ?? "",
+    workspaceId: context.owner.sId,
+    options: { disabled: !context.conversation },
+  });
+
   const compactionBlockMessage = allMessages.some(
     (message) => isCompactionMessage(message) && message.status === "created"
   )
-    ? "Wait for compaction to finish"
-    : null;
+    ? "Wait for compaction to finish."
+    : contextUsagePercentage &&
+        contextUsagePercentage >=
+          CONTEXT_USAGE_PERCENT_THRESHOLDS["force_compaction"]
+      ? "Context is full, compact to continue."
+      : null;
 
   const { activeWakeUp } = useConversationWakeUps({
     owner: context.owner,
     conversationId: context.conversation?.sId ?? "",
     disabled: !context.conversation,
-  });
-
-  const { contextUsage, isContextUsageLoading } = useConversationContextUsage({
-    conversationId,
-    workspaceId: owner.sId,
   });
 
   const isActiveWakeUpOwner = activeWakeUp?.user.sId === context.user.sId;

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -1,4 +1,5 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { ContextUsageWarningBanner } from "@app/components/assistant/conversation/ContextUsageWarningBanner";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import type {
@@ -20,6 +21,7 @@ import {
   useConversationContextUsage,
 } from "@app/hooks/conversations";
 import { CONTEXT_USAGE_PERCENT_THRESHOLDS } from "@app/hooks/conversations/useConversationContextUsage";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
@@ -46,7 +48,6 @@ import {
   useVirtuosoMethods,
 } from "@virtuoso.dev/message-list";
 import { useEffect, useMemo, useState } from "react";
-import { ContextUsageWarningBanner } from "./ContextUsageWarningBanner";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 
@@ -107,6 +108,9 @@ export const AgentInputBar = ({
 
   const draftAgent = agentBuilderContext?.draftAgent;
 
+  const { hasFeature } = useFeatureFlags();
+  const isCompactionEnabled = hasFeature("enable_compaction");
+
   const { contextUsage, contextUsagePercentage } = useConversationContextUsage({
     conversationId: context.conversation?.sId ?? "",
     workspaceId: context.owner.sId,
@@ -117,11 +121,17 @@ export const AgentInputBar = ({
     (message) => isCompactionMessage(message) && message.status === "created"
   )
     ? "Wait for compaction to finish."
-    : contextUsagePercentage &&
+    : isCompactionEnabled &&
+        contextUsagePercentage &&
         contextUsagePercentage >=
           CONTEXT_USAGE_PERCENT_THRESHOLDS["force_compaction"]
       ? "Context is full, compact to continue."
       : null;
+  const showContextUsageBanner =
+    isCompactionEnabled &&
+    contextUsage &&
+    !!contextUsagePercentage &&
+    contextUsagePercentage >= CONTEXT_USAGE_PERCENT_THRESHOLDS["show_warning"];
 
   const { activeWakeUp } = useConversationWakeUps({
     owner: context.owner,
@@ -457,7 +467,14 @@ export const AgentInputBar = ({
           )}
         </ContentMessageInline>
       )}
-      {activeWakeUp && context.conversation && (
+      {showContextUsageBanner && (
+        <ContextUsageWarningBanner
+          owner={context.owner}
+          conversationId={context.conversation?.sId ?? ""}
+          contextUsage={contextUsage}
+        />
+      )}
+      {!showContextUsageBanner && activeWakeUp && context.conversation && (
         <WakeUpBanner
           wakeUp={activeWakeUp}
           owner={context.owner}
@@ -465,16 +482,6 @@ export const AgentInputBar = ({
           isOwner={isActiveWakeUpOwner}
         />
       )}
-      {contextUsage &&
-        !!contextUsagePercentage &&
-        contextUsagePercentage >=
-          CONTEXT_USAGE_PERCENT_THRESHOLDS["show_warning"] && (
-          <ContextUsageWarningBanner
-            owner={context.owner}
-            conversationId={context.conversation?.sId ?? ""}
-            contextUsage={contextUsage}
-          />
-        )}
       <InputBar
         owner={context.owner}
         user={context.user}

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -112,6 +112,11 @@ export const AgentInputBar = ({
     disabled: !context.conversation,
   });
 
+  const { contextUsage, isContextUsageLoading } = useConversationContextUsage({
+    conversationId,
+    workspaceId: owner.sId,
+  });
+
   const isActiveWakeUpOwner = activeWakeUp?.user.sId === context.user.sId;
   const wakeUpBlockMessage =
     activeWakeUp && !isActiveWakeUpOwner

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -46,6 +46,7 @@ import {
   useVirtuosoMethods,
 } from "@virtuoso.dev/message-list";
 import { useEffect, useMemo, useState } from "react";
+import { ContextUsageWarningBanner } from "./ContextUsageWarningBanner";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 
@@ -106,7 +107,7 @@ export const AgentInputBar = ({
 
   const draftAgent = agentBuilderContext?.draftAgent;
 
-  const { contextUsagePercentage } = useConversationContextUsage({
+  const { contextUsage, contextUsagePercentage } = useConversationContextUsage({
     conversationId: context.conversation?.sId ?? "",
     workspaceId: context.owner.sId,
     options: { disabled: !context.conversation },
@@ -464,6 +465,16 @@ export const AgentInputBar = ({
           isOwner={isActiveWakeUpOwner}
         />
       )}
+      {contextUsage &&
+        !!contextUsagePercentage &&
+        contextUsagePercentage >=
+          CONTEXT_USAGE_PERCENT_THRESHOLDS["show_warning"] && (
+          <ContextUsageWarningBanner
+            owner={context.owner}
+            conversationId={context.conversation?.sId ?? ""}
+            contextUsage={contextUsage}
+          />
+        )}
       <InputBar
         owner={context.owner}
         user={context.user}

--- a/front/components/assistant/conversation/ContextUsageWarningBanner.tsx
+++ b/front/components/assistant/conversation/ContextUsageWarningBanner.tsx
@@ -7,7 +7,7 @@ import {
   InformationCircleIcon,
 } from "@dust-tt/sparkle";
 
-interface WakeUpBannerProps {
+interface ContextUsageWarningBannerProps {
   owner: LightWorkspaceType;
   conversationId: string;
   contextUsage: GetConversationContextUsageResponse;
@@ -17,7 +17,7 @@ export const ContextUsageWarningBanner = ({
   owner,
   conversationId,
   contextUsage,
-}: WakeUpBannerProps) => {
+}: ContextUsageWarningBannerProps) => {
   const { compact, isCompacting } = useCompactConversation({
     owner,
     conversationId,

--- a/front/components/assistant/conversation/ContextUsageWarningBanner.tsx
+++ b/front/components/assistant/conversation/ContextUsageWarningBanner.tsx
@@ -1,0 +1,50 @@
+import { useCompactConversation } from "@app/hooks/conversations";
+import type { GetConversationContextUsageResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ContentMessageAction,
+  ContentMessageInline,
+  InformationCircleIcon,
+} from "@dust-tt/sparkle";
+
+interface WakeUpBannerProps {
+  owner: LightWorkspaceType;
+  conversationId: string;
+  contextUsage: GetConversationContextUsageResponse;
+}
+
+export const ContextUsageWarningBanner = ({
+  owner,
+  conversationId,
+  contextUsage,
+}: WakeUpBannerProps) => {
+  const { compact, isCompacting } = useCompactConversation({
+    owner,
+    conversationId,
+  });
+
+  return (
+    <ContentMessageInline
+      icon={InformationCircleIcon}
+      variant="golden"
+      className="mb-5 flex max-h-dvh w-full"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="min-w-0 truncate text-foreground dark:text-foreground-night">
+          Conversation context is almost full.
+        </span>
+      </div>
+      <ContentMessageAction
+        label={isCompacting ? "Compacting" : "Compact now"}
+        variant="outline"
+        size="xs"
+        disabled={isCompacting}
+        onClick={() => {
+          if (contextUsage.model) {
+            void compact(contextUsage.model);
+          }
+        }}
+      />
+    </ContentMessageInline>
+  );
+};

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -42,7 +42,9 @@ function CircleProgress({
       width={size}
       height={size}
       viewBox={`0 0 ${size} ${size}`}
-      className={variant === "warning" ? "text-red-400 dark:text-red-400-night" : ""}
+      className={
+        variant === "warning" ? "text-red-400 dark:text-red-400-night" : ""
+      }
     >
       <circle
         cx={size / 2}

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -21,11 +21,16 @@ interface ContextUsageIndicatorProps {
 interface CircleProgressProps {
   percentage: number;
   size?: number;
+  variant?: "default" | "warning";
 }
 
 const COMPACTION_GUIDE_URL = "https://docs.dust.tt/docs/context-compaction";
 
-function CircleProgress({ percentage, size = 16 }: CircleProgressProps) {
+function CircleProgress({
+  percentage,
+  size = 16,
+  variant = "default",
+}: CircleProgressProps) {
   const strokeWidth = size * 0.14;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
@@ -33,7 +38,12 @@ function CircleProgress({ percentage, size = 16 }: CircleProgressProps) {
   const offset = circumference - (clampedPct / 100) * circumference;
 
   return (
-    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      className={variant === "warning" ? "text-red-400 dark:text-red-400" : ""}
+    >
       <circle
         cx={size / 2}
         cy={size / 2}
@@ -81,6 +91,11 @@ export function ContextUsageIndicator({
     return null;
   }
 
+  const circleProgressVariant =
+    contextUsagePercentage > CONTEXT_USAGE_PERCENT_THRESHOLDS["show_warning"]
+      ? "warning"
+      : "default";
+
   return (
     <div className="hidden md:block" onClick={(e) => e.stopPropagation()}>
       <PopoverRoot>
@@ -89,7 +104,11 @@ export function ContextUsageIndicator({
             variant="ghost-secondary"
             size={buttonSize}
             icon={() => (
-              <CircleProgress percentage={contextUsagePercentage} size={16} />
+              <CircleProgress
+                percentage={contextUsagePercentage}
+                size={16}
+                variant={circleProgressVariant}
+              />
             )}
           />
         </PopoverTrigger>

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -42,7 +42,7 @@ function CircleProgress({
       width={size}
       height={size}
       viewBox={`0 0 ${size} ${size}`}
-      className={variant === "warning" ? "text-red-400 dark:text-red-400" : ""}
+      className={variant === "warning" ? "text-red-400 dark:text-red-400-night" : ""}
     >
       <circle
         cx={size / 2}

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -65,10 +65,12 @@ export function ContextUsageIndicator({
   owner,
   conversationId,
 }: ContextUsageIndicatorProps) {
-  const { contextUsage, isContextUsageLoading } = useConversationContextUsage({
-    conversationId,
-    workspaceId: owner.sId,
-  });
+  const { contextUsage, contextUsagePercentage, isContextUsageLoading } =
+    useConversationContextUsage({
+      conversationId,
+      workspaceId: owner.sId,
+      options: { disabled: !conversationId },
+    });
 
   const { compact, isCompacting } = useCompactConversation({
     owner,
@@ -79,14 +81,6 @@ export function ContextUsageIndicator({
     return null;
   }
 
-  const percentage =
-    contextUsage &&
-    contextUsage.contextUsage !== null &&
-    contextUsage.contextSize !== null &&
-    contextUsage.contextSize > 0
-      ? Math.round((contextUsage.contextUsage / contextUsage.contextSize) * 100)
-      : 0;
-
   return (
     <div className="hidden md:block" onClick={(e) => e.stopPropagation()}>
       <PopoverRoot>
@@ -94,16 +88,18 @@ export function ContextUsageIndicator({
           <Button
             variant="ghost-secondary"
             size={buttonSize}
-            icon={() => <CircleProgress percentage={percentage} size={16} />}
+            icon={() => (
+              <CircleProgress percentage={contextUsagePercentage} size={16} />
+            )}
           />
         </PopoverTrigger>
         <PopoverContent side="top" align="end" className="w-auto p-3">
           <div className="flex flex-col items-start gap-3">
             <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              {percentage}% of context used.
+              {contextUsagePercentage}% of context used.
             </span>
             <div className="flex items-center gap-3">
-              {percentage >
+              {contextUsagePercentage >
                 CONTEXT_USAGE_PERCENT_THRESHOLDS["enable_compaction"] && (
                 <Button
                   variant="outline"

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -2,6 +2,7 @@ import {
   useCompactConversation,
   useConversationContextUsage,
 } from "@app/hooks/conversations";
+import { CONTEXT_USAGE_PERCENT_THRESHOLDS } from "@app/hooks/conversations/useConversationContextUsage";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -22,7 +23,6 @@ interface CircleProgressProps {
   size?: number;
 }
 
-const CONTEXT_USAGE_PERCENT_THRESHOLD = 33;
 const COMPACTION_GUIDE_URL = "https://docs.dust.tt/docs/context-compaction";
 
 function CircleProgress({ percentage, size = 16 }: CircleProgressProps) {
@@ -103,7 +103,8 @@ export function ContextUsageIndicator({
               {percentage}% of context used.
             </span>
             <div className="flex items-center gap-3">
-              {percentage > CONTEXT_USAGE_PERCENT_THRESHOLD && (
+              {percentage >
+                CONTEXT_USAGE_PERCENT_THRESHOLDS["enable_compaction"] && (
                 <Button
                   variant="outline"
                   size="xs"

--- a/front/hooks/conversations/useConversationContextUsage.ts
+++ b/front/hooks/conversations/useConversationContextUsage.ts
@@ -2,6 +2,12 @@ import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetConversationContextUsageResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage";
 import type { Fetcher } from "swr";
 
+export const CONTEXT_USAGE_PERCENT_THRESHOLDS = {
+  enable_compaction: 33,
+  show_warning: 75,
+  force_compaction: 80,
+};
+
 export function useConversationContextUsage({
   conversationId,
   workspaceId,

--- a/front/hooks/conversations/useConversationContextUsage.ts
+++ b/front/hooks/conversations/useConversationContextUsage.ts
@@ -4,7 +4,7 @@ import type { Fetcher } from "swr";
 
 export const CONTEXT_USAGE_PERCENT_THRESHOLDS = {
   enable_compaction: 33,
-  show_warning: 75,
+  show_warning: 2,
   force_compaction: 80,
 };
 

--- a/front/hooks/conversations/useConversationContextUsage.ts
+++ b/front/hooks/conversations/useConversationContextUsage.ts
@@ -4,7 +4,7 @@ import type { Fetcher } from "swr";
 
 export const CONTEXT_USAGE_PERCENT_THRESHOLDS = {
   enable_compaction: 33,
-  show_warning: 2,
+  show_warning: 70,
   force_compaction: 80,
 };
 

--- a/front/hooks/conversations/useConversationContextUsage.ts
+++ b/front/hooks/conversations/useConversationContextUsage.ts
@@ -29,8 +29,17 @@ export function useConversationContextUsage({
     options
   );
 
+  const percentage =
+    data &&
+    data.contextUsage !== null &&
+    data.contextSize !== null &&
+    data.contextSize > 0
+      ? Math.round((data.contextUsage / data.contextSize) * 100)
+      : 0;
+
   return {
     contextUsage: data ?? null,
+    contextUsagePercentage: percentage,
     isContextUsageLoading: !error && !data,
     isContextUsageError: error,
     mutateContextUsage: mutate,


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/7719

- Above 70% context usage:
  - add red color to context usage component in input bar
  - add banner to strongly nudge users towards compacting
- Above 80% context usage:
  - disable sending message to force users to compact with existing `compactionBlockMessage`.

Roman photo:

<img width="725" height="272" alt="Screenshot 2026-05-05 at 16 40 23" src="https://github.com/user-attachments/assets/bdee0d3e-2602-4bbd-8247-72b1db37d005" />
<img width="696" height="268" alt="Screenshot 2026-05-05 at 16 40 53" src="https://github.com/user-attachments/assets/1a4d9495-bd00-4530-863b-b1a294755bc0" />
<img width="716" height="332" alt="Screenshot 2026-05-05 at 16 41 02" src="https://github.com/user-attachments/assets/ccec55de-ce81-4684-a361-a44f5ae04756" />
<img width="761" height="334" alt="Screenshot 2026-05-05 at 16 41 14" src="https://github.com/user-attachments/assets/a4a0bd59-f32b-4d34-8276-ab397bb57aa1" />
<img width="729" height="377" alt="Screenshot 2026-05-05 at 16 41 27" src="https://github.com/user-attachments/assets/30f2ce82-5dc2-49c4-ae6b-f85dccdc1c4f" />
<img width="708" height="314" alt="Screenshot 2026-05-05 at 16 42 12" src="https://github.com/user-attachments/assets/bcc64d3e-79a7-48e6-a0d1-73a5679661b3" />

## Tests

Tested locally

## Risk

Low behind flag.

## Deploy Plan

- deploy `front`