### PR TITLE
feat(google-calendar): add transparency, eventType, reminders, visibility, extendedProperties to create/update_event

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -69,6 +69,18 @@ export interface GoogleCalendarEvent {
     title?: string;
   };
   eventType?: string;
+  focusTimeProperties?: {
+    autoDeclineMode?: string;
+    chatStatus?: string;
+    declineMessage?: string;
+  };
+  outOfOfficeProperties?: {
+    autoDeclineMode?: string;
+    declineMessage?: string;
+  };
+  extendedProperties?: {
+    private?: Record<string, string>;
+  };
   conferenceData?: {
     createRequest?: {
       requestId?: string;
@@ -307,6 +319,23 @@ export function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
       })
       .join(", ");
     lines.push(`Attendees: ${attendeeList}`);
+  }
+
+  if (event.transparency === "transparent") {
+    lines.push("Availability: Free");
+  }
+
+  if (event.visibility && event.visibility !== "default") {
+    lines.push(`Visibility: ${event.visibility}`);
+  }
+
+  if (event.reminders?.overrides && event.reminders.overrides.length > 0) {
+    const formatted = event.reminders.overrides
+      .filter((r) => r.method !== undefined && r.minutes !== undefined)
+      .map((r) => `${r.method} ${r.minutes} min before`);
+    if (formatted.length > 0) {
+      lines.push(`Reminders: ${formatted.join(", ")}`);
+    }
   }
 
   if (event.status) {

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -4,6 +4,72 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
+const autoDeclineMode = z
+  .enum([
+    "declineNone",
+    "declineAllConflictingInvitations",
+    "declineOnlyNewConflictingInvitations",
+  ])
+  .optional();
+
+// Fields specific to eventType — grouped adjacent to eventType in both tools.
+const eventTypeSpecificFields = {
+  focusTimeProperties: z
+    .object({
+      autoDeclineMode,
+      chatStatus: z.enum(["available", "doNotDisturb"]).optional(),
+      declineMessage: z.string().max(500).optional(),
+    })
+    .optional()
+    .describe("Only applies when eventType is 'focusTime'."),
+  outOfOfficeProperties: z
+    .object({
+      autoDeclineMode,
+      declineMessage: z.string().max(500).optional(),
+    })
+    .optional()
+    .describe(
+      "Only applies when eventType is 'outOfOffice'. Controls auto-decline behavior for conflicting invitations."
+    ),
+};
+
+const sharedEventFields = {
+  transparency: z
+    .enum(["opaque", "transparent"])
+    .optional()
+    .describe(
+      "'transparent' = Free (won't block booking availability). Default 'opaque' = Busy."
+    ),
+  visibility: z
+    .enum(["default", "public", "private", "confidential"])
+    .optional()
+    .describe(
+      "'private' hides event details from other calendar viewers. Changing this on an existing event affects all viewers immediately."
+    ),
+  reminders: z
+    .object({
+      useDefault: z.boolean(),
+      overrides: z
+        .array(
+          z.object({
+            method: z.enum(["email", "popup"]),
+            minutes: z.number().int().min(0),
+          })
+        )
+        .optional(),
+    })
+    .optional()
+    .describe("Custom reminders. Set useDefault: false and provide overrides."),
+  extendedProperties: z
+    .object({
+      private: z.record(z.string(), z.string()).optional(),
+    })
+    .optional()
+    .describe(
+      "Private key-value metadata visible only to this application. Keys and values must be plain strings."
+    ),
+};
+
 export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
   list_calendars: {
     description:
@@ -95,6 +161,14 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Whether to create a conference (Google Meet) for the event. Defaults to true."
         ),
+      eventType: z
+        .enum(["default", "focusTime", "outOfOffice"])
+        .optional()
+        .describe(
+          "'focusTime' creates a native Focus Time block (DND in Google Chat, auto-decline). 'outOfOffice' creates an OOO block. Primary calendar only. Cannot be changed after creation."
+        ),
+      ...eventTypeSpecificFields,
+      ...sharedEventFields,
     },
     stake: "medium",
     displayLabels: {
@@ -132,6 +206,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Whether to create a conference (Google Meet) for the event. If not provided, existing conference settings are preserved."
         ),
