### PR TITLE
chore: speed up biome execution

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,18 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
   "root": true,
-  "plugins": [
-    "./.grit/patterns/noRawSql.grit",
-    "./.grit/patterns/noBulkLodash.grit",
-    "./.grit/patterns/noDirectSparkleNotification.grit",
-    "./.grit/patterns/noUnverifiedWorkspaceBypass.grit",
-    "./.grit/patterns/noMcpServerInstructions.grit",
-    "./.grit/patterns/enforceClientTypesInPublicApi.grit",
-    "./.grit/patterns/nextjsPageComponentNaming.grit",
-    "./.grit/patterns/nextjsNoDataFetchingInGetssp.grit",
-    "./.grit/patterns/tooLongIndexName.grit",
-    "./.grit/patterns/noClientDeepImports.grit"
-  ],
+  "plugins": [],
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -82,20 +71,88 @@
   },
   "overrides": [
     {
-      "includes": ["**", "!front/pages/**", "!front/lib/api/sse.ts"],
+      "includes": [
+        "front/**/*.{js,jsx,ts,tsx}",
+        "connectors/src/**/*.{js,jsx,ts,tsx}",
+        "cli/dust-cli/**/*.{js,jsx,ts,tsx}",
+        "extension/**/*.{js,jsx,ts,tsx}"
+      ],
+      "plugins": [
+        "./.grit/patterns/noBulkLodash.grit",
+        "./.grit/patterns/noDirectSparkleNotification.grit"
+      ]
+    },
+    {
+      "includes": [
+        "front/**/*.{js,jsx,ts,tsx}",
+        "connectors/src/**/*.{js,jsx,ts,tsx}"
+      ],
+      "plugins": [
+        "./.grit/patterns/noRawSql.grit",
+        "./.grit/patterns/noUnverifiedWorkspaceBypass.grit"
+      ]
+    },
+    {
+      "includes": ["front/**/*.{js,jsx,ts,tsx}"],
+      "plugins": [
+        "./.grit/patterns/enforceClientTypesInPublicApi.grit",
+        "./.grit/patterns/noClientDeepImports.grit"
+      ]
+    },
+    {
+      "includes": [
+        "extension/**/*.{js,jsx,ts,tsx}",
+        "front-spa/**/*.{js,jsx,ts,tsx}",
+        "front/**/*.{js,jsx,ts,tsx}",
+        "sparkle/**/*.{js,jsx,ts,tsx}",
+        "!front/pages/**",
+        "!front/lib/api/sse.ts",
+        "!sparkle/.storybook/**",
+        "!sparkle/playground/**"
+      ],
       "plugins": ["./.grit/patterns/noNextImports.grit"]
     },
     {
       "includes": [
-        "**",
-        "!front/components/dev/devStyleOverrides.ts",
-        "!front/components/sparkle/ThemeContext.tsx"
+        "front/components/**/*.{js,jsx,ts,tsx}",
+        "front/lib/**/*.tsx",
+        "front/pages/**/*.{jsx,tsx}",
+        "front-spa/**/*.{js,jsx,ts,tsx}",
+        "sparkle/src/**/*.{js,jsx,ts,tsx}",
+        "viz/**/*.{js,jsx,ts,tsx}",
+        "!**/*.stories.{js,jsx,ts,tsx}",
+        "!sparkle/src/lottie/**",
+        "!sparkle/playground/**"
       ],
       "plugins": ["./.grit/patterns/noCssImportant.grit"]
     },
     {
       "includes": ["front/**/*.tsx", "front-spa/**/*.tsx"],
       "plugins": ["./.grit/patterns/noSparkleClassInFront.grit"]
+    },
+    {
+      "includes": ["**/pages/**/*.{js,jsx,ts,tsx}"],
+      "plugins": [
+        "./.grit/patterns/nextjsPageComponentNaming.grit",
+        "./.grit/patterns/nextjsNoDataFetchingInGetssp.grit"
+      ]
+    },
+    {
+      "includes": [
+        "front/lib/actions/mcp_internal_actions/**/*.{js,jsx,ts,tsx}",
+        "front/lib/api/actions/servers/**/*.{js,jsx,ts,tsx}"
+      ],
+      "plugins": ["./.grit/patterns/noMcpServerInstructions.grit"]
+    },
+    {
+      "includes": [
+        "connectors/src/lib/models/**/*.ts",
+        "connectors/src/resources/storage/models/**/*.ts",
+        "front/lib/models/**/*.ts",
+        "front/lib/resources/storage/models/**/*.ts",
+        "front/lib/resources/storage/wrappers/**/*.ts"
+      ],
+      "plugins": ["./.grit/patterns/tooLongIndexName.grit"]
     },
     {
       "includes": ["cli/dust-cli/**", "sparkle/**"],

--- a/biome.json
+++ b/biome.json
@@ -101,19 +101,6 @@
     },
     {
       "includes": [
-        "extension/**/*.{js,jsx,ts,tsx}",
-        "front-spa/**/*.{js,jsx,ts,tsx}",
-        "front/**/*.{js,jsx,ts,tsx}",
-        "sparkle/**/*.{js,jsx,ts,tsx}",
-        "!front/pages/**",
-        "!front/lib/api/sse.ts",
-        "!sparkle/.storybook/**",
-        "!sparkle/playground/**"
-      ],
-      "plugins": ["./.grit/patterns/noNextImports.grit"]
-    },
-    {
-      "includes": [
         "front/components/**/*.{js,jsx,ts,tsx}",
         "front/lib/**/*.tsx",
         "front/pages/**/*.{jsx,tsx}",
@@ -125,6 +112,19 @@
         "!sparkle/playground/**"
       ],
       "plugins": ["./.grit/patterns/noCssImportant.grit"]
+    },
+    {
+      "includes": [
+        "extension/**/*.{js,jsx,ts,tsx}",
+        "front-spa/**/*.{js,jsx,ts,tsx}",
+        "front/**/*.{js,jsx,ts,tsx}",
+        "sparkle/**/*.{js,jsx,ts,tsx}",
+        "!front/pages/**",
+        "!front/lib/api/sse.ts",
+        "!sparkle/.storybook/**",
+        "!sparkle/playground/**"
+      ],
+      "plugins": ["./.grit/patterns/noNextImports.grit"]
     },
     {
       "includes": ["front/**/*.tsx", "front-spa/**/*.tsx"],

--- a/biome.json
+++ b/biome.json
@@ -83,16 +83,6 @@
       ]
     },
     {
-      "includes": [
-        "front/**/*.{js,jsx,ts,tsx}",
-        "connectors/src/**/*.{js,jsx,ts,tsx}"
-      ],
-      "plugins": [
-        "./.grit/patterns/noRawSql.grit",
-        "./.grit/patterns/noUnverifiedWorkspaceBypass.grit"
-      ]
-    },
-    {
       "includes": ["front/**/*.{js,jsx,ts,tsx}"],
       "plugins": [
         "./.grit/patterns/enforceClientTypesInPublicApi.grit",
@@ -112,6 +102,16 @@
         "!sparkle/playground/**"
       ],
       "plugins": ["./.grit/patterns/noCssImportant.grit"]
+    },
+    {
+      "includes": [
+        "front/**/*.{js,jsx,ts,tsx}",
+        "connectors/src/**/*.{js,jsx,ts,tsx}"
+      ],
+      "plugins": [
+        "./.grit/patterns/noRawSql.grit",
+        "./.grit/patterns/noUnverifiedWorkspaceBypass.grit"
+      ]
     },
     {
       "includes": [

--- a/front/components/dev/devStyleOverrides.ts
+++ b/front/components/dev/devStyleOverrides.ts
@@ -97,12 +97,20 @@ export function injectColorStyles(overrides: ColorOverrides): void {
       const cssProperty = CSS_PROPERTY_MAP[prop];
       for (const suffix of variantSuffixes) {
         const className = `${prop}-${cssName}${suffix}`;
-        rules.push(`.${className} { ${cssProperty}: ${color} !important; }`);
         rules.push(
+          // biome-ignore lint/plugin/noCssImportant: dev-only overrides must win over app styles.
+          `.${className} { ${cssProperty}: ${color} !important; }`
+        );
+        rules.push(
+          // biome-ignore lint/plugin/noCssImportant: dev-only overrides must win over app styles.
           `.dark .${className}-night { ${cssProperty}: ${color} !important; }`
         );
-        rules.push(`.s-${className} { ${cssProperty}: ${color} !important; }`);
         rules.push(
+          // biome-ignore lint/plugin/noCssImportant: dev-only overrides must win over app styles.
+          `.s-${className} { ${cssProperty}: ${color} !important; }`
+        );
+        rules.push(
+          // biome-ignore lint/plugin/noCssImportant: dev-only overrides must win over app styles.
           `.dark .s-${className}-night { ${cssProperty}: ${color} !important; }`
         );
       }
@@ -178,6 +186,7 @@ export function injectTypoStyles(overrides: TypoOverrides): void {
     const declarations = Object.entries(props)
       .map(
         ([prop, value]) =>
+          // biome-ignore lint/plugin/noCssImportant: dev-only overrides must win over app styles.
           `${TYPO_PROP_CSS[prop as TypoProp]}: ${value} !important`
       )
       .join("; ");
@@ -265,19 +274,23 @@ export function injectFontFamilyStyles(overrides: FontFamilyOverrides): void {
   const rules: string[] = [];
   if (overrides.sans) {
     rules.push(
+      // biome-ignore lint/plugin/noCssImportant: dev-only overrides must win over app styles.
       `body { font-family: "${overrides.sans}", sans-serif !important; }`
     );
     rules.push(
+      // biome-ignore lint/plugin/noCssImportant: dev-only overrides must win over app styles.
       `body :not(.s-font-mono):not(code):not(pre):not(kbd):not(samp):not([class*="heading-mono"]):not([class*="icon"]):not([class*="Icon"]) { font-family: inherit !important; }`
     );
     if (!overrides.mono) {
       rules.push(
+        // biome-ignore lint/plugin/noCssImportant: dev-only overrides must win over app styles.
         `.s-font-mono, code, pre, kbd, samp, [class*="heading-mono"] { font-family: "Geist Mono", monospace !important; }`
       );
     }
   }
   if (overrides.mono) {
     rules.push(
+      // biome-ignore lint/plugin/noCssImportant: dev-only overrides must win over app styles.
       `.s-font-mono, code, pre, kbd, samp, [class*="heading-mono"] { font-family: "${overrides.mono}", monospace !important; }`
     );
   }

--- a/front/components/sparkle/ThemeContext.tsx
+++ b/front/components/sparkle/ThemeContext.tsx
@@ -62,6 +62,7 @@ const disableAnimation = () => {
   const css = document.createElement("style");
   css.appendChild(
     document.createTextNode(
+      // biome-ignore lint/plugin/noCssImportant: theme changes intentionally disable transitions for one frame.
       `*,*::before,*::after{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}`
     )
   );


### PR DESCRIPTION
## Description

Full-repo Biome checks take over 15 minutes in CI.

The custom Grit plugin execution is taking most of the time (reported under `plugin/plugin`): on main that bucket dominated the profile with `1515.540s` of aggregate rule time across `68382` plugin executions.

This PR scopes Grit plugins so each rule only runs on paths where it can reasonably apply.
- The CSS `!important` rule still tracks UI/CSS-facing code and tests, but no longer runs on unrelated backend files, stories, generated-heavy paths, or known exceptions.

Full Biome check:
- Before: 133.59s wall, 1406.81s user CPU
- After: 56.30s wall, 560.08s user CPU
- Speedup: 2.37x wall-clock, 2.51x CPU

Custom Grit plugin work:
- Before: 1550.810s aggregate plugin/plugin
- After: 562.742s
- Reduction: 2.76x less plugin time
- Plugin evaluations: 68382 -> 37476, 45% fewer

Main contributor:
- noCssImportant: 1037.309s -> 258.537s
- Saves 778.772s, about 85% of the isolated plugin-time reduction

Other meaningful contributors:
- tooLongIndexName: saves 37.456s
- nextjsPageComponentNaming: saves 29.164s
- noMcpServerInstructions: saves 23.461s
- nextjsNoDataFetchingInGetssp: saves 22.409s

> [!NOTE]
> Devxp stays the same: this only reduces unnecessary plugin work done by Biome.

> [!IMPORTANT]
> For future readers: the override scopes defined by this PR are meant to be quite generic: all TS code in production, all TS `front` code, all TS code where we use `Sequelize`, all front-end component code. Only a few rules at the bottom have super custom scopes.
> Ideally, when we add a rule we put it in one of these scopes and avoid running plugins on everything as it can be quite slow. 

## Tests

Quick overview of the commands ran to do the breakdown:
- Full-repo profiling: `biome check --profile-rules --reporter=summary --diagnostic-level=error --max-diagnostics=20 .`
- Single-file profiling: `biome check --profile-rules --reporter=summary --diagnostic-level=error --max-diagnostics=20 <file>`
- Final full-repo validation: `biome check --reporter=summary --diagnostic-level=error --max-diagnostics=20 .`

Examples of files that were used for the benchmark:
- `front/lib/resources/conversation_resource.test.ts`
- `sparkle/src/lottie/spinnerDust.ts`

## Risk

- Medium. These changes should not change the coverage at all but we do rely on these rules quite heavily

## Deploy Plan

- No runtime deploy required.
