### PR TITLE
Read trial plan from auth context in agent builder

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -15,7 +15,6 @@ import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MC
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
-import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
@@ -155,10 +154,8 @@ function PreviewContent({
 
 export function AgentBuilderPreview() {
   const { owner, isAdmin } = useAgentBuilderContext();
-  const { user } = useAuth();
-  const { activeSubscription } = useWorkspaceActiveSubscription({ owner });
-  const isTrialPlan =
-    activeSubscription && isFreeTrialPhonePlan(activeSubscription.plan.code);
+  const { user, subscription } = useAuth();
+  const isTrialPlan = isFreeTrialPhonePlan(subscription.plan.code);
   const { isMCPServerViewsLoading } = useMCPServerViewsContext();
   const { isPreviewPanelOpen } = usePreviewPanelContext();
 

--- a/front/components/agent_builder/AgentBuilderSidekick.tsx
+++ b/front/components/agent_builder/AgentBuilderSidekick.tsx
@@ -13,7 +13,6 @@ import {
 } from "@app/components/markdown/suggestion/SidekickSuggestionDirective";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
-import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import type { UserType, WorkspaceType } from "@app/types/user";
@@ -138,10 +137,8 @@ function SidekickContent({
 
 export function AgentBuilderSidekick() {
   const { owner, isAdmin } = useAgentBuilderContext();
-  const { user } = useAuth();
-  const { activeSubscription } = useWorkspaceActiveSubscription({ owner });
-  const isTrialPlan =
-    activeSubscription && isFreeTrialPhonePlan(activeSubscription.plan.code);
+  const { user, subscription } = useAuth();
+  const isTrialPlan = isFreeTrialPhonePlan(subscription.plan.code);
 
   const { currentPanel } = useConversationSidePanelContext();
 


### PR DESCRIPTION
## Description

The agent builder Sidekick and Preview components used `useWorkspaceActiveSubscription` to derive `isTrialPlan`, which hits the admin-only `/api/w/[wId]/subscriptions` endpoint. Non-admin users trigger 403 logs on every agent builder mount, and the trial banner never renders for them because the SWR fetch fails. This causes up to [90k daily error logs](https://app.datadoghq.eu/logs?query=-status%3A%28info%20OR%20warn%29%20source%3Afront%20%40apiError.api_error.message%3A%22Only%20users%20that%20are%20%60admins%60%20for%20the%20current%20workspace%20can%20access%20this%20endpoint.%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40error.name&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1775486459186&to_ts=1778078459186&live=true)

Read subscription from useAuth() instead.

## Tests

Local
## Risk

Low

## Deploy Plan

Front