### PR TITLE
Upg: "group" filter for project conversations now account for subscribed participants and previous participants.

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -4,6 +4,7 @@ import { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
   ConversationModel,
+  ConversationParticipantModel,
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
@@ -6289,6 +6290,138 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
     const sIds = resultWithDeleted.conversations.map((c) => c.sId);
     expect(sIds).toContain(convo1.sId);
     expect(sIds).toContain(convo2.sId);
+  });
+
+  it("group filter includes conversations with two participants posted or subscribed", async () => {
+    const convo = await createConvoWithUpdatedAt(1);
+    const adminUser = adminAuth.getNonNullableUser();
+
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const addRes = await space.addMembers(adminAuth, {
+      userIds: [otherUser.sId],
+    });
+    assert(addRes.isOk(), "Failed to add user to space");
+
+    await ConversationParticipantModel.create({
+      workspaceId: workspace.id,
+      conversationId: convo.id,
+      userId: adminUser.id,
+      action: "posted",
+      actionRequired: false,
+    });
+    await ConversationParticipantModel.create({
+      workspaceId: workspace.id,
+      conversationId: convo.id,
+      userId: otherUser.id,
+      action: "subscribed",
+      actionRequired: false,
+    });
+
+    const result = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        filter: "group",
+        pagination: { limit: 10 },
+      }
+    );
+
+    expect(result.conversations.map((c) => c.sId)).toContain(convo.sId);
+  });
+
+  it("group filter includes conversations with two distinct message authors when a participant row was removed", async () => {
+    const convo = await createConvoWithUpdatedAt(1);
+    const adminUser = adminAuth.getNonNullableUser();
+
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const addRes = await space.addMembers(adminAuth, {
+      userIds: [otherUser.sId],
+    });
+    assert(addRes.isOk(), "Failed to add user to space");
+
+    await ConversationParticipantModel.create({
+      workspaceId: workspace.id,
+      conversationId: convo.id,
+      userId: adminUser.id,
+      action: "posted",
+      actionRequired: false,
+    });
+    await ConversationParticipantModel.create({
+      workspaceId: workspace.id,
+      conversationId: convo.id,
+      userId: otherUser.id,
+      action: "posted",
+      actionRequired: false,
+    });
+
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+    await ConversationFactory.createUserMessageWithRank({
+      auth: otherAuth,
+      workspace,
+      conversationId: convo.id,
+      rank: 2,
+      content: "Second user message",
+    });
+
+    await ConversationParticipantModel.destroy({
+      where: {
+        workspaceId: workspace.id,
+        conversationId: convo.id,
+        userId: otherUser.id,
+      },
+    });
+
+    const result = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        filter: "group",
+        pagination: { limit: 10 },
+      }
+    );
+
+    expect(result.conversations.map((c) => c.sId)).toContain(convo.sId);
+  });
+
+  it("getDistinctUserCountsByConversationIds counts distinct user message authors", async () => {
+    expect(
+      (
+        await ConversationResource.getDistinctUserCountsByConversationIds(
+          workspace.id,
+          []
+        )
+      ).size
+    ).toBe(0);
+
+    const convo = await createConvoWithUpdatedAt(1);
+
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+    await ConversationFactory.createUserMessageWithRank({
+      auth: otherAuth,
+      workspace,
+      conversationId: convo.id,
+      rank: 2,
+      content: "Second user",
+    });
+
+    const counts =
+      await ConversationResource.getDistinctUserCountsByConversationIds(
+        workspace.id,
+        [convo.id]
+      );
+
+    expect(counts.get(convo.id)).toBe(2);
   });
 });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -539,6 +539,55 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   /**
+   * Returns counts of distinct workspace users who authored a user message (non-null
+   * {@link UserMessageModel.userId}) per conversation.
+   */
+  static async getDistinctUserCountsByConversationIds(
+    workspaceId: ModelId,
+    conversationIds: ModelId[]
+  ): Promise<Map<ModelId, number>> {
+    const result = new Map<ModelId, number>();
+    if (conversationIds.length === 0) {
+      return result;
+    }
+
+    const rows = await MessageModel.findAll({
+      attributes: [
+        "conversationId",
+        [
+          fn("COUNT", fn("DISTINCT", col("userMessage.userId"))),
+          "distinctUserCount",
+        ],
+      ],
+      include: [
+        {
+          model: UserMessageModel,
+          as: "userMessage",
+          attributes: [],
+          required: true,
+          where: {
+            userId: { [Op.ne]: null },
+          },
+        },
+      ],
+      where: {
+        workspaceId,
+        conversationId: { [Op.in]: conversationIds },
+        userMessageId: { [Op.ne]: null },
+      },
+      group: ["message.conversationId"],
+    });
+
+    for (const row of rows) {
+      result.set(
+        row.conversationId,
+        parseInt(row.get("distinctUserCount") as string, 10)
+      );
+    }
+    return result;
+  }
+
+  /**
    * Returns counts of failed agent messages grouped by conversationId for the
    * given conversation model IDs.
    */
