### PR TITLE
Sarah/plan mode approval card

### DIFF
--- a/front/components/assistant/conversation/BlockedAction.tsx
+++ b/front/components/assistant/conversation/BlockedAction.tsx
@@ -1,6 +1,7 @@
 import { GoogleDriveFileAuthorizationRequired } from "@app/components/assistant/conversation/GoogleDriveFileAuthorizationRequired";
 import { MCPServerPersonalAuthenticationRequired } from "@app/components/assistant/conversation/MCPServerPersonalAuthenticationRequired";
 import { MCPToolValidationRequired } from "@app/components/assistant/conversation/MCPToolValidationRequired";
+import { PendingPlanApprovalCard } from "@app/components/assistant/conversation/plan_mode/PendingPlanApprovalCard";
 import { UserAnswerRequired } from "@app/components/assistant/conversation/UserAnswerRequired";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -28,6 +29,17 @@ export function BlockedAction({
 }: BlockedActionProps) {
   switch (blockedAction.status) {
     case "blocked_validation_required":
+      if (blockedAction.metadata.toolName === "request_plan_approval") {
+        return (
+          <PendingPlanApprovalCard
+            triggeringUser={triggeringUser}
+            owner={owner}
+            blockedAction={blockedAction}
+            conversationId={conversationId}
+            messageId={messageId}
+          />
+        );
+      }
       return (
         <MCPToolValidationRequired
           triggeringUser={triggeringUser}

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -188,7 +188,8 @@ export function BlockedActionsProvider({
       return blockedActionsQueue.some(
         (action) =>
           action.blockedAction.status === "blocked_validation_required" &&
-          action.blockedAction.userId === userId
+          action.blockedAction.userId === userId &&
+          action.blockedAction.metadata.toolName !== "request_plan_approval"
       );
     },
     [blockedActionsQueue]
@@ -196,17 +197,16 @@ export function BlockedActionsProvider({
 
   const getBlockedActions = useCallback(
     (userId: string) => {
-      return (
-        blockedActionsQueue
-          // Either actions associated to the user or actions created through the Public API and not
-          // associated to any user.
-          .filter(
-            (action) =>
-              action.blockedAction.userId === userId ||
-              !action.blockedAction.userId
-          )
-          .map((action) => action.blockedAction)
-      );
+      return blockedActionsQueue
+        .filter(
+          (action) =>
+            // Either actions associated to the user or actions created through the
+            // Public API and not associated to any user.
+            (action.blockedAction.userId === userId ||
+              !action.blockedAction.userId) &&
+            action.blockedAction.metadata.toolName !== "request_plan_approval"
+        )
+        .map((action) => action.blockedAction);
     },
     [blockedActionsQueue]
   );

--- a/front/components/assistant/conversation/plan_mode/ApprovalStateChip.tsx
+++ b/front/components/assistant/conversation/plan_mode/ApprovalStateChip.tsx
@@ -1,0 +1,21 @@
+import type { PlanApprovalState } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/plan_mode";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { Chip } from "@dust-tt/sparkle";
+
+interface ApprovalStateChipProps {
+  state: PlanApprovalState;
+}
+
+export function ApprovalStateChip({ state }: ApprovalStateChipProps) {
+  switch (state) {
+    case "approved":
+      return <Chip size="mini" color="success" label="Approved" />;
+    case "pending":
+      return <Chip size="mini" color="golden" label="Pending approval" />;
+    case "draft":
+      return null;
+    default:
+      assertNeverAndIgnore(state);
+      return null;
+  }
+}

--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -2,12 +2,14 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import {
   ApprovalStateChip,
   extractPlanTitle,
+  PlanTaskBullet,
+  splitPlanContent,
 } from "@app/components/assistant/conversation/plan_mode/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Markdown, Spinner, XMarkIcon } from "@dust-tt/sparkle";
+import { Button, cn, Markdown, Spinner, XMarkIcon } from "@dust-tt/sparkle";
 
 interface ConversationPlanModePanelProps {
   conversation: ConversationWithoutContentType;
@@ -25,6 +27,7 @@ export function ConversationPlanModePanel({
   });
 
   const title = extractPlanTitle(content);
+  const { preamble, tasks } = splitPlanContent(content);
 
   return (
     <div className="flex h-full flex-col">
@@ -57,7 +60,26 @@ export function ConversationPlanModePanel({
           // Key by planFile.version so React remounts on each edit. Sparkle's `Markdown`
           // memoizes AST nodes for streaming reveal, which can hold stale child nodes when the
           // full content prop changes between edits. Remounting forces a clean render.
-          content && <Markdown key={planFile.version} content={content} />
+          content && (
+            <div key={planFile.version}>
+              <Markdown content={preamble} />
+              {tasks.length > 0 && (
+                <ul
+                  className={cn(
+                    "copy-sm mt-3 flex flex-col gap-3 font-medium",
+                    "text-muted-foreground dark:text-muted-foreground-night"
+                  )}
+                >
+                  {tasks.map((task, idx) => (
+                    <li key={idx} className="flex items-start gap-2 py-1">
+                      <PlanTaskBullet />
+                      <span>{task}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )
         )}
       </div>
     </div>

--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -1,10 +1,7 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import {
-  ApprovalStateChip,
-  extractPlanTitle,
-  PlanTaskBullet,
-  splitPlanContent,
-} from "@app/components/assistant/conversation/plan_mode/utils";
+import { ApprovalStateChip } from "@app/components/assistant/conversation/plan_mode/ApprovalStateChip";
+import { PlanTaskBullet } from "@app/components/assistant/conversation/plan_mode/PlanTaskBullet";
+import { parsePlan } from "@app/components/assistant/conversation/plan_mode/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -26,8 +23,7 @@ export function ConversationPlanModePanel({
     workspaceId: owner.sId,
   });
 
-  const title = extractPlanTitle(content);
-  const { preamble, tasks } = splitPlanContent(content);
+  const { title, preamble, tasks } = parsePlan(content);
 
   return (
     <div className="flex h-full flex-col">
@@ -71,9 +67,12 @@ export function ConversationPlanModePanel({
                   )}
                 >
                   {tasks.map((task, idx) => (
-                    <li key={idx} className="flex items-start gap-2 py-1">
+                    <li
+                      key={`${idx}-${task}`}
+                      className="flex items-start gap-2 py-1"
+                    >
                       <PlanTaskBullet />
-                      <span>{task}</span>
+                      <Markdown content={task} compactSpacing />
                     </li>
                   ))}
                 </ul>

--- a/front/components/assistant/conversation/plan_mode/PendingPlanApprovalCard.tsx
+++ b/front/components/assistant/conversation/plan_mode/PendingPlanApprovalCard.tsx
@@ -1,0 +1,167 @@
+import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import {
+  extractPlanTitle,
+  extractTaskList,
+} from "@app/components/assistant/conversation/plan_mode/utils";
+import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
+import { useValidateAction } from "@app/hooks/useValidateAction";
+import type { MCPValidationOutputType } from "@app/lib/actions/constants";
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import { ActionListCheckIcon, Button, cn, Icon } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+const TASK_PREVIEW_LIMIT = 8;
+
+const CARD_CONTAINER_CLASSES = cn(
+  "flex w-full rounded-2xl border p-4",
+  "border-border-dark/50 bg-background",
+  "dark:border-border-dark-night/30 dark:bg-background-night"
+);
+
+interface PendingPlanApprovalCardProps {
+  triggeringUser: UserType | null;
+  owner: LightWorkspaceType;
+  blockedAction: BlockedToolExecution;
+  conversationId: string;
+  messageId: string;
+}
+
+export function PendingPlanApprovalCard({
+  triggeringUser,
+  owner,
+  blockedAction,
+  conversationId,
+  messageId,
+}: PendingPlanApprovalCardProps) {
+  const { user } = useAuth();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;
+
+  const { removeCompletedAction, isActionPulsing, stopPulsingAction } =
+    useBlockedActionsContext();
+  const { validateAction, isValidating } = useValidateAction({
+    owner,
+    conversationId,
+    onError: setErrorMessage,
+  });
+  const { openPanel } = useConversationSidePanelContext();
+  const { content } = usePlanFile({
+    // Skip the fetch when waiting on another user — we only render their name.
+    conversationId: isTriggeredByCurrentUser ? conversationId : null,
+    workspaceId: owner.sId,
+  });
+
+  const isPulsing = isActionPulsing(blockedAction.actionId);
+
+  const title = extractPlanTitle(content);
+  const tasks = extractTaskList(content);
+  const visibleTasks = tasks.slice(0, TASK_PREVIEW_LIMIT);
+  const hiddenTaskCount = tasks.length - visibleTasks.length;
+
+  const handleValidation = async (approved: MCPValidationOutputType) => {
+    stopPulsingAction(blockedAction.actionId);
+    setErrorMessage(null);
+
+    const result = await validateAction({
+      validationRequest: blockedAction,
+      messageId,
+      approved,
+    });
+
+    if (!result.success) {
+      setErrorMessage("Failed to assess action approval. Please try again.");
+      return;
+    }
+    removeCompletedAction(blockedAction.actionId);
+  };
+
+  const iconBadge = (
+    <span
+      className={cn(
+        "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border",
+        "border-border-dark bg-muted-background",
+        "dark:border-border-dark-night dark:bg-muted-background-night"
+      )}
+    >
+      <Icon visual={ActionListCheckIcon} size="sm" />
+    </span>
+  );
+
+  if (!isTriggeredByCurrentUser) {
+    return (
+      <div className={cn(CARD_CONTAINER_CLASSES, "items-center gap-3")}>
+        {iconBadge}
+        <span className="copy-base text-foreground dark:text-foreground-night">
+          Waiting for{" "}
+          <span className="font-semibold">{triggeringUser?.fullName}</span> to
+          approve the plan.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn(CARD_CONTAINER_CLASSES, "flex-col")}>
+      <div className="flex items-center gap-3">
+        {iconBadge}
+        <span className="heading-base grow truncate">Plan: {title}</span>
+        <Button
+          variant="outline"
+          size="xs"
+          label="Read full plan"
+          onClick={() => openPanel({ type: "plan" })}
+        />
+      </div>
+      {visibleTasks.length > 0 && (
+        <ol className="copy-sm mt-6 flex flex-col gap-5 font-medium text-primary dark:text-primary-night">
+          {visibleTasks.map((task, idx) => (
+            <li key={idx} className="flex items-start gap-2 py-2">
+              <span
+                aria-hidden
+                className={cn(
+                  // mt-0.5 vertically centers the 16px circle on the 20px first
+                  // line of `copy-sm`; without it the circle would top-align.
+                  "mt-0.5 h-4 w-4 shrink-0 rounded-full border-2",
+                  "border-faint dark:border-faint-night"
+                )}
+              />
+              <span>{task}</span>
+            </li>
+          ))}
+          {hiddenTaskCount > 0 && (
+            <li className="text-muted-foreground dark:text-muted-foreground-night">
+              +{hiddenTaskCount} more
+            </li>
+          )}
+        </ol>
+      )}
+      {errorMessage && (
+        <div className="copy-sm mt-3 text-warning-800 dark:text-warning-800-night">
+          {errorMessage}
+        </div>
+      )}
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          label="Cancel"
+          disabled={isValidating}
+          isPulsing={isPulsing}
+          onClick={() => void handleValidation("rejected")}
+        />
+        <Button
+          variant="highlight"
+          size="sm"
+          label="Approve plan"
+          disabled={isValidating}
+          isPulsing={isPulsing}
+          onClick={() => void handleValidation("approved")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/plan_mode/PendingPlanApprovalCard.tsx
+++ b/front/components/assistant/conversation/plan_mode/PendingPlanApprovalCard.tsx
@@ -1,26 +1,41 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import {
-  extractPlanTitle,
-  extractTaskList,
-  PlanTaskBullet,
-} from "@app/components/assistant/conversation/plan_mode/utils";
+import { PlanTaskBullet } from "@app/components/assistant/conversation/plan_mode/PlanTaskBullet";
+import { parsePlan } from "@app/components/assistant/conversation/plan_mode/utils";
 import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { ActionListCheckIcon, Button, cn, Icon } from "@dust-tt/sparkle";
+import {
+  ActionListCheckIcon,
+  Button,
+  cn,
+  Icon,
+  Markdown,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
-
-const TASK_PREVIEW_LIMIT = 8;
 
 const CARD_CONTAINER_CLASSES = cn(
   "flex w-full rounded-2xl border p-4",
   "border-border-dark/50 bg-background",
   "dark:border-border-dark-night/30 dark:bg-background-night"
 );
+
+function PlanIconBadge() {
+  return (
+    <span
+      className={cn(
+        "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border",
+        "border-border-dark bg-muted-background",
+        "dark:border-border-dark-night dark:bg-muted-background-night"
+      )}
+    >
+      <Icon visual={ActionListCheckIcon} size="sm" />
+    </span>
+  );
+}
 
 interface PendingPlanApprovalCardProps {
   triggeringUser: UserType | null;
@@ -42,8 +57,7 @@ export function PendingPlanApprovalCard({
 
   const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;
 
-  const { removeCompletedAction, isActionPulsing, stopPulsingAction } =
-    useBlockedActionsContext();
+  const { removeCompletedAction } = useBlockedActionsContext();
   const { validateAction, isValidating } = useValidateAction({
     owner,
     conversationId,
@@ -56,15 +70,9 @@ export function PendingPlanApprovalCard({
     workspaceId: owner.sId,
   });
 
-  const isPulsing = isActionPulsing(blockedAction.actionId);
-
-  const title = extractPlanTitle(content);
-  const tasks = extractTaskList(content);
-  const visibleTasks = tasks.slice(0, TASK_PREVIEW_LIMIT);
-  const hiddenTaskCount = tasks.length - visibleTasks.length;
+  const { title, tasks } = parsePlan(content);
 
   const handleValidation = async (approved: MCPValidationOutputType) => {
-    stopPulsingAction(blockedAction.actionId);
     setErrorMessage(null);
 
     const result = await validateAction({
@@ -80,22 +88,10 @@ export function PendingPlanApprovalCard({
     removeCompletedAction(blockedAction.actionId);
   };
 
-  const iconBadge = (
-    <span
-      className={cn(
-        "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border",
-        "border-border-dark bg-muted-background",
-        "dark:border-border-dark-night dark:bg-muted-background-night"
-      )}
-    >
-      <Icon visual={ActionListCheckIcon} size="sm" />
-    </span>
-  );
-
   if (!isTriggeredByCurrentUser) {
     return (
       <div className={cn(CARD_CONTAINER_CLASSES, "items-center gap-3")}>
-        {iconBadge}
+        <PlanIconBadge />
         <span className="copy-base text-foreground dark:text-foreground-night">
           Waiting for{" "}
           <span className="font-semibold">{triggeringUser?.fullName}</span> to
@@ -108,7 +104,7 @@ export function PendingPlanApprovalCard({
   return (
     <div className={cn(CARD_CONTAINER_CLASSES, "flex-col")}>
       <div className="flex items-center gap-3">
-        {iconBadge}
+        <PlanIconBadge />
         <span className="heading-base grow truncate">Plan: {title}</span>
         <Button
           variant="outline"
@@ -117,19 +113,14 @@ export function PendingPlanApprovalCard({
           onClick={() => openPanel({ type: "plan" })}
         />
       </div>
-      {visibleTasks.length > 0 && (
+      {tasks.length > 0 && (
         <ul className="copy-sm mt-6 flex flex-col gap-5 font-medium text-primary dark:text-primary-night">
-          {visibleTasks.map((task, idx) => (
-            <li key={idx} className="flex items-start gap-2 py-2">
+          {tasks.map((task, idx) => (
+            <li key={`${idx}-${task}`} className="flex items-start gap-2 py-2">
               <PlanTaskBullet />
-              <span>{task}</span>
+              <Markdown content={task} compactSpacing />
             </li>
           ))}
-          {hiddenTaskCount > 0 && (
-            <li className="text-muted-foreground dark:text-muted-foreground-night">
-              +{hiddenTaskCount} more
-            </li>
-          )}
         </ul>
       )}
       {errorMessage && (
@@ -143,7 +134,6 @@ export function PendingPlanApprovalCard({
           size="sm"
           label="Cancel"
           disabled={isValidating}
-          isPulsing={isPulsing}
           onClick={() => void handleValidation("rejected")}
         />
         <Button
@@ -151,7 +141,6 @@ export function PendingPlanApprovalCard({
           size="sm"
           label="Approve plan"
           disabled={isValidating}
-          isPulsing={isPulsing}
           onClick={() => void handleValidation("approved")}
         />
       </div>

--- a/front/components/assistant/conversation/plan_mode/PendingPlanApprovalCard.tsx
+++ b/front/components/assistant/conversation/plan_mode/PendingPlanApprovalCard.tsx
@@ -3,6 +3,7 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import {
   extractPlanTitle,
   extractTaskList,
+  PlanTaskBullet,
 } from "@app/components/assistant/conversation/plan_mode/utils";
 import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
 import { useValidateAction } from "@app/hooks/useValidateAction";
@@ -117,18 +118,10 @@ export function PendingPlanApprovalCard({
         />
       </div>
       {visibleTasks.length > 0 && (
-        <ol className="copy-sm mt-6 flex flex-col gap-5 font-medium text-primary dark:text-primary-night">
+        <ul className="copy-sm mt-6 flex flex-col gap-5 font-medium text-primary dark:text-primary-night">
           {visibleTasks.map((task, idx) => (
             <li key={idx} className="flex items-start gap-2 py-2">
-              <span
-                aria-hidden
-                className={cn(
-                  // mt-0.5 vertically centers the 16px circle on the 20px first
-                  // line of `copy-sm`; without it the circle would top-align.
-                  "mt-0.5 h-4 w-4 shrink-0 rounded-full border-2",
-                  "border-faint dark:border-faint-night"
-                )}
-              />
+              <PlanTaskBullet />
               <span>{task}</span>
             </li>
           ))}
@@ -137,7 +130,7 @@ export function PendingPlanApprovalCard({
               +{hiddenTaskCount} more
             </li>
           )}
-        </ol>
+        </ul>
       )}
       {errorMessage && (
         <div className="copy-sm mt-3 text-warning-800 dark:text-warning-800-night">

--- a/front/components/assistant/conversation/plan_mode/PlanCard.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanCard.tsx
@@ -1,8 +1,6 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import {
-  ApprovalStateChip,
-  extractPlanTitle,
-} from "@app/components/assistant/conversation/plan_mode/utils";
+import { ApprovalStateChip } from "@app/components/assistant/conversation/plan_mode/ApprovalStateChip";
+import { parsePlan } from "@app/components/assistant/conversation/plan_mode/utils";
 import { usePlanFile } from "@app/hooks/conversations/usePlanFile";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { ChevronRightIcon, cn, DocumentTextIcon, Icon } from "@dust-tt/sparkle";
@@ -44,7 +42,7 @@ export const PlanCard = React.memo(function PlanCard({
   });
   const { openPanel } = useConversationSidePanelContext();
 
-  const title = useMemo(() => extractPlanTitle(content), [content]);
+  const { title } = useMemo(() => parsePlan(content), [content]);
   const progress = useMemo(() => countProgress(content), [content]);
 
   // Hide the card until the plan has been edited at least once (version >= 2). The skeleton

--- a/front/components/assistant/conversation/plan_mode/PlanTaskBullet.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanTaskBullet.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@dust-tt/sparkle";
+
+// `mt-0.5` vertically centers the 16px circle on the 20px first line of
+// `copy-sm` text.
+export function PlanTaskBullet() {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "mt-0.5 h-4 w-4 shrink-0 rounded-full border-2",
+        "border-faint dark:border-faint-night"
+      )}
+    />
+  );
+}

--- a/front/components/assistant/conversation/plan_mode/utils.test.ts
+++ b/front/components/assistant/conversation/plan_mode/utils.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "vitest";
+
+import { parsePlan } from "./utils";
+
+describe("parsePlan", () => {
+  describe("title extraction", () => {
+    test("extracts the first H1 as the title", () => {
+      const result = parsePlan("# Build a thing\n\nsome content");
+      expect(result.title).toBe("Build a thing");
+    });
+
+    test("trims whitespace inside the H1", () => {
+      const result = parsePlan("#    Build a thing   \n");
+      expect(result.title).toBe("Build a thing");
+    });
+
+    test("falls back when no H1 is present", () => {
+      const result = parsePlan("## Context\n\nsome content");
+      expect(result.title).toBe("Untitled plan");
+    });
+
+    test("falls back on empty input", () => {
+      expect(parsePlan("").title).toBe("Untitled plan");
+      expect(parsePlan(null).title).toBe("Untitled plan");
+    });
+  });
+
+  describe("preamble + tasks split", () => {
+    test("returns content as preamble and no tasks when there's no Tasks heading", () => {
+      const content = "# Plan\n\n## Context\n\nbackground only";
+      const result = parsePlan(content);
+      expect(result.preamble).toBe(content);
+      expect(result.tasks).toEqual([]);
+    });
+
+    test("splits at '## Tasks' (plural) and keeps the heading in preamble", () => {
+      const content = [
+        "# Plan",
+        "",
+        "## Context",
+        "why",
+        "",
+        "## Tasks",
+        "- [ ] First",
+        "- [ ] Second",
+      ].join("\n");
+      const result = parsePlan(content);
+      expect(result.preamble.endsWith("## Tasks")).toBe(true);
+      expect(result.tasks).toEqual(["First", "Second"]);
+    });
+
+    test("also matches '## Task' (singular)", () => {
+      const content = "# Plan\n\n## Task\n- [ ] Only one";
+      const result = parsePlan(content);
+      expect(result.tasks).toEqual(["Only one"]);
+    });
+
+    test("matches the first heading when multiple Tasks sections exist", () => {
+      const content = [
+        "# Plan",
+        "## Tasks",
+        "- [ ] First-set",
+        "## Tasks",
+        "- [ ] Second-set",
+      ].join("\n");
+      const result = parsePlan(content);
+      expect(result.tasks).toEqual(["First-set", "Second-set"]);
+      // Both end up in tasks because everything after the first heading match
+      // is scanned for task markers; the second heading doesn't re-anchor.
+    });
+  });
+
+  describe("task marker parsing", () => {
+    test("parses [ ] / [x] / [X] / [!] markers", () => {
+      const content = [
+        "# Plan",
+        "## Tasks",
+        "- [ ] open",
+        "- [x] done lowercase",
+        "- [X] done uppercase",
+        "- [!] blocked",
+      ].join("\n");
+      const result = parsePlan(content);
+      expect(result.tasks).toEqual([
+        "open",
+        "done lowercase",
+        "done uppercase",
+        "blocked",
+      ]);
+    });
+
+    test("trims surrounding whitespace from task text", () => {
+      const content = "## Tasks\n-  [ ]   spaced out   ";
+      const result = parsePlan(content);
+      expect(result.tasks).toEqual(["spaced out"]);
+    });
+
+    test("tolerates leading whitespace before the dash", () => {
+      const content = "## Tasks\n   - [ ] indented";
+      const result = parsePlan(content);
+      expect(result.tasks).toEqual(["indented"]);
+    });
+
+    test("ignores lines that aren't task markers", () => {
+      const content = [
+        "## Tasks",
+        "- [ ] real task",
+        "not a task",
+        "- [?] not a recognized marker",
+        "- [ ] another real task",
+      ].join("\n");
+      const result = parsePlan(content);
+      expect(result.tasks).toEqual(["real task", "another real task"]);
+    });
+  });
+});

--- a/front/components/assistant/conversation/plan_mode/utils.tsx
+++ b/front/components/assistant/conversation/plan_mode/utils.tsx
@@ -3,6 +3,7 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { Chip } from "@dust-tt/sparkle";
 
 const TITLE_REGEX = /^#\s+(.+)$/m;
+const TASK_LINE_REGEX = /^\s*-\s*\[[ xX!]\]\s*(.+)$/gm;
 
 export function extractPlanTitle(content: string | null): string {
   if (!content) {
@@ -10,6 +11,13 @@ export function extractPlanTitle(content: string | null): string {
   }
   const match = content.match(TITLE_REGEX);
   return match ? match[1].trim() : "Untitled plan";
+}
+
+export function extractTaskList(content: string | null): string[] {
+  if (!content) {
+    return [];
+  }
+  return Array.from(content.matchAll(TASK_LINE_REGEX)).map((m) => m[1].trim());
 }
 
 export function ApprovalStateChip({ state }: { state: PlanApprovalState }) {

--- a/front/components/assistant/conversation/plan_mode/utils.tsx
+++ b/front/components/assistant/conversation/plan_mode/utils.tsx
@@ -1,6 +1,6 @@
 import type { PlanApprovalState } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/plan_mode";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { Chip } from "@dust-tt/sparkle";
+import { Chip, cn } from "@dust-tt/sparkle";
 
 const TITLE_REGEX = /^#\s+(.+)$/m;
 const TASK_LINE_REGEX = /^\s*-\s*\[[ xX!]\]\s*(.+)$/gm;
@@ -20,12 +20,51 @@ export function extractTaskList(content: string | null): string[] {
   return Array.from(content.matchAll(TASK_LINE_REGEX)).map((m) => m[1].trim());
 }
 
+const TASKS_HEADING_REGEX = /^##\s+Tasks?\s*$/m;
+
+// Splits plan markdown around the "## Tasks" (or "## Task") heading so the
+// preamble can render through Markdown while the task list itself is rendered
+// as a custom component with the project's circle markers. The heading line
+// stays in the preamble so it inherits Markdown heading styles.
+export function splitPlanContent(content: string | null): {
+  preamble: string;
+  tasks: string[];
+} {
+  if (!content) {
+    return { preamble: "", tasks: [] };
+  }
+  const match = content.match(TASKS_HEADING_REGEX);
+  if (!match || match.index === undefined) {
+    return { preamble: content, tasks: [] };
+  }
+  const splitIdx = match.index + match[0].length;
+  return {
+    preamble: content.slice(0, splitIdx),
+    tasks: extractTaskList(content.slice(splitIdx)),
+  };
+}
+
+// Outlined 16px circle used as a task marker in both the approval card and the
+// side panel. `mt-0.5` vertically centers the 16px circle on the 20px first
+// line of `copy-sm` text.
+export function PlanTaskBullet() {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "mt-0.5 h-4 w-4 shrink-0 rounded-full border-2",
+        "border-faint dark:border-faint-night"
+      )}
+    />
+  );
+}
+
 export function ApprovalStateChip({ state }: { state: PlanApprovalState }) {
   switch (state) {
     case "approved":
       return <Chip size="mini" color="success" label="Approved" />;
     case "pending":
-      return <Chip size="mini" color="warning" label="Pending approval" />;
+      return <Chip size="mini" color="golden" label="Pending approval" />;
     case "draft":
       return null;
     default:

--- a/front/components/assistant/conversation/plan_mode/utils.tsx
+++ b/front/components/assistant/conversation/plan_mode/utils.tsx
@@ -1,74 +1,32 @@
-import type { PlanApprovalState } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/plan_mode";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { Chip, cn } from "@dust-tt/sparkle";
-
 const TITLE_REGEX = /^#\s+(.+)$/m;
 const TASK_LINE_REGEX = /^\s*-\s*\[[ xX!]\]\s*(.+)$/gm;
-
-export function extractPlanTitle(content: string | null): string {
-  if (!content) {
-    return "Untitled plan";
-  }
-  const match = content.match(TITLE_REGEX);
-  return match ? match[1].trim() : "Untitled plan";
-}
-
-export function extractTaskList(content: string | null): string[] {
-  if (!content) {
-    return [];
-  }
-  return Array.from(content.matchAll(TASK_LINE_REGEX)).map((m) => m[1].trim());
-}
-
 const TASKS_HEADING_REGEX = /^##\s+Tasks?\s*$/m;
 
-// Splits plan markdown around the "## Tasks" (or "## Task") heading so the
-// preamble can render through Markdown while the task list itself is rendered
-// as a custom component with the project's circle markers. The heading line
-// stays in the preamble so it inherits Markdown heading styles.
-export function splitPlanContent(content: string | null): {
+const FALLBACK_TITLE = "Untitled plan";
+
+// Heading stays inside `preamble` so Markdown styles it consistently with
+// the other section headings; the task list is rendered separately.
+export function parsePlan(content: string | null): {
+  title: string;
   preamble: string;
   tasks: string[];
 } {
   if (!content) {
-    return { preamble: "", tasks: [] };
+    return { title: FALLBACK_TITLE, preamble: "", tasks: [] };
   }
-  const match = content.match(TASKS_HEADING_REGEX);
-  if (!match || match.index === undefined) {
-    return { preamble: content, tasks: [] };
-  }
-  const splitIdx = match.index + match[0].length;
-  return {
-    preamble: content.slice(0, splitIdx),
-    tasks: extractTaskList(content.slice(splitIdx)),
-  };
-}
 
-// Outlined 16px circle used as a task marker in both the approval card and the
-// side panel. `mt-0.5` vertically centers the 16px circle on the 20px first
-// line of `copy-sm` text.
-export function PlanTaskBullet() {
-  return (
-    <span
-      aria-hidden
-      className={cn(
-        "mt-0.5 h-4 w-4 shrink-0 rounded-full border-2",
-        "border-faint dark:border-faint-night"
-      )}
-    />
-  );
-}
+  const titleMatch = content.match(TITLE_REGEX);
+  const title = titleMatch ? titleMatch[1].trim() : FALLBACK_TITLE;
 
-export function ApprovalStateChip({ state }: { state: PlanApprovalState }) {
-  switch (state) {
-    case "approved":
-      return <Chip size="mini" color="success" label="Approved" />;
-    case "pending":
-      return <Chip size="mini" color="golden" label="Pending approval" />;
-    case "draft":
-      return null;
-    default:
-      assertNeverAndIgnore(state);
-      return null;
+  const headingMatch = content.match(TASKS_HEADING_REGEX);
+  if (!headingMatch || headingMatch.index === undefined) {
+    return { title, preamble: content, tasks: [] };
   }
+
+  const splitIdx = headingMatch.index + headingMatch[0].length;
+  const tasks = Array.from(
+    content.slice(splitIdx).matchAll(TASK_LINE_REGEX)
+  ).map((m) => m[1].trim());
+
+  return { title, preamble: content.slice(0, splitIdx), tasks };
 }


### PR DESCRIPTION
## Description
First set of plan mode UI improvements:
1. Adds custom tool approval card with list of tasks, cancel/accept buttons
2. Hides blocked action banner if this is the only blocking action
3. Uses same empty check styling for side panel

Designs changed a bit since I started implementing so this isn't complete but it is an improvement from current state! 
Designs live here: https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=5367-12194&m=dev
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="1191" height="859" alt="Screenshot 2026-05-05 at 11 09 02 PM" src="https://github.com/user-attachments/assets/12db2752-7af9-4815-96de-2aa103795abc" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
