### PR TITLE
[Branching] Keep ES list hydration lean

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1649,8 +1649,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     // ES because every mark-as-read would force a full document re-index (write amplification).
     const dbConversations = await this.fetchByIds(
       auth,
-      items.map((i) => i.sId),
-      { includeForkingData: true }
+      items.map((i) => i.sId)
     );
     const readMap = await this.fetchReadMapForUser(
       auth,
@@ -1690,9 +1689,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           }
 
           const dbItem = dbResource.toListItem();
-          // Omit `nextWakeupAt`: DB always returns null vs ES has the real wakeup time.
-          const esCleaned = omit(esItem, "nextWakeupAt");
-          const dbCleaned = omit(dbItem, "nextWakeupAt");
+          // nextWakeupAt is ES-only. DB list items also derive title fallbacks for untitled
+          // conversations, which would require rehydrating fork data to compare here.
+          const keysToOmit =
+            dbResource.title === null
+              ? ["nextWakeupAt", "title"]
+              : ["nextWakeupAt"];
+          const esCleaned = omit(esItem, keysToOmit);
+          const dbCleaned = omit(dbItem, keysToOmit);
           if (!isEqual(esCleaned, dbCleaned)) {
             const divergingKeys = (
               Object.keys({ ...esCleaned, ...dbCleaned }) as Array<


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/25261.

Remove the unnecessary `includeForkingData` hydration from the ES-backed private conversation list. Shadow validation now skips title comparison only for untitled DB rows, where the list title is a derived display fallback and comparing it would require the extra fork-data join.

## Risks

Blast radius: ES-backed private conversation list shadow validation.
Risk: low

## Deploy Plan
- pmrr
- deploy front
