### PR TITLE
[front] fix: API V1 unauthenticated call to getNonNullableUser

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.test.ts
@@ -1,0 +1,99 @@
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/programmatic_usage/tracking", () => ({
+  isProgrammaticUsage: () => false,
+  checkProgrammaticUsageLimits: vi.fn(),
+}));
+
+import handler from "./index";
+
+describe("POST /api/v1/w/[wId]/assistant/conversations", () => {
+  it("returns 401 when an API key (no user) sends selectedMCPServerViewIds", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    req.url = `/api/v1/w/${workspace.sId}/assistant/conversations`;
+    req.body = {
+      title: "Test conversation",
+      message: {
+        content: "Hello",
+        mentions: [],
+        context: {
+          username: "tester",
+          timezone: "Europe/Paris",
+          origin: "api",
+          selectedMCPServerViewIds: ["msv_abcdef123456"],
+        },
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "Selecting MCP server views is only available to authenticated users.",
+      },
+    });
+  });
+
+  it("returns 401 when an API key (no user) sends clientSideMCPServerIds", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    req.url = `/api/v1/w/${workspace.sId}/assistant/conversations`;
+    req.body = {
+      title: "Test conversation",
+      message: {
+        content: "Hello",
+        mentions: [],
+        context: {
+          username: "tester",
+          timezone: "Europe/Paris",
+          origin: "api",
+          clientSideMCPServerIds: ["mcp_local_abc"],
+        },
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Local MCP servers are only available to authenticated users.",
+      },
+    });
+  });
+
+  it("returns 400 when the request body fails schema validation", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    req.url = `/api/v1/w/${workspace.sId}/assistant/conversations`;
+    req.body = { message: { content: "missing mentions and context" } };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "PATCH",
+    });
+    req.url = `/api/v1/w/${workspace.sId}/assistant/conversations`;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -417,6 +417,17 @@ async function handler(
 
         // If tools are enabled, we need to add the MCP server views to the conversation before posting the message.
         if (message.context.selectedMCPServerViewIds) {
+          if (!auth.user()) {
+            return apiError(req, res, {
+              status_code: 401,
+              api_error: {
+                type: "invalid_request_error",
+                message:
+                  "Selecting MCP server views is only available to authenticated users.",
+              },
+            });
+          }
+
           const mcpServerViews = await MCPServerViewResource.fetchByIds(
             auth,
             message.context.selectedMCPServerViewIds


### PR DESCRIPTION
## Description

POST /api/v1/w/[wId]/assistant/conversations 500'd with "Unexpected unauthenticated call to getNonNullableUser" when an API-key caller passed message.context.selectedMCPServerViewIds. 

The handler called ConversationResource.upsertMCPServerViews, which does auth.getNonNullableUser().id to populate the non-nullable userId column on ConversationMCPServerViewModel. 

API-key auth has no user, so it threw — the conversation was created but its MCP tools weren't attached.

Fix: Added an auth.user() guard at the top of the if (message.context.selectedMCPServerViewIds) block in front/pages/api/v1/w/[wId]/assistant/conversations/index.ts, mirroring the existing pattern used for clientSideMCPServerIds a few lines above. Returns 401 invalid_request_error with message "Selecting MCP server views is only available to authenticated users." when auth.user() is null.

This fix the current issue while making it future proof if we decide to introduce user-scoped api keys.

## Tests

Unit tests

## Risk

Low

## Deploy Plan

- [ ] Deploy front