### PR TITLE
[metronome] Backfill seats memberships

### DIFF
--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -333,7 +333,7 @@ export async function countMauForWorkspace(
     since: thirtyDaysAgo,
     workspace,
   });
-  return Math.max(count, 1);
+  return count;
 }
 
 /**

--- a/front/lib/metronome/mau_sync.ts
+++ b/front/lib/metronome/mau_sync.ts
@@ -324,15 +324,13 @@ export async function syncMauCount({
     workspace,
   });
 
-  const totalMau = Math.max(mauCount, 1);
-
   // Get subscriptions that need updating (works for both simple and tiered).
   const subscriptions =
     mauInfo.type === "simple" ? [mauInfo.subscription] : mauInfo.subscriptions;
-  const toUpdate = distributeMauAcrossTiers(totalMau, subscriptions);
+  const toUpdate = distributeMauAcrossTiers(mauCount, subscriptions);
 
   logger.info(
-    { workspaceId: workspace.sId, contractId, toUpdate, totalMau },
+    { workspaceId: workspace.sId, contractId, toUpdate, mauCount },
     "[Metronome] Updating MAU quantities"
   );
 

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -119,7 +119,7 @@ export async function syncSeatCount({
     metronomeCustomerId,
     contractId,
     subscriptionId,
-    quantity: Math.max(memberCount, 1),
+    quantity: memberCount,
     startingAt,
   });
 }

--- a/front/scripts/backfill_metronome_seat_count.ts
+++ b/front/scripts/backfill_metronome_seat_count.ts
@@ -1,0 +1,276 @@
+/**
+ * Backfill Workspace Seat quantity history on Metronome from the memberships table.
+ *
+ * For each workspace with an active Metronome contract:
+ * - Fetches the active contract.
+ * - Looks for the "Workspace Seat" subscription on the contract; skips if absent.
+ * - Reads the seat subscription's current billing period start.
+ * - Reconstructs the seat count timeline within the current billing period using
+ *   MembershipModel rows (membership active for time t when startAt <= t < endAt
+ *   or endAt is null). Emits the initial count at the period start, then one
+ *   entry per change.
+ * - Sends a single batched v2.contracts.edit call with the quantity_updates
+ *   (hour-floored, same-hour events collapsed, no-op changes dropped).
+ *
+ * Run with:
+ *   npx tsx scripts/backfill_metronome_seat_count.ts [--execute] [--workspaceId <sId>]
+ */
+
+import {
+  floorToHourISO,
+  getMetronomeClient,
+  getMetronomeContractById,
+} from "@app/lib/metronome/client";
+import { getProductWorkspaceSeatId } from "@app/lib/metronome/constants";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import type { Logger } from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Op } from "sequelize";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+interface SeatTimelineEntry {
+  startingAt: string; // hour-floored ISO
+  quantity: number;
+}
+
+/**
+ * Build the (hour-floored, deduped) seat-count timeline within the current
+ * billing period. The first entry sets the count at periodStart itself.
+ */
+async function buildSeatTimeline({
+  workspace,
+  periodStart,
+}: {
+  workspace: LightWorkspaceType;
+  periodStart: Date;
+}): Promise<SeatTimelineEntry[]> {
+  const now = new Date();
+
+  // Initial count: memberships active at periodStart.
+  const initialCount = await MembershipModel.count({
+    where: {
+      workspaceId: workspace.id,
+      startAt: { [Op.lte]: periodStart },
+      [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: periodStart } }],
+    },
+  });
+
+  // All memberships whose startAt or endAt falls in (periodStart, now].
+  const memberships = await MembershipModel.findAll({
+    attributes: ["startAt", "endAt"],
+    where: {
+      workspaceId: workspace.id,
+      [Op.or]: [
+        { startAt: { [Op.gt]: periodStart, [Op.lte]: now } },
+        { endAt: { [Op.gt]: periodStart, [Op.lte]: now } },
+      ],
+    },
+  });
+
+  const events: Array<{ at: Date; delta: number }> = [];
+  for (const m of memberships) {
+    if (m.startAt > periodStart && m.startAt <= now) {
+      events.push({ at: m.startAt, delta: 1 });
+    }
+    if (m.endAt && m.endAt > periodStart && m.endAt <= now) {
+      events.push({ at: m.endAt, delta: -1 });
+    }
+  }
+
+  events.sort((a, b) => a.at.getTime() - b.at.getTime());
+
+  // Always emit the initial count at periodStart so the seat quantity is reset
+  // at the start of the billing period.
+  const timeline: SeatTimelineEntry[] = [
+    {
+      startingAt: floorToHourISO(periodStart),
+      quantity: initialCount,
+    },
+  ];
+  let runningCount = initialCount;
+  let lastEmittedQuantity = timeline[0].quantity;
+  let pendingHour: string | null = null;
+
+  for (const ev of events) {
+    const hourIso = floorToHourISO(ev.at);
+
+    // Moved past the previous hour: flush its accumulated quantity.
+    if (pendingHour !== null && hourIso !== pendingHour) {
+      if (runningCount !== lastEmittedQuantity) {
+        timeline.push({ startingAt: pendingHour, quantity: runningCount });
+        lastEmittedQuantity = runningCount;
+      }
+      pendingHour = null;
+    }
+
+    runningCount += ev.delta;
+    pendingHour = hourIso;
+  }
+
+  // Flush the final pending hour.
+  if (pendingHour !== null && runningCount !== lastEmittedQuantity) {
+    timeline.push({ startingAt: pendingHour, quantity: runningCount });
+  }
+
+  return timeline;
+}
+
+async function backfillSeatCountForWorkspace(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  if (workspace.metadata?.maintenance) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "[SeatBackfill] Workspace in maintenance, skipping"
+    );
+    return;
+  }
+
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return;
+  }
+
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  const metronomeContractId = subscription?.metronomeContractId;
+  if (!metronomeContractId) {
+    return;
+  }
+
+  const contractResult = await getMetronomeContractById({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (contractResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        metronomeContractId,
+        error: contractResult.error.message,
+      },
+      "[SeatBackfill] Failed to fetch contract"
+    );
+    return;
+  }
+
+  const contract = contractResult.value;
+  const seatProductId = getProductWorkspaceSeatId();
+  const seatSubscription = contract.subscriptions?.find(
+    (s) => s.subscription_rate.product.id === seatProductId
+  );
+  if (!seatSubscription?.id) {
+    logger.info(
+      { workspaceId: workspace.sId, metronomeContractId },
+      "[SeatBackfill] No Workspace Seat subscription on contract, skipping"
+    );
+    return;
+  }
+
+  const currentPeriodStart =
+    seatSubscription.billing_periods?.current?.starting_at;
+  if (!currentPeriodStart) {
+    logger.warn(
+      { workspaceId: workspace.sId, metronomeContractId },
+      "[SeatBackfill] Seat subscription has no current billing period, skipping"
+    );
+    return;
+  }
+
+  const periodStart = new Date(currentPeriodStart);
+  if (Number.isNaN(periodStart.getTime())) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        metronomeContractId,
+        currentPeriodStart,
+      },
+      "[SeatBackfill] Invalid billing period starting_at, skipping"
+    );
+    return;
+  }
+
+  const timeline = await buildSeatTimeline({ workspace, periodStart });
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      metronomeContractId,
+      subscriptionId: seatSubscription.id,
+      periodStart: periodStart.toISOString(),
+      changes: timeline.length,
+      first: timeline[0],
+      last: timeline[timeline.length - 1],
+    },
+    `[SeatBackfill] ${execute ? "Applying" : "[DRY RUN] Would apply"} ${timeline.length} seat quantity update(s)`
+  );
+
+  if (!execute) {
+    for (const entry of timeline) {
+      logger.info(
+        { workspaceId: workspace.sId, ...entry },
+        "[SeatBackfill] [DRY RUN] quantity update"
+      );
+    }
+    return;
+  }
+
+  try {
+    await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+      update_subscriptions: [
+        {
+          subscription_id: seatSubscription.id,
+          quantity_updates: timeline.map((e) => ({
+            starting_at: e.startingAt,
+            quantity: e.quantity,
+          })),
+        },
+      ],
+    });
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        metronomeContractId,
+        applied: timeline.length,
+      },
+      "[SeatBackfill] Applied seat quantity updates"
+    );
+  } catch (err) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        metronomeContractId,
+        error: normalizeError(err).message,
+      },
+      "[SeatBackfill] Failed to apply seat quantity updates"
+    );
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string" as const,
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await backfillSeatCountForWorkspace(workspace, execute, logger);
+      },
+      { concurrency: 4, wId: workspaceId }
+    );
+  }
+);

