### PR TITLE
feat: replace agentId with agentName for project tools

### DIFF
--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -350,19 +350,19 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
 
   create_conversation: {
     description:
-      "Create a new conversation in the project and post a user message. Default: always pass an agentId to delegate the task to an agent running inside the project. Do NOT do the work yourself — if work needs to be done, delegate it via agentId. Omit agentId only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output.",
+      "Create a new conversation in the project and post a user message. Default: always pass an agentName to delegate the task to an agent running inside the project. Do NOT do the work yourself — if work needs to be done, delegate it via agentName. Omit agentName only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output.",
     schema: {
       message: z
         .string()
         .describe(
-          "When agentId is provided: the raw task description and context for the agent to act on. When agentId is omitted: the complete finished output to deposit as-is."
+          "When agentName is provided: the raw task description and context for the agent to act on. When agentName is omitted: the complete finished output to deposit as-is."
         ),
       title: z.string().describe("Title for the conversation"),
-      agentId: z
+      agentName: z
         .string()
         .optional()
         .describe(
-          "The agent to trigger in the new conversation. Use this whenever the user asks for work to be done in a project (research, analysis, drafting, etc.). When omitted, no agent is triggered and the message is posted as a static result — use this only to deposit a finished artifact you have already fully produced."
+          "The name of the agent to trigger in the new conversation. The tool searches matching agent configurations and uses the best match. Use this whenever the user asks for work to be done in a project (research, analysis, drafting, etc.). When omitted, no agent is triggered and the message is posted as a static result — use this only to deposit a finished artifact you have already fully produced."
         ),
       dustProject:
         ConfigurableToolInputSchemas[
@@ -432,7 +432,7 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   add_message_to_conversation: {
     description:
-      "Post a user message to an existing conversation in this project. Default: always pass an agentId to delegate the task to an agent running inside the conversation. Do NOT do the work yourself — if work needs to be done, delegate it via agentId. Omit agentId only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output." +
+      "Post a user message to an existing conversation in this project. Default: always pass an agentName to delegate the task to an agent running inside the conversation. Do NOT do the work yourself — if work needs to be done, delegate it via agentName. Omit agentName only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output." +
       "The conversation must belong to the same project. If conversationId is omitted, the current agent conversation is used (when available).",
     schema: {
       conversationId: z
@@ -444,13 +444,13 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "When agentId is provided: the raw task description and context for the agent to act on. When agentId is omitted: the complete finished output to deposit as-is."
+          "When agentName is provided: the raw task description and context for the agent to act on. When agentName is omitted: the complete finished output to deposit as-is."
         ),
-      agentId: z
+      agentName: z
         .string()
         .optional()
         .describe(
-          "The agent to trigger in the conversation. Use this whenever the user asks for work to be done in a project (research, analysis, drafting, etc.). When omitted, no agent is triggered and the message is posted as a static result — use this only to deposit a finished artifact you have already fully produced."
+          "The name of the agent to trigger in the conversation. The tool searches matching agent configurations and uses the best match. Use this whenever the user asks for work to be done in a project (research, analysis, drafting, etc.). When omitted, no agent is triggered and the message is posted as a static result — use this only to deposit a finished artifact you have already fully produced."
         ),
       dustProject:
         ConfigurableToolInputSchemas[

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -18,6 +18,7 @@ import {
 } from "@app/lib/api/actions/servers/project_manager/helpers";
 import { PROJECT_MANAGER_TOOLS_METADATA } from "@app/lib/api/actions/servers/project_manager/metadata";
 import { searchFunction } from "@app/lib/api/actions/servers/search/tools";
+import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
 import {
   createConversation,
   postUserMessage,
@@ -1079,10 +1080,22 @@ export function createProjectManagerTools(
         const agentProfilePictureUrl =
           agentLoopContext?.runContext?.agentConfiguration?.pictureUrl ?? null;
 
-        // Build mentions if agentId is provided
-        const mentions = params.agentId
-          ? [{ configurationId: params.agentId }]
-          : [];
+        let mentions: { configurationId: string }[] = [];
+        if (params.agentName) {
+          const matchedAgentId = await resolveAgentConfigurationIdByName(
+            auth,
+            params.agentName
+          );
+          if (!matchedAgentId) {
+            return new Err(
+              new MCPError(
+                `No agent found matching name: "${params.agentName}"`,
+                { tracked: false }
+              )
+            );
+          }
+          mentions = [{ configurationId: matchedAgentId }];
+        }
 
         // Create conversation in the project space
         const conversation = await createConversation(auth, {
@@ -1355,9 +1368,22 @@ export function createProjectManagerTools(
         const agentProfilePictureUrl =
           agentLoopContext?.runContext?.agentConfiguration?.pictureUrl ?? null;
 
-        const mentions = params.agentId
-          ? [{ configurationId: params.agentId }]
-          : [];
+        let mentions: { configurationId: string }[] = [];
+        if (params.agentName) {
+          const matchedAgentId = await resolveAgentConfigurationIdByName(
+            auth,
+            params.agentName
+          );
+          if (!matchedAgentId) {
+            return new Err(
+              new MCPError(
+                `No agent found matching name: "${params.agentName}"`,
+                { tracked: false }
+              )
+            );
+          }
+          mentions = [{ configurationId: matchedAgentId }];
+        }
 
         const messageRes = await postUserMessage(auth, {
           conversation,

--- a/front/lib/api/actions/servers/project_todos/tools/index.ts
+++ b/front/lib/api/actions/servers/project_todos/tools/index.ts
@@ -10,46 +10,16 @@ import {
   withErrorHandling,
 } from "@app/lib/api/actions/servers/project_manager/helpers";
 import { PROJECT_TODOS_TOOLS_METADATA } from "@app/lib/api/actions/servers/project_todos/metadata";
-import { searchAgentConfigurationsByName } from "@app/lib/api/assistant/configuration/agent";
-import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
+import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import { startAgentForProjectTodo } from "@app/lib/project_todo/start_agent";
 import { ProjectTodoResource } from "@app/lib/resources/project_todo_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
-import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok } from "@app/types/shared/result";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
-async function resolveAgentConfigurationIdByName(
-  auth: Authenticator,
-  agentName: string
-): Promise<string | null> {
-  const normalizedAgentName = agentName.trim().toLowerCase();
-  if (normalizedAgentName === "dust" || normalizedAgentName === "dust agent") {
-    return GLOBAL_AGENTS_SID.DUST;
-  }
-
-  const [workspaceMatches, globalAgents] = await Promise.all([
-    searchAgentConfigurationsByName(auth, agentName),
-    getGlobalAgents(auth, undefined, "light"),
-  ]);
-  const globalMatches = globalAgents.filter((a) =>
-    a.name.toLowerCase().includes(normalizedAgentName)
-  );
-  const matches = [...workspaceMatches, ...globalMatches];
-  if (matches.length === 0) {
-    return null;
-  }
-
-  // Prefer exact case-insensitive match, otherwise fallback to first result.
-  const exactMatch = matches.find(
-    (a) => a.name.trim().toLowerCase() === normalizedAgentName
-  );
-  return exactMatch?.sId ?? matches[0].sId;
-}
 
 function formatTodo(todo: ProjectTodoResource): string {
   const json = todo.toJSON();

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -68,7 +68,10 @@ import type {
   LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
-import { isGlobalAgentId } from "@app/types/assistant/assistant";
+import {
+  GLOBAL_AGENTS_SID,
+  isGlobalAgentId,
+} from "@app/types/assistant/assistant";
 import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import { validateResponseFormat } from "@app/types/assistant/models/utils";
 import { CoreAPI } from "@app/types/core/core_api";
@@ -408,6 +411,40 @@ export async function searchAgentConfigurationsByName(
   });
 
   return removeNulls(agents);
+}
+
+/**
+ * Resolve an agent configuration sId from a name. Searches workspace agents and
+ * global agents (case-insensitive substring), preferring an exact match. Returns
+ * null when no agent matches.
+ */
+export async function resolveAgentConfigurationIdByName(
+  auth: Authenticator,
+  agentName: string
+): Promise<string | null> {
+  const normalizedAgentName = agentName.trim().toLowerCase();
+  if (normalizedAgentName === "dust" || normalizedAgentName === "dust agent") {
+    return GLOBAL_AGENTS_SID.DUST;
+  }
+
+  const workspaceMatches = await searchAgentConfigurationsByName(
+    auth,
+    agentName
+  );
+  const globalAgents = await getGlobalAgents(auth, undefined, "light");
+  const globalMatches = globalAgents.filter((a) =>
+    a.name.toLowerCase().includes(normalizedAgentName)
+  );
+  const matches = [...workspaceMatches, ...globalMatches];
+  if (matches.length === 0) {
+    return null;
+  }
+
+  // Prefer exact case-insensitive match, otherwise fallback to first result.
+  const exactMatch = matches.find(
+    (a) => a.name.trim().toLowerCase() === normalizedAgentName
+  );
+  return exactMatch?.sId ?? matches[0].sId;
 }
 
 export async function createAgentConfiguration(


### PR DESCRIPTION
## Description

This PR replaces `agentId` with `agentName` in project manager tools. Custom agents do not have access to agentIds so we use the name instead.

## Tests

Manually

## Risks

Low. 

## Deploy Plan

Standard deployment.
