### PR TITLE
feat(google-calendar): add transparency, eventType, reminders, visibility, extendedProperties + fix LLM hallucination on write calls

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -206,7 +206,6 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Whether to create a conference (Google Meet) for the event. If not provided, existing conference settings are preserved."
         ),
-      ...eventTypeSpecificFields,
       ...sharedEventFields,
     },
     stake: "medium",

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -4,35 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-const autoDeclineMode = z
-  .enum([
-    "declineNone",
-    "declineAllConflictingInvitations",
-    "declineOnlyNewConflictingInvitations",
-  ])
-  .optional();
-
-// Fields specific to eventType — grouped adjacent to eventType in both tools.
-const eventTypeSpecificFields = {
-  focusTimeProperties: z
-    .object({
-      autoDeclineMode,
-      chatStatus: z.enum(["available", "doNotDisturb"]).optional(),
-      declineMessage: z.string().max(500).optional(),
-    })
-    .optional()
-    .describe("Only applies when eventType is 'focusTime'."),
-  outOfOfficeProperties: z
-    .object({
-      autoDeclineMode,
-      declineMessage: z.string().max(500).optional(),
-    })
-    .optional()
-    .describe(
-      "Only applies when eventType is 'outOfOffice'. Controls auto-decline behavior for conflicting invitations."
-    ),
-};
-
 const sharedEventFields = {
   transparency: z
     .enum(["opaque", "transparent"])
@@ -167,7 +138,6 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .describe(
           "'focusTime' creates a native Focus Time block (DND in Google Chat, auto-decline). 'outOfOffice' creates an OOO block. Primary calendar only. Cannot be changed after creation."
         ),
-      ...eventTypeSpecificFields,
       ...sharedEventFields,
     },
     stake: "medium",

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -141,8 +141,6 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       reminders,
       extendedProperties,
       eventType,
-      focusTimeProperties,
-      outOfOfficeProperties,
     },
     { authInfo, agentLoopContext }
   ) => {
@@ -171,18 +169,26 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
           ...(reminders && { reminders }),
           ...(extendedProperties && { extendedProperties }),
           ...(eventType && { eventType }),
-          ...(eventType === "focusTime" &&
-            focusTimeProperties && { focusTimeProperties }),
-          ...(eventType === "outOfOffice" &&
-            outOfOfficeProperties && { outOfOfficeProperties }),
-          ...(createConference && {
-            conferenceData: {
-              createRequest: {
-                requestId: `conference-${randomUUID()}`,
-                conferenceSolutionKey: { type: "hangoutsMeet" },
-              },
+          ...(eventType === "focusTime" && {
+            focusTimeProperties: {
+              autoDeclineMode: "declineAllConflictingInvitations",
             },
           }),
+          ...(eventType === "outOfOffice" && {
+            outOfOfficeProperties: {
+              autoDeclineMode: "declineAllConflictingInvitations",
+            },
+          }),
+          ...(createConference &&
+            eventType !== "focusTime" &&
+            eventType !== "outOfOffice" && {
+              conferenceData: {
+                createRequest: {
+                  requestId: `conference-${randomUUID()}`,
+                  conferenceSolutionKey: { type: "hangoutsMeet" },
+                },
+              },
+            }),
         },
       });
 

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -171,8 +171,10 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
           ...(reminders && { reminders }),
           ...(extendedProperties && { extendedProperties }),
           ...(eventType && { eventType }),
-          ...(focusTimeProperties && { focusTimeProperties }),
-          ...(outOfOfficeProperties && { outOfOfficeProperties }),
+          ...(eventType === "focusTime" &&
+            focusTimeProperties && { focusTimeProperties }),
+          ...(eventType === "outOfOffice" &&
+            outOfOfficeProperties && { outOfOfficeProperties }),
           ...(createConference && {
             conferenceData: {
               createRequest: {
@@ -224,8 +226,6 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       visibility,
       reminders,
       extendedProperties,
-      focusTimeProperties,
-      outOfOfficeProperties,
     },
     { authInfo, agentLoopContext }
   ) => {
@@ -254,8 +254,6 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
           ...(visibility && { visibility }),
           ...(reminders && { reminders }),
           ...(extendedProperties && { extendedProperties }),
-          ...(focusTimeProperties && { focusTimeProperties }),
-          ...(outOfOfficeProperties && { outOfOfficeProperties }),
           ...(createConference && {
             conferenceData: {
               createRequest: {


### PR DESCRIPTION
**Problem**

Events created by agents (focus blocks, OOO) showed as Busy in Google Calendar, blocking booking tools like Calendly and GCal's "Find a time." There was no way to tag agent-created events, set custom reminders, or keep event descriptions private.

A second issue was introduced when adding these fields: the Google Calendar API started rejecting every write request with `outOfOfficeProperties requires an event type of outOfOffice`. The LLM was sending `outOfOfficeProperties: {}` on every call because the field existed in the tool schema — an empty object is truthy in JS and was passing through to the API.

**What changed**

`create_event` and `update_event` now support:
- `transparency` — marks events as Free so they don't block availability checks
- `eventType` (`focusTime` / `outOfOffice`) — native GCal Focus Time (DND + auto-decline) and OOO blocks. Primary calendar only, immutable after creation, so `eventType` is only on `create_event`
- `reminders` — custom per-event reminder overrides
- `extendedProperties.private` — private key-value metadata for tagging agent-created events (only `private`, not `shared` — shared properties are readable by any OAuth app)
- `visibility` — hide event details from other calendar viewers

**How the LLM hallucination is fixed**

Rather than expose `focusTimeProperties` / `outOfOfficeProperties` in the schema (which the LLM fills with empty objects on every call), the handler injects the correct defaults server-side when `eventType` matches:

```typescript
...(eventType === "focusTime" && {
  focusTimeProperties: { autoDeclineMode: "declineAllConflictingInvitations" },
}),
...(eventType === "outOfOffice" && {
  outOfOfficeProperties: { autoDeclineMode: "declineAllConflictingInvitations" },
}),
```

Conference links are also hard-blocked on `focusTime` and `outOfOffice` events regardless of the `createConference` parameter.

**Tested**

1. Regular event — clean inputs, no spurious fields, Meet link created
2. Focus block (`eventType: focusTime`) — DND + auto-decline confirmed in GCal, no Meet link, no spurious fields in tool inputs
3. OOO block (`eventType: outOfOffice`) — auto-decline confirmed, no Meet link
4. `transparency: transparent` — event shows as Free, confirmed in GCal
5. `extendedProperties.private` — metadata attached, not visible to other apps
6. `visibility: private` — event details hidden from other viewers
7. `reminders` — custom overrides confirmed, no "Reminders: Default" noise on normal events
8. Minimal event with no parameters — confirmed no API errors (previously broke on every write)

**Reviewed**

- All 3 changed files line by line — no dead code, no unused variables
- Confirmed `eventType` correctly absent from `update_event` (immutable after creation)
- Confirmed `createConference` guard is additive — no behaviour change for regular events
- Checked all downstream consumers (`constants.ts`, `mcp_actions.test.ts`, `index.ts`) — unaffected
- `r.method`/`r.minutes` undefined guard added in `formatEventAsText` for malformed API responses