### PR TITLE
Add configurable global limit for reinforcement costs

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -431,14 +431,20 @@ export interface WorkspaceMetadata {
   maintenance?: "relocation" | "relocation-done";
   killSwitched?: WorkspaceKillSwitchValue;
   allowContentCreationFileSharing?: boolean;
+  allowEmailAgents?: boolean;
   allowVoiceTranscription?: boolean;
   allowOpenProjects?: boolean;
   allowManualProjectKnowledgeManagement?: boolean;
+  allowReinforcement?: boolean;
+  allowReinforcementBatchMode?: boolean;
   privateConversationUrlsByDefault?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;
   disableManualInvitations?: boolean;
+  disableExtensionMcpTools?: boolean;
+  isBusiness?: boolean;
   phoneCountry?: string;
   sandboxAllowAgentEgressRequests?: boolean;
+  reinforcementCapMicroUsd?: number;
 }
 
 export async function updateWorkspaceMetadata(

--- a/front/lib/reinforcement/constants.ts
+++ b/front/lib/reinforcement/constants.ts
@@ -28,6 +28,10 @@ export const PENDING_SUGGESTION_MAX_AGE_DAYS = 30;
 // Max conversations analyzed per skill in a single run.
 export const PER_SKILL_CONVERSATION_CAP = 20;
 
+// Default monthly cap for reinforcement cost (in microUSD).
+// $100 = 100_000_000 microUSD.
+export const DEFAULT_REINFORCEMENT_CAP_MICRO_USD = 100_000_000;
+
 // Scoring weights for conversation selection.
 export const WEIGHT_FEEDBACK = 0.45;
 export const WEIGHT_TOOL_ERRORS = 0.3;

--- a/front/lib/reinforcement/constants.ts
+++ b/front/lib/reinforcement/constants.ts
@@ -28,7 +28,7 @@ export const PENDING_SUGGESTION_MAX_AGE_DAYS = 30;
 // Max conversations analyzed per skill in a single run.
 export const PER_SKILL_CONVERSATION_CAP = 20;
 
-// Default monthly cap for reinforcement cost (in microUSD).
+// Default monthly cap for reinforcement cost for the whole workspace (in microUSD).
 // $100 = 100_000_000 microUSD.
 export const DEFAULT_REINFORCEMENT_CAP_MICRO_USD = 100_000_000;
 

--- a/front/lib/reinforcement/consumption.test.ts
+++ b/front/lib/reinforcement/consumption.test.ts
@@ -1,0 +1,42 @@
+import type { Authenticator } from "@app/lib/auth";
+import { DEFAULT_REINFORCEMENT_CAP_MICRO_USD } from "@app/lib/reinforcement/constants";
+import { getReinforcementMonthlyCapMicroUsd } from "@app/lib/reinforcement/consumption";
+import { describe, expect, it } from "vitest";
+
+function makeAuth(
+  workspaceSId: string,
+  metadata?: { reinforcementCapMicroUsd?: number }
+): Authenticator {
+  return {
+    getNonNullableWorkspace: () => ({
+      sId: workspaceSId,
+      metadata: metadata ?? null,
+    }),
+  } as unknown as Authenticator;
+}
+
+describe("getReinforcementMonthlyCapMicroUsd", () => {
+  it("returns default cap when workspace has no metadata", () => {
+    const auth = makeAuth("ws-1");
+    expect(getReinforcementMonthlyCapMicroUsd(auth)).toBe(
+      DEFAULT_REINFORCEMENT_CAP_MICRO_USD
+    );
+  });
+
+  it("returns default cap when metadata has no reinforcementCapMicroUsd", () => {
+    const auth = makeAuth("ws-1", {});
+    expect(getReinforcementMonthlyCapMicroUsd(auth)).toBe(
+      DEFAULT_REINFORCEMENT_CAP_MICRO_USD
+    );
+  });
+
+  it("returns workspace override when set", () => {
+    const auth = makeAuth("ws-1", { reinforcementCapMicroUsd: 50_000_000 });
+    expect(getReinforcementMonthlyCapMicroUsd(auth)).toBe(50_000_000);
+  });
+
+  it("allows cap of 0", () => {
+    const auth = makeAuth("ws-1", { reinforcementCapMicroUsd: 0 });
+    expect(getReinforcementMonthlyCapMicroUsd(auth)).toBe(0);
+  });
+});

--- a/front/lib/reinforcement/consumption.ts
+++ b/front/lib/reinforcement/consumption.ts
@@ -1,0 +1,15 @@
+import type { Authenticator } from "@app/lib/auth";
+import { DEFAULT_REINFORCEMENT_CAP_MICRO_USD } from "@app/lib/reinforcement/constants";
+
+/**
+ * Return the workspace's monthly reinforcement cap in microUSD.
+ * Uses the workspace metadata override if set, otherwise the default ($100).
+ */
+export function getReinforcementMonthlyCapMicroUsd(
+  auth: Authenticator
+): number {
+  const workspace = auth.getNonNullableWorkspace();
+  return typeof workspace.metadata?.reinforcementCapMicroUsd === "number"
+    ? workspace.metadata.reinforcementCapMicroUsd
+    : DEFAULT_REINFORCEMENT_CAP_MICRO_USD;
+}

--- a/front/pages/api/w/[wId]/index.test.ts
+++ b/front/pages/api/w/[wId]/index.test.ts
@@ -377,6 +377,52 @@ describe("POST /api/w/[wId]", () => {
     });
   });
 