+      ...eventTypeSpecificFields,
+      ...sharedEventFields,
     },
     stake: "medium",
     displayLabels: {

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -136,6 +136,13 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       location,
       colorId,
       createConference = true,
+      transparency,
+      visibility,
+      reminders,
+      extendedProperties,
+      eventType,
+      focusTimeProperties,
+      outOfOfficeProperties,
     },
     { authInfo, agentLoopContext }
   ) => {
@@ -146,52 +153,35 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
     );
 
     try {
-      const event: {
-        summary: string;
-        description?: string;
-        start: { dateTime: string };
-        end: { dateTime: string };
-        attendees?: { email: string }[];
-        location?: string;
-        colorId?: string;
-        conferenceData?: {
-          createRequest: {
-            requestId: string;
-            conferenceSolutionKey: {
-              type: string;
-            };
-          };
-        };
-      } = {
-        summary,
-        description,
-        start,
-        end,
-      };
-      if (attendees) {
-        event.attendees = attendees.map((email: string) => ({ email }));
-      }
-      if (location) {
-        event.location = location;
-      }
-      if (colorId) {
-        event.colorId = colorId;
-      }
-      if (createConference) {
-        const requestId = `conference-${randomUUID()}`;
-        event.conferenceData = {
-          createRequest: {
-            requestId,
-            conferenceSolutionKey: {
-              type: "hangoutsMeet",
-            },
-          },
-        };
-      }
       const res = await calendar.events.insert({
         calendarId,
-        requestBody: event,
         conferenceDataVersion: 1,
+        requestBody: {
+          summary,
+          description,
+          start,
+          end,
+          ...(attendees && {
+            attendees: attendees.map((email) => ({ email })),
+          }),
+          ...(location && { location }),
+          ...(colorId && { colorId }),
+          ...(transparency && { transparency }),
+          ...(visibility && { visibility }),
+          ...(reminders && { reminders }),
+          ...(extendedProperties && { extendedProperties }),
+          ...(eventType && { eventType }),
+          ...(focusTimeProperties && { focusTimeProperties }),
+          ...(outOfOfficeProperties && { outOfOfficeProperties }),
+          ...(createConference && {
+            conferenceData: {
+              createRequest: {
+                requestId: `conference-${randomUUID()}`,
+                conferenceSolutionKey: { type: "hangoutsMeet" },
+              },
+            },
+          }),
+        },
       });
 
       const userTimezone = getUserTimezone(agentLoopContext);
@@ -230,6 +220,12 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       location,
       colorId,
       createConference,
+      transparency,
+      visibility,
+      reminders,
+      extendedProperties,
+      focusTimeProperties,
+      outOfOfficeProperties,
     },
     { authInfo, agentLoopContext }
   ) => {
@@ -240,62 +236,35 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
     );
 
     try {
-      const event: {
-        summary?: string;
-        description?: string;
-        start?: { dateTime: string };
-        end?: { dateTime: string };
-        attendees?: { email: string }[];
-        location?: string;
-        colorId?: string;
-        conferenceData?: {
-          createRequest: {
-            requestId: string;
-            conferenceSolutionKey: {
-              type: string;
-            };
-          };
-        };
-      } = {};
-      if (summary) {
-        event.summary = summary;
-      }
-      if (description) {
-        event.description = description;
-      }
-      if (start) {
-        event.start = start;
-      }
-      if (end) {
-        event.end = end;
-      }
-      if (attendees) {
-        event.attendees = attendees.map((email: string) => ({ email }));
-      }
-      if (location) {
-        event.location = location;
-      }
-      if (colorId) {
-        event.colorId = colorId;
-      }
-      if (createConference !== undefined) {
-        if (createConference) {
-          const requestId = `conference-${randomUUID()}`;
-          event.conferenceData = {
-            createRequest: {
-              requestId,
-              conferenceSolutionKey: {
-                type: "hangoutsMeet",
-              },
-            },
-          };
-        }
-      }
       const res = await calendar.events.patch({
         calendarId,
         eventId,
-        requestBody: event,
         conferenceDataVersion: 1,
+        requestBody: {
+          ...(summary && { summary }),
+          ...(description && { description }),
+          ...(start && { start }),
+          ...(end && { end }),
+          ...(attendees && {
+            attendees: attendees.map((email) => ({ email })),
+          }),
+          ...(location && { location }),
+          ...(colorId && { colorId }),
+          ...(transparency && { transparency }),
+          ...(visibility && { visibility }),
+          ...(reminders && { reminders }),
+          ...(extendedProperties && { extendedProperties }),
+          ...(focusTimeProperties && { focusTimeProperties }),
+          ...(outOfOfficeProperties && { outOfOfficeProperties }),
+          ...(createConference && {
+            conferenceData: {
+              createRequest: {
+                requestId: `conference-${randomUUID()}`,
+                conferenceSolutionKey: { type: "hangoutsMeet" },
+              },
+            },
+          }),
+        },
       });
 
       const userTimezone = getUserTimezone(agentLoopContext);


### PR DESCRIPTION
**Problem**

Events created by agents (e.g. focus blocks) show as Busy in Google Calendar, blocking booking tools like Calendly, HubSpot, and GCal's "Find a time." There was also no way to tag agent-created events, set custom reminders, or keep event descriptions private.

**What changed**

Added 5 new optional fields to `create_event` and `update_event` tools in the Google Calendar MCP server:

- `transparency` — marks events as Free so they don't block availability checks
- `eventType` + `focusTimeProperties` / `outOfOfficeProperties` — native GCal Focus Time and OOO blocks with DND and auto-decline support (`create_event` only — `eventType` is immutable after creation)
- `reminders` — custom per-event reminder overrides (email/popup, minutes before)
- `extendedProperties.private` — private key-value metadata for tagging agent-created events
- `visibility` — hide event details from other calendar viewers

**Implementation notes**

- `eventType` is intentionally absent from `update_event` — the Google API rejects PATCH requests that include it
- Only `extendedProperties.private` is exposed (not `shared`) — shared properties are readable by any app with calendar access
- Shared fields are defined once as const spreads and composed into both tool schemas — no duplication
- `formatEventAsText` only renders non-default values to avoid noise (e.g. Availability only shown when Free, visibility only shown when non-default, reminders only shown when overrides are present)

**Tested**

1. Focus block with `transparency: transparent` → confirmed "Availability: Free" in event output, event shows as Free in calendar
2. `eventType: focusTime` with `focusTimeProperties` → confirmed native Focus Time block created with DND/auto-decline
3. `extendedProperties.private` with `{"source": "dust-agent"}` → confirmed metadata attached, not visible to other apps
4. `visibility: private` → confirmed event details hidden from other viewers
5. `reminders` with custom popup/email overrides → confirmed reminders set correctly, no "Reminders: Default" noise on normal events

**Reviewed**

- All 3 changed files reviewed line by line
- Confirmed no breaking changes to existing tool signatures (all new fields are optional)
- Confirmed `createConference` conditional spread is behaviourally identical to the old if/else
- Checked all downstream consumers (`constants.ts`, `mcp_actions.test.ts`, `index.ts`) — unaffected
- Verified `r.method`/`r.minutes` undefined guard in `formatEventAsText` handles malformed API responses