### PR TITLE
feat(project-todos): skip merge candidates matching a soft-deleted todo

### DIFF
--- a/front/lib/project_todo/merge_into_project.test.ts
+++ b/front/lib/project_todo/merge_into_project.test.ts
@@ -1,7 +1,9 @@
 import type { Authenticator } from "@app/lib/auth";
+import type { DeduplicatedGroup } from "@app/lib/project_todo/deduplicate_candidates";
 import {
   actionItemBlob,
   collectDocumentCandidates,
+  createOrLinkTodos,
   updateTodoIfChanged,
 } from "@app/lib/project_todo/merge_into_project";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
@@ -14,7 +16,9 @@ import type {
   ProjectTodoSourceInfo,
   ProjectTodoStatus,
 } from "@app/types/project_todo";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { TodoVersionedActionItem } from "@app/types/takeaways";
+import type { Logger } from "pino";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Shared fixtures ───────────────────────────────────────────────────────────
@@ -470,5 +474,107 @@ describe("updateTodoIfChanged", () => {
 
     expect(updated).toBe(false);
     expect(todo.updateWithVersion).not.toHaveBeenCalled();
+  });
+});
+
+// ── createOrLinkTodos ─────────────────────────────────────────────────────────
+
+const fakeLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+} as unknown as Logger;
+
+describe("createOrLinkTodos", () => {
+  it("skips candidates when the matched existing todo is soft-deleted", async () => {
+    const upsertSource = vi.fn();
+    const deletedTodo = {
+      deletedAt: new Date("2026-04-01T00:00:00.000Z"),
+      sId: "todo-deleted",
+      upsertSource,
+    } as unknown as ProjectTodoResource;
+
+    const group: DeduplicatedGroup = {
+      kind: "existing",
+      todo: deletedTodo,
+      candidates: [
+        { itemId: "item-x", userId: 1 as ModelId, text: "Do the thing" },
+      ],
+    };
+
+    const { deduplicated, createdNew } = await createOrLinkTodos(fakeAuth, {
+      localLogger: fakeLogger,
+      newCandidates: [
+        {
+          itemId: "item-x",
+          userId: 1 as ModelId,
+          blob: {
+            text: "Do the thing",
+            status: "todo",
+            doneAt: null,
+            reasoningDoneAt: null,
+            reasoningCreatedAt: null,
+          },
+          source: makeSource(),
+        },
+      ],
+      dedupGroups: [group],
+      spaceModelId: 1 as ModelId,
+    });
+
+    expect(upsertSource).not.toHaveBeenCalled();
+    expect(deduplicated).toBe(0);
+    expect(createdNew).toBe(0);
+  });
+
+  it("links source when the matched existing todo is not deleted", async () => {
+    const upsertSource = vi.fn().mockResolvedValue(undefined);
+    const updateWithVersion = vi.fn().mockResolvedValue(undefined);
+    const liveTodo = {
+      deletedAt: null,
+      sId: "todo-live",
+      status: "todo",
+      createdByType: "agent",
+      markedAsDoneByType: null,
+      text: "Do the thing",
+      doneAt: null,
+      actorRationale: null,
+      userId: 1 as ModelId,
+      upsertSource,
+      updateWithVersion,
+    } as unknown as ProjectTodoResource;
+
+    const group: DeduplicatedGroup = {
+      kind: "existing",
+      todo: liveTodo,
+      candidates: [
+        { itemId: "item-y", userId: 1 as ModelId, text: "Do the thing" },
+      ],
+    };
+
+    const { deduplicated, createdNew } = await createOrLinkTodos(fakeAuth, {
+      localLogger: fakeLogger,
+      newCandidates: [
+        {
+          itemId: "item-y",
+          userId: 1 as ModelId,
+          blob: {
+            text: "Do the thing",
+            status: "todo",
+            doneAt: null,
+            reasoningDoneAt: null,
+            reasoningCreatedAt: null,
+          },
+          source: makeSource(),
+        },
+      ],
+      dedupGroups: [group],
+      spaceModelId: 1 as ModelId,
+    });
+
+    expect(upsertSource).toHaveBeenCalledOnce();
+    expect(deduplicated).toBe(1);
+    expect(createdNew).toBe(0);
   });
 });

