### PR TITLE
[front] enh: use file explorer view for Skill Builder files

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFilePreviewDialog.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilePreviewDialog.tsx
@@ -33,7 +33,7 @@ interface ConversationFilePreviewDialogProps {
   conversationId: string;
   entry: GCSMountFileEntry | null;
   isOpen: boolean;
-  onDownload: (entry: GCSMountFileEntry) => void;
+  onDownload: (entry: GCSMountFileEntry) => Promise<void>;
   onNext?: () => void;
   onOpenChange: (open: boolean) => void;
   onPrev?: () => void;
@@ -81,9 +81,9 @@ export function ConversationFilePreviewDialog({
     <FilePreviewDialog
       file={file}
       isOpen={isOpen}
-      onDownload={() => {
+      onDownload={async () => {
         if (entry) {
-          onDownload(entry);
+          await onDownload(entry);
         }
       }}
       onNext={onNext}

--- a/front/components/assistant/conversation/files_panel/ConversationFilePreviewDialog.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilePreviewDialog.tsx
@@ -26,7 +26,7 @@ function getConversationFileUrl(
   const scoped = parseScopedFilePath(filePath);
   const rel = scoped ? scoped.rel : filePath;
 
-  return `${config.getClientFacingUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${rel}`;
+  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${rel}`;
 }
 
 interface ConversationFilePreviewDialogProps {

--- a/front/components/assistant/conversation/files_panel/ConversationFilePreviewDialog.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilePreviewDialog.tsx
@@ -1,0 +1,94 @@
+import {
+  FilePreviewDialog,
+  needsFilePreviewTextContent,
+} from "@app/components/files/FilePreviewDialog";
+import { useConversationFileContent } from "@app/hooks/conversations/useConversationFileContent";
+import config from "@app/lib/api/config";
+import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
+import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
+import type { LightWorkspaceType } from "@app/types/user";
+
+function getConversationFileUrl(
+  owner: LightWorkspaceType,
+  {
+    conversationId,
+    filePath,
+  }: {
+    conversationId: string;
+    filePath: string;
+  }
+): string {
+  // TODO(20260504 FILE SYSTEM): Align endpoint so it accepts the scoped version.
+  // entry.path is scoped (e.g. "conversation/notes.txt") but [...rel].ts
+  // expects the path relative to the conversation's /files/ base, so strip the scope prefix.
+  // Use an absolute URL so iframe/audio src attributes resolve against the API origin, not the
+  // browser's current origin.
+  const scoped = parseScopedFilePath(filePath);
+  const rel = scoped ? scoped.rel : filePath;
+
+  return `${config.getClientFacingUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${rel}`;
+}
+
+interface ConversationFilePreviewDialogProps {
+  conversationId: string;
+  entry: GCSMountFileEntry | null;
+  isOpen: boolean;
+  onDownload: (entry: GCSMountFileEntry) => void;
+  onNext?: () => void;
+  onOpenChange: (open: boolean) => void;
+  onPrev?: () => void;
+  owner: LightWorkspaceType;
+}
+
+export function ConversationFilePreviewDialog({
+  conversationId,
+  entry,
+  isOpen,
+  onDownload,
+  onNext,
+  onOpenChange,
+  onPrev,
+  owner,
+}: ConversationFilePreviewDialogProps) {
+  const needsTextContent = entry
+    ? needsFilePreviewTextContent(entry.contentType)
+    : false;
+
+  const { fileContent, isFileContentLoading, fileContentError } =
+    useConversationFileContent({
+      owner,
+      conversationId,
+      filePath: entry?.path ?? null,
+      disabled: !isOpen || !entry || !needsTextContent,
+    });
+
+  const file = entry
+    ? {
+        content: fileContent,
+        contentError: fileContentError,
+        contentType: entry.contentType,
+        fileName: entry.fileName,
+        isContentLoading: isFileContentLoading,
+        thumbnailUrl: entry.thumbnailUrl,
+        viewUrl: getConversationFileUrl(owner, {
+          conversationId,
+          filePath: entry.path,
+        }),
+      }
+    : null;
+
+  return (
+    <FilePreviewDialog
+      file={file}
+      isOpen={isOpen}
+      onDownload={() => {
+        if (entry) {
+          onDownload(entry);
+        }
+      }}
+      onNext={onNext}
+      onOpenChange={onOpenChange}
+      onPrev={onPrev}
+    />
+  );
+}

--- a/front/components/assistant/conversation/files_panel/FileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorer.tsx
@@ -154,7 +154,7 @@ export function NewFileExplorer({
             </div>
           </div>
         </AppLayoutTitle>
-        <div className="flex flex-1 min-h-0 flex-col gap-5 pt-5">
+        <div className="flex min-h-0 flex-1 flex-col gap-5 pt-5">
           <div className="px-4">
             <FileExplorerToolbar
               searchQuery={searchQuery}

--- a/front/components/assistant/conversation/files_panel/FileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorer.tsx
@@ -1,9 +1,9 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { ConversationFilePreviewDialog } from "@app/components/assistant/conversation/files_panel/ConversationFilePreviewDialog";
 import { FileExplorerContent } from "@app/components/assistant/conversation/files_panel/FileExplorerContent";
 import { FileExplorerFilters } from "@app/components/assistant/conversation/files_panel/FileExplorerFilters";
 import type { ViewMode } from "@app/components/assistant/conversation/files_panel/FileExplorerItem";
 import { FileExplorerToolbar } from "@app/components/assistant/conversation/files_panel/FileExplorerToolbar";
-import { FilePreviewDialog } from "@app/components/assistant/conversation/files_panel/FilePreviewDialog";
 import { getFileExplorerPipeline } from "@app/components/assistant/conversation/files_panel/fileExplorerPipeline";
 import { SandboxStatusChip } from "@app/components/assistant/conversation/files_panel/SandboxStatusChip";
 import type {
@@ -185,7 +185,7 @@ export function NewFileExplorer({
         </div>
       </div>
 
-      <FilePreviewDialog
+      <ConversationFilePreviewDialog
         owner={owner}
         entry={previewFile}
         conversationId={conversation.sId}

--- a/front/components/assistant/conversation/files_panel/FileExplorerContent.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorerContent.tsx
@@ -2,14 +2,12 @@ import {
   FileExplorerEmptyState,
   FileExplorerFileCard,
   FileExplorerFolderCard,
+  fileExplorerCardGridClasses,
   type ViewMode,
 } from "@app/components/assistant/conversation/files_panel/FileExplorerItem";
 import type { SandboxTreeNode } from "@app/components/assistant/conversation/files_panel/types";
 import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import { CardGrid, ScrollArea, Spinner } from "@dust-tt/sparkle";
-
-const cardGridClasses =
-  "grid-cols-2 @xxs:grid-cols-3 @sm:grid-cols-4 @md:grid-cols-5 @lg:grid-cols-6";
 
 interface FileExplorerContentProps {
   isLoading: boolean;
@@ -82,7 +80,9 @@ export function FileExplorerContent({
         {viewMode === "list" ? (
           <div className="flex flex-col gap-0.5">{items}</div>
         ) : (
-          <CardGrid gridClassName={cardGridClasses}>{items}</CardGrid>
+          <CardGrid gridClassName={fileExplorerCardGridClasses}>
+            {items}
+          </CardGrid>
         )}
       </div>
     </ScrollArea>

--- a/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
@@ -22,6 +22,7 @@ import {
   MoreIcon,
   Spinner,
   Tooltip,
+  XMarkIcon,
 } from "@dust-tt/sparkle";
 import { intlFormatDistance } from "date-fns";
 import type { ComponentType } from "react";
@@ -32,7 +33,7 @@ export type ViewMode = "grid" | "list";
 export const fileExplorerCardGridClasses =
   "grid-cols-2 @xxs:grid-cols-3 @sm:grid-cols-4 @md:grid-cols-5 @lg:grid-cols-6";
 
-export interface FileExplorerItemMenuAction {
+interface FileExplorerItemMenuAction {
   disabled?: boolean;
   icon?: ButtonProps["icon"];
   id: string;
@@ -42,9 +43,9 @@ export interface FileExplorerItemMenuAction {
 }
 
 export type FileExplorerItemProps = {
-  actions?: FileExplorerItemMenuAction[];
   onDownload?: () => Promise<void> | void;
   onOpen?: () => void;
+  onRemove?: () => Promise<void> | void;
   subtitle: string;
   titleClassName?: string;
   title: string;
@@ -85,9 +86,9 @@ export function FileExplorerViewToggle({
 // TODO(2026-04-27 FILE SYSTEM): Candidate for Sparkle once the GCS file explorer pattern stabilises.
 export function FileExplorerItem(props: FileExplorerItemProps) {
   const {
-    actions,
     onDownload,
     onOpen,
+    onRemove,
     subtitle,
     title,
     titleClassName,
@@ -124,7 +125,17 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
           },
         ]
       : []),
-    ...(actions ?? []),
+    ...(onRemove
+      ? [
+          {
+            icon: XMarkIcon,
+            id: "remove",
+            label: "Remove",
+            loadingLabel: "Removing…",
+            onClick: onRemove,
+          },
+        ]
+      : []),
   ];
 
   const handleMenuAction = async (

--- a/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
@@ -39,13 +39,13 @@ interface FileExplorerItemMenuAction {
   id: string;
   label: string;
   loadingLabel?: string;
-  onClick: () => Promise<void> | void;
+  onClick: () => Promise<void>;
 }
 
 export type FileExplorerItemProps = {
-  onDownload?: () => Promise<void> | void;
+  onDownload?: () => Promise<void>;
   onOpen?: () => void;
-  onRemove?: () => Promise<void> | void;
+  onRemove?: () => Promise<void>;
   subtitle: string;
   titleClassName?: string;
   title: string;

--- a/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
@@ -7,6 +7,7 @@ import { cn } from "@app/components/poke/shadcn/lib/utils";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import {
+  type ActionCardDiffStatus,
   ArrowDownOnSquareIcon,
   Button,
   type ButtonProps,
@@ -42,8 +43,13 @@ interface FileExplorerItemMenuAction {
   onClick: () => Promise<void>;
 }
 
+const TITLE_DIFF_STATUS_CLASSES: Record<ActionCardDiffStatus, string> = {
+  added: "text-success dark:text-success-night",
+  removed: "text-warning dark:text-warning-night",
+};
+
 export type FileExplorerItemProps = {
-  isAdded?: boolean;
+  diffStatus?: ActionCardDiffStatus;
   onDownload?: () => Promise<void>;
   onOpen?: () => void;
   onRemove?: () => Promise<void>;
@@ -85,8 +91,15 @@ export function FileExplorerViewToggle({
 
 // TODO(2026-04-27 FILE SYSTEM): Candidate for Sparkle once the GCS file explorer pattern stabilises.
 export function FileExplorerItem(props: FileExplorerItemProps) {
-  const { onDownload, onOpen, onRemove, isAdded, subtitle, title, viewMode } =
-    props;
+  const {
+    diffStatus,
+    onDownload,
+    onOpen,
+    onRemove,
+    subtitle,
+    title,
+    viewMode,
+  } = props;
 
   const thumbnailContent =
     props.kind === "icon" ? (
@@ -194,7 +207,7 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
             className={cn(
               "text-sm truncate text-foreground dark:text-foreground-night leading-5",
               "justify-start",
-              isAdded && "text-success dark:text-success-night"
+              diffStatus && TITLE_DIFF_STATUS_CLASSES[diffStatus]
             )}
           >
             {title}

--- a/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
@@ -9,6 +9,7 @@ import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/convers
 import {
   ArrowDownOnSquareIcon,
   Button,
+  type ButtonProps,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -16,29 +17,82 @@ import {
   FolderIcon,
   FolderOpenIcon,
   Icon,
+  ListCheckIcon,
+  ListIcon,
   MoreIcon,
   Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
 import { intlFormatDistance } from "date-fns";
+import type { ComponentType } from "react";
 import { useState } from "react";
 
 export type ViewMode = "grid" | "list";
 
+export const fileExplorerCardGridClasses =
+  "grid-cols-2 @xxs:grid-cols-3 @sm:grid-cols-4 @md:grid-cols-5 @lg:grid-cols-6";
+
+export interface FileExplorerItemMenuAction {
+  disabled?: boolean;
+  icon?: ButtonProps["icon"];
+  id: string;
+  label: string;
+  loadingLabel?: string;
+  onClick: () => Promise<void> | void;
+}
+
 export type FileExplorerItemProps = {
-  onDownload?: () => Promise<void>;
-  onOpen: () => void;
+  actions?: FileExplorerItemMenuAction[];
+  onDownload?: () => Promise<void> | void;
+  onOpen?: () => void;
   subtitle: string;
+  titleClassName?: string;
   title: string;
   viewMode: ViewMode;
 } & (
-  | { kind: "icon"; visual: React.ComponentType }
+  | { kind: "icon"; visual: ComponentType }
   | { kind: "thumbnail"; thumbnailSrc: string | null }
 );
 
 // TODO(2026-04-27 FILE SYSTEM): Candidate for Sparkle once the GCS file explorer pattern stabilises.
+export interface FileExplorerViewToggleProps {
+  value: ViewMode;
+  onValueChange: (v: ViewMode) => void;
+}
+
+export function FileExplorerViewToggle({
+  value,
+  onValueChange,
+}: FileExplorerViewToggleProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          icon={value === "grid" ? ListIcon : ListCheckIcon}
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem label="Grid" onClick={() => onValueChange("grid")} />
+        <DropdownMenuItem label="List" onClick={() => onValueChange("list")} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// TODO(2026-04-27 FILE SYSTEM): Candidate for Sparkle once the GCS file explorer pattern stabilises.
 export function FileExplorerItem(props: FileExplorerItemProps) {
-  const { onDownload, onOpen, subtitle, title, viewMode } = props;
+  const {
+    actions,
+    onDownload,
+    onOpen,
+    subtitle,
+    title,
+    titleClassName,
+    viewMode,
+  } = props;
 
   const thumbnailContent =
     props.kind === "icon" ? (
@@ -56,27 +110,42 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
     );
 
   const [menuOpen, setMenuOpen] = useState(false);
-  const [isDownloading, setIsDownloading] = useState(false);
+  const [activeActionId, setActiveActionId] = useState<string | null>(null);
 
-  const handleDownload = async (e: React.MouseEvent) => {
-    if (!onDownload) {
-      return;
-    }
+  const menuActions: FileExplorerItemMenuAction[] = [
+    ...(onDownload
+      ? [
+          {
+            icon: ArrowDownOnSquareIcon,
+            id: "download",
+            label: "Download",
+            loadingLabel: "Downloading…",
+            onClick: onDownload,
+          },
+        ]
+      : []),
+    ...(actions ?? []),
+  ];
+
+  const handleMenuAction = async (
+    e: React.MouseEvent,
+    action: FileExplorerItemMenuAction
+  ) => {
     e.stopPropagation();
-    setIsDownloading(true);
+    setActiveActionId(action.id);
     try {
-      await onDownload();
+      await action.onClick();
     } finally {
-      setIsDownloading(false);
+      setActiveActionId(null);
       setMenuOpen(false);
     }
   };
 
-  const menu = onDownload && (
+  const menu = menuActions.length > 0 && (
     <DropdownMenu
       open={menuOpen}
       onOpenChange={(open) => {
-        if (!open && isDownloading) {
+        if (!open && activeActionId !== null) {
           return;
         }
         setMenuOpen(open);
@@ -91,12 +160,22 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          label={isDownloading ? "Downloading…" : "Download"}
-          icon={ArrowDownOnSquareIcon}
-          disabled={isDownloading}
-          onClick={handleDownload}
-        />
+        {menuActions.map((action) => {
+          const isActive = activeActionId === action.id;
+          return (
+            <DropdownMenuItem
+              key={action.id}
+              label={
+                isActive && action.loadingLabel
+                  ? action.loadingLabel
+                  : action.label
+              }
+              icon={action.icon}
+              disabled={action.disabled || activeActionId !== null}
+              onClick={(e: React.MouseEvent) => handleMenuAction(e, action)}
+            />
+          );
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -110,7 +189,8 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
           <span
             className={cn(
               "text-sm truncate text-foreground dark:text-foreground-night leading-5",
-              "justify-start"
+              "justify-start",
+              titleClassName
             )}
           >
             {title}
@@ -132,8 +212,9 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
     return (
       <div
         className={cn(
-          "flex cursor-pointer items-center gap-4 rounded-xl px-3 py-2",
-          "hover:bg-muted-background dark:hover:bg-muted-background-night"
+          "flex items-center gap-4 rounded-xl px-3 py-2",
+          onOpen &&
+            "cursor-pointer hover:bg-muted-background dark:hover:bg-muted-background-night"
         )}
         onClick={onOpen}
       >
@@ -150,8 +231,8 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
     <div className="flex flex-col gap-1">
       <div
         className={cn(
-          "flex h-24 cursor-pointer items-center justify-center overflow-hidden rounded-xl",
-          "bg-muted-background hover:brightness-95 dark:bg-muted-background-night",
+          "flex h-24 items-center justify-center overflow-hidden rounded-xl bg-muted-background dark:bg-muted-background-night",
+          onOpen && "cursor-pointer hover:brightness-95",
           props.kind === "icon" && "p-4"
         )}
         onClick={onOpen}

--- a/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorerItem.tsx
@@ -43,11 +43,11 @@ interface FileExplorerItemMenuAction {
 }
 
 export type FileExplorerItemProps = {
+  isAdded?: boolean;
   onDownload?: () => Promise<void>;
   onOpen?: () => void;
   onRemove?: () => Promise<void>;
   subtitle: string;
-  titleClassName?: string;
   title: string;
   viewMode: ViewMode;
 } & (
@@ -85,15 +85,8 @@ export function FileExplorerViewToggle({
 
 // TODO(2026-04-27 FILE SYSTEM): Candidate for Sparkle once the GCS file explorer pattern stabilises.
 export function FileExplorerItem(props: FileExplorerItemProps) {
-  const {
-    onDownload,
-    onOpen,
-    onRemove,
-    subtitle,
-    title,
-    titleClassName,
-    viewMode,
-  } = props;
+  const { onDownload, onOpen, onRemove, isAdded, subtitle, title, viewMode } =
+    props;
 
   const thumbnailContent =
     props.kind === "icon" ? (
@@ -201,7 +194,7 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
             className={cn(
               "text-sm truncate text-foreground dark:text-foreground-night leading-5",
               "justify-start",
-              titleClassName
+              isAdded && "text-success dark:text-success-night"
             )}
           >
             {title}

--- a/front/components/files/FilePreviewDialog.tsx
+++ b/front/components/files/FilePreviewDialog.tsx
@@ -1,13 +1,14 @@
-import { getFilePreviewConfig } from "@app/components/spaces/FilePreviewSheet";
-import { useConversationFileContent } from "@app/hooks/conversations/useConversationFileContent";
-import config from "@app/lib/api/config";
-import type { ProcessedContent } from "@app/lib/file_content_utils";
-import { processFileContent } from "@app/lib/file_content_utils";
+import {
+  type FilePreviewCategory,
+  getFilePreviewConfig,
+} from "@app/components/spaces/FilePreviewSheet";
+import {
+  type ProcessedContent,
+  processFileContent,
+} from "@app/lib/file_content_utils";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
-import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import { stripMimeParameters } from "@app/types/files";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   ArrowDownOnSquareIcon,
   Button,
@@ -31,18 +32,21 @@ import { useEffect, useState } from "react";
 
 const MAX_CSV_ROWS = 200;
 const MAX_TEXT_CHARS = 100_000;
+const TEXT_CONTENT_PREVIEW_CATEGORIES: FilePreviewCategory[] = [
+  "code",
+  "markdown",
+  "text",
+  "delimited",
+];
 
-function getConversationFileUrl(
-  owner: LightWorkspaceType,
-  {
-    conversationId,
-    filePath,
-  }: {
-    conversationId: string;
-    filePath: string;
-  }
-): string {
-  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${filePath}`;
+export interface FilePreviewDialogFile {
+  content: string | null;
+  contentError: Error | null;
+  isContentLoading: boolean;
+  contentType: string;
+  fileName: string;
+  thumbnailUrl?: string | null;
+  viewUrl: string;
 }
 
 const EXTENSION_TO_LANGUAGE: Record<string, string> = {
@@ -79,6 +83,12 @@ function getCodeLanguage(fileName: string): string {
   const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
 
   return EXTENSION_TO_LANGUAGE[ext] ?? "text";
+}
+
+export function needsFilePreviewTextContent(contentType: string): boolean {
+  const { category } = getFilePreviewConfig(stripMimeParameters(contentType));
+
+  return TEXT_CONTENT_PREVIEW_CATEGORIES.includes(category);
 }
 
 function getDelimitedRecordCount({
@@ -157,29 +167,18 @@ function DelimitedPreview({ content, mimeType }: DelimitedPreviewProps) {
 }
 
 interface FilePreviewDialogContentProps {
-  category: ReturnType<typeof getFilePreviewConfig>["category"];
-  conversationId: string;
-  entry: GCSMountFileEntry;
-  fileContent: string | null;
+  category: FilePreviewCategory;
+  file: FilePreviewDialogFile;
   isContentLoading: boolean;
-  owner: LightWorkspaceType;
   processedContent: ProcessedContent | null;
 }
 
 function FilePreviewDialogContent({
   category,
-  conversationId,
-  entry,
-  fileContent,
+  file,
   isContentLoading,
-  owner,
   processedContent,
 }: FilePreviewDialogContentProps) {
-  const fileUrl = getConversationFileUrl(owner, {
-    conversationId,
-    filePath: entry.path,
-  });
-
   if (isContentLoading) {
     return (
       <div className="flex h-48 items-center justify-center">
@@ -195,8 +194,8 @@ function FilePreviewDialogContent({
     case "image":
       return (
         <img
-          src={entry.thumbnailUrl ?? fileUrl}
-          alt={entry.fileName}
+          src={file.thumbnailUrl ?? file.viewUrl}
+          alt={file.fileName}
           className="w-full rounded-lg object-contain"
         />
       );
@@ -204,9 +203,9 @@ function FilePreviewDialogContent({
     case "pdf":
       return (
         <iframe
-          src={`${fileUrl}#navpanes=0`}
+          src={`${file.viewUrl}#navpanes=0`}
           className="h-[70vh] w-full rounded-lg border-0"
-          title={entry.fileName}
+          title={file.fileName}
         />
       );
 
@@ -223,18 +222,18 @@ function FilePreviewDialogContent({
     case "audio":
       return (
         <div className="flex flex-col gap-4">
-          <audio controls className="w-full" src={fileUrl}>
+          <audio controls className="w-full" src={file.viewUrl}>
             Your browser does not support the audio element.
           </audio>
         </div>
       );
 
     case "delimited":
-      if (fileContent) {
+      if (file.content) {
         return (
           <DelimitedPreview
-            content={fileContent.slice(0, MAX_TEXT_CHARS)}
-            mimeType={stripMimeParameters(entry.contentType)}
+            content={file.content.slice(0, MAX_TEXT_CHARS)}
+            mimeType={stripMimeParameters(file.contentType)}
           />
         );
       }
@@ -252,14 +251,14 @@ function FilePreviewDialogContent({
       return null;
 
     case "code": {
-      const lang = getCodeLanguage(entry.fileName);
-      const raw = fileContent?.slice(0, MAX_TEXT_CHARS) ?? "";
+      const lang = getCodeLanguage(file.fileName);
+      const raw = file.content?.slice(0, MAX_TEXT_CHARS) ?? "";
       let displayContent = raw;
       if (lang === "json") {
         try {
           displayContent = JSON.stringify(JSON.parse(raw), null, 2);
         } catch {
-          // keep raw if not valid JSON
+          // Keep raw content if the JSON is invalid.
         }
       }
       return (
@@ -278,22 +277,18 @@ function FilePreviewDialogContent({
 }
 
 interface FilePreviewDialogProps {
-  conversationId: string;
-  entry: GCSMountFileEntry | null;
+  file: FilePreviewDialogFile | null;
   isOpen: boolean;
-  onDownload: (entry: GCSMountFileEntry) => Promise<void>;
+  onDownload: (file: FilePreviewDialogFile) => Promise<void> | void;
   onNext?: () => void;
   onOpenChange: (open: boolean) => void;
   onPrev?: () => void;
-  owner: LightWorkspaceType;
 }
 
 export function FilePreviewDialog({
-  entry,
-  conversationId,
+  file,
   isOpen,
   onOpenChange,
-  owner,
   onDownload,
   onPrev,
   onNext,
@@ -301,12 +296,12 @@ export function FilePreviewDialog({
   const [isDownloading, setIsDownloading] = useState(false);
 
   const handleDownload = async () => {
-    if (!entry) {
+    if (!file) {
       return;
     }
     setIsDownloading(true);
     try {
-      await onDownload(entry);
+      await onDownload(file);
     } finally {
       setIsDownloading(false);
     }
@@ -337,36 +332,23 @@ export function FilePreviewDialog({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onPrev, onNext]);
 
-  const mimeType = stripMimeParameters(entry?.contentType ?? "");
+  const mimeType = stripMimeParameters(file?.contentType ?? "");
   const { category } = getFilePreviewConfig(mimeType);
 
-  const needsTextContent =
-    category === "code" ||
-    category === "markdown" ||
-    category === "text" ||
-    category === "delimited";
-
-  const { fileContent, isFileContentLoading, fileContentError } =
-    useConversationFileContent({
-      owner,
-      conversationId,
-      filePath: entry?.path ?? null,
-      disabled: !isOpen || !entry || !needsTextContent,
-    });
-
-  const hasError = needsTextContent && !!fileContentError;
+  const hasError =
+    TEXT_CONTENT_PREVIEW_CATEGORIES.includes(category) && !!file?.contentError;
   const isContentLoading =
-    isOpen && !!entry && !hasError && needsTextContent && isFileContentLoading;
+    isOpen && !!file && !hasError && file.isContentLoading;
 
-  const truncatedContent = fileContent?.slice(0, MAX_TEXT_CHARS) ?? null;
+  const truncatedContent = file?.content?.slice(0, MAX_TEXT_CHARS) ?? null;
 
   const processedContent =
     (category === "markdown" || category === "text") && truncatedContent
       ? processFileContent(truncatedContent, mimeType)
       : null;
 
-  const FileIcon = entry
-    ? getFileTypeIcon(entry.contentType, entry.fileName)
+  const FileIcon = file
+    ? getFileTypeIcon(file.contentType, file.fileName)
     : null;
 
   const recordCounts =
@@ -394,7 +376,7 @@ export function FilePreviewDialog({
                   "text-foreground dark:text-foreground-night"
                 )}
               >
-                {entry?.fileName ?? ""}
+                {file?.fileName ?? ""}
               </span>
             </div>
             {recordCounts && (
@@ -418,28 +400,22 @@ export function FilePreviewDialog({
           </div>
         ) : category === "delimited" ? (
           <div className="flex min-h-0 flex-1 flex-col px-4">
-            {entry && (
+            {file && (
               <FilePreviewDialogContent
                 category={category}
-                conversationId={conversationId}
-                entry={entry}
-                fileContent={truncatedContent}
+                file={file}
                 isContentLoading={isContentLoading}
-                owner={owner}
                 processedContent={processedContent}
               />
             )}
           </div>
         ) : (
           <div className="min-h-0 flex-1 overflow-y-auto px-4">
-            {entry && (
+            {file && (
               <FilePreviewDialogContent
                 category={category}
-                conversationId={conversationId}
-                entry={entry}
-                fileContent={truncatedContent}
+                file={file}
                 isContentLoading={isContentLoading}
-                owner={owner}
                 processedContent={processedContent}
               />
             )}
@@ -469,9 +445,9 @@ export function FilePreviewDialog({
               variant="outline"
               size="sm"
               icon={ArrowDownOnSquareIcon}
-              label={isDownloading ? "Downloading…" : "Download"}
+              label={isDownloading ? "Downloading..." : "Download"}
               onClick={handleDownload}
-              disabled={!entry || isDownloading}
+              disabled={!file || isDownloading}
             />
           </div>
         </DialogFooter>

--- a/front/components/files/FilePreviewDialog.tsx
+++ b/front/components/files/FilePreviewDialog.tsx
@@ -279,7 +279,7 @@ function FilePreviewDialogContent({
 interface FilePreviewDialogProps {
   file: FilePreviewDialogFile | null;
   isOpen: boolean;
-  onDownload: (file: FilePreviewDialogFile) => Promise<void> | void;
+  onDownload: (file: FilePreviewDialogFile) => Promise<void>;
   onNext?: () => void;
   onOpenChange: (open: boolean) => void;
   onPrev?: () => void;

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -134,17 +134,20 @@ export function SkillBuilderFilesSection() {
       )
     : -1;
 
-  const previewPreviousFile = () => {
-    if (previewIndex > 0) {
-      setPreviewFileAttachment(sortedFields[previewIndex - 1]?.field ?? null);
-    }
-  };
-
-  const previewNextFile = () => {
-    if (previewIndex >= 0 && previewIndex < sortedFields.length - 1) {
-      setPreviewFileAttachment(sortedFields[previewIndex + 1]?.field ?? null);
-    }
-  };
+  const handlePreviewPrev =
+    previewIndex > 0
+      ? () =>
+          setPreviewFileAttachment(
+            sortedFields[previewIndex - 1]?.field ?? null
+          )
+      : undefined;
+  const handlePreviewNext =
+    previewIndex >= 0 && previewIndex < sortedFields.length - 1
+      ? () =>
+          setPreviewFileAttachment(
+            sortedFields[previewIndex + 1]?.field ?? null
+          )
+      : undefined;
 
   const downloadFile = async (fileAttachment: SkillBuilderFileAttachment) => {
     window.open(
@@ -339,12 +342,8 @@ export function SkillBuilderFilesSection() {
             await downloadFile(previewFileAttachment);
           }
         }}
-        onPrev={previewIndex > 0 ? previewPreviousFile : undefined}
-        onNext={
-          previewIndex >= 0 && previewIndex < sortedFields.length - 1
-            ? previewNextFile
-            : undefined
-        }
+        onPrev={handlePreviewPrev}
+        onNext={handlePreviewNext}
         onOpenChange={(open) => {
           if (!open) {
             setPreviewFileAttachment(null);

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -1,6 +1,5 @@
 import {
   FileExplorerItem,
-  type FileExplorerItemMenuAction,
   FileExplorerViewToggle,
   fileExplorerCardGridClasses,
   type ViewMode,
@@ -29,7 +28,6 @@ import {
   PlusIcon,
   ScrollArea,
   Spinner,
-  XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
@@ -229,16 +227,6 @@ export function SkillBuilderFilesSection() {
 
   const fileItems = sortedFields.map(({ field, originalIndex }) => {
     const isAdded = isDiffMode && !compareFileIds.has(field.fileId);
-    const actions: FileExplorerItemMenuAction[] = !isDiffMode
-      ? [
-          {
-            icon: XMarkIcon,
-            id: "remove",
-            label: "Remove",
-            onClick: () => removeFile({ fileAttachment: field, originalIndex }),
-          },
-        ]
-      : [];
     const FileIcon = getFileTypeIcon(field.contentType, field.fileName);
 
     return (
@@ -252,7 +240,11 @@ export function SkillBuilderFilesSection() {
         subtitle={getSingularFileCategoryLabelForContentType(field.contentType)}
         onOpen={canPreviewFiles ? () => openPreviewDialog(field) : undefined}
         onDownload={() => downloadFile(field)}
-        actions={actions}
+        onRemove={
+          !isDiffMode
+            ? () => removeFile({ fileAttachment: field, originalIndex })
+            : undefined
+        }
       />
     );
   });

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -1,8 +1,17 @@
+import {
+  FilePreviewDialog,
+  needsFilePreviewTextContent,
+} from "@app/components/files/FilePreviewDialog";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
+import {
+  getFileDownloadUrl,
+  getSkillFileContentUrl,
+  useSkillFileContent,
+} from "@app/lib/swr/files";
 import {
   ArrowGoBackIcon,
   Button,
@@ -10,6 +19,7 @@ import {
   cn,
   DocumentIcon,
   EmptyCTA,
+  EyeIcon,
   PlusIcon,
   Spinner,
   XMarkIcon,
@@ -17,12 +27,17 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
+type SkillBuilderFileAttachment =
+  SkillBuilderFormData["fileAttachments"][number];
+
 export function SkillBuilderFilesSection() {
   const { owner, skillId } = useSkillBuilderContext();
   const sendNotification = useSendNotification();
   const { setValue } = useFormContext<SkillBuilderFormData>();
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
   const [canScrollFilesDown, setCanScrollFilesDown] = useState(false);
+  const [previewFileAttachment, setPreviewFileAttachment] =
+    useState<SkillBuilderFileAttachment | null>(null);
 
   const { fields, append, remove } = useFieldArray<
     SkillBuilderFormData,
@@ -111,6 +126,28 @@ export function SkillBuilderFilesSection() {
     fileInputRef.current?.click();
   };
 
+  const canPreviewFiles = !!skillId;
+  const isPreviewOpen = canPreviewFiles && previewFileAttachment !== null;
+
+  const { fileContent, isFileContentLoading, fileContentError } =
+    useSkillFileContent({
+      fileId: previewFileAttachment?.fileId ?? null,
+      owner,
+      skillId,
+      disabled:
+        !isPreviewOpen ||
+        !skillId ||
+        !needsFilePreviewTextContent(previewFileAttachment?.contentType ?? ""),
+    });
+
+  const openPreviewDialog = (fileAttachment: SkillBuilderFileAttachment) => {
+    if (!canPreviewFiles) {
+      return;
+    }
+
+    setPreviewFileAttachment(fileAttachment);
+  };
+
   const onFileInputChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const files = e.target.files;
@@ -135,7 +172,11 @@ export function SkillBuilderFilesSection() {
         if (uploaded) {
           for (const blob of uploaded) {
             if (blob.fileId) {
-              append({ fileId: blob.fileId, fileName: blob.filename });
+              append({
+                contentType: blob.contentType,
+                fileId: blob.fileId,
+                fileName: blob.filename,
+              });
             }
           }
         }
@@ -237,17 +278,48 @@ export function SkillBuilderFilesSection() {
                       </span>
                     }
                     visual={<ContextItem.Visual visual={DocumentIcon} />}
-                    hoverAction={!isDiffMode}
+                    hoverAction={canPreviewFiles || !isDiffMode}
                     action={
-                      !isDiffMode ? (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          icon={XMarkIcon}
-                          size="xs"
-                          onClick={() => remove(originalIndex)}
-                        />
+                      canPreviewFiles || !isDiffMode ? (
+                        <div className="flex items-center gap-1">
+                          {canPreviewFiles && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              icon={EyeIcon}
+                              size="xs"
+                              tooltip="Preview"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                openPreviewDialog(field);
+                              }}
+                            />
+                          )}
+                          {!isDiffMode && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              icon={XMarkIcon}
+                              size="xs"
+                              tooltip="Remove"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                remove(originalIndex);
+                                if (
+                                  previewFileAttachment?.fileId === field.fileId
+                                ) {
+                                  setPreviewFileAttachment(null);
+                                }
+                              }}
+                            />
+                          )}
+                        </div>
                       ) : undefined
+                    }
+                    onClick={
+                      canPreviewFiles
+                        ? () => openPreviewDialog(field)
+                        : undefined
                     }
                   />
                 );
@@ -266,6 +338,38 @@ export function SkillBuilderFilesSection() {
           />
         </div>
       )}
+      <FilePreviewDialog
+        file={
+          previewFileAttachment && skillId
+            ? {
+                content: fileContent,
+                contentError: fileContentError,
+                contentType: previewFileAttachment.contentType,
+                fileName: previewFileAttachment.fileName,
+                isContentLoading: isFileContentLoading,
+                viewUrl: getSkillFileContentUrl(
+                  owner,
+                  skillId,
+                  previewFileAttachment.fileId
+                ),
+              }
+            : null
+        }
+        isOpen={isPreviewOpen}
+        onDownload={() => {
+          if (previewFileAttachment) {
+            window.open(
+              getFileDownloadUrl(owner, previewFileAttachment.fileId),
+              "_blank"
+            );
+          }
+        }}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPreviewFileAttachment(null);
+          }
+        }}
+      />
     </div>
   );
 }

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -126,25 +126,16 @@ export function SkillBuilderFilesSection() {
     fileInputRef.current?.click();
   };
 
-  const canPreviewFiles = !!skillId;
-  const isPreviewOpen = canPreviewFiles && previewFileAttachment !== null;
-
   const { fileContent, isFileContentLoading, fileContentError } =
     useSkillFileContent({
       fileId: previewFileAttachment?.fileId ?? null,
       owner,
       skillId,
       disabled:
-        !isPreviewOpen ||
-        !skillId ||
         !needsFilePreviewTextContent(previewFileAttachment?.contentType ?? ""),
     });
 
   const openPreviewDialog = (fileAttachment: SkillBuilderFileAttachment) => {
-    if (!canPreviewFiles) {
-      return;
-    }
-
     setPreviewFileAttachment(fileAttachment);
   };
 
@@ -278,11 +269,11 @@ export function SkillBuilderFilesSection() {
                       </span>
                     }
                     visual={<ContextItem.Visual visual={DocumentIcon} />}
-                    hoverAction={canPreviewFiles || !isDiffMode}
+                    hoverAction={!!skillId || !isDiffMode}
                     action={
-                      canPreviewFiles || !isDiffMode ? (
+                      skillId || !isDiffMode ? (
                         <div className="flex items-center gap-1">
-                          {canPreviewFiles && (
+                          {skillId && (
                             <Button
                               type="button"
                               variant="ghost"
@@ -291,7 +282,7 @@ export function SkillBuilderFilesSection() {
                               tooltip="Preview"
                               onClick={(e) => {
                                 e.stopPropagation();
-                                openPreviewDialog(field);
+                                setPreviewFileAttachment(field);
                               }}
                             />
                           )}
@@ -317,7 +308,7 @@ export function SkillBuilderFilesSection() {
                       ) : undefined
                     }
                     onClick={
-                      canPreviewFiles
+                      skillId
                         ? () => openPreviewDialog(field)
                         : undefined
                     }
@@ -355,7 +346,7 @@ export function SkillBuilderFilesSection() {
               }
             : null
         }
-        isOpen={isPreviewOpen}
+        isOpen={skillId !== null && previewFileAttachment !== null}
         onDownload={() => {
           if (previewFileAttachment) {
             window.open(

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -146,7 +146,7 @@ export function SkillBuilderFilesSection() {
     }
   };
 
-  const downloadFile = (fileAttachment: SkillBuilderFileAttachment) => {
+  const downloadFile = async (fileAttachment: SkillBuilderFileAttachment) => {
     window.open(
       getFileDownloadUrl(owner, fileAttachment.fileId),
       "_blank",
@@ -154,7 +154,7 @@ export function SkillBuilderFilesSection() {
     );
   };
 
-  const removeFile = ({
+  const removeFile = async ({
     fileAttachment,
     originalIndex,
   }: {
@@ -334,9 +334,9 @@ export function SkillBuilderFilesSection() {
             : null
         }
         isOpen={isPreviewOpen}
-        onDownload={() => {
+        onDownload={async () => {
           if (previewFileAttachment) {
-            downloadFile(previewFileAttachment);
+            await downloadFile(previewFileAttachment);
           }
         }}
         onPrev={previewIndex > 0 ? previewPreviousFile : undefined}

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -150,11 +150,7 @@ export function SkillBuilderFilesSection() {
       : undefined;
 
   const downloadFile = async (fileAttachment: SkillBuilderFileAttachment) => {
-    window.open(
-      getFileDownloadUrl(owner, fileAttachment.fileId),
-      "_blank",
-      "noopener,noreferrer"
-    );
+    window.open(getFileDownloadUrl(owner, fileAttachment.fileId), "_blank");
   };
 
   const removeFile = async ({

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -225,7 +225,8 @@ export function SkillBuilderFilesSection() {
   );
 
   const fileItems = sortedFields.map(({ field, originalIndex }) => {
-    const isAdded = isDiffMode && !compareFileIds.has(field.fileId);
+    const diffStatus =
+      isDiffMode && !compareFileIds.has(field.fileId) ? "added" : undefined;
     const FileIcon = getFileTypeIcon(field.contentType, field.fileName);
 
     return (
@@ -235,7 +236,7 @@ export function SkillBuilderFilesSection() {
         visual={FileIcon}
         viewMode={viewMode}
         title={field.fileName}
-        isAdded={isAdded}
+        diffStatus={diffStatus}
         subtitle={getSingularFileCategoryLabelForContentType(field.contentType)}
         onOpen={canPreviewFiles ? () => openPreviewDialog(field) : undefined}
         onDownload={() => downloadFile(field)}

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -131,8 +131,9 @@ export function SkillBuilderFilesSection() {
       fileId: previewFileAttachment?.fileId ?? null,
       owner,
       skillId,
-      disabled:
-        !needsFilePreviewTextContent(previewFileAttachment?.contentType ?? ""),
+      disabled: !needsFilePreviewTextContent(
+        previewFileAttachment?.contentType ?? ""
+      ),
     });
 
   const openPreviewDialog = (fileAttachment: SkillBuilderFileAttachment) => {
@@ -308,9 +309,7 @@ export function SkillBuilderFilesSection() {
                       ) : undefined
                     }
                     onClick={
-                      skillId
-                        ? () => openPreviewDialog(field)
-                        : undefined
+                      skillId ? () => openPreviewDialog(field) : undefined
                     }
                   />
                 );

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -235,7 +235,7 @@ export function SkillBuilderFilesSection() {
         visual={FileIcon}
         viewMode={viewMode}
         title={field.fileName}
-        titleClassName={isAdded ? "text-success dark:text-success-night" : ""}
+        isAdded={isAdded}
         subtitle={getSingularFileCategoryLabelForContentType(field.contentType)}
         onOpen={canPreviewFiles ? () => openPreviewDialog(field) : undefined}
         onDownload={() => downloadFile(field)}

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -1,4 +1,12 @@
 import {
+  FileExplorerItem,
+  type FileExplorerItemMenuAction,
+  FileExplorerViewToggle,
+  fileExplorerCardGridClasses,
+  type ViewMode,
+} from "@app/components/assistant/conversation/files_panel/FileExplorerItem";
+import { getSingularFileCategoryLabelForContentType } from "@app/components/assistant/conversation/files_panel/utils";
+import {
   FilePreviewDialog,
   needsFilePreviewTextContent,
 } from "@app/components/files/FilePreviewDialog";
@@ -7,6 +15,7 @@ import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBu
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
   getFileDownloadUrl,
   getSkillFileContentUrl,
@@ -15,16 +24,14 @@ import {
 import {
   ArrowGoBackIcon,
   Button,
-  ContextItem,
-  cn,
-  DocumentIcon,
+  CardGrid,
   EmptyCTA,
-  EyeIcon,
   PlusIcon,
+  ScrollArea,
   Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
 type SkillBuilderFileAttachment =
@@ -35,9 +42,9 @@ export function SkillBuilderFilesSection() {
   const sendNotification = useSendNotification();
   const { setValue } = useFormContext<SkillBuilderFormData>();
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
-  const [canScrollFilesDown, setCanScrollFilesDown] = useState(false);
   const [previewFileAttachment, setPreviewFileAttachment] =
     useState<SkillBuilderFileAttachment | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>("grid");
 
   const { fields, append, remove } = useFieldArray<
     SkillBuilderFormData,
@@ -48,8 +55,6 @@ export function SkillBuilderFilesSection() {
   const hasFileAttachments = fields.length > 0;
 
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const fileListRef = useRef<HTMLDivElement>(null);
-  const fileListBottomSentinelRef = useRef<HTMLDivElement>(null);
 
   const { handleFilesUpload, isProcessingFiles } = useFileUploaderService({
     hasSandboxTools: false,
@@ -89,30 +94,6 @@ export function SkillBuilderFilesSection() {
     (currentFileIds.size !== compareFileIds.size ||
       [...currentFileIds].some((id) => !compareFileIds.has(id)));
 
-  useEffect(() => {
-    const list = fileListRef.current;
-    const sentinel = fileListBottomSentinelRef.current;
-
-    if (
-      !hasFileAttachments ||
-      !list ||
-      !sentinel ||
-      typeof IntersectionObserver === "undefined"
-    ) {
-      setCanScrollFilesDown(false);
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => setCanScrollFilesDown(!entry.isIntersecting),
-      { root: list, threshold: 0.1 }
-    );
-
-    observer.observe(sentinel);
-
-    return () => observer.disconnect();
-  }, [hasFileAttachments]);
-
   const restoreFiles = () => {
     if (!compareVersion) {
       return;
@@ -120,24 +101,72 @@ export function SkillBuilderFilesSection() {
     setValue("fileAttachments", compareVersion.fileAttachments, {
       shouldDirty: true,
     });
+    setPreviewFileAttachment(null);
   };
 
   const onUploadClick = () => {
     fileInputRef.current?.click();
   };
 
+  const canPreviewFiles = !!skillId;
+  const isPreviewOpen = canPreviewFiles && previewFileAttachment !== null;
+
   const { fileContent, isFileContentLoading, fileContentError } =
     useSkillFileContent({
       fileId: previewFileAttachment?.fileId ?? null,
       owner,
       skillId,
-      disabled: !needsFilePreviewTextContent(
-        previewFileAttachment?.contentType ?? ""
-      ),
+      disabled:
+        !isPreviewOpen ||
+        !skillId ||
+        !needsFilePreviewTextContent(previewFileAttachment?.contentType ?? ""),
     });
 
   const openPreviewDialog = (fileAttachment: SkillBuilderFileAttachment) => {
+    if (!canPreviewFiles) {
+      return;
+    }
+
     setPreviewFileAttachment(fileAttachment);
+  };
+
+  const previewIndex = previewFileAttachment
+    ? sortedFields.findIndex(
+        ({ field }) => field.fileId === previewFileAttachment.fileId
+      )
+    : -1;
+
+  const previewPreviousFile = () => {
+    if (previewIndex > 0) {
+      setPreviewFileAttachment(sortedFields[previewIndex - 1]?.field ?? null);
+    }
+  };
+
+  const previewNextFile = () => {
+    if (previewIndex >= 0 && previewIndex < sortedFields.length - 1) {
+      setPreviewFileAttachment(sortedFields[previewIndex + 1]?.field ?? null);
+    }
+  };
+
+  const downloadFile = (fileAttachment: SkillBuilderFileAttachment) => {
+    window.open(
+      getFileDownloadUrl(owner, fileAttachment.fileId),
+      "_blank",
+      "noopener,noreferrer"
+    );
+  };
+
+  const removeFile = ({
+    fileAttachment,
+    originalIndex,
+  }: {
+    fileAttachment: SkillBuilderFileAttachment;
+    originalIndex: number;
+  }) => {
+    remove(originalIndex);
+    if (previewFileAttachment?.fileId === fileAttachment.fileId) {
+      setPreviewFileAttachment(null);
+    }
   };
 
   const onFileInputChange = useCallback(
@@ -180,16 +209,53 @@ export function SkillBuilderFilesSection() {
     [handleFilesUpload, append, existingFileNames, sendNotification]
   );
 
-  const headerActions = !isDiffMode && hasFileAttachments && (
-    <Button
-      type="button"
-      onClick={onUploadClick}
-      label="Upload files"
-      icon={isProcessingFiles ? Spinner : PlusIcon}
-      variant="outline"
-      disabled={isProcessingFiles}
-    />
+  const headerActions = (
+    <>
+      {hasFileAttachments && (
+        <FileExplorerViewToggle value={viewMode} onValueChange={setViewMode} />
+      )}
+      {!isDiffMode && hasFileAttachments && (
+        <Button
+          type="button"
+          onClick={onUploadClick}
+          label="Upload files"
+          icon={isProcessingFiles ? Spinner : PlusIcon}
+          variant="outline"
+          disabled={isProcessingFiles}
+        />
+      )}
+    </>
   );
+
+  const fileItems = sortedFields.map(({ field, originalIndex }) => {
+    const isAdded = isDiffMode && !compareFileIds.has(field.fileId);
+    const actions: FileExplorerItemMenuAction[] = !isDiffMode
+      ? [
+          {
+            icon: XMarkIcon,
+            id: "remove",
+            label: "Remove",
+            onClick: () => removeFile({ fileAttachment: field, originalIndex }),
+          },
+        ]
+      : [];
+    const FileIcon = getFileTypeIcon(field.contentType, field.fileName);
+
+    return (
+      <FileExplorerItem
+        key={field.id}
+        kind="icon"
+        visual={FileIcon}
+        viewMode={viewMode}
+        title={field.fileName}
+        titleClassName={isAdded ? "text-success dark:text-success-night" : ""}
+        subtitle={getSingularFileCategoryLabelForContentType(field.contentType)}
+        onOpen={canPreviewFiles ? () => openPreviewDialog(field) : undefined}
+        onDownload={() => downloadFile(field)}
+        actions={actions}
+      />
+    );
+  });
 
   return (
     <div className="flex flex-col gap-3">
@@ -248,85 +314,15 @@ export function SkillBuilderFilesSection() {
           />
         )
       ) : (
-        <div className="relative">
-          <div
-            ref={fileListRef}
-            className="max-h-64 overflow-y-auto overflow-x-hidden"
-          >
-            <ContextItem.List>
-              {sortedFields.map(({ field, originalIndex }) => {
-                const isAdded = isDiffMode && !compareFileIds.has(field.fileId);
-                return (
-                  <ContextItem
-                    key={field.id}
-                    title={
-                      <span
-                        className={cn(
-                          "text-sm font-normal",
-                          isAdded && "text-success dark:text-success-night"
-                        )}
-                      >
-                        {field.fileName}
-                      </span>
-                    }
-                    visual={<ContextItem.Visual visual={DocumentIcon} />}
-                    hoverAction={!!skillId || !isDiffMode}
-                    action={
-                      skillId || !isDiffMode ? (
-                        <div className="flex items-center gap-1">
-                          {skillId && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              icon={EyeIcon}
-                              size="xs"
-                              tooltip="Preview"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setPreviewFileAttachment(field);
-                              }}
-                            />
-                          )}
-                          {!isDiffMode && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              icon={XMarkIcon}
-                              size="xs"
-                              tooltip="Remove"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                remove(originalIndex);
-                                if (
-                                  previewFileAttachment?.fileId === field.fileId
-                                ) {
-                                  setPreviewFileAttachment(null);
-                                }
-                              }}
-                            />
-                          )}
-                        </div>
-                      ) : undefined
-                    }
-                    onClick={
-                      skillId ? () => openPreviewDialog(field) : undefined
-                    }
-                  />
-                );
-              })}
-            </ContextItem.List>
-            <div ref={fileListBottomSentinelRef} className="h-px" aria-hidden />
-          </div>
-          <div
-            className={cn(
-              "pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t",
-              "from-background via-background/60 to-transparent transition-opacity duration-300",
-              "dark:from-background-night dark:via-background-night/60",
-              canScrollFilesDown ? "opacity-100" : "opacity-0"
-            )}
-            aria-hidden
-          />
-        </div>
+        <ScrollArea className="max-h-64">
+          {viewMode === "list" ? (
+            <div className="flex flex-col gap-0.5">{fileItems}</div>
+          ) : (
+            <CardGrid gridClassName={fileExplorerCardGridClasses}>
+              {fileItems}
+            </CardGrid>
+          )}
+        </ScrollArea>
       )}
       <FilePreviewDialog
         file={
@@ -345,15 +341,18 @@ export function SkillBuilderFilesSection() {
               }
             : null
         }
-        isOpen={skillId !== null && previewFileAttachment !== null}
+        isOpen={isPreviewOpen}
         onDownload={() => {
           if (previewFileAttachment) {
-            window.open(
-              getFileDownloadUrl(owner, previewFileAttachment.fileId),
-              "_blank"
-            );
+            downloadFile(previewFileAttachment);
           }
         }}
+        onPrev={previewIndex > 0 ? previewPreviousFile : undefined}
+        onNext={
+          previewIndex >= 0 && previewIndex < sortedFields.length - 1
+            ? previewNextFile
+            : undefined
+        }
         onOpenChange={(open) => {
           if (!open) {
             setPreviewFileAttachment(null);

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -15,6 +15,7 @@ export const attachedKnowledgeSchema = z.object({
 });
 
 const fileAttachmentSchema = z.object({
+  contentType: z.string(),
   fileId: z.string(),
   fileName: z.string(),
 });

--- a/front/components/spaces/FilePreviewSheet.tsx
+++ b/front/components/spaces/FilePreviewSheet.tsx
@@ -66,7 +66,7 @@ function isViewerCompatible(contentType: string): boolean {
   );
 }
 
-type FilePreviewCategory =
+export type FilePreviewCategory =
   | "frame"
   | "code"
   | "pdf"

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2728,6 +2728,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         };
       }),
       fileAttachments: this.fileAttachments.map((file) => ({
+        contentType: file.contentType,
         fileId: file.sId,
         fileName: file.fileName,
       })),

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -24,32 +24,34 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher, SWRConfiguration } from "swr";
 
-export const getFileProcessedUrl = (
+export function getFileProcessedUrl(
   owner: LightWorkspaceType,
   fileId: string | null | undefined
-) =>
-  `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view&version=processed`;
+) {
+return   `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view&version=processed`;
+}
 
-export const getProcessedFileDownloadUrl = (
+export function getProcessedFileDownloadUrl(
   owner: LightWorkspaceType,
   fileId: string
-) =>
-  `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download&version=processed`;
+) {
+  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download&version=processed`;}
 
-export const getFileDownloadUrl = (owner: LightWorkspaceType, fileId: string) =>
-  `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
+export function getFileDownloadUrl(owner: LightWorkspaceType, fileId: string)
+  {return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;}
 
-export const getFileViewUrl = (
+export function getFileViewUrl(
   owner: LightWorkspaceType,
   fileId: string | null | undefined
-) => `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view`;
+) {return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view`;}
 
-export const getSkillFileContentUrl = (
+export function getSkillFileContentUrl(
   owner: LightWorkspaceType,
   skillId: string,
   fileId: string
-) =>
-  `${config.getApiBaseUrl()}/api/w/${owner.sId}/skills/${skillId}/files/${fileId}/content`;
+) {
+  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/skills/${skillId}/files/${fileId}/content`;
+}
 
 export async function downloadSandboxFile(
   owner: LightWorkspaceType,

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -44,6 +44,13 @@ export const getFileViewUrl = (
   fileId: string | null | undefined
 ) => `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view`;
 
+export const getSkillFileContentUrl = (
+  owner: LightWorkspaceType,
+  skillId: string,
+  fileId: string
+) =>
+  `${config.getApiBaseUrl()}/api/w/${owner.sId}/skills/${skillId}/files/${fileId}/content`;
+
 export async function downloadSandboxFile(
   owner: LightWorkspaceType,
   conversationId: string,
@@ -247,9 +254,7 @@ export function useSkillFileContent({
   disabled?: boolean;
 }) {
   const { data, error, mutate, isLoading } = useSWRWithDefaults(
-    skillId && fileId
-      ? `/api/w/${owner.sId}/skills/${skillId}/files/${fileId}/content`
-      : null,
+    skillId && fileId ? getSkillFileContentUrl(owner, skillId, fileId) : null,
     async (url: string) => {
       const response = await clientFetch(url);
       if (!response.ok) {

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -28,22 +28,26 @@ export function getFileProcessedUrl(
   owner: LightWorkspaceType,
   fileId: string | null | undefined
 ) {
-return   `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view&version=processed`;
+  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view&version=processed`;
 }
 
 export function getProcessedFileDownloadUrl(
   owner: LightWorkspaceType,
   fileId: string
 ) {
-  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download&version=processed`;}
+  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download&version=processed`;
+}
 
-export function getFileDownloadUrl(owner: LightWorkspaceType, fileId: string)
-  {return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;}
+export function getFileDownloadUrl(owner: LightWorkspaceType, fileId: string) {
+  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
+}
 
 export function getFileViewUrl(
   owner: LightWorkspaceType,
   fileId: string | null | undefined
-) {return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view`;}
+) {
+  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view`;
+}
 
 export function getSkillFileContentUrl(
   owner: LightWorkspaceType,

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -659,6 +659,9 @@
  *           items:
  *             type: object
  *             properties:
+ *               contentType:
+ *                 type: string
+ *                 description: MIME type of the attached file
  *               fileId:
  *                 type: string
  *                 description: Unique string identifier for the attached file

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -686,6 +686,7 @@ describe("PATCH /api/w/[wId]/skills/[sId] - file attachments", () => {
     expect(res._getStatusCode()).toBe(200);
     expect(data.skill.fileAttachments).toHaveLength(1);
     expect(data.skill.fileAttachments[0].fileName).toBe("template.txt");
+    expect(data.skill.fileAttachments[0].contentType).toBe("text/plain");
 
     // Verify persistence.
     const updatedSkill = await SkillResource.fetchById(

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -939,6 +939,18 @@ describe("POST /api/w/[wId]/skills - file attachments", () => {
     );
     expect(fileNames).toContain("template.txt");
     expect(fileNames).toContain("schema.json");
+    expect(data.skill.fileAttachments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          contentType: "text/plain",
+          fileName: "template.txt",
+        }),
+        expect.objectContaining({
+          contentType: "application/json",
+          fileName: "schema.json",
+        }),
+      ])
+    );
 
     // Verify persistence.
     const createdSkill = await SkillResource.fetchById(auth, data.skill.sId);

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -13598,6 +13598,10 @@
             "items": {
               "type": "object",
               "properties": {
+                "contentType": {
+                  "type": "string",
+                  "description": "MIME type of the attached file"
+                },
                 "fileId": {
                   "type": "string",
                   "description": "Unique string identifier for the attached file"

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -48,6 +48,7 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
   requestedSpaceIds: z.array(z.string()),
   fileAttachments: z.array(
     z.object({
+      contentType: z.string(),
       fileId: z.string(),
       fileName: z.string(),
     })


### PR DESCRIPTION
## Description

- Replace the Skill Builder file attachment list with the same grid/list file explorer UI used for conversation files. The existing implementation is both custom to the Skill Builder and has less features, the main one being the ability to preview the files (useful to get an idea of what's in the file without having to download it).
- Add file previews for existing skills through the shared file preview dialog and scoped skill file content endpoint.
- Include attachment `contentType` in skill data so the UI can choose the right file icon and preview behavior.
- Bundles some other misc changes such as adding support for files diff (changes the color of the title).

New list view (also supports a grid mode)

<img width="893" height="238" alt="Screenshot 2026-05-18 at 3 30 32 PM" src="https://github.com/user-attachments/assets/0432386d-5f1e-4f8f-9a88-b0dfff29f8db" />

When clicking on an item

<img width="1107" height="1099" alt="Screenshot 2026-05-18 at 3 30 45 PM" src="https://github.com/user-attachments/assets/48e669b7-cc84-4948-9406-b0b4dc4eb7f7" />

## Tests

- Updated tests.
- Tested locally.

## Risk

- Low, files in skill is behind a feature flag.

## Deploy Plan

- Deploy front
