### PR TITLE
feat: sticky user mention mode

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -28,6 +28,7 @@ import { describeWakeUpSchedule } from "@app/lib/utils/wakeup_description";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   isRichAgentMention,
+  isRichUserMention,
   toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
 import { pluralize } from "@app/types/shared/utils/string_utils";
@@ -163,6 +164,13 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
       return [currentUserAgentMention];
     }
 
+    // Current user's last message was in user mention mode (user mentions, no agent mention) → restore them.
+    const lastMessageUserMentions =
+      lastUserMessage?.richMentions.filter(isRichUserMention) ?? [];
+    if (lastMessageUserMentions.length > 0 && !currentUserAgentMention) {
+      return lastMessageUserMentions;
+    }
+
     // @sidekick is not available in accessibleAgentIds so we need to skip it
     if (agentBuilderContext) {
       return lastAgentMentionInConversation
@@ -178,11 +186,16 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     }
 
     // Ultimate fallback: select the "dust" agent if available.
-    const dustAgent = agentConfigurations.find(
-      (a) => a.sId === GLOBAL_AGENTS_SID.DUST
-    );
-    if (dustAgent) {
-      return [toRichAgentMentionType(dustAgent)];
+    // Only for new conversations; for existing conversations, return [] while messages are
+    // still loading to avoid a spurious @dust intermediate state that races with sticky
+    // user mentions being restored from conversation history.
+    if (!context.conversation) {
+      const dustAgent = agentConfigurations.find(
+        (a) => a.sId === GLOBAL_AGENTS_SID.DUST
+      );
+      if (dustAgent) {
+        return [toRichAgentMentionType(dustAgent)];
+      }
     }
 
     return [];
@@ -193,6 +206,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     accessibleAgentIds,
     agentConfigurations,
     agentBuilderContext,
+    context.conversation,
   ]);
 
   // Calculate positions and determine which user messages are navigable.

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -104,20 +104,12 @@ export const InputBar = React.memo(function InputBar({
 
   const { droppedFiles, setDroppedFiles } = useFileDrop();
 
-  const { saveDraft, getDraft, clearDraft, flushDraft } = useConversationDrafts({
+  const { saveDraft, getDraft, clearDraft } = useConversationDrafts({
     workspaceId: owner.sId,
     userId: user?.sId ?? null,
     draftKey,
     shouldUseDraft: !isAgentBuilder,
   });
-
-  // Flush any pending debounced draft save when switching conversations so that
-  // content typed just before the switch is not lost.
-  useEffect(() => {
-    return () => {
-      flushDraft();
-    };
-  }, [draftKey, flushDraft]);
 
   useEffect(() => {
     if (droppedFiles.length > 0) {

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -104,12 +104,20 @@ export const InputBar = React.memo(function InputBar({
 
   const { droppedFiles, setDroppedFiles } = useFileDrop();
 
-  const { saveDraft, getDraft, clearDraft } = useConversationDrafts({
+  const { saveDraft, getDraft, clearDraft, flushDraft } = useConversationDrafts({
     workspaceId: owner.sId,
     userId: user?.sId ?? null,
     draftKey,
     shouldUseDraft: !isAgentBuilder,
   });
+
+  // Flush any pending debounced draft save when switching conversations so that
+  // content typed just before the switch is not lost.
+  useEffect(() => {
+    return () => {
+      flushDraft();
+    };
+  }, [draftKey, flushDraft]);
 
   useEffect(() => {
     if (droppedFiles.length > 0) {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -641,11 +641,14 @@ const InputBarContainer = ({
     }
   };
 
-  // When the selected agent changes, remove any @user mentions (which are
+  // When the selected agent changes, remove leading @user mentions (which are
   // incompatible with single-agent mode), notify the user, and persist the draft.
+  // Non-leading user mentions are allowed alongside an agent and are left intact.
   useEffect(() => {
     if (selectedSingleAgent) {
-      const hadUserMentions = editorService.removeUserMentions();
+      const { markdown } = editorService.getMarkdownAndMentions();
+      const hadUserMentions =
+        startsWithUserMention(markdown) && editorService.removeUserMentions();
       if (hadUserMentions) {
         sendNotification({
           type: "info",
@@ -655,8 +658,9 @@ const InputBarContainer = ({
         });
       }
       editorService.focusEnd();
-      const { markdown } = editorService.getMarkdownAndMentions();
-      saveDraft(markdown, selectedSingleAgent);
+      const { markdown: updatedMarkdown } =
+        editorService.getMarkdownAndMentions();
+      saveDraft(updatedMarkdown, selectedSingleAgent);
     }
   }, [selectedSingleAgent, editorService, saveDraft, sendNotification]);
 

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -619,7 +619,19 @@ const InputBarContainer = ({
   // Ref to expose the current selectedSingleAgent to the editor update listener
   // without re-registering it on every selection change.
   const selectedSingleAgentRef = useRef(selectedSingleAgent);
+
+  // Set to "" by useHandleMentions when it programmatically pre-fills the editor
+  // with sticky user mentions. Used by handleUpdate to skip saving that pre-fill
+  // content as a draft (it's not user-typed content).
+  const stickyMentionsTextContent = useRef<string | null>(null);
   selectedSingleAgentRef.current = selectedSingleAgent;
+
+  // Stable ref so the selectedSingleAgent effect can call saveDraft without
+  // listing it as a dependency. Without this, changing draftKey (conversation
+  // switch) recreates saveDraft, re-runs the effect with the stale agent from
+  // the previous conversation, and overwrites the current draft with an empty sentinel.
+  const saveDraftRef = useRef(saveDraft);
+  saveDraftRef.current = saveDraft;
 
   // When a user mention is *newly added* in single-agent mode, deselect the agent
   // and clear side-channel capabilities. Only triggers on the transition from no-user-mention to
@@ -660,9 +672,12 @@ const InputBarContainer = ({
       editorService.focusEnd();
       const { markdown: updatedMarkdown } =
         editorService.getMarkdownAndMentions();
-      saveDraft(updatedMarkdown, selectedSingleAgent);
+      saveDraftRef.current(updatedMarkdown, selectedSingleAgent);
     }
-  }, [selectedSingleAgent, editorService, saveDraft, sendNotification]);
+    // saveDraft is accessed via ref so this effect does not re-run when draftKey
+    // changes (which recreates saveDraft and would overwrite the current draft).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedSingleAgent, editorService, sendNotification]);
 
   // Update the editor ref when the editor is created and listen for updates to the editor.
   useEffect(() => {
@@ -673,8 +688,20 @@ const InputBarContainer = ({
       // Auto-save draft when content changes and track user mentions.
       // Include the selected single agent so the debounced save doesn't
       // overwrite the agent mention saved by the single-agent effect.
+      // Skip saving when the editor holds only pre-fill mention nodes (no typed
+      // text): stickyMentionsTextContent is "" in that mode and getTrimmedText()
+      // is "" for mention-only content. Saving this would persist the programmatic
+      // pre-fill as a draft that later gets incorrectly restored as user content.
       const { markdown } = editorService.getMarkdownAndMentions();
-      saveDraft(editorIsEmpty ? "" : markdown, selectedSingleAgentRef.current);
+      const isOnlyPrefillContent =
+        stickyMentionsTextContent.current === "" &&
+        editorService.getTrimmedText() === "";
+      if (!isOnlyPrefillContent) {
+        saveDraft(
+          editorIsEmpty ? "" : markdown,
+          selectedSingleAgentRef.current
+        );
+      }
       const isLeadingUserMention = startsWithUserMention(markdown);
       setHasUserMention(isLeadingUserMention);
       onEditorMentionsChangedRef.current(isLeadingUserMention);
@@ -919,7 +946,7 @@ const InputBarContainer = ({
     getDraft,
   ]);
 
-  const { stickyMentionsTextContent } = useHandleMentions({
+  useHandleMentions({
     allAgents,
     conversation,
     disableAutoFocus,
@@ -929,6 +956,7 @@ const InputBarContainer = ({
     pendingInputText,
     selectedAgent,
     stickyMentions,
+    stickyMentionsTextContent,
   });
 
   const buttonSize = useMemo(() => {

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -135,9 +135,14 @@ export function useConversationDrafts({
     );
   }, [getDraftsFromStorage, saveDraftsToStorage]);
 
-  const flushDraft = useCallback(() => {
-    debouncedSaveRef.current?.flush();
-  }, []);
+  // Flush any pending debounced save when draftKey changes (conversation switch)
+  // so that content typed within the debounce window is not lost on navigation.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: draftKey is listed to trigger the cleanup on conversation switch; it is not used in the effect body
+  useEffect(() => {
+    return () => {
+      debouncedSaveRef.current?.flush();
+    };
+  }, [draftKey]);
 
   const clearDraft = useCallback(() => {
     if (!shouldUseDraft || !userId) {
@@ -166,7 +171,19 @@ export function useConversationDrafts({
       }
 
       if (text.trim().length === 0) {
-        clearDraft();
+        // Cancel any pending debounced save. If there is already a saved draft
+        // for this conversation, overwrite it with an empty sentinel so that the
+        // sticky-mention pre-fill does not fire on the next visit (the user
+        // intentionally cleared content). If there is no draft (e.g. right after
+        // clearDraft() is called on message send), leave storage as-is so the
+        // pre-fill can still fire on return.
+        debouncedSaveRef.current?.cancel();
+        const drafts = getDraftsFromStorage();
+        const key = getKeyId(workspaceId, userId, draftKey);
+        if (drafts[key] !== undefined) {
+          drafts[key] = { text: "", timestamp: Date.now() };
+          saveDraftsToStorage(drafts);
+        }
         return;
       }
 
@@ -179,7 +196,14 @@ export function useConversationDrafts({
         agentMention,
       });
     },
-    [workspaceId, userId, shouldUseDraft, draftKey, clearDraft]
+    [
+      workspaceId,
+      userId,
+      shouldUseDraft,
+      draftKey,
+      getDraftsFromStorage,
+      saveDraftsToStorage,
+    ]
   );
 
   const getDraft = useCallback((): ConversationDraft | null => {
@@ -206,5 +230,5 @@ export function useConversationDrafts({
     saveDraftsToStorage(drafts);
   }, [getDraftsFromStorage, userId, saveDraftsToStorage]);
 
-  return { saveDraft, getDraft, clearDraft, clearAllDraftsFromUser, flushDraft };
+  return { saveDraft, getDraft, clearDraft, clearAllDraftsFromUser };
 }

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -135,6 +135,10 @@ export function useConversationDrafts({
     );
   }, [getDraftsFromStorage, saveDraftsToStorage]);
 
+  const flushDraft = useCallback(() => {
+    debouncedSaveRef.current?.flush();
+  }, []);
+
   const clearDraft = useCallback(() => {
     if (!shouldUseDraft || !userId) {
       return;
@@ -202,5 +206,5 @@ export function useConversationDrafts({
     saveDraftsToStorage(drafts);
   }, [getDraftsFromStorage, userId, saveDraftsToStorage]);
 
-  return { saveDraft, getDraft, clearDraft, clearAllDraftsFromUser };
+  return { saveDraft, getDraft, clearDraft, clearAllDraftsFromUser, flushDraft };
 }

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -13,7 +13,7 @@ import {
   isRichUserMention,
   toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
-import { useContext, useEffect, useRef } from "react";
+import { type MutableRefObject, useContext, useEffect, useRef } from "react";
 
 interface UseHandleMentionsOptions {
   allAgents: LightAgentConfigurationType[];
@@ -28,6 +28,7 @@ interface UseHandleMentionsOptions {
   pendingInputText?: string | null;
   selectedAgent: RichAgentMention | null;
   stickyMentions?: RichMention[];
+  stickyMentionsTextContent: MutableRefObject<string | null>;
 }
 
 const useHandleMentions = ({
@@ -40,8 +41,8 @@ const useHandleMentions = ({
   pendingInputText,
   selectedAgent,
   stickyMentions,
+  stickyMentionsTextContent,
 }: UseHandleMentionsOptions) => {
-  const stickyMentionsTextContent = useRef<string | null>(null);
   const { setSelectedSingleAgent } = useContext(InputBarContext);
 
   // Priority: draft > sticky mentions > @dust fallback.
@@ -53,6 +54,7 @@ const useHandleMentions = ({
   // stickyMentions or the @Dust fallback.
   const externalAgentSetRef = useRef(false);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: stickyMentionsTextContent is a ref and doesn't need to be in the dependency array
   useEffect(() => {
     const currentId = conversation?.sId ?? null;
     if (currentId !== prevConversationIdRef.current) {
@@ -108,7 +110,7 @@ const useHandleMentions = ({
       const userMentions = stickyMentions.filter(isRichUserMention);
       if (userMentions.length > 0) {
         setSelectedSingleAgent(null);
-        if (editorService.isEmpty() && !draft?.text?.trim()) {
+        if (editorService.isEmpty() && draft === null) {
           stickyMentionsTextContent.current = "";
           queueMicrotask(() =>
             editorService.resetWithMentions(userMentions, disableAutoFocus)
@@ -146,7 +148,7 @@ const useHandleMentions = ({
     }
   }, [selectedAgent, pendingInputText, editorService, setSelectedSingleAgent]);
 
-  return { stickyMentionsTextContent };
+  return {};
 };
 
 export default useHandleMentions;

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -1,5 +1,6 @@
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { EditorService } from "@app/components/editor/input_bar/useCustomEditor";
+import { startsWithUserMention } from "@app/lib/mentions/format";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -9,6 +10,7 @@ import type {
 } from "@app/types/assistant/mentions";
 import {
   isRichAgentMention,
+  isRichUserMention,
   toRichAgentMentionType,
 } from "@app/types/assistant/mentions";
 import { useContext, useEffect, useRef } from "react";
@@ -31,6 +33,7 @@ interface UseHandleMentionsOptions {
 const useHandleMentions = ({
   allAgents,
   conversation,
+  disableAutoFocus,
   editorService,
   getDraft,
   isAgentBuilder,
@@ -55,6 +58,7 @@ const useHandleMentions = ({
     if (currentId !== prevConversationIdRef.current) {
       prevConversationIdRef.current = currentId;
       externalAgentSetRef.current = false;
+      stickyMentionsTextContent.current = null;
       setSelectedSingleAgent(null);
     }
 
@@ -78,6 +82,14 @@ const useHandleMentions = ({
       return;
     }
 
+    // 1b. Draft starts with a user mention → stay in user mention mode.
+    // Prevents sticky agent mentions (from conversation history) or the @dust fallback
+    // from overriding a draft that was typed in user mention mode.
+    if (draft?.text && startsWithUserMention(draft.text)) {
+      setSelectedSingleAgent(null);
+      return;
+    }
+
     // 2. Sticky mentions contain an agent (existing conversation / agent builder) → use it.
     // stickyMentions carries both the agent builder's draft agent
     // and the last agent mention resolved from conversation history (computed in AgentInputBar).
@@ -85,6 +97,23 @@ const useHandleMentions = ({
       const agentMention = stickyMentions.find(isRichAgentMention) ?? null;
       if (agentMention) {
         setSelectedSingleAgent(agentMention);
+        return;
+      }
+
+      // 2b. Last message was in user mention mode → pre-fill the editor with those mentions.
+      // Only pre-fill when the editor is empty and there is no draft, so we don't wipe content
+      // the user is actively editing. stickyMentionsTextContent is set to "" so the draft
+      // restore effect can detect and overwrite the pre-fill if a draft later takes priority
+      // (getTrimmedText returns "" for mention-only content).
+      const userMentions = stickyMentions.filter(isRichUserMention);
+      if (userMentions.length > 0) {
+        setSelectedSingleAgent(null);
+        if (editorService.isEmpty() && !draft?.text?.trim()) {
+          stickyMentionsTextContent.current = "";
+          queueMicrotask(() =>
+            editorService.resetWithMentions(userMentions, disableAutoFocus)
+          );
+        }
         return;
       }
     }
@@ -103,6 +132,8 @@ const useHandleMentions = ({
     allAgents,
     getDraft,
     setSelectedSingleAgent,
+    editorService,
+    disableAutoFocus,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

After sending a message in user mention mode (a message starting with `@user`), the next input bar is pre-filled with the same user mention(s) so the user stays in that mode across consecutive messages.

AgentInputBar.tsx: autoMentions now also returns user mentions from the last user message when no agent mention is present, feeding them into stickyMentions.

`useHandleMentions.tsx`: three additions to the priority resolution effect. 

Step 1b: if the saved draft starts with a user mention, skip sticky agent mentions and the `@dust `fallback so a reload does not trigger the "can't mix users and agents" notification. 

Step 2b: when stickyMentions carries user mentions, clear the agent chip and pre-fill the editor via resetWithMentions, guarded by `editorService.isEmpty() && !draft?.text?.trim()` to avoid wiping active editor content or a draft being restored in parallel. `stickyMentionsTextContent.current` is also reset to null on conversation change so the pre-fill guard resets cleanly between conversations.

## Tests

Locally.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