--- a/front/scripts/migrate_metronome_contracts.ts
+++ b/front/scripts/migrate_metronome_contracts.ts
@@ -19,8 +19,11 @@
 import {
   ceilToHourISO,
   epochSecondsToFloorHourISO,
+  floorToHourISO,
   getMetronomeClient,
+  getMetronomeContractById,
 } from "@app/lib/metronome/client";
+import { getProductWorkspaceSeatId } from "@app/lib/metronome/constants";
 import {
   applyEnterpriseOverrides,
   buildEnterpriseOverrides,
@@ -29,7 +32,6 @@ import {
   extractEnterprisePricing,
 } from "@app/lib/metronome/contracts";
 import { syncMauCount } from "@app/lib/metronome/mau_sync";
-import { syncSeatCount } from "@app/lib/metronome/seats";
 import {
   LEGACY_BUSINESS_PACKAGE_ALIAS,
   LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS,
@@ -44,12 +46,14 @@ import {
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { Logger } from "@app/logger/logger";
 import { isSupportedCurrency } from "@app/types/currency";
 import type { LightWorkspaceType } from "@app/types/user";
+import { Op } from "sequelize";
 import { makeScript } from "./helpers";
 import { runOnAllWorkspaces } from "./workspace_helpers";
 
@@ -508,20 +512,129 @@ async function migrateWorkspace(
       );
     }
   } else {
-    const seatResult = await syncSeatCount({
-      metronomeCustomerId,
-      contractId: newContractId,
-      workspace,
-      startingAt: subInfo.startDate,
+    // Backfill seat counts across the current billing period: start with the
+    // member count at periodStart, then push every change since then.
+    const periodStart = new Date(subInfo.startDate);
+    const now = new Date();
+
+    const initialCount = await MembershipModel.count({
+      where: {
+        workspaceId: workspace.id,
+        startAt: { [Op.lte]: periodStart },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: periodStart } }],
+      },
     });
-    if (seatResult.isErr()) {
+
+    const memberships = await MembershipModel.findAll({
+      attributes: ["startAt", "endAt"],
+      where: {
+        workspaceId: workspace.id,
+        [Op.or]: [
+          { startAt: { [Op.gt]: periodStart, [Op.lte]: now } },
+          { endAt: { [Op.gt]: periodStart, [Op.lte]: now } },
+        ],
+      },
+    });
+
+    const events: Array<{ at: Date; delta: number }> = [];
+    for (const m of memberships) {
+      if (m.startAt > periodStart && m.startAt <= now) {
+        events.push({ at: m.startAt, delta: 1 });
+      }
+      if (m.endAt && m.endAt > periodStart && m.endAt <= now) {
+        events.push({ at: m.endAt, delta: -1 });
+      }
+    }
+    events.sort((a, b) => a.at.getTime() - b.at.getTime());
+
+    const timeline: Array<{ startingAt: string; quantity: number }> = [
+      {
+        startingAt: floorToHourISO(periodStart),
+        quantity: initialCount,
+      },
+    ];
+    let runningCount = initialCount;
+    let lastEmittedQuantity = timeline[0].quantity;
+    let pendingHour: string | null = null;
+    for (const ev of events) {
+      const hourIso = floorToHourISO(ev.at);
+      if (pendingHour !== null && hourIso !== pendingHour) {
+        if (runningCount !== lastEmittedQuantity) {
+          timeline.push({ startingAt: pendingHour, quantity: runningCount });
+          lastEmittedQuantity = runningCount;
+        }
+        pendingHour = null;
+      }
+      runningCount += ev.delta;
+      pendingHour = hourIso;
+    }
+    if (pendingHour !== null && runningCount !== lastEmittedQuantity) {
+      timeline.push({ startingAt: pendingHour, quantity: runningCount });
+    }
+
+    // Find the seat subscription id on the freshly-created contract.
+    const contractResult = await getMetronomeContractById({
+      metronomeCustomerId,
+      metronomeContractId: newContractId,
+    });
+    if (contractResult.isErr()) {
       logger.error(
         {
           workspaceId: workspace.sId,
           contractId: newContractId,
-          error: seatResult.error.message,
+          error: contractResult.error.message,
         },
-        "Failed to provision seats on new contract"
+        "Failed to fetch new contract for seat backfill"
+      );
+      return;
+    }
+    const seatProductId = getProductWorkspaceSeatId();
+    const seatSubscription = contractResult.value.subscriptions?.find(
+      (s) => s.subscription_rate.product.id === seatProductId
+    );
+    if (!seatSubscription?.id) {
+      logger.error(
+        { workspaceId: workspace.sId, contractId: newContractId },
+        "No Workspace Seat subscription on new contract — cannot backfill seats"
+      );
+      return;
+    }
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        contractId: newContractId,
+        subscriptionId: seatSubscription.id,
+        periodStart: periodStart.toISOString(),
+        changes: timeline.length,
+        first: timeline[0],
+        last: timeline[timeline.length - 1],
+      },
+      `Applying ${timeline.length} seat quantity update(s) to new contract`
+    );
+
+    try {
+      await client.v2.contracts.edit({
+        customer_id: metronomeCustomerId,
+        contract_id: newContractId,
+        update_subscriptions: [
+          {
+            subscription_id: seatSubscription.id,
+            quantity_updates: timeline.map((e) => ({
+              starting_at: e.startingAt,
+              quantity: e.quantity,
+            })),
+          },
+        ],
+      });
+    } catch (err) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          contractId: newContractId,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to apply seat quantity updates on new contract"
       );
     }
   }


