### PR TITLE
Pin file system behavior per conversation via metadata.useFileSystem

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -15,7 +15,6 @@ import { useConversationSandboxFiles } from "@app/hooks/conversations/useConvers
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { downloadSandboxFile } from "@app/lib/swr/files";
 import type { GCSMountFileEntry } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -40,8 +39,7 @@ export function ConversationFilesPanel({
   conversation,
   owner,
 }: ConversationFilesPanelProps) {
-  const { hasFeature } = useFeatureFlags();
-  const isNewFileExplorer = hasFeature("new_file_explorer");
+  const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
 
   const [activeTab, setActiveTab] = useState("files");
   const [previewFile, setPreviewFile] = useState<MinimalFileForPreview | null>(

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1141,8 +1141,7 @@ export const INTERNAL_MCP_SERVERS = {
     id: 1033,
     availability: "auto_hidden_builder",
     allowMultipleInstances: false,
-    isRestricted: ({ featureFlags }) =>
-      !featureFlags.includes("new_file_explorer"),
+    isRestricted: undefined,
     isPreview: false,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -8,7 +8,6 @@ import {
 } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/conversation_files/tools";
 import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const NEW_FILE_EXPLORER_HIDDEN_TOOLS = new Set([
@@ -22,10 +21,12 @@ async function createServer(
 ): Promise<McpServer> {
   const server = makeInternalMCPServer("conversation_files");
 
-  const isNewFileExplorer = await hasFeatureFlag(auth, "new_file_explorer");
+  const useFileSystem =
+    agentLoopContext?.runContext?.conversation.metadata?.useFileSystem ===
+    true;
 
   for (const tool of TOOLS) {
-    if (isNewFileExplorer && NEW_FILE_EXPLORER_HIDDEN_TOOLS.has(tool.name)) {
+    if (useFileSystem && NEW_FILE_EXPLORER_HIDDEN_TOOLS.has(tool.name)) {
       continue;
     }
 

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -22,8 +22,7 @@ async function createServer(
   const server = makeInternalMCPServer("conversation_files");
 
   const useFileSystem =
-    agentLoopContext?.runContext?.conversation.metadata?.useFileSystem ===
-    true;
+    agentLoopContext?.runContext?.conversation.metadata?.useFileSystem === true;
 
   for (const tool of TOOLS) {
     if (useFileSystem && NEW_FILE_EXPLORER_HIDDEN_TOOLS.has(tool.name)) {

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -24,7 +24,6 @@ import {
 import { getConversationDataSourceViews } from "@app/lib/api/assistant/jit/utils";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
   CONTENT_OUTDATED_MSG,
@@ -91,10 +90,10 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
     const conversation = agentLoopContext.runContext.conversation;
     const allAttachments = await listAttachments(auth, { conversation });
 
-    // When new_file_explorer is on, files are surfaced via the `files` server.
-    // Only list content nodes and queryable attachments (tables) here.
-    const isNewFileExplorer = await hasFeatureFlag(auth, "new_file_explorer");
-    const attachments = isNewFileExplorer
+    // When the conversation uses the new file system, files are surfaced via the
+    // `files` server. Only list content nodes and queryable attachments (tables) here.
+    const useFileSystem = conversation.metadata?.useFileSystem === true;
+    const attachments = useFileSystem
       ? allAttachments.filter(
           (a) => isContentNodeAttachmentType(a) || a.isQueryable
         )

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -608,7 +608,9 @@ export async function createConversationFork(
         triggerId: null,
         spaceId: parentConversation.space?.id ?? null,
         requestedSpaceIds: [...parentConversation.requestedSpaceIds],
-        metadata: {},
+        metadata: {
+          useFileSystem: parentConversation.metadata?.useFileSystem ?? false,
+        },
       },
       parentConversation.space,
       { transaction }

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -497,7 +497,13 @@ export async function renderContentFragment(
   auth: Authenticator,
   m: any, // ContentFragmentType
   model: ModelConfigurationType,
-  excludeImages: boolean
+  {
+    excludeImages,
+    useFileSystem,
+  }: {
+    excludeImages: boolean;
+    useFileSystem: boolean;
+  }
 ): Promise<ModelMessageTypeMultiActions | null> {
   const renderedContentFragment = await renderLightContentFragmentForModel(
     auth,
@@ -505,6 +511,7 @@ export async function renderContentFragment(
     model,
     {
       excludeImages: Boolean(excludeImages),
+      useFileSystem,
     }
   );
   return renderedContentFragment;

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -222,7 +222,10 @@ export async function renderAllMessages(
           auth,
           m,
           model,
-          !!excludeImages
+          {
+            excludeImages: !!excludeImages,
+            useFileSystem: conversation.metadata?.useFileSystem === true,
+          }
         );
         if (renderedContentFragment) {
           messages.push(renderedContentFragment);

--- a/front/lib/api/assistant/jit/files.ts
+++ b/front/lib/api/assistant/jit/files.ts
@@ -14,6 +14,10 @@ export function getFilesServer(
   conversation: ConversationWithoutContentType,
   autoInternalViews: Map<AutoInternalMCPServerNameType, MCPServerViewResource>
 ): ServerSideMCPServerConfigurationType | null {
+  if (conversation.metadata?.useFileSystem !== true) {
+    return null;
+  }
+
   const filesView = autoInternalViews.get("files") ?? null;
 
   if (!filesView) {

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -2,7 +2,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type {
   ContentNodeContentFragmentType,
@@ -105,13 +104,13 @@ describe("renderLightContentFragmentForModel", () => {
     ).mockResolvedValue("https://signed.url/image.png");
   });
 
-  describe("new_file_explorer FF off", () => {
+  describe("useFileSystem: false", () => {
     it("renders a regular file as <attachment>", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("application/pdf"),
         visionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: false }
       );
       expect(result?.content[0]).toMatchObject({ type: "text" });
       expect((result?.content[0] as { text: string }).text).toContain(
@@ -127,7 +126,7 @@ describe("renderLightContentFragmentForModel", () => {
           snippet: "",
         }),
         visionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: false }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<attachment"
@@ -139,7 +138,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("text/vnd.dust.attachment.pasted"),
         visionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: false }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<pastedContent"
@@ -151,7 +150,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("image/png"),
         visionModel,
-        { excludeImages: true }
+        { excludeImages: true, useFileSystem: false }
       );
       const text = (result?.content[0] as { text: string }).text;
       expect(text).toContain("<attachment");
@@ -165,7 +164,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("image/png"),
         nonVisionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: false }
       );
       const text = (result?.content[0] as { text: string }).text;
       expect(text).toContain("<attachment");
@@ -179,7 +178,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeContentNodeFragment(),
         visionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: false }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<attachment"
@@ -187,17 +186,13 @@ describe("renderLightContentFragmentForModel", () => {
     });
   });
 
-  describe("new_file_explorer FF on", () => {
-    beforeEach(async () => {
-      await FeatureFlagFactory.basic(authenticator, "new_file_explorer");
-    });
-
+  describe("useFileSystem: true", () => {
     it("renders a regular file as <file> without snippet", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("application/pdf"),
         visionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: true }
       );
       expect(result?.content[0]).toMatchObject({
         type: "text",
@@ -210,7 +205,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("text/plain", { snippet: "First 256 chars..." }),
         visionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: true }
       );
       expect(result?.content[0]).toMatchObject({
         type: "text",
@@ -226,7 +221,7 @@ describe("renderLightContentFragmentForModel", () => {
           snippet: "",
         }),
         visionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: true }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<attachment"
@@ -238,7 +233,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeContentNodeFragment(),
         visionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: true }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<attachment"
@@ -250,7 +245,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("text/vnd.dust.attachment.pasted"),
         visionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: true }
       );
       expect((result?.content[0] as { text: string }).text).toContain(
         "<pastedContent"
@@ -262,7 +257,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("image/png"),
         visionModel,
-        { excludeImages: true }
+        { excludeImages: true, useFileSystem: true }
       );
       const text = (result?.content[0] as { text: string }).text;
       expect(text).toContain(`<file name="file" path="conversation/file">`);
@@ -276,7 +271,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("image/png"),
         nonVisionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: true }
       );
       const text = (result?.content[0] as { text: string }).text;
       expect(text).toContain(`<file name="file" path="conversation/file">`);
@@ -290,7 +285,7 @@ describe("renderLightContentFragmentForModel", () => {
         authenticator,
         makeFileFragment("image/png"),
         visionModel,
-        { excludeImages: false }
+        { excludeImages: false, useFileSystem: true }
       );
       expect(result?.content).toHaveLength(2);
       expect(result?.content[0]).toMatchObject({ type: "image_url" });

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -15,7 +15,6 @@ import config from "@app/lib/api/config";
 
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { MessageModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -1189,8 +1188,10 @@ export async function renderLightContentFragmentForModel(
   model: ModelConfigurationType,
   {
     excludeImages,
+    useFileSystem,
   }: {
     excludeImages: boolean;
+    useFileSystem: boolean;
   }
 ): Promise<ContentFragmentMessageTypeModel | null> {
   const { contentType } = message;
@@ -1217,9 +1218,7 @@ export async function renderLightContentFragmentForModel(
   const fileStringId =
     message.contentFragmentType === "file" ? message.fileId : null;
 
-  const isNewFileExplorer = fileStringId
-    ? await hasFeatureFlag(auth, "new_file_explorer")
-    : false;
+  const isNewFileExplorer = fileStringId ? useFileSystem : false;
 
   // Pasted content is always inlined regardless of feature flags.
   if (fileStringId && isPastedFile(contentType)) {
@@ -1284,10 +1283,10 @@ export async function renderLightContentFragmentForModel(
     };
   }
 
-  // When new_file_explorer is on, regular file attachments are accessible via the `files` server
-  // (path-based). Emit a slim <file> tag so the model knows the file exists and how to reach it.
-  // Queryable tables and content nodes are excluded: they rely on legacy attachment XML for
-  // query_tables_v2 and include_file wiring.
+  // When the conversation uses the new file system, regular file attachments are accessible via
+  // the `files` server (path-based). Emit a slim <file> tag so the model knows the file exists
+  // and how to reach it. Queryable tables and content nodes are excluded: they rely on legacy
+  // attachment XML for query_tables_v2 and include_file wiring.
   if (
     isNewFileExplorer &&
     !attachment.isQueryable &&

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -448,9 +448,18 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         ? [...blob.requestedSpaceIds, space.id]
         : blob.requestedSpaceIds;
 
+    // Default `useFileSystem` from the workspace feature flag when the caller hasn't pinned a
+    // value. Pinning the flag on the conversation gives stable behavior across its lifetime:
+    // existing conversations (no flag set) keep the legacy behavior even after the FF flips on.
+    const metadata: ConversationMetadata = blob.metadata ?? {};
+    if (metadata.useFileSystem === undefined) {
+      metadata.useFileSystem = await hasFeatureFlag(auth, "new_file_explorer");
+    }
+
     const conversation = await this.model.create(
       {
         ...blob,
+        metadata,
         requestedSpaceIds,
         workspaceId: workspace.id,
       },

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -263,7 +263,7 @@ async function handler(
         conversation,
       });
 
-      const isNewFileExplorer = await hasFeatureFlag(auth, "new_file_explorer");
+      const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
 
       const promptSections = constructPromptMultiActions(auth, {
         userMessage,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -386,7 +386,7 @@ export async function runModel(
     conversation,
   });
 
-  const isNewFileExplorer = await hasFeatureFlag(auth, "new_file_explorer");
+  const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
 
   const prompt = constructPromptMultiActions(auth, {
     userMessage,

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -446,6 +446,7 @@ export const CONVERSATION_METADATA_URL_ACCESS_MODE_KEY = "urlAccessMode";
 export type ConversationMetadata = Record<string, unknown> & {
   urlAccessMode?: ConversationUrlAccessMode;
   projectTodoId?: string;
+  useFileSystem?: boolean;
 };
 
 export function isConversationUrlAccessMode(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We're rolling out the new file explorer / file system experience, which fundamentally changes how files are exposed to the model: instead of `<attachment>` tags and file IDs surfaced through the legacy `conversation_files` MCP tools, files are mounted at paths under `conversation/<filename>` and the model interacts with them through the new files MCP server.

Today this is gated by the workspace feature flag `new_file_explorer`. Flipping that flag mid-flight is unsafe for ongoing conversations. The model has been working with a specific representation of attachments (file IDs, `<attachment>` blobs, `cat_file` / `search_files` tools), and any references it has made in earlier turns assume that contract. Switching the gate would suddenly hide those tools, replace the XML representation, and break the continuity of what the model already saw.

This PR pins the behavior on the conversation itself. It adds a temporary `useFileSystem` boolean to `ConversationMetadata`, defaulted at creation time inside `ConversationResource.makeNew` based on the workspace FF, and we route every gate that previously read the FF (UI panel, MCP tool list, attachment filter, prompt construction, content fragment rendering, auto-attach of the files server) through that conversation flag instead. New conversations created on
FF-enabled workspaces get the new behavior. Existing conversations keep what the model has been seeing all along, regardless of how the workspace flag is toggled afterward.
Forks explicitly inherit the parent's value (defaulting to false for legacy parents) so the child never silently switches representation.

A backfill of existing conversations to `useFileSystem: true` will follow in a separate PR once we're ready to migrate older conversations onto the new representation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
