### PR TITLE
db: remove lastCleanedAt from ProjectTaskState

### DIFF
--- a/front/lib/resources/project_todo_state_resource.test.ts
+++ b/front/lib/resources/project_todo_state_resource.test.ts
@@ -122,7 +122,6 @@ describe("ProjectTaskStateResource", () => {
       );
 
       expect(state.lastReadAt).toEqual(lastReadAt);
-      expect(state.lastCleanedAt).toBeNull();
     });
 
     it("updates lastReadAt on subsequent calls", async () => {

--- a/front/lib/resources/storage/models/project_task_state.ts
+++ b/front/lib/resources/storage/models/project_task_state.ts
@@ -13,7 +13,6 @@ export class ProjectTaskStateModel extends WorkspaceAwareModel<ProjectTaskStateM
   declare spaceId: ForeignKey<SpaceModel["id"]>;
   declare userId: ForeignKey<UserModel["id"]>;
   declare lastReadAt: Date;
-  declare lastCleanedAt: Date | null;
 
   declare space: NonAttribute<SpaceModel>;
   declare user: NonAttribute<UserModel>;
@@ -34,11 +33,6 @@ ProjectTaskStateModel.init(
     lastReadAt: {
       type: DataTypes.DATE,
       allowNull: false,
-    },
-    lastCleanedAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-      defaultValue: null,
     },
     spaceId: {
       type: DataTypes.BIGINT,

--- a/front/migrations/db/migration_626.sql
+++ b/front/migrations/db/migration_626.sql
@@ -1,0 +1,2 @@
+-- Migration created on mai 06, 2026
+ALTER TABLE "public"."project_todo_states" DROP COLUMN IF EXISTS "lastCleanedAt";


### PR DESCRIPTION
## Description

This PR removes the `lastCleanedAt` column from the `ProjectTaskState` database table.

## Tests

Manually

## Risks

Low risk - column is no longer used after the other PRs in the stack removed the clean tasks functionality.

## Deploy Plan

Deploy and then run migration.