### PR TITLE
[front] Only enter user mention mode when message starts with a use mention

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -16,6 +16,7 @@ import {
 import { RUNNING_AGENT_SWITCH_BLOCK_MESSAGE } from "@app/lib/api/assistant/errors";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { DustError } from "@app/lib/error";
+import { startsWithUserMention } from "@app/lib/mentions/format";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { TRACKING_AREAS, trackEvent } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
@@ -258,10 +259,10 @@ export const InputBar = React.memo(function InputBar({
     const { mentions: rawMentions, markdown } = markdownAndMentions;
     // When single-agent input is enabled, inject the selected agent into mentions
     // since it's no longer in the editor as a mention node.
-    const hasUserMention = rawMentions.some((m) => m.type === "user");
+    const isLeadingUserMention = startsWithUserMention(markdown);
     const shouldInjectSelectedAgent =
       selectedSingleAgent &&
-      !hasUserMention &&
+      !isLeadingUserMention &&
       !rawMentions.some((m) => m.id === selectedSingleAgent.id);
 
     const allMentions = shouldInjectSelectedAgent

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -22,6 +22,7 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
+import { startsWithUserMention } from "@app/lib/mentions/format";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
@@ -670,11 +671,11 @@ const InputBarContainer = ({
       // Auto-save draft when content changes and track user mentions.
       // Include the selected single agent so the debounced save doesn't
       // overwrite the agent mention saved by the single-agent effect.
-      const { markdown, mentions } = editorService.getMarkdownAndMentions();
+      const { markdown } = editorService.getMarkdownAndMentions();
       saveDraft(editorIsEmpty ? "" : markdown, selectedSingleAgentRef.current);
-      const userMentioned = mentions.some((m) => m.type === "user");
-      setHasUserMention(userMentioned);
-      onEditorMentionsChangedRef.current(userMentioned);
+      const isLeadingUserMention = startsWithUserMention(markdown);
+      setHasUserMention(isLeadingUserMention);
+      onEditorMentionsChangedRef.current(isLeadingUserMention);
     };
 
     if (editorRef.current) {

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -25,7 +25,7 @@ import type { JSONContent } from "@tiptap/react";
 export const AGENT_MENTION_REGEX = /:mention\[([^\]]+)]\{sId=([^}]+?)}/g;
 export const AGENT_MENTION_REGEX_BEGINNING = new RegExp(
   "^" + AGENT_MENTION_REGEX.source,
-  AGENT_MENTION_REGEX.flags
+  AGENT_MENTION_REGEX.flags.replace("g", "")
 );
 
 /**
@@ -35,8 +35,12 @@ export const AGENT_MENTION_REGEX_BEGINNING = new RegExp(
 export const USER_MENTION_REGEX = /:mention_user\[([^\]]+)]\{sId=([^}]+?)}/g;
 export const USER_MENTION_REGEX_BEGINNING = new RegExp(
   "^" + USER_MENTION_REGEX.source,
-  USER_MENTION_REGEX.flags
+  USER_MENTION_REGEX.flags.replace("g", "")
 );
+
+export function startsWithUserMention(markdown: string): boolean {
+  return USER_MENTION_REGEX_BEGINNING.test(markdown.trimStart());
+}
 
 /**
  * Extracts mentions from content.


### PR DESCRIPTION
## Description

`Hello @Daphné` and `@Daphné Hello` were both treated as user mention mode, pinging only the user with no agent response. User mention mode should only activate when the message starts with a user mention.

This PR changes both the real-time editor listener in InputBarContainer and the submit handler in InputBar to check for a leading user mention instead of any user mention. The check is centralised in a new startsWithUserMention helper in lib/mentions/format.ts, which uses the existing USER_MENTION_REGEX_BEGINNING. The `@Daphné Hello` case is unchanged.

## Tests

Locally

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 