### PR TITLE
[refacto] - front(TODO): todo components

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer.tsx
@@ -1,13 +1,6 @@
 import {
   MANUAL_ADD_TASK_PLACEHOLDER,
-  MANUAL_ADD_TODO_INPUT_FIELD_CLASS,
   NEW_MANUAL_TASK_MAX_CHARS,
-  PROJECT_TODO_EDIT_ACTION_CLUSTER_CLASS,
-  PROJECT_TODO_ITEM_ROW_FRAME_CLASS,
-  PROJECT_TODO_MANUAL_ADD_LEADING_ASSIGNEE_ANCHOR_CLASS,
-  PROJECT_TODO_MANUAL_ADD_LEADING_CLASS,
-  PROJECT_TODO_TABLE_ROW_INSET_CLASS,
-  stripNewlines,
 } from "@app/components/assistant/conversation/space/conversations/project_tasks/utils";
 import { removeDiacritics } from "@app/lib/utils";
 import { PROJECT_TASK_NO_ASSIGNEE_LABEL } from "@app/types/project_task";
@@ -16,15 +9,16 @@ import type { SpaceUserType } from "@app/types/user";
 import {
   Avatar,
   Button,
-  cn,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Input,
+  UserIcon,
 } from "@dust-tt/sparkle";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 export type AddTaskAssigneeChoice =
   | { kind: "default" }
@@ -66,61 +60,26 @@ function memberRowAssigneeChecked(
   }
 }
 
