### PR TITLE
feat(projects): improve logging

### DIFF
--- a/front/lib/project_task/analyze_document/index.ts
+++ b/front/lib/project_task/analyze_document/index.ts
@@ -44,7 +44,8 @@ async function buildPromptProjectMembers(
 }
 
 // Calls the LLM with a forced extract_action_items tool call and parses the result.
-// Returns null if the call fails, produces no tool call, or the output fails parsing.
+// Returns extraction=null if the call fails, produces no tool call, or the output fails parsing.
+// Always returns the scoped logger (with langfuseSpanId bound) so callers can keep using it.
 async function callExtractActionItemsLLM(
   auth: Authenticator,
   {
@@ -60,12 +61,16 @@ async function callExtractActionItemsLLM(
     prompt: string;
     document: TakeawaySourceDocument;
   }
-): Promise<ExtractionResult | null> {
+): Promise<{ extraction: ExtractionResult | null; scopedLogger: Logger }> {
   const owner = auth.getNonNullableWorkspace();
+  let scopedLogger = localLogger;
   const res = await startActiveObservation(
     "project-todo-analyze-document",
-    () =>
-      runMultiActionsAgent(
+    (span) => {
+      scopedLogger = localLogger.child({ langfuseSpanId: span.id });
+      scopedLogger.info("Document takeaway: LLM call started");
+
+      return runMultiActionsAgent(
         auth,
         {
           providerId: model.providerId,
@@ -95,31 +100,32 @@ async function callExtractActionItemsLLM(
             workspaceId: owner.sId,
           },
         }
-      )
+      );
+    }
   );
   if (res.isErr()) {
-    localLogger.error(
+    scopedLogger.error(
       { error: res.error },
       "Document takeaway: LLM call failed"
     );
-    return null;
+    return { extraction: null, scopedLogger };
   }
 
   const action = res.value.actions?.[0];
   if (!action?.arguments) {
-    localLogger.warn("Document takeaway: no tool call in LLM response");
-    return null;
+    scopedLogger.warn("Document takeaway: no tool call in LLM response");
+    return { extraction: null, scopedLogger };
   }
 
   const parsed = ExtractTakeawaysInputSchema.safeParse(action.arguments);
   if (!parsed.success) {
-    localLogger.warn(
+    scopedLogger.warn(
       { error: parsed.error, arguments: action.arguments },
       "Document takeaway: failed to parse LLM response"
     );
-    return null;
+    return { extraction: null, scopedLogger };
   }
-  return parsed.data;
+  return { extraction: parsed.data, scopedLogger };
 }
 
 // Maps raw LLM-extracted items to typed action items, reusing sIds from the
@@ -195,7 +201,7 @@ export async function extractDocumentTakeaways(
     .join("\n\n");
   const specification = buildSpec();
 
-  const extraction = await callExtractActionItemsLLM(auth, {
+  const { extraction, scopedLogger } = await callExtractActionItemsLLM(auth, {
     localLogger,
     model,
     specification,
@@ -203,7 +209,7 @@ export async function extractDocumentTakeaways(
     document,
   });
   if (!extraction) {
-    localLogger.error("Document takeaway: no extraction result");
+    scopedLogger.error("Document takeaway: no extraction result");
     return null;
   }
 
@@ -226,7 +232,7 @@ export async function extractDocumentTakeaways(
     },
     previousActionItems,
     validAssigneesUserIds,
-    localLogger
+    scopedLogger
   );
 
   const stats: ExtractedTakeawayStats = {
@@ -234,7 +240,7 @@ export async function extractDocumentTakeaways(
   };
 
   if (stats.actionItems === 0) {
-    localLogger.info("Document takeaway: no takeaways extracted");
+    scopedLogger.info("Document takeaway: no takeaways extracted");
     return stats;
   }
 
@@ -244,7 +250,7 @@ export async function extractDocumentTakeaways(
     actionItems,
   });
 
-  localLogger.info(
+  scopedLogger.info(
     {
       ...stats,
     },

--- a/front/lib/project_task/deduplicate_candidates.ts
+++ b/front/lib/project_task/deduplicate_candidates.ts
@@ -32,11 +32,11 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
-import logger from "@app/logger/logger";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import { startActiveObservation } from "@langfuse/tracing";
+import type { Logger } from "pino";
 import { z } from "zod";
 
 // ── Public types ──────────────────────────────────────────────────────────────
@@ -47,18 +47,22 @@ export type DeduplicateCandidate = {
   text: string;
 };
 
-// One task that Phase 3 will touch.
+// One task that Phase 3 will touch. `scopedLogger` carries the langfuseSpanId
+// of the LLM call that produced the group (or the unscoped logger when no LLM
+// call was made).
 export type DeduplicatedGroup =
   | {
       kind: "existing";
       todo: ProjectTaskResource;
       candidates: DeduplicateCandidate[];
+      scopedLogger: Logger;
     }
   | {
       kind: "new";
       // Non-empty. candidates[0] drives the new todo's content; later entries
       // attach their sources to that todo.
       candidates: DeduplicateCandidate[];
+      scopedLogger: Logger;
     };
 
 // ── LLM tool ─────────────────────────────────────────────────────────────────
@@ -149,15 +153,17 @@ function buildDeduplicationPrompt(
 export async function runDeduplicationLLMCall(
   auth: Authenticator,
   {
+    localLogger,
     model,
     candidates,
     existingTodos,
   }: {
+    localLogger: Logger;
     model: ModelConfigurationType;
     candidates: DeduplicateCandidate[];
     existingTodos: ProjectTaskResource[];
   }
-): Promise<number[][]> {
+): Promise<{ groups: number[][]; scopedLogger: Logger }> {
   const owner = auth.getNonNullableWorkspace();
   const prompt = buildDeduplicationPrompt(existingTodos, candidates);
   const specification = buildDeduplicationSpec();
@@ -172,10 +178,17 @@ export async function runDeduplicationLLMCall(
     ],
   };
 
+  let scopedLogger = localLogger;
   const res = await startActiveObservation(
     "project-todo-deduplicate-candidates",
-    () =>
-      runMultiActionsAgent(
+    (span) => {
+      scopedLogger = localLogger.child({ langfuseSpanId: span.id });
+      scopedLogger.info(
+        { workspaceId: owner.sId },
+        "Project todo dedup: LLM call started"
+      );
+
+      return runMultiActionsAgent(
         auth,
         {
           providerId: model.providerId,
@@ -197,36 +210,37 @@ export async function runDeduplicationLLMCall(
             workspaceId: owner.sId,
           },
         }
-      )
+      );
+    }
   );
 
   if (res.isErr()) {
-    logger.warn(
+    scopedLogger.warn(
       { error: res.error, workspaceId: owner.sId },
       "Project todo dedup: LLM call failed, treating all candidates as new"
     );
-    return [];
+    return { groups: [], scopedLogger };
   }
 
   const action = res.value.actions?.[0];
   if (!action?.arguments) {
-    logger.warn(
+    scopedLogger.warn(
       { workspaceId: owner.sId },
       "Project todo dedup: no tool call in LLM response, treating all as new"
     );
-    return [];
+    return { groups: [], scopedLogger };
   }
 
   const parsed = DeduplicationResultSchema.safeParse(action.arguments);
   if (!parsed.success) {
-    logger.warn(
+    scopedLogger.warn(
       { error: parsed.error, workspaceId: owner.sId },
       "Project todo dedup: failed to parse LLM response, treating all as new"
     );
-    return [];
+    return { groups: [], scopedLogger };
   }
 
-  return parsed.data.groups;
+  return { groups: parsed.data.groups, scopedLogger };
 }
 
 // ── Group resolution ─────────────────────────────────────────────────────────
@@ -322,10 +336,12 @@ export function resolveDeduplicationGroups<TTodo>(
 export async function batchDeduplicateCandidates(
   auth: Authenticator,
   {
+    localLogger,
     model,
     candidates,
     existingTodos,
   }: {
+    localLogger: Logger;
     model: ModelConfigurationType;
     candidates: DeduplicateCandidate[];
     existingTodos: ProjectTaskResource[];
@@ -339,13 +355,13 @@ export async function batchDeduplicateCandidates(
 
   // Fast path: single candidate with no existing todos needs no LLM call.
   if (existingTodos.length === 0 && candidates.length === 1) {
-    return [{ kind: "new", candidates }];
+    return [{ kind: "new", candidates, scopedLogger: localLogger }];
   }
 
   const totalItems = existingTodos.length + candidates.length;
 
   if (totalItems > CONTEXT_PRESSURE_THRESHOLD) {
-    logger.warn(
+    localLogger.warn(
       {
         workspaceId: owner.sId,
         existingTodoCount: existingTodos.length,
@@ -356,7 +372,7 @@ export async function batchDeduplicateCandidates(
       "Project todo dedup: large combined item count may cause context pressure — proceeding with single LLM call"
     );
   } else {
-    logger.info(
+    localLogger.info(
       {
         workspaceId: owner.sId,
         existingTodoCount: existingTodos.length,
@@ -367,11 +383,17 @@ export async function batchDeduplicateCandidates(
     );
   }
 
-  const llmGroups = await runDeduplicationLLMCall(auth, {
-    model,
-    candidates,
-    existingTodos,
-  });
+  const { groups: llmGroups, scopedLogger } = await runDeduplicationLLMCall(
+    auth,
+    {
+      localLogger,
+      model,
+      candidates,
+      existingTodos,
+    }
+  );
 
-  return resolveDeduplicationGroups(candidates, existingTodos, llmGroups);
+  return resolveDeduplicationGroups(candidates, existingTodos, llmGroups).map(
+    (group) => ({ ...group, scopedLogger })
+  );
 }

--- a/front/lib/project_task/merge_into_project.test.ts
+++ b/front/lib/project_task/merge_into_project.test.ts
@@ -175,6 +175,7 @@ describe("createOrLinkTodos", () => {
       candidates: [
         { itemId: "item-x", userId: 1 as ModelId, text: "Do the thing" },
       ],
+      scopedLogger: fakeLogger,
     };
 
     const { deduplicated, createdNew } = await createOrLinkTodos(fakeAuth, {
@@ -221,6 +222,7 @@ describe("createOrLinkTodos", () => {
       candidates: [
         { itemId: "item-y", userId: 1 as ModelId, text: "Do the thing" },
       ],
+      scopedLogger: fakeLogger,
     };
 
     const { deduplicated, createdNew } = await createOrLinkTodos(fakeAuth, {

--- a/front/lib/project_task/merge_into_project.ts
+++ b/front/lib/project_task/merge_into_project.ts
@@ -316,7 +316,11 @@ async function buildDeduplicationGroups(
     localLogger.warn(
       "Project todo merge: no whitelisted model, skipping deduplication"
     );
-    return dedupInput.map((c) => ({ kind: "new", candidates: [c] }));
+    return dedupInput.map((c) => ({
+      kind: "new",
+      candidates: [c],
+      scopedLogger: localLogger,
+    }));
   }
 
   // Fetch all existing tasks for the space in one pass (including deleted).
@@ -327,6 +331,7 @@ async function buildDeduplicationGroups(
     });
 
   return batchDeduplicateCandidates(auth, {
+    localLogger,
     model,
     candidates: dedupInput,
     existingTodos,
@@ -390,7 +395,7 @@ export async function createOrLinkTodos(
           });
           deduplicated++;
 
-          localLogger.info(
+          group.scopedLogger.info(
             {
               existingTodoId: group.todo.sId,
               itemId: pending.itemId,
@@ -429,7 +434,7 @@ export async function createOrLinkTodos(
       });
       createdNew++;
 
-      localLogger.info(
+      group.scopedLogger.info(
         {
           todoId: todo.sId,
           itemId: primary.itemId,
@@ -450,7 +455,7 @@ export async function createOrLinkTodos(
         });
         deduplicated++;
 
-        localLogger.info(
+        group.scopedLogger.info(
           {
             todoId: todo.sId,
             itemId: pending.itemId,

--- a/front/tests/dedup-evals/lib/dedup-executor.ts
+++ b/front/tests/dedup-evals/lib/dedup-executor.ts
@@ -4,6 +4,7 @@ import {
   runDeduplicationLLMCall,
 } from "@app/lib/project_task/deduplicate_candidates";
 import type { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
+import logger from "@app/logger/logger";
 import { MODEL_ID } from "@app/tests/dedup-evals/lib/config";
 import type {
   DedupExecutionResult,
@@ -52,7 +53,8 @@ export async function executeDedup(
   const existingTodos = buildMockExistingTodos(testCase);
   const candidates = buildCandidates(testCase);
 
-  const llmGroups = await runDeduplicationLLMCall(auth, {
+  const { groups: llmGroups } = await runDeduplicationLLMCall(auth, {
+    localLogger: logger,
     model,
     candidates,
     existingTodos,


### PR DESCRIPTION
## Description

Improve project todo workflow logging by attaching the Langfuse span id to every log line emitted around an LLM call. It'll ease the debugging of the flow

- `analyze_document`: `callExtractActionItemsLLM` now opens a child logger bound to `langfuseSpanId` inside `startActiveObservation` and returns it alongside the extraction so the rest of the pipeline (`buildActionItems`, "no takeaways extracted", "analysis complete") logs with the same span id.
- `deduplicate_candidates`: `runDeduplicationLLMCall` does the same, returning `{ groups, scopedLogger }`. `batchDeduplicateCandidates` attaches the per-LLM-call `scopedLogger` to every `DeduplicatedGroup` it produces (including the no-LLM fast path and the no-model fallback), so Phase 3 logs in `createOrLinkTodos` carry the span id of the LLM call that produced the group.
- `localLogger` is no longer needed in `createOrLinkTodos` and was removed from its signature; per-group logs now go through `group.scopedLogger`.

## Tests

Existing `merge_into_project.test.ts` updated for the new `DeduplicatedGroup.scopedLogger` field and the dropped `localLogger` argument; all 17 tests pass.
