### PR TITLE
[front] fix: Transcript missing config must not be retried

### DIFF
--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -253,7 +253,7 @@ export async function processTranscriptActivity(
     );
 
   if (!transcriptsConfiguration) {
-    throw new Error(
+    throw new TranscriptNonRetryableError(
       `Could not find transcript configuration for id ${transcriptsConfigurationId}.`
     );
   }


### PR DESCRIPTION
## Description

Transcript config missing error are thrown as plain errors, causing the temporal workflow to be retried forever.
Since there is no path to recovery from a missing config, the right thing to do is to thrown a non-retriable error (which is done for other errors in this codepath)

## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy front