### PR TITLE
Track more blog articles properties

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -271,14 +271,19 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
         }
         event.properties["user_agent"] = navigator.userAgent;
 
-        // Inject blog SEO article flag from page-level meta tag.
+        // Inject blog article classification flags from page-level meta tags.
         if (event.event === "$pageview") {
-          const seoMeta = document.querySelector(
-            'meta[name="dust:is_seo_article"]'
-          );
-          if (seoMeta) {
-            event.properties["is_seo_article"] =
-              seoMeta.getAttribute("content") === "true";
+          const articleFlags = [
+            ["dust:is_seo_article", "is_seo_article"],
+            ["dust:is_geo_article", "is_geo_article"],
+            ["dust:is_thought_leadership", "is_thought_leadership"],
+          ] as const;
+          for (const [metaName, propertyName] of articleFlags) {
+            const meta = document.querySelector(`meta[name="${metaName}"]`);
+            if (meta) {
+              event.properties[propertyName] =
+                meta.getAttribute("content") === "true";
+            }
           }
         }
 

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -643,6 +643,12 @@ function contentfulEntryToBlogPost(
   const isSeoArticleField = fields.isSeoArticle;
   const isSeoArticle =
     typeof isSeoArticleField === "boolean" && isSeoArticleField;
+  const isGeoArticleField = fields.isGeoArticle;
+  const isGeoArticle =
+    typeof isGeoArticleField === "boolean" && isGeoArticleField;
+  const isThoughtLeadershipField = fields.isThoughtLeadership;
+  const isThoughtLeadership =
+    typeof isThoughtLeadershipField === "boolean" && isThoughtLeadershipField;
 
   return {
     id: sys.id,
@@ -656,6 +662,8 @@ function contentfulEntryToBlogPost(
     createdAt: publishedAt,
     updatedAt: sys.updatedAt,
     isSeoArticle,
+    isGeoArticle,
+    isThoughtLeadership,
   };
 }
 
@@ -669,6 +677,8 @@ function contentfulEntryToBlogPostSummary(post: BlogPost): BlogPostSummary {
     image: post.image,
     createdAt: post.createdAt,
     isSeoArticle: post.isSeoArticle,
+    isGeoArticle: post.isGeoArticle,
+    isThoughtLeadership: post.isThoughtLeadership,
   };
 }
 

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -18,6 +18,8 @@ export interface BlogPageFields {
   publishedAt?: string;
   authors?: Entry<AuthorSkeleton>[];
   isSeoArticle?: boolean;
+  isGeoArticle?: boolean;
+  isThoughtLeadership?: boolean;
 }
 
 export type BlogPageSkeleton = EntrySkeletonType<BlogPageFields, "blogPage">;
@@ -46,6 +48,8 @@ export interface BlogPost {
   createdAt: string;
   updatedAt: string;
   isSeoArticle: boolean;
+  isGeoArticle: boolean;
+  isThoughtLeadership: boolean;
 }
 
 export interface BlogPostSummary {
@@ -57,6 +61,8 @@ export interface BlogPostSummary {
   image: BlogImage | null;
   createdAt: string;
   isSeoArticle: boolean;
+  isGeoArticle: boolean;
+  isThoughtLeadership: boolean;
 }
 
 export interface BlogListingPageProps {

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -134,6 +134,11 @@ export default function BlogPost({
           <meta key={tag} property="article:tag" content={tag} />
         ))}
         <meta name="dust:is_seo_article" content={String(post.isSeoArticle)} />
+        <meta name="dust:is_geo_article" content={String(post.isGeoArticle)} />
+        <meta
+          name="dust:is_thought_leadership"
+          content={String(post.isThoughtLeadership)}
+        />
 
         <script
           type="application/ld+json"

--- a/front/pages/blog/index.tsx
+++ b/front/pages/blog/index.tsx
@@ -81,13 +81,14 @@ export default function BlogListing({ posts }: BlogListingPageProps) {
     return posts.filter((post) => post.tags.includes(selectedTag));
   }, [posts, selectedTag]);
 
-  // Split into regular and SEO articles.
+  // SEO and GEO articles are surfaced in the "Further reading" list rather
+  // than the main grid. Thought-leadership posts stay in the main grid.
   const regularPosts = useMemo(
-    () => filteredPosts.filter((p) => !p.isSeoArticle),
+    () => filteredPosts.filter((p) => !p.isSeoArticle && !p.isGeoArticle),
     [filteredPosts]
   );
-  const seoPosts = useMemo(
-    () => filteredPosts.filter((p) => p.isSeoArticle),
+  const furtherReadingPosts = useMemo(
+    () => filteredPosts.filter((p) => p.isSeoArticle || p.isGeoArticle),
     [filteredPosts]
   );
 
@@ -121,9 +122,10 @@ export default function BlogListing({ posts }: BlogListingPageProps) {
   );
 
   const seoStartIndex = (currentPage - 1) * SEO_PAGE_SIZE;
-  const paginatedSeoPosts = useMemo(
-    () => seoPosts.slice(seoStartIndex, seoStartIndex + SEO_PAGE_SIZE),
-    [seoPosts, seoStartIndex]
+  const paginatedFurtherReadingPosts = useMemo(
+    () =>
+      furtherReadingPosts.slice(seoStartIndex, seoStartIndex + SEO_PAGE_SIZE),
+    [furtherReadingPosts, seoStartIndex]
   );
 
   const showFeatured = featuredPost && currentPage === 1;
@@ -177,7 +179,7 @@ export default function BlogListing({ posts }: BlogListingPageProps) {
           </div>
         )}
 
-        <SeoArticleList posts={paginatedSeoPosts} />
+        <SeoArticleList posts={paginatedFurtherReadingPosts} />
       </BlogLayout>
     </>
   );

--- a/front/pages/blog/page/[page].tsx
+++ b/front/pages/blog/page/[page].tsx
@@ -23,7 +23,7 @@ import type { ReactElement } from "react";
 
 interface BlogPageProps {
   posts: BlogPostSummary[];
-  seoPosts: BlogPostSummary[];
+  furtherReadingPosts: BlogPostSummary[];
   currentPage: number;
   totalPages: number;
   totalPosts: number;
@@ -73,9 +73,14 @@ export const getStaticProps: GetStaticProps<BlogPageProps> = async ({
 
   const allPosts = result.value;
 
-  // Split into regular and SEO articles.
-  const regularPosts = allPosts.filter((post) => !post.isSeoArticle);
-  const seoPosts = allPosts.filter((post) => post.isSeoArticle);
+  // SEO and GEO articles are surfaced in the "Further reading" list rather
+  // than the main grid. Thought-leadership posts stay in the main grid.
+  const regularPosts = allPosts.filter(
+    (post) => !post.isSeoArticle && !post.isGeoArticle
+  );
+  const furtherReadingPosts = allPosts.filter(
+    (post) => post.isSeoArticle || post.isGeoArticle
+  );
 
   // Extract all tags.
   const tagSet = new Set<string>();
@@ -99,7 +104,7 @@ export const getStaticProps: GetStaticProps<BlogPageProps> = async ({
   const startIndex = (page - 1) * BLOG_PAGE_SIZE;
   const posts = remainingPosts.slice(startIndex, startIndex + BLOG_PAGE_SIZE);
   const seoStartIndex = (page - 1) * SEO_PAGE_SIZE;
-  const paginatedSeoPosts = seoPosts.slice(
+  const paginatedFurtherReadingPosts = furtherReadingPosts.slice(
     seoStartIndex,
     seoStartIndex + SEO_PAGE_SIZE
   );
@@ -107,7 +112,7 @@ export const getStaticProps: GetStaticProps<BlogPageProps> = async ({
   return {
     props: {
       posts,
-      seoPosts: paginatedSeoPosts,
+      furtherReadingPosts: paginatedFurtherReadingPosts,
       currentPage: page,
       totalPages,
       totalPosts: remainingPosts.length,
@@ -121,7 +126,7 @@ export const getStaticProps: GetStaticProps<BlogPageProps> = async ({
 // biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
 export default function BlogPage({
   posts,
-  seoPosts,
+  furtherReadingPosts,
   currentPage,
   totalPages,
   totalPosts,
@@ -191,7 +196,7 @@ export default function BlogPage({
           </div>
         )}
 
-        <SeoArticleList posts={seoPosts} />
+        <SeoArticleList posts={furtherReadingPosts} />
       </BlogLayout>
     </>
   );


### PR DESCRIPTION
 ## Description 

Same setup as #23748, but for other types of articles. New booleans on the `blogPage` content type, surfaced as `dust:is_geo_article` and `dust:is_thought_leadership` meta tags, then picked up by PostHog on `$pageview` as `is_geo_article` / `is_thought_leadership` properties. 

Also peels GEO articles out of the main grid on `/blog` and folds them into the existing "Further reading" list alongside SEO. 

Extends PostHog tracking for those types.

## Tests

Tested locally against prod Contentful:

## Risk

Low. Field reads are guarded by `typeof === "boolean"` so missing/unset Contentful fields fall back to `false`, matching today's behavior. Easy rollback.

## Deploy Plan

N/A
