### PR TITLE
Skip tables_query for delimited files in sandbox workspaces

### DIFF
--- a/extension/ui/hooks/useFileUploaderService.ts
+++ b/extension/ui/hooks/useFileUploaderService.ts
@@ -41,7 +41,6 @@ export function useFileUploaderService(
     getFileBlobs,
     isProcessingFiles,
   } = useFrontFileUploaderService({
-    hasNewFileExplorer: false,
     hasSandboxTools: false,
     owner: workspace,
     useCase: "conversation",

--- a/extension/ui/hooks/useFileUploaderService.ts
+++ b/extension/ui/hooks/useFileUploaderService.ts
@@ -41,6 +41,8 @@ export function useFileUploaderService(
     getFileBlobs,
     isProcessingFiles,
   } = useFrontFileUploaderService({
+    hasNewFileExplorer: false,
+    hasSandboxTools: false,
     owner: workspace,
     useCase: "conversation",
     useCaseMetadata,

--- a/front/components/agent_builder/settings/avatar_picker/AgentBuilderCustomUpload.tsx
+++ b/front/components/agent_builder/settings/avatar_picker/AgentBuilderCustomUpload.tsx
@@ -37,7 +37,6 @@ const AgentBuilderCustomUpload = forwardRef<
   const imageRef = useRef<HTMLImageElement | null>(null);
 
   const fileUploaderService = useFileUploaderService({
-    hasNewFileExplorer: false,
     hasSandboxTools: false,
     owner,
     useCase: "avatar",

--- a/front/components/agent_builder/settings/avatar_picker/AgentBuilderCustomUpload.tsx
+++ b/front/components/agent_builder/settings/avatar_picker/AgentBuilderCustomUpload.tsx
@@ -37,6 +37,8 @@ const AgentBuilderCustomUpload = forwardRef<
   const imageRef = useRef<HTMLImageElement | null>(null);
 
   const fileUploaderService = useFileUploaderService({
+    hasNewFileExplorer: false,
+    hasSandboxTools: false,
     owner,
     useCase: "avatar",
   });

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -161,7 +161,6 @@ export function InputBarProvider({ children }: InputBarProviderProps) {
   }, [conversationId]);
 
   const fileUploaderService = useFileUploaderService({
-    hasNewFileExplorer: hasFeature("new_file_explorer"),
     hasSandboxTools: hasFeature("sandbox_tools"),
     owner: workspace,
     useCase: "conversation",

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -3,7 +3,7 @@ import {
   type FileUploaderService,
   useFileUploaderService,
 } from "@app/hooks/useFileUploaderService";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { RichAgentMention } from "@app/types/assistant/mentions";
 import {
   createContext,
@@ -149,6 +149,7 @@ export function InputBarProvider({ children }: InputBarProviderProps) {
   const conversationId = useActiveConversationId();
 
   const { workspace } = useAuth();
+  const { hasFeature } = useFeatureFlags();
 
   const useCaseMetadata = useMemo(() => {
     if (!conversationId) {
@@ -160,6 +161,8 @@ export function InputBarProvider({ children }: InputBarProviderProps) {
   }, [conversationId]);
 
   const fileUploaderService = useFileUploaderService({
+    hasNewFileExplorer: hasFeature("new_file_explorer"),
+    hasSandboxTools: hasFeature("sandbox_tools"),
     owner: workspace,
     useCase: "conversation",
     useCaseMetadata,

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -61,6 +61,8 @@ export function createPlaceholderUserMessage({
             type: "content_fragment" as const,
             contentFragmentType: "file" as const,
             fileId: cf.fileId,
+            mountRelativePath: null,
+            skipFileProcessing: false,
             title: cf.title,
             snippet: null,
             generatedTables: [],

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -61,7 +61,7 @@ export function createPlaceholderUserMessage({
             type: "content_fragment" as const,
             contentFragmentType: "file" as const,
             fileId: cf.fileId,
-            mountRelativePath: null,
+            path: null,
             skipFileProcessing: false,
             title: cf.title,
             snippet: null,

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -231,6 +231,8 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
   });
 
   const projectFileUpload = useFileUploaderService({
+    hasNewFileExplorer: false,
+    hasSandboxTools: false,
     owner,
     useCase: "project_context",
     useCaseMetadata: {

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -231,7 +231,6 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
   });
 
   const projectFileUpload = useFileUploaderService({
-    hasNewFileExplorer: false,
     hasSandboxTools: false,
     owner,
     useCase: "project_context",

--- a/front/components/data_source/DocumentUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentUploadOrEditModal.tsx
@@ -89,7 +89,6 @@ export const DocumentUploadOrEditModal = ({
     mimeType: null,
   });
   const fileUploaderService = useFileUploaderService({
-    hasNewFileExplorer: false,
     hasSandboxTools: false,
     owner,
     useCase: "folders_document",

--- a/front/components/data_source/DocumentUploadOrEditModal.tsx
+++ b/front/components/data_source/DocumentUploadOrEditModal.tsx
@@ -89,6 +89,8 @@ export const DocumentUploadOrEditModal = ({
     mimeType: null,
   });
   const fileUploaderService = useFileUploaderService({
+    hasNewFileExplorer: false,
+    hasSandboxTools: false,
     owner,
     useCase: "folders_document",
     useCaseMetadata: {

--- a/front/components/data_source/MultipleFilesUpload.tsx
+++ b/front/components/data_source/MultipleFilesUpload.tsx
@@ -78,6 +78,8 @@ export const MultipleFilesUpload = ({
 
   // Used for creating document files, with text extraction post-processing
   const documentUploaderService = useFileUploaderService({
+    hasNewFileExplorer: false,
+    hasSandboxTools: false,
     owner,
     useCase: useCaseForDocument,
     useCaseMetadata: {
@@ -87,6 +89,8 @@ export const MultipleFilesUpload = ({
 
   // Used for creating table files (CSV, XLS, XLSX) with structured data processing
   const tableUploaderService = useFileUploaderService({
+    hasNewFileExplorer: false,
+    hasSandboxTools: false,
     owner,
     useCase: "upsert_table",
     useCaseMetadata: {

--- a/front/components/data_source/MultipleFilesUpload.tsx
+++ b/front/components/data_source/MultipleFilesUpload.tsx
@@ -78,7 +78,6 @@ export const MultipleFilesUpload = ({
 
   // Used for creating document files, with text extraction post-processing
   const documentUploaderService = useFileUploaderService({
-    hasNewFileExplorer: false,
     hasSandboxTools: false,
     owner,
     useCase: useCaseForDocument,
@@ -89,7 +88,6 @@ export const MultipleFilesUpload = ({
 
   // Used for creating table files (CSV, XLS, XLSX) with structured data processing
   const tableUploaderService = useFileUploaderService({
-    hasNewFileExplorer: false,
     hasSandboxTools: false,
     owner,
     useCase: "upsert_table",

--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -82,6 +82,8 @@ export const TableUploadOrEditModal = ({
 
   // Get the processed file content from the file API
   const fileUploaderService = useFileUploaderService({
+    hasNewFileExplorer: false,
+    hasSandboxTools: false,
     owner,
     useCase: "upsert_table",
     useCaseMetadata: {

--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -82,7 +82,6 @@ export const TableUploadOrEditModal = ({
 
   // Get the processed file content from the file API
   const fileUploaderService = useFileUploaderService({
-    hasNewFileExplorer: false,
     hasSandboxTools: false,
     owner,
     useCase: "upsert_table",

--- a/front/components/me/AccountSettings.tsx
+++ b/front/components/me/AccountSettings.tsx
@@ -73,7 +73,6 @@ export function AccountSettings({ owner }: AccountSettingsProps) {
   const [hasNotificationChanges, setHasNotificationChanges] = useState(false);
 
   const fileUploaderService = useFileUploaderService({
-    hasNewFileExplorer: false,
     hasSandboxTools: false,
     owner,
     useCase: "avatar",

--- a/front/components/me/AccountSettings.tsx
+++ b/front/components/me/AccountSettings.tsx
@@ -73,6 +73,8 @@ export function AccountSettings({ owner }: AccountSettingsProps) {
   const [hasNotificationChanges, setHasNotificationChanges] = useState(false);
 
   const fileUploaderService = useFileUploaderService({
+    hasNewFileExplorer: false,
+    hasSandboxTools: false,
     owner,
     useCase: "avatar",
   });

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -37,7 +37,6 @@ export function SkillBuilderFilesSection() {
   const fileListBottomSentinelRef = useRef<HTMLDivElement>(null);
 
   const { handleFilesUpload, isProcessingFiles } = useFileUploaderService({
-    hasNewFileExplorer: false,
     hasSandboxTools: false,
     owner,
     useCase: "skill_attachment",

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -37,6 +37,8 @@ export function SkillBuilderFilesSection() {
   const fileListBottomSentinelRef = useRef<HTMLDivElement>(null);
 
   const { handleFilesUpload, isProcessingFiles } = useFileUploaderService({
+    hasNewFileExplorer: false,
+    hasSandboxTools: false,
     owner,
     useCase: "skill_attachment",
     useCaseMetadata: skillId ? { skillId } : undefined,

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -6,18 +6,19 @@ import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files
 import type { FileUploadedRequestResponseBody } from "@app/pages/api/w/[wId]/files/[fileId]";
 import { isAPIErrorResponse } from "@app/types/error";
 import type {
-  FileFormatCategory,
   FileUseCase,
   FileUseCaseMetadata,
   SupportedFileContentType,
 } from "@app/types/files";
 import {
+  contentTypeFromFileName,
   DEFAULT_FILE_CONTENT_TYPE,
   ensureFileSizeByFormatCategory,
+  fileSizeToHumanReadable,
   getFileFormatCategory,
   isSupportedFileContentType,
-  MAX_FILE_SIZES,
   resolveFileContentType,
+  resolveMaxFileSizes,
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -49,10 +50,14 @@ class FileBlobUploadError extends Error {
 }
 
 export function useFileUploaderService({
+  hasNewFileExplorer,
+  hasSandboxTools,
   owner,
   useCase,
   useCaseMetadata,
 }: {
+  hasNewFileExplorer: boolean;
+  hasSandboxTools: boolean;
   owner: LightWorkspaceType;
   useCase: FileUseCase;
   useCaseMetadata?: FileUseCaseMetadata;
@@ -63,6 +68,32 @@ export function useFileUploaderService({
   const isProcessingFiles = numFilesProcessing > 0;
 
   const sendNotification = useSendNotification();
+
+  const sizeResolverOpts = useMemo(
+    () => ({
+      hasNewFileExplorer,
+      hasSandboxTools,
+      useCase,
+    }),
+    [hasNewFileExplorer, hasSandboxTools, useCase]
+  );
+
+  const maxFileSizes = useMemo(
+    () => resolveMaxFileSizes(sizeResolverOpts),
+    [sizeResolverOpts]
+  );
+
+  const resolveSelectedFileContentType = useCallback((file: File): string => {
+    const resolvedContentType = resolveFileContentType(file.type, file.name);
+    if (isSupportedFileContentType(resolvedContentType)) {
+      return resolvedContentType;
+    }
+
+    return (
+      contentTypeFromFileName(file.name) ??
+      (resolvedContentType || DEFAULT_FILE_CONTENT_TYPE)
+    );
+  }, []);
 
   const findAvailableTitle = useCallback(
     (baseTitle: string, ext: string, existingTitles: string[]) => {
@@ -95,9 +126,7 @@ export function useFileUploaderService({
 
       return selectedFiles.reduce<Result<FileBlob, FileBlobUploadError>[]>(
         (acc, file) => {
-          const fileType =
-            resolveFileContentType(file.type, file.name) ||
-            DEFAULT_FILE_CONTENT_TYPE;
+          const fileType = resolveSelectedFileContentType(file);
 
           // File objects are immutable - we can't modify their properties directly.
           // When we need to change the name or type, we must create a new File object.
@@ -121,7 +150,7 @@ export function useFileUploaderService({
         []
       );
     },
-    [fileBlobs, findAvailableTitle]
+    [fileBlobs, findAvailableTitle, resolveSelectedFileContentType]
   );
 
   const uploadFiles = useCallback(
@@ -284,36 +313,33 @@ export function useFileUploaderService({
     async (files: File[]) => {
       setNumFilesProcessing((prev) => prev + files.length);
 
-      const categoryToSize: Map<FileFormatCategory, number> = new Map();
+      const oversizedFiles = files
+        .map((file) => {
+          const contentType = resolveSelectedFileContentType(file);
+          const category = getFileFormatCategory(contentType) ?? "data";
+          return { category, file };
+        })
+        .filter(({ category, file }) => {
+          return !ensureFileSizeByFormatCategory(
+            category,
+            file.size,
+            sizeResolverOpts
+          );
+        });
 
-      for (const f of [...fileBlobs, ...files]) {
-        const contentType = f instanceof File ? f.type : f.contentType;
-
-        const category = getFileFormatCategory(contentType) ?? "data";
-        // The fallback should never happen, but let's avoid a crash.
-
-        categoryToSize.set(
-          category,
-          (categoryToSize.get(category) ?? 0) + f.size
-        );
-      }
-
-      const oversizedCategories = [...categoryToSize].filter(([cat, size]) => {
-        return !ensureFileSizeByFormatCategory(cat, size);
-      });
-
-      for (const cat of oversizedCategories) {
+      for (const { category, file } of oversizedFiles) {
         sendNotification({
           type: "error",
-          title: "Files too large.",
-          description: `Combined ${cat[0]} file sizes exceed the limit of ${MAX_FILE_SIZES[cat[0]] / 1024 / 1024}MB. Please upload smaller files.`,
+          title: "File too large.",
+          description: `File "${file.name}" (${fileSizeToHumanReadable(file.size)}) exceeds the ${category} limit of ${fileSizeToHumanReadable(maxFileSizes[category])}. Please upload a smaller file.`,
         });
       }
 
-      if (oversizedCategories.length > 0) {
+      if (oversizedFiles.length > 0) {
         setNumFilesProcessing((prev) => prev - files.length);
         return;
       }
+
       const previewResults = processSelectedFiles(files);
       const newFileBlobs = processResults(previewResults, true);
 
@@ -325,10 +351,12 @@ export function useFileUploaderService({
       return finalFileBlobs;
     },
     [
-      fileBlobs,
+      maxFileSizes,
       processResults,
       processSelectedFiles,
+      resolveSelectedFileContentType,
       sendNotification,
+      sizeResolverOpts,
       uploadFiles,
     ]
   );

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -50,13 +50,11 @@ class FileBlobUploadError extends Error {
 }
 
 export function useFileUploaderService({
-  hasNewFileExplorer,
   hasSandboxTools,
   owner,
   useCase,
   useCaseMetadata,
 }: {
-  hasNewFileExplorer: boolean;
   hasSandboxTools: boolean;
   owner: LightWorkspaceType;
   useCase: FileUseCase;
@@ -71,11 +69,10 @@ export function useFileUploaderService({
 
   const sizeResolverOpts = useMemo(
     () => ({
-      hasNewFileExplorer,
       hasSandboxTools,
       useCase,
     }),
-    [hasNewFileExplorer, hasSandboxTools, useCase]
+    [hasSandboxTools, useCase]
   );
 
   const maxFileSizes = useMemo(

--- a/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
@@ -17,6 +17,7 @@ function makeFileAttachment(
     isQueryable: false,
     creator: null,
     source: null,
+    mountRelativePath: null,
     hidden: false,
     ...partial,
   };

--- a/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
@@ -17,7 +17,7 @@ function makeFileAttachment(
     isQueryable: false,
     creator: null,
     source: null,
-    mountRelativePath: null,
+    path: null,
     hidden: false,
     ...partial,
   };

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -143,7 +143,13 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
           continue;
         }
 
-        if (!ensureFileSize(contentType, attachment.size)) {
+        if (
+          !ensureFileSize(contentType, attachment.size, {
+            hasNewFileExplorer: false,
+            hasSandboxTools: false,
+            useCase: "conversation",
+          })
+        ) {
           contentBlocks.push({
             type: "text" as const,
             text:

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -145,7 +145,6 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
 
         if (
           !ensureFileSize(contentType, attachment.size, {
-            hasNewFileExplorer: false,
             hasSandboxTools: false,
             useCase: "conversation",
           })

--- a/front/lib/api/assistant/content_fragments.test.ts
+++ b/front/lib/api/assistant/content_fragments.test.ts
@@ -34,6 +34,8 @@ function createMockContentFragment(
     contentFragmentVersion: "latest",
     expiredReason: null,
     contentFragmentType: "file",
+    mountRelativePath: null,
+    skipFileProcessing: false,
     fileId: generateRandomModelSId(),
     snippet: null,
     generatedTables: [],

--- a/front/lib/api/assistant/content_fragments.test.ts
+++ b/front/lib/api/assistant/content_fragments.test.ts
@@ -34,7 +34,7 @@ function createMockContentFragment(
     contentFragmentVersion: "latest",
     expiredReason: null,
     contentFragmentType: "file",
-    mountRelativePath: null,
+    path: null,
     skipFileProcessing: false,
     fileId: generateRandomModelSId(),
     snippet: null,

--- a/front/lib/api/assistant/conversation/attachments.test.ts
+++ b/front/lib/api/assistant/conversation/attachments.test.ts
@@ -87,7 +87,7 @@ function makeFileContentFragment({
     contentFragmentVersion: "latest",
     expiredReason: null,
     contentFragmentType: "file",
-    mountRelativePath: "conversation/data.csv",
+    path: "conversation/data.csv",
     skipFileProcessing,
     fileId: "fil_123",
     snippet,
@@ -110,7 +110,7 @@ describe("getAttachmentFromFileContentFragment", () => {
     expect(attachment?.isQueryable).toBe(false);
     expect(attachment?.isIncludable).toBe(false);
     expect(attachment?.generatedTables).toEqual([]);
-    expect(attachment?.mountRelativePath).toBe("conversation/data.csv");
+    expect(attachment?.path).toBe("conversation/data.csv");
   });
 
   it("keeps old-style CSV files queryable when skipFileProcessing is false", () => {

--- a/front/lib/api/assistant/conversation/attachments.test.ts
+++ b/front/lib/api/assistant/conversation/attachments.test.ts
@@ -1,4 +1,8 @@
-import { makeFileAttachment } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  getAttachmentFromFileContentFragment,
+  makeFileAttachment,
+} from "@app/lib/api/assistant/conversation/attachments";
+import type { FileContentFragmentType } from "@app/types/content_fragment";
 import { describe, expect, it } from "vitest";
 
 describe("makeFileAttachment", () => {
@@ -49,5 +53,85 @@ describe("makeFileAttachment", () => {
     });
 
     expect(attachment.isSearchable).toBe(false);
+  });
+});
+
+function makeFileContentFragment({
+  isInProjectContext = false,
+  skipFileProcessing = false,
+  snippet = "snippet",
+}: {
+  isInProjectContext?: boolean;
+  skipFileProcessing?: boolean;
+  snippet?: string | null;
+}): FileContentFragmentType {
+  return {
+    type: "content_fragment",
+    id: 1,
+    sId: "cf_123",
+    created: Date.now(),
+    visibility: "visible",
+    version: 1,
+    rank: 0,
+    branchId: null,
+    sourceUrl: null,
+    title: "data.csv",
+    contentType: "text/csv",
+    context: {
+      username: null,
+      fullName: null,
+      email: null,
+      profilePictureUrl: null,
+    },
+    contentFragmentId: "cf_123",
+    contentFragmentVersion: "latest",
+    expiredReason: null,
+    contentFragmentType: "file",
+    mountRelativePath: "conversation/data.csv",
+    skipFileProcessing,
+    fileId: "fil_123",
+    snippet,
+    generatedTables: [],
+    textUrl: "",
+    textBytes: null,
+    sourceProvider: null,
+    sourceIcon: null,
+    isInProjectContext,
+    hidden: false,
+  };
+}
+
+describe("getAttachmentFromFileContentFragment", () => {
+  it("suppresses queryable and includable hints for raw sandbox delimited files", () => {
+    const attachment = getAttachmentFromFileContentFragment(
+      makeFileContentFragment({ skipFileProcessing: true })
+    );
+
+    expect(attachment?.isQueryable).toBe(false);
+    expect(attachment?.isIncludable).toBe(false);
+    expect(attachment?.generatedTables).toEqual([]);
+    expect(attachment?.mountRelativePath).toBe("conversation/data.csv");
+  });
+
+  it("keeps old-style CSV files queryable when skipFileProcessing is false", () => {
+    const attachment = getAttachmentFromFileContentFragment(
+      makeFileContentFragment({ skipFileProcessing: false })
+    );
+
+    expect(attachment?.isQueryable).toBe(true);
+    expect(attachment?.isIncludable).toBe(true);
+    expect(attachment?.generatedTables).toEqual(["fil_123"]);
+  });
+
+  it("does not suppress project-context CSV hints", () => {
+    const attachment = getAttachmentFromFileContentFragment(
+      makeFileContentFragment({
+        isInProjectContext: true,
+        skipFileProcessing: true,
+      })
+    );
+
+    expect(attachment?.isQueryable).toBe(true);
+    expect(attachment?.isIncludable).toBe(true);
   });
 });

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -49,7 +49,7 @@ export type BaseConversationAttachmentType = {
 
 export type FileAttachmentType = BaseConversationAttachmentType & {
   fileId: string;
-  mountRelativePath: string | null;
+  path: string | null;
   source: "agent" | "user" | null;
   createdAt?: number;
   updatedAt?: number;
@@ -256,7 +256,7 @@ export function getAttachmentFromFileContentFragment(
   return {
     ...baseAttachment,
     fileId,
-    mountRelativePath: cf.mountRelativePath ?? null,
+    path: cf.path ?? null,
     source: "user",
     createdAt: cf.created,
   };
@@ -273,7 +273,7 @@ export function makeFileAttachment({
   isInProjectContext,
   hideFromUser,
   skipDataSourceIndexing = false,
-  mountRelativePath = null,
+  path = null,
   creator = null,
 }: {
   fileId: string;
@@ -286,7 +286,7 @@ export function makeFileAttachment({
   isInProjectContext: boolean;
   hideFromUser: boolean;
   skipDataSourceIndexing?: boolean;
-  mountRelativePath?: string | null;
+  path?: string | null;
   creator?: AttachmentCreator | null;
 }): FileAttachmentType {
   const canDoJIT = snippet !== null;
@@ -299,7 +299,7 @@ export function makeFileAttachment({
 
   return {
     fileId,
-    mountRelativePath,
+    path,
     source,
     createdAt,
     updatedAt,

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -22,6 +22,7 @@ import {
 import type { ContentNodeType } from "@app/types/core/content_node";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import type { AllSupportedFileContentType } from "@app/types/files";
+import { isSupportedDelimitedTextContentType } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { CONTENT_NODE_MIME_TYPES } from "@dust-tt/client";
@@ -48,6 +49,7 @@ export type BaseConversationAttachmentType = {
 
 export type FileAttachmentType = BaseConversationAttachmentType & {
   fileId: string;
+  mountRelativePath: string | null;
   source: "agent" | "user" | null;
   createdAt?: number;
   updatedAt?: number;
@@ -173,6 +175,22 @@ export function getAttachmentFromContentNodeContentFragment(
   };
 }
 
+function shouldSuppressTabularAttachmentHints({
+  contentType,
+  isInProjectContext,
+  skipFileProcessing,
+}: {
+  contentType: SupportedContentFragmentType;
+  isInProjectContext: boolean | null;
+  skipFileProcessing: boolean;
+}): boolean {
+  return (
+    isInProjectContext !== true &&
+    skipFileProcessing &&
+    isSupportedDelimitedTextContentType(contentType)
+  );
+}
+
 export function getAttachmentFromFileContentFragment(
   cf: FileContentFragmentType
 ): FileAttachmentType | null {
@@ -192,8 +210,19 @@ export function getAttachmentFromFileContentFragment(
   // actions, and differentiate them from the newer file attachments that do have a snippet.
   // Former ones cannot be used in JIT.
   const canDoJIT = cf.snippet !== null;
-  const isQueryable = canDoJIT && isQueryableContentType(cf.contentType);
-  const isIncludable = isConversationIncludableFileContentType(cf.contentType);
+  const isInProjectContext = cf.isInProjectContext === true;
+  const shouldSuppressTabularHints = shouldSuppressTabularAttachmentHints({
+    contentType: cf.contentType,
+    isInProjectContext,
+    skipFileProcessing: cf.skipFileProcessing === true,
+  });
+  const isQueryable =
+    !shouldSuppressTabularHints &&
+    canDoJIT &&
+    isQueryableContentType(cf.contentType);
+  const isIncludable =
+    !shouldSuppressTabularHints &&
+    isConversationIncludableFileContentType(cf.contentType);
   const isSearchable = canDoJIT && isSearchableContentType(cf.contentType);
   const creator: AttachmentCreator | null = cf.context.fullName
     ? {
@@ -219,7 +248,7 @@ export function getAttachmentFromFileContentFragment(
     isIncludable,
     isQueryable,
     isSearchable,
-    isInProjectContext: cf.isInProjectContext,
+    isInProjectContext,
     hidden: cf.hidden,
     creator,
   };
@@ -227,6 +256,7 @@ export function getAttachmentFromFileContentFragment(
   return {
     ...baseAttachment,
     fileId,
+    mountRelativePath: cf.mountRelativePath ?? null,
     source: "user",
     createdAt: cf.created,
   };
@@ -243,6 +273,7 @@ export function makeFileAttachment({
   isInProjectContext,
   hideFromUser,
   skipDataSourceIndexing = false,
+  mountRelativePath = null,
   creator = null,
 }: {
   fileId: string;
@@ -255,6 +286,7 @@ export function makeFileAttachment({
   isInProjectContext: boolean;
   hideFromUser: boolean;
   skipDataSourceIndexing?: boolean;
+  mountRelativePath?: string | null;
   creator?: AttachmentCreator | null;
 }): FileAttachmentType {
   const canDoJIT = snippet !== null;
@@ -267,6 +299,7 @@ export function makeFileAttachment({
 
   return {
     fileId,
+    mountRelativePath,
     source,
     createdAt,
     updatedAt,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -12,6 +12,7 @@ import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/conversat
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
+import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import {
   isFileTypeUpsertableForUseCase,
   processAndUpsertToDataSource,
@@ -297,6 +298,10 @@ async function addFileToConversationDatasource(
     carriedFile: FileResource;
   }
 ): Promise<void> {
+  if (isSandboxRawDelimitedConversationFile(carriedFile)) {
+    return;
+  }
+
   const childDataSourceRes = await getOrCreateConversationDataSourceFromFile(
     auth,
     carriedFile
@@ -494,6 +499,7 @@ async function carryOverConversationAttachments(
       const shouldCopyFileToDatasource =
         carriedFile !== null &&
         !carriedFile.useCaseMetadata?.skipDataSourceIndexing &&
+        !isSandboxRawDelimitedConversationFile(carriedFile) &&
         isFileTypeUpsertableForUseCase(carriedFile);
 
       if (shouldCopyFileToDatasource) {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -354,12 +354,20 @@ function constructAttachmentsSection(): string {
   );
 }
 
-function constructAttachmentsSectionNewFileExplorer(): string {
+function constructAttachmentsSectionNewFileExplorer({
+  hasSandboxTools,
+}: {
+  hasSandboxTools: boolean;
+}): string {
+  const tabularFilesLine = hasSandboxTools
+    ? '- Tabular files (CSV, spreadsheets) attached as `<file>` tags are mounted under /files/conversation; analyze them with code via the sandbox. Tabular files attached as `<attachment isQueryable="true">` tags (for example tool-generated CSVs) remain queryable via the query tables tool;\n'
+    : "- Tabular files (CSV, spreadsheets) are queryable via the query tables tool;\n";
+
   return (
     "# FILES\n" +
     `Files attached to the conversation are accessible via the \`${FILES_SERVER_NAME}\` server.\n\n` +
     "Some attachments remain visible in the conversation history as metadata tags:\n\n" +
-    "- Tabular files (CSV, spreadsheets) are queryable via the query tables tool;\n" +
+    tabularFilesLine +
     "- Connected data references (content nodes with a `nodeId` and `sourceUrl`) appear as `<attachment>` tags; use the available search and retrieval tools to access their full content.\n\n" +
     "Pasted content appears inline in `<pastedContent>` tags and already contains the full text, no tool call needed.\n"
   );
@@ -484,6 +492,7 @@ export function constructPromptMultiActions(
     workspaceContext,
     projectContext,
     isNewFileExplorer = false,
+    hasSandboxTools = false,
   }: {
     userMessage: UserMessageType;
     agentConfiguration: AgentConfigurationType;
@@ -504,6 +513,7 @@ export function constructPromptMultiActions(
     workspaceContext?: string;
     projectContext?: string;
     isNewFileExplorer?: boolean;
+    hasSandboxTools?: boolean;
   }
 ): SystemPromptSections {
   const owner = auth.workspace();
@@ -549,7 +559,7 @@ export function constructPromptMultiActions(
         equippedSkills,
       });
   const attachmentsSection = isNewFileExplorer
-    ? constructAttachmentsSectionNewFileExplorer()
+    ? constructAttachmentsSectionNewFileExplorer({ hasSandboxTools })
     : constructAttachmentsSection();
   const pastedContentSection = constructPastedContentSection();
   const guidelinesSection = constructGuidelinesSection({ agentConfiguration });

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -78,6 +78,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          mountRelativePath: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
@@ -337,6 +338,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          mountRelativePath: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
@@ -392,6 +394,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          mountRelativePath: null,
           source: "user",
           title: "test.txt",
           contentType: "text/plain",
@@ -443,6 +446,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          mountRelativePath: null,
           source: "user",
           title: "test.txt",
           contentType: "text/plain",
@@ -485,6 +489,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          mountRelativePath: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
@@ -530,6 +535,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          mountRelativePath: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
@@ -583,6 +589,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          mountRelativePath: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
@@ -664,6 +671,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
+          mountRelativePath: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -78,7 +78,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
-          mountRelativePath: null,
+          path: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
@@ -338,7 +338,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
-          mountRelativePath: null,
+          path: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
@@ -394,7 +394,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
-          mountRelativePath: null,
+          path: null,
           source: "user",
           title: "test.txt",
           contentType: "text/plain",
@@ -446,7 +446,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
-          mountRelativePath: null,
+          path: null,
           source: "user",
           title: "test.txt",
           contentType: "text/plain",
@@ -489,7 +489,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
-          mountRelativePath: null,
+          path: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
@@ -535,7 +535,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
-          mountRelativePath: null,
+          path: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
@@ -589,7 +589,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
-          mountRelativePath: null,
+          path: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",
@@ -671,7 +671,7 @@ describe("getJITServers", () => {
       const attachments: ConversationAttachmentType[] = [
         {
           fileId: file.sId,
-          mountRelativePath: null,
+          path: null,
           source: "user",
           title: "test.csv",
           contentType: "text/csv",

--- a/front/lib/api/files/attachments.ts
+++ b/front/lib/api/files/attachments.ts
@@ -1,4 +1,5 @@
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
+import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import {
   isFileTypeUpsertableForUseCase,
   processAndUpsertToDataSource,
@@ -51,7 +52,10 @@ export async function maybeUpsertFileAttachment(
           });
 
           // Only upsert if the file is upsertable.
-          if (isFileTypeUpsertableForUseCase(fileResource)) {
+          if (
+            !isSandboxRawDelimitedConversationFile(fileResource) &&
+            isFileTypeUpsertableForUseCase(fileResource)
+          ) {
             const jitDataSource =
               await getOrCreateConversationDataSourceFromFile(
                 auth,

--- a/front/lib/api/files/processing.test.ts
+++ b/front/lib/api/files/processing.test.ts
@@ -242,4 +242,39 @@ describe("processAndStoreFile", () => {
     expect(writes).toHaveLength(1);
     expect(writes[0].contentType).toBe("text/plain");
   });
+
+  it("should skip processed version creation for raw sandbox spreadsheets", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+
+    const contentType =
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    const file = await FileFactory.create(auth, null, {
+      contentType,
+      fileName: "large.xlsx",
+      fileSize: 100,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: {
+        conversationId: "conv-raw",
+        skipDataSourceIndexing: true,
+        skipFileProcessing: true,
+      },
+    });
+
+    const result = await processAndStoreFile(auth, {
+      file,
+      content: { type: "string", value: "fake xlsx bytes" },
+    });
+
+    assert(
+      result.isOk(),
+      `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
+    );
+
+    const writes = fileStorageMock.writeStreamCalls;
+    expect(writes).toHaveLength(1);
+    expect(writes[0].contentType).toBe(contentType);
+  });
 });

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import { isSupportedForAvatar } from "@app/lib/api/files/use_cases/avatar";
 import { isSupportedForConversation } from "@app/lib/api/files/use_cases/conversation";
 import { isSupportedForFoldersDocument } from "@app/lib/api/files/use_cases/folders_document";
@@ -568,6 +569,10 @@ const maybeApplyProcessing = async (
   auth: Authenticator,
   file: FileResource
 ): Promise<Result<undefined, Error>> => {
+  if (isSandboxRawDelimitedConversationFile(file)) {
+    return new Ok(undefined);
+  }
+
   const entry = getProcessingEntry(file.contentType);
   if (!entry) {
     // No processing needed. The original file is used as-is.

--- a/front/lib/api/files/sandbox_raw.ts
+++ b/front/lib/api/files/sandbox_raw.ts
@@ -1,0 +1,74 @@
+import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import type {
+  AllSupportedFileContentType,
+  FileUseCase,
+  FileUseCaseMetadata,
+} from "@app/types/files";
+import { isSupportedDelimitedTextContentType } from "@app/types/files";
+
+export function isSandboxRawDelimitedConversationFile(
+  file: FileResource
+): boolean {
+  return (
+    file.useCase === "conversation" &&
+    file.useCaseMetadata?.skipFileProcessing === true &&
+    isSupportedDelimitedTextContentType(file.contentType)
+  );
+}
+
+export function shouldStampSandboxRawDelimited({
+  contentType,
+  flags,
+  useCase,
+}: {
+  contentType: AllSupportedFileContentType;
+  flags: { hasNewFileExplorer: boolean; hasSandboxTools: boolean };
+  useCase: FileUseCase;
+}): boolean {
+  return (
+    flags.hasSandboxTools &&
+    flags.hasNewFileExplorer &&
+    useCase === "conversation" &&
+    isSupportedDelimitedTextContentType(contentType)
+  );
+}
+
+export function buildEffectiveUseCaseMetadata({
+  contentType,
+  fileName,
+  flags,
+  providedMetadata,
+  useCase,
+}: {
+  contentType: AllSupportedFileContentType;
+  fileName: string;
+  flags: { hasNewFileExplorer: boolean; hasSandboxTools: boolean };
+  providedMetadata: FileUseCaseMetadata | undefined;
+  useCase: FileUseCase;
+}): FileUseCaseMetadata | undefined {
+  const skipDataSourceIndexing = shouldSkipDataSourceIndexing({
+    contentType,
+    fileName,
+  });
+  const isSandboxRawDelimited = shouldStampSandboxRawDelimited({
+    contentType,
+    flags,
+    useCase,
+  });
+
+  if (!skipDataSourceIndexing && !isSandboxRawDelimited) {
+    return providedMetadata;
+  }
+
+  return {
+    ...(providedMetadata ?? {}),
+    ...(skipDataSourceIndexing ? { skipDataSourceIndexing: true } : {}),
+    ...(isSandboxRawDelimited
+      ? {
+          skipDataSourceIndexing: true,
+          skipFileProcessing: true,
+        }
+      : {}),
+  };
+}

--- a/front/lib/api/files/sandbox_raw.ts
+++ b/front/lib/api/files/sandbox_raw.ts
@@ -23,12 +23,11 @@ export function shouldStampSandboxRawDelimited({
   useCase,
 }: {
   contentType: AllSupportedFileContentType;
-  flags: { hasNewFileExplorer: boolean; hasSandboxTools: boolean };
+  flags: { hasSandboxTools: boolean };
   useCase: FileUseCase;
 }): boolean {
   return (
     flags.hasSandboxTools &&
-    flags.hasNewFileExplorer &&
     useCase === "conversation" &&
     isSupportedDelimitedTextContentType(contentType)
   );
@@ -43,7 +42,7 @@ export function buildEffectiveUseCaseMetadata({
 }: {
   contentType: AllSupportedFileContentType;
   fileName: string;
-  flags: { hasNewFileExplorer: boolean; hasSandboxTools: boolean };
+  flags: { hasSandboxTools: boolean };
   providedMetadata: FileUseCaseMetadata | undefined;
   useCase: FileUseCase;
 }): FileUseCaseMetadata | undefined {

--- a/front/lib/api/files/sandbox_raw.ts
+++ b/front/lib/api/files/sandbox_raw.ts
@@ -1,9 +1,7 @@
-import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type {
   AllSupportedFileContentType,
   FileUseCase,
-  FileUseCaseMetadata,
 } from "@app/types/files";
 import { isSupportedDelimitedTextContentType } from "@app/types/files";
 
@@ -31,43 +29,4 @@ export function shouldStampSandboxRawDelimited({
     useCase === "conversation" &&
     isSupportedDelimitedTextContentType(contentType)
   );
-}
-
-export function buildEffectiveUseCaseMetadata({
-  contentType,
-  fileName,
-  flags,
-  providedMetadata,
-  useCase,
-}: {
-  contentType: AllSupportedFileContentType;
-  fileName: string;
-  flags: { hasSandboxTools: boolean };
-  providedMetadata: FileUseCaseMetadata | undefined;
-  useCase: FileUseCase;
-}): FileUseCaseMetadata | undefined {
-  const skipDataSourceIndexing = shouldSkipDataSourceIndexing({
-    contentType,
-    fileName,
-  });
-  const isSandboxRawDelimited = shouldStampSandboxRawDelimited({
-    contentType,
-    flags,
-    useCase,
-  });
-
-  if (!skipDataSourceIndexing && !isSandboxRawDelimited) {
-    return providedMetadata;
-  }
-
-  return {
-    ...(providedMetadata ?? {}),
-    ...(skipDataSourceIndexing ? { skipDataSourceIndexing: true } : {}),
-    ...(isSandboxRawDelimited
-      ? {
-          skipDataSourceIndexing: true,
-          skipFileProcessing: true,
-        }
-      : {}),
-  };
 }

--- a/front/lib/api/files/upload_metadata.ts
+++ b/front/lib/api/files/upload_metadata.ts
@@ -1,0 +1,46 @@
+import { shouldStampSandboxRawDelimited } from "@app/lib/api/files/sandbox_raw";
+import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
+import type {
+  AllSupportedFileContentType,
+  FileUseCase,
+  FileUseCaseMetadata,
+} from "@app/types/files";
+
+export function buildEffectiveUseCaseMetadata({
+  contentType,
+  fileName,
+  flags,
+  providedMetadata,
+  useCase,
+}: {
+  contentType: AllSupportedFileContentType;
+  fileName: string;
+  flags: { hasSandboxTools: boolean };
+  providedMetadata: FileUseCaseMetadata | undefined;
+  useCase: FileUseCase;
+}): FileUseCaseMetadata | undefined {
+  const skipDataSourceIndexing = shouldSkipDataSourceIndexing({
+    contentType,
+    fileName,
+  });
+  const isSandboxRawDelimited = shouldStampSandboxRawDelimited({
+    contentType,
+    flags,
+    useCase,
+  });
+
+  if (!skipDataSourceIndexing && !isSandboxRawDelimited) {
+    return providedMetadata;
+  }
+
+  return {
+    ...(providedMetadata ?? {}),
+    ...(skipDataSourceIndexing ? { skipDataSourceIndexing: true } : {}),
+    ...(isSandboxRawDelimited
+      ? {
+          skipDataSourceIndexing: true,
+          skipFileProcessing: true,
+        }
+      : {}),
+  };
+}

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -1,6 +1,5 @@
 import { createDataSourceFolder, upsertTable } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
-import { generateSnippet } from "@app/lib/api/files/snippet";
 import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -170,34 +169,6 @@ describe("processAndUpsertToDataSource", () => {
         params.tableId
       );
     }
-  });
-
-  it("should leave snippets null and skip upsert for raw sandbox CSV files", async () => {
-    const file = await FileFactory.csv(auth, null, {
-      useCase: "conversation",
-      fileName: "large.csv",
-      status: "ready",
-      useCaseMetadata: {
-        conversationId: "test-conversation-id",
-        skipDataSourceIndexing: true,
-        skipFileProcessing: true,
-      },
-    });
-
-    const space = await SpaceFactory.global(workspace);
-    const datasourceView = await DataSourceViewFactory.folder(workspace, space);
-
-    const result = await processAndUpsertToDataSource(
-      auth,
-      datasourceView.dataSource,
-      { file }
-    );
-
-    expect(result.isOk()).toBe(true);
-    expect(result.isOk() ? result.value.snippet : "unexpected").toBeNull();
-    expect(generateSnippet).not.toHaveBeenCalled();
-    expect(upsertTable).not.toHaveBeenCalled();
-    expect(createDataSourceFolder).not.toHaveBeenCalled();
   });
 
   it("should append to existing generatedTables when processing a CSV file", async () => {

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -1,5 +1,6 @@
 import { createDataSourceFolder, upsertTable } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
+import { generateSnippet } from "@app/lib/api/files/snippet";
 import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -169,6 +170,34 @@ describe("processAndUpsertToDataSource", () => {
         params.tableId
       );
     }
+  });
+
+  it("should leave snippets null and skip upsert for raw sandbox CSV files", async () => {
+    const file = await FileFactory.csv(auth, null, {
+      useCase: "conversation",
+      fileName: "large.csv",
+      status: "ready",
+      useCaseMetadata: {
+        conversationId: "test-conversation-id",
+        skipDataSourceIndexing: true,
+        skipFileProcessing: true,
+      },
+    });
+
+    const space = await SpaceFactory.global(workspace);
+    const datasourceView = await DataSourceViewFactory.folder(workspace, space);
+
+    const result = await processAndUpsertToDataSource(
+      auth,
+      datasourceView.dataSource,
+      { file }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() ? result.value.snippet : "unexpected").toBeNull();
+    expect(generateSnippet).not.toHaveBeenCalled();
+    expect(upsertTable).not.toHaveBeenCalled();
+    expect(createDataSourceFolder).not.toHaveBeenCalled();
   });
 
   it("should append to existing generatedTables when processing a CSV file", async () => {

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -12,7 +12,6 @@ import {
   upsertTable,
 } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
-import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import { generateSnippet } from "@app/lib/api/files/snippet";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -572,10 +571,6 @@ export async function processAndUpsertToDataSource(
       code: "file_not_ready",
       message: "File is not ready for post processing.",
     });
-  }
-
-  if (isSandboxRawDelimitedConversationFile(file)) {
-    return new Ok(file);
   }
 
   if (!isFileTypeUpsertableForUseCase(file)) {

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -12,6 +12,7 @@ import {
   upsertTable,
 } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
+import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import { generateSnippet } from "@app/lib/api/files/snippet";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -571,6 +572,10 @@ export async function processAndUpsertToDataSource(
       code: "file_not_ready",
       message: "File is not ready for post processing.",
     });
+  }
+
+  if (isSandboxRawDelimitedConversationFile(file)) {
+    return new Ok(file);
   }
 
   if (!isFileTypeUpsertableForUseCase(file)) {

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -5,7 +5,7 @@ import type {
   FileVersion,
 } from "@app/lib/resources/file_resource";
 import { streamToBuffer } from "@app/lib/utils/streams";
-import { stripMimeParameters } from "@app/types/files";
+import { resolveFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { File } from "formidable";
@@ -48,7 +48,8 @@ export const parseUploadRequest = async (
         !part.mimetype ||
         part.mimetype === "application/octet-stream" ||
         // The mime params are already stripped from the file content type.
-        stripMimeParameters(part.mimetype) === file.contentType,
+        resolveFileContentType(part.mimetype, file.fileName) ===
+          file.contentType,
     });
 
     const [, files] = await form.parse(req);

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -21,10 +21,14 @@ function makeFileFragment(
   contentType: SupportedContentFragmentType,
   {
     generatedTables = [],
+    mountRelativePath = null,
     snippet = null,
+    skipFileProcessing = false,
   }: {
     generatedTables?: string[];
+    mountRelativePath?: string | null;
     snippet?: string | null;
+    skipFileProcessing?: boolean;
   } = {}
 ): FileContentFragmentType {
   return {
@@ -44,6 +48,8 @@ function makeFileFragment(
     contentFragmentVersion: "latest",
     expiredReason: null,
     contentFragmentType: "file",
+    mountRelativePath,
+    skipFileProcessing,
     fileId: "fil_abc123",
     snippet,
     generatedTables,
@@ -210,6 +216,22 @@ describe("renderLightContentFragmentForModel", () => {
       expect(result?.content[0]).toMatchObject({
         type: "text",
         text: `<file name="file" path="conversation/file">First 256 chars...\n</file>`,
+      });
+    });
+
+    it("renders a slim file reference using the mount path when available", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("application/pdf", {
+          mountRelativePath: "conversation/report_fil_abc123.pdf",
+        }),
+        visionModel,
+        { excludeImages: false, useFileSystem: true }
+      );
+      expect(result).not.toBeNull();
+      expect(result?.content[0]).toMatchObject({
+        type: "text",
+        text: `<file name="file" path="conversation/report_fil_abc123.pdf"/>`,
       });
     });
 

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -21,12 +21,12 @@ function makeFileFragment(
   contentType: SupportedContentFragmentType,
   {
     generatedTables = [],
-    mountRelativePath = null,
+    path = null,
     snippet = null,
     skipFileProcessing = false,
   }: {
     generatedTables?: string[];
-    mountRelativePath?: string | null;
+    path?: string | null;
     snippet?: string | null;
     skipFileProcessing?: boolean;
   } = {}
@@ -48,7 +48,7 @@ function makeFileFragment(
     contentFragmentVersion: "latest",
     expiredReason: null,
     contentFragmentType: "file",
-    mountRelativePath,
+    path,
     skipFileProcessing,
     fileId: "fil_abc123",
     snippet,
@@ -223,7 +223,7 @@ describe("renderLightContentFragmentForModel", () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("application/pdf", {
-          mountRelativePath: "conversation/report_fil_abc123.pdf",
+          path: "conversation/report_fil_abc123.pdf",
         }),
         visionModel,
         { excludeImages: false, useFileSystem: true }

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -1210,8 +1210,7 @@ function renderFileOrAttachmentXml(
   }
 ): string {
   if (isNewFileExplorer) {
-    const explicitPath =
-      "path" in attachment ? attachment.path : null;
+    const explicitPath = "path" in attachment ? attachment.path : null;
     const path = explicitPath ?? `conversation/${attachment.title}`;
     if (!explicitPath) {
       logger.warn(

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -77,7 +77,7 @@ export type RenderContentFragmentToTypeSource =
 export const CONTENT_OUTDATED_MSG =
   "Content is outdated. Please refer to the latest version of this content.";
 
-function getConversationMountRelativePath({
+function getConversationFilePath({
   conversationId,
   mountFilePath,
   workspaceId,
@@ -804,7 +804,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
           ...baseContentFragment,
           contentFragmentType: "file",
           expiredReason: fr.expiredReason,
-          mountRelativePath: null,
+          path: null,
           skipFileProcessing: false,
           fileId: null,
           snippet: null,
@@ -862,7 +862,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       let sourceIcon: string | null = null;
       let isInProjectContext = false;
       let hidden = true;
-      let mountRelativePath: string | null = null;
+      let path: string | null = null;
       let skipFileProcessing = false;
 
       if (fileResource) {
@@ -876,7 +876,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         hidden = !!fileResource.useCaseMetadata?.hideFromUser;
         skipFileProcessing =
           fileResource.useCaseMetadata?.skipFileProcessing === true;
-        mountRelativePath = getConversationMountRelativePath({
+        path = getConversationFilePath({
           workspaceId: workspace.sId,
           conversationId: fileResource.useCaseMetadata?.conversationId,
           mountFilePath: fileResource.mountFilePath,
@@ -895,7 +895,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         title,
         contentFragmentType: "file",
         expiredReason: null,
-        mountRelativePath,
+        path,
         skipFileProcessing,
         fileId: fileStringId,
         snippet,
@@ -1210,10 +1210,10 @@ function renderFileOrAttachmentXml(
   }
 ): string {
   if (isNewFileExplorer) {
-    const mountRelativePath =
-      "mountRelativePath" in attachment ? attachment.mountRelativePath : null;
-    const path = mountRelativePath ?? `conversation/${attachment.title}`;
-    if (!mountRelativePath) {
+    const explicitPath =
+      "path" in attachment ? attachment.path : null;
+    const path = explicitPath ?? `conversation/${attachment.title}`;
+    if (!explicitPath) {
       logger.warn(
         {
           fileId: "fileId" in attachment ? attachment.fileId : null,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -13,6 +13,7 @@ import {
 import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
 
+import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -75,6 +76,31 @@ export type RenderContentFragmentToTypeSource =
 
 export const CONTENT_OUTDATED_MSG =
   "Content is outdated. Please refer to the latest version of this content.";
+
+function getConversationMountRelativePath({
+  conversationId,
+  mountFilePath,
+  workspaceId,
+}: {
+  conversationId: string | null | undefined;
+  mountFilePath: string | null;
+  workspaceId: string;
+}): string | null {
+  if (!mountFilePath || !conversationId) {
+    return null;
+  }
+
+  const prefix = getConversationFilesBasePath({
+    workspaceId,
+    conversationId,
+  });
+
+  if (!mountFilePath.startsWith(prefix)) {
+    return null;
+  }
+
+  return `conversation/${mountFilePath.slice(prefix.length)}`;
+}
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -778,6 +804,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
           ...baseContentFragment,
           contentFragmentType: "file",
           expiredReason: fr.expiredReason,
+          mountRelativePath: null,
+          skipFileProcessing: false,
           fileId: null,
           snippet: null,
           generatedTables: [],
@@ -834,6 +862,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       let sourceIcon: string | null = null;
       let isInProjectContext = false;
       let hidden = true;
+      let mountRelativePath: string | null = null;
+      let skipFileProcessing = false;
 
       if (fileResource) {
         title = fileResource.fileName;
@@ -844,6 +874,13 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         sourceIcon = fileResource.useCaseMetadata?.sourceIcon ?? null;
         isInProjectContext = !!fileResource.useCaseMetadata?.spaceId;
         hidden = !!fileResource.useCaseMetadata?.hideFromUser;
+        skipFileProcessing =
+          fileResource.useCaseMetadata?.skipFileProcessing === true;
+        mountRelativePath = getConversationMountRelativePath({
+          workspaceId: workspace.sId,
+          conversationId: fileResource.useCaseMetadata?.conversationId,
+          mountFilePath: fileResource.mountFilePath,
+        });
       }
 
       if (source.kind === "project_context") {
@@ -858,6 +895,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         title,
         contentFragmentType: "file",
         expiredReason: null,
+        mountRelativePath,
+        skipFileProcessing,
         fileId: fileStringId,
         snippet,
         generatedTables,
@@ -1171,7 +1210,18 @@ function renderFileOrAttachmentXml(
   }
 ): string {
   if (isNewFileExplorer) {
-    const path = `conversation/${attachment.title}`;
+    const mountRelativePath =
+      "mountRelativePath" in attachment ? attachment.mountRelativePath : null;
+    const path = mountRelativePath ?? `conversation/${attachment.title}`;
+    if (!mountRelativePath) {
+      logger.warn(
+        {
+          fileId: "fileId" in attachment ? attachment.fileId : null,
+          title: attachment.title,
+        },
+        "Falling back to file title for new file explorer path."
+      );
+    }
     return content
       ? `<file name="${attachment.title}" path="${path}">${content}\n</file>`
       : `<file name="${attachment.title}" path="${path}"/>`;

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -833,6 +833,28 @@ describe("FileResource", () => {
       expect(path).toContain("/processed");
     });
 
+    it("should resolve to 'original' version for spreadsheets when file processing is skipped", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType:
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        fileName: "large.xlsx",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: {
+          conversationId: "conv-1",
+          skipFileProcessing: true,
+        },
+      });
+
+      const { path } = file.getContentBucketAndPath(auth);
+      expect(path).toContain("/original");
+    });
+
     it("should resolve to 'processed' version for images in conversation", async () => {
       const { authenticator: auth } = await createResourceTest({
         role: "admin",

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -591,6 +591,10 @@ export class FileResource extends BaseResource<FileModel> {
    * Returns the file version to read for "best available" content.
    */
   private getContentVersion(): FileVersion {
+    if (this.useCaseMetadata?.skipFileProcessing === true) {
+      return "original";
+    }
+
     return hasProcessedVersion(this.contentType) ? "processed" : "original";
   }
 
@@ -1050,6 +1054,13 @@ export class FileResource extends BaseResource<FileModel> {
 
     const bucket = getPrivateUploadBucket();
     await bucket.delete(this.mountFilePath, { ignoreNotFound: true });
+
+    if (
+      this.useCaseMetadata?.skipFileProcessing === true ||
+      !hasProcessedVersion(this.contentType)
+    ) {
+      return;
+    }
 
     // Only delete processed mount file if this file type has real processing.
     const processedMountPath = makeProcessedMountFileName({

--- a/front/lib/resources/skill/code_defined/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.test.ts
@@ -30,6 +30,20 @@ describe("sandboxSkill", () => {
     expect(instructionsWithDsbxTools).toContain("name: dsbx");
   });
 
+  it("instructs the model to analyze mounted tabular files with code", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+
+    const instructions = await sandboxSkill.fetchInstructions(auth, {
+      spaceIds: [],
+    });
+
+    expect(instructions).toContain("tabular files (CSV, TSV, Excel)");
+    expect(instructions).toContain("pandas.read_csv");
+    expect(instructions).toContain("DuckDB");
+  });
+
   it("hides agent egress request instructions until enabled", async () => {
     const {
       authenticator: auth,

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -84,7 +84,12 @@ Typical workflow when a prior tool returned a large output: locate the most
 recent matching file under \`/files/conversation/results/\`, then use
 \`jq\` / \`rg\` / \`grep\` to extract just the fields or lines you need,
 instead of paging the whole blob back through \`files__cat\` or re-running
-the tool.`;
+the tool.
+
+For tabular files (CSV, TSV, Excel) under \`/files/conversation\`, code is
+the preferred way to interact with them: analyze them with pandas, DuckDB,
+or the standard csv module. For very large files prefer chunked reads
+(\`pandas.read_csv(..., chunksize=...)\`) or DuckDB to keep memory bounded.`;
 }
 
 function formatWorkspaceAllowlist(domains: string[]): string {

--- a/front/lib/utils/files.test.ts
+++ b/front/lib/utils/files.test.ts
@@ -4,7 +4,14 @@ import { copyContent } from "@app/lib/utils/files";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-function makeSourceFile(contentType: AllSupportedFileContentType) {
+function makeSourceFile(
+  contentType: AllSupportedFileContentType,
+  {
+    skipFileProcessing = false,
+  }: {
+    skipFileProcessing?: boolean;
+  } = {}
+) {
   const sourceBuckets = {
     original: {
       copyFile: vi.fn(),
@@ -22,6 +29,7 @@ function makeSourceFile(contentType: AllSupportedFileContentType) {
 
   return {
     contentType,
+    useCaseMetadata: skipFileProcessing ? { skipFileProcessing: true } : null,
     getBucketForVersion: vi.fn(
       (version: FileVersion) => sourceBuckets[version]
     ),
@@ -31,6 +39,7 @@ function makeSourceFile(contentType: AllSupportedFileContentType) {
     sourceBuckets,
   } satisfies {
     contentType: AllSupportedFileContentType;
+    useCaseMetadata: { skipFileProcessing: true } | null;
     getBucketForVersion: ReturnType<typeof vi.fn>;
     getCloudStoragePath: ReturnType<typeof vi.fn>;
     sourceBuckets: Record<
@@ -143,5 +152,24 @@ describe("copyContent", () => {
       "target/processed",
       targetFile.targetBuckets.processed
     );
+  });
+
+  it("does not copy a processed version when upload-time processing was skipped", async () => {
+    const auth = {} as Authenticator;
+    const sourceFile = makeSourceFile(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      { skipFileProcessing: true }
+    );
+    const targetFile = makeTargetFile();
+
+    await copyContent(
+      auth,
+      sourceFile as unknown as Parameters<typeof copyContent>[1],
+      targetFile as unknown as Parameters<typeof copyContent>[2],
+      { includeProcessedVersion: true }
+    );
+
+    expect(sourceFile.sourceBuckets.original.copyFile).toHaveBeenCalledTimes(1);
+    expect(sourceFile.sourceBuckets.processed.copyFile).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/utils/files.ts
+++ b/front/lib/utils/files.ts
@@ -29,6 +29,7 @@ export async function copyContent(
 
   if (
     !includeProcessedVersion ||
+    sourceFile.useCaseMetadata?.skipFileProcessing === true ||
     !hasProcessedVersion(sourceFile.contentType)
   ) {
     return;

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -586,10 +586,10 @@
  *           type: string
  *           nullable: true
  *           description: Present for file content fragments
- *         mountRelativePath:
+ *         path:
  *           type: string
  *           nullable: true
- *           description: Scoped path for mounted conversation files.
+ *           description: Path of this file inside the sandbox conversation mount.
  *         skipFileProcessing:
  *           type: boolean
  *           description: Whether upload-time file processing was skipped.

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -586,6 +586,13 @@
  *           type: string
  *           nullable: true
  *           description: Present for file content fragments
+ *         mountRelativePath:
+ *           type: string
+ *           nullable: true
+ *           description: Scoped path for mounted conversation files.
+ *         skipFileProcessing:
+ *           type: boolean
+ *           description: Whether upload-time file processing was skipped.
  *         snippet:
  *           type: string
  *           nullable: true

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -1,6 +1,7 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
+import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import {
   isFileTypeUpsertableForUseCase,
   processAndUpsertToDataSource,
@@ -217,6 +218,7 @@ async function handler(
       // For files with useCase "conversation" that support upsert, directly add them to the data source.
       if (
         file.useCase === "conversation" &&
+        !isSandboxRawDelimitedConversationFile(file) &&
         isFileTypeUpsertableForUseCase(file)
       ) {
         const jitDataSource = await getOrCreateConversationDataSourceFromFile(

--- a/front/pages/api/v1/w/[wId]/files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.test.ts
@@ -100,12 +100,11 @@ describe("POST /api/w/[wId]/files", () => {
     expect(res._getStatusCode()).toBe(200);
   });
 
-  it("accepts and stamps raw sandbox CSV uploads when both required flags are enabled", async () => {
+  it("accepts and stamps raw sandbox CSV uploads when sandbox_tools is enabled", async () => {
     const { req, res, auth } = await createPublicApiMockRequest({
       method: "POST",
     });
     await FeatureFlagFactory.basic(auth, "sandbox_tools");
-    await FeatureFlagFactory.basic(auth, "new_file_explorer");
 
     req.body = {
       contentType: "text/csv",
@@ -123,11 +122,10 @@ describe("POST /api/w/[wId]/files", () => {
     expect(file?.useCaseMetadata?.skipDataSourceIndexing).toBe(true);
   });
 
-  it("keeps the 50 MB CSV limit when new_file_explorer is not enabled", async () => {
-    const { req, res, auth } = await createPublicApiMockRequest({
+  it("keeps the 50 MB CSV limit when sandbox_tools is not enabled", async () => {
+    const { req, res } = await createPublicApiMockRequest({
       method: "POST",
     });
-    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     req.body = {
       contentType: "text/csv",
@@ -147,7 +145,6 @@ describe("POST /api/w/[wId]/files", () => {
       systemKey: true,
     });
     await FeatureFlagFactory.basic(auth, "sandbox_tools");
-    await FeatureFlagFactory.basic(auth, "new_file_explorer");
 
     req.body = {
       contentType: "text/csv",

--- a/front/pages/api/v1/w/[wId]/files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.test.ts
@@ -1,3 +1,5 @@
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import {
   createPublicApiAuthenticationTests,
   createPublicApiMockRequest,
@@ -96,5 +98,66 @@ describe("POST /api/w/[wId]/files", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("accepts and stamps raw sandbox CSV uploads when both required flags are enabled", async () => {
+    const { req, res, auth } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    await FeatureFlagFactory.basic(auth, "new_file_explorer");
+
+    req.body = {
+      contentType: "text/csv",
+      fileName: "large.csv",
+      fileSize: 60 * 1024 * 1024,
+      useCase: "conversation",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = JSON.parse(res._getData());
+    const file = await FileResource.fetchById(auth, data.file.sId);
+    expect(file?.useCaseMetadata?.skipFileProcessing).toBe(true);
+    expect(file?.useCaseMetadata?.skipDataSourceIndexing).toBe(true);
+  });
+
+  it("keeps the 50 MB CSV limit when new_file_explorer is not enabled", async () => {
+    const { req, res, auth } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+
+    req.body = {
+      contentType: "text/csv",
+      fileName: "large.csv",
+      fileSize: 60 * 1024 * 1024,
+      useCase: "conversation",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it("does not raise the CSV limit for upsert_table system-key uploads", async () => {
+    const { req, res, auth } = await createPublicApiMockRequest({
+      method: "POST",
+      systemKey: true,
+    });
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    await FeatureFlagFactory.basic(auth, "new_file_explorer");
+
+    req.body = {
+      contentType: "text/csv",
+      fileName: "large.csv",
+      fileSize: 60 * 1024 * 1024,
+      useCase: "upsert_table",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
   });
 });

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -164,11 +164,9 @@ async function handler(
 
       const flags = await getFeatureFlags(auth);
       const hasSandboxTools = flags.includes("sandbox_tools");
-      const hasNewFileExplorer = flags.includes("new_file_explorer");
 
       if (
         !ensureFileSize(contentType, fileSize, {
-          hasNewFileExplorer,
           hasSandboxTools,
           useCase,
         })
@@ -192,7 +190,7 @@ async function handler(
         useCaseMetadata: buildEffectiveUseCaseMetadata({
           contentType,
           fileName,
-          flags: { hasNewFileExplorer, hasSandboxTools },
+          flags: { hasSandboxTools },
           providedMetadata: useCaseMetadata,
           useCase,
         }),

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -1,6 +1,6 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
-import { buildEffectiveUseCaseMetadata } from "@app/lib/api/files/sandbox_raw";
+import { buildEffectiveUseCaseMetadata } from "@app/lib/api/files/upload_metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -1,7 +1,8 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
-import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
+import { buildEffectiveUseCaseMetadata } from "@app/lib/api/files/sandbox_raw";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
@@ -161,7 +162,17 @@ async function handler(
         });
       }
 
-      if (!ensureFileSize(contentType, fileSize)) {
+      const flags = await getFeatureFlags(auth);
+      const hasSandboxTools = flags.includes("sandbox_tools");
+      const hasNewFileExplorer = flags.includes("new_file_explorer");
+
+      if (
+        !ensureFileSize(contentType, fileSize, {
+          hasNewFileExplorer,
+          hasSandboxTools,
+          useCase,
+        })
+      ) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -171,13 +182,6 @@ async function handler(
         });
       }
 
-      const effectiveUseCaseMetadata = shouldSkipDataSourceIndexing({
-        contentType,
-        fileName,
-      })
-        ? { ...(useCaseMetadata ?? {}), skipDataSourceIndexing: true }
-        : useCaseMetadata;
-
       const file = await FileResource.makeNew({
         contentType,
         fileName,
@@ -185,7 +189,13 @@ async function handler(
         userId: user?.id ?? null,
         workspaceId: owner.id,
         useCase,
-        useCaseMetadata: effectiveUseCaseMetadata,
+        useCaseMetadata: buildEffectiveUseCaseMetadata({
+          contentType,
+          fileName,
+          flags: { hasNewFileExplorer, hasSandboxTools },
+          providedMetadata: useCaseMetadata,
+          useCase,
+        }),
       });
 
       res.status(200).json({ file: file.toPublicJSONWithUploadUrl(auth) });

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -397,10 +397,10 @@
  *           type: string
  *           description: The id of the previously uploaded file (optional if `content` and `contentType` are set)
  *           example: fil_123456
- *         mountRelativePath:
+ *         path:
  *           type: string
  *           nullable: true
- *           description: Scoped path for mounted conversation files.
+ *           description: Path of this file inside the sandbox conversation mount.
  *           example: conversation/report.csv
  *         skipFileProcessing:
  *           type: boolean

--- a/front/pages/api/v1/w/[wId]/swagger_schemas.ts
+++ b/front/pages/api/v1/w/[wId]/swagger_schemas.ts
@@ -397,6 +397,14 @@
  *           type: string
  *           description: The id of the previously uploaded file (optional if `content` and `contentType` are set)
  *           example: fil_123456
+ *         mountRelativePath:
+ *           type: string
+ *           nullable: true
+ *           description: Scoped path for mounted conversation files.
+ *           example: conversation/report.csv
+ *         skipFileProcessing:
+ *           type: boolean
+ *           description: Whether upload-time file processing was skipped.
  *         nodeId:
  *           type: string
  *           description: The id of the content node (optional if `content` and `contentType` are set)

--- a/front/pages/api/w/[wId]/files/[fileId]/index.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.test.ts
@@ -574,4 +574,43 @@ describe("POST /api/w/[wId]/files/[fileId]", () => {
     expect(res._getStatusCode()).toBe(200);
     expect(processAndUpsertToDataSource).toHaveBeenCalled();
   });
+
+  it("should not upsert raw sandbox delimited conversation files", async () => {
+    const { processAndUpsertToDataSource } = await import(
+      "@app/lib/api/files/upsert"
+    );
+
+    const { req, res, user, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [new Date()],
+    });
+
+    const file = await FileFactory.create(auth, user, {
+      contentType: "text/csv",
+      fileName: "large.csv",
+      fileSize: 1024,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: {
+        conversationId: conversation.sId,
+        skipDataSourceIndexing: true,
+        skipFileProcessing: true,
+      },
+    });
+
+    req.query = {
+      ...req.query,
+      fileId: file.sId,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(processAndUpsertToDataSource).not.toHaveBeenCalled();
+  });
 });

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -122,6 +122,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
+import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import {
   isFileTypeUpsertableForUseCase,
   processAndUpsertToDataSource,
@@ -436,6 +437,7 @@ async function handler(
       // For files with useCase "conversation" that support upsert, directly add them to the data source.
       if (
         file.useCase === "conversation" &&
+        !isSandboxRawDelimitedConversationFile(file) &&
         isFileTypeUpsertableForUseCase(file)
       ) {
         const jitDataSource = await getOrCreateConversationDataSourceFromFile(

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -199,11 +199,9 @@ async function handler(
 
       const flags = await getFeatureFlags(auth);
       const hasSandboxTools = flags.includes("sandbox_tools");
-      const hasNewFileExplorer = flags.includes("new_file_explorer");
 
       if (
         !ensureFileSize(contentType, fileSize, {
-          hasNewFileExplorer,
           hasSandboxTools,
           useCase,
         })
@@ -227,7 +225,7 @@ async function handler(
         useCaseMetadata: buildEffectiveUseCaseMetadata({
           contentType,
           fileName,
-          flags: { hasNewFileExplorer, hasSandboxTools },
+          flags: { hasSandboxTools },
           providedMetadata: useCaseMetadata,
           useCase,
         }),

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -55,8 +55,9 @@
  */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
-import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
+import { buildEffectiveUseCaseMetadata } from "@app/lib/api/files/sandbox_raw";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
@@ -196,7 +197,17 @@ async function handler(
         });
       }
 
-      if (!ensureFileSize(contentType, fileSize)) {
+      const flags = await getFeatureFlags(auth);
+      const hasSandboxTools = flags.includes("sandbox_tools");
+      const hasNewFileExplorer = flags.includes("new_file_explorer");
+
+      if (
+        !ensureFileSize(contentType, fileSize, {
+          hasNewFileExplorer,
+          hasSandboxTools,
+          useCase,
+        })
+      ) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -206,13 +217,6 @@ async function handler(
         });
       }
 
-      const effectiveUseCaseMetadata = shouldSkipDataSourceIndexing({
-        contentType,
-        fileName,
-      })
-        ? { ...(useCaseMetadata ?? {}), skipDataSourceIndexing: true }
-        : useCaseMetadata;
-
       const file = await FileResource.makeNew({
         contentType,
         fileName,
@@ -220,7 +224,13 @@ async function handler(
         userId: user.id,
         workspaceId: owner.id,
         useCase,
-        useCaseMetadata: effectiveUseCaseMetadata,
+        useCaseMetadata: buildEffectiveUseCaseMetadata({
+          contentType,
+          fileName,
+          flags: { hasNewFileExplorer, hasSandboxTools },
+          providedMetadata: useCaseMetadata,
+          useCase,
+        }),
       });
 
       res.status(200).json({ file: file.toJSONWithUploadUrl(auth) });

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -55,7 +55,7 @@
  */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
-import { buildEffectiveUseCaseMetadata } from "@app/lib/api/files/sandbox_raw";
+import { buildEffectiveUseCaseMetadata } from "@app/lib/api/files/upload_metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -10671,6 +10671,15 @@
             "nullable": true,
             "description": "Present for file content fragments"
           },
+          "mountRelativePath": {
+            "type": "string",
+            "nullable": true,
+            "description": "Scoped path for mounted conversation files."
+          },
+          "skipFileProcessing": {
+            "type": "boolean",
+            "description": "Whether upload-time file processing was skipped."
+          },
           "snippet": {
             "type": "string",
             "nullable": true
@@ -13134,6 +13143,16 @@
             "type": "string",
             "description": "The id of the previously uploaded file (optional if `content` and `contentType` are set)",
             "example": "fil_123456"
+          },
+          "mountRelativePath": {
+            "type": "string",
+            "nullable": true,
+            "description": "Scoped path for mounted conversation files.",
+            "example": "conversation/report.csv"
+          },
+          "skipFileProcessing": {
+            "type": "boolean",
+            "description": "Whether upload-time file processing was skipped."
           },
           "nodeId": {
             "type": "string",

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -10671,10 +10671,10 @@
             "nullable": true,
             "description": "Present for file content fragments"
           },
-          "mountRelativePath": {
+          "path": {
             "type": "string",
             "nullable": true,
-            "description": "Scoped path for mounted conversation files."
+            "description": "Path of this file inside the sandbox conversation mount."
           },
           "skipFileProcessing": {
             "type": "boolean",
@@ -13144,10 +13144,10 @@
             "description": "The id of the previously uploaded file (optional if `content` and `contentType` are set)",
             "example": "fil_123456"
           },
-          "mountRelativePath": {
+          "path": {
             "type": "string",
             "nullable": true,
-            "description": "Scoped path for mounted conversation files.",
+            "description": "Path of this file inside the sandbox conversation mount.",
             "example": "conversation/report.csv"
           },
           "skipFileProcessing": {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -387,6 +387,7 @@ export async function runModel(
   });
 
   const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
+  const hasSandboxTools = await hasFeatureFlag(auth, "sandbox_tools");
 
   const prompt = constructPromptMultiActions(auth, {
     userMessage,
@@ -408,6 +409,7 @@ export async function runModel(
     workspaceContext,
     projectContext,
     isNewFileExplorer,
+    hasSandboxTools,
   });
   const leadingMessages = renderSkillsAsUserMessages
     ? removeNulls([renderEquippedSkillsUserMessage(equippedSkills)])

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -79,6 +79,8 @@ export type ContentNodeContentFragmentType = BaseContentFragmentType & {
 
 export type FileContentFragmentType = BaseContentFragmentType & {
   contentFragmentType: "file";
+  mountRelativePath?: string | null;
+  skipFileProcessing?: boolean;
 } & (
     | {
         expiredReason: null;

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -79,7 +79,7 @@ export type ContentNodeContentFragmentType = BaseContentFragmentType & {
 
 export type FileContentFragmentType = BaseContentFragmentType & {
   contentFragmentType: "file";
-  mountRelativePath?: string | null;
+  path?: string | null;
   skipFileProcessing?: boolean;
 } & (
     | {

--- a/front/types/files.test.ts
+++ b/front/types/files.test.ts
@@ -6,10 +6,9 @@ import {
 import { describe, expect, it } from "vitest";
 
 describe("resolveMaxFileSizes", () => {
-  it("raises the delimited limit only for sandbox conversations with new file explorer", () => {
+  it("raises the delimited limit only for sandbox conversations", () => {
     expect(
       resolveMaxFileSizes({
-        hasNewFileExplorer: true,
         hasSandboxTools: true,
         useCase: "conversation",
       }).delimited
@@ -17,15 +16,13 @@ describe("resolveMaxFileSizes", () => {
 
     expect(
       resolveMaxFileSizes({
-        hasNewFileExplorer: false,
-        hasSandboxTools: true,
+        hasSandboxTools: false,
         useCase: "conversation",
       }).delimited
     ).toBe(50 * 1024 * 1024);
 
     expect(
       resolveMaxFileSizes({
-        hasNewFileExplorer: true,
         hasSandboxTools: true,
         useCase: "upsert_table",
       }).delimited
@@ -35,7 +32,6 @@ describe("resolveMaxFileSizes", () => {
   it("enforces the resolved per-file limit", () => {
     expect(
       ensureFileSize("text/csv", 60 * 1024 * 1024, {
-        hasNewFileExplorer: true,
         hasSandboxTools: true,
         useCase: "conversation",
       })
@@ -43,7 +39,6 @@ describe("resolveMaxFileSizes", () => {
 
     expect(
       ensureFileSize("text/csv", 60 * 1024 * 1024, {
-        hasNewFileExplorer: true,
         hasSandboxTools: true,
         useCase: "upsert_table",
       })

--- a/front/types/files.test.ts
+++ b/front/types/files.test.ts
@@ -1,0 +1,63 @@
+import {
+  ensureFileSize,
+  resolveFileContentType,
+  resolveMaxFileSizes,
+} from "@app/types/files";
+import { describe, expect, it } from "vitest";
+
+describe("resolveMaxFileSizes", () => {
+  it("raises the delimited limit only for sandbox conversations with new file explorer", () => {
+    expect(
+      resolveMaxFileSizes({
+        hasNewFileExplorer: true,
+        hasSandboxTools: true,
+        useCase: "conversation",
+      }).delimited
+    ).toBe(350 * 1024 * 1024);
+
+    expect(
+      resolveMaxFileSizes({
+        hasNewFileExplorer: false,
+        hasSandboxTools: true,
+        useCase: "conversation",
+      }).delimited
+    ).toBe(50 * 1024 * 1024);
+
+    expect(
+      resolveMaxFileSizes({
+        hasNewFileExplorer: true,
+        hasSandboxTools: true,
+        useCase: "upsert_table",
+      }).delimited
+    ).toBe(50 * 1024 * 1024);
+  });
+
+  it("enforces the resolved per-file limit", () => {
+    expect(
+      ensureFileSize("text/csv", 60 * 1024 * 1024, {
+        hasNewFileExplorer: true,
+        hasSandboxTools: true,
+        useCase: "conversation",
+      })
+    ).toBe(true);
+
+    expect(
+      ensureFileSize("text/csv", 60 * 1024 * 1024, {
+        hasNewFileExplorer: true,
+        hasSandboxTools: true,
+        useCase: "upsert_table",
+      })
+    ).toBe(false);
+  });
+});
+
+describe("resolveFileContentType", () => {
+  it("normalizes Excel files reported as octet-stream", () => {
+    expect(resolveFileContentType("application/octet-stream", "data.xls")).toBe(
+      "application/vnd.ms-excel"
+    );
+    expect(
+      resolveFileContentType("application/octet-stream", "data.xlsx")
+    ).toBe("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+  });
+});

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -143,16 +143,13 @@ export const MAX_FILE_SIZES_LARGE_DELIMITED: Record<
 export const MAX_FILE_SIZES = MAX_FILE_SIZES_DEFAULT;
 
 export function resolveMaxFileSizes({
-  hasNewFileExplorer,
   hasSandboxTools,
   useCase,
 }: {
-  hasNewFileExplorer: boolean;
   hasSandboxTools: boolean;
   useCase: FileUseCase;
 }): Record<FileFormatCategory, number> {
-  const eligible =
-    hasSandboxTools && hasNewFileExplorer && useCase === "conversation";
+  const eligible = hasSandboxTools && useCase === "conversation";
 
   return eligible ? MAX_FILE_SIZES_LARGE_DELIMITED : MAX_FILE_SIZES_DEFAULT;
 }
@@ -184,7 +181,6 @@ export function ensureFileSize(
   contentType: AllSupportedFileContentType,
   fileSize: number,
   opts: {
-    hasNewFileExplorer: boolean;
     hasSandboxTools: boolean;
     useCase: FileUseCase;
   }
@@ -202,7 +198,6 @@ export function ensureFileSizeByFormatCategory(
   category: FileFormatCategory,
   fileSize: number,
   opts: {
-    hasNewFileExplorer: boolean;
     hasSandboxTools: boolean;
     useCase: FileUseCase;
   }

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -49,7 +49,12 @@ export type FileUseCaseMetadata = {
   sourceProvider?: string;
   sourceIcon?: string;
   hideFromUser?: boolean;
+  // `skipDataSourceIndexing` means "do not write this file to Qdrant / data source"
+  // (audio/webm, pasted, Slack threads, Chrome captures, tool-output offloads).
+  // `skipFileProcessing` means "do not run upload-time processing (Tika / resize / transcribe)";
+  // only the original blob exists. Stamped together for sandbox-mounted raw delimited files.
   skipDataSourceIndexing?: boolean;
+  skipFileProcessing?: boolean;
   // Plan mode. `isPlanFile: true` marks a file as agent-owned (user can't directly mutate).
   // `planModeLastApproval` is set when the agent's `request_plan_approval` is approved.
   // `isPlanClosed: true` marks the plan as retired — hidden from UI and ignored by the skill.
@@ -119,13 +124,38 @@ export type FileFormatCategory =
   | "audio";
 
 // Define max sizes for each category.
-export const MAX_FILE_SIZES: Record<FileFormatCategory, number> = {
+export const MAX_FILE_SIZES_DEFAULT: Record<FileFormatCategory, number> = {
   data: 50 * 1024 * 1024, // 50MB.
   code: 50 * 1024 * 1024, // 50MB.
   delimited: 50 * 1024 * 1024, // 50MB.
   image: 20 * 1024 * 1024, // 20MB - Gemini limit due to base64 conversion overhead
   audio: 100 * 1024 * 1024, // 100 MB, audio files can be large, ex transcript of meetings
 };
+
+export const MAX_FILE_SIZES_LARGE_DELIMITED: Record<
+  FileFormatCategory,
+  number
+> = {
+  ...MAX_FILE_SIZES_DEFAULT,
+  delimited: 350 * 1024 * 1024,
+};
+
+export const MAX_FILE_SIZES = MAX_FILE_SIZES_DEFAULT;
+
+export function resolveMaxFileSizes({
+  hasNewFileExplorer,
+  hasSandboxTools,
+  useCase,
+}: {
+  hasNewFileExplorer: boolean;
+  hasSandboxTools: boolean;
+  useCase: FileUseCase;
+}): Record<FileFormatCategory, number> {
+  const eligible =
+    hasSandboxTools && hasNewFileExplorer && useCase === "conversation";
+
+  return eligible ? MAX_FILE_SIZES_LARGE_DELIMITED : MAX_FILE_SIZES_DEFAULT;
+}
 
 export function fileSizeToHumanReadable(size: number, decimals = 0) {
   if (size < 1024) {
@@ -152,12 +182,17 @@ export function isBigFileSize(size: number) {
 // Function to ensure file size is within max limit for given content type.
 export function ensureFileSize(
   contentType: AllSupportedFileContentType,
-  fileSize: number
+  fileSize: number,
+  opts: {
+    hasNewFileExplorer: boolean;
+    hasSandboxTools: boolean;
+    useCase: FileUseCase;
+  }
 ): boolean {
   const format = getFileFormat(contentType);
 
   if (format) {
-    return fileSize <= MAX_FILE_SIZES[format.cat];
+    return fileSize <= resolveMaxFileSizes(opts)[format.cat];
   }
 
   return false;
@@ -165,9 +200,14 @@ export function ensureFileSize(
 
 export function ensureFileSizeByFormatCategory(
   category: FileFormatCategory,
-  fileSize: number
+  fileSize: number,
+  opts: {
+    hasNewFileExplorer: boolean;
+    hasSandboxTools: boolean;
+    useCase: FileUseCase;
+  }
 ): boolean {
-  return fileSize <= MAX_FILE_SIZES[category];
+  return fileSize <= resolveMaxFileSizes(opts)[category];
 }
 
 type FileFormat = {
@@ -638,6 +678,8 @@ const EXTENSION_CONTENT_TYPE_OVERRIDES: Record<
 > = {
   ".csv": "text/csv",
   ".tsv": "text/tsv",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 };
 
 export function stripMimeParameters(contentType: string): string {


### PR DESCRIPTION
## Description

For workspaces with both `sandbox_tools` and `new_file_explorer`, delimited files (CSV, TSV, XLSX, XLS) uploaded in the conversation input bar now bypass `tables_query` entirely:

- All upload-time processing skipped: no Tika, no snippet, no JIT data source, no table upsert. Raw blob only in GCS.
- Per-file delimited size cap raised from 50 MB to 350 MB.
- Attachment hints `isQueryable=true` / `isIncludable=true` suppressed at read time so the model is not nudged to `tables_query` or `cat_file` for these files.
- Sandbox skill prose updated to tell the model to analyze tabular files with code (pandas, DuckDB, csv module), with chunked reads for very large files.
- `<file path="...">` rendering now uses the actual GCS mount path (handles `disambiguateFileName` collisions) rather than the user-supplied title.

New `useCaseMetadata.skipFileProcessing` bit, orthogonal to the existing `skipDataSourceIndexing` (which keeps its current meaning for audio/webm transcription, pasted snippets, Slack/Chrome captures, tool-output offloads). Bit is stamped at upload time only when both flags are on, useCase is `conversation`, and content is delimited. Pre-existing files keep their queryable behavior; cleanup is a separate follow-up.

Tool-output flows (`extract_data`, `query_tables_v2`, `run_dust_app`, etc.) are unchanged: agent-emitted CSVs remain queryable.

## Tests

Manually verified the orthogonality regression guards (audio/webm still transcribes, pasted content still snippets) via the new test cases. Did not exercise a real 350 MB upload through the dev server; the upload path was unit-tested at the endpoints with a 60 MB CSV (passes when both flags on, rejected with one flag, rejected for `upsert_table` use case). Sandbox image manifest (pandas, openpyxl, pyarrow, duckdb) is an open question, see design doc.

## Risk

Low. The new path is gated behind two feature flags and only activates on new uploads. Pre-existing files in flagged workspaces keep their queryable behavior unchanged. The orthogonal metadata bit avoids any overlap with existing `skipDataSourceIndexing` consumers (audio/webm, pasted, Slack, Chrome, tool outputs). Public API content fragment schema gains two optional fields (no required-field additions, non-breaking per BACK12).

## Deploy Plan

Standard deploy. Roll the flags to internal workspaces first to validate the 350 MB upload + sandbox round-trip end-to-end before broader rollout.