@@ -2055,13 +2104,18 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       }
 
       if (filter === "group") {
+        const workspaceId = auth.getNonNullableWorkspace().id;
+        const batchConversationIds = conversationsBatch.map((c) => c.id);
+
         const participants = await ConversationParticipantModel.findAll({
           where: {
-            workspaceId: auth.getNonNullableWorkspace().id,
+            workspaceId,
             conversationId: {
-              [Op.in]: conversationsBatch.map((c) => c.id),
+              [Op.in]: batchConversationIds,
             },
-            action: "posted",
+            action: {
+              [Op.in]: ["posted", "subscribed"],
+            },
           },
           attributes: ["conversationId", "userId"],
         });
@@ -2081,12 +2135,33 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           );
         }
 
-        const groupConversationIds = new Set<ModelId>(
+        const groupConversationIdsFromParticipants = new Set<ModelId>(
           [...participantUserIdsByConversation.entries()].flatMap(
             ([conversationId, participantUserIds]) =>
               participantUserIds.size >= 2 ? [conversationId] : []
           )
         );
+
+        const candidateIdsForMessagePass = batchConversationIds.filter(
+          (id) => !groupConversationIdsFromParticipants.has(id)
+        );
+
+        const distinctAuthorsByConversation =
+          candidateIdsForMessagePass.length === 0
+            ? new Map<ModelId, number>()
+            : await this.getDistinctUserCountsByConversationIds(
+                workspaceId,
+                candidateIdsForMessagePass
+              );
+
+        const groupConversationIds = new Set<ModelId>(
+          groupConversationIdsFromParticipants
+        );
+        for (const [conversationId, count] of distinctAuthorsByConversation) {
+          if (count > 1) {
+            groupConversationIds.add(conversationId);
+          }
+        }
 
         matchingConversations = conversationsBatch.filter((conversation) =>
           groupConversationIds.has(conversation.id)


### PR DESCRIPTION
## Description

The "Shared" conversation filter only counted participants with `action: "posted"`. Two cases were missed:

1. **Subscribed participants** — a user who is subscribed to a conversation without having posted (e.g. tagged in, following a thread) was not counted, so two-person conversations where one person only subscribed would incorrectly not appear in the filter - **Happens 100% if you "invite" users by mentionning them.**
2. **Removed participant rows** — when a `ConversationParticipantModel` row is deleted after the fact (e.g. the user left the project), a conversation with two distinct message authors would also be excluded

**Fix**

The filter now uses a two-pass approach:
- **Pass 1** — count distinct `userId`s in `ConversationParticipantModel` where `action IN ("posted", "subscribed")`; conversations with ≥ 2 are immediately included
- **Pass 2** — for conversations not already matched, run `getDistinctUserCountsByConversationIds` (a new static helper that counts distinct `UserMessage.userId` values via a GROUP BY query) as a fallback; conversations with ≥ 2 distinct message authors are included

Add `getDistinctUserCountsByConversationIds` static helper with its own unit test.

## Tests

3 new test cases: subscribed participant, removed participant row, and distinct author count helper.

## Risk

Low — the filter only becomes more inclusive (previously missed conversations can now appear); conversations that were already shown are unaffected

## Deploy Plan

Deploy `front`
