### PR TITLE
[connector] enh: Add jitter on gong connector to handle more 429 cases

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -5,6 +5,7 @@ import {
   isNotFoundError,
 } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
+import { statsDClient } from "@connectors/logger/withlogging";
 import type { ModelId } from "@connectors/types";
 import { isLeft } from "fp-ts/Either";
 import * as t from "io-ts";
@@ -236,6 +237,20 @@ const GongPermissionProfilesResponseCodec = t.intersection([
   CatchAllCodec,
 ]);
 
+// Gong's documented Retry-After unit is seconds, we have observerd it to be in anything betwee 1 to 55k,
+// which indicates that it's in miliseconds, or in seconds, but with a bug
+// if you remove oultiers, the distribution is centered around 10 (which we treat a seconds)
+// so flooring the retry after to 10.
+const RETRY_AFTER_FLOOR_MS = 10_000;
+const RETRY_AFTER_CEILING_MS = 60 * 60_000;
+
+export function clampRetryAfterMs(raw: number | undefined): number | undefined {
+  if (raw === undefined || Number.isNaN(raw)) {
+    return undefined;
+  }
+  return Math.min(Math.max(raw, RETRY_AFTER_FLOOR_MS), RETRY_AFTER_CEILING_MS);
+}
+
 export class GongClient {
   private readonly baseUrl = "https://api.gong.io/v2";
 
@@ -296,6 +311,11 @@ export class GongClient {
           },
           "Rate limit hit on Gong API."
         );
+
+        statsDClient.increment("gong.api.rate_limit", 1, [
+          `endpoint:${endpoint}`,
+          `provider:gong`,
+        ]);
 
         // Don't attempt to parse the body in JSON.
         const body = await response.text();

--- a/connectors/src/connectors/gong/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/gong/temporal/cast_known_errors.ts
@@ -1,5 +1,9 @@
 import { GongAPIError } from "@connectors/connectors/gong/lib/errors";
-import { DustConnectorWorkflowError } from "@connectors/lib/error";
+import { clampRetryAfterMs } from "@connectors/connectors/gong/lib/gong_api";
+import {
+  DustConnectorWorkflowError,
+  ProviderRateLimitError,
+} from "@connectors/lib/error";
 import { ApplicationFailure } from "@temporalio/common";
 import type {
   ActivityExecuteInput,
@@ -19,21 +23,23 @@ export class GongCastKnownErrorsInterceptor
     } catch (err: unknown) {
       if (err instanceof GongAPIError) {
         switch (err.status) {
-          case 429:
-            if (err.retryAfterMs) {
+          case 429: {
+            const clampedMs = clampRetryAfterMs(err.retryAfterMs);
+            if (clampedMs !== undefined) {
               // Override the default retry delay of the activity policy.
               throw ApplicationFailure.create({
-                message: `${err.message}. Retry after ${err.retryAfterMs}ms`,
-                nextRetryDelay: err.retryAfterMs,
+                message: `${err.message}. Retry after ${clampedMs}ms`,
+                nextRetryDelay: clampedMs,
                 cause: err,
               });
             }
 
-            throw new DustConnectorWorkflowError(
-              "429 - Rate Limit Exceeded",
-              "rate_limit_error",
+            throw new ProviderRateLimitError(
+              "gong",
+              "429 - Rate Limit Exceeded (no Retry-After)",
               err
             );
+          }
 
           case 400: {
             const isExpiredCursorError =

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -115,6 +115,7 @@ export async function withSlackErrorHandling<T>(
     // Rate limit errors.
     if (isWebAPIRateLimitedError(e)) {
       throw new ProviderRateLimitError(
+        "slack",
         `Rate limited: ${e.message} (retry after ${e.retryAfter}s)`,
         e,
         // Slack returns retryAfter in seconds, but Temporal expects milliseconds.

--- a/connectors/src/connectors/slack/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/slack/temporal/cast_known_errors.ts
@@ -18,10 +18,10 @@ export class SlackCastKnownErrorsInterceptor
     } catch (err: unknown) {
       // Ensure rate limit errors with retryAfterMs are honored.
       if (err instanceof ProviderRateLimitError) {
-        if (err.retryAfter) {
+        if (err.retryAfterMs) {
           throw ApplicationFailure.create({
-            message: `${err.message}. Retry after ${err.retryAfter / 1000}s`,
-            nextRetryDelay: err.retryAfter,
+            message: `${err.message}. Retry after ${err.retryAfterMs / 1000}s`,
+            nextRetryDelay: err.retryAfterMs,
             cause: err,
           });
         }

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -55,11 +55,12 @@ export class ProviderWorkflowError extends DustConnectorWorkflowError {
 
 export class ProviderRateLimitError extends ProviderWorkflowError {
   constructor(
+    provider: ConnectorProvider,
     message: string,
     originalError?: Error | APIError,
-    readonly retryAfter?: number
+    readonly retryAfterMs?: number
   ) {
-    super("slack", message, "rate_limit_error", originalError);
+    super(provider, message, "rate_limit_error", originalError);
   }
 }
 


### PR DESCRIPTION
## Description

Add some jitter in activity retries on gong connector.
The goal is to burst less often the retries, to let their throttling cool down.

Some refactor along the way.

## Tests

N/A


## Risk

Low

## Deploy Plan

- Deploy connector