### PR TITLE
feat(poke): enrich project TODO details with full metadata

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/project_todo_details.ts
+++ b/front/lib/api/poke/plugins/workspaces/project_todo_details.ts
@@ -105,21 +105,44 @@ export const projectTodoDetailsPlugin = createPlugin({
             })
             .join("\n");
 
-    const doneAt = todo.doneAt ? new Date(todo.doneAt).toISOString() : "—";
-    const createdAt = new Date(todo.createdAt).toISOString();
+    const json = todo.toJSON();
+    const doneAt = json.doneAt ? new Date(json.doneAt).toISOString() : "—";
+    const createdAt = new Date(json.createdAt).toISOString();
+    const updatedAt = new Date(json.updatedAt).toISOString();
+
+    const assignee = json.user
+      ? `${json.user.fullName} (\`${json.user.sId}\`)`
+      : "_Unassigned_";
+
+    const creatorId =
+      json.createdByType === "agent"
+        ? (json.createdByAgentConfigurationId ?? "—")
+        : (json.createdByUserId ?? "—");
+
+    const markedDoneBy = json.markedAsDoneByType
+      ? json.markedAsDoneByType === "agent"
+        ? `agent \`${json.markedAsDoneByAgentConfigurationId ?? "unknown"}\``
+        : `user \`${json.markedAsDoneByUserId ?? "unknown"}\``
+      : "—";
 
     return new Ok({
       display: "markdown",
-      value: `## ${statusEmoji[todo.status] ?? "❓"} Project TODO \`${todo.id}\` \`${todo.sId}\` 
+      value: `## ${statusEmoji[json.status] ?? "❓"} Project TODO \`${todo.id}\` \`${todo.sId}\`
 
-**Text:** ${todo.text}
+**Text:** ${json.text}
 
 | Field | Value |
 |---|---|
-| Status | \`${todo.status}\` |
-| Created by | \`${todo.createdByType}\` |
+| Status | \`${json.status}\` |
+| Assignee | ${assignee} |
+| Created by | \`${json.createdByType}\` \`${creatorId}\` |
 | Created at | ${createdAt} |
+| Updated at | ${updatedAt} |
 | Done at | ${doneAt} |
+| Marked done by | ${markedDoneBy} |
+| Rationale | ${json.actorRationale ?? "—"} |
+| Agent suggestion | ${json.agentSuggestionStatus ?? "—"} |
+| Agent instructions | ${json.agentInstructions ? `\`\`\`\n${json.agentInstructions}\n\`\`\`` : "—"} |
 
 ## Sources (${sources.length})
 

--- a/front/temporal/project_todo/activities.ts
+++ b/front/temporal/project_todo/activities.ts
@@ -14,10 +14,11 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { ProjectTodoSourceType } from "@app/types/project_todo";
+import { Err, type Result } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { TimeFrame } from "@app/types/shared/utils/time_frame";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES, Ok } from "@dust-tt/client";
 
 function resultToTakeawaySourceDocument(
   result: any
@@ -77,6 +78,49 @@ function resultToTakeawaySourceDocument(
   return null;
 }
 
+async function runChecksAndGetValues({
+  workspaceId,
+  spaceId,
+  localLogger,
+}: {
+  workspaceId: string;
+  spaceId: string;
+  runId: string;
+  localLogger: typeof logger;
+}): Promise<
+  Result<
+    {
+      space: SpaceResource;
+      adminAuth: Authenticator;
+      metadata: ProjectMetadataResource;
+    },
+    boolean
+  >
+> {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    localLogger.error("Workspace not found");
+    return new Err(false);
+  }
+
+  const adminAuth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const space = await SpaceResource.fetchById(adminAuth, spaceId);
+  if (!space || !space.isProject()) {
+    localLogger.error("Space not found or not a project");
+    return new Err(false);
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(adminAuth, space);
+  if (!metadata?.todoGenerationEnabled) {
+    localLogger.info(
+      "Todo generation is disabled or not configured for this project; skipping project todo merge"
+    );
+    return new Err(false);
+  }
+
+  return new Ok({ space, adminAuth, metadata });
+}
+
 export async function analyzeProjectTodosActivity({
   workspaceId,
   spaceId,
@@ -91,31 +135,17 @@ export async function analyzeProjectTodosActivity({
 
   localLogger.info("Starting project todo analysis");
 
-  if (!workspaceId) {
-    localLogger.error("Workspace ID is required");
+  const checkResult = await runChecksAndGetValues({
+    workspaceId,
+    spaceId,
+    runId,
+    localLogger,
+  });
+  if (checkResult.isErr()) {
     return;
   }
 
-  const workspace = await WorkspaceResource.fetchById(workspaceId);
-  if (!workspace) {
-    localLogger.error("Workspace not found");
-    return;
-  }
-  const adminAuth = await Authenticator.internalAdminForWorkspace(workspaceId);
-
-  const space = await SpaceResource.fetchById(adminAuth, spaceId);
-  if (!space || !space.isProject()) {
-    localLogger.error("Space not found or not a project");
-    return;
-  }
-
-  const metadata = await ProjectMetadataResource.fetchBySpace(adminAuth, space);
-  if (!metadata?.todoGenerationEnabled) {
-    localLogger.info(
-      "Todo generation is disabled or not configured for this project; skipping project todo analysis"
-    );
-    return;
-  }
+  const { space, adminAuth, metadata } = checkResult.value;
 
   const { groupsToProcess } =
     await space.fetchManualGroupsMemberships(adminAuth);
@@ -255,29 +285,13 @@ export async function mergeTodosForProjectActivity({
 
   localLogger.info("Starting merge of project todo takeaways");
 
-  if (!workspaceId) {
-    localLogger.error("Workspace ID is required");
-    return;
-  }
-
-  const workspace = await WorkspaceResource.fetchById(workspaceId);
-  if (!workspace) {
-    localLogger.error("Workspace not found");
-    return;
-  }
-
-  const adminAuth = await Authenticator.internalAdminForWorkspace(workspaceId);
-  const space = await SpaceResource.fetchById(adminAuth, spaceId);
-  if (!space || !space.isProject()) {
-    localLogger.error("Space not found or not a project");
-    return;
-  }
-
-  const metadata = await ProjectMetadataResource.fetchBySpace(adminAuth, space);
-  if (!metadata?.todoGenerationEnabled) {
-    localLogger.info(
-      "Todo generation is disabled or not configured for this project; skipping project todo merge"
-    );
+  const checkResult = await runChecksAndGetValues({
+    workspaceId,
+    spaceId,
+    runId,
+    localLogger,
+  });
+  if (checkResult.isErr()) {
     return;
   }
 


### PR DESCRIPTION
## Description

Adds missing metadata fields to the poke "Project TODO Details" plugin output.

**Before:** the detail table showed only Status, Created by, Created at, and Done at.

**After:** the table also shows:
- **Assignee** — user full name + sId, or "Unassigned"
- **Updated at** — last modification timestamp
- **Created by** — now includes the creator's sId or agent config sId alongside the actor type
- **Marked done by** — who (user sId or agent config sId) marked the TODO as done
- **Rationale** — `actorRationale` captured when the TODO was closed
- **Agent suggestion** — `agentSuggestionStatus` (pending / approved / rejected)
- **Agent instructions** — optional instructions stored on the TODO
