### PR TITLE
[MCP] Add meta key-value fields to remote MCP servers

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -27,6 +27,18 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 
+async function patchServer(serverUrl: string, body: object) {
+  const response = await clientFetch(serverUrl, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const res = await response.json();
+    throw new Error(res.error?.message ?? "Failed to update server");
+  }
+}
+
 interface MCPServerDetailsProps {
   owner: WorkspaceType;
   onClose: () => void;
@@ -187,13 +199,15 @@ export function MCPServerDetails({
     icon?: string;
     authSharedSecret?: string;
     authCustomHeaders?: any;
+    authMeta?: Record<string, string> | null;
   }) => {
     const hasServerViewChanges = diff.serverView !== undefined;
     const hasIconChanges = diff.icon !== undefined;
     const hasSecretChanges = diff.authSharedSecret !== undefined;
     const hasHeaderChanges = diff.authCustomHeaders !== undefined;
+    const hasMetaChanges = diff.authMeta !== undefined;
     const hasRemoteChanges =
-      hasIconChanges || hasSecretChanges || hasHeaderChanges;
+      hasIconChanges || hasSecretChanges || hasHeaderChanges || hasMetaChanges;
 
     if (!hasServerViewChanges && !hasRemoteChanges) {
       return;
@@ -215,31 +229,22 @@ export function MCPServerDetails({
       }
     }
 
-    // Patch remote server settings if needed.
-    if (hasRemoteChanges) {
-      const patchBody: any = {};
-      if (diff.icon) {
-        patchBody.icon = diff.icon;
-      }
-      if (diff.authSharedSecret) {
-        patchBody.sharedSecret = diff.authSharedSecret;
-      }
-      if (diff.authCustomHeaders !== undefined) {
-        patchBody.customHeaders = diff.authCustomHeaders;
-      }
+    // Patch remote server settings if needed. icon and meta use separate
+    // requests because they are distinct discriminants in the API schema.
+    // sharedSecret and customHeaders can be combined in one request.
+    const serverUrl = `/api/w/${owner.sId}/mcp/${mcpServerView?.server.sId}`;
 
-      const response = await clientFetch(
-        `/api/w/${owner.sId}/mcp/${mcpServerView?.server.sId}`,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(patchBody),
-        }
-      );
-      if (!response.ok) {
-        const body = await response.json();
-        throw new Error(body.error?.message ?? "Failed to update server");
-      }
+    if (hasIconChanges) {
+      await patchServer(serverUrl, { icon: diff.icon });
+    }
+    if (hasSecretChanges || hasHeaderChanges) {
+      await patchServer(serverUrl, {
+        ...(hasSecretChanges && { sharedSecret: diff.authSharedSecret }),
+        ...(hasHeaderChanges && { customHeaders: diff.authCustomHeaders }),
+      });
+    }
+    if (hasMetaChanges) {
+      await patchServer(serverUrl, { meta: diff.authMeta });
     }
   };
 

--- a/front/components/actions/mcp/MCPServerMetaFields.tsx
+++ b/front/components/actions/mcp/MCPServerMetaFields.tsx
@@ -1,0 +1,56 @@
+import type { MetaRow } from "@app/types/shared/utils/http_headers";
+import { Button, Input, XMarkIcon } from "@dust-tt/sparkle";
+import { useFieldArray, useFormContext } from "react-hook-form";
+
+type FormWithMetaFields = {
+  metaFields: MetaRow[];
+};
+
+export function MCPServerMetaFields() {
+  const { control, register } = useFormContext<FormWithMetaFields>();
+  const { fields, append, remove } = useFieldArray<
+    FormWithMetaFields,
+    "metaFields"
+  >({
+    control,
+    name: "metaFields",
+  });
+
+  return (
+    <div className="flex w-full flex-col">
+      <div className="flex flex-col gap-4">
+        {fields.map((field, index) => (
+          <div key={field.id} className="flex items-center gap-2">
+            <div className="grid flex-1 grid-cols-3 gap-2 px-1">
+              <div className="col-span-1">
+                <Input
+                  {...register(`metaFields.${index}.key`)}
+                  placeholder="Key"
+                  className="w-full"
+                />
+              </div>
+              <div className="col-span-2">
+                <Input
+                  {...register(`metaFields.${index}.value`)}
+                  placeholder="Value"
+                  className="w-full"
+                />
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              icon={XMarkIcon}
+              onClick={() => remove(index)}
+            />
+          </div>
+        ))}
+      </div>
+      <Button
+        className="mt-4"
+        variant="outline"
+        label="Add Meta Field"
+        onClick={() => append({ key: "", value: "" })}
+      />
+    </div>
+  );
+}

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -1,5 +1,6 @@
 import type { MCPServerFormValues } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import { MCPServerHeaders } from "@app/components/actions/mcp/MCPServerHeaders";
+import { MCPServerMetaFields } from "@app/components/actions/mcp/MCPServerMetaFields";
 import type { RemoteMCPServerType } from "@app/lib/api/mcp";
 import { useSyncRemoteMCPServer } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -41,6 +42,9 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
 
   const headerFields = useWatch<MCPServerFormValues, "customHeaders">({
     name: "customHeaders",
+  });
+  const metaFields = useWatch<MCPServerFormValues, "metaFields">({
+    name: "metaFields",
   });
   const { syncServer } = useSyncRemoteMCPServer(owner, mcpServer.sId);
 
@@ -166,6 +170,23 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
         <CollapsibleContent>
           <div className="space-y-2">
             <MCPServerHeaders />
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+
+      <Collapsible>
+        <CollapsibleTrigger>
+          <div className="heading-lg">
+            Meta Fields ({(metaFields ?? []).length})
+          </div>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="space-y-2">
+            <p className="text-xs text-gray-500 dark:text-gray-500-night">
+              Key-value pairs sent as <code className="font-mono">_meta</code>{" "}
+              on every tool call to this server.
+            </p>
+            <MCPServerMetaFields />
           </div>
         </CollapsibleContent>
       </Collapsible>

--- a/front/components/actions/mcp/forms/mcpServerFormSchema.ts
+++ b/front/components/actions/mcp/forms/mcpServerFormSchema.ts
@@ -15,7 +15,7 @@ import {
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import type { HeaderRow } from "@app/types/shared/utils/http_headers";
+import type { HeaderRow, MetaRow } from "@app/types/shared/utils/http_headers";
 import { sanitizeHeadersArray } from "@app/types/shared/utils/http_headers";
 import { z } from "zod";
 
@@ -64,6 +64,7 @@ export type ServerSettings = {
   icon?: string;
   sharedSecret?: string;
   customHeaders?: HeaderRow[] | null;
+  metaFields?: MetaRow[] | null;
 };
 
 // Complete form values including all tabs.
@@ -184,6 +185,9 @@ export function getMCPServerFormDefaults(
 
   if (isRemoteMCPServerType(view.server)) {
     defaults.icon = view.server.icon;
+    defaults.metaFields = Object.entries(view.server.meta ?? {}).map(
+      ([key, value]) => ({ key, value })
+    );
   }
 
   return defaults;
@@ -225,6 +229,10 @@ export function getMCPServerFormSchema(
   if (isRemoteMCPServerType(view.server)) {
     schema = schema.extend({
       icon: z.string().optional(),
+      metaFields: z
+        .array(z.object({ key: z.string(), value: z.string() }))
+        .nullable()
+        .optional(),
     });
   }
 
@@ -251,6 +259,7 @@ type FormDiffType = {
   icon?: string;
   authSharedSecret?: string;
   authCustomHeaders?: HeaderRow[] | null;
+  authMeta?: Record<string, string> | null;
   toolChanges?: Array<{
     toolName: string;
     enabled: boolean;
@@ -290,6 +299,15 @@ export function diffMCPServerForm(
   if (isRemote) {
     if (current.icon && current.icon !== initial.icon) {
       out.icon = current.icon;
+    }
+
+    const iMeta = sanitizeHeadersArray(initial.metaFields ?? []);
+    const cMeta = sanitizeHeadersArray(current.metaFields ?? []);
+    if (JSON.stringify(iMeta) !== JSON.stringify(cMeta)) {
+      out.authMeta =
+        cMeta.length > 0
+          ? Object.fromEntries(cMeta.map(({ key, value }) => [key, value]))
+          : null;
     }
   }
 

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -157,6 +157,7 @@ export async function fetchMCPServerActionConfigurations(
       | InternalAllowedIconType
       | CustomResourceIconType
       | undefined = undefined;
+    let serverMeta: Record<string, string> | undefined = undefined;
 
     if (!mcpServerView) {
       logger.warn(
@@ -165,11 +166,12 @@ export async function fetchMCPServerActionConfigurations(
       serverName = "Missing";
       serverDescription = "Missing";
     } else {
-      const { name, description, icon } = mcpServerView.toJSON().server;
+      const { name, description, icon, meta } = mcpServerView.toJSON().server;
 
       serverName = name;
       serverDescription = description;
       serverIcon = icon;
+      serverMeta = meta ?? undefined;
     }
     if (!actionsByConfigurationId.has(agentConfigurationId)) {
       actionsByConfigurationId.set(agentConfigurationId, []);
@@ -212,6 +214,7 @@ export async function fetchMCPServerActionConfigurations(
           childAgentConfigurations.length > 0
             ? childAgentConfigurations[0].agentConfigurationId
             : null,
+        meta: serverMeta,
         additionalConfiguration: config.additionalConfiguration,
         timeFrame: config.timeFrame,
         jsonSchema: config.jsonSchema,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -218,6 +218,7 @@ export function makeServerSideMCPToolConfigurations(
     childAgentId: config.childAgentId,
     timeFrame: config.timeFrame,
     jsonSchema: config.jsonSchema,
+    meta: config.meta,
     additionalConfiguration: config.additionalConfiguration,
     permission: tool.stakeLevel,
     toolServerId: tool.toolServerId,
@@ -453,6 +454,7 @@ export async function* tryCallMCPTool(
             name: toolConfiguration.originalName,
             arguments: inputs,
             _meta: {
+              ...toolConfiguration.meta,
               progressToken,
             },
           },

--- a/front/lib/actions/mcp_schemas.ts
+++ b/front/lib/actions/mcp_schemas.ts
@@ -24,6 +24,7 @@ export const BaseMCPServerConfigurationSchema = z.object({
   name: z.string(),
   description: z.string().nullable(),
   icon: ResourceIconSchema.optional(),
+  meta: z.record(z.string(), z.string()).optional(),
 });
 
 export const ServerSideMCPServerConfigurationSchema =

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -78,6 +78,7 @@ export type MCPServerType = {
   developerSecretSelectionDescription?: string | null;
   sharedSecret?: string | null;
   customHeaders?: Record<string, string> | null;
+  meta?: Record<string, string> | null;
 };
 
 export type MCPServerViewTypeType = "remote" | "internal";

--- a/front/lib/models/agent/actions/remote_mcp_server.ts
+++ b/front/lib/models/agent/actions/remote_mcp_server.ts
@@ -28,6 +28,7 @@ export class RemoteMCPServerModel extends WorkspaceAwareModel<RemoteMCPServerMod
   declare sharedSecret: string | null;
   declare authorization: AuthorizationInfo | null;
   declare customHeaders: Record<string, string> | null;
+  declare meta: Record<string, string> | null;
 }
 
 RemoteMCPServerModel.init(
@@ -87,6 +88,11 @@ RemoteMCPServerModel.init(
       defaultValue: null,
     },
     customHeaders: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: null,
+    },
+    meta: {
       type: DataTypes.JSONB,
       allowNull: true,
       defaultValue: null,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -319,6 +319,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       icon,
       sharedSecret,
       customHeaders,
+      meta,
       cachedName,
       cachedDescription,
       cachedTools,
@@ -328,6 +329,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       icon?: CustomResourceIconType | InternalAllowedIconType;
       sharedSecret?: string;
       customHeaders?: Record<string, string>;
+      meta?: Record<string, string> | null;
       cachedName?: string;
       cachedDescription?: string;
       cachedTools?: MCPToolType[];
@@ -361,6 +363,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       icon,
       sharedSecret,
       customHeaders,
+      meta,
       cachedName,
       cachedDescription,
       cachedTools,
@@ -565,6 +568,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     lastError: string | null;
     sharedSecret: string | null;
     customHeaders: Record<string, string> | null;
+    meta: Record<string, string> | null;
   } {
     const currentTime = new Date();
     const createdAt = new Date(this.createdAt);
@@ -612,6 +616,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       lastError: this.lastError,
       sharedSecret: secret,
       customHeaders: headers,
+      meta: this.meta,
       documentationUrl: null,
     };
   }

--- a/front/migrations/db/migration_625.sql
+++ b/front/migrations/db/migration_625.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 5, 2026
+ALTER TABLE "remote_mcp_servers"
+  ADD COLUMN IF NOT EXISTS "meta" JSONB DEFAULT NULL;

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -41,6 +41,11 @@ const PatchMCPServerBodySchema = z
           message: "Either sharedSecret or customHeaders must be provided",
         }
       )
+  )
+  .or(
+    z.object({
+      meta: z.record(z.string(), z.string()).nullable(),
+    })
   );
 
 export type PatchMCPServerBody = z.infer<typeof PatchMCPServerBodySchema>;
@@ -326,6 +331,17 @@ async function handleRemotePatch(
     const update = await server.updateMetadata(auth, {
       sharedSecret: body.sharedSecret,
       customHeaders: sanitizedRecord,
+      lastSyncAt: new Date(),
+    });
+    if (update.isErr()) {
+      if (update.error.code === "unauthorized") {
+        return respondUnauthorizedUpdate(req, res);
+      }
+      return assertNever(update.error.code);
+    }
+  } else if ("meta" in body) {
+    const update = await server.updateMetadata(auth, {
+      meta: body.meta,
       lastSyncAt: new Date(),
     });
     if (update.isErr()) {

--- a/front/types/shared/utils/http_headers.ts
+++ b/front/types/shared/utils/http_headers.ts
@@ -1,6 +1,7 @@
 import { stripCRLF } from "./string_utils";
 
 export type HeaderRow = { key: string; value: string };
+export type MetaRow = { key: string; value: string };
 
 export function sanitizeHeaderPart(s: string): string {
   return stripCRLF(s).trim();


### PR DESCRIPTION
## Description

Adds a `meta` field (JSONB) to remote MCP servers: workspace admins can now define arbitrary key-value pairs in the server settings UI, which are spread into `_meta` on every tool call sent to that server. This lets server authors receive workspace-scoped context without requiring custom headers or auth secrets.

## Tests

Tested manually: added meta fields via the settings UI, verified they appear in the `_meta` payload on tool calls, and confirmed the PATCH endpoint correctly persists and clears the field.

<img width="278" height="156" alt="image" src="https://github.com/user-attachments/assets/95576ea0-6ec4-41df-9638-44b7ac0c3bd1" />


## Risk

Low. The new `meta` column is additive and nullable with a `DEFAULT NULL`. The migration must run before deploy (see below). No existing behaviour changes — meta is simply spread into the already-present `_meta` object.

## Deploy Plan

> ⚠️ Additive migration (ADD) — run migration BEFORE deploying

1. Block `front` deployment on #deployments (❌)
2. Merge PR on main
3. On Prodbox (US then EU): `psql $FRONT_DATABASE_URI -f ./migrations/db/migration_623.sql`
4. Deploy `main` on `front`
5. Unlock #deployments (✅)
6. Monitor deployment