### PR TITLE
[Programmatic Usage] Enforce limits in conversation posting

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1497,6 +1497,7 @@ describe("postUserMessage", () => {
       throw new Error("Failed to fetch conversation");
     }
 
+    const noCreditWorkspace = noCreditAuth.getNonNullableWorkspace();
     const rateLimiterSpy = vi
       .spyOn(rateLimiterModule, "rateLimiter")
       .mockResolvedValue(100);
@@ -1526,6 +1527,11 @@ describe("postUserMessage", () => {
         "programmatic usage credits"
       );
     }
+    expect(rateLimiterSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: `workspace:${noCreditWorkspace.sId}:programmatic_usage_rate_limit`,
+      })
+    );
 
     rateLimiterSpy.mockRestore();
   });

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -84,15 +84,50 @@ vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
   getContentFragmentBlob: vi.fn(),
 }));
 
+import { runOnRedis } from "@app/lib/api/redis";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { CreditResource } from "@app/lib/resources/credit_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 // Mock rateLimiter from the utils module
 import * as rateLimiterModule from "@app/lib/utils/rate_limiter";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+
+const TEST_PROGRAMMATIC_CREDIT_AMOUNT_MICRO_USD = 100_000_000;
+const TEST_CREDIT_START_DELAY_MS = 1000;
+const TEST_CREDIT_EXPIRATION_DAYS = 365;
+const TEST_CREDIT_EXPIRATION_DELAY_MS =
+  TEST_CREDIT_EXPIRATION_DAYS * 24 * 60 * 60 * 1000;
+const TEST_DAILY_USAGE_TTL_SECONDS = 60 * 60;
+
+async function createActiveProgrammaticCredit(
+  auth: Authenticator
+): Promise<void> {
+  const credit = await CreditResource.makeNew(auth, {
+    type: "free",
+    initialAmountMicroUsd: TEST_PROGRAMMATIC_CREDIT_AMOUNT_MICRO_USD,
+    consumedAmountMicroUsd: 0,
+  });
+
+  const result = await credit.start(auth, {
+    startDate: new Date(Date.now() - TEST_CREDIT_START_DELAY_MS),
+    expirationDate: new Date(Date.now() + TEST_CREDIT_EXPIRATION_DELAY_MS),
+  });
+
+  if (result.isErr()) {
+    throw result.error;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  await runOnRedis({ origin: "daily_usage_tracking" }, async (redis) => {
+    await redis.set(`workspace-daily-usage:${workspace.sId}`, "0", {
+      EX: TEST_DAILY_USAGE_TTL_SECONDS,
+    });
+  });
+}
 
 describe("retryAgentMessage", () => {
   let auth: Authenticator;
@@ -551,6 +586,7 @@ describe("retryAgentMessage", () => {
     const systemKey = await KeyFactory.system(globalGroup);
     const mixedAuth = auth.exchangeKey(systemKey.toAuthJSON());
     const userId = auth.getNonNullableUser().id;
+    await createActiveProgrammaticCredit(mixedAuth);
 
     const rateLimiterSpy = vi
       .spyOn(rateLimiterModule, "rateLimiter")
@@ -1415,6 +1451,7 @@ describe("postUserMessage", () => {
       name: "Test Agent 1",
       description: "First test agent",
     });
+    await createActiveProgrammaticCredit(auth);
 
     const conversationWithoutContent = await ConversationFactory.create(auth, {
       agentConfigurationId: agentConfig1.sId,
@@ -1432,6 +1469,65 @@ describe("postUserMessage", () => {
     conversation = fetchedConversationResult.value;
 
     vi.clearAllMocks();
+  });
+
+  it("should reject programmatic messages when programmatic credits are exhausted", async () => {
+    const setup = await createResourceTest({});
+    const noCreditAuth = setup.authenticator;
+    const noCreditAgent = await AgentConfigurationFactory.createTestAgent(
+      noCreditAuth,
+      {
+        name: "No Credit Test Agent",
+        description: "No Credit Test Agent Description",
+      }
+    );
+    const conversationWithoutContent = await ConversationFactory.create(
+      noCreditAuth,
+      {
+        agentConfigurationId: noCreditAgent.sId,
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      }
+    );
+    const fetchedConversationResult = await getConversation(
+      noCreditAuth,
+      conversationWithoutContent.sId
+    );
+    if (fetchedConversationResult.isErr()) {
+      throw new Error("Failed to fetch conversation");
+    }
+
+    const rateLimiterSpy = vi
+      .spyOn(rateLimiterModule, "rateLimiter")
+      .mockResolvedValue(100);
+    const noCreditUser = noCreditAuth.getNonNullableUser();
+    const noCreditUserJson = noCreditUser.toJSON();
+
+    const result = await postUserMessage(noCreditAuth, {
+      conversation: fetchedConversationResult.value,
+      content: "Programmatic message",
+      mentions: [],
+      context: {
+        username: noCreditUserJson.username,
+        timezone: "UTC",
+        fullName: noCreditUserJson.fullName,
+        email: noCreditUserJson.email,
+        profilePictureUrl: noCreditUserJson.image,
+        origin: "triggered_programmatic",
+      },
+      skipToolsValidation: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(403);
+      expect(result.error.api_error.type).toBe("credits_exhausted");
+      expect(result.error.api_error.message).toContain(
+        "programmatic usage credits"
+      );
+    }
+
+    rateLimiterSpy.mockRestore();
   });
 
   it("should preserve agent mentions in the returned userMessage", async () => {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
-
+import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { StepContext } from "@app/lib/actions/types";
 import {
@@ -2377,7 +2377,11 @@ export async function softDeleteAgentMessage(
 
 interface MessageLimit {
   isLimitReached: boolean;
-  limitType: "rate_limit_error" | "plan_message_limit_exceeded" | null;
+  limitType:
+    | "rate_limit_error"
+    | "plan_message_limit_exceeded"
+    | "credits_exhausted"
+    | null;
 }
 
 async function checkMessagesLimit(
@@ -2611,7 +2615,22 @@ async function isMessagesLimitReached(
   }
 
   if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
-    return checkProgrammaticUsageRateLimit(auth);
+    const programmaticUsageRateLimit =
+      await checkProgrammaticUsageRateLimit(auth);
+    if (programmaticUsageRateLimit.isLimitReached) {
+      return programmaticUsageRateLimit;
+    }
+    const limitsResult = await checkProgrammaticUsageLimits(auth);
+    if (limitsResult.isErr()) {
+      return {
+        isLimitReached: true,
+        limitType: "credits_exhausted",
+      };
+    }
+    return {
+      isLimitReached: false,
+      limitType: null,
+    };
   }
 
   // Checking rate limit

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -576,7 +576,6 @@ export async function postUserMessage(
     agenticMessageData,
     skipToolsValidation,
     skipDustAutoMention,
-    skipMessageLimitCheck,
     doNotAssociateUser,
   }: {
     conversation: ConversationType;
@@ -587,7 +586,6 @@ export async function postUserMessage(
     skipToolsValidation: boolean;
     doNotAssociateUser?: boolean;
     skipDustAutoMention?: boolean;
-    skipMessageLimitCheck?: boolean;
   }
 ): Promise<
   Result<
@@ -671,11 +669,10 @@ export async function postUserMessage(
     }
   }
 
-  if (!skipMessageLimitCheck) {
-    const limitResult = await checkMessagesLimit(auth, { mentions, context });
-    if (limitResult.isErr()) {
-      return limitResult;
-    }
+  // Check plan and rate limit.
+  const limitResult = await checkMessagesLimit(auth, { mentions, context });
+  if (limitResult.isErr()) {
+    return limitResult;
   }
 
   // Block posting while compaction is in progress, for now. It's not too hard to add support for

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,5 +1,4 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
-import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { StepContext } from "@app/lib/actions/types";
 import {
@@ -50,7 +49,10 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
-import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
+import {
+  checkProgrammaticUsageLimits,
+  isProgrammaticUsage,
+} from "@app/lib/api/programmatic_usage/tracking";
 import { fetchLatestProjectContextFileContentFragment } from "@app/lib/api/projects/context";
 import { isModelAvailable, isProviderWhitelisted } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
@@ -2375,13 +2377,35 @@ export async function softDeleteAgentMessage(
   return new Ok({ success: true });
 }
 
-interface MessageLimit {
-  isLimitReached: boolean;
+type ReachedMessageLimit = {
+  isLimitReached: true;
   limitType:
     | "rate_limit_error"
     | "plan_message_limit_exceeded"
-    | "credits_exhausted"
-    | null;
+    | "credits_exhausted";
+  message?: string;
+};
+
+type MessageLimit =
+  | ReachedMessageLimit
+  | {
+      isLimitReached: false;
+      limitType: null;
+    };
+
+function getMessageLimitErrorMessage(limit: ReachedMessageLimit): string {
+  if (limit.message) {
+    return limit.message;
+  }
+
+  switch (limit.limitType) {
+    case "plan_message_limit_exceeded":
+      return "The message limit for this plan has been exceeded.";
+    case "credits_exhausted":
+      return "Your workspace has run out of credits. Please purchase more credits to continue.";
+    case "rate_limit_error":
+      return "Rate limit exceeded. Please retry later.";
+  }
 }
 
 async function checkMessagesLimit(
@@ -2430,15 +2454,12 @@ async function checkMessagesLimit(
     mentions,
     context,
   });
-  if (messageLimit.isLimitReached && messageLimit.limitType) {
+  if (messageLimit.isLimitReached) {
     return new Err({
       status_code: 403,
       api_error: {
         type: messageLimit.limitType,
-        message:
-          messageLimit.limitType === "plan_message_limit_exceeded"
-            ? "The message limit for this plan has been exceeded."
-            : "Rate limit exceeded. Please retry later.",
+        message: getMessageLimitErrorMessage(messageLimit),
       },
     });
   }
@@ -2625,6 +2646,7 @@ async function isMessagesLimitReached(
       return {
         isLimitReached: true,
         limitType: "credits_exhausted",
+        message: limitsResult.error.message,
       };
     }
     return {
@@ -2709,9 +2731,16 @@ async function isMessagesLimitReached(
   const isLimitReached =
     remainingMentions.length > 0 &&
     remainingMentions.filter((r) => r > 0).length === 0;
+  if (isLimitReached) {
+    return {
+      isLimitReached: true,
+      limitType: "plan_message_limit_exceeded",
+    };
+  }
+
   return {
-    isLimitReached,
-    limitType: isLimitReached ? "plan_message_limit_exceeded" : null,
+    isLimitReached: false,
+    limitType: null,
   };
 }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2636,19 +2636,21 @@ async function isMessagesLimitReached(
   }
 
   if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
+    const limitsResult = await checkProgrammaticUsageLimits(auth);
+    if (limitsResult.isErr()) {
+      return {
+        isLimitReached: true,
+        limitType: limitsResult.error.type,
+        message: limitsResult.error.message,
+      };
+    }
+
     const programmaticUsageRateLimit =
       await checkProgrammaticUsageRateLimit(auth);
     if (programmaticUsageRateLimit.isLimitReached) {
       return programmaticUsageRateLimit;
     }
-    const limitsResult = await checkProgrammaticUsageLimits(auth);
-    if (limitsResult.isErr()) {
-      return {
-        isLimitReached: true,
-        limitType: "credits_exhausted",
-        message: limitsResult.error.message,
-      };
-    }
+
     return {
       isLimitReached: false,
       limitType: null,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -576,6 +576,7 @@ export async function postUserMessage(
     agenticMessageData,
     skipToolsValidation,
     skipDustAutoMention,
+    skipMessageLimitCheck,
     doNotAssociateUser,
   }: {
     conversation: ConversationType;
@@ -586,6 +587,7 @@ export async function postUserMessage(
     skipToolsValidation: boolean;
     doNotAssociateUser?: boolean;
     skipDustAutoMention?: boolean;
+    skipMessageLimitCheck?: boolean;
   }
 ): Promise<
   Result<
@@ -669,10 +671,11 @@ export async function postUserMessage(
     }
   }
 
-  // Check plan and rate limit.
-  const limitResult = await checkMessagesLimit(auth, { mentions, context });
-  if (limitResult.isErr()) {
-    return limitResult;
+  if (!skipMessageLimitCheck) {
+    const limitResult = await checkMessagesLimit(auth, { mentions, context });
+    if (limitResult.isErr()) {
+      return limitResult;
+    }
   }
 
   // Block posting while compaction is in progress, for now. It's not too hard to add support for

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2377,28 +2377,28 @@ export async function softDeleteAgentMessage(
   return new Ok({ success: true });
 }
 
-type ReachedMessageLimit = {
-  isLimitReached: true;
+interface MessageLimit {
+  isLimitReached: boolean;
   limitType:
     | "rate_limit_error"
     | "plan_message_limit_exceeded"
-    | "credits_exhausted";
+    | "credits_exhausted"
+    | null;
   message?: string;
-};
+}
 
-type MessageLimit =
-  | ReachedMessageLimit
-  | {
-      isLimitReached: false;
-      limitType: null;
-    };
-
-function getMessageLimitErrorMessage(limit: ReachedMessageLimit): string {
-  if (limit.message) {
-    return limit.message;
+function getMessageLimitErrorMessage({
+  limitType,
+  message,
+}: {
+  limitType: NonNullable<MessageLimit["limitType"]>;
+  message?: string;
+}): string {
+  if (message) {
+    return message;
   }
 
-  switch (limit.limitType) {
+  switch (limitType) {
     case "plan_message_limit_exceeded":
       return "The message limit for this plan has been exceeded.";
     case "credits_exhausted":
@@ -2454,12 +2454,15 @@ async function checkMessagesLimit(
     mentions,
     context,
   });
-  if (messageLimit.isLimitReached) {
+  if (messageLimit.isLimitReached && messageLimit.limitType) {
     return new Err({
       status_code: 403,
       api_error: {
         type: messageLimit.limitType,
-        message: getMessageLimitErrorMessage(messageLimit),
+        message: getMessageLimitErrorMessage({
+          limitType: messageLimit.limitType,
+          message: messageLimit.message,
+        }),
       },
     });
   }
@@ -2733,16 +2736,9 @@ async function isMessagesLimitReached(
   const isLimitReached =
     remainingMentions.length > 0 &&
     remainingMentions.filter((r) => r > 0).length === 0;
-  if (isLimitReached) {
-    return {
-      isLimitReached: true,
-      limitType: "plan_message_limit_exceeded",
-    };
-  }
-
   return {
-    isLimitReached: false,
-    limitType: null,
+    isLimitReached,
+    limitType: isLimitReached ? "plan_message_limit_exceeded" : null,
   };
 }
 

--- a/front/lib/api/assistant/conversation/branches.test.ts
+++ b/front/lib/api/assistant/conversation/branches.test.ts
@@ -174,7 +174,7 @@ describe("mergeConversationBranch", () => {
       userContextFullName: "Test User",
       userContextEmail: "test@example.com",
       userContextProfilePictureUrl: null,
-      userContextOrigin: "api",
+      userContextOrigin: "web",
       clientSideMCPServerIds: [],
     });
 
@@ -265,7 +265,7 @@ describe("mergeConversationBranch", () => {
       userContextFullName: "Test User",
       userContextEmail: "test@example.com",
       userContextProfilePictureUrl: null,
-      userContextOrigin: "api",
+      userContextOrigin: "web",
       clientSideMCPServerIds: [],
     });
 
@@ -298,7 +298,7 @@ describe("mergeConversationBranch", () => {
       userContextFullName: "Test User",
       userContextEmail: "test@example.com",
       userContextProfilePictureUrl: null,
-      userContextOrigin: "api",
+      userContextOrigin: "web",
       clientSideMCPServerIds: [],
     });
 
@@ -377,7 +377,9 @@ describe("mergeConversationBranch", () => {
     expect(mergedUserMessage?.userMessage?.content).toBe(
       "Original user content"
     );
-    expect(mergedUserMessage?.userMessage?.userContextOrigin).toBe("web");
+    expect(mergedUserMessage?.userMessage?.userContextOrigin).toBe(
+      branchedUserMessage.userContextOrigin
+    );
 
     const mergedAgentMessages = await MessageModel.findAll({
       where: {

--- a/front/lib/api/assistant/conversation/branches.test.ts
+++ b/front/lib/api/assistant/conversation/branches.test.ts
@@ -377,6 +377,7 @@ describe("mergeConversationBranch", () => {
     expect(mergedUserMessage?.userMessage?.content).toBe(
       "Original user content"
     );
+    expect(mergedUserMessage?.userMessage?.userContextOrigin).toBe("web");
 
     const mergedAgentMessages = await MessageModel.findAll({
       where: {

--- a/front/lib/api/assistant/conversation/branches.ts
+++ b/front/lib/api/assistant/conversation/branches.ts
@@ -283,6 +283,8 @@ export async function mergeConversationBranch(
     skipToolsValidation: true,
     // We do not want to auto-mention @dust for branches's merge.
     skipDustAutoMention: true,
+    // The branch message was already accepted when created. The merge only copies it.
+    skipMessageLimitCheck: true,
     // Ensure we don't accidentally attribute to someone else.
     doNotAssociateUser: false,
   });

--- a/front/lib/api/assistant/conversation/branches.ts
+++ b/front/lib/api/assistant/conversation/branches.ts
@@ -247,7 +247,8 @@ export async function mergeConversationBranch(
     fullName: src.userContextFullName,
     email: src.userContextEmail,
     profilePictureUrl: src.userContextProfilePictureUrl,
-    origin: src.userContextOrigin,
+    // Merging a branch is a user action, even if the source branch message was programmatic.
+    origin: "web",
     clientSideMCPServerIds: src.clientSideMCPServerIds,
     lastTriggerRunAt: src.userContextLastTriggerRunAt
       ? src.userContextLastTriggerRunAt.getTime()
@@ -283,8 +284,6 @@ export async function mergeConversationBranch(
     skipToolsValidation: true,
     // We do not want to auto-mention @dust for branches's merge.
     skipDustAutoMention: true,
-    // The branch message was already accepted when created. The merge only copies it.
-    skipMessageLimitCheck: true,
     // Ensure we don't accidentally attribute to someone else.
     doNotAssociateUser: false,
   });

--- a/front/lib/api/assistant/conversation/branches.ts
+++ b/front/lib/api/assistant/conversation/branches.ts
@@ -247,8 +247,7 @@ export async function mergeConversationBranch(
     fullName: src.userContextFullName,
     email: src.userContextEmail,
     profilePictureUrl: src.userContextProfilePictureUrl,
-    // Merging a branch is a user action, even if the source branch message was programmatic.
-    origin: "web",
+    origin: src.userContextOrigin,
     clientSideMCPServerIds: src.clientSideMCPServerIds,
     lastTriggerRunAt: src.userContextLastTriggerRunAt
       ? src.userContextLastTriggerRunAt.getTime()

--- a/front/lib/api/programmatic_usage/tracking.test.ts
+++ b/front/lib/api/programmatic_usage/tracking.test.ts
@@ -2,6 +2,7 @@ import {
   compareCreditsForConsumption,
   computeCreditAlertThresholdKey,
   decreaseProgrammaticCredits,
+  isProgrammaticUsage,
 } from "@app/lib/api/programmatic_usage/tracking";
 import { Authenticator } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
@@ -138,6 +139,27 @@ describe("compareCreditsForConsumption", () => {
       expect(sorted[4].expirationDate).toEqual(NOW);
       expect(sorted[5].type).toBe("payg");
     });
+  });
+});
+
+describe("isProgrammaticUsage", () => {
+  let auth: Authenticator;
+
+  beforeEach(async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    await GroupFactory.defaults(workspace);
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+  });
+
+  it("should treat wake-up messages as user usage", () => {
+    expect(isProgrammaticUsage(auth, { userMessageOrigin: "wakeup" })).toBe(
+      false
+    );
   });
 });
 

--- a/front/lib/api/programmatic_usage/tracking.test.ts
+++ b/front/lib/api/programmatic_usage/tracking.test.ts
@@ -1,4 +1,5 @@
 import {
+  checkProgrammaticUsageLimits,
   compareCreditsForConsumption,
   computeCreditAlertThresholdKey,
   decreaseProgrammaticCredits,
@@ -160,6 +161,16 @@ describe("isProgrammaticUsage", () => {
     expect(isProgrammaticUsage(auth, { userMessageOrigin: "wakeup" })).toBe(
       false
     );
+  });
+
+  it("should return credits_exhausted when no active credits are available", async () => {
+    const result = await checkProgrammaticUsageLimits(auth);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("credits_exhausted");
+      expect(result.error.message).toContain("programmatic usage credits");
+    }
   });
 });
 

--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -25,6 +25,17 @@ import { Err, Ok } from "@app/types/shared/result";
 
 const CREDIT_ALERT_THRESHOLD_PERCENT = 80;
 
+type ProgrammaticUsageLimitErrorType = "credits_exhausted" | "rate_limit_error";
+
+export class ProgrammaticUsageLimitError extends Error {
+  type: ProgrammaticUsageLimitErrorType;
+
+  constructor(type: ProgrammaticUsageLimitErrorType, message: string) {
+    super(message);
+    this.type = type;
+  }
+}
+
 export function isProgrammaticUsage(
   auth: Authenticator,
   { userMessageOrigin }: { userMessageOrigin: UserMessageOrigin }
@@ -59,7 +70,7 @@ export async function hasReachedProgrammaticUsageLimits(
  */
 export async function checkProgrammaticUsageLimits(
   auth: Authenticator
-): Promise<Result<void, Error>> {
+): Promise<Result<void, ProgrammaticUsageLimitError>> {
   const isAdmin = auth.isAdmin();
 
   // First check workspace credits.
@@ -70,7 +81,9 @@ export async function checkProgrammaticUsageLimits(
         "Please purchase more credits in the Developers > Credits section of the Dust dashboard."
       : "Your workspace has run out of programmatic usage credits. " +
         "Please ask a Dust workspace admin to purchase more credits.";
-    return new Err(new Error(message));
+    return new Err(
+      new ProgrammaticUsageLimitError("credits_exhausted", message)
+    );
   }
 
   // Then check per-key cap.
@@ -81,7 +94,9 @@ export async function checkProgrammaticUsageLimits(
         "Please increase the cap in the Developers > API Keys section of the Dust dashboard."
       : "This API key has reached its monthly usage cap. " +
         "Please ask a Dust workspace admin to increase the cap.";
-    return new Err(new Error(message));
+    return new Err(
+      new ProgrammaticUsageLimitError("rate_limit_error", message)
+    );
   }
 
   // Finally check daily cap.
@@ -92,7 +107,9 @@ export async function checkProgrammaticUsageLimits(
         "The cap will reset at midnight UTC, or you can increase it in admin settings."
       : "Your workspace has reached its daily programmatic usage cap. " +
         "Please contact your Dust workspace admin.";
-    return new Err(new Error(message));
+    return new Err(
+      new ProgrammaticUsageLimitError("rate_limit_error", message)
+    );
   }
 
   return new Ok(undefined);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -10,10 +10,6 @@ import {
 } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import {
-  checkProgrammaticUsageLimits,
-  isProgrammaticUsage,
-} from "@app/lib/api/programmatic_usage/tracking";
 import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -67,6 +63,8 @@ import { fromError } from "zod-validation-error";
  *         description: Bad Request. Missing or invalid parameters.
  *       401:
  *         description: Unauthorized. Invalid or missing authentication token.
+ *       403:
+ *         description: Forbidden. Workspace or usage limits exceeded, or access denied.
  *       429:
  *         description: Rate limit exceeded.
  *       500:
@@ -137,19 +135,6 @@ async function handler(
       }
 
       const origin = context.origin ?? "api";
-
-      if (isProgrammaticUsage(auth, { userMessageOrigin: origin })) {
-        const limitsResult = await checkProgrammaticUsageLimits(auth);
-        if (limitsResult.isErr()) {
-          return apiError(req, res, {
-            status_code: 429,
-            api_error: {
-              type: "rate_limit_error",
-              message: limitsResult.error.message,
-            },
-          });
-        }
-      }
 
       if (isEmptyString(context.username)) {
         return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -175,6 +175,8 @@ async function handler(
       const origin = message?.context.origin ?? "api";
 
       if (message) {
+        // Keep this before createConversation to avoid creating an empty conversation when the
+        // initial programmatic message is blocked.
         if (isProgrammaticUsage(auth, { userMessageOrigin: origin })) {
           const limitsResult = await checkProgrammaticUsageLimits(auth);
           if (limitsResult.isErr()) {

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -2358,6 +2358,9 @@
           "401": {
             "description": "Unauthorized. Invalid or missing authentication token."
           },
+          "403": {
+            "description": "Forbidden. Workspace or usage limits exceeded, or access denied."
+          },
           "429": {
             "description": "Rate limit exceeded."
           },

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -226,6 +226,7 @@ export async function runTriggeredAgentsActivity({
       conversationResult.error.api_error;
     const isNonRetryable =
       errorType === "plan_message_limit_exceeded" ||
+      errorType === "credits_exhausted" ||
       errorType === "model_disabled" ||
       errorType === "invalid_request_error" ||
       errorType === "agent_inaccessible";


### PR DESCRIPTION
## Description
Context: [slack thread](https://dust4ai.slack.com/archives/C09SB1J0FKM/p1777875575968329)

Moves the programmatic usage limit check into the shared conversation posting path so programmatic messages created outside the public API entrypoints are gated consistently. Also keeps wake-up messages classified as user usage, matching the Slack thread decision, and preserves the specific programmatic limit error message when the lower-level gate rejects a message.

## Risks
Blast radius: conversation posting for programmatic message origins and wake-up usage classification.
Risk: standard

## Deploy Plan
- deploy front

## Tests
- [x] `NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest run --passWithNoTests=false lib/api/programmatic_usage/tracking.test.ts lib/api/assistant/conversation.test.ts`