### PR TITLE
feat(projects): propose all TODOs to the model

### DIFF
--- a/front/lib/project_task/deduplicate_candidates.ts
+++ b/front/lib/project_task/deduplicate_candidates.ts
@@ -1,8 +1,8 @@
 // Semantic deduplication for project TODO candidates during the merge workflow.
 //
-// batchDeduplicateCandidates groups candidates by (userId, category), runs one
-// LLM call per non-empty group, and returns a flat list of DeduplicatedGroup.
-// Each group describes one todo that Phase 3 will touch:
+// batchDeduplicateCandidates receives ALL candidates and ALL existing todos for
+// the space (across all users), runs ONE LLM call, and returns a flat list of
+// DeduplicatedGroup. Each group describes one todo that Phase 3 will touch:
 //
 //   - { kind: "existing", todo, candidates }
 //       Attach every candidate's source to the existing todo.
@@ -14,9 +14,8 @@
 // forgets to include it in any partition, it is emitted as a singleton
 // "new" group so sources are never silently dropped.
 //
-// The LLM is handed one flat, numbered list of items per (userId, category)
-// group — existing todos first, then new candidates — and asked to partition
-// it into semantic clusters. Per cluster:
+// The LLM is handed one flat, numbered list — existing todos first, then new
+// candidates — and asked to partition it into semantic clusters. Per cluster:
 //
 //   - no existing → the cluster becomes one "new" group; the first candidate
 //     drives the content, the rest attach their sources;
@@ -25,15 +24,14 @@
 //     additional existing todos in the same cluster are ignored (we don't
 //     merge existing todos here).
 //
-// On LLM failure the affected (userId, category) group is treated as all-new
-// (one singleton "new" group per candidate), so the caller always falls back
-// to creating fresh todos rather than silently discarding data.
+// On LLM failure the whole call is treated as all-new (one singleton "new"
+// group per candidate), so the caller always falls back to creating fresh todos
+// rather than silently discarding data.
 
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
@@ -49,9 +47,7 @@ export type DeduplicateCandidate = {
   text: string;
 };
 
-// One todo that Phase 3 will touch. A group's candidates all share the same
-// userId and category (grouping is per (userId, category) before the LLM
-// call).
+// One task that Phase 3 will touch.
 export type DeduplicatedGroup =
   | {
       kind: "existing";
@@ -65,13 +61,14 @@ export type DeduplicatedGroup =
       candidates: DeduplicateCandidate[];
     };
 
-// Nested map shape for existing todos passed in by the caller:
-// userId → todos.
-export type ExistingTodosByUser = Map<ModelId, ProjectTaskResource[]>;
-
 // ── LLM tool ─────────────────────────────────────────────────────────────────
 
 const REPORT_GROUPS_FUNCTION_NAME = "report_groups";
