### PR TITLE
Fix plugins after migration to Zod

### DIFF
--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -27,18 +27,12 @@ export const config = {
 
 const SupportedResourceTypeSchema = z.enum(supportedResourceTypes);
 
-const RunPluginParamsSchema = z.union([
-  z.object({
-    pluginId: z.string(),
-    resourceType: SupportedResourceTypeSchema,
-  }),
-  z.object({
-    pluginId: z.string(),
-    resourceId: z.string(),
-    resourceType: SupportedResourceTypeSchema,
-    workspaceId: z.string(),
-  }),
-]);
+const RunPluginParamsSchema = z.object({
+  pluginId: z.string(),
+  resourceType: SupportedResourceTypeSchema,
+  resourceId: z.string().optional(),
+  workspaceId: z.string().optional(),
+});
 
 export interface PokeRunPluginResponseBody {
   result: PluginResponse;
@@ -77,14 +71,8 @@ async function handler(
         });
       }
 
-      const { pluginId, resourceType } = pluginRunValidation.data;
-      const { resourceId, workspaceId } =
-        "resourceId" in pluginRunValidation.data
-          ? pluginRunValidation.data
-          : {
-              resourceId: undefined,
-              workspaceId: undefined,
-            };
+      const { pluginId, resourceType, resourceId, workspaceId } =
+        pluginRunValidation.data;
 
       // If the run targets a specific workspace, use a workspace-scoped authenticator.
       if (workspaceId) {


### PR DESCRIPTION
## Description

The io-ts → zod migration in #25236 silently broke every resource-targeted poke plugin (Run Reinforcement, and others) — they all failed with their "resource not found" error.

Root cause: `RunPluginParamsSchema` was a `z.union` with the simpler 2-field schema listed first. zod's `z.union` returns the first variant that parses, and `z.object` strips unknown keys by default. So a request carrying `{ pluginId, resourceType, resourceId, workspaceId }` matched the simpler variant, came back without `resourceId`/`workspaceId`, and the handler then skipped both `fetchPluginResource(...)` and the workspace-scoped auth.

io-ts `t.type` retains extra keys, which is why the previous code worked.

Fix: collapse to a single `z.object` with optional `resourceId`/`workspaceId`, matching how downstream code already uses them.

## Tests

Manual

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front