### PR TITLE
feat: remove clean tasks backend

### DIFF
--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -1,7 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { ProjectTaskStateResource } from "@app/lib/resources/project_task_state_resource";
 import {
   ProjectTaskConversationModel,
   ProjectTaskModel,
@@ -715,37 +714,6 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };
-  }
-
-  // ── Lifecycle ──────────────────────────────────────────────────────────────
-
-  // Marks all done todos as "cleaned" for the authenticated user in the given
-  // space by updating the per-user cutoff timestamp stored in project_todo_state.
-  static async cleanDoneBySpace(
-    auth: Authenticator,
-    { spaceId }: { spaceId: ModelId }
-  ): Promise<Result<{ cleanedCount: number }, Error>> {
-    const cleanedAt = new Date();
-    const workspaceId = auth.getNonNullableWorkspace().id;
-    const userId = auth.getNonNullableUser().id;
-
-    const cleanedCount = await ProjectTaskModel.count({
-      where: {
-        workspaceId,
-        spaceId,
-        userId,
-        deletedAt: null,
-        status: "done",
-        doneAt: { [Op.lte]: cleanedAt },
-      },
-    });
-
-    await ProjectTaskStateResource.upsertLastCleanedAtBySpace(auth, {
-      spaceId,
-      lastCleanedAt: cleanedAt,
-    });
-
-    return new Ok({ cleanedCount });
   }
 
   // Applies the same updates to a batch of todos in a single transaction.

--- a/front/lib/resources/project_task_state_resource.ts
+++ b/front/lib/resources/project_task_state_resource.ts
@@ -77,43 +77,12 @@ export class ProjectTaskStateResource extends BaseResource<ProjectTaskStateModel
         spaceId,
         userId,
         lastReadAt,
-        lastCleanedAt: null,
       },
       transaction,
     });
 
     if (!created) {
       await row.update({ lastReadAt }, { transaction });
-    }
-
-    return new this(ProjectTaskStateModel, row.get());
-  }
-
-  // Creates or updates the last-cleaned timestamp for a (space, user) pair.
-  // Call this when the user clicks "clean done".
-  static async upsertLastCleanedAtBySpace(
-    auth: Authenticator,
-    { spaceId, lastCleanedAt }: { spaceId: ModelId; lastCleanedAt: Date },
-    transaction?: Transaction
-  ): Promise<ProjectTaskStateResource> {
-    const workspaceId = auth.getNonNullableWorkspace().id;
-    const userId = auth.getNonNullableUser().id;
-
-    const [row, created] = await ProjectTaskStateModel.findOrCreate({
-      where: { workspaceId, spaceId, userId },
-      defaults: {
-        workspaceId,
-        spaceId,
-        userId,
-        // If we haven't tracked reads yet, initialize to "now" to satisfy NOT NULL.
-        lastReadAt: new Date(),
-        lastCleanedAt,
-      },
-      transaction,
-    });
-
-    if (!created) {
-      await row.update({ lastCleanedAt }, { transaction });
     }
 
     return new this(ProjectTaskStateModel, row.get());

--- a/front/lib/resources/project_todo_state_resource.test.ts
+++ b/front/lib/resources/project_todo_state_resource.test.ts
@@ -150,47 +150,4 @@ describe("ProjectTaskStateResource", () => {
       expect(result!.lastReadAt).toEqual(updatedAt);
     });
   });
-
-  describe("upsertLastCleanedAtBySpace", () => {
-    it("creates a state with lastCleanedAt when none exists", async () => {
-      const { workspace, authenticator } = await createResourceTest({
-        role: "user",
-      });
-      const space = await SpaceFactory.project(workspace);
-      const lastCleanedAt = new Date("2025-06-01T00:00:00Z");
-
-      const state = await ProjectTaskStateResource.upsertLastCleanedAtBySpace(
-        authenticator,
-        { spaceId: space.id, lastCleanedAt }
-      );
-
-      expect(state.lastCleanedAt).toEqual(lastCleanedAt);
-      expect(state.lastReadAt).toBeDefined();
-    });
-
-    it("updates lastCleanedAt on subsequent calls", async () => {
-      const { workspace, authenticator } = await createResourceTest({
-        role: "user",
-      });
-      const space = await SpaceFactory.project(workspace);
-
-      await ProjectTaskStateResource.upsertLastCleanedAtBySpace(authenticator, {
-        spaceId: space.id,
-        lastCleanedAt: new Date("2025-01-01T00:00:00Z"),
-      });
-
-      const newCleanedAt = new Date("2025-06-01T00:00:00Z");
-      await ProjectTaskStateResource.upsertLastCleanedAtBySpace(authenticator, {
-        spaceId: space.id,
-        lastCleanedAt: newCleanedAt,
-      });
-
-      const result = await ProjectTaskStateResource.fetchBySpace(
-        authenticator,
-        { spaceId: space.id }
-      );
-
-      expect(result!.lastCleanedAt).toEqual(newCleanedAt);
-    });
-  });
 });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.test.ts