-function assigneeTriggerTitleAndAria(
-  choice: AddTaskAssigneeChoice,
-  selectedUser: SpaceUserType | null | undefined,
-  viewerUserId: string | null
-): { title: string; ariaLabel: string } {
-  if (selectedUser) {
-    const youSuffix = viewerUserId === selectedUser.sId ? " (you)" : "";
-    return {
-      title: `Assign to ${selectedUser.fullName}${youSuffix} — click to change`,
-      ariaLabel: `Assign to ${selectedUser.fullName}${youSuffix}, open menu to change`,
-    };
-  }
-  switch (choice.kind) {
-    case "unassigned":
-      return {
-        title: `${PROJECT_TASK_NO_ASSIGNEE_LABEL} — click to change assignee`,
-        ariaLabel: `${PROJECT_TASK_NO_ASSIGNEE_LABEL}, open menu to change assignee`,
-      };
-    case "default":
-    case "member":
-      return {
-        title: "Choose assignee",
-        ariaLabel: "Choose assignee",
-      };
-    default:
-      assertNeverAndIgnore(choice);
-      return {
-        title: "Choose assignee",
-        ariaLabel: "Choose assignee",
-      };
-  }
-}
-
-function TodoRowAssigneeMenu({
-  ariaNamePrefix,
-  members,
-  viewerUserId,
-  defaultAssigneeSId,
-  choice,
-  onChoiceChange,
-  onMenuOpenChange,
-  disabled,
-}: {
-  ariaNamePrefix: string;
+interface TaskRowAssigneeMenuProps {
   members: SpaceUserType[];
   viewerUserId: string | null;
   defaultAssigneeSId: string;
   choice: AddTaskAssigneeChoice;
   onChoiceChange: (next: AddTaskAssigneeChoice) => void;
-  onMenuOpenChange?: (open: boolean) => void;
   disabled?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
+}
+
+function TaskRowAssigneeMenu({
+  members,
+  viewerUserId,
+  defaultAssigneeSId,
+  choice,
+  onChoiceChange,
+  disabled,
+}: TaskRowAssigneeMenuProps) {
   const [search, setSearch] = useState("");
   const q = removeDiacritics(search.trim()).toLowerCase();
+
   const filteredMembers = useMemo(() => {
     if (!q) {
       return [...members];
@@ -130,84 +89,59 @@ function TodoRowAssigneeMenu({
     );
   }, [q, members]);
 
-  const assigneeSearchLabelNorm = removeDiacritics(
+  const noAssigneeLabelNorm = removeDiacritics(
     PROJECT_TASK_NO_ASSIGNEE_LABEL
   ).toLowerCase();
   const showNoAssigneeRow =
-    members.length !== 1 && (q === "" || assigneeSearchLabelNorm.includes(q));
+    members.length !== 1 && (q === "" || noAssigneeLabelNorm.includes(q));
 
-  let effectiveMemberSId: string | null;
-  switch (choice.kind) {
-    case "unassigned":
-      effectiveMemberSId = null;
-      break;
-    case "default":
-      effectiveMemberSId = defaultAssigneeSId;
-      break;
-    case "member":
-      effectiveMemberSId = choice.sId;
-      break;
-    default:
-      assertNeverAndIgnore(choice);
-      effectiveMemberSId = null;
-  }
+  const effectiveMemberSId = resolveSubmitAssigneeSId(
+    choice,
+    defaultAssigneeSId
+  );
   const selectedUser = effectiveMemberSId
     ? members.find((m) => m.sId === effectiveMemberSId)
     : null;
-
-  const { title, ariaLabel } = assigneeTriggerTitleAndAria(
-    choice,
-    selectedUser,
-    viewerUserId
-  );
+  const tooltip = selectedUser
+    ? `Assign to ${selectedUser.fullName}${viewerUserId === selectedUser.sId ? " (you)" : ""}`
+    : choice.kind === "unassigned"
+      ? PROJECT_TASK_NO_ASSIGNEE_LABEL
+      : "Choose assignee";
 
   return (
     <DropdownMenu
-      modal={false}
-      open={open}
-      onOpenChange={(nextOpen) => {
-        setOpen(nextOpen);
-        onMenuOpenChange?.(nextOpen);
-        if (nextOpen) {
+      onOpenChange={(open) => {
+        if (open) {
           setSearch("");
         }
       }}
     >
       <DropdownMenuTrigger asChild>
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          size="icon"
+          isRounded
           disabled={disabled}
-          title={title}
-          aria-label={ariaLabel}
-          onMouseDown={(e) => e.preventDefault()}
-          className={cn(
-            "flex size-7 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-full bg-background p-0 ring-1 ring-border/60 ring-inset hover:brightness-105",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-            "dark:bg-background-night dark:ring-border-night/55",
-            "disabled:pointer-events-none disabled:opacity-40"
-          )}
-        >
-          {selectedUser ? (
-            <Avatar
-              size="xs"
-              isRounded
-              visual={selectedUser.image ?? "/static/humanavatar/anonymous.png"}
-            />
-          ) : (
-            <span
-              className="block size-[1.625rem] shrink-0 rounded-full ring-1 ring-inset ring-border/70 dark:ring-border-night/60"
-              aria-hidden
-            />
-          )}
-        </button>
+          tooltip={tooltip}
+          icon={
+            selectedUser ? (
+              <Avatar
+                size="xs"
+                isRounded
+                visual={
+                  selectedUser.image ?? "/static/humanavatar/anonymous.png"
+                }
+              />
+            ) : (
+              UserIcon
+            )
+          }
+        />
       </DropdownMenuTrigger>
-      <DropdownMenuContent
-        className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
-        align="start"
-      >
+      <DropdownMenuContent className="w-80" align="start">
         <DropdownMenuSearchbar
           autoFocus
-          name={`${ariaNamePrefix}-assignee-search`}
+          name="add-task-assignee-search"
           placeholder="Search members"
           value={search}
           onChange={setSearch}
@@ -218,60 +152,42 @@ function TodoRowAssigneeMenu({
             <>
               {showNoAssigneeRow && (
                 <DropdownMenuCheckboxItem
-                  key={`${ariaNamePrefix}-no-assignee`}
+                  key="add-task-no-assignee"
                   label={PROJECT_TASK_NO_ASSIGNEE_LABEL}
                   checked={choice.kind === "unassigned"}
-                  onClick={() => {
-                    onChoiceChange({ kind: "unassigned" });
-                    setOpen(false);
-                    onMenuOpenChange?.(false);
-                  }}
-                  onSelect={(event) => {
-                    event.preventDefault();
-                  }}
+                  onClick={() => onChoiceChange({ kind: "unassigned" })}
                 />
               )}
-              {showNoAssigneeRow && filteredMembers.length > 0 ? (
+              {showNoAssigneeRow && filteredMembers.length > 0 && (
                 <DropdownMenuSeparator />
-              ) : null}
-              {filteredMembers.length > 0 ? (
-                filteredMembers.map((member) => (
-                  <DropdownMenuCheckboxItem
-                    key={`${ariaNamePrefix}-member-${member.sId}`}
-                    icon={() => (
-                      <Avatar
-                        size="xxs"
-                        isRounded
-                        visual={
-                          member.image ?? "/static/humanavatar/anonymous.png"
-                        }
-                      />
-                    )}
-                    label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
-                    checked={memberRowAssigneeChecked(
-                      choice,
-                      member.sId,
-                      defaultAssigneeSId
-                    )}
-                    onClick={() => {
-                      onChoiceChange(
-                        member.sId === defaultAssigneeSId
-                          ? { kind: "default" }
-                          : { kind: "member", sId: member.sId }
-                      );
-                      setOpen(false);
-                      onMenuOpenChange?.(false);
-                    }}
-                    onSelect={(event) => {
-                      event.preventDefault();
-                    }}
-                  />
-                ))
-              ) : !showNoAssigneeRow ? (
-                <div className="px-3 py-2 text-sm text-muted-foreground">
-                  No members found
-                </div>
-              ) : null}
+              )}
+              {filteredMembers.map((member) => (
+                <DropdownMenuCheckboxItem
+                  key={`add-task-member-${member.sId}`}
+                  icon={() => (
+                    <Avatar
+                      size="xxs"
+                      isRounded
+                      visual={
+                        member.image ?? "/static/humanavatar/anonymous.png"
+                      }
+                    />
+                  )}
+                  label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
+                  checked={memberRowAssigneeChecked(
+                    choice,
+                    member.sId,
+                    defaultAssigneeSId
+                  )}
+                  onClick={() =>
+                    onChoiceChange(
+                      member.sId === defaultAssigneeSId
+                        ? { kind: "default" }
+                        : { kind: "member", sId: member.sId }
+                    )
+                  }
+                />
+              ))}
             </>
           ) : (
             <div className="px-3 py-2 text-sm text-muted-foreground">
@@ -284,26 +200,29 @@ function TodoRowAssigneeMenu({
   );
 }
 
-export function AddTodoComposer({
-  projectMembers,
-  viewerUserId,
-  defaultAssigneeSId,
-  hideAssigneePicker = false,
-  onAdd,
-}: {
+interface AddTaskComposerProps {
   projectMembers: SpaceUserType[];
   viewerUserId: string | null;
   defaultAssigneeSId: string;
   /** When true, always assigns to `defaultAssigneeSId` with no picker. */
   hideAssigneePicker?: boolean;
   onAdd: (text: string, assigneeSId: string | null) => Promise<boolean>;
-}) {
+}
+
+export function AddTaskComposer({
+  projectMembers,
+  viewerUserId,
+  defaultAssigneeSId,
+  hideAssigneePicker = false,
+  onAdd,
+}: AddTaskComposerProps) {
   const [text, setText] = useState("");
   const [assigneeChoice, setAssigneeChoice] = useState<AddTaskAssigneeChoice>(
-    () => ({
-      kind: "default",
-    })
+    () => ({ kind: "default" })
   );
+  const [isAdding, setIsAdding] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
   useEffect(() => {
     if (hideAssigneePicker || projectMembers.length !== 1) {
       return;
@@ -312,23 +231,13 @@ export function AddTodoComposer({
       c.kind === "unassigned" ? { kind: "default" } : c
     );
   }, [hideAssigneePicker, projectMembers.length]);
-  const [isAdding, setIsAdding] = useState(false);
-  const [inputFocused, setInputFocused] = useState(false);
-  const [assigneeMenuOpen, setAssigneeMenuOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const submitAssigneeSId = hideAssigneePicker
     ? defaultAssigneeSId
     : resolveSubmitAssigneeSId(assigneeChoice, defaultAssigneeSId);
 
-  const isExpanded =
-    inputFocused ||
-    (!hideAssigneePicker && assigneeMenuOpen) ||
-    stripNewlines(text).trim().length > 0;
-
-  const handleSubmit = useCallback(async () => {
-    const trimmed = stripNewlines(text).trim();
+  const handleSubmit = async () => {
+    const trimmed = text.trim();
     if (!trimmed || isAdding) {
       return;
     }
@@ -337,124 +246,54 @@ export function AddTodoComposer({
     setIsAdding(false);
     if (ok) {
       setText("");
-      // Re-assert focus after paint; `readOnly` keeps focus during `onAdd`, but
-      // some browsers / parent updates can still drop it.
-      queueMicrotask(() => {
-        const el = inputRef.current;
-        if (el) {
-          el.focus();
-          setInputFocused(true);
-        }
-      });
+      queueMicrotask(() => inputRef.current?.focus());
     }
-  }, [text, submitAssigneeSId, isAdding, onAdd]);
-
-  const sideChromeToneClass = cn(
-    "transition-opacity duration-300 ease-in-out motion-reduce:transition-none motion-reduce:duration-75",
-    isExpanded ? "opacity-100" : "opacity-[0.4] hover:opacity-[0.88]"
-  );
-
-  const assigneeChromeToneClass = cn(
-    "transition-[opacity,filter] duration-300 ease-in-out motion-reduce:transition-none motion-reduce:duration-75",
-    isExpanded
-      ? "opacity-100 grayscale-0 brightness-100"
-      : "opacity-[0.42] grayscale brightness-[0.88] hover:opacity-[0.9] hover:grayscale-[0.12] hover:brightness-100"
-  );
+  };
 
   return (
-    <div ref={containerRef} className={PROJECT_TODO_TABLE_ROW_INSET_CLASS}>
-      <div className={PROJECT_TODO_ITEM_ROW_FRAME_CLASS}>
-        {hideAssigneePicker ? (
-          <div className={PROJECT_TODO_MANUAL_ADD_LEADING_CLASS} aria-hidden />
-        ) : (
-          <div className={PROJECT_TODO_MANUAL_ADD_LEADING_CLASS}>
-            <div
-              className={cn(
-                PROJECT_TODO_MANUAL_ADD_LEADING_ASSIGNEE_ANCHOR_CLASS,
-                assigneeChromeToneClass
-              )}
-            >
-              <TodoRowAssigneeMenu
-                ariaNamePrefix="add-task"
-                members={projectMembers}
-                viewerUserId={viewerUserId}
-                defaultAssigneeSId={defaultAssigneeSId}
-                choice={assigneeChoice}
-                onChoiceChange={setAssigneeChoice}
-                onMenuOpenChange={setAssigneeMenuOpen}
-                disabled={isAdding}
-              />
-            </div>
-          </div>
-        )}
-        <div className="flex min-w-0 flex-1 items-center gap-1">
-          <div
-            className={cn(
-              "box-border flex h-[2.375rem] min-h-[2.375rem] min-w-0 max-w-3xl flex-1 flex-col justify-center rounded-md",
-              "border border-border/55 bg-muted-background/70 px-2 py-1.5",
-              "cursor-text transition-colors hover:bg-muted-background/85 dark:border-border-night/55 dark:bg-muted-background-night/45 dark:hover:bg-muted-background-night/60",
-              "focus-within:border-border-highlight focus-within:ring-2 focus-within:ring-highlight/35 dark:focus-within:border-highlight-night"
-            )}
-          >
-            <input
-              ref={inputRef}
-              type="text"
-              name="new-manual-project-task"
-              aria-label="New task"
-              autoComplete="off"
-              maxLength={NEW_MANUAL_TASK_MAX_CHARS}
-              placeholder={MANUAL_ADD_TASK_PLACEHOLDER}
-              value={text}
-              readOnly={isAdding}
-              aria-busy={isAdding}
-              className={cn(
-                MANUAL_ADD_TODO_INPUT_FIELD_CLASS,
-                isAdding && "cursor-wait opacity-60"
-              )}
-              onChange={(e) => setText(stripNewlines(e.target.value))}
-              onFocus={() => setInputFocused(true)}
-              onBlur={(e) => {
-                const next = e.relatedTarget;
-                if (
-                  next instanceof Node &&
-                  containerRef.current?.contains(next)
-                ) {
-                  return;
-                }
-                setInputFocused(false);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  e.preventDefault();
-                  inputRef.current?.blur();
-                  setInputFocused(false);
-                  return;
-                }
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  void handleSubmit();
-                }
-              }}
-            />
-          </div>
-          <div
-            className={cn(
-              PROJECT_TODO_EDIT_ACTION_CLUSTER_CLASS,
-              sideChromeToneClass
-            )}
-          >
-            <Button
-              size="sm"
-              variant="highlight"
-              label="Add"
-              isLoading={isAdding}
-              disabled={isAdding || !stripNewlines(text).trim()}
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={() => void handleSubmit()}
-            />
-          </div>
-        </div>
-      </div>
+    <div className="flex w-full min-w-0 items-center gap-2">
+      {!hideAssigneePicker && (
+        <TaskRowAssigneeMenu
+          members={projectMembers}
+          viewerUserId={viewerUserId}
+          defaultAssigneeSId={defaultAssigneeSId}
+          choice={assigneeChoice}
+          onChoiceChange={setAssigneeChoice}
+          disabled={isAdding}
+        />
+      )}
+      <Input
+        ref={inputRef}
+        name="new-manual-project-task"
+        aria-label="New task"
+        autoComplete="off"
+        maxLength={NEW_MANUAL_TASK_MAX_CHARS}
+        placeholder={MANUAL_ADD_TASK_PLACEHOLDER}
+        value={text}
+        readOnly={isAdding}
+        aria-busy={isAdding}
+        containerClassName="min-w-0 flex-1"
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            inputRef.current?.blur();
+            return;
+          }
+          if (e.key === "Enter") {
+            e.preventDefault();
+            void handleSubmit();
+          }
+        }}
+      />
+      <Button
+        size="sm"
+        variant="highlight"
+        label="Add"
+        isLoading={isAdding}
+        disabled={isAdding || !text.trim()}
+        onClick={() => void handleSubmit()}
+      />
     </div>
   );
 }

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksDataTableCell.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksDataTableCell.tsx
@@ -150,7 +150,7 @@ export function ProjectTasksDataTableCell({
   const task = original.task;
 
   return (
-    <div className="py-0.5 pl-4 pr-0">
+    <>
       {variant === "suggested" ? (
         <SuggestedTaskItem
           key={task.sId}
@@ -186,7 +186,7 @@ export function ProjectTasksDataTableCell({
           allowAssigneeReassign={allowAssigneeReassign}
         />
       )}
-    </div>
+    </>
   );
 }
 

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelMain.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelMain.tsx
@@ -1,4 +1,4 @@
-import { AddTodoComposer } from "@app/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer";
+import { AddTaskComposer } from "@app/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer";
 import { ProjectTasksDataTable } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksDataTable";
 import { useProjectTasksPanel } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelContext";
 import { normalizeProjectTaskSearchNeedle } from "@app/components/assistant/conversation/space/conversations/project_tasks/utils";
@@ -49,7 +49,7 @@ export function ProjectTasksPanelMain() {
               No project members available to assign.
             </p>
           ) : (
-            <AddTodoComposer
+            <AddTaskComposer
               projectMembers={projectMembers}
               viewerUserId={viewerUserId}
               defaultAssigneeSId={defaultNewAssigneeSId!}

--- a/front/components/assistant/conversation/space/conversations/project_tasks/utils.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/utils.ts
@@ -84,47 +84,6 @@ export function useAutosizeTextArea(
   }, [active, adjustHeight]);
 }
 
-/** Indents standalone rows (e.g. add block) to match `ProjectTasksDataTable` task rows. */
-export const PROJECT_TODO_TABLE_ROW_INSET_CLASS = "pl-4 pr-0";
-
-/** Outer frame for the manual-add row (avatar · input · action). */
-export const PROJECT_TODO_ITEM_ROW_FRAME_CLASS =
-  "flex w-full min-w-0 items-center gap-3 rounded-md px-1 py-1";
-
-/**
- * Manual-add gutter width: matches task rows (`Checkbox` / leading icon = `size-4`)
- * so the input lines up under task text.
- */
-export const PROJECT_TODO_MANUAL_ADD_LEADING_CLASS =
-  "relative h-[2.375rem] w-4 shrink-0 flex-none overflow-visible";
-
-/** Centers `size-7` assignee control in the narrow gutter without affecting layout width */
-export const PROJECT_TODO_MANUAL_ADD_LEADING_ASSIGNEE_ANCHOR_CLASS =
-  "absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 shrink-0";
-
-/** Invisible spacer in the checkbox / sparkles column when that column is unused. */
-export const PROJECT_TODO_LEADING_GUTTER_CLASS =
-  "mt-0.5 flex size-4 shrink-0 items-center justify-center";
-
-/** Manual-add trailing actions: hugs the input (`w-auto`); height `2.375rem` matches shell. */
-export const PROJECT_TODO_EDIT_ACTION_CLUSTER_CLASS =
-  "flex h-[2.375rem] w-auto shrink-0 flex-none items-center justify-start gap-1";
-
-/** Single-line field inside the manual-add shell (paired with TODO_TEXTAREA styling). */
-export const MANUAL_ADD_TODO_INPUT_FIELD_CLASS = cn(
-  "m-0 block h-[1.5rem] w-full min-w-0 border-0 bg-transparent px-0 py-0 align-middle text-base leading-6 text-foreground",
-  "shadow-none [box-shadow:none]",
-  "outline-none ring-0 ring-offset-0",
-  "focus:shadow-none focus:[box-shadow:none] focus:outline-none focus:ring-0 focus:ring-offset-0",
-  // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
-  "focus:!ring-0 focus:!ring-offset-0",
-  "focus-visible:shadow-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
-  // biome-ignore lint/plugin/noCssImportant: legacy [GEN12] — needs cleanup
-  "focus-visible:!ring-0",
-  "placeholder:text-muted-foreground",
-  "dark:text-foreground-night dark:placeholder:text-muted-foreground-night"
-);
-
 export const TODO_TEXTAREA_FIELD_CLASS = cn(
   "m-0 block min-h-[1.5rem] w-full min-w-0 resize-none overflow-hidden border-0 bg-transparent px-0 py-0 align-top text-base leading-6 text-foreground break-words",
   "shadow-none [box-shadow:none]",


### PR DESCRIPTION
## Description

Further simplifies the `AddTodoComposer` layout and state management by switching to modern Sparkle components and removing legacy CSS utility classes. The composer now uses `Input` and `Button` from Sparkle instead of custom-styled HTML elements, eliminates unnecessary focus state tracking, and streamlines the assignee menu implementation by removing redundant local open/close state handling.

## Tests

- [x] Locally
- [ ] 
## Risk

Low

## Deploy Plan

- Deploy `front`