### PR TITLE
[front] sbx: add duckdb python package

### DIFF
--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -13,7 +13,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.3";
+const DUST_BASE_IMAGE_VERSION = "0.8.4";
 const DSBX_CLI_VERSION = "0.1.5";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
@@ -67,6 +67,11 @@ const PYTHON_LIBRARIES: PythonLibrary[] = [
     name: "opencv-python",
     version: "4.13.0.92",
     description: "OpenCV package for python",
+  },
+  {
+    name: "duckdb",
+    version: "1.4.0",
+    description: "In-process OLAP / SQL on dataframes",
   },
 ];
 


### PR DESCRIPTION
## Description

Adds `duckdb==1.4.0` to the sandbox base image so agents can run in-process OLAP / SQL over dataframes, parquet and CSV without spinning up a server. Bumps `DUST_BASE_IMAGE_VERSION` to `0.8.4`.

Follow up of #25251.

## Tests

Typecheck clean locally. Sandbox image rebuild will exercise the actual install.

## Risk

Low. Worst case the image build fails on the new package and the base image just doesn't roll out. Safe to rollback.

## Deploy Plan

Standard deploy. Sandbox base image rebuild picks up `0.8.4`.