### PR TITLE
refactor(projects): remove status from takeaway action items

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/project_task_details.ts
+++ b/front/lib/api/poke/plugins/workspaces/project_task_details.ts
@@ -98,7 +98,7 @@ export const projectTodoDetailsPlugin = createPlugin({
                 (item) => item.sId === src.itemId
               );
               const itemDetail = actionItem
-                ? `\n  - _"${actionItem.shortDescription}"_ (status: \`${actionItem.status}\`)`
+                ? `\n  - _"${actionItem.shortDescription}"_`
                 : `\n  - _item \`${src.itemId}\` not found in takeaway_`;
 
               return `- ${label}${itemDetail}`;

--- a/front/lib/project_task/analyze_document/action_items.test.ts
+++ b/front/lib/project_task/analyze_document/action_items.test.ts
@@ -14,9 +14,6 @@ function makePrev(
     shortDescription: "Existing task",
     assigneeUserId: null,
     assigneeName: null,
-    status: "open",
-    detectedDoneAt: null,
-    detectedDoneRationale: null,
     detectedCreationRationale: null,
     ...overrides,
   };
@@ -46,9 +43,6 @@ describe("buildActionItems — new items", () => {
     expect(result[0].shortDescription).toBe("Review PR");
     expect(result[0].assigneeName).toBe("Alice");
     expect(result[0].assigneeUserId).toBe("user-abc");
-    expect(result[0].status).toBe("open");
-    expect(result[0].detectedDoneAt).toBeNull();
-    expect(result[0].detectedDoneRationale).toBeNull();
     expect(result[0].detectedCreationRationale).toBe(
       "Alice committed to reviewing the PR"
     );
@@ -157,58 +151,6 @@ describe("buildActionItems — updated items", () => {
     expect(result[0].assigneeName).toBe("Bob");
   });
 
-  it("transitions an open item to done and sets detectedDoneAt to now", () => {
-    const before = new Date().toISOString();
-    const prev = makePrev({ status: "open" });
-    const result = buildActionItems(
-      {
-        newItems: [],
-        updatedItems: [
-          {
-            sId: prev.sId,
-            done: { detected_done_rationale: "User confirmed it shipped" },
-          },
-        ],
-      },
-      [prev],
-      new Set(),
-      logger
-    );
-    const after = new Date().toISOString();
-
-    expect(result[0].status).toBe("done");
-    expect(result[0].detectedDoneAt).not.toBeNull();
-    expect(result[0].detectedDoneAt! >= before).toBe(true);
-    expect(result[0].detectedDoneAt! <= after).toBe(true);
-    expect(result[0].detectedDoneRationale).toBe("User confirmed it shipped");
-  });
-
-  it("does not overwrite detectedDoneAt when an item is already done", () => {
-    const prev = makePrev({
-      status: "done",
-      detectedDoneAt: "2024-01-01T00:00:00.000Z",
-      detectedDoneRationale: "Original rationale",
-    });
-    const result = buildActionItems(
-      {
-        newItems: [],
-        updatedItems: [
-          {
-            sId: prev.sId,
-            done: { detected_done_rationale: "Mentioned again" },
-          },
-        ],
-      },
-      [prev],
-      new Set(),
-      logger
-    );
-
-    expect(result[0].status).toBe("done");
-    expect(result[0].detectedDoneAt).toBe("2024-01-01T00:00:00.000Z");
-    expect(result[0].detectedDoneRationale).toBe("Mentioned again");
-  });
-
   it("drops updates referencing an unknown sId", () => {
     const prev = makePrev({ sId: "prev-1" });
     const result = buildActionItems(
@@ -244,9 +186,6 @@ describe("buildPromptActionItems", () => {
         shortDescription: "Refactor auth",
         assigneeName: "Bob",
         assigneeUserId: null,
-        status: "open",
-        detectedDoneAt: null,
-        detectedDoneRationale: null,
         detectedCreationRationale: null,
       },
       {
@@ -254,19 +193,16 @@ describe("buildPromptActionItems", () => {
         shortDescription: "Ship feature",
         assigneeName: null,
         assigneeUserId: null,
-        status: "done",
-        detectedDoneAt: "2024-01-01T00:00:00.000Z",
-        detectedDoneRationale: null,
         detectedCreationRationale: null,
       },
     ];
     const prompt = buildPromptActionItems(items);
     expect(prompt).toContain("Previously tracked action items");
     expect(prompt).toContain(
-      `<action_item sId="abc" status="open"><short_description>Refactor auth</short_description><assignee name="Bob" /></action_item>`
+      `<action_item sId="abc"><short_description>Refactor auth</short_description><assignee name="Bob" /></action_item>`
     );
     expect(prompt).toContain(
-      `<action_item sId="def" status="done"><short_description>Ship feature</short_description></action_item>`
+      `<action_item sId="def"><short_description>Ship feature</short_description></action_item>`
     );
   });
 });

--- a/front/lib/project_task/analyze_document/action_items.test.ts
+++ b/front/lib/project_task/analyze_document/action_items.test.ts
@@ -48,7 +48,7 @@ describe("buildActionItems — new items", () => {
     );
   });
 
-  it("drops new items whose assignee is not a project member", () => {
+  it("keeps new items whose assignee is not a project member, but clears the assignee", () => {
     const result = buildActionItems(
       {
         newItems: [
@@ -66,7 +66,32 @@ describe("buildActionItems — new items", () => {
       logger
     );
 
-    expect(result).toEqual([]);
+    expect(result).toHaveLength(1);
+    expect(result[0].shortDescription).toBe("Call client");
+    expect(result[0].assigneeUserId).toBeNull();
+    expect(result[0].assigneeName).toBeNull();
+  });
+
+  it("appends a new item with no assignee when assignee fields are absent", () => {
+    const result = buildActionItems(
+      {
+        newItems: [
+          {
+            short_description: "Update the deployment docs",
+            detected_creation_rationale: "Team agreed docs were out of date",
+          },
+        ],
+        updatedItems: [],
+      },
+      [],
+      new Set(["user-abc"]),
+      logger
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].shortDescription).toBe("Update the deployment docs");
+    expect(result[0].assigneeUserId).toBeNull();
+    expect(result[0].assigneeName).toBeNull();
   });
 });
 

--- a/front/lib/project_task/analyze_document/action_items.ts
+++ b/front/lib/project_task/analyze_document/action_items.ts
@@ -25,7 +25,6 @@ export function buildActionItems(
   validUserIds: Set<string>,
   localLogger: Logger
 ): TodoVersionedActionItem[] {
-  const now = new Date().toISOString();
   const updatesBySId = new Map(updatedItems.map((u) => [u.sId, u]));
 
   const merged: TodoVersionedActionItem[] = previousItems.map((prev) => {
@@ -41,8 +40,6 @@ export function buildActionItems(
         ? update.assignee
         : null;
 
-    const transitioningToDone = update.done && prev.status !== "done";
-
     return {
       sId: prev.sId,
       shortDescription: update.short_description ?? prev.shortDescription,
@@ -52,10 +49,6 @@ export function buildActionItems(
       assigneeName: validAssigneeChange
         ? validAssigneeChange.name
         : prev.assigneeName,
-      status: update.done ? "done" : prev.status,
-      detectedDoneAt: transitioningToDone ? now : prev.detectedDoneAt,
-      detectedDoneRationale:
-        update.done?.detected_done_rationale ?? prev.detectedDoneRationale,
       detectedCreationRationale: prev.detectedCreationRationale,
     };
   });
@@ -77,9 +70,6 @@ export function buildActionItems(
       shortDescription: item.short_description,
       assigneeUserId: item.assignee_user_id,
       assigneeName: item.assignee_name,
-      status: "open",
-      detectedDoneAt: null,
-      detectedDoneRationale: null,
       detectedCreationRationale: item.detected_creation_rationale,
     });
   }
@@ -99,8 +89,7 @@ export function buildPromptActionItems(
     "2. **Commitment**: someone explicitly committed to doing a concrete task, or was " +
     "clearly asked to do one. Only extract tasks with a clear deliverable — 'I'll fix X' " +
     "qualifies, 'I'll think about it' does not.\n" +
-    "3. **Durability**: the task is still relevant — if it was already resolved within " +
-    "the same conversation, mark it done; if the request was immediately " +
+    "3. **Durability**: the task is still relevant — if the request was immediately " +
     "fulfilled inline (e.g., answering a question), do not extract it at all.\n" +
     "4. **Distinctness**: it is not a duplicate of another action item or a rephrasing " +
     "5. **Relevance**: the task is work-related and project-relevant. Purely social plans " +
@@ -116,8 +105,6 @@ export function buildPromptActionItems(
     "- Place changes to previously tracked items in `updated_action_items`, keyed by their sId. " +
     "Only include fields that materially changed in this document; omit unchanged fields. " +
     "Do not include items that have not changed at all.\n" +
-    "- Mark an item as done by setting the `done` object with a brief rationale. Items can only " +
-    "transition to done; never back to open.\n" +
     "- Be concise: one action item per distinct task.\n" +
     "- Make descriptions self-sufficient: include both the action AND its subject so the item is understandable without opening the source document. Prefer specific over vague — not 'Fix the bug' but 'Fix crash in batchRenderMessages when agent config is unavailable'; not 'Review PR' but 'Review PR #24679 — improves takeaway extraction prompts'.\n" +
     "- In the description, mention other users and agents by their name, NOT via their id or via a generic term like User, Agent or Bot.\n" +
@@ -127,7 +114,7 @@ export function buildPromptActionItems(
       "Previously tracked action items — ALREADY RECORDED, do NOT re-add to `new_action_items`. " +
       "Only reference in `updated_action_items` if this document explicitly changes them:\n";
     for (const item of previousActionItems) {
-      prompt += `<action_item sId="${item.sId}" status="${item.status}">`;
+      prompt += `<action_item sId="${item.sId}">`;
       prompt += `<short_description>${item.shortDescription}</short_description>`;
       if (item.assigneeName) {
         prompt += `<assignee name="${item.assigneeName}"`;

--- a/front/lib/project_task/analyze_document/action_items.ts
+++ b/front/lib/project_task/analyze_document/action_items.ts
@@ -54,22 +54,26 @@ export function buildActionItems(
   });
 
   for (const item of newItems) {
-    if (!validUserIds.has(item.assignee_user_id)) {
+    const hasValidAssignee =
+      item.assignee_user_id !== undefined &&
+      validUserIds.has(item.assignee_user_id);
+
+    if (item.assignee_user_id !== undefined && !hasValidAssignee) {
       localLogger.warn(
         {
           assigneeUserId: item.assignee_user_id,
           assigneeName: item.assignee_name,
           shortDescription: item.short_description,
         },
-        "Document takeaway: dropping new action item with unknown assignee"
+        "Document takeaway: new action item has unknown assignee, keeping as unassigned"
       );
-      continue;
     }
+
     merged.push({
       sId: uuidv4(),
       shortDescription: item.short_description,
-      assigneeUserId: item.assignee_user_id,
-      assigneeName: item.assignee_name,
+      assigneeUserId: hasValidAssignee ? (item.assignee_user_id ?? null) : null,
+      assigneeName: hasValidAssignee ? (item.assignee_name ?? null) : null,
       detectedCreationRationale: item.detected_creation_rationale,
     });
   }
@@ -97,8 +101,8 @@ export function buildPromptActionItems(
     "commits to arranging them.\n\n" +
     "Output rules:\n" +
     "- Place brand-new action items (not already in the tracked list below) in `new_action_items`. " +
-    "They MUST have a clear assignee matching one of the project members; if you cannot identify " +
-    "a project member as assignee, do not extract the item.\n" +
+    "Set `assignee_user_id` and `assignee_name` only when you can confidently identify a project " +
+    "member as the owner; leave both fields absent when the assignee is unclear or not a project member.\n" +
     "- **Never re-extract tracked items**: any item already listed under 'Previously tracked' below is " +
     "already recorded. Do NOT put it in `new_action_items` even if you see it in the document — " +
     "doing so creates a duplicate. If nothing changed, omit it entirely.\n" +

--- a/front/lib/project_task/analyze_document/types.ts
+++ b/front/lib/project_task/analyze_document/types.ts
@@ -61,16 +61,6 @@ const UpdatedActionItemSchema = z.object({
     .describe(
       "Set together when the assignee changes. Both fields are required when present; omit otherwise."
     ),
-  done: z
-    .object({
-      detected_done_rationale: z
-        .string()
-        .describe("Brief explanation of why the item is considered done."),
-    })
-    .optional()
-    .describe(
-      "Set only when the item was explicitly resolved in the document. Items can only transition to done; never back to open."
-    ),
 });
 
 export type UpdatedActionItem = z.infer<typeof UpdatedActionItemSchema>;

--- a/front/lib/project_task/analyze_document/types.ts
+++ b/front/lib/project_task/analyze_document/types.ts
@@ -6,10 +6,11 @@ export const EXTRACT_DOCUMENT_TAKEAWAYS_FUNCTION_NAME =
 export const MIN_SHORT_DESCRIPTION_LENGTH = 16;
 export const MAX_SHORT_DESCRIPTION_LENGTH = 256;
 
-// New items require an assignee_user_id matching a known project member. Items
-// whose assignee cannot be resolved to a project member are intentionally
-// dropped — we'd rather miss an item than track one we can't route to a real
-// user, since the assignee drives downstream notifications and ownership.
+// Assignee fields are optional: if the document does not name a clear project
+// member as owner, the item is still created without an assignee rather than
+// being dropped. When assignee_user_id is provided it must match a known
+// project member id — unresolvable ids are cleared and the item is kept
+// unassigned.
 const NewActionItemSchema = z.object({
   short_description: z
     .string()
@@ -18,11 +19,13 @@ const NewActionItemSchema = z.object({
     .describe("Short description of the action item."),
   assignee_name: z
     .string()
+    .optional()
     .describe("Name of the assignee, as it appears in the document."),
   assignee_user_id: z
     .string()
+    .optional()
     .describe(
-      "The participant id of the assigned person. Must be one of the participant ids listed in the prompt."
+      "The participant id of the assigned person. Must be one of the participant ids listed in the prompt. Omit if no project member can be identified as assignee."
     ),
   detected_creation_rationale: z
     .string()

--- a/front/lib/project_task/merge_into_project.test.ts
+++ b/front/lib/project_task/merge_into_project.test.ts
@@ -190,6 +190,7 @@ describe("createOrLinkTodos", () => {
           source: makeSource(),
         },
       ],
+      unassignedCandidates: [],
       dedupGroups: [group],
       spaceModelId: 1 as ModelId,
     });
@@ -235,6 +236,7 @@ describe("createOrLinkTodos", () => {
           source: makeSource(),
         },
       ],
+      unassignedCandidates: [],
       dedupGroups: [group],
       spaceModelId: 1 as ModelId,
     });

--- a/front/lib/project_task/merge_into_project.test.ts
+++ b/front/lib/project_task/merge_into_project.test.ts
@@ -4,18 +4,13 @@ import {
   actionItemBlob,
   collectDocumentCandidates,
   createOrLinkTodos,
-  updateTodoIfChanged,
 } from "@app/lib/project_task/merge_into_project";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { TakeawaysWithSource } from "@app/lib/resources/takeaways_resource";
 import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import type {
-  ProjectTaskActorType,
-  ProjectTaskSourceInfo,
-  ProjectTaskStatus,
-} from "@app/types/project_task";
+import type { ProjectTaskSourceInfo } from "@app/types/project_task";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { TodoVersionedActionItem } from "@app/types/takeaways";
 import type { Logger } from "pino";
@@ -31,9 +26,6 @@ function makeActionItem(
     shortDescription: "Write the report",
     assigneeUserId: null,
     assigneeName: null,
-    status: "open",
-    detectedDoneAt: null,
-    detectedDoneRationale: null,
     detectedCreationRationale: null,
     ...overrides,
   };
@@ -54,34 +46,18 @@ function makeSource(
 // ── actionItemBlob ────────────────────────────────────────────────────────────
 
 describe("actionItemBlob", () => {
-  it("maps open status to todo", () => {
-    const blob = actionItemBlob(makeActionItem({ status: "open" }));
-    expect(blob.status).toBe("todo");
-    expect(blob.doneAt).toBeNull();
-  });
-
-  it("maps done status to done and parses detectedDoneAt", () => {
-    const doneAt = "2024-06-15T10:00:00.000Z";
-    const blob = actionItemBlob(
-      makeActionItem({ status: "done", detectedDoneAt: doneAt })
-    );
-    expect(blob.status).toBe("done");
-    expect(blob.doneAt).toEqual(new Date(doneAt));
-  });
-
-  it("sets doneAt to null when done but detectedDoneAt is absent", () => {
-    const blob = actionItemBlob(
-      makeActionItem({ status: "done", detectedDoneAt: null })
-    );
-    expect(blob.status).toBe("done");
-    expect(blob.doneAt).toBeNull();
-  });
-
-  it("preserves shortDescription", () => {
+  it("preserves shortDescription as text", () => {
     const blob = actionItemBlob(
       makeActionItem({ shortDescription: "Deploy to prod" })
     );
     expect(blob.text).toBe("Deploy to prod");
+  });
+
+  it("forwards detectedCreationRationale as reasoningCreatedAt", () => {
+    const blob = actionItemBlob(
+      makeActionItem({ detectedCreationRationale: "Alice committed to it" })
+    );
+    expect(blob.reasoningCreatedAt).toBe("Alice committed to it");
   });
 });
 
@@ -125,21 +101,19 @@ describe("collectDocumentCandidates", () => {
       makeActionItem({
         sId: "item-new",
         assigneeUserId: user.sId,
-        status: "open",
       }),
     ]);
 
-    const { candidates, existingUpdated } = await collectDocumentCandidates(
-      auth,
-      { takeawayWithSource: tws, usersById }
-    );
+    const candidates = await collectDocumentCandidates(auth, {
+      takeawayWithSource: tws,
+      usersById,
+    });
 
     expect(candidates).toHaveLength(1);
     expect(candidates[0].itemId).toBe("item-new");
-    expect(existingUpdated).toBe(0);
   });
 
-  it("updates the existing agent-created todo and returns no candidate when status changed", async () => {
+  it("skips items already linked to a todo and returns no candidate", async () => {
     const todo = await ProjectTaskResource.makeNew(auth, {
       spaceId: takeawayBase.spaceId,
       userId: user.id,
@@ -161,323 +135,23 @@ describe("collectDocumentCandidates", () => {
       makeActionItem({
         sId: "item-existing",
         assigneeUserId: user.sId,
-        status: "done",
-        detectedDoneAt: "2026-05-01T10:00:00.000Z",
       }),
     ]);
 
-    const { candidates, existingUpdated } = await collectDocumentCandidates(
-      auth,
-      { takeawayWithSource: tws, usersById }
-    );
+    const candidates = await collectDocumentCandidates(auth, {
+      takeawayWithSource: tws,
+      usersById,
+    });
 
     expect(candidates).toHaveLength(0);
-    expect(existingUpdated).toBe(1);
     const refreshed = await ProjectTaskResource.fetchBySId(auth, todo.sId);
-    expect(refreshed?.status).toBe("done");
-  });
-
-  it("skips entirely when multiple existing todos are present and any is done", async () => {
-    const spaceId = takeawayBase.spaceId;
-    const agentBlob = {
-      spaceId,
-      userId: user.id,
-      createdByType: "agent" as const,
-      createdByUserId: null,
-      createdByAgentConfigurationId: "butler",
-      markedAsDoneByType: null,
-      markedAsDoneByUserId: null,
-      markedAsDoneByAgentConfigurationId: null,
-      text: "Multi item",
-      status: "todo" as const,
-      doneAt: null,
-      actorRationale: null,
-      agentInstructions: null,
-    };
-
-    const doneTodo = await ProjectTaskResource.makeNew(auth, {
-      ...agentBlob,
-      status: "done",
-      doneAt: new Date("2026-04-01T00:00:00.000Z"),
-    });
-    await doneTodo.upsertSource(auth, {
-      itemId: "item-multi-done",
-      source: { ...source, sourceId: "src-done" },
-    });
-
-    const openTodo = await ProjectTaskResource.makeNew(auth, agentBlob);
-    await openTodo.upsertSource(auth, {
-      itemId: "item-multi-done",
-      source: { ...source, sourceId: "src-open" },
-    });
-
-    const tws = makeTakeawayWithSource([
-      makeActionItem({
-        sId: "item-multi-done",
-        assigneeUserId: user.sId,
-        status: "done",
-        detectedDoneAt: "2026-05-01T00:00:00.000Z",
-      }),
-    ]);
-
-    const { candidates, existingUpdated } = await collectDocumentCandidates(
-      auth,
-      { takeawayWithSource: tws, usersById }
-    );
-
-    expect(candidates).toHaveLength(0);
-    expect(existingUpdated).toBe(0);
-  });
-
-  it("updates only the most recently created todo when multiple exist and none is done", async () => {
-    const spaceId = takeawayBase.spaceId;
-    const agentBlob = {
-      spaceId,
-      userId: user.id,
-      createdByType: "agent" as const,
-      createdByUserId: null,
-      createdByAgentConfigurationId: "butler",
-      markedAsDoneByType: null,
-      markedAsDoneByUserId: null,
-      markedAsDoneByAgentConfigurationId: null,
-      text: "Multi open item",
-      status: "todo" as const,
-      doneAt: null,
-      actorRationale: null,
-      agentInstructions: null,
-    };
-
-    const olderTodo = await ProjectTaskResource.makeNew(auth, agentBlob);
-    await olderTodo.upsertSource(auth, {
-      itemId: "item-multi-open",
-      source: { ...source, sourceId: "src-older" },
-    });
-
-    const newerTodo = await ProjectTaskResource.makeNew(auth, agentBlob);
-    await newerTodo.upsertSource(auth, {
-      itemId: "item-multi-open",
-      source: { ...source, sourceId: "src-newer" },
-    });
-
-    const tws = makeTakeawayWithSource([
-      makeActionItem({
-        sId: "item-multi-open",
-        assigneeUserId: user.sId,
-        status: "done",
-        detectedDoneAt: "2026-05-01T00:00:00.000Z",
-      }),
-    ]);
-
-    const { candidates, existingUpdated } = await collectDocumentCandidates(
-      auth,
-      { takeawayWithSource: tws, usersById }
-    );
-
-    expect(candidates).toHaveLength(0);
-    expect(existingUpdated).toBe(1);
-
-    const olderRefreshed = await ProjectTaskResource.fetchBySId(
-      auth,
-      olderTodo.sId
-    );
-    const newerRefreshed = await ProjectTaskResource.fetchBySId(
-      auth,
-      newerTodo.sId
-    );
-    // The newer todo (higher createdAt) should have been updated to done.
-    expect(newerRefreshed?.status).toBe("done");
-    expect(olderRefreshed?.status).toBe("todo");
-  });
-});
-
-// ── updateTodoIfChanged ───────────────────────────────────────────────────────
-
-type TodoStub = {
-  createdByType: ProjectTaskActorType;
-  markedAsDoneByType: ProjectTaskActorType | null;
-  text: string;
-  status: ProjectTaskStatus;
-  doneAt: Date | null;
-  actorRationale: string | null;
-  updateWithVersion: ReturnType<typeof vi.fn>;
-};
-
-function makeTodoStub(overrides: Partial<TodoStub> = {}): TodoStub {
-  return {
-    createdByType: "agent",
-    markedAsDoneByType: null,
-    text: "Write the report",
-    status: "todo",
-    doneAt: null,
-    actorRationale: null,
-    updateWithVersion: vi.fn().mockResolvedValue(undefined),
-    ...overrides,
-  };
-}
-
-function makeBlob(
-  overrides: Partial<{
-    text: string;
-    status: "todo" | "done";
-    doneAt: Date | null;
-    reasoningDoneAt: string | null;
-    reasoningCreatedAt: string | null;
-  }> = {}
-) {
-  return {
-    text: "Write the report",
-    status: "todo" as const,
-    doneAt: null,
-    reasoningDoneAt: null,
-    reasoningCreatedAt: null,
-    ...overrides,
-  };
-}
-
-// Auth is not touched on the early-return paths; on the update path it is
-// forwarded to updateWithVersion, which is a spy here.
-const fakeAuth = {} as Authenticator;
-
-describe("updateTodoIfChanged", () => {
-  it("returns false and does not update a user-created todo even when content changed", async () => {
-    const todo = makeTodoStub({ createdByType: "user", text: "Old text" });
-    const blob = makeBlob({ text: "New text" });
-
-    const updated = await updateTodoIfChanged(
-      todo as unknown as ProjectTaskResource,
-      fakeAuth,
-      blob
-    );
-
-    expect(updated).toBe(false);
-    expect(todo.updateWithVersion).not.toHaveBeenCalled();
-  });
-
-  it("returns false and does not update an agent-created todo that was marked done by a user", async () => {
-    // Concrete scenario: agent created the todo, user marked it done, next
-    // extraction still sees the underlying item as open. The user's completion
-    // must stick — no revert.
-    const todo = makeTodoStub({
-      createdByType: "agent",
-      markedAsDoneByType: "user",
-      status: "done",
-      doneAt: new Date("2026-04-20T10:00:00.000Z"),
-    });
-    const blob = makeBlob({ status: "todo", doneAt: null });
-
-    const updated = await updateTodoIfChanged(
-      todo as unknown as ProjectTaskResource,
-      fakeAuth,
-      blob
-    );
-
-    expect(updated).toBe(false);
-    expect(todo.updateWithVersion).not.toHaveBeenCalled();
-  });
-
-  it("returns false when nothing changed on an agent-created todo", async () => {
-    const todo = makeTodoStub({
-      text: "Write the report",
-      status: "todo",
-      doneAt: null,
-    });
-    const blob = makeBlob({
-      text: "Write the report",
-      status: "todo",
-      doneAt: null,
-    });
-
-    const updated = await updateTodoIfChanged(
-      todo as unknown as ProjectTaskResource,
-      fakeAuth,
-      blob
-    );
-
-    expect(updated).toBe(false);
-    expect(todo.updateWithVersion).not.toHaveBeenCalled();
-  });
-
-  it("ignores text changes on an agent-created todo (first version wins)", async () => {
-    const todo = makeTodoStub({ text: "Old text" });
-    const blob = makeBlob({ text: "New text" });
-
-    const updated = await updateTodoIfChanged(
-      todo as unknown as ProjectTaskResource,
-      fakeAuth,
-      blob
-    );
-
-    expect(updated).toBe(false);
-    expect(todo.updateWithVersion).not.toHaveBeenCalled();
-  });
-
-  it("preserves the original text when status changes on an agent-created todo", async () => {
-    const doneAt = new Date("2026-04-21T12:00:00.000Z");
-    const todo = makeTodoStub({ text: "Old text", status: "todo" });
-    const blob = makeBlob({
-      text: "New text",
-      status: "done",
-      doneAt,
-    });
-
-    const updated = await updateTodoIfChanged(
-      todo as unknown as ProjectTaskResource,
-      fakeAuth,
-      blob
-    );
-
-    expect(updated).toBe(true);
-    expect(todo.updateWithVersion).toHaveBeenCalledWith(fakeAuth, {
-      text: "Old text",
-      status: "done",
-      doneAt,
-      actorRationale: null,
-    });
-  });
-
-  it("updates an agent-created todo when the status flipped open→done (agent detection)", async () => {
-    const doneAt = new Date("2026-04-21T12:00:00.000Z");
-    const todo = makeTodoStub({ status: "todo", doneAt: null });
-    const blob = makeBlob({ status: "done", doneAt });
-
-    const updated = await updateTodoIfChanged(
-      todo as unknown as ProjectTaskResource,
-      fakeAuth,
-      blob
-    );
-
-    expect(updated).toBe(true);
-    expect(todo.updateWithVersion).toHaveBeenCalledWith(fakeAuth, {
-      text: "Write the report",
-      status: "done",
-      doneAt,
-      actorRationale: null,
-    });
-  });
-
-  it("returns false when the system tries to reopen a done todo (regardless of who marked it done)", async () => {
-    // The system must never flip a completed todo back to open — only a user
-    // can reopen a todo. This aplies even when the todo was marked done by an
-    // agent (not a user).
-    const todo = makeTodoStub({
-      markedAsDoneByType: "agent",
-      status: "done",
-      doneAt: new Date("2026-04-20T10:00:00.000Z"),
-    });
-    const blob = makeBlob({ status: "todo", doneAt: null });
-
-    const updated = await updateTodoIfChanged(
-      todo as unknown as ProjectTaskResource,
-      fakeAuth,
-      blob
-    );
-
-    expect(updated).toBe(false);
-    expect(todo.updateWithVersion).not.toHaveBeenCalled();
+    expect(refreshed?.status).toBe("todo");
   });
 });
 
 // ── createOrLinkTodos ─────────────────────────────────────────────────────────
+
+const fakeAuth = {} as Authenticator;
 
 const fakeLogger = {
   info: vi.fn(),
@@ -511,9 +185,6 @@ describe("createOrLinkTodos", () => {
           userId: 1 as ModelId,
           blob: {
             text: "Do the thing",
-            status: "todo",
-            doneAt: null,
-            reasoningDoneAt: null,
             reasoningCreatedAt: null,
           },
           source: makeSource(),
@@ -530,7 +201,6 @@ describe("createOrLinkTodos", () => {
 
   it("links source when the matched existing todo is not deleted", async () => {
     const upsertSource = vi.fn().mockResolvedValue(undefined);
-    const updateWithVersion = vi.fn().mockResolvedValue(undefined);
     const liveTodo = {
       deletedAt: null,
       sId: "todo-live",
@@ -542,7 +212,6 @@ describe("createOrLinkTodos", () => {
       actorRationale: null,
       userId: 1 as ModelId,
       upsertSource,
-      updateWithVersion,
     } as unknown as ProjectTaskResource;
 
     const group: DeduplicatedGroup = {
@@ -561,9 +230,6 @@ describe("createOrLinkTodos", () => {
           userId: 1 as ModelId,
           blob: {
             text: "Do the thing",
-            status: "todo",
-            doneAt: null,
-            reasoningDoneAt: null,
             reasoningCreatedAt: null,
           },
           source: makeSource(),

--- a/front/lib/project_task/merge_into_project.ts
+++ b/front/lib/project_task/merge_into_project.ts
@@ -8,8 +8,9 @@
 //   Phase 1 — Collect new candidates.
 //     For every (takeaway, item, targetUser) triple:
 //       - fetchByItemId(itemId):
-//           found     → update status/doneAt if changed (no new row, text
-//                       always preserved from the first version)
+//           found     → skip (the item is already linked to a todo; the
+//                       takeaway no longer carries any status that could
+//                       update it)
 //           not found → push to newCandidates[]
 //
 //   Phase 2 — Semantic deduplication.
@@ -21,15 +22,8 @@
 //
 //   Phase 3 — Create or link.
 //     For each candidate in newCandidates:
-//       - Key in dedupMap → addSource on existing todo.
-//           If existing todo is user-created: preserve text/status (user wins).
-//           If existing todo is agent-created: update status/doneAt if
-//           changed (text is always preserved from the first version).
-//       - Not in dedupMap → makeNew + addSource (current behaviour).
-//
-// Category mapping:
-//   actionItems  (open)    → "to_do",   status: "todo"
-//   actionItems  (done)    → "to_do",   status: "done"
+//       - Key in dedupMap → upsertSource on existing todo.
+//       - Not in dedupMap → makeNew + addSource.
 
 import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
@@ -50,7 +44,6 @@ import {
 } from "@app/lib/resources/takeaways_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import logger from "@app/logger/logger";
 import type { ProjectTaskSourceInfo } from "@app/types/project_task";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { TodoVersionedActionItem } from "@app/types/takeaways";
@@ -68,9 +61,6 @@ type PendingByUserId = Map<ModelId, Map<string, PendingCandidate>>;
 
 type TodoBlob = {
   text: string;
-  status: "todo" | "done";
-  doneAt: Date | null;
-  reasoningDoneAt: string | null;
   reasoningCreatedAt: string | null;
 };
 
@@ -88,7 +78,6 @@ export type PendingCandidate = {
 export type MergeStats = {
   takeawaysProcessed: number;
   candidatesCollected: number;
-  existingUpdated: number;
   deduplicated: number;
   createdNew: number;
 };
@@ -97,7 +86,6 @@ function emptyMergeStats(): MergeStats {
   return {
     takeawaysProcessed: 0,
     candidatesCollected: 0,
-    existingUpdated: 0,
     deduplicated: 0,
     createdNew: 0,
   };
@@ -150,16 +138,14 @@ export async function mergeTakeawaysIntoProject({
     allUserIds.size > 0 ? await UserResource.fetchByIds([...allUserIds]) : [];
   const usersById = new Map<string, UserResource>(users.map((u) => [u.sId, u]));
 
-  // ── Phase 1: collect new candidates, update already-linked items ──────────
+  // ── Phase 1: collect new candidates ──────────────────────────────────────
 
-  const { candidates: newCandidates, existingUpdated } =
-    await collectNewCandidates(adminAuth, {
-      latestTakeawaysWithSource,
-      usersById,
-    });
+  const newCandidates = await collectNewCandidates(adminAuth, {
+    latestTakeawaysWithSource,
+    usersById,
+  });
 
   stats.candidatesCollected = newCandidates.length;
-  stats.existingUpdated = existingUpdated;
 
   if (newCandidates.length === 0) {
     localLogger.info("Project todo merge: no new candidates found, skipping");
@@ -191,9 +177,9 @@ export async function mergeTakeawaysIntoProject({
 
 // ── Phase 1 ───────────────────────────────────────────────────────────────────
 
-// For each (takeaway, item, targetUser) triple: if a source link already exists,
-// update the todo's content if it has changed. Otherwise, push the item to the
-// returned candidates list for semantic dedup in phase 2.
+// For each (takeaway, item, targetUser) triple: skip if a source link already
+// exists, otherwise push the item to the returned candidates list for semantic
+// dedup in phase 2.
 async function collectNewCandidates(
   auth: Authenticator,
   {
@@ -203,28 +189,28 @@ async function collectNewCandidates(
     latestTakeawaysWithSource: TakeawaysWithSource[];
     usersById: Map<string, UserResource>;
   }
-): Promise<{ candidates: PendingCandidate[]; existingUpdated: number }> {
+): Promise<PendingCandidate[]> {
   const newCandidates: PendingCandidate[] = [];
-  let existingUpdated = 0;
 
   await concurrentExecutor(
     latestTakeawaysWithSource,
     async (takeawayWithSource) => {
-      const result = await collectDocumentCandidates(auth, {
+      const candidates = await collectDocumentCandidates(auth, {
         takeawayWithSource,
         usersById,
       });
-      newCandidates.push(...result.candidates);
-      existingUpdated += result.existingUpdated;
+      newCandidates.push(...candidates);
     },
     { concurrency: 4 }
   );
 
-  return { candidates: newCandidates, existingUpdated };
+  return newCandidates;
 }
 
-// Processes one document's takeaway: updates todos whose source link already
-// exists and returns items that need to go through dedup + creation.
+// Processes one document's takeaway: returns items that have no existing
+// source link and need to go through dedup + creation. Items already linked
+// to a todo are skipped — the takeaway no longer carries any state that
+// could update them.
 export async function collectDocumentCandidates(
   auth: Authenticator,
   {
@@ -234,7 +220,7 @@ export async function collectDocumentCandidates(
     takeawayWithSource: TakeawaysWithSource;
     usersById: Map<string, UserResource>;
   }
-): Promise<{ candidates: PendingCandidate[]; existingUpdated: number }> {
+): Promise<PendingCandidate[]> {
   function resolveTargetUserIds(userSIds: string[]): ModelId[] {
     return userSIds
       .map((sId) => usersById.get(sId)?.id)
@@ -256,7 +242,7 @@ export async function collectDocumentCandidates(
   }));
 
   // Batch-fetch existing todos by itemId. A hit means "this item is already
-  // linked to a todo — skip dedup".
+  // linked to a todo — skip".
   const allActionItemIds = actionItems.map((t) => t.itemId);
   const existingByItemId: TodosByItemId =
     await ProjectTaskResource.fetchByItemIds(auth, {
@@ -264,41 +250,21 @@ export async function collectDocumentCandidates(
     });
 
   const candidates: PendingCandidate[] = [];
-  let existingUpdated = 0;
-  for (const { itemId, targetUserIds, blob: actionItemBlob } of actionItems) {
+  for (const { itemId, targetUserIds, blob } of actionItems) {
     for (const userId of targetUserIds) {
       const existing = existingByItemId.get(itemId)?.get(userId) ?? [];
       if (existing.length === 0) {
         candidates.push({
           itemId,
           userId,
-          blob: actionItemBlob,
+          blob,
           source: takeawayWithSource.source,
         });
-      } else if (
-        existing.length > 1 &&
-        existing.some((t) => t.status === "done")
-      ) {
-        // Multiple existing todos with at least one done — skip.
-      } else {
-        // Source link exists — update content if it has changed. When there
-        // are multiple undone todos, prefer the most recently created one.
-        const targetTodo = existing.reduce((a, b) =>
-          a.createdAt >= b.createdAt ? a : b
-        );
-        const updated = await updateTodoIfChanged(
-          targetTodo,
-          auth,
-          actionItemBlob
-        );
-        if (updated) {
-          existingUpdated++;
-        }
       }
     }
   }
 
-  return { candidates, existingUpdated };
+  return candidates;
 }
 
 // ── Phase 2 ───────────────────────────────────────────────────────────────────
@@ -409,13 +375,7 @@ export async function createOrLinkTodos(
           // Candidate matched a deleted todo — do not re-create or re-link.
           return;
         }
-        // Attach every candidate's source to the existing todo. The update
-        // guard lives in updateTodoIfChanged — no-op when the target todo was
-        // created by a user or already marked done by one.
-        const primary = lookupPending(group.candidates[0]);
-        if (primary) {
-          await updateTodoIfChanged(group.todo, auth, primary.blob);
-        }
+        // Attach every candidate's source to the existing todo.
         for (const candidate of group.candidates) {
           const pending = lookupPending(candidate);
           if (!pending) {
@@ -457,8 +417,8 @@ export async function createOrLinkTodos(
           createdByAgentConfigurationId: BUTLER_AGENT_SID,
           agentSuggestionStatus: "pending",
           text: primary.blob.text,
-          status: primary.blob.status,
-          doneAt: primary.blob.doneAt,
+          status: "todo",
+          doneAt: null,
           actorRationale: primary.blob.reasoningCreatedAt,
         },
         itemId: primary.itemId,
@@ -504,63 +464,11 @@ export async function createOrLinkTodos(
   return { deduplicated, createdNew };
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-// Creates a new version of a todo only when status or doneAt has changed, AND
-// the todo's state is not user-owned. Returns true if an update was performed.
-// Text is intentionally never updated: the first version's wording is
-// preserved across re-extractions.
-//
-// The agent path must never overwrite user-owned state:
-//   - If the todo was created by a user, the user's phrasing and status win.
-//   - If an agent-created todo was then marked done by a user, the user's
-//     completion sticks — even if the next extraction still reports the item
-//     as open.
-export async function updateTodoIfChanged(
-  todo: ProjectTaskResource,
-  auth: Authenticator,
-  blob: TodoBlob
-): Promise<boolean> {
-  if (todo.createdByType !== "agent") {
-    return false;
-  }
-  if (todo.markedAsDoneByType === "user") {
-    return false;
-  }
-
-  if (todo.status === "done" && blob.status === "todo") {
-    logger.debug(
-      { todoId: todo.sId, userId: todo.userId },
-      "Project todo merge: system attempted to reopen a done todo — ignored"
-    );
-    return false;
-  }
-
-  const statusChanged = todo.status !== blob.status;
-
-  if (statusChanged) {
-    await todo.updateWithVersion(auth, {
-      text: todo.text,
-      status: blob.status,
-      doneAt: blob.doneAt,
-      actorRationale: blob.reasoningDoneAt,
-    });
-    return true;
-  }
-  return false;
-}
-
 // ── Blob helpers ─────────────────────────────────────────────────────────────
 
 export function actionItemBlob(item: TodoVersionedActionItem): TodoBlob {
-  const isDone = item.status === "done";
   return {
     text: item.shortDescription,
-    status: isDone ? "done" : "todo",
-    doneAt:
-      isDone && item.detectedDoneAt ? new Date(item.detectedDoneAt) : null,
-    reasoningDoneAt:
-      isDone && item.detectedDoneRationale ? item.detectedDoneRationale : null,
     reasoningCreatedAt: item.detectedCreationRationale,
   };
 }

--- a/front/lib/project_task/merge_into_project.ts
+++ b/front/lib/project_task/merge_into_project.ts
@@ -56,8 +56,8 @@ const BUTLER_AGENT_SID = "butler";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-// Outer key: userId (ModelId), inner key: itemId (action item sId).
-type PendingByUserId = Map<ModelId, Map<string, PendingCandidate>>;
+// Outer key: userId (ModelId | null), inner key: itemId (action item sId).
+type PendingByUserId = Map<ModelId | null, Map<string, PendingCandidate>>;
 
 type TodoBlob = {
   text: string;
@@ -66,9 +66,10 @@ type TodoBlob = {
 
 // A candidate todo that has no existing source link yet and therefore needs to
 // go through the deduplication check before being created or linked.
+// userId is null for unassigned action items.
 export type PendingCandidate = {
   itemId: string;
-  userId: ModelId;
+  userId: ModelId | null;
   blob: TodoBlob;
   source: ProjectTaskSourceInfo;
 };
@@ -152,11 +153,15 @@ export async function mergeTakeawaysIntoProject({
     return stats;
   }
 
-  // ── Phase 2: semantic deduplication ──────────────────────────────────────
+  // Separate unassigned candidates — they bypass dedup (no userId to group by).
+  const unassignedCandidates = newCandidates.filter((c) => c.userId === null);
+  const assignedCandidates = newCandidates.filter((c) => c.userId !== null);
+
+  // ── Phase 2: semantic deduplication (assigned only) ───────────────────────
 
   const dedupGroups = await buildDeduplicationGroups(adminAuth, {
     localLogger,
-    newCandidates,
+    newCandidates: assignedCandidates,
     spaceModelId,
   });
 
@@ -164,7 +169,8 @@ export async function mergeTakeawaysIntoProject({
 
   const { deduplicated, createdNew } = await createOrLinkTodos(adminAuth, {
     localLogger,
-    newCandidates,
+    newCandidates: assignedCandidates,
+    unassignedCandidates,
     dedupGroups,
     spaceModelId,
   });
@@ -251,12 +257,28 @@ export async function collectDocumentCandidates(
 
   const candidates: PendingCandidate[] = [];
   for (const { itemId, targetUserIds, blob } of actionItems) {
-    for (const userId of targetUserIds) {
-      const existing = existingByItemId.get(itemId)?.get(userId) ?? [];
-      if (existing.length === 0) {
+    if (targetUserIds.length > 0) {
+      for (const userId of targetUserIds) {
+        const existing = existingByItemId.get(itemId)?.get(userId) ?? [];
+        if (existing.length === 0) {
+          candidates.push({
+            itemId,
+            userId,
+            blob,
+            source: takeawayWithSource.source,
+          });
+        }
+      }
+    } else {
+      // Unassigned item: create a candidate with null userId if no todo is
+      // already linked for this itemId (any userId).
+      const existingForItem = existingByItemId.get(itemId);
+      const alreadyLinked =
+        existingForItem !== undefined && existingForItem.size > 0;
+      if (!alreadyLinked) {
         candidates.push({
           itemId,
-          userId,
+          userId: null,
           blob,
           source: takeawayWithSource.source,
         });
@@ -286,7 +308,7 @@ async function buildDeduplicationGroups(
 ): Promise<DeduplicatedGroup[]> {
   const dedupInput: DeduplicateCandidate[] = newCandidates.map((c) => ({
     itemId: c.itemId,
-    userId: c.userId,
+    userId: c.userId as ModelId,
     text: c.blob.text,
   }));
 
@@ -301,7 +323,9 @@ async function buildDeduplicationGroups(
   // Fetch all existing todos for each unique target user in a single pass,
   // then nest them under userId → category → todos for lookup by the LLM
   // calls.
-  const uniqueUserIds = [...new Set(newCandidates.map((c) => c.userId))];
+  const uniqueUserIds = [
+    ...new Set(newCandidates.map((c) => c.userId as ModelId)),
+  ];
   const existingTodosByUser: ExistingTodosByUser = new Map();
 
   await concurrentExecutor(
@@ -341,11 +365,13 @@ export async function createOrLinkTodos(
   {
     localLogger,
     newCandidates,
+    unassignedCandidates,
     dedupGroups,
     spaceModelId,
   }: {
     localLogger: Logger;
     newCandidates: PendingCandidate[];
+    unassignedCandidates: PendingCandidate[];
     dedupGroups: DeduplicatedGroup[];
     spaceModelId: ModelId;
   }
@@ -457,6 +483,41 @@ export async function createOrLinkTodos(
           "Project todo merge: linked source to new todo (intra-batch duplicate)"
         );
       }
+    },
+    { concurrency: 4 }
+  );
+
+  // Create unassigned todos directly — no dedup needed since there is no user
+  // to group them by.
+  await concurrentExecutor(
+    unassignedCandidates,
+    async (candidate) => {
+      const todo = await ProjectTaskResource.makeNewWithSource(auth, {
+        blob: {
+          spaceId: spaceModelId,
+          userId: null,
+          createdByType: "agent",
+          createdByUserId: null,
+          createdByAgentConfigurationId: BUTLER_AGENT_SID,
+          agentSuggestionStatus: "pending",
+          text: candidate.blob.text,
+          status: "todo",
+          doneAt: null,
+          actorRationale: candidate.blob.reasoningCreatedAt,
+        },
+        itemId: candidate.itemId,
+        source: candidate.source,
+      });
+      createdNew++;
+
+      localLogger.info(
+        {
+          todoId: todo.sId,
+          itemId: candidate.itemId,
+          source: candidate.source,
+        },
+        "Project todo merge: created new unassigned todo"
+      );
     },
     { concurrency: 4 }
   );

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -31,8 +31,11 @@ import {
 } from "sequelize";
 
 // Return type of fetchByItemIds: outer key is itemId (action item sId), inner
-// key is userId (ModelId).
-export type TodosByItemId = Map<string, Map<ModelId, ProjectTaskResource[]>>;
+// key is userId (ModelId | null, where null represents unassigned todos).
+export type TodosByItemId = Map<
+  string,
+  Map<ModelId | null, ProjectTaskResource[]>
+>;
 
 type ProjectTaskVersionCreationAttributes =
   CreationAttributes<ProjectTaskModel> & {
@@ -440,7 +443,7 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
   static async fetchByItemIds(
     auth: Authenticator,
     { itemIds }: { itemIds: string[] }
-  ): Promise<Map<string, Map<ModelId, ProjectTaskResource[]>>> {
+  ): Promise<TodosByItemId> {
     if (itemIds.length === 0) {
       return new Map();
     }
@@ -473,11 +476,10 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
         continue;
       }
       const byUser =
-        result.get(source.itemId) ?? new Map<ModelId, ProjectTaskResource[]>();
+        result.get(source.itemId) ??
+        new Map<ModelId | null, ProjectTaskResource[]>();
       const userId = todo.userId;
-      if (userId !== null) {
-        byUser.set(userId, [...(byUser.get(userId) ?? []), todo]);
-      }
+      byUser.set(userId, [...(byUser.get(userId) ?? []), todo]);
       result.set(source.itemId, byUser);
     }
 

--- a/front/lib/resources/takeaways_resource.test.ts
+++ b/front/lib/resources/takeaways_resource.test.ts
@@ -47,9 +47,6 @@ describe("TakeawaysResource", () => {
         shortDescription: "Follow up with customer",
         assigneeUserId: null,
         assigneeName: null,
-        status: "open" as const,
-        detectedDoneAt: null,
-        detectedDoneRationale: null,
         detectedCreationRationale: null,
       };
       const updated = await takeaway.updateWithVersion(auth, {
@@ -75,9 +72,6 @@ describe("TakeawaysResource", () => {
               shortDescription: "Cross-tenant action item",
               assigneeUserId: null,
               assigneeName: null,
-              status: "open",
-              detectedDoneAt: null,
-              detectedDoneRationale: null,
               detectedCreationRationale: null,
             },
           ],
@@ -93,9 +87,6 @@ describe("TakeawaysResource", () => {
         shortDescription: "First action item",
         assigneeUserId: null,
         assigneeName: null,
-        status: "open" as const,
-        detectedDoneAt: null,
-        detectedDoneRationale: null,
         detectedCreationRationale: null,
       };
       const actionItem2 = {
@@ -103,9 +94,6 @@ describe("TakeawaysResource", () => {
         shortDescription: "Second action item",
         assigneeUserId: null,
         assigneeName: null,
-        status: "done" as const,
-        detectedDoneAt: "2026-04-24T00:00:00.000Z",
-        detectedDoneRationale: "Mentioned as completed in summary",
         detectedCreationRationale: null,
       };
 
@@ -142,9 +130,6 @@ describe("TakeawaysResource", () => {
         shortDescription: "Updated action item",
         assigneeUserId: null,
         assigneeName: null,
-        status: "open" as const,
-        detectedDoneAt: null,
-        detectedDoneRationale: null,
         detectedCreationRationale: null,
       };
 
@@ -244,9 +229,6 @@ describe("TakeawaysResource", () => {
         shortDescription: "A versioned action item",
         assigneeUserId: null,
         assigneeName: null,
-        status: "open" as const,
-        detectedDoneAt: null,
-        detectedDoneRationale: null,
         detectedCreationRationale: null,
       };
 

--- a/front/tests/takeaway-evals/lib/assertions.ts
+++ b/front/tests/takeaway-evals/lib/assertions.ts
@@ -34,12 +34,6 @@ export function validateTakeawayAssertion(
           error: `Expected action item "${assertion.descriptionContains}" to be assigned to "${assertion.assigneeUserId}", but got "${match.assigneeUserId}"`,
         };
       }
-      if (assertion.status && match.status !== assertion.status) {
-        return {
-          success: false,
-          error: `Expected action item "${assertion.descriptionContains}" to have status "${assertion.status}", but got "${match.status}"`,
-        };
-      }
       return { success: true };
     }
 

--- a/front/tests/takeaway-evals/lib/types.ts
+++ b/front/tests/takeaway-evals/lib/types.ts
@@ -29,7 +29,6 @@ export type TakeawayAssertion =
       type: "shouldExtractActionItem";
       descriptionContains: string;
       assigneeUserId?: string;
-      status?: "open" | "done";
     }
   | { type: "shouldNotExtractActionItem"; descriptionContains: string }
   | { type: "minActionItems"; count: number }
@@ -45,7 +44,7 @@ export type TakeawayAssertion =
 
 export function shouldExtractActionItem(
   descriptionContains: string,
-  opts?: { assigneeUserId?: string; status?: "open" | "done" }
+  opts?: { assigneeUserId?: string }
 ): TakeawayAssertion {
   return {
     type: "shouldExtractActionItem",
@@ -144,7 +143,7 @@ export function formatExtractionResult(
     const items = result.actionItems
       .map(
         (a) =>
-          `  - [${a.status}] ${a.shortDescription}${a.assigneeUserId ? ` (assignee: ${a.assigneeUserId})` : ""}`
+          `  - ${a.shortDescription}${a.assigneeUserId ? ` (assignee: ${a.assigneeUserId})` : ""}`
       )
       .join("\n");
     parts.push(`Action items:\n${items}`);

--- a/front/tests/takeaway-evals/test-suites/action-items.ts
+++ b/front/tests/takeaway-evals/test-suites/action-items.ts
@@ -36,15 +36,12 @@ export const actionItemsSuite: TakeawayTestSuite = {
       expectedAssertions: [
         shouldExtractActionItem("migration", {
           assigneeUserId: "user-bob",
-          status: "open",
         }),
         shouldExtractActionItem("review", {
           assigneeUserId: "user-alice",
-          status: "open",
         }),
         shouldExtractActionItem("monitoring", {
           assigneeUserId: "user-carol",
-          status: "open",
         }),
       ],
       judgeCriteria: `Three clear action items with explicit assignees:
@@ -55,7 +52,7 @@ export const actionItemsSuite: TakeawayTestSuite = {
 Score 0 if fewer than 2 action items extracted.
 Score 1 if items extracted but assignees are wrong.
 Score 2 if all items extracted, most assignees correct.
-Score 3 if all 3 items extracted with correct assignees and open status.`,
+Score 3 if all 3 items extracted with correct assignees.`,
     },
 
     // ── Agent response should NOT become action item ──────────────────────────
@@ -92,66 +89,6 @@ Score 0 if the agent's responses are extracted as action items.
 Score 1 if Alice's action item is missing.
 Score 2 if Alice's item is extracted but agent items also appear.
 Score 3 if only Alice's action item is extracted, agent responses correctly ignored.`,
-    },
-
-    // ── Status transition to done ─────────────────────────────────────────────
-
-    {
-      scenarioId: "status-transition-to-done",
-      document: {
-        id: "doc-3",
-        title: "Sprint review",
-        type: "slack",
-        text: [
-          "Bob: Quick update — the migration script is done, deployed to staging yesterday",
-          "Alice: I've reviewed the PR, looks good. Still need to update the API docs though",
-        ].join("\n"),
-        uri: "https://example.com/doc-3",
-      },
-      members: [
-        { sId: "user-alice", fullName: "Alice Martin", email: "alice@co.com" },
-        { sId: "user-bob", fullName: "Bob Chen", email: "bob@co.com" },
-      ],
-      previousVersion: {
-        actionItems: [
-          {
-            sId: "prev-action-1",
-            shortDescription: "Write the migration script",
-            assigneeUserId: "user-bob",
-            assigneeName: "Bob Chen",
-            status: "open",
-            detectedDoneAt: null,
-            detectedDoneRationale: null,
-            detectedCreationRationale: null,
-          },
-          {
-            sId: "prev-action-2",
-            shortDescription: "Review the PR",
-            assigneeUserId: "user-alice",
-            assigneeName: "Alice Martin",
-            status: "open",
-            detectedDoneAt: null,
-            detectedDoneRationale: null,
-            detectedCreationRationale: null,
-          },
-        ],
-      },
-      expectedAssertions: [
-        shouldExtractActionItem("migration", { status: "done" }),
-        shouldExtractActionItem("review", { status: "done" }),
-        shouldExtractActionItem("API docs", { status: "open" }),
-        shouldPreserveSId("actionItem", "prev-action-1"),
-        shouldPreserveSId("actionItem", "prev-action-2"),
-      ],
-      judgeCriteria: `Two previously tracked action items should transition to done:
-- The migration script is explicitly stated as done by Bob → status "done"
-- The PR review is explicitly completed by Alice → status "done"
-- A new action item for updating API docs should be created (status "open")
-
-Score 0 if status transitions are wrong (done items shown as open or vice versa).
-Score 1 if only one of the two items is correctly marked as done.
-Score 2 if both done transitions are correct but the new API docs item is missing.
-Score 3 if all 3 items present with correct statuses (2 done, 1 open).`,
     },
 
     // ── Invalid assignee should be filtered ───────────────────────────────────
@@ -212,7 +149,6 @@ Score 3 if Dave's action has no assignee_user_id and Bob's action is correctly a
         shouldNotExtractActionItem("error messages"),
         shouldExtractActionItem("hotfix", {
           assigneeUserId: "user-alice",
-          status: "open",
         }),
         maxActionItems(2),
       ],
@@ -287,11 +223,9 @@ Score 3 if only the hotfix is extracted as an action item.`,
       expectedAssertions: [
         shouldExtractActionItem("show", {
           assigneeUserId: "abcdef",
-          status: "open",
         }),
         shouldExtractActionItem("opt-in", {
           assigneeUserId: "zxcvb",
-          status: "open",
         }),
         shouldNotExtractActionItem("1 and 2"),
         maxActionItems(4),
@@ -299,8 +233,8 @@ Score 3 if only the hotfix is extracted as an action item.`,
       judgeCriteria: `Seb commits to working on items 3, 4, and 5 of the TODO UX improvements, and defers 1 and 2 to further brainstorming.
 Rcs is described as owning the opt-in part.
 
-- Rcs's opt-in ownership → action item assigned to user-rcs (open)
-- Seb's commitment to items 3, 4 and 5 → action items assigned to user-seb (open); these can be grouped or individual
+- Rcs's opt-in ownership → action item assigned to user-rcs
+- Seb's commitment to items 3, 4 and 5 → action items assigned to user-seb; these can be grouped or individual
 - Items 1 and 2 (manually add / edit TODO) are explicitly deferred — NOT action items
 
 Score 0 if deferred items 1 and 2 are extracted as action items.
@@ -334,9 +268,6 @@ Score 3 if Rcs's opt-in item and Seb's items 3/4/5 are correctly extracted, item
             shortDescription: "Write the migration script for the users table",
             assigneeUserId: "user-alice",
             assigneeName: "Alice Martin",
-            status: "open",
-            detectedDoneAt: null,
-            detectedDoneRationale: null,
             detectedCreationRationale:
               "Alice committed to writing the migration script by Friday",
           },
@@ -345,9 +276,6 @@ Score 3 if Rcs's opt-in item and Seb's items 3/4/5 are correctly extracted, item
             shortDescription: "Review the migration PR once it's ready",
             assigneeUserId: "user-bob",
             assigneeName: "Bob Chen",
-            status: "open",
-            detectedDoneAt: null,
-            detectedDoneRationale: null,
             detectedCreationRationale:
               "Bob committed to reviewing the migration PR",
           },
@@ -391,15 +319,14 @@ Score 3 if the two existing items are preserved with their original sIds and no 
       expectedAssertions: [
         shouldExtractActionItem("runbook", {
           assigneeUserId: "user-bob",
-          status: "open",
         }),
         maxActionItems(1),
       ],
       judgeCriteria: `One new task assigned:
-- Bob asked to update the runbook (open)
+- Bob asked to update the runbook
 
-Score 0 if no tasks are extracted as open.
-Score 3 if the task item are correct with right statuses and no spurious extractions.`,
+Score 0 if no tasks are extracted.
+Score 3 if the task item is correct and no spurious extractions.`,
     },
   ],
 };

--- a/front/types/takeaways.ts
+++ b/front/types/takeaways.ts
@@ -1,12 +1,7 @@
-export type TodoVersionedActionItemStatus = "open" | "done";
-
 export type TodoVersionedActionItem = {
   sId: string;
   shortDescription: string;
   assigneeUserId: string | null;
   assigneeName: string | null;
-  status: TodoVersionedActionItemStatus;
-  detectedDoneAt: string | null;
-  detectedDoneRationale: string | null;
   detectedCreationRationale: string | null;
 };


### PR DESCRIPTION
## Description

Two related cleanups to takeaway action items:

**Remove `status` from action items** — `TodoVersionedActionItem` no longer carries `status`, `detectedDoneAt`, or `detectedDoneRationale`. The `done` block is removed from the LLM extraction schema. Done-state tracking lives on the `ProjectTask` row; the takeaway snapshot no longer carries any state that could update an already-linked task.

**Make assignee optional** — `assignee_user_id` and `assignee_name` are now optional in `NewActionItemSchema`. Previously, items with an unresolvable assignee were silently dropped. Now they are kept as unassigned tasks (`assigneeUserId: null`). The merge pipeline routes unassigned candidates directly to creation, bypassing the LLM dedup phase (which groups by userId). `fetchByItemIds` in `ProjectTaskResource` now also tracks todos with `null` userId.

## Tests

Updated unit tests in `action_items.test.ts` (unknown-assignee items now kept as unassigned, new test for absent assignee fields) and `merge_into_project.test.ts` (new `unassignedCandidates` param). All 16 affected tests pass.
