### PR TITLE
Wake-ups: move them to be non programmatic

### DIFF
--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -29,7 +29,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   transcript: "user",
   triggered_programmatic: "programmatic",
   triggered: "user",
-  wakeup: "programmatic",
+  wakeup: "user",
   web: "user",
   zapier: "programmatic",
   zendesk: "user",


### PR DESCRIPTION
## Description

Re-qualify wake-us to being non-programmatic.

Rationale: 
- cron-based triggers are non programmatic so we should align.
- programmatic caused issues since wake-ups didn't check for programmatic usage credits, creating check failures.

Analysis of usage so far. Some outliers but still OK. Will be destroyed in the acid of the new pricing anywa.

https://app.dust.tt/w/0ec9852c2f/conversation/7vSqolLIPB#?spid=fil_oDldr79vxSr95A%401778056595193&spt=interactive_content

## Tests

Covered by tests / tested locally.

## Risk

Low

## Deploy Plan

- deploy `front`