+
+// Warn when combined item count risks context pressure. The LLM call still
+// fires — this is purely a signal for monitoring.
+// 500 * 256 = 128k
+const CONTEXT_PRESSURE_THRESHOLD = 500;
 
 const DeduplicationResultSchema = z.object({
   groups: z.array(z.array(z.number().int())),
@@ -144,13 +141,11 @@ function buildDeduplicationPrompt(
   ].join("\n");
 }
 
-// ── LLM call for a single (userId, category) group ───────────────────────────
+// ── LLM call ─────────────────────────────────────────────────────────────────
 
 // Returns the LLM's partitioning of `[...existingTodos, ...candidates]` as
 // an array of groups of 0-based indexes, or an empty array on failure (each
 // candidate then ends up in its own singleton "new" group downstream).
-// Precondition: all candidates must share the same category — batchDeduplicateCandidates
-// enforces this by grouping on (userId, category) before calling here.
 export async function runDeduplicationLLMCall(
   auth: Authenticator,
   {
@@ -314,67 +309,69 @@ export function resolveDeduplicationGroups<TTodo>(
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-// Runs semantic deduplication for all new candidates. Groups candidates by
-// (userId, category), executes one LLM call per group (up to 4 concurrent),
-// and returns a flat list of DeduplicatedGroup covering every input
-// candidate.
+// Runs semantic deduplication for all new candidates in a single LLM call.
+// All candidates and all existing todos (across all users) are presented to the
+// model as one flat numbered list. Returns a flat list of DeduplicatedGroup
+// covering every input candidate.
+//
+// Fast path: if there is at most one candidate and no existing todos, the LLM
+// call is skipped and a singleton "new" group is returned directly.
+//
+// On LLM failure every candidate is returned as its own singleton "new" group
+// so the caller always creates fresh todos rather than silently dropping data.
 export async function batchDeduplicateCandidates(
   auth: Authenticator,
   {
     model,
     candidates,
-    existingTodosByUser,
+    existingTodos,
   }: {
     model: ModelConfigurationType;
     candidates: DeduplicateCandidate[];
-    existingTodosByUser: ExistingTodosByUser;
+    existingTodos: ProjectTaskResource[];
   }
 ): Promise<DeduplicatedGroup[]> {
-  const results: DeduplicatedGroup[] = [];
-
-  // Group candidates by userId → candidates.
-  // TODO: to move above, we are doing it for each batch this is wasteful
-  const candidatesByUserId = new Map<ModelId, DeduplicateCandidate[]>();
-  for (const candidate of candidates) {
-    const bucket = candidatesByUserId.get(candidate.userId) ?? [];
-
-    bucket.push(candidate);
-    candidatesByUserId.set(candidate.userId, bucket);
+  if (candidates.length === 0) {
+    return [];
   }
 
-  // Flatten to a list of (candidates, existingTodos) jobs so the executor
-  // can schedule them at a fixed parallelism.
-  const jobs: Array<{
-    candidates: DeduplicateCandidate[];
-    existingTodos: ProjectTaskResource[];
-  }> = [];
-  for (const [userId, candidates] of candidatesByUserId) {
-    const existingTodos = existingTodosByUser.get(userId) ?? [];
-    jobs.push({ candidates, existingTodos });
+  const owner = auth.getNonNullableWorkspace();
+
+  // Fast path: single candidate with no existing todos needs no LLM call.
+  if (existingTodos.length === 0 && candidates.length === 1) {
+    return [{ kind: "new", candidates }];
   }
 
-  await concurrentExecutor(
-    jobs,
-    async ({ candidates, existingTodos }) => {
-      // Fast path: one candidate, no existing. No LLM call needed; emit a
-      // singleton "new" group directly.
-      if (existingTodos.length === 0 && candidates.length <= 1) {
-        results.push({ kind: "new", candidates });
-        return;
-      }
+  const totalItems = existingTodos.length + candidates.length;
 
-      const llmGroups = await runDeduplicationLLMCall(auth, {
-        model,
-        candidates,
-        existingTodos,
-      });
+  if (totalItems > CONTEXT_PRESSURE_THRESHOLD) {
+    logger.warn(
+      {
+        workspaceId: owner.sId,
+        existingTodoCount: existingTodos.length,
+        candidateCount: candidates.length,
+        totalItems,
+        threshold: CONTEXT_PRESSURE_THRESHOLD,
+      },
+      "Project todo dedup: large combined item count may cause context pressure — proceeding with single LLM call"
+    );
+  } else {
+    logger.info(
+      {
+        workspaceId: owner.sId,
+        existingTodoCount: existingTodos.length,
+        candidateCount: candidates.length,
+        totalItems,
+      },
+      "Project todo dedup: running single LLM call for all users"
+    );
+  }
 
-      results.push(
-        ...resolveDeduplicationGroups(candidates, existingTodos, llmGroups)
-      );
-    },
-    { concurrency: 4 }
-  );
+  const llmGroups = await runDeduplicationLLMCall(auth, {
+    model,
+    candidates,
+    existingTodos,
+  });
 
-  return results;
+  return resolveDeduplicationGroups(candidates, existingTodos, llmGroups);
 }

--- a/front/lib/project_task/merge_into_project.ts
+++ b/front/lib/project_task/merge_into_project.ts
@@ -14,8 +14,8 @@
 //           not found → push to newCandidates[]
 //
 //   Phase 2 — Semantic deduplication.
-//     - Pre-fetch existing todos per (userId, category) for the space.
-//     - Run one LLM call per non-empty (userId, category) group to detect
+//     - Pre-fetch all existing todos for the space (all users, including deleted).
+//     - Run ONE LLM call with all candidates and all existing todos to detect
 //       items that describe the same task despite different wording.
 //     - Build dedupMap: `${userId}:${itemId}` → matching ProjectTaskResource.
 //       Missing keys mean the candidate is genuinely new.
@@ -31,7 +31,6 @@ import {
   batchDeduplicateCandidates,
   type DeduplicateCandidate,
   type DeduplicatedGroup,
-  type ExistingTodosByUser,
 } from "@app/lib/project_task/deduplicate_candidates";
 import {
   ProjectTaskResource,
@@ -291,9 +290,9 @@ export async function collectDocumentCandidates(
 
 // ── Phase 2 ───────────────────────────────────────────────────────────────────
 
-// Pre-fetches all existing todos per (userId, category) and runs batch semantic
-// deduplication via LLM. Returns one singleton "new" group per candidate if no
-// model is available — Phase 3 then creates fresh todos for all of them.
+// Pre-fetches all existing todos for the space and runs semantic deduplication
+// via a single LLM call across all users. Returns one singleton "new" group per
+// candidate if no model is available — Phase 3 then creates fresh todos for all.
 async function buildDeduplicationGroups(
   auth: Authenticator,
   {
@@ -320,39 +319,17 @@ async function buildDeduplicationGroups(
     return dedupInput.map((c) => ({ kind: "new", candidates: [c] }));
   }
 
-  // Fetch all existing todos for each unique target user in a single pass,
-  // then nest them under userId → category → todos for lookup by the LLM
-  // calls.
-  const uniqueUserIds = [
-    ...new Set(newCandidates.map((c) => c.userId as ModelId)),
-  ];
-  const existingTodosByUser: ExistingTodosByUser = new Map();
-
-  await concurrentExecutor(
-    uniqueUserIds,
-    async (userId) => {
-      // we want deleted TODOs to match them
-      const todos =
-        await ProjectTaskResource.fetchLatestBySpaceForUserIncludingDeleted(
-          auth,
-          { spaceId: spaceModelId, userId }
-        );
-      for (const todo of todos) {
-        if (todo.userId === null) {
-          continue;
-        }
-        const bucket = existingTodosByUser.get(todo.userId) ?? [];
-        bucket.push(todo);
-        existingTodosByUser.set(todo.userId, bucket);
-      }
-    },
-    { concurrency: 4 }
-  );
+  // Fetch all existing tasks for the space in one pass (including deleted).
+  // All tasks across all users are passed to a single LLM call.
+  const existingTodos =
+    await ProjectTaskResource.fetchAllBySpaceIncludingDeleted(auth, {
+      spaceId: spaceModelId,
+    });
 
   return batchDeduplicateCandidates(auth, {
     model,
     candidates: dedupInput,
-    existingTodosByUser,
+    existingTodos,
   });
 }
 

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -419,19 +419,14 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
     });
   }
 
-  // Like fetchLatestBySpaceForUser but also includes soft-deleted rows. Used by
-  // the merge workflow to detect candidates that match a previously deleted todo
-  // so that the merge skips them rather than re-creating the todo.
-  static async fetchLatestBySpaceForUserIncludingDeleted(
+  // Fetches all todos for the given space across all users, including
+  // soft-deleted rows. Used by the merge workflow for space-wide dedup.
+  static async fetchAllBySpaceIncludingDeleted(
     auth: Authenticator,
-    { spaceId, userId }: { spaceId: ModelId; userId: ModelId }
+    { spaceId }: { spaceId: ModelId }
   ): Promise<ProjectTaskResource[]> {
     const todos = await ProjectTaskModel.findAll({
-      where: {
-        spaceId,
-        userId,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
+      where: { workspaceId: auth.getNonNullableWorkspace().id, spaceId },
       order: [["createdAt", "DESC"]],
     });
     return todos.map((todo) => new this(ProjectTaskModel, todo.get()));

--- a/front/tests/dedup-evals/test-suites/todo-deduplication.ts
+++ b/front/tests/dedup-evals/test-suites/todo-deduplication.ts
@@ -354,6 +354,67 @@ Score 0 if the model attempts to report one candidate as a duplicate of the othe
 Score 3 if both candidates are correctly reported as new.`,
     },
 
+    // ── Soft-deleted existing todo: LLM must still match ──────────────────
+    //
+    // fetchAllBySpaceIncludingDeleted now passes deleted todos into
+    // existingTodosByUser. The LLM never sees deletedAt — it only sees text.
+    // createOrLinkTodos is responsible for skipping a candidate that matched a
+    // deleted todo. These scenarios validate that the LLM correctly recognises
+    // the match even when the existing todo is logically deleted.
+
+    {
+      scenarioId: "deleted-todo-exact-match",
+      // existing-1 is soft-deleted in production (deletedAt is set).
+      // The LLM only sees the text, so it must match as usual.
+      existingTodos: [
+        {
+          sId: "existing-deleted-1",
+          text: "Migrate the database from MySQL to PostgreSQL",
+        },
+        {
+          sId: "existing-2",
+          text: "Add unit tests for the authentication module",
+        },
+      ],
+      candidates: [
+        {
+          itemId: "c-0",
+          text: "Move all data from MySQL over to the new PostgreSQL database",
+        },
+      ],
+      expectedMatches: [shouldMatchExisting(0, "existing-deleted-1")],
+      judgeCriteria: `existing-deleted-1 is soft-deleted in production, but the LLM only sees its
+text. The candidate is a semantic duplicate of that deleted todo and must be matched to it.
+createOrLinkTodos will then skip re-creating it.
+
+Score 0 if the candidate is treated as new or matched to existing-2.
+Score 3 if correctly matched to existing-deleted-1.`,
+    },
+
+    {
+      scenarioId: "deleted-todo-genuinely-new",
+      // Same soft-deleted existing setup, but the candidate is unrelated.
+      // The LLM must NOT match just because there is a deleted todo around.
+      existingTodos: [
+        {
+          sId: "existing-deleted-1",
+          text: "Migrate the database from MySQL to PostgreSQL",
+        },
+      ],
+      candidates: [
+        {
+          itemId: "c-0",
+          text: "Add dark mode support to the settings page",
+        },
+      ],
+      expectedMatches: [shouldBeNew(0)],
+      judgeCriteria: `The existing todo (database migration, soft-deleted) is entirely unrelated to
+the candidate (dark mode). The candidate must be identified as new.
+
+Score 0 if the candidate is matched to existing-deleted-1.
+Score 3 if correctly identified as new.`,
+    },
+
     // ── Large candidate batch: index tracking ──────────────────────────────
 
     {


### PR DESCRIPTION
## Description

To prevent recreation of TODOs reassigned we get all TODOs of everyone

  Replaces the per-user concurrent DB fetch in buildDeduplicationGroups with a single space-wide query. Previously, deduplication fetched todos user-by-user using; now fetchAllBySpaceIncludingDeleted fetches every todo in the space in one shot and groups them by userId in memory.                                                                                                 
   
  The old method fetchLatestBySpaceForUserIncludingDeleted is renamed to fetchAllBySpaceIncludingDeleted (dropping the userId parameter) to reflect its broadened scope.                                                                 
                              
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
