### PR TITLE
[front] fix: prevent showing sub-agent conversations in the sidebar

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -325,11 +325,13 @@ async function handler(
         spaceId: resolvedSpaceModelId,
       });
 
-      await ConversationResource.upsertParticipation(auth, {
-        conversation,
-        action: "subscribed",
-        user: auth.user()?.toJSON() ?? null,
-      });
+      if (conversation.depth === 0) {
+        await ConversationResource.upsertParticipation(auth, {
+          conversation,
+          action: "subscribed",
+          user: auth.user()?.toJSON() ?? null,
+        });
+      }
 
       let newContentFragment: ContentFragmentType | null = null;
       let newMessage: UserMessageType | null = null;

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -295,11 +295,13 @@ async function handler(
         metadata,
       });
 
-      await ConversationResource.upsertParticipation(auth, {
-        conversation,
-        action: "subscribed",
-        user: user.toJSON(),
-      });
+      if (conversation.depth === 0) {
+        await ConversationResource.upsertParticipation(auth, {
+          conversation,
+          action: "subscribed",
+          user: user.toJSON(),
+        });
+      }
 
       const newContentFragments: ContentFragmentType[] = [];
       let newMessage: UserMessageType | null = null;


### PR DESCRIPTION
## Description

- Prevent sub-agent conversations from being added to the sidebar by only upserting conversation participation for root conversations
- Upsert introduced in https://github.com/dust-tt/dust/pull/25242

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
