### PR TITLE
Reinforcement: support agentFacingDescription edits in skill suggestions

### DIFF
--- a/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
+++ b/front/components/poke/pages/SkillSuggestionDetailsPage.tsx
@@ -39,6 +39,10 @@ export function SkillSuggestionDetailsPage() {
     () => data?.skillInstructionsHtml ?? "",
     [data?.skillInstructionsHtml]
   );
+  const getCurrentAgentFacingDescription = useCallback(
+    () => data?.skillAgentFacingDescription ?? "",
+    [data?.skillAgentFacingDescription]
+  );
 
   if (isLoading) {
     return (
@@ -136,6 +140,9 @@ export function SkillSuggestionDetailsPage() {
             <SkillSuggestionCard
               suggestion={suggestion}
               getSkillInstructionsHtml={getSkillInstructionsHtml}
+              getCurrentAgentFacingDescription={
+                getCurrentAgentFacingDescription
+              }
               workspaceId={owner.sId}
             />
           </MCPServerViewsContext.Provider>

--- a/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
+++ b/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
@@ -32,6 +32,10 @@ export function SkillBuilderSuggestionsPanel() {
     () => getValues("instructionsHtml") ?? "",
     [getValues]
   );
+  const getCurrentAgentFacingDescription = useCallback(
+    () => getValues("agentFacingDescription") ?? "",
+    [getValues]
+  );
   const { mcpServerViews } = useMCPServerViewsContext();
 
   const { suggestions, isSuggestionsLoading, mutateSuggestions } =
@@ -79,12 +83,27 @@ export function SkillBuilderSuggestionsPanel() {
     [getValues, setValue, mcpServerViews]
   );
 
+  const applyAgentFacingDescriptionEdit = useCallback(
+    (suggestion: SkillSuggestionType) => {
+      const { agentFacingDescriptionEdit } = suggestion.suggestion;
+      if (!agentFacingDescriptionEdit) {
+        return;
+      }
+      setValue("agentFacingDescription", agentFacingDescriptionEdit.content, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    },
+    [setValue]
+  );
+
   const handleAccept = useCallback(
     async (suggestion: SkillSuggestionType) => {
       const result = await patchSuggestions([suggestion.sId], "approved");
       if (result) {
         acceptInstructionEdits?.(suggestion.sId);
         applyToolEdits(suggestion);
+        applyAgentFacingDescriptionEdit(suggestion);
         setSelectedSuggestionId(null);
         await mutateSuggestions();
       }
@@ -94,6 +113,7 @@ export function SkillBuilderSuggestionsPanel() {
       mutateSuggestions,
       acceptInstructionEdits,
       applyToolEdits,
+      applyAgentFacingDescriptionEdit,
       setSelectedSuggestionId,
     ]
   );
@@ -158,6 +178,9 @@ export function SkillBuilderSuggestionsPanel() {
                 onAccept={handleAccept}
                 onDecline={handleDecline}
                 getSkillInstructionsHtml={getSkillInstructionsHtml}
+                getCurrentAgentFacingDescription={
+                  getCurrentAgentFacingDescription
+                }
                 isSelected={selectedSuggestionId === suggestion.sId}
                 onSelect={() => handleSelect(suggestion.sId)}
                 workspaceId={owner.sId}

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -3,6 +3,7 @@ import { getBlockOuterHtml } from "@app/components/shared/utils";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_instructions_extensions";
 import type {
+  SkillAgentFacingDescriptionEditType,
   SkillInstructionEditItemType,
   SkillSuggestionType,
   SkillToolEditItemType,
@@ -77,6 +78,36 @@ function ToolEditsSection({ toolEdits }: ToolEditsSectionProps) {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+interface AgentFacingDescriptionEditSectionProps {
+  edit: SkillAgentFacingDescriptionEditType;
+  currentAgentFacingDescription: string;
+}
+
+function AgentFacingDescriptionEditSection({
+  edit,
+  currentAgentFacingDescription,
+}: AgentFacingDescriptionEditSectionProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+        Description change
+      </span>
+      <DiffBlock>
+        <div className="flex flex-col gap-1 p-3 text-sm">
+          {currentAgentFacingDescription && (
+            <p className="text-muted-foreground line-through dark:text-muted-foreground-night">
+              {currentAgentFacingDescription}
+            </p>
+          )}
+          <p className="text-foreground dark:text-foreground-night">
+            {edit.content}
+          </p>
+        </div>
+      </DiffBlock>
     </div>
   );
 }
@@ -195,6 +226,7 @@ interface SkillSuggestionCardProps {
   onAccept?: (suggestion: SkillSuggestionType) => void;
   onDecline?: (suggestion: SkillSuggestionType) => void;
   getSkillInstructionsHtml: () => string;
+  getCurrentAgentFacingDescription: () => string;
   isSelected?: boolean;
   onSelect?: () => void;
   workspaceId: string;
@@ -205,11 +237,13 @@ export function SkillSuggestionCard({
   onAccept,
   onDecline,
   getSkillInstructionsHtml,
+  getCurrentAgentFacingDescription,
   isSelected = false,
   onSelect,
   workspaceId,
 }: SkillSuggestionCardProps) {
-  const { instructionEdits, toolEdits } = suggestion.suggestion;
+  const { instructionEdits, toolEdits, agentFacingDescriptionEdit } =
+    suggestion.suggestion;
   const isClickable = !!onSelect;
   const hasActions = !!onAccept && !!onDecline;
 
@@ -245,6 +279,13 @@ export function SkillSuggestionCard({
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             {suggestion.analysis}
           </p>
+        )}
+
+        {agentFacingDescriptionEdit && (
+          <AgentFacingDescriptionEditSection
+            edit={agentFacingDescriptionEdit}
+            currentAgentFacingDescription={getCurrentAgentFacingDescription()}
+          />
         )}
 
         {toolEdits && toolEdits.length > 0 && (

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -79,6 +79,29 @@ function makeToolSuggestion(
   } as SkillSuggestionType;
 }
 
+function makeAgentFacingDescriptionSuggestion(
+  overrides: Partial<SkillSuggestionType> = {}
+): SkillSuggestionType {
+  return {
+    sId: "sug-3",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    skillConfigurationId: "skl_abc123",
+    analysis: "Description is misleading the agent on routing",
+    title: null,
+    state: "pending",
+    source: "synthetic",
+    sourceConversationsCount: 0,
+    kind: "edit",
+    suggestion: {
+      agentFacingDescriptionEdit: {
+        content: "Use this skill when answering pricing questions.",
+      },
+    },
+    ...overrides,
+  } as SkillSuggestionType;
+}
+
 describe("buildSkillAggregationPrompt", () => {
   it("includes the skill name in the user message", () => {
     const { userMessage } = buildSkillAggregationPrompt(
@@ -200,6 +223,51 @@ describe("buildSkillAggregationPrompt", () => {
     );
 
     expect(systemPrompt).toContain("edit_skill");
+  });
+
+  it("system prompt allows description edits and asks for them to be standalone", () => {
+    const { systemPrompt } = buildSkillAggregationPrompt(
+      makeSkill(),
+      [makeAgentFacingDescriptionSuggestion()],
+      { pending: [], rejected: [] }
+    );
+
+    // The previous prohibition must be gone.
+    expect(systemPrompt).not.toMatch(/MUST NOT use edit_skill to change it/i);
+    // Aggregation rules must mention description edits and steer toward
+    // one-per-skill, standalone suggestions.
+    expect(systemPrompt).toMatch(/agent-facing description/i);
+    expect(systemPrompt).toMatch(/standalone|its own/i);
+  });
+
+  it("formats agent-facing description edits with the new content", () => {
+    const suggestion = makeAgentFacingDescriptionSuggestion({
+      suggestion: {
+        agentFacingDescriptionEdit: {
+          content: "Use for pricing questions only.",
+        },
+      },
+    } as Partial<SkillSuggestionType>);
+
+    const { userMessage } = buildSkillAggregationPrompt(
+      makeSkill(),
+      [suggestion],
+      { pending: [], rejected: [] }
+    );
+
+    expect(userMessage).toContain("<agentFacingDescriptionEdit>");
+    expect(userMessage).toContain("Use for pricing questions only.");
+    expect(userMessage).toContain("</agentFacingDescriptionEdit>");
+  });
+
+  it("does not emit an empty agentFacingDescriptionEdit element for instruction-only suggestions", () => {
+    const { userMessage } = buildSkillAggregationPrompt(
+      makeSkill(),
+      [makeInstructionSuggestion()],
+      { pending: [], rejected: [] }
+    );
+
+    expect(userMessage).not.toContain("agentFacingDescriptionEdit");
   });
 
   it("system prompt requires the aggregator to author a title per suggestion", () => {

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -225,21 +225,6 @@ describe("buildSkillAggregationPrompt", () => {
     expect(systemPrompt).toContain("edit_skill");
   });
 
-  it("system prompt allows description edits and asks for them to be standalone", () => {
-    const { systemPrompt } = buildSkillAggregationPrompt(
-      makeSkill(),
-      [makeAgentFacingDescriptionSuggestion()],
-      { pending: [], rejected: [] }
-    );
-
-    // The previous prohibition must be gone.
-    expect(systemPrompt).not.toMatch(/MUST NOT use edit_skill to change it/i);
-    // Aggregation rules must mention description edits and steer toward
-    // one-per-skill, standalone suggestions.
-    expect(systemPrompt).toMatch(/agent-facing description/i);
-    expect(systemPrompt).toMatch(/standalone|its own/i);
-  });
-
   it("formats agent-facing description edits with the new content", () => {
     const suggestion = makeAgentFacingDescriptionSuggestion({
       suggestion: {

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -232,7 +232,7 @@ describe("buildSkillAggregationPrompt", () => {
           content: "Use for pricing questions only.",
         },
       },
-    } as Partial<SkillSuggestionType>);
+    });
 
     const { userMessage } = buildSkillAggregationPrompt(
       makeSkill(),

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -53,7 +53,7 @@ It is ok to simply call no tool if all suggestions are minor.
 Start by grouping suggestions by skill, then within each skill group by topic:
 - For instruction edits, group by coherent theme within the skill (e.g. tone, tool usage, formatting). Suggestions that address different topics MUST be kept as separate suggestions — do NOT merge unrelated topics into one suggestion.
 - For tool changes, group by the target tool within each skill. NEVER create more than one suggestion per tool.
-- For agent-facing description edits, create AT MOST ONE description-edit suggestion per skill. The description edit SHOULD be its own standalone suggestion — do NOT bundle it with instructionEdits or toolEdits unless they are tightly coupled to the same routing fix. When multiple drafts target the description, merge them into a single coherent replacement.
+- For agent-facing description edits, create AT MOST ONE description-edit suggestion per skill. When multiple drafts target the description, merge them into a single coherent replacement.
 NEVER create more than one suggestion per (skill, topic) pair.
 
 Rank the groups based on impact to the skill. Use these heuristics in priority order to determine highest impact:

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -37,7 +37,7 @@ const REINFORCED_SKILL_AGGREGATION_SECTIONS: Record<
 Your job is to produce a subset of the highest quality suggestions for the skill builder to review.
 
 You have access to the following tools:
-- edit_skill: For suggesting instruction edits and tool add/remove for one skill. The skill block above includes <agentFacingDescription> when set (for context only); you MUST NOT use edit_skill to change it.
+- edit_skill: For suggesting instruction edits, tool add/remove, and/or agent-facing description changes for one skill.
 - reject_suggestion: For discarding source suggestions that are invalid, not actionable, or too similar to already declined suggestions. Do NOT reject minor but valid suggestions, simply ignore them.
 
 Your goal is to keep the most impactful suggestions. NEVER create more than 5 suggestions.
@@ -53,6 +53,7 @@ It is ok to simply call no tool if all suggestions are minor.
 Start by grouping suggestions by skill, then within each skill group by topic:
 - For instruction edits, group by coherent theme within the skill (e.g. tone, tool usage, formatting). Suggestions that address different topics MUST be kept as separate suggestions — do NOT merge unrelated topics into one suggestion.
 - For tool changes, group by the target tool within each skill. NEVER create more than one suggestion per tool.
+- For agent-facing description edits, create AT MOST ONE description-edit suggestion per skill. The description edit SHOULD be its own standalone suggestion — do NOT bundle it with instructionEdits or toolEdits unless they are tightly coupled to the same routing fix. When multiple drafts target the description, merge them into a single coherent replacement.
 NEVER create more than one suggestion per (skill, topic) pair.
 
 Rank the groups based on impact to the skill. Use these heuristics in priority order to determine highest impact:
@@ -108,6 +109,9 @@ function formatSuggestion(s: SkillSuggestionType): string {
           xml += `<toolEdit action="${escapeXml(t.action)}" toolId="${escapeXml(t.toolId)}"/>`;
         }
         xml += "</toolEdits>";
+      }
+      if (s.suggestion.agentFacingDescriptionEdit) {
+        xml += `<agentFacingDescriptionEdit><content>${escapeXml(s.suggestion.agentFacingDescriptionEdit.content)}</content></agentFacingDescriptionEdit>`;
       }
       xml += "</suggestion>";
       return xml;

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -112,9 +112,6 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(systemPrompt).toContain("<agent_facing_description_guidance>");
     // Description edits are about routing (when to enable the skill), not behavior.
     expect(systemPrompt).toMatch(/routing|when to enable/i);
-    // The prompt must steer the model to send description edits as standalone
-    // edit_skill calls, not bundled with instruction/tool edits.
-    expect(systemPrompt).toMatch(/own edit_skill call|standalone/i);
   });
 
   it("includes skill configured tools in user message", () => {

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -104,6 +104,19 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(systemPrompt).toContain("get_available_tools");
   });
 
+  it("system prompt has guidance for agent-facing description edits", () => {
+    const { systemPrompt } = buildSkillAnalysisPrompt("User: hello", [
+      makeSkill(),
+    ]);
+
+    expect(systemPrompt).toContain("<agent_facing_description_guidance>");
+    // Description edits are about routing (when to enable the skill), not behavior.
+    expect(systemPrompt).toMatch(/routing|when to enable/i);
+    // The prompt must steer the model to send description edits as standalone
+    // edit_skill calls, not bundled with instruction/tool edits.
+    expect(systemPrompt).toMatch(/own edit_skill call|standalone/i);
+  });
+
   it("includes skill configured tools in user message", () => {
     const skill = makeSkill({
       tools: [

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -72,7 +72,7 @@ Consider the following improvements to a skill:
 - If the skill references or requires external actions or knowledge, then tools may need to be added or removed. See <tools_guidance>.
 - If the conversation reveals that the agent enabled the skill in the wrong situation, or failed to enable it when it should have, the agent-facing description may need to be improved. See <agent_facing_description_guidance>.
 All improvements that should be treated as a single atomic unit should be grouped together in a single suggestion.
-NEVER group things that are not related to each other. In particular, an agent-facing description change should almost always be its own suggestion.
+NEVER group things that are not related to each other.
 
 Step 5: For each skill, look for agent behavior that is directly aligned with the skill's purpose, but the behavior was not defined in the skill instructions.
 This is an opportunity to improve the skill instructions for all future agents and conversations.
@@ -124,8 +124,7 @@ When suggesting a description edit:
 - Provide the FULL replacement text in \`agentFacingDescriptionEdit.content\` — it overwrites the existing description.
 - Preserve the skill's actual purpose. Sharpen the trigger conditions; do not redefine the skill.
 - Keep it focused on routing signals (when to use, what scenarios). Do not duplicate the instructions.
-- Use the same language as the existing description.
-- Make the description edit its OWN edit_skill call. Do NOT bundle it with instructionEdits or toolEdits unless they are tightly coupled to the same routing fix.`,
+- Use the same language as the existing description.`,
 };
 
 export function buildSkillAnalysisSystemPrompt(): string {

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -16,6 +16,7 @@ const ASSEMBLY_ORDER = [
   "instructions_guidance",
   "instruction_editing",
   "tools_guidance",
+  "agent_facing_description_guidance",
 ] as const;
 
 type SectionKey = (typeof ASSEMBLY_ORDER)[number];
@@ -69,8 +70,9 @@ ALWAYS ensure that the suggestion is inline with the skill's purpose and instruc
 Consider the following improvements to a skill:
 - Review instructions to determine if the skill is meeting the user intent and properly utilizing the configured tools: <instructions_guidance>.
 - If the skill references or requires external actions or knowledge, then tools may need to be added or removed. See <tools_guidance>.
+- If the conversation reveals that the agent enabled the skill in the wrong situation, or failed to enable it when it should have, the agent-facing description may need to be improved. See <agent_facing_description_guidance>.
 All improvements that should be treated as a single atomic unit should be grouped together in a single suggestion.
-NEVER group things that are not related to each other.
+NEVER group things that are not related to each other. In particular, an agent-facing description change should almost always be its own suggestion.
 
 Step 5: For each skill, look for agent behavior that is directly aligned with the skill's purpose, but the behavior was not defined in the skill instructions.
 This is an opportunity to improve the skill instructions for all future agents and conversations.
@@ -110,6 +112,20 @@ ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmeti
 - Only suggest removing a tool if there is clear evidence the tool is causing confusion or is unused and cluttering the skill configuration.
 - When suggesting a tool addition, ensure the tool exists in the workspace by checking available tools first.
 - When the conversation involves a tool call that failed or produced unexpected results, call describe_mcp for the relevant MCP to understand the full list of available tools and their correct usage before suggesting instruction changes.`,
+
+  agent_facing_description_guidance: `The agent-facing description (\`<agentFacingDescription>\` in the skill context) is what the agent reads to decide WHEN to enable the skill. It is NOT the skill's behavior — that lives in \`<instructions>\`.
+
+Suggest editing it only when the conversation surfaces clear evidence of a routing problem:
+- The agent enabled the skill in a situation it does not actually cover.
+- The agent failed to enable the skill in a situation that should obviously have triggered it.
+- The current description is misleading, vague, or incomplete in a way that explains the routing mistake.
+
+When suggesting a description edit:
+- Provide the FULL replacement text in \`agentFacingDescriptionEdit.content\` — it overwrites the existing description.
+- Preserve the skill's actual purpose. Sharpen the trigger conditions; do not redefine the skill.
+- Keep it focused on routing signals (when to use, what scenarios). Do not duplicate the instructions.
+- Use the same language as the existing description.
+- Make the description edit its OWN edit_skill call. Do NOT bundle it with instructionEdits or toolEdits unless they are tightly coupled to the same routing fix.`,
 };
 
 export function buildSkillAnalysisSystemPrompt(): string {

--- a/front/lib/reinforcement/run_reinforced_analysis.test.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.test.ts
@@ -74,3 +74,71 @@ describe("TOOL_SCHEMAS.edit_skill title validation", () => {
     expect(parsed.success).toBe(true);
   });
 });
+
+describe("TOOL_SCHEMAS.edit_skill agentFacingDescriptionEdit", () => {
+  it("accepts a description-only edit (no instruction or tool edits)", () => {
+    const parsed = TOOL_SCHEMAS.edit_skill.safeParse({
+      skillId: "skl_abc",
+      agentFacingDescriptionEdit: {
+        content: "Use this skill when answering pricing questions.",
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("accepts a description edit alongside instruction/tool edits", () => {
+    const parsed = TOOL_SCHEMAS.edit_skill.safeParse({
+      skillId: "skl_abc",
+      instructionEdits: [
+        {
+          targetBlockId: "abc12345",
+          content: "<p>Updated.</p>",
+          type: "replace",
+        },
+      ],
+      toolEdits: [{ action: "add" as const, toolId: "tool_x" }],
+      agentFacingDescriptionEdit: { content: "New description." },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects an empty description content", () => {
+    const parsed = TOOL_SCHEMAS.edit_skill.safeParse({
+      skillId: "skl_abc",
+      agentFacingDescriptionEdit: { content: "" },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("buildReinforcedSkillsLLMParams edit_skill spec", () => {
+  it("exposes agentFacingDescriptionEdit on the analyze edit_skill input schema", () => {
+    const params = buildReinforcedSkillsLLMParams(
+      { systemPrompt: "System.", userMessage: "User." },
+      "reinforcement_analyze_conversation"
+    );
+    const editSkillSpec = params.specifications?.find(
+      (s) => s.name === "edit_skill"
+    );
+    expect(editSkillSpec).toBeDefined();
+    // The JSON schema goes to the LLM verbatim — make sure the new field is
+    // discoverable by name.
+    expect(JSON.stringify(editSkillSpec?.inputSchema)).toContain(
+      "agentFacingDescriptionEdit"
+    );
+  });
+
+  it("exposes agentFacingDescriptionEdit on the aggregate edit_skill input schema", () => {
+    const params = buildReinforcedSkillsLLMParams(
+      { systemPrompt: "System.", userMessage: "User." },
+      "reinforcement_aggregate_suggestions"
+    );
+    const editSkillSpec = params.specifications?.find(
+      (s) => s.name === "edit_skill"
+    );
+    expect(editSkillSpec).toBeDefined();
+    expect(JSON.stringify(editSkillSpec?.inputSchema)).toContain(
+      "agentFacingDescriptionEdit"
+    );
+  });
+});

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -113,6 +113,19 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
         )
         .optional()
         .describe("Tools to add or remove from the skill."),
+      agentFacingDescriptionEdit: z
+        .object({
+          content: z
+            .string()
+            .min(1)
+            .describe(
+              "The full new agent-facing description (replaces the current one)."
+            ),
+        })
+        .optional()
+        .describe(
+          "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction or tool edits."
+        ),
       analysis: z
         .string()
         .optional()
@@ -508,11 +521,17 @@ async function createSkillSuggestionsFromToolCall({
       const hasInstructionEdits =
         (parsed.data.instructionEdits?.length ?? 0) > 0;
       const hasToolEdits = (parsed.data.toolEdits?.length ?? 0) > 0;
-      if (!hasInstructionEdits && !hasToolEdits) {
+      const hasAgentFacingDescriptionEdit =
+        parsed.data.agentFacingDescriptionEdit !== undefined;
+      if (
+        !hasInstructionEdits &&
+        !hasToolEdits &&
+        !hasAgentFacingDescriptionEdit
+      ) {
         return {
           type: "error",
           errorMessage:
-            "edit_skill requires at least one instruction edit or tool edit.",
+            "edit_skill requires at least one instruction edit, tool edit, or description edit.",
         };
       }
 
@@ -529,6 +548,7 @@ async function createSkillSuggestionsFromToolCall({
           {
             instructionEdits: parsed.data.instructionEdits,
             toolEdits: parsed.data.toolEdits,
+            agentFacingDescriptionEdit: parsed.data.agentFacingDescriptionEdit,
           },
           skill.instructionsHtml
         )
@@ -567,6 +587,7 @@ async function createSkillSuggestionsFromToolCall({
           suggestion: {
             instructionEdits: parsed.data.instructionEdits,
             toolEdits: parsed.data.toolEdits,
+            agentFacingDescriptionEdit: parsed.data.agentFacingDescriptionEdit,
           },
           analysis: parsed.data.analysis ?? null,
           title: parsed.data.title ?? null,

--- a/front/lib/reinforcement/skill_suggestion_pruning.test.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.test.ts
@@ -2,6 +2,7 @@ import { buildDescendantMap } from "@app/lib/editor/instructions_block_conflict"
 import {
   hasSuggestionSelfConflict,
   instructionEditSetsConflict,
+  pruneConflictingSkillEditSuggestions,
   pruneOutdatedSkillEditSuggestions,
   toolEditSetsConflict,
 } from "@app/lib/reinforcement/skill_suggestion_pruning";
@@ -412,5 +413,100 @@ describe("pruneOutdatedSkillEditSuggestions", () => {
       );
       expect(fetched?.state).toBe("outdated");
     });
+  });
+});
+
+describe("pruneConflictingSkillEditSuggestions — agentFacingDescriptionEdit", () => {
+  let authenticator: Awaited<
+    ReturnType<typeof createResourceTest>
+  >["authenticator"];
+
+  beforeEach(async () => {
+    ({ authenticator } = await createResourceTest({ role: "admin" }));
+  });
+
+  it("a new description-edit suggestion outdates an older description-edit suggestion", async () => {
+    const skill = await SkillFactory.create(authenticator, {
+      instructionsHtml: '<p data-block-id="block-1">Content.</p>',
+    });
+    const older = await SkillSuggestionFactory.createEdit(authenticator, skill, {
+      suggestion: {
+        agentFacingDescriptionEdit: { content: "First proposed description." },
+      },
+    });
+    const newer = await SkillSuggestionFactory.createEdit(authenticator, skill, {
+      suggestion: {
+        agentFacingDescriptionEdit: { content: "Second proposed description." },
+      },
+    });
+
+    await pruneConflictingSkillEditSuggestions(authenticator, skill, newer);
+
+    const olderRefetched = await SkillSuggestionResource.fetchById(
+      authenticator,
+      older.sId
+    );
+    const newerRefetched = await SkillSuggestionResource.fetchById(
+      authenticator,
+      newer.sId
+    );
+    expect(olderRefetched?.state).toBe("outdated");
+    expect(newerRefetched?.state).toBe("pending");
+  });
+
+  it("a new description-edit suggestion does NOT outdate a tool-only suggestion", async () => {
+    const skill = await SkillFactory.create(authenticator, {
+      instructionsHtml: '<p data-block-id="block-1">Content.</p>',
+    });
+    const toolOnly = await SkillSuggestionFactory.createEdit(
+      authenticator,
+      skill,
+      {
+        suggestion: {
+          toolEdits: [{ action: "add", toolId: "tool-search" }],
+        },
+      }
+    );
+    const newer = await SkillSuggestionFactory.createEdit(authenticator, skill, {
+      suggestion: {
+        agentFacingDescriptionEdit: { content: "New description." },
+      },
+    });
+
+    await pruneConflictingSkillEditSuggestions(authenticator, skill, newer);
+
+    const refetched = await SkillSuggestionResource.fetchById(
+      authenticator,
+      toolOnly.sId
+    );
+    expect(refetched?.state).toBe("pending");
+  });
+
+  it("a new instruction-only suggestion does NOT outdate an older description-edit suggestion", async () => {
+    const skill = await SkillFactory.create(authenticator, {
+      instructionsHtml: '<p data-block-id="block-1">Content.</p>',
+    });
+    const descriptionOnly = await SkillSuggestionFactory.createEdit(
+      authenticator,
+      skill,
+      {
+        suggestion: {
+          agentFacingDescriptionEdit: { content: "Existing description." },
+        },
+      }
+    );
+    const newer = await SkillSuggestionFactory.createEdit(authenticator, skill, {
+      suggestion: {
+        instructionEdits: [makeInstructionEdit("block-1")],
+      },
+    });
+
+    await pruneConflictingSkillEditSuggestions(authenticator, skill, newer);
+
+    const refetched = await SkillSuggestionResource.fetchById(
+      authenticator,
+      descriptionOnly.sId
+    );
+    expect(refetched?.state).toBe("pending");
   });
 });

--- a/front/lib/reinforcement/skill_suggestion_pruning.test.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.test.ts
@@ -429,16 +429,28 @@ describe("pruneConflictingSkillEditSuggestions — agentFacingDescriptionEdit", 
     const skill = await SkillFactory.create(authenticator, {
       instructionsHtml: '<p data-block-id="block-1">Content.</p>',
     });
-    const older = await SkillSuggestionFactory.createEdit(authenticator, skill, {
-      suggestion: {
-        agentFacingDescriptionEdit: { content: "First proposed description." },
-      },
-    });
-    const newer = await SkillSuggestionFactory.createEdit(authenticator, skill, {
-      suggestion: {
-        agentFacingDescriptionEdit: { content: "Second proposed description." },
-      },
-    });
+    const older = await SkillSuggestionFactory.createEdit(
+      authenticator,
+      skill,
+      {
+        suggestion: {
+          agentFacingDescriptionEdit: {
+            content: "First proposed description.",
+          },
+        },
+      }
+    );
+    const newer = await SkillSuggestionFactory.createEdit(
+      authenticator,
+      skill,
+      {
+        suggestion: {
+          agentFacingDescriptionEdit: {
+            content: "Second proposed description.",
+          },
+        },
+      }
+    );
 
     await pruneConflictingSkillEditSuggestions(authenticator, skill, newer);
 
@@ -467,11 +479,15 @@ describe("pruneConflictingSkillEditSuggestions — agentFacingDescriptionEdit", 
         },
       }
     );
-    const newer = await SkillSuggestionFactory.createEdit(authenticator, skill, {
-      suggestion: {
-        agentFacingDescriptionEdit: { content: "New description." },
-      },
-    });
+    const newer = await SkillSuggestionFactory.createEdit(
+      authenticator,
+      skill,
+      {
+        suggestion: {
+          agentFacingDescriptionEdit: { content: "New description." },
+        },
+      }
+    );
 
     await pruneConflictingSkillEditSuggestions(authenticator, skill, newer);
 
@@ -495,11 +511,15 @@ describe("pruneConflictingSkillEditSuggestions — agentFacingDescriptionEdit", 
         },
       }
     );
-    const newer = await SkillSuggestionFactory.createEdit(authenticator, skill, {
-      suggestion: {
-        instructionEdits: [makeInstructionEdit("block-1")],
-      },
-    });
+    const newer = await SkillSuggestionFactory.createEdit(
+      authenticator,
+      skill,
+      {
+        suggestion: {
+          instructionEdits: [makeInstructionEdit("block-1")],
+        },
+      }
+    );
 
     await pruneConflictingSkillEditSuggestions(authenticator, skill, newer);
 

--- a/front/lib/reinforcement/skill_suggestion_pruning.ts
+++ b/front/lib/reinforcement/skill_suggestion_pruning.ts
@@ -113,6 +113,8 @@ export async function pruneConflictingSkillEditSuggestions(
 
   const newInstructionEdits = newSuggestion.suggestion.instructionEdits ?? [];
   const newToolEdits = newSuggestion.suggestion.toolEdits ?? [];
+  const newHasAgentFacingDescriptionEdit =
+    newSuggestion.suggestion.agentFacingDescriptionEdit !== undefined;
 
   // Full rewrite — everything is outdated.
   if (
@@ -145,6 +147,8 @@ export async function pruneConflictingSkillEditSuggestions(
       : new Map<string, Set<string>>();
 
   const toMarkOutdated = existingPending.filter((existing) => {
+    const existingHasAgentFacingDescriptionEdit =
+      existing.suggestion.agentFacingDescriptionEdit !== undefined;
     return (
       instructionEditSetsConflict(
         newInstructionEdits,
@@ -152,7 +156,9 @@ export async function pruneConflictingSkillEditSuggestions(
         skill.instructionsHtml,
         descendantMap
       ) ||
-      toolEditSetsConflict(newToolEdits, existing.suggestion.toolEdits ?? [])
+      toolEditSetsConflict(newToolEdits, existing.suggestion.toolEdits ?? []) ||
+      (newHasAgentFacingDescriptionEdit &&
+        existingHasAgentFacingDescriptionEdit)
     );
   });
 

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -75,6 +75,19 @@ export const TOOL_SCHEMAS: Record<
       )
       .optional()
       .describe("Tools to add or remove from the skill."),
+    agentFacingDescriptionEdit: z
+      .object({
+        content: z
+          .string()
+          .min(1)
+          .describe(
+            "The full new agent-facing description (replaces the current one)."
+          ),
+      })
+      .optional()
+      .describe(
+        "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction or tool edits."
+      ),
     analysis: z
       .string()
       .optional()

--- a/front/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -13,6 +13,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 export type PokeGetSkillSuggestionDetails = {
   suggestion: SkillSuggestionType;
   skillInstructionsHtml: string | null;
+  skillAgentFacingDescription: string | null;
 };
 
 async function handler(
@@ -74,9 +75,11 @@ async function handler(
     suggestion.skillConfigurationSId
   );
 
+  const skillJson = skill?.toJSON(auth);
   return res.status(200).json({
     suggestion: suggestion.toJSON(),
-    skillInstructionsHtml: skill?.toJSON(auth).instructionsHtml ?? null,
+    skillInstructionsHtml: skillJson?.instructionsHtml ?? null,
+    skillAgentFacingDescription: skillJson?.agentFacingDescription ?? null,
   });
 }
 

--- a/front/scripts/seed/reinforcement/assets/skill_suggestions.json
+++ b/front/scripts/seed/reinforcement/assets/skill_suggestions.json
@@ -46,6 +46,19 @@
     }
   },
   {
+    "skillName": "SearchInfoContactWithSuggestion",
+    "kind": "edit",
+    "title": "Improve agent-facing description",
+    "analysis": "The current description does not mention web search as a fallback source. Updating it to reflect the broader search capabilities makes the skill's scope clearer to the agent.",
+    "state": "pending",
+    "source": "reinforcement",
+    "suggestion": {
+      "agentFacingDescriptionEdit": {
+        "content": "Guidelines for searching and retrieving contact information from internal directories, databases, and the web."
+      }
+    }
+  },
+  {
     "skillName": "MeetingNotesFormatter",
     "kind": "edit",
     "title": "Flag confidential topics",

--- a/front/scripts/seed/reinforcement/seed.test.ts
+++ b/front/scripts/seed/reinforcement/seed.test.ts
@@ -134,7 +134,7 @@ describe("reinforcement seed script integration test", () => {
     // Verify skill suggestions: 2 for SearchInfoContactWithSuggestion + 2 for MeetingNotesFormatter + 1 for BookKeeper
     const skillSuggestions =
       await SkillSuggestionResource.listByWorkspace(authenticator);
-    expect(skillSuggestions).toHaveLength(5);
+    expect(skillSuggestions).toHaveLength(6);
 
     const allPending = skillSuggestions.every((s) => s.state === "pending");
     expect(allPending).toBe(true);

--- a/front/tests/utils/SkillSuggestionFactory.ts
+++ b/front/tests/utils/SkillSuggestionFactory.ts
@@ -53,6 +53,7 @@ export class SkillSuggestionFactory {
           type: "replace";
         }[];
         toolEdits?: { action: "add" | "remove"; toolId: string }[];
+        agentFacingDescriptionEdit?: { content: string };
       };
       analysis: string | null;
       title: string | null;

--- a/front/types/suggestions/skill_suggestion.ts
+++ b/front/types/suggestions/skill_suggestion.ts
@@ -61,6 +61,19 @@ export const SkillToolEditItemSchema = z.object({
 
 export type SkillToolEditItemType = z.infer<typeof SkillToolEditItemSchema>;
 
+export const SkillAgentFacingDescriptionEditSchema = z.object({
+  content: z
+    .string()
+    .min(1)
+    .describe(
+      "The full new agent-facing description that will replace the current one."
+    ),
+});
+
+export type SkillAgentFacingDescriptionEditType = z.infer<
+  typeof SkillAgentFacingDescriptionEditSchema
+>;
+
 export const SkillEditSuggestionSchema = z
   .object({
     instructionEdits: z
@@ -71,12 +84,17 @@ export const SkillEditSuggestionSchema = z
       .array(SkillToolEditItemSchema)
       .optional()
       .describe("Tools to add or remove from the skill."),
+    agentFacingDescriptionEdit:
+      SkillAgentFacingDescriptionEditSchema.optional().describe(
+        "Replacement for the skill's agent-facing description."
+      ),
   })
   .refine(
     (d) =>
       (d.instructionEdits && d.instructionEdits.length > 0) ||
-      (d.toolEdits && d.toolEdits.length > 0),
-    "At least one of instructionEdits or toolEdits must be provided."
+      (d.toolEdits && d.toolEdits.length > 0) ||
+      d.agentFacingDescriptionEdit !== undefined,
+    "At least one of instructionEdits, toolEdits, or agentFacingDescriptionEdit must be provided."
   );
 
 export type SkillEditSuggestionType = z.infer<typeof SkillEditSuggestionSchema>;


### PR DESCRIPTION
## Description

Reinforcement currently lets the analysis/aggregation flow suggest changes to a skill's instructions and tools, but not its agentFacingDescription. The description is what the agent reads to decide when to enable the skill, so a stale or misleading one shows up in conversations as routing mistakes (skill enabled in the wrong context, or not enabled when it should have been). This PR lets reinforcement suggest fixes to it.

### Schema & persistence

- Added agentFacingDescriptionEdit (single object with content) to SkillEditSuggestionSchema. The refine now accepts a suggestion that carries only a description edit. The field is also threaded through both edit_skill tool schemas (parser in lib/reinforcement/types.ts and the JSON schema sent to the LLM in run_reinforced_analysis.ts) and through createSuggestionForSkill.
- skill_suggestion_pruning.ts: a new pending suggestion that touches the description marks any older pending one that also touches the description as outdated (same idea as the existing tool/instruction conflict logic).

### Prompts

- analyze_conversation.ts: new agent_facing_description_guidance section, plus a step in the analysis workflow telling the model to consider description edits when the conversation reveals a routing mistake.
- aggregate_suggestions.ts: removed the previous prohibition (you MUST NOT use edit_skill to change it), added an aggregation rule (max 1 description-edit suggestion per skill), and extended formatSuggestion so the aggregator can see prior description-edit drafts.

### UI

- SkillSuggestionCard: new AgentFacingDescriptionEditSection rendered above the tool/instruction sections (they're typically standalone). Shows the current description with a strikethrough above the proposed text inside a DiffBlock for visual consistency with instruction diffs.
- SkillBuilderSuggestionsPanel: passes getCurrentAgentFacingDescription to the card and applies the new content to the form's agentFacingDescription field on accept.
- Poke details page + endpoint: returns skillAgentFacingDescription so the poke preview renders the same diff.

<img width="662" height="873" alt="Screenshot 2026-05-06 at 10 48 43" src="https://github.com/user-attachments/assets/4216a2c2-df61-489f-8c2c-bc1c378d1bf8" />

## Tests

Added

## Risk

Low, stil under flag

## Deploy Plan

Front