### PR TITLE
Stop storing interactive content results in new file system

### DIFF
--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -310,9 +310,10 @@ describe("processToolResults", () => {
     const toolOutputWrite = uploadCalls.find((call) =>
       call[0].filePath.includes("results/")
     );
+
     expect(toolOutputWrite).toBeDefined();
     expect(toolOutputWrite?.[0].filePath).toMatch(
-      /results\/\d+_test_server\.txt$/
+      /results\/\d+_test_tool\.txt$/
     );
   });
 
@@ -347,7 +348,7 @@ describe("processToolResults", () => {
     );
     expect(toolOutputWrite).toBeDefined();
     expect(toolOutputWrite?.[0].filePath).toMatch(
-      /results\/\d+_test_server\.json$/
+      /results\/\d+_test_tool\.json$/
     );
   });
 });

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -58,7 +58,6 @@ import type { Logger } from "pino";
 const TEXT_OFFLOAD_EXEMPT_MCP_SERVERS: readonly string[] = [
   "conversation_files",
   "files",
-  "interactive_content",
   "sandbox",
 ];
 
@@ -175,7 +174,8 @@ export async function processToolResults(
     toolCallResultContent,
     async (block, idx) => {
       await persistToolOutput(auth, conversation, block, {
-        toolName: toolConfiguration.mcpServerName,
+        toolName: toolConfiguration.name,
+        serverName: toolConfiguration.mcpServerName,
       });
 
       switch (block.type) {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -58,6 +58,7 @@ import type { Logger } from "pino";
 const TEXT_OFFLOAD_EXEMPT_MCP_SERVERS: readonly string[] = [
   "conversation_files",
   "files",
+  "interactive_content",
   "sandbox",
 ];
 

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -37,7 +37,7 @@ export async function persistToolOutput(
   auth: Authenticator,
   conversation: ConversationType,
   block: CallToolResult["content"][number],
-  { toolName }: { toolName: string }
+  { toolName, serverName }: { toolName: string; serverName: string }
 ): Promise<PersistedToolOutput | null> {
   const owner = auth.getNonNullableWorkspace();
   const basePath = getConversationToolOutputsBasePath({
@@ -62,7 +62,7 @@ export async function persistToolOutput(
   }
 
   // Text blocks above the offload threshold.
-  if (shouldOffloadTextBlock(block)) {
+  if (shouldOffloadTextBlock(block, { serverName })) {
     const { fileName, contentType } = inferTextFileMetadata(
       block.text,
       toolName

--- a/front/lib/api/files/action_output_fs/registry.ts
+++ b/front/lib/api/files/action_output_fs/registry.ts
@@ -46,11 +46,17 @@ export function resolveResourceOutput(
   return null;
 }
 
+const TEXT_OFFLOAD_EXEMPT_MCP_SERVERS: readonly string[] = [
+  "interactive_content",
+];
+
 export function shouldOffloadTextBlock(
-  block: CallToolResult["content"][number]
+  block: CallToolResult["content"][number],
+  { serverName }: { serverName: string }
 ): block is { type: "text"; text: string } {
   return (
     block.type === "text" &&
-    Buffer.byteLength(block.text, "utf8") > FILE_OFFLOAD_TEXT_SIZE_BYTES
+    Buffer.byteLength(block.text, "utf8") > FILE_OFFLOAD_TEXT_SIZE_BYTES &&
+    !TEXT_OFFLOAD_EXEMPT_MCP_SERVERS.includes(serverName)
   );
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When agents use the `interactive_content` server, it often ends up being offloaded to the new file system, creating some kind of loop. This PR ensures we never offload to file system, interactive content results. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
