### PR TITLE
[front] sbx: bump duckdb to 1.4.4 for cp314 wheels

### DIFF
--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -70,7 +70,7 @@ const PYTHON_LIBRARIES: PythonLibrary[] = [
   },
   {
     name: "duckdb",
-    version: "1.4.0",
+    version: "1.4.4",
     description: "In-process OLAP / SQL on dataframes",
   },
 ];


### PR DESCRIPTION
## Description

duckdb 1.4.0 doesn't publish Python 3.14 wheels, so uv fell back to a source build in the sandbox image and CMake failed because the base image has no C++ compiler. Bumping to 1.4.4 (first 1.4.x with cp314 wheels) fixes the build.

Failing run: https://github.com/dust-tt/dust/actions/runs/25443213668/job/74640238772

## Tests

Will be validated by the build-templates job on this PR.

## Risk

Low. Patch bump within the same minor.

## Deploy Plan

Standard deploy.