### PR TITLE
Update credit id in db if exists

### DIFF
--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -195,7 +195,9 @@ export async function grantFreeCreditFromMetronomeSegment({
   );
   if (existingForPeriod) {
     await existingForPeriod.setMetronomeCreditId(metronomeCreditId);
-    if (amountMicroUsd > existingForPeriod.consumedAmountMicroUsd) {
+    const amountUpdated =
+      amountMicroUsd > existingForPeriod.consumedAmountMicroUsd;
+    if (amountUpdated) {
       await existingForPeriod.updateInitialAmountMicroUsd(auth, amountMicroUsd);
     }
     logger.info(
@@ -204,13 +206,17 @@ export async function grantFreeCreditFromMetronomeSegment({
         existingCreditId: existingForPeriod.id,
         existingMetronomeCreditId: existingForPeriod.metronomeCreditId,
         newMetronomeCreditId: metronomeCreditId,
-        amountMicroUsd,
+        existingInitialAmountMicroUsd: existingForPeriod.initialAmountMicroUsd,
+        existingConsumedAmountMicroUsd:
+          existingForPeriod.consumedAmountMicroUsd,
+        newAmountMicroUsd: amountMicroUsd,
+        amountUpdated,
         segmentId,
         contractId,
         periodStart,
         periodEnd,
       },
-      "[Free Credits] free credit already exists for this period (likely contract recreated), updated metronomeCreditId and amount"
+      `[Free Credits] free credit already exists for this period (likely contract recreated), updated metronomeCreditId${amountUpdated ? " and amount" : ""}`
     );
     return new Ok({
       credit: existingForPeriod,

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -195,7 +195,9 @@ export async function grantFreeCreditFromMetronomeSegment({
   );
   if (existingForPeriod) {
     await existingForPeriod.setMetronomeCreditId(metronomeCreditId);
-    await existingForPeriod.updateInitialAmountMicroUsd(auth, amountMicroUsd);
+    if (amountMicroUsd > existingForPeriod.consumedAmountMicroUsd) {
+      await existingForPeriod.updateInitialAmountMicroUsd(auth, amountMicroUsd);
+    }
     logger.info(
       {
         workspaceId: workspace.sId,

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -194,18 +194,21 @@ export async function grantFreeCreditFromMetronomeSegment({
     periodEnd
   );
   if (existingForPeriod) {
+    await existingForPeriod.setMetronomeCreditId(metronomeCreditId);
+    await existingForPeriod.updateInitialAmountMicroUsd(auth, amountMicroUsd);
     logger.info(
       {
         workspaceId: workspace.sId,
         existingCreditId: existingForPeriod.id,
         existingMetronomeCreditId: existingForPeriod.metronomeCreditId,
         newMetronomeCreditId: metronomeCreditId,
+        amountMicroUsd,
         segmentId,
         contractId,
         periodStart,
         periodEnd,
       },
-      "[Free Credits] free credit already exists for this period (likely contract recreated), ignoring"
+      "[Free Credits] free credit already exists for this period (likely contract recreated), updated metronomeCreditId and amount"
     );
     return new Ok({
       credit: existingForPeriod,


### PR DESCRIPTION
## Description

When a Metronome contract is recreated within the same billing period, the `credit.segment.start` webhook fires again for a period that already has a DB credit. Previously, the code detected this via `fetchByTypeAndDates` and logged that it was ignoring the duplicate. This PR updates the behavior to reconcile the existing credit row with the new Metronome credit ID and amount by calling `setMetronomeCreditId()` and `updateInitialAmountMicroUsd()` instead of leaving it unchanged.

## Risk

Low.

## Deploy Plan

Deploy front