### PR TITLE
add support for agentFacingDescription edits in skill eval tests

### DIFF
--- a/front/tests/reinforcement-evals/lib/assertions.ts
+++ b/front/tests/reinforcement-evals/lib/assertions.ts
@@ -87,6 +87,21 @@ function getToolEdits(args: Record<string, unknown>): ToolEditItem[] {
   return edits.filter(isToolEditItem);
 }
 
+function getAgentFacingDescriptionEditContent(
+  args: Record<string, unknown>
+): string | undefined {
+  const edit = args.agentFacingDescriptionEdit;
+  if (
+    typeof edit !== "object" ||
+    edit === null ||
+    !("content" in edit) ||
+    typeof edit.content !== "string"
+  ) {
+    return undefined;
+  }
+  return edit.content;
+}
+
 function findEditSkillCall(toolCalls: ToolCall[]): ToolCall | undefined {
   return toolCalls.find((tc) => tc.name === "edit_skill");
 }
@@ -165,6 +180,30 @@ export function validateToolCallAssertion(
       }
       return { success: true };
     }
+    case "editSkillWithAgentFacingDescription": {
+      const editCalls = toolCalls.filter((tc) => tc.name === "edit_skill");
+      const matching = editCalls.find(
+        (call) =>
+          getSkillId(call.arguments) === assertion.skillId &&
+          getAgentFacingDescriptionEditContent(call.arguments) !== undefined
+      );
+      if (!matching) {
+        return {
+          success: false,
+          error: `Expected edit_skill to be called with agentFacingDescriptionEdit for skillId "${assertion.skillId}", but no such call was made`,
+        };
+      }
+      if (assertion.sourceSuggestionIds) {
+        const sourceResult = validateSourceSuggestionIds(
+          matching,
+          assertion.sourceSuggestionIds
+        );
+        if (sourceResult) {
+          return sourceResult;
+        }
+      }
+      return { success: true };
+    }
     case "editSkill": {
       const call = findEditSkillCall(toolCalls);
       if (!call) {
@@ -198,10 +237,16 @@ export function validateToolCallAssertion(
         }
         const instructionEdits = getInstructionEdits(tc.arguments);
         const toolEdits = getToolEdits(tc.arguments);
-        if (instructionEdits.length > 0 || toolEdits.length > 0) {
+        const hasDescriptionEdit =
+          getAgentFacingDescriptionEditContent(tc.arguments) !== undefined;
+        if (
+          instructionEdits.length > 0 ||
+          toolEdits.length > 0 ||
+          hasDescriptionEdit
+        ) {
           return {
             success: false,
-            error: `Expected no suggestions, but edit_skill was called with ${instructionEdits.length} instructionEdit(s) and ${toolEdits.length} toolEdit(s)`,
+            error: `Expected no suggestions, but edit_skill was called with ${instructionEdits.length} instructionEdit(s), ${toolEdits.length} toolEdit(s)${hasDescriptionEdit ? ", and an agentFacingDescriptionEdit" : ""}`,
           };
         }
       }

--- a/front/tests/reinforcement-evals/lib/assertions.ts
+++ b/front/tests/reinforcement-evals/lib/assertions.ts
@@ -102,8 +102,11 @@ function getAgentFacingDescriptionEditContent(
   return edit.content;
 }
 
-function findEditSkillCall(toolCalls: ToolCall[]): ToolCall | undefined {
-  return toolCalls.find((tc) => tc.name === "edit_skill");
+function findEditSkillCall(
+  toolCalls: ToolCall[],
+  predicate: (call: ToolCall) => boolean = () => true
+): ToolCall | undefined {
+  return toolCalls.find((tc) => tc.name === "edit_skill" && predicate(tc));
 }
 
 /**
@@ -115,25 +118,16 @@ export function validateToolCallAssertion(
 ): AssertionResult {
   switch (assertion.type) {
     case "editSkillWithInstructions": {
-      const call = findEditSkillCall(toolCalls);
+      const call = findEditSkillCall(
+        toolCalls,
+        (c) =>
+          getSkillId(c.arguments) === assertion.skillId &&
+          getInstructionEdits(c.arguments).length > 0
+      );
       if (!call) {
         return {
           success: false,
-          error: `Expected edit_skill to be called with instructionEdits for skillId "${assertion.skillId}", but edit_skill was not called`,
-        };
-      }
-      const skillId = getSkillId(call.arguments);
-      if (skillId !== assertion.skillId) {
-        return {
-          success: false,
-          error: `Expected edit_skill for skillId "${assertion.skillId}", but got skillId "${skillId}"`,
-        };
-      }
-      const instructionEdits = getInstructionEdits(call.arguments);
-      if (instructionEdits.length === 0) {
-        return {
-          success: false,
-          error: `Expected edit_skill to contain instructionEdits for skillId "${assertion.skillId}", but instructionEdits is empty or missing`,
+          error: `Expected an edit_skill call with instructionEdits for skillId "${assertion.skillId}", but no such call was made`,
         };
       }
       if (assertion.sourceSuggestionIds) {
@@ -148,25 +142,16 @@ export function validateToolCallAssertion(
       return { success: true };
     }
     case "editSkillWithTool": {
-      const call = findEditSkillCall(toolCalls);
+      const call = findEditSkillCall(
+        toolCalls,
+        (c) =>
+          getSkillId(c.arguments) === assertion.skillId &&
+          getToolEdits(c.arguments).some((t) => t.toolId === assertion.toolId)
+      );
       if (!call) {
         return {
           success: false,
-          error: `Expected edit_skill to be called with toolEdits for skillId "${assertion.skillId}" and toolId "${assertion.toolId}", but edit_skill was not called`,
-        };
-      }
-      const skillId = getSkillId(call.arguments);
-      if (skillId !== assertion.skillId) {
-        return {
-          success: false,
-          error: `Expected edit_skill for skillId "${assertion.skillId}", but got skillId "${skillId}"`,
-        };
-      }
-      const toolEdits = getToolEdits(call.arguments);
-      if (!toolEdits.some((t) => t.toolId === assertion.toolId)) {
-        return {
-          success: false,
-          error: `Expected edit_skill to contain toolEdit with toolId "${assertion.toolId}", but got: ${JSON.stringify(toolEdits)}`,
+          error: `Expected an edit_skill call with toolEdit toolId "${assertion.toolId}" for skillId "${assertion.skillId}", but no such call was made`,
         };
       }
       if (assertion.sourceSuggestionIds) {
@@ -181,21 +166,21 @@ export function validateToolCallAssertion(
       return { success: true };
     }
     case "editSkillWithAgentFacingDescription": {
-      const editCalls = toolCalls.filter((tc) => tc.name === "edit_skill");
-      const matching = editCalls.find(
-        (call) =>
-          getSkillId(call.arguments) === assertion.skillId &&
-          getAgentFacingDescriptionEditContent(call.arguments) !== undefined
+      const call = findEditSkillCall(
+        toolCalls,
+        (c) =>
+          getSkillId(c.arguments) === assertion.skillId &&
+          getAgentFacingDescriptionEditContent(c.arguments) !== undefined
       );
-      if (!matching) {
+      if (!call) {
         return {
           success: false,
-          error: `Expected edit_skill to be called with agentFacingDescriptionEdit for skillId "${assertion.skillId}", but no such call was made`,
+          error: `Expected an edit_skill call with agentFacingDescriptionEdit for skillId "${assertion.skillId}", but no such call was made`,
         };
       }
       if (assertion.sourceSuggestionIds) {
         const sourceResult = validateSourceSuggestionIds(
-          matching,
+          call,
           assertion.sourceSuggestionIds
         );
         if (sourceResult) {
@@ -205,18 +190,14 @@ export function validateToolCallAssertion(
       return { success: true };
     }
     case "editSkill": {
-      const call = findEditSkillCall(toolCalls);
+      const call = findEditSkillCall(
+        toolCalls,
+        (c) => getSkillId(c.arguments) === assertion.skillId
+      );
       if (!call) {
         return {
           success: false,
-          error: `Expected edit_skill to be called for skillId "${assertion.skillId}", but edit_skill was not called`,
-        };
-      }
-      const skillId = getSkillId(call.arguments);
-      if (skillId !== assertion.skillId) {
-        return {
-          success: false,
-          error: `Expected edit_skill for skillId "${assertion.skillId}", but got skillId "${skillId}"`,
+          error: `Expected an edit_skill call for skillId "${assertion.skillId}", but no such call was made`,
         };
       }
       if (assertion.sourceSuggestionIds) {

--- a/front/tests/reinforcement-evals/lib/types.ts
+++ b/front/tests/reinforcement-evals/lib/types.ts
@@ -204,6 +204,11 @@ export type ToolCallAssertion =
       toolId: string;
       sourceSuggestionIds?: string[];
     }
+  | {
+      type: "editSkillWithAgentFacingDescription";
+      skillId: string;
+      sourceSuggestionIds?: string[];
+    }
   | { type: "editSkill"; skillId: string; sourceSuggestionIds?: string[] }
   | { type: "editSkillCallCount"; count: number }
   | { type: "editSkillCallsWithSources"; sourceSuggestionIdGroups: string[][] }
@@ -229,6 +234,18 @@ export function editSkillWithTool(
   sourceSuggestionIds?: string[]
 ): ToolCallAssertion {
   return { type: "editSkillWithTool", skillId, toolId, sourceSuggestionIds };
+}
+
+/** Expects an edit_skill call with an agentFacingDescriptionEdit for the given skill. */
+export function editSkillWithAgentFacingDescription(
+  skillId: string,
+  sourceSuggestionIds?: string[]
+): ToolCallAssertion {
+  return {
+    type: "editSkillWithAgentFacingDescription",
+    skillId,
+    sourceSuggestionIds,
+  };
 }
 
 /** Expects an edit_skill call for the given skill (any edit type). */

--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -488,7 +488,7 @@ Score 3 if no edit_skill suggestion is created AND reject_suggestion is not call
           sId: "sug-tool-1",
           skillConfigurationId: "skill_payment_resolver",
           analysis:
-            "User asked the skill to file an internal incident ticket for a flagged chargeback. The skill had no JIRA tool to do so.",
+            "User asked the skill to file an internal incident ticket for a flagged chargeback. The skill had no JIRA tool to do so, it's crucial to add it.",
           action: "add",
           toolId: "mcp_jira",
         }),

--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -1,5 +1,7 @@
 import {
+  editSkillCallCount,
   editSkillCallsWithSources,
+  editSkillWithAgentFacingDescription,
   editSkillWithInstructions,
   editSkillWithTool,
   mockTool,
@@ -71,6 +73,33 @@ function makeToolSuggestion(input: {
     kind: "edit",
     suggestion: {
       toolEdits: [{ action: input.action, toolId: input.toolId }],
+    },
+  };
+}
+
+function makeAgentFacingDescriptionSuggestion(input: {
+  sId: string;
+  analysis: string;
+  content: string;
+  skillConfigurationId?: string;
+  source?: "reinforcement" | "synthetic";
+}): SkillSuggestionType {
+  return {
+    sId: input.sId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    skillConfigurationId: input.skillConfigurationId ?? SKILL_SID,
+    analysis: input.analysis,
+    title: null,
+    state: "pending",
+    source: input.source ?? "synthetic",
+    sourceConversationsCount: 0,
+    visibleSourceConversationIds: [],
+    notificationConversationId: null,
+    updatedBy: null,
+    kind: "edit",
+    suggestion: {
+      agentFacingDescriptionEdit: { content: input.content },
     },
   };
 }
@@ -427,6 +456,63 @@ Score 0 if it creates any edit_skill suggestion based on this single minor synth
 Score 1 if no edit_skill suggestion is created but reject_suggestion is not called for sug-1.
 Score 1 if reject_suggestion is called.
 Score 3 if no edit_skill suggestion is created AND reject_suggestion is not called.`,
+    },
+    {
+      scenarioId: "merge-description-edits-keep-tool-separate",
+      type: "aggregation",
+      skillConfig: {
+        name: "Payment Issue Resolver",
+        sId: "skill_payment_resolver",
+        description: "Helps customers with payment issues.",
+        instructions:
+          "When a payment fails, ask for the transaction ID and call payment-retry. For chargeback disputes, collect the dispute reason and call chargeback-open.",
+      },
+      syntheticSuggestions: [
+        makeAgentFacingDescriptionSuggestion({
+          sId: "sug-desc-1",
+          skillConfigurationId: "skill_payment_resolver",
+          analysis:
+            "Skill triggered for a billing address change. The description is too generic, the agent should not have selected this skill.",
+          content:
+            "Use this skill ONLY for failed payments and chargeback disputes. Do not use it for billing address updates, invoice questions, or other account-management tasks.",
+        }),
+        makeAgentFacingDescriptionSuggestion({
+          sId: "sug-desc-2",
+          skillConfigurationId: "skill_payment_resolver",
+          analysis:
+            "Skill triggered for an invoice download request. Description gives no signal that this skill is scoped to payment failures and chargebacks only.",
+          content:
+            "For payment failures and chargeback disputes only. Skip this skill for invoice or receipt requests — those are handled elsewhere.",
+        }),
+        makeToolSuggestion({
+          sId: "sug-tool-1",
+          skillConfigurationId: "skill_payment_resolver",
+          analysis:
+            "User asked the skill to file an internal incident ticket for a flagged chargeback. The skill had no JIRA tool to do so.",
+          action: "add",
+          toolId: "mcp_jira",
+        }),
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [
+        editSkillCallCount(2),
+        editSkillWithAgentFacingDescription("skill_payment_resolver", [
+          "sug-desc-1",
+          "sug-desc-2",
+        ]),
+        editSkillWithTool("skill_payment_resolver", "mcp_jira", ["sug-tool-1"]),
+      ],
+      judgeCriteria: `Two of the three drafts target the agent-facing description (both about narrowing routing), and one is unrelated tooling work (adding JIRA). Aggregation rules require:
+- ONE description-edit suggestion per skill, merging both description drafts (sug-desc-1 + sug-desc-2). The merged description must explicitly limit the skill to payment failures + chargebacks AND steer the agent away from generic billing/invoice/account-management requests.
+- The description edit MUST be its own standalone edit_skill call. Do NOT bundle it with the tool addition (different topic, different fix).
+- A separate edit_skill call for the JIRA tool addition (sug-tool-1).
+
+Score 0 if no edit_skill call carries an agentFacingDescriptionEdit for skill_payment_resolver.
+Score 0 if the description edit and the tool addition are bundled into a single edit_skill call.
+Score 0 if more than 2 edit_skill calls are produced (failure to merge sug-desc-1 + sug-desc-2).
+Score 1 if 2 separate edit_skill calls are made but the merged description doesn't explicitly carve out billing/invoice routing (i.e. it stays vague).
+Score 2 if 2 separate edit_skill calls are made and the merged description narrows scope but does not reference both supporting drafts (sug-desc-1 + sug-desc-2 in sourceSuggestionIds).
+Score 3 if exactly 2 edit_skill calls are made: one with agentFacingDescriptionEdit consolidating sug-desc-1 + sug-desc-2 into a description that limits the skill to failures/chargebacks AND explicitly excludes generic billing/invoice/account-management requests; one with toolEdits adding mcp_jira referencing sug-tool-1.`,
     },
   ],
 };

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -1,5 +1,6 @@
 import {
   calledDescribeMcp,
+  editSkillWithAgentFacingDescription,
   editSkillWithInstructions,
   editSkillWithTool,
   type MockMcpDescription,
@@ -669,6 +670,65 @@ CRITICAL constraints:
 Score 0 if no edit_skill call is made for skill_github_reporter, or if edit_skill is called for skill_jira_extractor or skill_notion_publisher.
 Score 1 if edit_skill is called only for skill_github_reporter but the suggestion doesn't specifically mention adding DevCode to the project list.
 Score 3 if edit_skill is called only for skill_github_reporter, the suggestion adds DevCode to the project list, and no other skills are modified.`,
+    },
+    {
+      scenarioId: "misleading-agent-facing-description",
+      type: "analysis",
+      skillConfigs: [
+        {
+          name: "Payment Issue Resolver",
+          sId: "skill_payment_resolver",
+          // Too broad: nothing tells the agent this skill is ONLY for failures
+          // and chargebacks, so it gets enabled for unrelated billing questions.
+          description: "Helps customers with payment issues.",
+          instructions:
+            "When a customer reports that a payment failed, walk them through the retry flow: first ask for the failed transaction ID, then call payment-retry with that ID, and report the new status. For chargeback disputes, collect the dispute reason and call chargeback-open with the transaction ID and reason. Always confirm the resolution before ending the conversation.",
+          tools: [{ name: "JIRA", sId: "mcp_jira" }],
+        },
+      ],
+      conversation: [
+        {
+          role: "user",
+          content:
+            "Hey, I just moved — how do I update the billing address on my account?",
+        },
+        {
+          role: "agent",
+          content:
+            "I can help you with your payment issue. To get started, what's the transaction ID of the payment that failed?",
+        },
+        {
+          role: "user",
+          content:
+            "There's no failed payment. I just want to change my billing address. Why are you asking about transaction IDs?",
+        },
+        {
+          role: "agent",
+          content:
+            "Apologies for the confusion. I'm set up to handle failed payments and chargebacks. For a billing address update you'll want to use Account Settings — I'm not able to do that here.",
+          feedback: {
+            direction: "down",
+            comment:
+              "This skill kicked in for a billing address change, which has nothing to do with payment failures. Its description is way too broad — the agent shouldn't have picked this skill at all for an address update.",
+          },
+        },
+      ],
+      workspaceContext: WORKSPACE_CONTEXT,
+      expectedToolCalls: [
+        editSkillWithAgentFacingDescription("skill_payment_resolver"),
+      ],
+      judgeCriteria: `The skill's instructions accurately describe what it does (handling failed payments and chargeback disputes), so they should NOT be edited. The routing problem comes entirely from the agentFacingDescription "Helps customers with payment issues." being too broad — it caused the agent to enable this skill for a billing address update.
+
+The analyst MUST call edit_skill with an agentFacingDescriptionEdit for skill "skill_payment_resolver". The new description should:
+- Narrow the skill to failed payments and chargeback disputes specifically
+- Explicitly steer the agent AWAY from generic billing/account changes (e.g. address updates, invoice questions)
+- Stay focused on routing signals (when to use vs. not), not behavior (which lives in the instructions)
+
+Score 0 if no edit_skill call with agentFacingDescriptionEdit is made for skill_payment_resolver.
+Score 0 if the suggestion is bundled with instructionEdits or toolEdits — per the analysis prompt, description edits should be a standalone edit_skill call when the routing problem is the only issue (the instructions and tools here are correct).
+Score 1 if a description edit is made but it does not narrow the scope (still vague) OR does not steer away from billing/address-style requests.
+Score 2 if the new description narrows the skill but the language is weak or does not call out what to skip.
+Score 3 if the new description clearly limits the skill to payment failures + chargebacks AND explicitly tells the agent not to use it for unrelated billing/account-management changes.`,
     },
     {
       scenarioId: "knowledge-tag-vague-runbook-instructions",


### PR DESCRIPTION
## Description

Follow-up to the agentFacingDescription support PR — adds end-to-end eval coverage for description edits in tests/reinforcement-evals.

Framework changes

- New editSkillWithAgentFacingDescription(skillId, sourceSuggestionIds?) assertion. It scans all edit_skill calls (not just the first) since description edits typically land in their own call alongside other edit_skill calls.
- noSuggestion now also fails if a stray agentFacingDescriptionEdit slipped through — previously it only checked instruction/tool edits, so a model returning only a description edit would have been silently accepted.

New scenarios

- Analysis: misleading-agent-facing-description — "Payment Issue Resolver" skill with a deliberately vague description ("Helps customers with payment issues"). The conversation shows the agent enabling it for a billing-address change, which the user calls out as wrong routing. Instructions and tools are correct — only the description should change. Judge top-scores when the new description (a) narrows scope to failures + chargebacks and (b) explicitly steers the agent away from billing/invoice/account-management requests; scores 0
  if the description edit is bundled with instruction/tool edits (per the standalone-call guidance).
- Aggregation: merge-description-edits-keep-tool-separate — three drafts on the same skill: two description edits (different routing-fix angles) plus one unrelated tool addition. Aggregator must produce exactly two edit_skill calls — one merging the description drafts (with both sourceSuggestionIds), one for the JIRA tool addition. Scores 0 if they get bundled into a single call.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

None