### PR TITLE
front: disable workspace subscription fetches for non-admins

### DIFF
--- a/front/components/pages/onboarding/SubscribePage.tsx
+++ b/front/components/pages/onboarding/SubscribePage.tsx
@@ -24,6 +24,7 @@ export function SubscribePage() {
 
   const { subscriptions } = useWorkspaceSubscriptions({
     owner: workspace,
+    disabled: !isAdmin,
   });
 
   const [billingPeriod, setBillingPeriod] =

--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -9,7 +9,7 @@ import { WorkspaceToolUsageChart } from "@app/components/workspace/analytics/Wor
 import { WorkspaceTopAgentsTable } from "@app/components/workspace/analytics/WorkspaceTopAgentsTable";
 import { WorkspaceTopUsersTable } from "@app/components/workspace/analytics/WorkspaceTopUsersTable";
 import { WorkspaceUsageChart } from "@app/components/workspace/analytics/WorkspaceUsageChart";
-import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useWorkspaceSubscriptions } from "@app/lib/swr/workspaces";
 import datadogLogger from "@app/logger/datadogLogger";
@@ -20,6 +20,7 @@ import { useState } from "react";
 
 export function AnalyticsPage() {
   const owner = useWorkspace();
+  const { isAdmin } = useAuth();
   const [downloadingMonth, setDownloadingMonth] = useState<string | null>(null);
   const [includeInactive, setIncludeInactive] = useState(true);
   const [period, setPeriod] =
@@ -27,6 +28,7 @@ export function AnalyticsPage() {
 
   const { subscriptions } = useWorkspaceSubscriptions({
     owner,
+    disabled: !isAdmin,
   });
 
   const handleDownload = async (selectedMonth: string | null) => {

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -96,21 +96,26 @@ export function useWorkspace({
 
 export function useWorkspaceSubscriptions({
   owner,
+  disabled,
 }: {
   owner: LightWorkspaceType;
+  disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
-  const workspaceSubscrptionsFetcher: Fetcher<GetSubscriptionsResponseBody> =
+  const workspaceSubscriptionsFetcher: Fetcher<GetSubscriptionsResponseBody> =
     fetcher;
 
   const { data, error } = useSWRWithDefaults(
     `/api/w/${owner.sId}/subscriptions`,
-    workspaceSubscrptionsFetcher
+    workspaceSubscriptionsFetcher,
+    {
+      disabled,
+    }
   );
 
   return {
     subscriptions: data?.subscriptions ?? emptyArray(),
-    isSubscriptionsLoading: !error && !data,
+    isSubscriptionsLoading: !error && !data && !disabled,
     isSubscriptionsError: error,
   };
 }


### PR DESCRIPTION
## Description

On a path to reducing [these logs](https://app.datadoghq.eu/logs/livetail?query=-status%3A%28info%20OR%20warn%29%20source%3Afront%20%40apiError.api_error.message%3A%22Only%20users%20that%20are%20%60admins%60%20for%20the%20current%20workspace%20can%20access%20this%20endpoint.%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40error.name%2C%40apiError.api_error.message&messageDisplay=inline&refresh_mode=sliding&storage=driveline&stream_sort=desc&viz=stream&from_ts=1778081177294&to_ts=1778082077294&live=true)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
