### PR TITLE
[front] PaymentProcessingPage with requireCanUseProduct: false

### DIFF
--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -94,6 +94,7 @@ export const adminRoutes: RouteObject[] = [
       {
         path: "subscription/payment_processing",
         element: <PaymentProcessingPage />,
+        handle: { requireCanUseProduct: false },
       },
       { path: "developers/api-keys", element: <APIKeysPage /> },
       {


### PR DESCRIPTION
## Description

Fix a race condition when calling page PaymentProcessingPage (url /w/[wId]/subscription/payment_processing?...) after completing Stripe checkout sessions.
The redirection to PaymentProcessingPage can happen before the subscription has been actually created in stripe "checkout.session.completed" webhook that leads to a redirection to subscribe page instead ("requireCanUseProduct" set to true)
=> PaymentProcessingPage should have "requireCanUseProduct" set to false so that the page can be loaded even though the subscription has not been created yet (there is a waiting mechanism in the page to wait for it)

## Tests

Tested locally

## Risk

None, page PaymentProcessingPage is quite empty and only used as a redirection page

## Deploy Plan

Deploy front