### PR DESCRIPTION
## Description

Backfill the Metronome **Workspace Seat** subscription quantity history from the memberships table so the seat count on Metronome matches what the workspace actually had at every point in the current billing period (instead of the single \"current value\" snapshot we used to push).

Two ways to run it:

- **New `front/scripts/backfill_metronome_seat_count.ts`** — standalone backfill for already-migrated contracts. Per workspace, finds the seat subscription on the active contract, reads `billing_periods.current.starting_at`, replays membership `startAt` / `endAt` events from there to now, and sends one batched `v2.contracts.edit` with the full `quantity_updates` array.
- **`migrate_metronome_contracts.ts`** — same logic inlined in the non-enterprise branch after the new contract is created (replaces the previous one-shot `syncSeatCount` call). Period start = the Stripe `current_period_start` we already use as the new contract's `starting_at`.

Behavior details:

- Initial entry sets the count at the period start (memberships with `startAt <= periodStart` AND (`endAt IS NULL` OR `endAt > periodStart`)).
- Then one entry per change, hour-floored (Metronome's granularity). Same-hour events are collapsed; no-op steps (quantity unchanged) are dropped.

Also dropped the `Math.max(*, 1)` floor that prevented quantities from reaching 0:

- `lib/metronome/seats.ts` (`syncSeatCount`)
- `lib/metronome/mau_sync.ts` (`syncMauCount` / `totalMau` → `mauCount`)
- `lib/metronome/contracts.ts` (`countMauForWorkspace`)
- the same sites duplicated in both scripts

The `Math.max(count, 0)` per-tier non-negative guard in `mau_sync.ts` is intentionally kept.

## Tests

- `npx tsgo --noEmit` clean.
- Existing `seats.test.ts` / `mau_sync.test.ts` unaffected (no assertions depended on the floor).
- Standalone script verified end-to-end via `--workspaceId <sId>` dry-run, then `--execute`.

## Risk

- **Past-period writes**: Metronome typically rejects `quantity_updates` whose `starting_at` falls inside an already-finalized billing period. Recommend running the standalone script first on a single workspace with `--workspaceId` to confirm the API accepts updates within the *current* (open) period.
- **Floor removal**: emitting `quantity: 0` is a behavior change. Verify Metronome accepts 0 on a `QUANTITY_ONLY` seat subscription (and, for enterprise, on MAU subscriptions / tiers).
- **No idempotency dedupe**: `quantity_schedule` only exposes the currently-effective entry plus future ones, so we can't tell whether a past update has already been applied. Re-running on the same period will re-push every step (Metronome should treat duplicates as no-ops, but worth keeping in mind).
- Rollback: revert the PR; no schema or data migration involved.

## Deploy Plan

1. Merge & deploy.
2. On a single Pro/Business workspace, dry-run the standalone backfill: `npx tsx scripts/backfill_metronome_seat_count.ts --workspaceId <sId>`.
3. Inspect the proposed timeline in the logs, then re-run with `--execute`.
4. Spot-check the Metronome contract UI to confirm the `quantity_schedule` reflects the membership history.
5. Roll out to all workspaces: `npx tsx scripts/backfill_metronome_seat_count.ts --execute`.
6. The migrate script changes apply automatically on the next migration run — no separate action needed.