### PR TITLE
[front] feat: allow upgrading flagged free workspaces to Metronome Enterprise

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -128,9 +128,11 @@ export function WorkspacePage() {
   const {
     activeSubscription,
     hasDummyFeature,
+    hasMetronomeFeature,
     membersCount,
     metronomeCustomerId,
     stripeSubscription,
+    stripeCustomerId,
     subscriptions,
     whitelistableFeatures,
     workspaceVerifiedDomains,
@@ -227,6 +229,8 @@ export function WorkspacePage() {
                   subscription={activeSubscription}
                   subscriptions={subscriptions}
                   programmaticUsageConfig={programmaticUsageConfig}
+                  hasMetronomeBillingFeature={hasMetronomeFeature}
+                  stripeCustomerId={stripeCustomerId}
                 />
               </TabsContent>
               <TabsContent value="planlimitations">

--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -81,6 +81,7 @@ export function InputField<T extends FieldValues>({
   placeholder,
   min,
   step,
+  readOnly,
   transformValue,
 }: {
   control: Control<T>;
@@ -92,6 +93,7 @@ export function InputField<T extends FieldValues>({
   min?: string;
   /** Native `step` attribute, useful for `number` and `datetime-local`. */
   step?: number | string;
+  readOnly?: boolean;
   /** Optional transform applied to the raw string value before updating the form. */
   transformValue?: (value: string) => string | number;
 }) {
@@ -126,6 +128,7 @@ export function InputField<T extends FieldValues>({
 
                 field.onChange(e.target.value);
               }}
+              readOnly={readOnly}
             />
           </PokeFormControl>
           <PokeFormMessage />

--- a/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/EnterpriseUpgradeDialog.tsx
@@ -53,12 +53,16 @@ interface EnterpriseUpgradeDialogProps {
   owner: WorkspaceType;
   subscription: SubscriptionType;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
+  hasMetronomeBillingFeature: boolean;
+  stripeCustomerId: string | null;
 }
 
 export default function EnterpriseUpgradeDialog({
   owner,
   subscription,
   programmaticUsageConfig,
+  hasMetronomeBillingFeature,
+  stripeCustomerId,
 }: EnterpriseUpgradeDialogProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -73,14 +77,15 @@ export default function EnterpriseUpgradeDialog({
     }
   }, []);
 
-  const isMetronomeBilled = isSubscriptionMetronomeBilled(subscription);
+  const useMetronomePath =
+    isSubscriptionMetronomeBilled(subscription) || hasMetronomeBillingFeature;
   const { plans } = usePokePlans();
   const {
     packages: metronomePackages,
     isPackagesLoading,
     packagesError,
   } = usePokeMetronomePackages({
-    disabled: !isMetronomeBilled || !open,
+    disabled: !useMetronomePath || !open,
   });
   const router = useAppRouter();
 
@@ -108,7 +113,7 @@ export default function EnterpriseUpgradeDialog({
     [metronomePackages]
   );
   const isEnterprisePackageSelectionDisabled =
-    isMetronomeBilled &&
+    useMetronomePath &&
     (isPackagesLoading ||
       !!packagesError ||
       enterprisePackageOptions.length === 0);
@@ -120,11 +125,12 @@ export default function EnterpriseUpgradeDialog({
   const form = useForm<EnterpriseUpgradeFormType>({
     resolver: ioTsResolver(EnterpriseUpgradeFormSchema),
     defaultValues: {
-      stripeSubscriptionId: !isMetronomeBilled
+      stripeSubscriptionId: !useMetronomePath
         ? (subscription.stripeSubscriptionId ?? "")
         : undefined,
-      metronomePackageId: isMetronomeBilled ? "" : undefined,
-      startingAt: isMetronomeBilled ? minStartingAtLocal : undefined,
+      metronomePackageId: useMetronomePath ? "" : undefined,
+      startingAt: useMetronomePath ? minStartingAtLocal : undefined,
+      stripeCustomerId: useMetronomePath ? (stripeCustomerId ?? "") : undefined,
       planCode: "",
       freeCreditsOverrideEnabled: freeCreditMicroUsd !== null,
       freeCreditsDollars:
@@ -216,7 +222,7 @@ export default function EnterpriseUpgradeDialog({
           <DialogTitle>Upgrade {owner.name} to Enterprise.</DialogTitle>
           <DialogDescription>
             Select the enterprise plan and provide the{" "}
-            {isMetronomeBilled
+            {useMetronomePath
               ? "Metronome package and contract start time"
               : "Stripe subscription Id"}{" "}
             of the customer.
@@ -250,7 +256,7 @@ export default function EnterpriseUpgradeDialog({
                         }))}
                     />
                   </div>
-                  {isMetronomeBilled ? (
+                  {useMetronomePath ? (
                     <>
                       {isPackagesLoading && (
                         <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -291,6 +297,15 @@ export default function EnterpriseUpgradeDialog({
                           min={minStartingAtLocal}
                           step={3600}
                           transformValue={snapDatetimeLocalToHour}
+                        />
+                      </div>
+                      <div className="grid-cols grid items-center gap-4">
+                        <InputField
+                          control={form.control}
+                          name="stripeCustomerId"
+                          title="Stripe Customer Id"
+                          placeholder="cus_1234567890"
+                          readOnly={stripeCustomerId !== null}
                         />
                       </div>
                     </>

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -169,6 +169,8 @@ interface ActiveSubscriptionTableProps {
   subscription: SubscriptionType;
   subscriptions: SubscriptionType[];
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
+  hasMetronomeBillingFeature: boolean;
+  stripeCustomerId: string | null;
 }
 
 export function ActiveSubscriptionTable({
@@ -177,6 +179,8 @@ export function ActiveSubscriptionTable({
   subscription,
   subscriptions,
   programmaticUsageConfig,
+  hasMetronomeBillingFeature,
+  stripeCustomerId,
 }: ActiveSubscriptionTableProps) {
   const status = getSubscriptionDisplayStatus(subscription);
   const { chipColor, chipLabel, cardClass } = STATUS_CONFIG[status];
@@ -200,6 +204,8 @@ export function ActiveSubscriptionTable({
               owner={owner}
               subscription={subscription}
               programmaticUsageConfig={programmaticUsageConfig}
+              hasMetronomeBillingFeature={hasMetronomeBillingFeature}
+              stripeCustomerId={stripeCustomerId}
             />
           </div>
           <PokeTable>
@@ -434,12 +440,16 @@ interface UpgradeDowngradeModalProps {
   owner: WorkspaceType;
   subscription: SubscriptionType;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
+  hasMetronomeBillingFeature: boolean;
+  stripeCustomerId: string | null;
 }
 
 function UpgradeDowngradeModal({
   owner,
   subscription,
   programmaticUsageConfig,
+  hasMetronomeBillingFeature,
+  stripeCustomerId,
 }: UpgradeDowngradeModalProps) {
   const router = useAppRouter();
   const { plans } = usePokePlans();
@@ -559,6 +569,8 @@ function UpgradeDowngradeModal({
                 owner={owner}
                 subscription={subscription}
                 programmaticUsageConfig={programmaticUsageConfig}
+                hasMetronomeBillingFeature={hasMetronomeBillingFeature}
+                stripeCustomerId={stripeCustomerId}
               />
             </div>
             {isProPlanPrefix(subscription.plan.code) && (

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -199,6 +199,33 @@ export async function updateMetronomeCustomerName(
 }
 
 /**
+ * Resolves the Stripe customer ID linked to a Metronome customer's active
+ * Stripe billing configuration. Returns `null` when no active Stripe
+ * configuration is set on the customer. Mirrors the read used by
+ * `ensureMetronomeStripeBillingConfig`.
+ */
+export async function getMetronomeCustomerStripeCustomerId(
+  metronomeCustomerId: string
+): Promise<Result<string | null, Error>> {
+  try {
+    const configs =
+      await getMetronomeClient().v1.customers.retrieveBillingConfigurations({
+        customer_id: metronomeCustomerId,
+      });
+    const activeStripeConfig = configs.data.find(
+      (c) => c.billing_provider === "stripe" && !c.archived_at
+    );
+    const stripeCustomerId =
+      activeStripeConfig?.configuration?.stripe_customer_id;
+    return new Ok(
+      typeof stripeCustomerId === "string" ? stripeCustomerId : null
+    );
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
  * Idempotently ensure a Metronome customer has a Stripe billing
  * configuration pointing to the given `stripeCustomerId`.
  *

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -399,6 +399,25 @@ export const getStripeSubscription = async (
   }
 };
 
+/**
+ * Calls the Stripe API to retrieve a customer by its ID. Returns `null` when
+ * the customer cannot be retrieved or has been deleted.
+ */
+export const getStripeCustomer = async (
+  stripeCustomerId: string
+): Promise<Stripe.Customer | null> => {
+  const stripe = getStripeClient();
+  try {
+    const customer = await stripe.customers.retrieve(stripeCustomerId);
+    if (customer.deleted) {
+      return null;
+    }
+    return customer;
+  } catch {
+    return null;
+  }
+};
+
 export async function getSubscriptionInvoices({
   subscriptionId,
   status,

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
@@ -1,20 +1,23 @@
 import { Authenticator } from "@app/lib/auth";
 import {
   createMetronomeContract,
-  findMetronomeCustomerByAlias,
   listMetronomeContracts,
   listMetronomePackages,
   scheduleMetronomeContractEnd,
   setMetronomeContractCustomFields,
 } from "@app/lib/metronome/client";
 import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
+import { ensureMetronomeCustomerForWorkspace } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
+import { getStripeCustomer } from "@app/lib/plans/stripe";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
+import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./upgrade_enterprise";
@@ -25,7 +28,6 @@ vi.mock("@app/lib/metronome/client", async () => {
   >("@app/lib/metronome/client");
   return {
     ...actual,
-    findMetronomeCustomerByAlias: vi.fn(),
     listMetronomePackages: vi.fn(),
     createMetronomeContract: vi.fn(),
     setMetronomeContractCustomFields: vi.fn(),
@@ -34,11 +36,32 @@ vi.mock("@app/lib/metronome/client", async () => {
   };
 });
 
+vi.mock("@app/lib/metronome/contracts", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/contracts")
+  >("@app/lib/metronome/contracts");
+  return {
+    ...actual,
+    ensureMetronomeCustomerForWorkspace: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/plans/stripe", async () => {
+  const actual = await vi.importActual<typeof import("@app/lib/plans/stripe")>(
+    "@app/lib/plans/stripe"
+  );
+  return {
+    ...actual,
+    getStripeCustomer: vi.fn(),
+  };
+});
+
 const METRONOME_CUSTOMER_ID = "cust_test_xxx";
 const EXISTING_CONTRACT_ID = "contract_existing_xxx";
 const NEW_CONTRACT_ID = "contract_new_yyy";
 const PACKAGE_ID = "pkg_ent_usd";
 const ENT_PLAN_CODE = "ENT_TEST_PLAN";
+const STRIPE_CUSTOMER_ID = "cus_test_xxx";
 
 async function ensureEnterprisePlan(): Promise<void> {
   await PlanModel.upsert({
@@ -117,6 +140,7 @@ function defaultBody(overrides: Record<string, unknown> = {}) {
     planCode: ENT_PLAN_CODE,
     metronomePackageId: PACKAGE_ID,
     startingAt: futureIso(2),
+    stripeCustomerId: STRIPE_CUSTOMER_ID,
     freeCreditsOverrideEnabled: false,
     paygEnabled: false,
     ...overrides,
@@ -125,9 +149,12 @@ function defaultBody(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   // Default-happy mocks; individual tests override as needed.
-  vi.mocked(findMetronomeCustomerByAlias).mockResolvedValue(
-    new Ok(METRONOME_CUSTOMER_ID)
+  vi.mocked(ensureMetronomeCustomerForWorkspace).mockResolvedValue(
+    new Ok({ metronomeCustomerId: METRONOME_CUSTOMER_ID })
   );
+  vi.mocked(getStripeCustomer).mockResolvedValue({
+    id: STRIPE_CUSTOMER_ID,
+  } as unknown as Stripe.Customer);
   vi.mocked(listMetronomePackages).mockResolvedValue(
     new Ok([{ id: PACKAGE_ID, name: "Enterprise USD", aliases: [] }])
   );
@@ -173,7 +200,7 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
 
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.message).toContain(
-      "not Metronome-only billed"
+      "Stripe-billed and not yet migrated"
     );
     expect(createMetronomeContract).not.toHaveBeenCalled();
   });
@@ -324,5 +351,79 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
     expect(sub).not.toBeNull();
     expect(sub!.metronomeContractId).toBe(EXISTING_CONTRACT_ID);
     expect(sub!.status).toBe("active");
+  });
+
+  it("rejects when stripeCustomerId is missing", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = defaultBody({ stripeCustomerId: undefined });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain("stripeCustomerId");
+    expect(createMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the Stripe customer does not exist", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+    vi.mocked(getStripeCustomer).mockResolvedValueOnce(null);
+
+    req.body = defaultBody();
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "Stripe customer not found"
+    );
+    expect(createMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("accepts a fresh workspace with the metronome_billing flag and provisions the Metronome customer with the Stripe link", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    // Don't mark Metronome-billed; default workspace has no Stripe sub.
+    // Enable the flag to unlock the fresh-Metronome path.
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(adminAuth, "metronome_billing");
+
+    req.body = defaultBody();
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(ensureMetronomeCustomerForWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ stripeCustomerId: STRIPE_CUSTOMER_ID })
+    );
+    expect(createMetronomeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: METRONOME_CUSTOMER_ID,
+        packageId: PACKAGE_ID,
+        enableStripeBilling: true,
+      })
+    );
+    expect(setMetronomeContractCustomFields).toHaveBeenCalledWith({
+      contractId: NEW_CONTRACT_ID,
+      customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
+    });
   });
 });

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -6,27 +6,29 @@ import {
   upsertProgrammaticUsageConfiguration,
 } from "@app/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { startOrResumeEnterprisePAYG } from "@app/lib/credits/payg";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import {
   ceilToHourISO,
   createMetronomeContract,
-  findMetronomeCustomerByAlias,
   listMetronomeContracts,
   listMetronomePackages,
   scheduleMetronomeContractEnd,
   setMetronomeContractCustomFields,
 } from "@app/lib/metronome/client";
 import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
+import { ensureMetronomeCustomerForWorkspace } from "@app/lib/metronome/contracts";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import {
   assertStripeSubscriptionIsValid,
+  getStripeCustomer,
   getStripeSubscription,
   isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { EnterpriseUpgradeFormSchema } from "@app/types/plan";
@@ -139,10 +141,20 @@ async function handler(
       const currentSubscription = auth.subscriptionResource();
       const isCurrentSubscriptionMetronomeBilled =
         currentSubscription?.isMetronomeOnlyBilled ?? false;
+      const hasMetronomeFlag = await hasFeatureFlag(auth, "metronome_billing");
+
+      // A workspace with the Metronome flag and no Stripe subscription
+      // (free / no plan) can be upgraded straight to a Metronome Enterprise
+      // contract: we'll provision the Metronome customer in this handler
+      // and let the ocntract.start webhook flip the subscription.
+      const canStartFreshMetronomeContract =
+        hasMetronomeFlag && !currentSubscription?.stripeSubscriptionId;
+
       const isMetronomeUpgrade =
         body.metronomePackageId !== undefined ||
         body.startingAt !== undefined ||
-        isCurrentSubscriptionMetronomeBilled;
+        isCurrentSubscriptionMetronomeBilled ||
+        canStartFreshMetronomeContract;
 
       // PAYG on the Metronome path is not yet wired up: there is no
       // Metronome-side cycle-renewal or invoicing for PAYG credits, so
@@ -180,13 +192,17 @@ async function handler(
       // Metronome path: schedule the upgrade in Metronome. The subscription
       // DB record is updated later by the contract.start webhook.
       if (isMetronomeUpgrade) {
-        if (!body.metronomePackageId || !body.startingAt) {
+        if (
+          !body.metronomePackageId ||
+          !body.startingAt ||
+          !body.stripeCustomerId
+        ) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
               message:
-                "metronomePackageId and startingAt are required for Metronome-billed subscriptions.",
+                "metronomePackageId, startingAt and stripeCustomerId are required for Metronome-billed subscriptions.",
             },
           });
         }
@@ -200,14 +216,17 @@ async function handler(
           });
         }
 
-        // Gate: only allow this flow for workspaces whose current subscription
-        // is Metronome-only billed. Running it on a free or Stripe-billed
-        // subscription would leave the workspace in a shadow-billed or
-        // orphaned state when the contract.start webhook swaps the subscription.
-        if (!isCurrentSubscriptionMetronomeBilled) {
+        // Allow this flow either when the workspace is already
+        // Metronome-only billed, or when it has the metronome_billing flag
+        // and no Stripe subscription.
+        if (
+          !isCurrentSubscriptionMetronomeBilled &&
+          !canStartFreshMetronomeContract
+        ) {
           const errorMessage =
-            "Workspace's current subscription is not Metronome-only billed. " +
-            "Migrate the workspace to Metronome billing before scheduling an Enterprise upgrade.";
+            "Workspace cannot be upgraded via the Metronome path: it is " +
+            "Stripe-billed and not yet migrated. Migrate the workspace to " +
+            "Metronome billing before scheduling an Enterprise upgrade.";
           await pluginRun.recordError(errorMessage);
           return apiError(req, res, {
             status_code: 400,
@@ -215,18 +234,34 @@ async function handler(
           });
         }
 
-        const customerResult = await findMetronomeCustomerByAlias(owner.sId);
-        if (customerResult.isErr() || !customerResult.value) {
+        // Validate the Stripe customer exists before we touch Metronome
+        const stripeCustomer = await getStripeCustomer(body.stripeCustomerId);
+        if (!stripeCustomer) {
+          const errorMessage = `Stripe customer not found: ${body.stripeCustomerId}.`;
+          await pluginRun.recordError(errorMessage);
           return apiError(req, res, {
             status_code: 400,
+            api_error: { type: "invalid_request_error", message: errorMessage },
+          });
+        }
+
+        const customerResult = await ensureMetronomeCustomerForWorkspace({
+          workspace: renderLightWorkspaceType({ workspace: owner }),
+          stripeCustomerId: body.stripeCustomerId,
+        });
+        if (customerResult.isErr()) {
+          const errorMessage = `Failed to ensure Metronome customer: ${customerResult.error.message}`;
+          await pluginRun.recordError(errorMessage);
+          return apiError(req, res, {
+            status_code: 502,
             api_error: {
-              type: "invalid_request_error",
-              message: "No Metronome customer found for this workspace.",
+              type: "internal_server_error",
+              message: errorMessage,
             },
           });
         }
 
-        const metronomeCustomerId = customerResult.value;
+        const { metronomeCustomerId } = customerResult.value;
 
         const ONE_HOUR_MS = 60 * 60 * 1000;
         const requestedStartMs = Date.parse(body.startingAt);

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -4,12 +4,14 @@ import config from "@app/lib/api/config";
 import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
 import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { getStripeSubscription } from "@app/lib/plans/stripe";
+import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
+import { getCustomerId, getStripeSubscription } from "@app/lib/plans/stripe";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ExtensionConfigurationType } from "@app/types/extension";
@@ -27,9 +29,11 @@ export type PokeGetWorkspaceInfo = {
   baseUrl: string;
   extensionConfig: ExtensionConfigurationType | null;
   hasDummyFeature: boolean;
+  hasMetronomeFeature: boolean;
   membersCount: number;
   metronomeCustomerId: string | null;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
+  stripeCustomerId: string | null;
   stripeSubscription: Stripe.Subscription | null;
   subscriptions: SubscriptionType[];
   whitelistableFeatures: WhitelistableFeature[];
@@ -101,6 +105,11 @@ async function handler(
         "dummy_feature_for_flag_testing"
       );
 
+      const hasMetronomeFeature = await hasFeatureFlag(
+        auth,
+        "metronome_billing"
+      );
+
       const membersCount = await MembershipResource.getMembersCountForWorkspace(
         {
           workspace: owner,
@@ -115,11 +124,34 @@ async function handler(
         );
       }
 
+      let stripeCustomerId: string | null = null;
+      if (stripeSubscription) {
+        stripeCustomerId = getCustomerId(stripeSubscription);
+      } else if (workspaceResource.metronomeCustomerId) {
+        const lookup = await getMetronomeCustomerStripeCustomerId(
+          workspaceResource.metronomeCustomerId
+        );
+        if (lookup.isOk()) {
+          stripeCustomerId = lookup.value;
+        } else {
+          logger.warn(
+            {
+              workspaceId: owner.sId,
+              metronomeCustomerId: workspaceResource.metronomeCustomerId,
+              error: lookup.error.message,
+            },
+            "[Poke workspace-info] Failed to resolve Stripe customer ID from Metronome billing config"
+          );
+        }
+      }
+
       return res.status(200).json({
         activeSubscription,
         hasDummyFeature,
+        hasMetronomeFeature,
         membersCount,
         metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,
+        stripeCustomerId,
         stripeSubscription,
         subscriptions,
         whitelistableFeatures: WHITELISTABLE_FEATURES,

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -158,9 +158,11 @@ export const EnterpriseUpgradeFormSchema = t.intersection([
     stripeSubscriptionId: NonEmptyString,
     // For the Metronome path: id of the Metronome package the customer will
     // be placed on, plus a timestamp at least one hour in the future
-    // when the new contracts starts (and the existing contract sunsets).
+    // when the new contracts starts (and the existing contract sunsets),
+    // and the Stripe customer ID to link as the Metronome billing provider.
     metronomePackageId: NonEmptyString,
     startingAt: NonEmptyString,
+    stripeCustomerId: NonEmptyString,
     freeCreditsDollars: t.number,
     defaultDiscountPercent: t.number,
     paygCapDollars: t.number,


### PR DESCRIPTION
## Description

Enterprise upgrade in poke now works for workspaces with the metronome_billing feature flag and no Stripe subscription: the handler provisions the Metronome customer (linked to a required Stripe customer ID), and the contract.start webhook flips the FREE_NO_PLAN subscription to the new Enterprise plan. The form prefills the Stripe customer ID from the existing Stripe subscription or Metronome billing config when known, and locks it read-only to prevent silent re-pointing.

## Tests

Local + unit tests

## Risk

Low, gated by metronome_billing flag

## Deploy Plan

front
