### PR TITLE
[front] CheckoutPage: improve UI

### DIFF
--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -79,6 +79,35 @@ export function CheckoutPage() {
     [billingPeriod, createSession, router]
   );
 
+  // We have to enforce light mode to fit with stripe embedded checkout session
+  // as there is not appearance selection field in EmbeddedCheckoutProvider
+  useEffect(() => {
+    const htmlEl = document.documentElement;
+    const bodyEl = document.body;
+    const hadDark = htmlEl.classList.contains("dark");
+    // biome-ignore lint/plugin/noSparkleClassInFront: s-dark is needed for Sparkle dark mode
+    const hadSDark = htmlEl.classList.contains("s-dark");
+    const hadNight = bodyEl.classList.contains("bg-background-night");
+
+    htmlEl.classList.remove("dark");
+    // biome-ignore lint/plugin/noSparkleClassInFront: s-dark is needed for Sparkle dark mode
+    htmlEl.classList.remove("s-dark");
+    bodyEl.classList.remove("bg-background-night");
+
+    return () => {
+      if (hadDark) {
+        htmlEl.classList.add("dark");
+      }
+      if (hadSDark) {
+        // biome-ignore lint/plugin/noSparkleClassInFront: s-dark is needed for Sparkle dark mode
+        htmlEl.classList.add("s-dark");
+      }
+      if (hadNight) {
+        bodyEl.classList.add("bg-background-night");
+      }
+    };
+  }, []);
+
   // On mount, create an initial checkout session.
   useEffect(() => {
     void initSession();

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -15,7 +15,7 @@ import {
 } from "@app/lib/swr/workspaces";
 import type { BillingPeriod } from "@app/types/plan";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { Page, Spinner } from "@dust-tt/sparkle";
+import { DustLogoSquare, Icon, Spinner } from "@dust-tt/sparkle";
 import {
   EmbeddedCheckout,
   EmbeddedCheckoutProvider,
@@ -142,44 +142,58 @@ export function CheckoutPage() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col">
-      <Page>
-        <div className="flex w-full flex-col gap-8 lg:flex-row lg:gap-12">
-          {/* Left pane: plan summary + coupon + total */}
-          <div className="flex flex-col gap-4 lg:w-1/2">
-            <h2 className="text-lg font-semibold">Plan summary</h2>
+    <main className="flex min-h-screen">
+      {/* Left pane: plan summary + coupon + total */}
+      <div className="flex w-1/2 flex-col gap-14 p-24">
+        {/* Logo */}
+        <div>
+          <Icon visual={DustLogoSquare} size="lg" />
+        </div>
 
-            {/* Line items */}
-            <div className="flex flex-col gap-3 text-sm">
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">
-                  Price per seat ({billingPeriod}), excl. taxes
-                </span>
-                <span>
-                  {getPriceAsString({
-                    currency,
-                    priceInCents: seatPriceCents,
-                  })}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Number of seats</span>
-                <span>{seats}</span>
-              </div>
-              <div className="flex justify-between border-t border-separator pt-3 font-medium">
-                <span>Subtotal, excl. taxes</span>
-                <span>
-                  {getPriceAsString({
-                    currency,
-                    priceInCents: subtotalCents,
-                  })}
-                </span>
-              </div>
+        <div className="flex flex-col gap-11">
+          {/* Plan header */}
+          <div className="flex flex-col">
+            <span className="text-base text-muted-foreground">Your plan</span>
+            <h1 className="text-5xl font-semibold text-foreground">
+              {isBusiness ? "Business plan" : "Pro plan"}
+            </h1>
+            <span className="text-sm text-muted-foreground">
+              {billingPeriod === "yearly"
+                ? "billed annually"
+                : "billed monthly"}
+            </span>
+          </div>
+
+          {/* Line items */}
+          <div className="flex flex-col text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">
+                Price per seat (excl. taxes)
+              </span>
+              <span>
+                {getPriceAsString({
+                  currency,
+                  priceInCents: seatPriceCents,
+                })}
+              </span>
+            </div>
+            <div className="mt-3 flex justify-between">
+              <span className="text-muted-foreground">Number of seats</span>
+              <span>{seats}</span>
+            </div>
+            <div className="mt-6 flex justify-between border-t border-separator pt-3 font-medium">
+              <span>Subtotal (excl. taxes)</span>
+              <span>
+                {getPriceAsString({
+                  currency,
+                  priceInCents: subtotalCents,
+                })}
+              </span>
             </div>
 
             {/* Total due today — always visible */}
-            <div className="flex justify-between border-t border-separator pt-3 text-base font-semibold">
-              <span>Total due today, excl. taxes</span>
+            <div className="mt-6 flex justify-between border-t border-separator pt-3 text-base font-semibold">
+              <span>Total due today (excl. taxes)</span>
               <span>
                 {getPriceAsString({
                   currency,
@@ -188,29 +202,29 @@ export function CheckoutPage() {
               </span>
             </div>
 
-            <p className="text-xs text-muted-foreground">
+            <p className="mt-11 text-xs text-muted-foreground">
               Final currency and tax amount are determined by the country
               entered in the payment form.
             </p>
           </div>
-
-          {/* Right pane: Stripe Embedded Checkout */}
-          <div className="lg:w-1/2">
-            {isCreating || !clientSecret ? (
-              <div className="flex h-64 items-center justify-center">
-                <Spinner size="lg" />
-              </div>
-            ) : (
-              <EmbeddedCheckoutProvider
-                stripe={getStripePromise()}
-                options={{ clientSecret }}
-              >
-                <EmbeddedCheckout />
-              </EmbeddedCheckoutProvider>
-            )}
-          </div>
         </div>
-      </Page>
+      </div>
+
+      {/* Right pane: Stripe Embedded Checkout */}
+      <div className="w-1/2 p-24">
+        {isCreating || !clientSecret ? (
+          <div className="flex h-64 items-center justify-center">
+            <Spinner size="lg" />
+          </div>
+        ) : (
+          <EmbeddedCheckoutProvider
+            stripe={getStripePromise()}
+            options={{ clientSecret }}
+          >
+            <EmbeddedCheckout />
+          </EmbeddedCheckoutProvider>
+        )}
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Description

Update CheckoutPage (for legacy Pro and Business Plans) to fit with design (inspired from initial Stripe page)
(could not impact the height of Stripe embedded session on the right unfortunately)
<img width="1501" height="739" alt="Screenshot 2026-05-06 at 16 45 12" src="https://github.com/user-attachments/assets/8c9690c0-50e3-4b4b-9e6f-dd0743953af7" />
<img width="1472" height="705" alt="Screenshot 2026-05-06 at 16 47 11" src="https://github.com/user-attachments/assets/86e60942-bc19-429f-88eb-ff184e86557b" />
<img width="1469" height="730" alt="Screenshot 2026-05-06 at 16 47 44" src="https://github.com/user-attachments/assets/7ecbafe1-9c7b-4df7-b3e0-13f0b407e657" />

## Tests

Tested locally in the 3 cases (business monthly, pro monthly, pro yearly

## Risk

Low, UI only

## Deploy Plan

Deploy front