### PR TITLE
[connctor] enh: add microsoft delta items cutoff

### DIFF
--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -264,6 +264,15 @@ export async function getDeltaResults({
   return { results: res.value };
 }
 
+export const DELTA_MAX_ITEMS = 500_000;
+
+export class DeltaTooLargeError extends Error {
+  constructor(public readonly itemCount: number) {
+    super(`Delta exceeded item threshold (${itemCount} items)`);
+    this.name = "DeltaTooLargeError";
+  }
+}
+
 /**
  * Similar to getDeltaResults but goes through pagination (returning results and
  * the deltalink)
@@ -287,6 +296,7 @@ export async function getFullDeltaResults({
   let pageCount = 0;
 
   do {
+    heartbeatFunction();
     const {
       results,
       nextLink: newNextLink,
@@ -302,6 +312,17 @@ export async function getFullDeltaResults({
       { pageCount, pageItems: results.length, totalItems: itemMap.size },
       "Delta pagination progress"
     );
+    if (itemMap.size > DELTA_MAX_ITEMS) {
+      logger.warn(
+        {
+          totalItems: itemMap.size,
+          parentInternalId,
+          threshold: DELTA_MAX_ITEMS,
+        },
+        "Delta exceeded item threshold, aborting incremental sync"
+      );
+      throw new DeltaTooLargeError(itemMap.size);
+    }
     nextLink = newNextLink;
     deltaLink = finalDeltaLink;
     heartbeatFunction();

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -2,6 +2,7 @@
 import { getMicrosoftClient } from "@connectors/connectors/microsoft";
 import {
   clientApiPost,
+  DeltaTooLargeError,
   getAllPaginatedEntities,
   getDeltaResults,
   getDriveInternalIdFromItem,
@@ -33,6 +34,8 @@ import {
   isJSONParsingError,
   isMalformedDriveError,
 } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
+// biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
+import { launchMicrosoftFullSyncWorkflow } from "@connectors/connectors/microsoft/temporal/client";
 import {
   deleteFile,
   deleteFolder,
@@ -1329,7 +1332,7 @@ export async function fetchDeltaForRootNodesInDrive({
   connectorId: ModelId;
   driveId: string;
   rootNodeIds: string[];
-}): Promise<{ gcsFilePath: string | null }> {
+}): Promise<{ gcsFilePath: string | null; deltaTooLarge: boolean }> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found`);
@@ -1364,7 +1367,7 @@ export async function fetchDeltaForRootNodesInDrive({
       },
       "Some root nodes not found in database, skipping delta sync for this drive"
     );
-    return { gcsFilePath: null };
+    return { gcsFilePath: null, deltaTooLarge: false };
   }
 
   const client = await getMicrosoftClient(connector.connectionId);
@@ -1390,7 +1393,7 @@ export async function fetchDeltaForRootNodesInDrive({
           { error: normalizeError(error).message, driveId },
           "Drive not found or malformed during delta population, skipping"
         );
-        return { gcsFilePath: null };
+        return { gcsFilePath: null, deltaTooLarge: false };
       }
       throw error;
     }
@@ -1419,12 +1422,19 @@ export async function fetchDeltaForRootNodesInDrive({
     results = resultsFromDelta;
     deltaLink = deltaLinkFromDelta;
   } catch (error) {
+    if (error instanceof DeltaTooLargeError) {
+      logger.warn(
+        { connectorId, driveId, rootNodeIds, itemCount: error.itemCount },
+        "Incremental delta too large, signaling workflow to recover"
+      );
+      return { gcsFilePath: null, deltaTooLarge: true };
+    }
     if (isItemNotFoundError(error) || isMalformedDriveError(error)) {
       logger.info(
         { error: error.message, driveId },
         "Drive not found or malformed, skipping"
       );
-      return { gcsFilePath: null };
+      return { gcsFilePath: null, deltaTooLarge: false };
     }
     throw error;
   }
@@ -1499,7 +1509,7 @@ export async function fetchDeltaForRootNodesInDrive({
       { connectorId, driveId, rootNodeIds },
       "No changes found, skipping delta sync"
     );
-    return { gcsFilePath: null };
+    return { gcsFilePath: null, deltaTooLarge: false };
   }
 
   const totalItems = sortedChangedItems.length;
@@ -1549,7 +1559,7 @@ export async function fetchDeltaForRootNodesInDrive({
     "Delta data fetched, processed, and uploaded to GCS"
   );
 
-  return { gcsFilePath };
+  return { gcsFilePath, deltaTooLarge: false };
 }
 
 export async function cleanupDeltaGCSFile({
@@ -2596,5 +2606,22 @@ export async function isMicrosoftFullSyncRunning(
       return false;
     }
     throw e;
+  }
+}
+
+export async function launchMicrosoftFullSyncForDrive({
+  connectorId,
+  rootNodeIds,
+}: {
+  connectorId: ModelId;
+  rootNodeIds: string[];
+}): Promise<void> {
+  const res = await launchMicrosoftFullSyncWorkflow(
+    connectorId,
+    rootNodeIds,
+    []
+  );
+  if (res.isErr()) {
+    throw res.error;
   }
 }

--- a/connectors/src/connectors/microsoft/temporal/config.ts
+++ b/connectors/src/connectors/microsoft/temporal/config.ts
@@ -1,2 +1,2 @@
-const WORKFLOW_VERSION = 2;
+const WORKFLOW_VERSION = 3;
 export const QUEUE_NAME = `microsoft-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -21,6 +21,7 @@ const {
   groupRootItemsByDriveId,
   isMicrosoftFullSyncRunning,
   reconcileSensitivityLabelsForParent,
+  launchMicrosoftFullSyncForDrive,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
 });
@@ -230,12 +231,19 @@ export async function incrementalSyncWorkflowV2({
 
   const startSyncTs = new Date().getTime();
   for (const nodeId of Object.keys(groupedItems)) {
+    const rootNodeIds = groupedItems[nodeId] as string[];
     // Step 1: Fetch delta data and upload to GCS
-    const { gcsFilePath } = await fetchDeltaForRootNodesInDrive({
+    const { gcsFilePath, deltaTooLarge } = await fetchDeltaForRootNodesInDrive({
       connectorId,
       driveId: nodeId,
-      rootNodeIds: groupedItems[nodeId] as string[],
+      rootNodeIds,
     });
+
+    if (deltaTooLarge) {
+      await populateDeltas(connectorId, rootNodeIds);
+      await launchMicrosoftFullSyncForDrive({ connectorId, rootNodeIds });
+      continue;
+    }
 
     // Skip processing if no delta data was fetched
     if (!gcsFilePath) {


### PR DESCRIPTION
## Description

Cutoff the Microsoft connector's delta items to 500k items in the changelog, after which we stop the incremental and launch a full sync.


1. When we process a delta, we need to process the full changelog (which can be millions of changes in some cases) before we can determine each file's latest version.
2. This can cause OOM in workers, or very long activity that do not heartbeat for more than 2 hours, both resulting in connector stalling.

This PR aims at fixing that by applying a threshold after which we stop the incremental sync, and start a fullsync on the drive.
Fullsync are more memory efficient (but slower) 


## Tests

N/A

## Risk

Low

## Deploy Plan

- [ ] Deploy connector