### PR TITLE
[Conversations] Fix initial attachments with private URLs

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -325,6 +325,14 @@ async function handler(
         spaceId: resolvedSpaceModelId,
       });
 
+      if (resolvedFragments.length > 0) {
+        await ConversationResource.upsertParticipation(auth, {
+          conversation,
+          action: "subscribed",
+          user: auth.user()?.toJSON() ?? null,
+        });
+      }
+
       let newContentFragment: ContentFragmentType | null = null;
       let newMessage: UserMessageType | null = null;
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -325,13 +325,11 @@ async function handler(
         spaceId: resolvedSpaceModelId,
       });
 
-      if (resolvedFragments.length > 0) {
-        await ConversationResource.upsertParticipation(auth, {
-          conversation,
-          action: "subscribed",
-          user: auth.user()?.toJSON() ?? null,
-        });
-      }
+      await ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "subscribed",
+        user: auth.user()?.toJSON() ?? null,
+      });
 
       let newContentFragment: ContentFragmentType | null = null;
       let newMessage: UserMessageType | null = null;

--- a/front/pages/api/w/[wId]/assistant/conversations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.test.ts
@@ -1,4 +1,5 @@
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -27,12 +28,17 @@ describe("POST /api/w/[wId]/assistant/conversations", () => {
     vi.clearAllMocks();
   });
 
-  it("creates a conversation with both content fragments and an initial message", async () => {
+  it("creates a conversation with content fragments when private conversation URLs are enabled", async () => {
     const { req, res, workspace, auth, globalSpace } =
       await createPrivateApiMockRequest({
         method: "POST",
         role: "admin",
       });
+
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    expect(updateResult.isOk()).toBe(true);
 
     const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
       auth,

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -295,13 +295,11 @@ async function handler(
         metadata,
       });
 
-      if (contentFragments.length > 0) {
-        await ConversationResource.upsertParticipation(auth, {
-          conversation,
-          action: "subscribed",
-          user: user.toJSON(),
-        });
-      }
+      await ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "subscribed",
+        user: user.toJSON(),
+      });
 
       const newContentFragments: ContentFragmentType[] = [];
       let newMessage: UserMessageType | null = null;

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -295,6 +295,14 @@ async function handler(
         metadata,
       });
 
+      if (contentFragments.length > 0) {
+        await ConversationResource.upsertParticipation(auth, {
+          conversation,
+          action: "subscribed",
+          user: user.toJSON(),
+        });
+      }
+
       const newContentFragments: ContentFragmentType[] = [];
       let newMessage: UserMessageType | null = null;
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7967.
Fixes regression introduced by https://github.com/dust-tt/dust/pull/24644.

When private conversation URLs are enabled by default, top-level conversations are only accessible to participants. PR #24644 added that access check to content fragment creation. In the new-conversation flow, initial content fragments are posted immediately after the conversation is created and before the initial user message is posted. The creator participation was normally recorded when posting the user message, so the content fragment access check could reject the creator with `Conversation access restricted`.

This PR keeps the fix scoped to the conversation creation API routes. After a route creates a conversation, it subscribes the authenticated creator before continuing with the rest of the request. This records the same creator participation earlier in the API flow, without changing `createConversation` itself or other lower-level callers. For v1/API-key creation requests without an authenticated user, the participation upsert remains a no-op.

## Risks
Blast radius: conversation creation API calls for authenticated users.

The behavioral change is limited to recording creator participation earlier in the request handled by the API route. This is the participation that would already be recorded later when the user message is posted.

Risk: low.


## Deploy Plan
- pmrr
- deploy front