### PR TITLE
Use floor hour for credits end dates

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -840,7 +840,7 @@ export async function createMetronomeCommit({
 }): Promise<Result<{ id: string } | null, Error>> {
   // Metronome requires dates on hour boundaries — round down start, round up end.
   const roundedStartingAt = floorToHourISO(startingAt);
-  const roundedEndingBefore = ceilToHourISO(endingBefore);
+  const roundedEndingBefore = floorToHourISO(endingBefore);
   try {
     logger.info(
       {
@@ -1225,7 +1225,7 @@ export async function createMetronomeCredit({
 }): Promise<Result<{ id: string } | null, Error>> {
   // Metronome requires dates on hour boundaries — round down start, round up end.
   const roundedStartingAt = floorToHourISO(new Date(startingAt));
-  const roundedEndingBefore = ceilToHourISO(new Date(endingBefore));
+  const roundedEndingBefore = floorToHourISO(new Date(endingBefore));
 
   try {
     const response = await getMetronomeClient().v1.customers.credits.create({

--- a/front/lib/metronome/coupons.test.ts
+++ b/front/lib/metronome/coupons.test.ts
@@ -345,16 +345,16 @@ describe("createCouponCredit", () => {
     expect(mockCreateMetronomeCredit).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        startingAt: "2026-04-01T10:00:00.000Z",
-        endingBefore: "2026-05-01T11:00:00.000Z",
+        startingAt: "2026-04-01T10:30:00.000Z",
+        endingBefore: "2026-05-01T10:30:00.000Z",
       })
     );
     // Month 1: May → Jun
     expect(mockCreateMetronomeCredit).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        startingAt: "2026-05-01T10:00:00.000Z",
-        endingBefore: "2026-06-01T11:00:00.000Z",
+        startingAt: "2026-05-01T10:30:00.000Z",
+        endingBefore: "2026-06-01T10:30:00.000Z",
       })
     );
   });
@@ -373,8 +373,8 @@ describe("createCouponCredit", () => {
 
     expect(mockCreateMetronomeCredit).toHaveBeenCalledWith(
       expect.objectContaining({
-        startingAt: "2026-04-01T10:00:00.000Z",
-        endingBefore: "2026-05-01T11:00:00.000Z",
+        startingAt: "2026-04-01T10:30:00.000Z",
+        endingBefore: "2026-05-01T10:30:00.000Z",
       })
     );
   });
@@ -450,7 +450,7 @@ describe("endCouponCredit", () => {
     );
   });
 
-  it("uses a ceiled hour boundary for accessEndingBefore", async () => {
+  it("uses a floored hour boundary for accessEndingBefore", async () => {
     await endCouponCredit({
       metronomeCustomerId: "cust-1",
       metronomeCreditIds: ["cid-1"],
@@ -459,7 +459,7 @@ describe("endCouponCredit", () => {
 
     expect(mockUpdateMetronomeCreditEndDate).toHaveBeenCalledWith(
       expect.objectContaining({
-        accessEndingBefore: "2026-05-15T15:00:00.000Z",
+        accessEndingBefore: "2026-05-15T14:00:00.000Z",
       })
     );
   });

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -5,7 +5,6 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { metronomeAmount } from "@app/lib/metronome/amounts";
 import {
-  ceilToHourISO,
   createMetronomeCredit,
   floorToHourISO,
   getMetronomeRateCardById,
@@ -110,8 +109,8 @@ export async function createCouponCredit({
       productId: getProductSeatSubscriptionCreditsId(),
       creditTypeId,
       amount: metronomeAmount(coupon.amount * 100, currency),
-      startingAt: floorToHourISO(item.startingAt),
-      endingBefore: ceilToHourISO(item.endingBefore),
+      startingAt: item.startingAt.toISOString(),
+      endingBefore: item.endingBefore.toISOString(),
       name: `Coupon: ${coupon.code}`,
       idempotencyKey: `coupon-${redemptionId}-${i}`,
       priority: 0,
@@ -141,7 +140,7 @@ export async function endCouponCredit({
   metronomeCreditIds: string[];
   endAt: Date;
 }): Promise<Result<void, Error>> {
-  const accessEndingBefore = ceilToHourISO(endAt);
+  const accessEndingBefore = floorToHourISO(endAt);
 
   for (const creditId of metronomeCreditIds) {
     const result = await updateMetronomeCreditEndDate({

--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -15,7 +15,6 @@
 
 import { Authenticator } from "@app/lib/auth";
 import {
-  ceilToHourISO,
   floorToHourISO,
   listMetronomeCustomerCredits,
 } from "@app/lib/metronome/client";
@@ -120,7 +119,7 @@ async function backfillFromMetronome(
     dbCredits
       .filter((c) => c.startDate !== null && c.expirationDate !== null)
       .map((c) => [
-        `${getSubtypeFromDbCredit(c.invoiceOrLineItemId)}:${floorToHourISO(c.startDate!)}:${ceilToHourISO(c.expirationDate!)}`,
+        `${getSubtypeFromDbCredit(c.invoiceOrLineItemId)}:${floorToHourISO(c.startDate!)}:${floorToHourISO(c.expirationDate!)}`,
         c,
       ])
   );
@@ -159,7 +158,7 @@ async function backfillFromMetronome(
       subtype = "unknown";
     }
 
-    const dateKey = `${subtype}:${floorToHourISO(startDate)}:${ceilToHourISO(expirationDate)}`;
+    const dateKey = `${subtype}:${floorToHourISO(startDate)}:${floorToHourISO(expirationDate)}`;
     const existingByDates = existingDateKeys.get(dateKey);
     if (existingByDates) {
       if (


### PR DESCRIPTION
## Description

Standardizes Metronome credit end date rounding to use `floorToHourISO` instead of `ceilToHourISO`. Previously, credit start dates were floored while end dates were ceiled, creating inconsistent hour boundaries. This changes all credit end dates to be floored to match the start date behavior and align with how the codebase handles date boundaries elsewhere (e.g., coupon credits in `coupons.ts` now pass raw ISO strings which get floored in `createMetronomeCredit`).

## Risk

Low

## Deploy Plan

Deploy front