--- a/front/lib/project_todo/merge_into_project.ts
+++ b/front/lib/project_todo/merge_into_project.ts
@@ -341,10 +341,12 @@ async function buildDeduplicationGroups(
   await concurrentExecutor(
     uniqueUserIds,
     async (userId) => {
-      const todos = await ProjectTodoResource.fetchLatestBySpaceForUser(auth, {
-        spaceId: spaceModelId,
-        userId,
-      });
+      // we want deleted TODOs to match them
+      const todos =
+        await ProjectTodoResource.fetchLatestBySpaceForUserIncludingDeleted(
+          auth,
+          { spaceId: spaceModelId, userId }
+        );
       for (const todo of todos) {
         if (todo.userId === null) {
           continue;
@@ -368,7 +370,7 @@ async function buildDeduplicationGroups(
 
 // Executes one dedup group per call, atomically: groups don't share state, so
 // they run in parallel at concurrency 4.
-async function createOrLinkTodos(
+export async function createOrLinkTodos(
   auth: Authenticator,
   {
     localLogger,
@@ -403,6 +405,10 @@ async function createOrLinkTodos(
     dedupGroups,
     async (group) => {
       if (group.kind === "existing") {
+        if (group.todo.deletedAt !== null) {
+          // Candidate matched a deleted todo — do not re-create or re-link.
+          return;
+        }
         // Attach every candidate's source to the existing todo. The update
         // guard lives in updateTodoIfChanged — no-op when the target todo was
         // created by a user or already marked done by one.

--- a/front/lib/resources/project_todo_resource.ts
+++ b/front/lib/resources/project_todo_resource.ts
@@ -412,22 +412,28 @@ export class ProjectTodoResource extends BaseResource<ProjectTodoModel> {
     auth: Authenticator,
     { spaceId }: { spaceId: ModelId }
   ): Promise<ProjectTodoResource[]> {
-    return this.fetchLatestBySpaceForUser(auth, {
-      spaceId,
-      userId: auth.getNonNullableUser().id,
+    return this.baseFetch(auth, {
+      where: { spaceId, userId: auth.getNonNullableUser().id },
+      order: [["createdAt", "DESC"]],
     });
   }
 
-  // Returns all todos for an explicit target userId in the given space.
-  // Used by the merge workflow which acts on behalf of specific target users.
-  static async fetchLatestBySpaceForUser(
+  // Like fetchLatestBySpaceForUser but also includes soft-deleted rows. Used by
+  // the merge workflow to detect candidates that match a previously deleted todo
+  // so that the merge skips them rather than re-creating the todo.
+  static async fetchLatestBySpaceForUserIncludingDeleted(
     auth: Authenticator,
     { spaceId, userId }: { spaceId: ModelId; userId: ModelId }
   ): Promise<ProjectTodoResource[]> {
-    return this.baseFetch(auth, {
-      where: { spaceId, userId },
+    const todos = await ProjectTodoModel.findAll({
+      where: {
+        spaceId,
+        userId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
       order: [["createdAt", "DESC"]],
     });
+    return todos.map((todo) => new this(ProjectTodoModel, todo.get()));
   }
 
   // Batch variant: fetches the current todo row for each itemId in one pass.


### PR DESCRIPTION
## Description

During the merge workflow (Phase 2), the deduplication pass now fetches existing todos for each target user **including soft-deleted rows** via a new `fetchLatestBySpaceForUserIncludingDeleted` method. This allows the LLM to detect when a new candidate semantically matches a todo the user already dismissed.

In Phase 3, if the dedup result points to a deleted todo (`deletedAt !== null`), the candidate is silently dropped — no new todo is created and no source link is attached.

Previously, a deleted todo was invisible to the dedup pass, so the merge workflow would re-create it on the next run.

## Tests

Added two unit tests in `createOrLinkTodos`:
- Deleted match: verifies `upsertSource` is never called and stats stay at zero.
- Live match: verifies the existing happy-path still links the source and increments `deduplicated`.
