### PR TITLE
Fix conversion rates, gives free credits for excess consumption

### DIFF
--- a/front/lib/api/analytics/metronome_usage.ts
+++ b/front/lib/api/analytics/metronome_usage.ts
@@ -19,7 +19,10 @@ import {
   getMetricToolInvocationsProgrammaticId,
 } from "@app/lib/metronome/constants";
 import type { MetronomeBalance } from "@app/lib/metronome/types";
-import { METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD } from "@app/lib/metronome/types";
+import {
+  isMetronomeExcessCredit,
+  METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD,
+} from "@app/lib/metronome/types";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -407,7 +410,7 @@ export async function handleMetronomeUsageRequest(
         ? balancesResult.value.filter(
             (entry) =>
               entry.access_schedule?.credit_type?.id ===
-              programmaticUsdCreditTypeId
+                programmaticUsdCreditTypeId && !isMetronomeExcessCredit(entry)
           )
         : [];
       const creditTotalsMap = calculateCreditTotalsFromBalances(

--- a/front/lib/api/credits/metronome_balances.ts
+++ b/front/lib/api/credits/metronome_balances.ts
@@ -5,7 +5,10 @@ import type {
   MetronomeCommit,
   MetronomeCredit,
 } from "@app/lib/metronome/types";
-import { METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD } from "@app/lib/metronome/types";
+import {
+  isMetronomeExcessCredit,
+  METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD,
+} from "@app/lib/metronome/types";
 import { apiError } from "@app/logger/withlogging";
 import type {
   CreditDisplayData,
@@ -140,7 +143,7 @@ export async function handleMetronomeBalancesRequest(
         .filter(
           (entry) =>
             entry.access_schedule?.credit_type?.id ===
-            programmaticUsdCreditTypeId
+              programmaticUsdCreditTypeId && !isMetronomeExcessCredit(entry)
         )
         .map(metronomeBalanceToDisplayData);
 

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -5,6 +5,11 @@
  * MetronomeEvent is our own type — stricter than the SDK's UsageIngestParams
  * because we enforce `properties: Record<string, string | number>` (no unknown).
  */
+
+import {
+  getCreditTypeProgrammaticUsdId,
+  getProductFreeCreditId,
+} from "@app/lib/metronome/constants";
 import type { Commit, Credit } from "@metronome/sdk/resources/shared";
 
 // Metronome package aliases for contract provisioning.
@@ -39,6 +44,34 @@ export interface MetronomeEvent {
 
 export type MetronomeBalance = Commit | Credit;
 export type { Commit as MetronomeCommit, Credit as MetronomeCredit };
+
+// Names of the recurring credits provisioned by scripts/metronome_setup.ts.
+export const FREE_MONTHLY_CREDIT_NAME = "Free Monthly Credits";
+export const FREE_ANNUAL_CREDIT_NAME = "Free Annual Credits";
+// The "excess" recurring credit absorbs over-consumption (priority 100,
+// granted at the start of each billing period). Defined in
+// scripts/metronome_setup.ts -> getFreeExcessRecurringCredits().
+export const FREE_EXCESS_CREDIT_NAME = "Free Excess Credits";
+
+// Excess credits are an internal accounting mechanism — they should not be
+// surfaced to end users or in the Poke UI.
+export function isMetronomeExcessCredit(entry: MetronomeBalance): boolean {
+  return entry.name === FREE_EXCESS_CREDIT_NAME;
+}
+
+// True for the recurring free credits granted to programmatic-usage workspaces
+// (monthly or annual cadence). The "excess" credit is excluded — it is a
+// separate internal accounting mechanism. Checks the full identifying tuple
+// (name, priority, product, credit type) so callers don't have to.
+export function isMetronomeFreeCredit(entry: MetronomeBalance): boolean {
+  return (
+    (entry.name === FREE_MONTHLY_CREDIT_NAME ||
+      entry.name === FREE_ANNUAL_CREDIT_NAME) &&
+    entry.priority === 1 &&
+    entry.product.id === getProductFreeCreditId() &&
+    entry.access_schedule?.credit_type?.id === getCreditTypeProgrammaticUsdId()
+  );
+}
 
 // Programmatic Usage Credits is a custom Metronome credit type (1 PUC = 1 USD).
 // `amount` and `balance` fields on commits/credits of this type are denominated in PUC.

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -14,12 +14,9 @@ import {
   listMetronomeContracts,
   updateMetronomeCreditSegmentAmount,
 } from "@app/lib/metronome/client";
-import {
-  getCreditTypeProgrammaticUsdId,
-  getProductFreeCreditId,
-  PLAN_CODE_CUSTOM_FIELD_KEY,
-} from "@app/lib/metronome/constants";
+import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
+import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
 import {
   getCustomerIdFromEvent,
   MetronomeWebhookEventSchema,
@@ -226,11 +223,7 @@ async function handler(
             break;
           }
 
-          if (
-            credit.product.id !== getProductFreeCreditId() ||
-            credit.access_schedule?.credit_type?.id !==
-              getCreditTypeProgrammaticUsdId()
-          ) {
+          if (!isMetronomeFreeCredit(credit)) {
             logger.info(
               {
                 customerId,

--- a/front/pages/api/poke/workspaces/[wId]/credits/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/credits/index.ts
@@ -5,6 +5,7 @@ import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { listMetronomeBalances } from "@app/lib/metronome/client";
 import { getCreditTypeProgrammaticUsdId } from "@app/lib/metronome/constants";
+import { isMetronomeExcessCredit } from "@app/lib/metronome/types";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -106,6 +107,9 @@ async function handler(
               entry.access_schedule?.credit_type?.id !==
               programmaticUsdCreditTypeId
             ) {
+              continue;
+            }
+            if (isMetronomeExcessCredit(entry)) {
               continue;
             }
             metronomeBySId.set(entry.id, metronomeBalanceToDisplayData(entry));

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -23,6 +23,11 @@ import {
   PROD_CREDIT_TYPE_PROG_USD_ID,
 } from "@app/lib/metronome/constants";
 import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
+import {
+  FREE_ANNUAL_CREDIT_NAME,
+  FREE_EXCESS_CREDIT_NAME,
+  FREE_MONTHLY_CREDIT_NAME,
+} from "@app/lib/metronome/types";
 
 // Number of pricing tiers for any tiered seat-style product (MAU, Regular
 // Seat, future). Tier products and rates are derived from the prefix.
@@ -497,7 +502,7 @@ function getRateCards(): RateCardDef[] {
       credit_type_conversions: [
         {
           custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: 0.01,
+          fiat_per_custom_credit: 100,
         },
       ],
       rates: [
@@ -528,7 +533,7 @@ function getRateCards(): RateCardDef[] {
       credit_type_conversions: [
         {
           custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: 0.01,
+          fiat_per_custom_credit: 100,
         },
       ],
       rates: [
@@ -559,7 +564,7 @@ function getRateCards(): RateCardDef[] {
       credit_type_conversions: [
         {
           custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: 0.01,
+          fiat_per_custom_credit: 100,
         },
       ],
       rates: [
@@ -594,7 +599,7 @@ function getRateCards(): RateCardDef[] {
       credit_type_conversions: [
         {
           custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: 0.01,
+          fiat_per_custom_credit: 100,
         },
       ],
       rates: [
@@ -771,7 +776,7 @@ function getRateCards(): RateCardDef[] {
       credit_type_conversions: [
         {
           custom_credit_type_id: getCreditTypeAwuId(),
-          fiat_per_custom_credit: 0.01,
+          fiat_per_custom_credit: 100,
         },
       ],
       rates: [
@@ -885,7 +890,44 @@ function getFreeMonthlyRecurringCredits(): RecurringCreditDef {
     starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
     applicable_product_tags: [USAGE_TAG],
     recurrence_frequency: "MONTHLY",
-    name: "Free Monthly Credits",
+    name: FREE_MONTHLY_CREDIT_NAME,
+  };
+}
+
+// Annual variant for annual packages. Same product, but the credit is granted
+// once per year. The credit.segment.start webhook detects ANNUAL recurrence
+// and multiplies the monthly bracket amount by 12.
+function getFreeAnnualRecurringCredits(): RecurringCreditDef {
+  return {
+    product_name: "Free Credits",
+    access_amount: {
+      credit_type_id: getCreditTypeProgrammaticUsdId(),
+      unit_price: 0,
+      quantity: 1,
+    },
+    commit_duration: { value: 1, unit: "PERIODS" },
+    priority: 1,
+    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
+    applicable_product_tags: [USAGE_TAG],
+    recurrence_frequency: "ANNUAL",
+    name: FREE_ANNUAL_CREDIT_NAME,
+  };
+}
+
+function getFreeExcessRecurringCredits(): RecurringCreditDef {
+  return {
+    product_name: "Free Credits",
+    access_amount: {
+      credit_type_id: getCreditTypeProgrammaticUsdId(),
+      unit_price: 0,
+      quantity: 1_000,
+    },
+    commit_duration: { value: 1, unit: "PERIODS" },
+    priority: 100,
+    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
+    applicable_product_tags: [USAGE_TAG],
+    recurrence_frequency: "MONTHLY",
+    name: FREE_EXCESS_CREDIT_NAME,
   };
 }
 
@@ -906,26 +948,6 @@ function getFreeUsageAwuRecurringCredits(): RecurringCreditDef {
     specifiers: [{ presentation_group_values: { is_free_usage: "true" } }],
     recurrence_frequency: "MONTHLY",
     name: "Free Usage Credits",
-  };
-}
-
-// Annual variant for annual packages. Same product, but the credit is granted
-// once per year. The credit.segment.start webhook detects ANNUAL recurrence
-// and multiplies the monthly bracket amount by 12.
-function getFreeAnnualRecurringCredits(): RecurringCreditDef {
-  return {
-    product_name: "Free Credits",
-    access_amount: {
-      credit_type_id: getCreditTypeProgrammaticUsdId(),
-      unit_price: 0,
-      quantity: 1,
-    },
-    commit_duration: { value: 1, unit: "PERIODS" },
-    priority: 1,
-    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
-    applicable_product_tags: [USAGE_TAG],
-    recurrence_frequency: "ANNUAL",
-    name: "Free Annual Credits",
   };
 }
 
@@ -997,7 +1019,10 @@ function getPackages(): PackageDef[] {
       aliases: [{ name: "legacy-pro-monthly" }],
       rate_card_name: "Legacy Pro USD",
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(),
+      ],
       ...BILLING_CYCLE_CONFIG,
     },
     {
@@ -1005,7 +1030,10 @@ function getPackages(): PackageDef[] {
       aliases: [{ name: "legacy-business" }],
       rate_card_name: "Legacy Business USD",
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(),
+      ],
       ...BILLING_CYCLE_CONFIG,
     },
     {
@@ -1013,7 +1041,10 @@ function getPackages(): PackageDef[] {
       aliases: [{ name: "legacy-pro-annual" }],
       rate_card_name: "Legacy Pro Annual USD",
       subscriptions: [LEGACY_SEAT_ANNUAL_SUBSCRIPTION],
-      recurring_credits: [getFreeAnnualRecurringCredits()],
+      recurring_credits: [
+        getFreeAnnualRecurringCredits(),
+        getFreeExcessRecurringCredits(),
+      ],
       ...BILLING_CYCLE_CONFIG,
     },
     // Enterprise: MAU-based billing, no seat subscriptions.
@@ -1022,7 +1053,10 @@ function getPackages(): PackageDef[] {
       aliases: [{ name: "legacy-enterprise" }],
       rate_card_name: "Legacy Enterprise MAU USD",
       scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(),
+      ],
       ...BILLING_CYCLE_CONFIG,
     },
     // EUR variants
@@ -1031,7 +1065,10 @@ function getPackages(): PackageDef[] {
       aliases: [{ name: "legacy-pro-monthly-eur" }],
       rate_card_name: "Legacy Pro EUR",
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(),
+      ],
       ...BILLING_CYCLE_CONFIG,
     },
     {
@@ -1039,7 +1076,10 @@ function getPackages(): PackageDef[] {
       aliases: [{ name: "legacy-business-eur" }],
       rate_card_name: "Legacy Business EUR",
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(),
+      ],
       ...BILLING_CYCLE_CONFIG,
     },
     {
@@ -1047,7 +1087,10 @@ function getPackages(): PackageDef[] {
       aliases: [{ name: "legacy-pro-annual-eur" }],
       rate_card_name: "Legacy Pro Annual EUR",
       subscriptions: [LEGACY_SEAT_ANNUAL_SUBSCRIPTION],
-      recurring_credits: [getFreeAnnualRecurringCredits()],
+      recurring_credits: [
+        getFreeAnnualRecurringCredits(),
+        getFreeExcessRecurringCredits(),
+      ],
       ...BILLING_CYCLE_CONFIG,
     },
     {
@@ -1055,7 +1098,10 @@ function getPackages(): PackageDef[] {
       aliases: [{ name: "legacy-enterprise-eur" }],
       rate_card_name: "Legacy Enterprise MAU EUR",
       scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [getFreeMonthlyRecurringCredits()],
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(),
+      ],
       ...BILLING_CYCLE_CONFIG,
     },
     // New Enterprise EUR — per-seat billing (Regular Seat) + AWU AI/Tool usage.
@@ -2171,11 +2217,11 @@ async function main(): Promise<void> {
     `Credit types: USD=${CREDIT_TYPE_USD_ID}, AWU=${getCreditTypeAwuId()}, PROG_USD=${getCreditTypeProgrammaticUsdId()}`
   );
 
+  await syncCustomFields();
   await syncMetrics();
   await syncProducts();
   await syncRateCards();
   await syncPackages();
-  await syncCustomFields();
   await syncAlerts();
 
   if (!EXECUTE) {


### PR DESCRIPTION
## Description

- Fixed conversion rates for programmatic credits to USD - was 0.01 instead of 100 ( 100 USDcents = 1 credit ). Euro was ok ( 0.87 EUR = 1 credit ). This conversio rate is only used for PAYG (once al credits/comits have been consumed).
- Add a free credit only for excess, priority 100 - used after free and committed, as we don't want to bill excess as PAYG by default. This credit will have to be disabled when we want to bill PAYG with metronome. Ensure webhook only create "free credits" for corresponding metronome credit (not excess)
- 

## Tests

Locally, redeployed contracts.

## Risk

Low, metronome only

## Deploy Plan

Redeploy all contracts
