### PR TITLE
feat: update project todo filter behevior

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskScopeFilter.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskScopeFilter.tsx
@@ -21,18 +21,27 @@ const PERIOD_OPTIONS: Array<{
   value: ProjectTaskPeriodScope;
   label: string;
 }> = [
-  { value: "active", label: "Active" },
-  { value: "last_24h", label: "Last 24h" },
-  { value: "last_7d", label: "Last 7 days" },
-  { value: "last_30d", label: "Last 30 days" },
+  { value: "active", label: "Open" },
+  { value: "last_24h", label: "Done today" },
+  { value: "last_7d", label: "Done in the last 7 days" },
+  { value: "last_30d", label: "Done in the last 30 days" },
 ];
 
 const PEOPLE_OPTIONS: Array<{
   value: ProjectTaskPeopleScope;
   label: string;
+  description: string;
 }> = [
-  { value: "all_project", label: "All project's" },
-  { value: "just_mine", label: "Just mine" },
+  {
+    value: "just_mine",
+    label: "Mine",
+    description: "Your to-dos only",
+  },
+  {
+    value: "all_project",
+    label: "Everyone",
+    description: "All to-dos in this project",
+  },
 ];
 
 export function ProjectTaskScopeFilter() {
@@ -67,7 +76,7 @@ export function ProjectTaskScopeFilter() {
         className="z-[1000] w-80 shadow-2xl ring-1 ring-border/60"
         align="start"
       >
-        <DropdownMenuLabel label="Historic" />
+        <DropdownMenuLabel label="Status" />
         <DropdownMenuRadioGroup
           value={taskOwnerFilter.periodScope}
           className="mb-2"
@@ -89,11 +98,12 @@ export function ProjectTaskScopeFilter() {
         <DropdownMenuSeparator />
         <DropdownMenuLabel label="People" />
         <DropdownMenuRadioGroup value={taskOwnerFilter.peopleScope}>
-          {PEOPLE_OPTIONS.map(({ value, label }) => (
+          {PEOPLE_OPTIONS.map(({ value, label, description }) => (
             <DropdownMenuRadioItem
               key={value}
               value={value}
               label={label}
+              description={description}
               onClick={() => {
                 onTaskOwnerFilterChange({
                   ...taskOwnerFilter,

--- a/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope.ts
@@ -20,15 +20,15 @@ export const DEFAULT_TASK_OWNER_FILTER: TaskOwnerFilter = {
 };
 
 const PERIOD_SCOPE_LABELS: Record<ProjectTaskPeriodScope, string> = {
-  active: "Active",
-  last_24h: "Last 24h",
-  last_7d: "Last 7 days",
-  last_30d: "Last 30 days",
+  active: "Open",
+  last_24h: "Done today",
+  last_7d: "Done in the last 7 days",
+  last_30d: "Done in the last 30 days",
 };
 
 const PEOPLE_SCOPE_LABELS: Record<ProjectTaskPeopleScope, string> = {
-  all_project: "All project's",
-  just_mine: "Just mine",
+  all_project: "Everyone",
+  just_mine: "Mine",
 };
 
 export function formatTaskScopeLabel(filter: TaskOwnerFilter): string {

--- a/front/lib/api/actions/servers/project_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/project_tasks/tools/index.ts
@@ -64,6 +64,7 @@ export function createProjectTasksTools(
         } else if (assigneeFilter === "all") {
           rows = await ProjectTaskResource.fetchBySpace(auth, {
             spaceId: space.id,
+            timeScope: "all",
           });
         }
 

--- a/front/lib/resources/project_task_resource.test.ts
+++ b/front/lib/resources/project_task_resource.test.ts
@@ -467,9 +467,6 @@ describe("ProjectTaskResource", () => {
         makeTodoBlob(space.id, user.id, { text: "Pending suggestion" })
       );
       await pending.updateWithVersion(auth, {
-        markedAsDoneByType: "user",
-        markedAsDoneByUserId: user.id,
-        markedAsDoneByAgentConfigurationId: null,
         agentSuggestionStatus: "pending",
       });
 

--- a/front/lib/resources/project_task_resource.test.ts
+++ b/front/lib/resources/project_task_resource.test.ts
@@ -440,17 +440,14 @@ describe("ProjectTaskResource", () => {
   });
 
   describe("fetchBySpace", () => {
-    it("should hide done todos completed before lastCleanedAt", async () => {
-      const cutoff = new Date();
-      const beforeCutoff = new Date(cutoff.getTime() - 60_000);
-
-      const oldDone = await ProjectTaskResource.makeNew(
+    it("should hide done todos in the active scope", async () => {
+      const done = await ProjectTaskResource.makeNew(
         auth,
-        makeTodoBlob(space.id, user.id, { text: "Hidden after clean" })
+        makeTodoBlob(space.id, user.id, { text: "Done todo" })
       );
-      await oldDone.updateWithVersion(auth, {
+      await done.updateWithVersion(auth, {
         status: "done",
-        doneAt: beforeCutoff,
+        doneAt: new Date(),
         markedAsDoneByType: "user",
         markedAsDoneByUserId: user.id,
         markedAsDoneByAgentConfigurationId: null,
@@ -458,23 +455,18 @@ describe("ProjectTaskResource", () => {
 
       const visible = await ProjectTaskResource.fetchBySpace(auth, {
         spaceId: space.id,
-        lastCleanedAt: cutoff,
+        timeScope: "active",
       });
 
-      expect(visible.map((t) => t.sId)).not.toContain(oldDone.sId);
+      expect(visible.map((t) => t.sId)).not.toContain(done.sId);
     });
 
-    it("should still return todos with pending agentSuggestionStatus when done before lastCleanedAt", async () => {
-      const cutoff = new Date();
-      const beforeCutoff = new Date(cutoff.getTime() - 60_000);
-
+    it("should still return todos with pending agentSuggestionStatus", async () => {
       const pending = await ProjectTaskResource.makeNew(
         auth,
         makeTodoBlob(space.id, user.id, { text: "Pending suggestion" })
       );
       await pending.updateWithVersion(auth, {
-        status: "done",
-        doneAt: beforeCutoff,
         markedAsDoneByType: "user",
         markedAsDoneByUserId: user.id,
         markedAsDoneByAgentConfigurationId: null,
@@ -483,7 +475,7 @@ describe("ProjectTaskResource", () => {
 
       const visible = await ProjectTaskResource.fetchBySpace(auth, {
         spaceId: space.id,
-        lastCleanedAt: cutoff,
+        timeScope: "active",
       });
 
       expect(visible.map((t) => t.sId)).toContain(pending.sId);

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -386,9 +386,7 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
 
     switch (timeScope) {
       case "active":
-        clauses.push({
-          [Op.or]: [{ status: { [Op.ne]: "done" } }],
-        });
+        clauses.push({ status: { [Op.ne]: "done" } });
         break;
       case "last_24h":
       case "last_7d":

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -21,6 +21,7 @@ import type {
 } from "@app/types/project_task";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WhereOptions } from "sequelize";
 import {
   type Attributes,
@@ -353,21 +354,17 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
     auth: Authenticator,
     {
       spaceId,
-      lastCleanedAt,
-      timeScope = "active",
+      timeScope,
       assigneeUserId = null,
     }: {
       spaceId: ModelId;
-      lastCleanedAt?: Date | null;
-      timeScope?: "active" | "last_24h" | "last_7d" | "last_30d";
+      timeScope: "active" | "last_24h" | "last_7d" | "last_30d" | "all";
       assigneeUserId?: ModelId | null;
     }
   ): Promise<ProjectTaskResource[]> {
     const MS_PER_HOUR = 60 * 60 * 1000;
 
-    const historicUpdatedSince = (
-      scope: "last_24h" | "last_7d" | "last_30d"
-    ): Date => {
+    const cutoffFor = (scope: "last_24h" | "last_7d" | "last_30d"): Date => {
       const now = Date.now();
       switch (scope) {
         case "last_24h":
@@ -376,6 +373,8 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
           return new Date(now - 7 * 24 * MS_PER_HOUR);
         case "last_30d":
           return new Date(now - 30 * 24 * MS_PER_HOUR);
+        default:
+          return assertNever(scope);
       }
     };
 
@@ -385,19 +384,21 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
       clauses.push({ userId: assigneeUserId });
     }
 
-    if (timeScope !== "active") {
-      clauses.push({
-        updatedAt: { [Op.gte]: historicUpdatedSince(timeScope) },
-      });
-    } else if (lastCleanedAt) {
-      clauses.push({
-        [Op.or]: [
-          { status: { [Op.ne]: "done" } },
-          { doneAt: null },
-          { doneAt: { [Op.gte]: lastCleanedAt } },
-          { agentSuggestionStatus: "pending" },
-        ],
-      });
+    switch (timeScope) {
+      case "active":
+        clauses.push({
+          [Op.or]: [{ status: { [Op.ne]: "done" } }],
+        });
+        break;
+      case "last_24h":
+      case "last_7d":
+      case "last_30d":
+        clauses.push({ doneAt: { [Op.gte]: cutoffFor(timeScope) } });
+        break;
+      case "all":
+        break;
+      default:
+        assertNever(timeScope);
     }
 
     const where: WhereOptions<ProjectTaskModel> =

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.test.ts
@@ -174,8 +174,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions", () => 
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toEqual({ success: true, cleanedCount: 1 });
 
-    // Cleaning is implemented via a per-user cutoff timestamp (lastCleanedAt),
-    // so direct fetches still work, but list queries should hide older done todos.
+    // Done todos are filtered out of the active view; open todos remain.
     const state = await ProjectTaskStateResource.fetchBySpace(viewerAuth, {
       spaceId: project.id,
     });
@@ -183,7 +182,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions", () => 
 
     const visibleTodos = await ProjectTaskResource.fetchBySpace(viewerAuth, {
       spaceId: project.id,
-      lastCleanedAt: state?.lastCleanedAt ?? null,
+      timeScope: "active",
     });
     const visibleSIds = new Set(visibleTodos.map((t) => t.sId));
     expect(visibleSIds.has(doneTodo.sId)).toBe(false);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
@@ -153,7 +153,7 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_tasks", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    const texts = res._getJSONData().todos.map((t: { text: string }) => t.text);
+    const texts = res._getJSONData().tasks.map((t: { text: string }) => t.text);
     expect(texts).toContain("Recently done");
     expect(texts).not.toContain("Done long ago");
     expect(texts).not.toContain("Still open");

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
@@ -1,6 +1,4 @@
 import { Authenticator } from "@app/lib/auth";
-import { ProjectTaskStateResource } from "@app/lib/resources/project_task_state_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { ProjectTaskFactory } from "@app/tests/utils/ProjectTaskFactory";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
@@ -212,49 +212,6 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_tasks", () => {
     expect(texts).toContain("My open");
   });
 
-  it("should still return done todos with pending agent suggestion in the active view", async () => {
-    const { user } = await setup();
-    const project = await SpaceFactory.project(workspace, user.id);
-    const adminAuth = await Authenticator.internalAdminForWorkspace(
-      workspace.sId
-    );
-
-    const pendingDone = await ProjectTaskFactory.create(workspace, project, {
-      userId: user.id,
-      text: "Pending approval but done",
-    });
-    await pendingDone.updateWithVersion(adminAuth, {
-      status: "done",
-      doneAt: new Date(),
-      markedAsDoneByType: "user",
-      markedAsDoneByUserId: user.id,
-      markedAsDoneByAgentConfigurationId: null,
-      agentSuggestionStatus: "pending",
-    });
-
-    const plainDone = await ProjectTaskFactory.create(workspace, project, {
-      userId: user.id,
-      text: "Plain done",
-    });
-    await plainDone.updateWithVersion(adminAuth, {
-      status: "done",
-      doneAt: new Date(),
-      markedAsDoneByType: "user",
-      markedAsDoneByUserId: user.id,
-      markedAsDoneByAgentConfigurationId: null,
-    });
-
-    req.query.spaceId = project.sId;
-    req.query.assignee = "all";
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(200);
-    const texts = res._getJSONData().tasks.map((t: { text: string }) => t.text);
-
-    expect(texts).toContain("Pending approval but done");
-    expect(texts).not.toContain("Plain done");
-  });
-
   it("should return 400 for non-project spaces", async () => {
     const { user } = await setup();
     const adminAuth = await Authenticator.internalAdminForWorkspace(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
@@ -114,43 +114,55 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_tasks", () => {
     expect(texts.sort()).toEqual(["Mine only"]);
   });
 
-  it("should omit todos stale by updatedAt when period=last_24h", async () => {
+  it("should return only todos completed within the window when period=last_24h", async () => {
     const { user } = await setup();
     const project = await SpaceFactory.project(workspace, user.id);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    const recentlyDone = await ProjectTaskFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Recently done",
+    });
+    await recentlyDone.updateWithVersion(adminAuth, {
+      status: "done",
+      doneAt: new Date(Date.now() - 60 * 60 * 1000),
+      markedAsDoneByType: "user",
+      markedAsDoneByUserId: user.id,
+      markedAsDoneByAgentConfigurationId: null,
+    });
+
+    const oldDone = await ProjectTaskFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Done long ago",
+    });
+    await oldDone.updateWithVersion(adminAuth, {
+      status: "done",
+      doneAt: new Date(Date.now() - 48 * 60 * 60 * 1000),
+      markedAsDoneByType: "user",
+      markedAsDoneByUserId: user.id,
+      markedAsDoneByAgentConfigurationId: null,
+    });
 
     await ProjectTaskFactory.create(workspace, project, {
       userId: user.id,
-      text: "Recent-ish",
+      text: "Still open",
     });
-    const staleTodo = await ProjectTaskFactory.create(workspace, project, {
-      userId: user.id,
-      text: "Stale update",
-    });
-    const stalePast = new Date(Date.now() - 48 * 60 * 60 * 1000);
-    // biome-ignore lint/plugin/noRawSql: Sequelize/workspace hooks block reliable updatedAt backdating for this row
-    await frontSequelize.query(
-      `UPDATE project_todos SET "updatedAt" = :updatedAt WHERE id = :id AND "workspaceId" = :wid`,
-      {
-        replacements: {
-          updatedAt: stalePast,
-          id: staleTodo.id,
-          wid: staleTodo.workspaceId,
-        },
-      }
-    );
 
     req.query.spaceId = project.sId;
     req.query.period = "last_24h";
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    const texts = res._getJSONData().tasks.map((t: { text: string }) => t.text);
-    expect(texts).toContain("Recent-ish");
-    expect(texts).not.toContain("Stale update");
+    const texts = res._getJSONData().todos.map((t: { text: string }) => t.text);
+    expect(texts).toContain("Recently done");
+    expect(texts).not.toContain("Done long ago");
+    expect(texts).not.toContain("Still open");
   });
 
-  it("should hide cleaned done todos for all users", async () => {
-    const { user, auth } = await setup();
+  it("should hide done todos in the active view for all users", async () => {
+    const { user } = await setup();
     const project = await SpaceFactory.project(workspace, user.id);
     const secondUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, secondUser, { role: "user" });
@@ -159,51 +171,32 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_tasks", () => {
       workspace.sId
     );
 
-    // Viewer has two done todos: one "old" (should be hidden) and one "new" (should remain).
-    const oldDone = await ProjectTaskFactory.create(workspace, project, {
+    const myDone = await ProjectTaskFactory.create(workspace, project, {
       userId: user.id,
-      text: "Old done",
+      text: "My done",
     });
-    const newDone = await ProjectTaskFactory.create(workspace, project, {
-      userId: user.id,
-      text: "New done",
-    });
-
-    // Another user's done todo should also be hidden by the viewer's cleaning.
     const otherDone = await ProjectTaskFactory.create(workspace, project, {
       userId: secondUser.id,
       text: "Other user's done",
     });
-
-    const cutoff = new Date();
-    const beforeCutoff = new Date(cutoff.getTime() - 60_000);
-    const afterCutoff = new Date(cutoff.getTime() + 60_000);
-
-    await oldDone.updateWithVersion(adminAuth, {
-      status: "done",
-      doneAt: beforeCutoff,
-      markedAsDoneByType: "user",
-      markedAsDoneByUserId: user.id,
-      markedAsDoneByAgentConfigurationId: null,
+    await ProjectTaskFactory.create(workspace, project, {
+      userId: user.id,
+      text: "My open",
     });
-    await newDone.updateWithVersion(adminAuth, {
+
+    await myDone.updateWithVersion(adminAuth, {
       status: "done",
-      doneAt: afterCutoff,
+      doneAt: new Date(),
       markedAsDoneByType: "user",
       markedAsDoneByUserId: user.id,
       markedAsDoneByAgentConfigurationId: null,
     });
     await otherDone.updateWithVersion(adminAuth, {
       status: "done",
-      doneAt: beforeCutoff,
+      doneAt: new Date(),
       markedAsDoneByType: "user",
       markedAsDoneByUserId: secondUser.id,
       markedAsDoneByAgentConfigurationId: null,
-    });
-
-    await ProjectTaskStateResource.upsertLastCleanedAtBySpace(auth, {
-      spaceId: project.id,
-      lastCleanedAt: cutoff,
     });
 
     req.query.spaceId = project.sId;
@@ -214,53 +207,41 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_tasks", () => {
     const data = res._getJSONData();
     const texts = data.tasks.map((t: any) => t.text);
 
-    expect(texts).not.toContain("Old done");
-    expect(texts).toContain("New done");
+    expect(texts).not.toContain("My done");
     expect(texts).not.toContain("Other user's done");
+    expect(texts).toContain("My open");
   });
 
-  it("should still return pending agent suggestion todos completed before lastCleanedAt", async () => {
-    const { user, auth } = await setup();
+  it("should still return done todos with pending agent suggestion in the active view", async () => {
+    const { user } = await setup();
     const project = await SpaceFactory.project(workspace, user.id);
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
 
-    const cutoff = new Date();
-    const beforeCutoff = new Date(cutoff.getTime() - 60_000);
-
     const pendingDone = await ProjectTaskFactory.create(workspace, project, {
       userId: user.id,
-      text: "Pending approval but done before clean",
+      text: "Pending approval but done",
     });
     await pendingDone.updateWithVersion(adminAuth, {
       status: "done",
-      doneAt: beforeCutoff,
+      doneAt: new Date(),
       markedAsDoneByType: "user",
       markedAsDoneByUserId: user.id,
       markedAsDoneByAgentConfigurationId: null,
       agentSuggestionStatus: "pending",
     });
 
-    const normallyHiddenDone = await ProjectTaskFactory.create(
-      workspace,
-      project,
-      {
-        userId: user.id,
-        text: "Plain old done before clean",
-      }
-    );
-    await normallyHiddenDone.updateWithVersion(adminAuth, {
+    const plainDone = await ProjectTaskFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Plain done",
+    });
+    await plainDone.updateWithVersion(adminAuth, {
       status: "done",
-      doneAt: beforeCutoff,
+      doneAt: new Date(),
       markedAsDoneByType: "user",
       markedAsDoneByUserId: user.id,
       markedAsDoneByAgentConfigurationId: null,
-    });
-
-    await ProjectTaskStateResource.upsertLastCleanedAtBySpace(auth, {
-      spaceId: project.id,
-      lastCleanedAt: cutoff,
     });
 
     req.query.spaceId = project.sId;
@@ -270,8 +251,8 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_tasks", () => {
     expect(res._getStatusCode()).toBe(200);
     const texts = res._getJSONData().tasks.map((t: { text: string }) => t.text);
 
-    expect(texts).toContain("Pending approval but done before clean");
-    expect(texts).not.toContain("Plain old done before clean");
+    expect(texts).toContain("Pending approval but done");
+    expect(texts).not.toContain("Plain done");
   });
 
   it("should return 400 for non-project spaces", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
@@ -103,12 +103,8 @@ async function handler(
         assigneeUserId = currentUser.id;
       }
 
-      const lastCleanedAtForFetch =
-        timeScope === "active" ? (state?.lastCleanedAt ?? null) : null;
-
       const todos = await ProjectTaskResource.fetchBySpace(auth, {
         spaceId: space.id,
-        lastCleanedAt: lastCleanedAtForFetch,
         timeScope,
         assigneeUserId,
       });

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -185,6 +185,7 @@ export async function scrubSpaceActivity({
   // Delete all project todos for this space, before the conversations as it's linked to convo
   const projectTodos = await ProjectTaskResource.fetchBySpace(auth, {
     spaceId: space.id,
+    timeScope: "all",
   });
   await concurrentExecutor(
     projectTodos,
@@ -230,6 +231,7 @@ export async function scrubSpaceActivity({
 
     const projectTodos = await ProjectTaskResource.fetchBySpace(auth, {
       spaceId: space.id,
+      timeScope: "all",
     });
     await concurrentExecutor(
       projectTodos,


### PR DESCRIPTION
## Description

This PR refactors the project todo filter behavior as per https://app.dust.tt/w/0ec9852c2f/conversation/WHlkVN43Am

- Updated filter labels
- Refactored the `fetchBySpace` method to use an explicit `timeScope` and removed `lastCleanedAt` for filtering
- Added a new "all" timeScope option to retrieve all todos without time-based filtering

In followup PRs I will remove the clean button and all its logic.

## Tests

Manually tested.

## Risks

Low. This refactors the filtering logic but maintains the same user-facing behavior. The main risk is ensuring all filter combinations work correctly across different time scopes.

## Deploy Plan

Standard deployment.