### PR TITLE
[AGENT] Surface max-step with no content as retryable empty_content error

### DIFF
--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -22,7 +22,8 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
   const errorIsRetryable =
     isAgentErrorCategory(error.metadata?.category) &&
     (error.metadata?.category === "retryable_model_error" ||
-      error.metadata?.category === "stream_error");
+      error.metadata?.category === "stream_error" ||
+      error.metadata?.category === "empty_content");
 
   const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
     async () => retryHandler()

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -773,6 +773,26 @@ export async function runModel(
       );
     }
 
+    // On the last step, if the model produced no textual content, it effectively
+    // ran out of iterations without finalizing an answer. Surface a retryable
+    // empty_content error.
+    if (isLastStep && !processedContent.length) {
+      await publishAgentError(
+        {
+          code: "max_step_reached",
+          message:
+            "This agent took too many steps to answer your query. " +
+            "Try narrowing down your question or breaking it into smaller parts.",
+          metadata: {
+            category: "empty_content",
+            errorTitle: "Too many steps",
+          },
+        },
+        dustRunId
+      );
+      return null;
+    }
+
     const chainOfThought =
       (nativeChainOfThought || contentParser.getChainOfThought()) ?? "";
 

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -267,6 +267,7 @@ export function getMaxActionsPerStep(depth: number): number {
 export const AgentErrorCategories = [
   "retryable_model_error",
   "context_window_exceeded",
+  "empty_content",
   "provider_internal_error",
   "stream_error",
   "unknown_error",


### PR DESCRIPTION
## Description

When the agent loop reached the last step without producing any textual content, the user got a generic, non-actionable error. This PR introduces a new `empty_content` agent error category, emits a retryable `max_step_reached` error from `runModel` in that exact situation, and surfaces a Retry button in the message UI so the user can re-run the query.

## Tests

Looked at the ui.

## Risk

Low — additive change. New error category is added to the union, existing flows are untouched. No migration, no API contract change.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`