### PR TITLE
feat: add project table in poke

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -9,6 +9,7 @@ import { GroupDataTable } from "@app/components/poke/groups/table";
 import { MCPServerViewsDataTable } from "@app/components/poke/mcp_server_views/table";
 import { WorkspaceDatasourceRetrievalTreemapPluginChart } from "@app/components/poke/plugins/components/WorkspaceDatasourceRetrievalTreemapPluginChart";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { ProjectsDataTable } from "@app/components/poke/projects/table";
 import {
   PokeAlert,
   PokeAlertDescription,
@@ -261,6 +262,7 @@ export function WorkspacePage() {
               <TabsTrigger value="featureflags" label="Feature Flags" />
               <TabsTrigger value="groups" label="Groups" />
               <TabsTrigger value="mcpviews" label="MCP Server Views" />
+              <TabsTrigger value="projects" label="Projects" />
               <TabsTrigger value="skills" label="Skills" />
               <TabsTrigger value="spaces" label="Spaces" />
 
@@ -278,6 +280,9 @@ export function WorkspacePage() {
             </TabsContent>
             <TabsContent value="mcpviews">
               <MCPServerViewsDataTable owner={owner} loadOnInit />
+            </TabsContent>
+            <TabsContent value="projects">
+              <ProjectsDataTable owner={owner} loadOnInit />
             </TabsContent>
             <TabsContent value="spaces">
               <SpaceDataTable owner={owner} loadOnInit />

--- a/front/components/poke/projects/columns.tsx
+++ b/front/components/poke/projects/columns.tsx
@@ -1,0 +1,75 @@
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { PokeProjectType } from "@app/pages/api/poke/workspaces/[wId]/projects";
+import type { WorkspaceType } from "@app/types/user";
+import { LinkWrapper } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+
+export function makeColumnsForProjects(
+  owner: WorkspaceType
+): ColumnDef<PokeProjectType>[] {
+  return [
+    {
+      accessorKey: "sId",
+      cell: ({ row }) => (
+        <LinkWrapper href={`/poke/${owner.sId}/spaces/${row.original.sId}`}>
+          {row.original.sId}
+        </LinkWrapper>
+      ),
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
+    },
+    {
+      accessorKey: "name",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
+    },
+    {
+      accessorKey: "description",
+      cell: ({ row }) => row.original.description ?? "-",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Description" />
+      ),
+    },
+    {
+      accessorKey: "isRestricted",
+      cell: ({ row }) => (row.original.isRestricted ? "Yes" : "No"),
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Restricted" />
+      ),
+    },
+    {
+      accessorKey: "archivedAt",
+      cell: ({ row }) =>
+        row.original.archivedAt
+          ? formatTimestampToFriendlyDate(row.original.archivedAt)
+          : "-",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Archived at" />
+      ),
+    },
+    {
+      accessorKey: "todoGenerationEnabled",
+      cell: ({ row }) => (row.original.todoGenerationEnabled ? "Yes" : "No"),
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Suggested tasks" />
+      ),
+    },
+    {
+      accessorKey: "createdAt",
+      cell: ({ row }) => formatTimestampToFriendlyDate(row.original.createdAt),
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
+    },
+    {
+      accessorKey: "updatedAt",
+      cell: ({ row }) => formatTimestampToFriendlyDate(row.original.updatedAt),
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Updated at" />
+      ),
+    },
+  ];
+}

--- a/front/components/poke/projects/table.tsx
+++ b/front/components/poke/projects/table.tsx
@@ -1,0 +1,28 @@
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
+import { makeColumnsForProjects } from "@app/components/poke/projects/columns";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { usePokeProjects } from "@app/poke/swr/projects";
+import type { WorkspaceType } from "@app/types/user";
+
+interface ProjectsDataTableProps {
+  owner: WorkspaceType;
+  loadOnInit?: boolean;
+}
+
+export function ProjectsDataTable({
+  owner,
+  loadOnInit,
+}: ProjectsDataTableProps) {
+  return (
+    <PokeDataTableConditionalFetch
+      header="Projects"
+      owner={owner}
+      loadOnInit={loadOnInit}
+      useSWRHook={usePokeProjects}
+    >
+      {(data) => (
+        <PokeDataTable columns={makeColumnsForProjects(owner)} data={data} />
+      )}
+    </PokeDataTableConditionalFetch>
+  );
+}

--- a/front/pages/api/poke/workspaces/[wId]/projects/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/index.ts
@@ -1,0 +1,86 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { SpaceType } from "@app/types/space";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type PokeProjectType = SpaceType & {
+  description: string | null;
+  archivedAt: number | null;
+  todoGenerationEnabled: boolean;
+};
+
+export type PokeListProjects = {
+  projects: PokeProjectType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeListProjects>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (typeof wId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+
+  const owner = auth.workspace();
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const projectSpaces = await SpaceResource.listProjectSpaces(auth);
+
+      const metadataResources = await ProjectMetadataResource.fetchBySpaceIds(
+        auth,
+        projectSpaces.map((s) => s.id)
+      );
+      const metadataBySpaceId = new Map(
+        metadataResources.map((m) => [m.spaceId, m])
+      );
+
+      const projects: PokeProjectType[] = projectSpaces.map((space) => {
+        const metadata = metadataBySpaceId.get(space.id);
+        return {
+          ...space.toJSON(),
+          description: metadata?.description ?? null,
+          archivedAt: metadata?.archivedAt?.getTime() ?? null,
+          todoGenerationEnabled: metadata?.todoGenerationEnabled ?? false,
+        };
+      });
+
+      return res.status(200).json({ projects });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/projects.ts
+++ b/front/poke/swr/projects.ts
@@ -1,0 +1,24 @@
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeListProjects } from "@app/pages/api/poke/workspaces/[wId]/projects";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type { Fetcher } from "swr";
+
+export function usePokeProjects({
+  disabled,
+  owner,
+}: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
+  const projectsFetcher: Fetcher<PokeListProjects> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/projects`,
+    projectsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data?.projects ?? emptyArray(),
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Description

This PR adds a new Projects table to Poke

- Added a new API endpoint `/api/poke/workspaces/[wId]/projects` that fetches project spaces along with their metadata (description, archived status, todo generation settings)
- Integrated the Projects table as a new tab in the workspace page

Notice that clicking on the id brings you to the space details page which already contains information about members and data sources.

## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment. No special migration or configuration required.
