### PR TITLE
Release context compaction

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -21,7 +21,6 @@ import {
   useConversationContextUsage,
 } from "@app/hooks/conversations";
 import { CONTEXT_USAGE_PERCENT_THRESHOLDS } from "@app/hooks/conversations/useConversationContextUsage";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
@@ -114,9 +113,6 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
 
   const draftAgent = agentBuilderContext?.draftAgent;
 
-  const { hasFeature } = useFeatureFlags();
-  const isCompactionEnabled = hasFeature("enable_compaction");
-
   const { contextUsage, contextUsagePercentage } = useConversationContextUsage({
     conversationId: context.conversation?.sId ?? "",
     workspaceId: context.owner.sId,
@@ -127,14 +123,12 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     (message) => isCompactionMessage(message) && message.status === "created"
   )
     ? "Wait for compaction to finish."
-    : isCompactionEnabled &&
-        contextUsagePercentage &&
+    : contextUsagePercentage &&
         contextUsagePercentage >=
           CONTEXT_USAGE_PERCENT_THRESHOLDS["force_compaction"]
       ? "Context is full, compact to continue."
       : null;
   const showContextUsageBanner =
-    isCompactionEnabled &&
     contextUsage &&
     !!contextUsagePercentage &&
     contextUsagePercentage >= CONTEXT_USAGE_PERCENT_THRESHOLDS["show_warning"];

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -47,7 +47,6 @@ import { useSubmitMessage } from "@app/hooks/useSubmitMessage";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import type { ConversationEvents } from "@app/lib/api/assistant/streaming/types";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
 import type { DustError } from "@app/lib/error";
 import {
@@ -253,8 +252,6 @@ export const ConversationViewer = ({
     >(null);
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
-  const { hasFeature } = useFeatureFlags();
-  const isCompactionEnabled = hasFeature("enable_compaction");
 
   const { mutateConversationAttachments } = useConversationAttachments({
     conversationId,
@@ -335,7 +332,7 @@ export const ConversationViewer = ({
   });
 
   const { mutateContextUsage } = useConversationContextUsage({
-    conversationId: isCompactionEnabled ? conversationId : null,
+    conversationId,
     workspaceId: owner.sId,
     options: { disabled: true },
   });

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -18,7 +18,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
@@ -191,8 +191,6 @@ const InputBarContainer = ({
   const isSubmitBlocked = submitBlockMessage !== null;
   const { subscription } = useAuth();
   const isMobile = useIsMobile();
-  const { hasFeature } = useFeatureFlags();
-  const isCompactionEnabled = hasFeature("enable_compaction");
   const { selectedSingleAgent, setSelectedSingleAgent } =
     useContext(InputBarContext);
 
@@ -1191,7 +1189,7 @@ const InputBarContainer = ({
             </>
           )}
           <div className="flex items-center">
-            {isCompactionEnabled && conversation && (
+            {conversation && (
               <ContextUsageIndicator
                 buttonSize={buttonSize}
                 owner={owner}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -297,11 +297,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Dummy feature flag used for testing feature flag behavior",
     stage: "dust_only",
   },
-  enable_compaction: {
-    description:
-      "Enable context compaction: summarize older messages to free up context window",
-    stage: "dust_only",
-  },
   browser_extension_mcp_tools: {
     description:
       "Show the browser extension MCP tools toggle in workspace access settings",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -752,7 +752,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "anthropic_reasoning_token_count"
   | "collapsible_messages"
   | "use_dust_keys"
-  | "enable_compaction"
   | "browser_extension_mcp_tools"
   | "sensitivity_labels"
   | "conversation_search_indexing"


### PR DESCRIPTION
## Description

Remove the `enable_compaction` feature flag now that context compaction is being released. Compaction UI affordances, context usage refreshes, warning banners, and force-compaction blocking now run unconditionally for conversations.

## Tests

N/A, tested locally with `npx tsgo --noEmit` from `front`.

## Risk

Low. This removes feature gating around an existing compaction path and leaves the compaction threshold constants unchanged.

## Deploy Plan

- deploy `front`
