### PR TITLE
Chrisjow/backfill credits table

### DIFF
--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -96,17 +96,12 @@ async function backfillFromMetronome(
     dbCredits
       .filter((c) => c.startDate !== null && c.expirationDate !== null)
       .map((c) => [
-        `${c.type}:${floorToHourISO(c.startDate!)}:${ceilToHourISO(c.expirationDate!)}`,
+        `${floorToHourISO(c.startDate!)}:${ceilToHourISO(c.expirationDate!)}`,
         c,
       ])
   );
 
   for (const entry of metronomeEntries) {
-    if (entry.type !== "CREDIT") {
-      continue;
-    }
-    const creditType = "free";
-
     if (existingMetronomeIds.has(entry.id)) {
       logger.info(
         { workspaceId: workspace.sId, metronomeId: entry.id },
@@ -126,7 +121,7 @@ async function backfillFromMetronome(
       continue;
     }
 
-    const dateKey = `${creditType}:${floorToHourISO(startDate)}:${ceilToHourISO(expirationDate)}`;
+    const dateKey = `${floorToHourISO(startDate)}:${ceilToHourISO(expirationDate)}`;
     const existingByDates = existingDateKeys.get(dateKey);
     if (existingByDates) {
       if (
@@ -142,7 +137,6 @@ async function backfillFromMetronome(
             metronomeId: entry.id,
             existingMetronomeCreditId: existingByDates.metronomeCreditId,
             creditId: existingByDates.id,
-            creditType,
             startDate: startDate.toISOString(),
             expirationDate: expirationDate.toISOString(),
             reason,
@@ -160,7 +154,6 @@ async function backfillFromMetronome(
           {
             workspaceId: workspace.sId,
             metronomeId: entry.id,
-            creditType,
             startDate: startDate.toISOString(),
             expirationDate: expirationDate.toISOString(),
           },
@@ -203,7 +196,6 @@ async function backfillFromMetronome(
       {
         workspaceId: workspace.sId,
         metronomeId: entry.id,
-        creditType,
         initialUsd: initialAmountMicroUsd / 1_000_000,
         consumedUsd: consumedAmountMicroUsd / 1_000_000,
         startDate: startDate.toISOString(),
@@ -220,7 +212,7 @@ async function backfillFromMetronome(
 
     try {
       const credit = await CreditResource.makeNew(auth, {
-        type: creditType,
+        type: "free",
         startDate,
         expirationDate,
         initialAmountMicroUsd,

--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -2,7 +2,7 @@
  * Backfill DB credits from Metronome.
  *
  * For each workspace with a metronomeCustomerId:
- * - Lists all credits and commits from Metronome (with include_balance)
+ * - Lists all credits from Metronome (with include_balance)
  * - For each entry, checks if it already exists in DB by metronomeCreditId or
  *   by the (type, startDate, expirationDate) unique key
  * - If not found in DB, creates a new credit row with the right amounts, dates,
@@ -17,7 +17,6 @@ import { Authenticator } from "@app/lib/auth";
 import {
   ceilToHourISO,
   floorToHourISO,
-  listMetronomeCustomerCommits,
   listMetronomeCustomerCredits,
 } from "@app/lib/metronome/client";
 import { getCreditTypeProgrammaticUsdId } from "@app/lib/metronome/constants";
@@ -62,18 +61,11 @@ async function backfillFromMetronome(
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   const programmaticUsdCreditTypeId = getCreditTypeProgrammaticUsdId();
 
-  const [creditsResult, commitsResult] = await Promise.all([
-    listMetronomeCustomerCredits({
-      metronomeCustomerId,
-      includeContractCredits: true,
-      includeBalance: true,
-    }),
-    listMetronomeCustomerCommits({
-      metronomeCustomerId,
-      includeContractCommits: true,
-      includeBalance: true,
-    }),
-  ]);
+  const creditsResult = await listMetronomeCustomerCredits({
+    metronomeCustomerId,
+    includeContractCredits: true,
+    includeBalance: true,
+  });
 
   if (creditsResult.isErr()) {
     logger.error(
@@ -82,18 +74,8 @@ async function backfillFromMetronome(
     );
     return;
   }
-  if (commitsResult.isErr()) {
-    logger.error(
-      { workspaceId: workspace.sId, error: commitsResult.error.message },
-      "[Backfill Metronome→DB] Failed to list commits from Metronome"
-    );
-    return;
-  }
 
-  const metronomeEntries: MetronomeBalance[] = [
-    ...creditsResult.value,
-    ...commitsResult.value,
-  ].filter(
+  const metronomeEntries: MetronomeBalance[] = creditsResult.value.filter(
     (entry) =>
       entry.access_schedule?.credit_type?.id === programmaticUsdCreditTypeId
   );

--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -10,7 +10,7 @@
  *
  * Idempotent: re-running will skip entries already present in DB.
  *
- * Run with: npx tsx scripts/backfill_db_credits_from_metronome.ts [--execute] [--workspaceId <sId>]
+ * Run with: npx tsx scripts/backfill_db_free_credits_from_metronome.ts [--execute] [--workspaceId <sId>]
  */
 
 import { Authenticator } from "@app/lib/auth";

--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -29,6 +29,30 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { makeScript } from "./helpers";
 import { runOnAllWorkspaces } from "./workspace_helpers";
 
+type FreeCreditSubtype =
+  | "free-poke"
+  | "free-yearly-renewal"
+  | "free-renewal"
+  | "unknown";
+
+function getSubtypeFromDbCredit(
+  invoiceOrLineItemId: string | null
+): FreeCreditSubtype {
+  if (!invoiceOrLineItemId) {
+    return "unknown";
+  }
+  if (invoiceOrLineItemId.startsWith("free-poke-")) {
+    return "free-poke";
+  }
+  if (invoiceOrLineItemId.startsWith("free-renewal-yearly-")) {
+    return "free-yearly-renewal";
+  }
+  if (invoiceOrLineItemId.startsWith("free-renewal-")) {
+    return "free-renewal";
+  }
+  return "unknown";
+}
+
 function getScheduleTotals(entry: MetronomeBalance): {
   initialAmountMicroUsd: number;
   startDate: Date | null;
@@ -96,7 +120,7 @@ async function backfillFromMetronome(
     dbCredits
       .filter((c) => c.startDate !== null && c.expirationDate !== null)
       .map((c) => [
-        `${floorToHourISO(c.startDate!)}:${ceilToHourISO(c.expirationDate!)}`,
+        `${getSubtypeFromDbCredit(c.invoiceOrLineItemId)}:${floorToHourISO(c.startDate!)}:${ceilToHourISO(c.expirationDate!)}`,
         c,
       ])
   );
@@ -121,7 +145,21 @@ async function backfillFromMetronome(
       continue;
     }
 
-    const dateKey = `${floorToHourISO(startDate)}:${ceilToHourISO(expirationDate)}`;
+    const contractId = entry.contract?.id;
+    const isPokeCredit = entry.name?.toLowerCase().includes("poke") ?? false;
+    let subtype: FreeCreditSubtype;
+    if (isPokeCredit) {
+      subtype = "free-poke";
+    } else if (contractId) {
+      const periodDurationSeconds =
+        (expirationDate.getTime() - startDate.getTime()) / 1000;
+      const isAnnual = periodDurationSeconds >= 60 * 24 * 60 * 60; // every credit valid for more than 2 months is considered annual
+      subtype = isAnnual ? "free-yearly-renewal" : "free-renewal";
+    } else {
+      subtype = "unknown";
+    }
+
+    const dateKey = `${subtype}:${floorToHourISO(startDate)}:${ceilToHourISO(expirationDate)}`;
     const existingByDates = existingDateKeys.get(dateKey);
     if (existingByDates) {
       if (
@@ -163,20 +201,14 @@ async function backfillFromMetronome(
       continue;
     }
 
-    // Define invoiceOrLineItemId
-    const contractId = entry.contract?.id;
     const periodStartSeconds = Math.floor(startDate.getTime() / 1000);
-    const isPokeCredit = entry.name?.toLowerCase().includes("poke") ?? false;
     let invoiceOrLineItemId: string | null;
-    if (isPokeCredit) {
+    if (subtype === "free-poke") {
       invoiceOrLineItemId = `free-poke-${workspace.sId}-${periodStartSeconds * 1000}`;
-    } else if (contractId) {
-      const periodDurationSeconds =
-        (expirationDate.getTime() - startDate.getTime()) / 1000;
-      const isAnnual = periodDurationSeconds >= 60 * 24 * 60 * 60; // every credit valid for more than 2 months is considered annual
-      invoiceOrLineItemId = isAnnual
-        ? `free-renewal-yearly-${contractId}-${periodStartSeconds}`
-        : `free-renewal-${contractId}-${periodStartSeconds}`;
+    } else if (subtype === "free-yearly-renewal" && contractId) {
+      invoiceOrLineItemId = `free-renewal-yearly-${contractId}-${periodStartSeconds}`;
+    } else if (subtype === "free-renewal" && contractId) {
+      invoiceOrLineItemId = `free-renewal-${contractId}-${periodStartSeconds}`;
     } else {
       invoiceOrLineItemId = null;
     }

--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -1,0 +1,292 @@
+/**
+ * Backfill DB credits from Metronome.
+ *
+ * For each workspace with a metronomeCustomerId:
+ * - Lists all credits and commits from Metronome (with include_balance)
+ * - For each entry, checks if it already exists in DB by metronomeCreditId or
+ *   by the (type, startDate, expirationDate) unique key
+ * - If not found in DB, creates a new credit row with the right amounts, dates,
+ *   and metronomeCreditId
+ *
+ * Idempotent: re-running will skip entries already present in DB.
+ *
+ * Run with: npx tsx scripts/backfill_db_credits_from_metronome.ts [--execute] [--workspaceId <sId>]
+ */
+
+import { Authenticator } from "@app/lib/auth";
+import {
+  ceilToHourISO,
+  floorToHourISO,
+  listMetronomeCustomerCommits,
+  listMetronomeCustomerCredits,
+} from "@app/lib/metronome/client";
+import { getCreditTypeProgrammaticUsdId } from "@app/lib/metronome/constants";
+import type { MetronomeBalance } from "@app/lib/metronome/types";
+import { METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD } from "@app/lib/metronome/types";
+import { CreditResource } from "@app/lib/resources/credit_resource";
+import type { Logger } from "@app/logger/logger";
+import type { LightWorkspaceType } from "@app/types/user";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+function getScheduleTotals(entry: MetronomeBalance): {
+  initialAmountMicroUsd: number;
+  startDate: Date | null;
+  expirationDate: Date | null;
+} {
+  const item = entry.access_schedule?.schedule_items?.[0];
+  if (!item) {
+    return { initialAmountMicroUsd: 0, startDate: null, expirationDate: null };
+  }
+
+  return {
+    initialAmountMicroUsd: Math.round(
+      item.amount * METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD
+    ),
+    startDate: new Date(item.starting_at),
+    expirationDate: new Date(item.ending_before),
+  };
+}
+
+async function backfillFromMetronome(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return;
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const programmaticUsdCreditTypeId = getCreditTypeProgrammaticUsdId();
+
+  const [creditsResult, commitsResult] = await Promise.all([
+    listMetronomeCustomerCredits({
+      metronomeCustomerId,
+      includeContractCredits: true,
+      includeBalance: true,
+    }),
+    listMetronomeCustomerCommits({
+      metronomeCustomerId,
+      includeContractCommits: true,
+      includeBalance: true,
+    }),
+  ]);
+
+  if (creditsResult.isErr()) {
+    logger.error(
+      { workspaceId: workspace.sId, error: creditsResult.error.message },
+      "[Backfill Metronome→DB] Failed to list credits from Metronome"
+    );
+    return;
+  }
+  if (commitsResult.isErr()) {
+    logger.error(
+      { workspaceId: workspace.sId, error: commitsResult.error.message },
+      "[Backfill Metronome→DB] Failed to list commits from Metronome"
+    );
+    return;
+  }
+
+  const metronomeEntries: MetronomeBalance[] = [
+    ...creditsResult.value,
+    ...commitsResult.value,
+  ].filter(
+    (entry) =>
+      entry.access_schedule?.credit_type?.id === programmaticUsdCreditTypeId
+  );
+
+  if (metronomeEntries.length === 0) {
+    return;
+  }
+
+  const metronomeEntryIds = new Set(metronomeEntries.map((e) => e.id));
+
+  const dbCredits = (await CreditResource.listAll(auth)).filter(
+    (c) => c.type === "free"
+  );
+  const existingMetronomeIds = new Set(
+    dbCredits.map((c) => c.metronomeCreditId).filter((id) => id !== null)
+  );
+  const existingDateKeys = new Map(
+    dbCredits
+      .filter((c) => c.startDate !== null && c.expirationDate !== null)
+      .map((c) => [
+        `${c.type}:${floorToHourISO(c.startDate!)}:${ceilToHourISO(c.expirationDate!)}`,
+        c,
+      ])
+  );
+
+  for (const entry of metronomeEntries) {
+    if (entry.type !== "CREDIT") {
+      continue;
+    }
+    const creditType = "free";
+
+    if (existingMetronomeIds.has(entry.id)) {
+      logger.info(
+        { workspaceId: workspace.sId, metronomeId: entry.id },
+        "[Backfill Metronome→DB] Already in DB by metronomeCreditId, skipping"
+      );
+      continue;
+    }
+
+    const { initialAmountMicroUsd, startDate, expirationDate } =
+      getScheduleTotals(entry);
+
+    if (!startDate || !expirationDate || initialAmountMicroUsd === 0) {
+      logger.warn(
+        { workspaceId: workspace.sId, metronomeId: entry.id },
+        "[Backfill Metronome→DB] No access_schedule dates or zero amount, skipping"
+      );
+      continue;
+    }
+
+    const dateKey = `${creditType}:${floorToHourISO(startDate)}:${ceilToHourISO(expirationDate)}`;
+    const existingByDates = existingDateKeys.get(dateKey);
+    if (existingByDates) {
+      if (
+        !existingByDates.metronomeCreditId ||
+        !metronomeEntryIds.has(existingByDates.metronomeCreditId)
+      ) {
+        const reason = !existingByDates.metronomeCreditId
+          ? "missing metronomeCreditId"
+          : "metronomeCreditId not in current Metronome entries";
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            metronomeId: entry.id,
+            existingMetronomeCreditId: existingByDates.metronomeCreditId,
+            creditId: existingByDates.id,
+            creditType,
+            startDate: startDate.toISOString(),
+            expirationDate: expirationDate.toISOString(),
+            reason,
+          },
+          execute
+            ? "[Backfill Metronome→DB] Already in DB by type+dates, updating metronomeCreditId"
+            : "[Backfill Metronome→DB] [DRY RUN] Already in DB by type+dates, would update metronomeCreditId"
+        );
+        if (execute) {
+          await existingByDates.setMetronomeCreditId(entry.id);
+          existingMetronomeIds.add(entry.id);
+        }
+      } else {
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            metronomeId: entry.id,
+            creditType,
+            startDate: startDate.toISOString(),
+            expirationDate: expirationDate.toISOString(),
+          },
+          "[Backfill Metronome→DB] Already in DB by type+dates, skipping"
+        );
+      }
+      continue;
+    }
+
+    // Define invoiceOrLineItemId
+    const contractId = entry.contract?.id;
+    const periodStartSeconds = Math.floor(startDate.getTime() / 1000);
+    const isPokeCredit = entry.name?.toLowerCase().includes("poke") ?? false;
+    let invoiceOrLineItemId: string | null;
+    if (isPokeCredit) {
+      invoiceOrLineItemId = `free-poke-${workspace.sId}-${periodStartSeconds * 1000}`;
+    } else if (contractId) {
+      const periodDurationSeconds =
+        (expirationDate.getTime() - startDate.getTime()) / 1000;
+      const isAnnual = periodDurationSeconds >= 60 * 24 * 60 * 60; // every credit valid for more than 2 months is considered annual
+      invoiceOrLineItemId = isAnnual
+        ? `free-renewal-yearly-${contractId}-${periodStartSeconds}`
+        : `free-renewal-${contractId}-${periodStartSeconds}`;
+    } else {
+      invoiceOrLineItemId = null;
+    }
+
+    const balanceCredits =
+      entry.balance ??
+      initialAmountMicroUsd / METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD;
+    const remainingAmountMicroUsd = Math.round(
+      balanceCredits * METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD
+    );
+    const consumedAmountMicroUsd = Math.max(
+      0,
+      initialAmountMicroUsd - remainingAmountMicroUsd
+    );
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        metronomeId: entry.id,
+        creditType,
+        initialUsd: initialAmountMicroUsd / 1_000_000,
+        consumedUsd: consumedAmountMicroUsd / 1_000_000,
+        startDate: startDate.toISOString(),
+        expirationDate: expirationDate.toISOString(),
+      },
+      execute
+        ? "[Backfill Metronome→DB] Creating credit in DB"
+        : "[Backfill Metronome→DB] [DRY RUN] Would create credit in DB"
+    );
+
+    if (!execute) {
+      continue;
+    }
+
+    try {
+      const credit = await CreditResource.makeNew(auth, {
+        type: creditType,
+        startDate,
+        expirationDate,
+        initialAmountMicroUsd,
+        consumedAmountMicroUsd,
+        metronomeCreditId: entry.id,
+        invoiceOrLineItemId,
+        discount: null,
+      });
+
+      existingMetronomeIds.add(entry.id);
+      existingDateKeys.set(dateKey, credit);
+
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          metronomeId: entry.id,
+          creditId: credit.id,
+        },
+        "[Backfill Metronome→DB] Credit created in DB"
+      );
+    } catch (error) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          metronomeId: entry.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "[Backfill Metronome→DB] Failed to create credit in DB"
+      );
+    }
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string" as const,
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await backfillFromMetronome(workspace, execute, logger);
+      },
+      { concurrency: 4, wId: workspaceId }
+    );
+  }
+);


### PR DESCRIPTION
## Description

Adds a backfill script to sync missing credits from Metronome to the database. This is the reverse of the existing `backfill_metronome_credits.ts` script (which syncs DB → Metronome). After PR #25129 made the Metronome webhook the source of truth for free credit creation, this script ensures any credits that exist in Metronome but are missing from the DB are backfilled. The script fetches all credits and commits from Metronome, filters for programmatic USD credits, and creates corresponding DB rows with proper `metronomeCreditId` linkage and consumption amounts. It also reconciles existing DB credits that have matching dates but missing `metronomeCreditId` by updating the link.

## Tests

Manually tested in dry-run and execute mode.

## Risk

Low. The script is idempotent and uses the same unique key logic (type + startDate + expirationDate) as existing credit creation paths.

## Deploy Plan

Deploy front