### PR TITLE
Zod migration of some MCP APIs

### DIFF
--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.ts
@@ -18,27 +18,26 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-const PostConnectionOAuthBodySchema = t.type({
-  connectionId: t.string,
-  mcpServerId: t.string,
+const PostConnectionOAuthBodySchema = z.object({
+  connectionId: z.string(),
+  mcpServerId: z.string(),
 });
 
-const PostConnectionCredentialsBodySchema = t.type({
-  credentialId: t.string,
-  mcpServerId: t.string,
+const PostConnectionCredentialsBodySchema = z.object({
+  credentialId: z.string(),
+  mcpServerId: z.string(),
 });
 
-const PostConnectionBodySchema = t.union([
+const PostConnectionBodySchema = z.union([
   PostConnectionOAuthBodySchema,
   PostConnectionCredentialsBodySchema,
 ]);
 
-export type PostConnectionBodyType = t.TypeOf<typeof PostConnectionBodySchema>;
+export type PostConnectionBodyType = z.infer<typeof PostConnectionBodySchema>;
 
 export type PostConnectionResponseBody = {
   success: boolean;
@@ -241,20 +240,18 @@ async function handler(
         connections: connections.map((c) => c.toJSON()),
       });
     case "POST":
-      const bodyValidation = PostConnectionBodySchema.decode(req.body);
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+      const bodyValidation = PostConnectionBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
           },
         });
       }
 
-      const validatedBody = bodyValidation.right;
+      const validatedBody = bodyValidation.data;
       const mcpServerId = validatedBody.mcpServerId;
       const authReference = getAuthReferenceFromBody(validatedBody);
 

--- a/front/pages/api/w/[wId]/mcp/deregister.ts
+++ b/front/pages/api/w/[wId]/mcp/deregister.ts
@@ -4,17 +4,16 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-const PostMCPDeregisterRequestBodyCodec = t.type({
-  serverId: t.string,
+const PostMCPDeregisterRequestBodySchema = z.object({
+  serverId: z.string(),
 });
 
-export type PostMCPDeregisterRequestBody = t.TypeOf<
-  typeof PostMCPDeregisterRequestBodyCodec
+export type PostMCPDeregisterRequestBody = z.infer<
+  typeof PostMCPDeregisterRequestBodySchema
 >;
 
 type DeregisterMCPResponseType = {
@@ -36,19 +35,18 @@ async function handler(
     });
   }
 
-  const bodyValidation = PostMCPDeregisterRequestBodyCodec.decode(req.body);
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+  const bodyValidation = PostMCPDeregisterRequestBodySchema.safeParse(req.body);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request body: ${pathError}`,
+        message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
       },
     });
   }
 
-  const { serverId } = bodyValidation.right;
+  const { serverId } = bodyValidation.data;
 
   await deregisterMCPServer(auth, { serverId });
 

--- a/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -9,9 +9,8 @@ import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_r
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export type DiscoverOAuthMetadataResponseBody =
   | {
@@ -22,12 +21,11 @@ export type DiscoverOAuthMetadataResponseBody =
       oauthRequired: false;
     };
 
-const PostQueryParamsSchema = t.type({
-  url: t.string,
-  customHeaders: t.union([
-    t.array(t.type({ key: t.string, value: t.string })),
-    t.undefined,
-  ]),
+const PostBodySchema = z.object({
+  url: z.string(),
+  customHeaders: z
+    .array(z.object({ key: z.string(), value: z.string() }))
+    .optional(),
 });
 
 /**
@@ -47,9 +45,9 @@ async function handler(
 
   switch (method) {
     case "POST": {
-      const r = PostQueryParamsSchema.decode(req.body);
+      const r = PostBodySchema.safeParse(req.body);
 
-      if (isLeft(r)) {
+      if (!r.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -59,7 +57,7 @@ async function handler(
         });
       }
 
-      const { url, customHeaders } = r.right;
+      const { url, customHeaders } = r.data;
 
       // Validate URL format
       try {

--- a/front/pages/api/w/[wId]/mcp/heartbeat.ts
+++ b/front/pages/api/w/[wId]/mcp/heartbeat.ts
@@ -4,17 +4,16 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-const PostMCPHeartbeatRequestBodyCodec = t.type({
-  serverId: t.string,
+const PostMCPHeartbeatRequestBodySchema = z.object({
+  serverId: z.string(),
 });
 
-export type PostMCPHeartbeatRequestBody = t.TypeOf<
-  typeof PostMCPHeartbeatRequestBodyCodec
+export type PostMCPHeartbeatRequestBody = z.infer<
+  typeof PostMCPHeartbeatRequestBodySchema
 >;
 
 interface MCPServerHeartbeatSuccess {
@@ -45,19 +44,18 @@ async function handler(
     });
   }
 
-  const bodyValidation = PostMCPHeartbeatRequestBodyCodec.decode(req.body);
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+  const bodyValidation = PostMCPHeartbeatRequestBodySchema.safeParse(req.body);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid server id: ${pathError}`,
+        message: `Invalid server id: ${fromError(bodyValidation.error).toString()}`,
       },
     });
   }
 
