### PR TITLE
fix(projects-sidebar): hide new button when no projects and fix action visibility on click

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -702,17 +702,19 @@ export function AgentSidebarMenu({
           onOpenChange={(open) => setProjectsSectionCollapsed(!open)}
           action={
             <>
-              <Button
-                size="xs"
-                icon={PlusIcon}
-                label="New"
-                variant="ghost"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  setIsCreateProjectModalOpen(true);
-                }}
-              />
+              {summary.length > 0 && (
+                <Button
+                  size="xs"
+                  icon={PlusIcon}
+                  label="New"
+                  variant="ghost"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setIsCreateProjectModalOpen(true);
+                  }}
+                />
+              )}
               <ProjectsBrowsePopover owner={owner} />
             </>
           }

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -433,7 +433,7 @@ const NavigationListCollapsibleSection = React.forwardRef<
         className={cn(
           "s-m-1.5 s-flex s-gap-1 s-pr-0.5 s-transition-opacity",
           actionOnHover
-            ? "[@media(hover:hover)]:s-opacity-0 hover:s-opacity-100 group-focus-within/menu-item:s-opacity-100 group-hover/menu-item:s-opacity-100"
+            ? "[@media(hover:hover)]:s-opacity-0 hover:s-opacity-100 group-has-[:focus-visible]/menu-item:s-opacity-100 group-hover/menu-item:s-opacity-100"
             : "s-opacity-100"
         )}
         onClick={(e) => {


### PR DESCRIPTION
## Description

Two small UX fixes in the projects sidebar:

- **`+ New` button**: the button in the Projects section header now only appears when at least one project exists. When there are no projects, the inline "Create a Project" list item is the only call-to-action, which avoids the visual redundancy.
- **Action buttons flickering on click**: clicking the `NavigationListCollapsibleSection` header was giving the trigger element browser focus, which caused `group-focus-within` to show the action buttons until the user clicked somewhere else. Changed to `group-has-[:focus-visible]` so the buttons only reveal on hover or keyboard navigation (`:focus-visible`), not on mouse clicks.

## Tests

Tested manually in the sidebar — confirmed both behaviors.

## Risk

Low. CSS-only change in a shared sparkle component (`NavigationListCollapsibleSection`); only affects the `actionOnHover=true` path (the default). The `+ New` button guard only reads from existing `summary` state.
