### PR TITLE
io-ts to zod migration in assistant files

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -6,22 +6,15 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { GetAgentConfigurationsResponseType } from "@dust-tt/client";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-export const GetAgentConfigurationsQuerySchema = t.type({
-  view: t.union([
-    t.literal("all"),
-    t.literal("list"),
-    t.literal("workspace"),
-    t.literal("published"),
-    t.literal("global"),
-    t.literal("favorites"),
-    t.undefined,
-  ]),
-  withAuthors: t.union([t.literal("true"), t.literal("false"), t.undefined]),
+export const GetAgentConfigurationsQuerySchema = z.object({
+  view: z
+    .enum(["all", "list", "workspace", "published", "global", "favorites"])
+    .optional(),
+  withAuthors: z.enum(["true", "false"]).optional(),
 });
 
 const viewRequiresUser = (view?: string): boolean =>
@@ -98,34 +91,33 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET": {
-      const queryValidation = GetAgentConfigurationsQuerySchema.decode(
+      const queryValidation = GetAgentConfigurationsQuerySchema.safeParse(
         req.query
       );
 
-      if (isLeft(queryValidation)) {
-        const pathError = reporter.formatValidationErrors(queryValidation.left);
+      if (!queryValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid query parameters: ${pathError}`,
+            message: `Invalid query parameters: ${fromError(queryValidation.error).toString()}`,
           },
         });
       }
 
-      if (viewRequiresUser(queryValidation.right.view) && !auth.user()) {
+      if (viewRequiresUser(queryValidation.data.view) && !auth.user()) {
         return apiError(req, res, {
           status_code: 401,
           api_error: {
             type: "invalid_request_error",
-            message: `The user must be authenticated with oAuth to retrieve ${queryValidation.right.view} agents.`,
+            message: `The user must be authenticated with oAuth to retrieve ${queryValidation.data.view} agents.`,
           },
         });
       }
 
       const defaultAgentGetView = auth.user() ? "list" : "all";
-      const agentsGetView = queryValidation.right.view ?? defaultAgentGetView;
-      const withAuthors = queryValidation.right.withAuthors === "true";
+      const agentsGetView = queryValidation.data.view ?? defaultAgentGetView;
+      const withAuthors = queryValidation.data.withAuthors === "true";
 
       let agentConfigurations = await getAgentConfigurationsForView({
         auth,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
@@ -13,17 +13,14 @@ import { launchAgentMessageFeedbackWorkflow } from "@app/temporal/analytics_queu
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { getUserEmailFromHeaders } from "@app/types/user";
 import type { PostMessageFeedbackResponseType } from "@dust-tt/client";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-const ThumbDirectionCodec = t.union([t.literal("up"), t.literal("down")]);
-
-export const MessageFeedbackRequestBodySchema = t.type({
-  thumbDirection: ThumbDirectionCodec,
-  feedbackContent: t.union([t.string, t.undefined, t.null]),
-  isConversationShared: t.union([t.boolean, t.undefined]),
+export const MessageFeedbackRequestBodySchema = z.object({
+  thumbDirection: z.enum(["up", "down"]),
+  feedbackContent: z.string().nullish(),
+  isConversationShared: z.boolean().optional(),
 });
 
 /**
@@ -235,14 +232,15 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const bodyValidation = MessageFeedbackRequestBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      const bodyValidation = MessageFeedbackRequestBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
           },
         });
       }
@@ -251,10 +249,10 @@ async function handler(
         messageId,
         conversation,
         user,
-        thumbDirection: bodyValidation.right.thumbDirection,
+        thumbDirection: bodyValidation.data.thumbDirection,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        content: bodyValidation.right.feedbackContent || "",
-        isConversationShared: bodyValidation.right.isConversationShared,
+        content: bodyValidation.data.feedbackContent || "",
+        isConversationShared: bodyValidation.data.isConversationShared,
       });
 
       if (created.isErr()) {
@@ -277,7 +275,7 @@ async function handler(
         conversationId: conversation.sId,
         messageId,
         agentConfigurationId: created.value.agentConfigurationId,
-        thumbDirection: bodyValidation.right.thumbDirection,
+        thumbDirection: bodyValidation.data.thumbDirection,
         feedbackId: created.value.feedbackId,
       });
       res.status(200).json({ success: true });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -9,16 +9,15 @@ import { apiError } from "@app/logger/withlogging";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { RetryMessageResponseType } from "@dust-tt/client";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-export const PostRetryRequestBodySchema = t.union([
-  t.null,
-  t.undefined,
-  t.literal(""),
-  t.type({}),
+export const PostRetryRequestBodySchema = z.union([
+  z.null(),
+  z.undefined(),
+  z.literal(""),
+  z.object({}),
 ]);
 
 /**
@@ -100,16 +99,14 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      const bodyValidation = PostRetryRequestBodySchema.decode(req.body);
+      const bodyValidation = PostRetryRequestBodySchema.safeParse(req.body);
 
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
@@ -11,20 +11,19 @@ import { apiError } from "@app/logger/withlogging";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { CreateGenericAgentConfigurationResponseType } from "@dust-tt/client";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-export const CreateGenericAgentRequestSchema = t.type({
-  name: t.string,
-  description: t.string,
-  instructions: t.string,
-  emoji: t.union([t.string, t.undefined]),
-  subAgentName: t.union([t.string, t.undefined]),
-  subAgentDescription: t.union([t.string, t.undefined]),
-  subAgentInstructions: t.union([t.string, t.undefined]),
-  subAgentEmoji: t.union([t.string, t.undefined]),
+export const CreateGenericAgentRequestSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  instructions: z.string(),
+  emoji: z.string().optional(),
+  subAgentName: z.string().optional(),
+  subAgentDescription: z.string().optional(),
+  subAgentInstructions: z.string().optional(),
+  subAgentEmoji: z.string().optional(),
 });
 
 function assistantHandleIsValid(handle: string) {
@@ -99,14 +98,15 @@ async function handler(
         });
       }
 
-      const bodyValidation = CreateGenericAgentRequestSchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      const bodyValidation = CreateGenericAgentRequestSchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
           },
         });
       }
@@ -120,7 +120,7 @@ async function handler(
         subAgentDescription,
         subAgentInstructions,
         subAgentEmoji,
-      } = bodyValidation.right;
+      } = bodyValidation.data;
 
       if (subAgentInstructions) {
         if (!subAgentName || subAgentName.trim() === "") {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tokenize.ts
@@ -8,17 +8,16 @@ import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { TokenizeResponseType } from "@dust-tt/client";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export type PostDatasourceTokenizeBody = {
   text: string;
 };
 
-const PostDatasourceTokenizeBodySchema = t.type({
-  text: t.string,
+const PostDatasourceTokenizeBodySchema = z.object({
+  text: z.string(),
 });
 
 /**
@@ -93,19 +92,19 @@ async function handler(
 
   switch (req.method) {
     case "POST": {
-      const bodyValidation = PostDatasourceTokenizeBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      const bodyValidation = PostDatasourceTokenizeBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
           },
         });
       }
-      const text = bodyValidation.right.text;
+      const text = bodyValidation.data.text;
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
       const coreTokenizeRes = await coreAPI.dataSourceTokenize(
         {

--- a/front/pages/api/v1/w/[wId]/usage.ts
+++ b/front/pages/api/v1/w/[wId]/usage.ts
@@ -7,25 +7,18 @@ import { getWorkspaceUsageRetentionErrorMessage } from "@app/lib/workspace_usage
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { GetWorkspaceUsageResponseType } from "@dust-tt/client";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-const DateString = t.refinement(
-  t.string,
-  (s): s is string => /^\d{4}-\d{2}-\d{2}$/.test(s),
-  "YYYY-MM-DD"
-);
+const DateString = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, { message: "YYYY-MM-DD" });
 
-const GetWorkspaceUsageSchema = t.intersection([
-  t.type({
-    start_date: DateString,
-  }),
-  t.partial({
-    end_date: t.union([DateString, t.undefined, t.null]),
-  }),
-]);
+const GetWorkspaceUsageSchema = z.object({
+  start_date: DateString,
+  end_date: DateString.nullish(),
+});
 
 /**
  * @ignoreswagger
@@ -52,19 +45,18 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const queryValidation = GetWorkspaceUsageSchema.decode(req.query);
-      if (isLeft(queryValidation)) {
-        const pathError = reporter.formatValidationErrors(queryValidation.left);
+      const queryValidation = GetWorkspaceUsageSchema.safeParse(req.query);
+      if (!queryValidation.success) {
         return apiError(req, res, {
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request query: ${pathError}`,
+            message: `Invalid request query: ${fromError(queryValidation.error).toString()}`,
           },
           status_code: 400,
         });
       }
 
-      const query = queryValidation.right;
+      const query = queryValidation.data;
       const startDate = new Date(query.start_date);
       const endDate = query.end_date ? new Date(query.end_date) : new Date();
       const conversationsRetentionDays =


### PR DESCRIPTION
## Description

This migrates the six remaining io-ts schemas under v1 API to zod, matching the pattern already used in sibling endpoints like conversations/index.ts.

## Tests

Manual using postman

## Risk

Some, lacking proper automated testing

## Deploy Plan

Front