+  it("sets reinforcement cap", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = {
+      reinforcementCapMicroUsd: 50_000_000,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      workspace: expect.objectContaining({
+        id: workspace.id,
+        metadata: expect.objectContaining({
+          reinforcementCapMicroUsd: 50_000_000,
+        }),
+      }),
+    });
+  });
+
+  it("sets reinforcement cap to 0", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.body = {
+      reinforcementCapMicroUsd: 0,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      workspace: expect.objectContaining({
+        id: workspace.id,
+        metadata: expect.objectContaining({
+          reinforcementCapMicroUsd: 0,
+        }),
+      }),
+    });
+  });
+
   it("returns 405 for non-POST methods", async () => {
     for (const method of ["PUT", "DELETE"] as const) {
       const { req, res } = await createPrivateApiMockRequest({

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -108,6 +108,10 @@ const WorkspaceSandboxAgentEgressRequestsUpdateBodySchema = t.type({
   sandboxAllowAgentEgressRequests: t.boolean,
 });
 
+const WorkspaceReinforcementCapUpdateBodySchema = t.type({
+  reinforcementCapMicroUsd: t.number,
+});
+
 const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceAllowedDomainUpdateBodySchema,
   WorkspaceBatchDomainUpdateBodySchema,
@@ -126,6 +130,7 @@ const PostWorkspaceRequestBodySchema = t.union([
   WorkspaceOpenProjectsUpdateBodySchema,
   WorkspaceManualProjectKnowledgeManagementUpdateBodySchema,
   WorkspaceSandboxAgentEgressRequestsUpdateBodySchema,
+  WorkspaceReinforcementCapUpdateBodySchema,
 ]);
 
 async function handler(
@@ -304,6 +309,14 @@ async function handler(
           ...previousMetadata,
           allowManualProjectKnowledgeManagement:
             body.allowManualProjectKnowledgeManagement,
+        };
+        await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+        owner.metadata = newMetadata;
+      } else if ("reinforcementCapMicroUsd" in body) {
+        const previousMetadata = owner.metadata ?? {};
+        const newMetadata = {
+          ...previousMetadata,
+          reinforcementCapMicroUsd: body.reinforcementCapMicroUsd,
         };
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;


### PR DESCRIPTION
## Description

Store the global consumption limit as metadata of the workspace.

Initial prep work before these follow ups:
 - actually use the limit
 - add UI to se the limit

## Tests

unit tests added

## Risk

low

## Deploy Plan

deploy front 