-  const { serverId } = bodyValidation.right;
+  const { serverId } = bodyValidation.data;
 
   // Update the heartbeat for the server.
   const result = await updateMCPServerHeartbeat(auth, {

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -31,9 +31,8 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
 import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export type GetMCPServersResponseBody = {
   success: true;
@@ -49,41 +48,35 @@ const MAX_URL_LENGTH = 2048;
 
 const MAX_NAME_LENGTH = 2048;
 
-const PostQueryParamsSchema = t.union([
-  t.type({
-    serverType: t.literal("remote"),
-    url: t.string,
-    defaultServerId: t.union([t.number, t.undefined]),
-    includeGlobal: t.union([t.boolean, t.undefined]),
-    sharedSecret: t.union([t.string, t.undefined]),
-    useCase: t.union([
-      t.literal("platform_actions"),
-      t.literal("personal_actions"),
-      t.undefined,
-    ]),
-    connectionId: t.union([t.string, t.undefined]),
-    customHeaders: t.union([
-      t.array(t.type({ key: t.string, value: t.string })),
-      t.undefined,
-    ]),
+const CustomHeadersSchema = z
+  .array(z.object({ key: z.string(), value: z.string() }))
+  .optional();
+
+const UseCaseSchema = z
+  .enum(["platform_actions", "personal_actions"])
+  .optional();
+
+const PostBodySchema = z.discriminatedUnion("serverType", [
+  z.object({
+    serverType: z.literal("remote"),
+    url: z.string(),
+    defaultServerId: z.number().optional(),
+    includeGlobal: z.boolean().optional(),
+    sharedSecret: z.string().optional(),
+    useCase: UseCaseSchema,
+    connectionId: z.string().optional(),
+    customHeaders: CustomHeadersSchema,
   }),
-  t.type({
-    serverType: t.literal("internal"),
-    name: t.string,
-    useCase: t.union([
-      t.literal("platform_actions"),
-      t.literal("personal_actions"),
-      t.undefined,
-    ]),
-    connectionId: t.union([t.string, t.undefined]),
-    includeGlobal: t.union([t.boolean, t.undefined]),
-    sharedSecret: t.union([t.string, t.undefined]),
-    customHeaders: t.union([
-      t.array(t.type({ key: t.string, value: t.string })),
-      t.undefined,
-    ]),
-    viewName: t.union([t.string, t.undefined]),
-    oauthScope: t.union([t.string, t.undefined]),
+  z.object({
+    serverType: z.literal("internal"),
+    name: z.string(),
+    useCase: UseCaseSchema,
+    connectionId: z.string().optional(),
+    includeGlobal: z.boolean().optional(),
+    sharedSecret: z.string().optional(),
+    customHeaders: CustomHeadersSchema,
+    viewName: z.string().optional(),
+    oauthScope: z.string().optional(),
   }),
 ]);
 
@@ -136,9 +129,9 @@ async function handler(
       });
     }
     case "POST": {
-      const r = PostQueryParamsSchema.decode(req.body);
+      const r = PostBodySchema.safeParse(req.body);
 
-      if (isLeft(r)) {
+      if (!r.success) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -148,7 +141,7 @@ async function handler(
         });
       }
 
-      const body = r.right;
+      const body = r.data;
       switch (body.serverType) {
         case "remote": {
           const { url, sharedSecret } = body;

--- a/front/pages/api/w/[wId]/mcp/register.ts
+++ b/front/pages/api/w/[wId]/mcp/register.ts
@@ -7,26 +7,26 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 const MIN_SERVER_NAME_LENGTH = 5;
 const MAX_SERVER_NAME_LENGTH = 30;
-export const ClientSideMCPServerNameCodec = t.refinement(
-  t.string,
-  (s) =>
-    s.trim().length >= MIN_SERVER_NAME_LENGTH &&
-    s.trim().length <= MAX_SERVER_NAME_LENGTH
-);
+export const ClientSideMCPServerNameSchema = z
+  .string()
+  .refine(
+    (s) =>
+      s.trim().length >= MIN_SERVER_NAME_LENGTH &&
+      s.trim().length <= MAX_SERVER_NAME_LENGTH
+  );
 
-const PostMCPRegisterRequestBodyCodec = t.type({
-  serverName: ClientSideMCPServerNameCodec,
+const PostMCPRegisterRequestBodySchema = z.object({
+  serverName: ClientSideMCPServerNameSchema,
 });
 
-export type PostMCPRegisterRequestBody = t.TypeOf<
-  typeof PostMCPRegisterRequestBodyCodec
+export type PostMCPRegisterRequestBody = z.infer<
+  typeof PostMCPRegisterRequestBodySchema
 >;
 
 type RegisterMCPResponseType = {
@@ -49,19 +49,18 @@ async function handler(
     });
   }
 
-  const bodyValidation = PostMCPRegisterRequestBodyCodec.decode(req.body);
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
+  const bodyValidation = PostMCPRegisterRequestBodySchema.safeParse(req.body);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid server name: ${pathError}`,
+        message: `Invalid server name: ${fromError(bodyValidation.error).toString()}`,
       },
     });
   }
 
-  const { serverName } = bodyValidation.right;
+  const { serverName } = bodyValidation.data;
 
   // Register the server.
   const registration = await registerMCPServer(auth, {

--- a/front/pages/api/w/[wId]/mcp/request_access.ts
+++ b/front/pages/api/w/[wId]/mcp/request_access.ts
@@ -8,18 +8,17 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import { isLeft } from "fp-ts/lib/Either";
 import { escape } from "html-escaper";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-export const PostRequestActionsAccessBodySchema = t.type({
-  emailMessage: t.string,
-  mcpServerViewId: t.string,
+export const PostRequestActionsAccessBodySchema = z.object({
+  emailMessage: z.string(),
+  mcpServerViewId: z.string(),
 });
 
-export type PostRequestActionsAccessBody = t.TypeOf<
+export type PostRequestActionsAccessBody = z.infer<
   typeof PostRequestActionsAccessBodySchema
 >;
 
@@ -53,21 +52,19 @@ async function handler(
     });
   }
 
-  const bodyValidation = PostRequestActionsAccessBodySchema.decode(req.body);
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
+  const bodyValidation = PostRequestActionsAccessBodySchema.safeParse(req.body);
+  if (!bodyValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request body: ${pathError}`,
+        message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
       },
     });
   }
 
   const emailRequester = user.email;
-  const { emailMessage, mcpServerViewId } = bodyValidation.right;
+  const { emailMessage, mcpServerViewId } = bodyValidation.data;
 
   const mcpServerView = await MCPServerViewResource.fetchById(
     auth,

--- a/front/pages/api/w/[wId]/mcp/requests.ts
+++ b/front/pages/api/w/[wId]/mcp/requests.ts
@@ -6,38 +6,32 @@ import { initSSEResponse } from "@app/lib/api/sse";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
-const GetMCPRequestsRequestQueryCodec = t.intersection([
-  t.type({
-    serverId: t.string,
-  }),
-  t.partial({
-    lastEventId: t.string,
-  }),
-]);
+const GetMCPRequestsRequestQuerySchema = z.object({
+  serverId: z.string(),
+  lastEventId: z.string().optional(),
+});
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<void>>,
   auth: Authenticator
 ): Promise<void> {
-  const queryValidation = GetMCPRequestsRequestQueryCodec.decode(req.query);
-  if (isLeft(queryValidation)) {
-    const pathError = reporter.formatValidationErrors(queryValidation.left);
+  const queryValidation = GetMCPRequestsRequestQuerySchema.safeParse(req.query);
+  if (!queryValidation.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Invalid request query: ${pathError}`,
+        message: `Invalid request query: ${fromError(queryValidation.error).toString()}`,
       },
     });
   }
 
-  const { lastEventId, serverId } = queryValidation.right;
+  const { lastEventId, serverId } = queryValidation.data;
 
   const isValidAccess = await validateMCPServerAccess(auth, {
     serverId,

--- a/front/pages/api/w/[wId]/mcp/results.ts
+++ b/front/pages/api/w/[wId]/mcp/results.ts
@@ -5,10 +5,9 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
-import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 export const config = {
   api: {
@@ -18,9 +17,9 @@ export const config = {
   },
 };
 
-const PostMCPResultsRequestBodyCodec = t.type({
-  result: t.unknown,
-  serverId: t.string,
+const PostMCPResultsRequestBodySchema = z.object({
+  result: z.unknown(),
+  serverId: z.string(),
 });
 
 type PostMCPResultsResponseType = {
@@ -32,20 +31,18 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostMCPResultsResponseType>>,
   auth: Authenticator
 ): Promise<void> {
-  const r = PostMCPResultsRequestBodyCodec.decode(req.body);
-  if (isLeft(r)) {
-    const pathError = reporter.formatValidationErrors(r.left);
-
+  const r = PostMCPResultsRequestBodySchema.safeParse(req.body);
+  if (!r.success) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: pathError.join(","),
+        message: fromError(r.error).toString(),
       },
     });
   }
 
-  const { serverId, result } = r.right;
+  const { serverId, result } = r.data;
 
   const isValidAccess = await validateMCPServerAccess(auth, {
     serverId,


### PR DESCRIPTION
## Description

Files migrated

- request_access.ts — PostRequestActionsAccessBodySchema
- deregister.ts — PostMCPDeregisterRequestBodySchema
- heartbeat.ts — PostMCPHeartbeatRequestBodySchema
- requests.ts — GetMCPRequestsRequestQuerySchema
- results.ts — PostMCPResultsRequestBodySchema
- register.ts — PostMCPRegisterRequestBodySchema + ClientSideMCPServerNameSchema
- discover_oauth_metadata.ts — PostBodySchema
- index.ts — PostBodySchema (remote/internal discriminated union)
- connections/[connectionType]/index.ts — PostConnectionBodySchema

## Tests

Did E2E testing of adding, using, removing both an internal and external MCP

## Risk

I may not have hit all the endpoints

## Deploy Plan

Front