### PR TITLE
[Branching] Fix fork notice fallback title

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -4275,6 +4275,10 @@ describe("conversation fetch forkingData", () => {
       { title: "Later fork" },
       { where: { id: firstChildConversation.id, workspaceId: workspace.id } }
     );
+    await ConversationModel.update(
+      { title: null },
+      { where: { id: secondChildConversation.id, workspaceId: workspace.id } }
+    );
 
     const parentConversationResource = await ConversationResource.fetchById(
       auth,

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -4257,6 +4257,11 @@ describe("conversation fetch forkingData", () => {
       agentConfigurationId: agent.sId,
       messagesCreatedAt: [new Date("2026-01-05T00:00:00.000Z")],
     });
+    const parentConversationTitle = "Parent fork source";
+    await ConversationModel.update(
+      { title: parentConversationTitle },
+      { where: { id: parentConversation.id, workspaceId: workspace.id } }
+    );
     const firstChildConversation = await ConversationFactory.create(auth, {
       agentConfigurationId: agent.sId,
       messagesCreatedAt: [],
@@ -4269,10 +4274,6 @@ describe("conversation fetch forkingData", () => {
     await ConversationModel.update(
       { title: "Later fork" },
       { where: { id: firstChildConversation.id, workspaceId: workspace.id } }
-    );
-    await ConversationModel.update(
-      { title: "Earlier fork" },
-      { where: { id: secondChildConversation.id, workspaceId: workspace.id } }
     );
 
     const parentConversationResource = await ConversationResource.fetchById(
@@ -4329,7 +4330,7 @@ describe("conversation fetch forkingData", () => {
     const expectedForkedChildren = [
       {
         childConversationId: secondChildConversation.sId,
-        childConversationTitle: "Earlier fork",
+        childConversationTitle: `Branched from '${parentConversationTitle}'`,
         sourceMessageId: sourceMessage.sId,
         branchedAt: earlierBranchedAt.getTime(),
         user: auth.getNonNullableUser().toJSON(),

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -307,7 +307,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           model: ConversationModel,
           as: "childConversation",
           required: true,
-          attributes: ["sId", "title"],
+          attributes: ["sId", "title", "createdAt"],
         },
         {
           model: MessageModel,
@@ -372,16 +372,32 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         return [];
       }
 
+      const branchedAt = fork.branchedAt.getTime();
+      const sourceMessageId = fork.sourceMessage.sId;
+      const user = new UserResource(
+        UserResource.model,
+        fork.createdByUser.get()
+      ).toJSON();
+
       return [
         {
           childConversationId: fork.childConversation.sId,
-          childConversationTitle: fork.childConversation.title,
-          sourceMessageId: fork.sourceMessage.sId,
-          branchedAt: fork.branchedAt.getTime(),
-          user: new UserResource(
-            UserResource.model,
-            fork.createdByUser.get()
-          ).toJSON(),
+          childConversationTitle: getConversationDisplayTitle({
+            created: fork.childConversation.createdAt.getTime(),
+            forkingData: {
+              forkedFrom: {
+                parentConversationId: conversation.sId,
+                parentConversationTitle: conversation.title,
+                sourceMessageId,
+                branchedAt,
+                user,
+              },
+            },
+            title: fork.childConversation.title,
+          }),
+          sourceMessageId,
+          branchedAt,
+          user,
         },
       ];
     });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -372,7 +372,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         return [];
       }
 
-      const branchedAt = fork.branchedAt.getTime();
+      const branchedAtMs = fork.branchedAt.getTime();
       const sourceMessageId = fork.sourceMessage.sId;
       const user = new UserResource(
         UserResource.model,
@@ -389,14 +389,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
                 parentConversationId: conversation.sId,
                 parentConversationTitle: conversation.title,
                 sourceMessageId,
-                branchedAt,
+                branchedAt: branchedAtMs,
                 user,
               },
             },
             title: fork.childConversation.title,
           }),
           sourceMessageId,
-          branchedAt,
+          branchedAt: branchedAtMs,
           user,
         },
       ];


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7975.

When serializing forked children in a source conversation, use the branch-aware display title fallback for titleless child conversations. This keeps the in-conversation branching notice from rendering `New Conversation`.

## Risks
Blast radius: fork notices in conversations
Low. This only changes the private forkingData payload used by the branching notice.

## Deploy Plan
- pmrr
- Deploy front.