@@ -1,6 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
-import { ProjectTaskStateResource } from "@app/lib/resources/project_task_state_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { ProjectTaskFactory } from "@app/tests/utils/ProjectTaskFactory";
@@ -145,48 +144,6 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions", () => 
     );
     expect(refreshedMyTodo?.status).toBe("done");
     expect(refreshedOtherTodo?.status).toBe("done");
-  });
-
-  it("should clean done todos for the user in the space", async () => {
-    const { user, auth: viewerAuth } = await setup();
-    const project = await SpaceFactory.project(workspace, user.id);
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-    const doneTodo = await ProjectTaskFactory.create(workspace, project, {
-      userId: user.id,
-    });
-    await doneTodo.updateWithVersion(auth, {
-      status: "done",
-      markedAsDoneByType: "user",
-      markedAsDoneByUserId: user.id,
-      markedAsDoneByAgentConfigurationId: null,
-      doneAt: new Date(),
-    });
-    const openTodo = await ProjectTaskFactory.create(workspace, project, {
-      userId: user.id,
-    });
-
-    req.query.spaceId = project.sId;
-    req.body = { action: "clean_done" };
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData()).toEqual({ success: true, cleanedCount: 1 });
-
-    // Done todos are filtered out of the active view; open todos remain.
-    const state = await ProjectTaskStateResource.fetchBySpace(viewerAuth, {
-      spaceId: project.id,
-    });
-    expect(state?.lastCleanedAt).not.toBeNull();
-
-    const visibleTodos = await ProjectTaskResource.fetchBySpace(viewerAuth, {
-      spaceId: project.id,
-      timeScope: "active",
-    });
-    const visibleSIds = new Set(visibleTodos.map((t) => t.sId));
-    expect(visibleSIds.has(doneTodo.sId)).toBe(false);
-    expect(visibleSIds.has(openTodo.sId)).toBe(true);
   });
 
   it("should approve pending agent suggestions in the space", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.ts
@@ -14,7 +14,6 @@ import { fromError } from "zod-validation-error";
 
 export type BulkActionsResponse = {
   success: boolean;
-  cleanedCount?: number;
 };
 
 const BulkActionsBodySchema = z.discriminatedUnion("action", [
@@ -22,9 +21,6 @@ const BulkActionsBodySchema = z.discriminatedUnion("action", [
     action: z.literal("set_status"),
     taskIds: z.array(z.string().min(1)).min(1).max(200),
     status: z.enum(PROJECT_TASK_STATUSES),
-  }),
-  z.object({
-    action: z.literal("clean_done"),
   }),
   z.object({
     action: z.literal("approve_agent_suggestion"),
@@ -113,26 +109,6 @@ async function handler(
       }
 
       return res.status(200).json({ success: true });
-    }
-
-    case "clean_done": {
-      const result = await ProjectTaskResource.cleanDoneBySpace(auth, {
-        spaceId: space.id,
-      });
-
-      if (result.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: result.error.message,
-          },
-        });
-      }
-
-      return res
-        .status(200)
-        .json({ success: true, cleanedCount: result.value.cleanedCount });
     }
 
     case "approve_agent_suggestion": {


### PR DESCRIPTION
## Description

This PR removes the backend functionality for "cleaning done tasks" from project spaces, continuing the work started in #25312.

- Removes `cleanDoneBySpace` method from `ProjectTaskResource` and `upsertLastCleanedAtBySpace` from `ProjectTaskStateResource`
- Removes the `clean_done` bulk action from the API endpoint
- Removes associated tests

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.
