### PR TITLE
[front] coupons: improve redemption

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -397,6 +397,7 @@ export interface MetronomePackageSummary {
   id: string;
   name: string;
   aliases: string[];
+  rateCardId?: string;
 }
 
 // Cache the package list for a few minutes as the catalog rarely changes and
@@ -424,6 +425,7 @@ export async function listMetronomePackages(): Promise<
         id: pkg.id,
         name: pkg.name ?? "",
         aliases: pkg.aliases?.map((a) => a.name) ?? [],
+        rateCardId: pkg.rate_card_id ?? undefined,
       });
     }
     packageListCache = {

--- a/front/lib/metronome/coupons.test.ts
+++ b/front/lib/metronome/coupons.test.ts
@@ -7,6 +7,7 @@ import {
   createCouponCredit,
   endCouponCredit,
   getCreditTypeFromContract,
+  getCreditTypeFromPackage,
   redeemCoupon,
   revokeCouponRedemption,
 } from "@app/lib/metronome/coupons";
@@ -48,12 +49,14 @@ const {
   mockGetActiveContract,
   mockEmitAuditLogEvent,
   mockGetMetronomeRateCardById,
+  mockListMetronomePackages,
 } = vi.hoisted(() => ({
   mockCreateMetronomeCredit: vi.fn(),
   mockUpdateMetronomeCreditEndDate: vi.fn(),
   mockGetActiveContract: vi.fn().mockResolvedValue(null),
   mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
   mockGetMetronomeRateCardById: vi.fn(),
+  mockListMetronomePackages: vi.fn(),
 }));
 
 vi.mock("@app/lib/metronome/client", async () => {
@@ -64,6 +67,7 @@ vi.mock("@app/lib/metronome/client", async () => {
     ...actual,
     createMetronomeCredit: mockCreateMetronomeCredit,
     getMetronomeRateCardById: mockGetMetronomeRateCardById,
+    listMetronomePackages: mockListMetronomePackages,
     updateMetronomeCreditEndDate: mockUpdateMetronomeCreditEndDate,
   };
 });
@@ -113,6 +117,23 @@ function makeCoupon(
     amount: overrides.amount ?? 10,
     durationMonths: overrides.durationMonths ?? null,
   } as unknown as CouponResource;
+}
+
+function makePackageSummary(
+  overrides: Partial<{
+    id: string;
+    name: string;
+    aliases: string[];
+    rateCardId: string | undefined;
+  }> = {}
+) {
+  return {
+    id: overrides.id ?? "pkg-1",
+    name: overrides.name ?? "Test Package",
+    aliases: overrides.aliases ?? ["test-alias"],
+    rateCardId:
+      "rateCardId" in overrides ? overrides.rateCardId : "rate-card-1",
+  };
 }
 
 function makeContract(rateCardId: string | undefined = "rate-card-1"): {
@@ -171,6 +192,7 @@ beforeEach(() => {
   mockGetActiveContract.mockReset();
   mockEmitAuditLogEvent.mockReset();
   mockGetMetronomeRateCardById.mockReset();
+  mockListMetronomePackages.mockReset();
   mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "credit-id-1" }));
   mockUpdateMetronomeCreditEndDate.mockResolvedValue(new Ok(undefined));
   mockGetActiveContract.mockResolvedValue({ rate_card_id: "rate-card-1" });
@@ -178,6 +200,7 @@ beforeEach(() => {
   mockGetMetronomeRateCardById.mockResolvedValue(
     new Ok(makeRateCard(CREDIT_TYPE_USD_ID))
   );
+  mockListMetronomePackages.mockResolvedValue(new Ok([makePackageSummary()]));
 });
 
 // ---------------------------------------------------------------------------
@@ -243,6 +266,68 @@ describe("getCreditTypeFromContract", () => {
 });
 
 // ---------------------------------------------------------------------------
+// getCreditTypeFromPackage
+// ---------------------------------------------------------------------------
+
+describe("getCreditTypeFromPackage", () => {
+  it("returns Ok with USD credit type resolved via package alias", async () => {
+    mockListMetronomePackages.mockResolvedValueOnce(
+      new Ok([
+        makePackageSummary({ aliases: ["pro-monthly"], rateCardId: "rc-usd" }),
+      ])
+    );
+    mockGetMetronomeRateCardById.mockResolvedValueOnce(
+      new Ok(makeRateCard(CREDIT_TYPE_USD_ID))
+    );
+
+    const result = await getCreditTypeFromPackage("pro-monthly");
+
+    expect(unwrapOk(result)).toEqual({
+      creditTypeId: CREDIT_TYPE_USD_ID,
+      currency: "usd",
+    });
+    expect(mockGetMetronomeRateCardById).toHaveBeenCalledWith({
+      rateCardId: "rc-usd",
+    });
+  });
+
+  it("returns Err when no package matches the alias", async () => {
+    mockListMetronomePackages.mockResolvedValueOnce(
+      new Ok([makePackageSummary({ aliases: ["other-alias"] })])
+    );
+
+    const result = await getCreditTypeFromPackage("unknown-alias");
+
+    expect(result.isErr()).toBe(true);
+    expect(unwrapErr(result).message).toContain("unknown-alias");
+    expect(mockGetMetronomeRateCardById).not.toHaveBeenCalled();
+  });
+
+  it("returns Err when the package has no rateCardId", async () => {
+    mockListMetronomePackages.mockResolvedValueOnce(
+      new Ok([
+        makePackageSummary({ aliases: ["no-rc-alias"], rateCardId: undefined }),
+      ])
+    );
+
+    const result = await getCreditTypeFromPackage("no-rc-alias");
+
+    expect(result.isErr()).toBe(true);
+    expect(mockGetMetronomeRateCardById).not.toHaveBeenCalled();
+  });
+
+  it("returns Err when listMetronomePackages fails", async () => {
+    mockListMetronomePackages.mockResolvedValueOnce(
+      new Err(new Error("packages api down"))
+    );
+
+    const result = await getCreditTypeFromPackage("any-alias");
+
+    expect(unwrapErr(result).message).toBe("packages api down");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // createCouponCredit
 // ---------------------------------------------------------------------------
 
@@ -293,43 +378,7 @@ describe("createCouponCredit", () => {
     );
   });
 
-  it("creates N monthly credits for a repeating coupon (durationMonths = N)", async () => {
-    mockCreateMetronomeCredit
-      .mockResolvedValueOnce(new Ok({ id: "credit-0" }))
-      .mockResolvedValueOnce(new Ok({ id: "credit-1" }))
-      .mockResolvedValueOnce(new Ok({ id: "credit-2" }));
-
-    const coupon = makeCoupon({ durationMonths: 3 });
-
-    const result = await createCouponCredit({
-      metronomeCustomerId: "cust-1",
-      coupon,
-      redemptionId: REDEMPTION_ID,
-      redeemedAt: REDEEMED_AT,
-      creditTypeId: CREDIT_TYPE_USD_ID,
-      currency: "usd",
-    });
-
-    expect(unwrapOk(result)).toEqual(["credit-0", "credit-1", "credit-2"]);
-    expect(mockCreateMetronomeCredit).toHaveBeenCalledTimes(3);
-
-    // Each call gets a sequential idempotency key
-    for (let i = 0; i < 3; i++) {
-      expect(mockCreateMetronomeCredit).toHaveBeenNthCalledWith(
-        i + 1,
-        expect.objectContaining({
-          idempotencyKey: `coupon-${REDEMPTION_ID}-${i}`,
-        })
-      );
-    }
-  });
-
-  it("uses correct monthly date boundaries for a 3-month repeating coupon", async () => {
-    mockCreateMetronomeCredit
-      .mockResolvedValueOnce(new Ok({ id: "c0" }))
-      .mockResolvedValueOnce(new Ok({ id: "c1" }))
-      .mockResolvedValueOnce(new Ok({ id: "c2" }));
-
+  it("uses correct date boundaries for a 3-month repeating coupon", async () => {
     const coupon = makeCoupon({ durationMonths: 3 });
 
     await createCouponCredit({
@@ -341,20 +390,11 @@ describe("createCouponCredit", () => {
       currency: "usd",
     });
 
-    // Month 0: Apr → May
-    expect(mockCreateMetronomeCredit).toHaveBeenNthCalledWith(
-      1,
+    expect(mockCreateMetronomeCredit).toHaveBeenCalledTimes(1);
+    expect(mockCreateMetronomeCredit).toHaveBeenCalledWith(
       expect.objectContaining({
-        startingAt: "2026-04-01T10:30:00.000Z",
-        endingBefore: "2026-05-01T10:30:00.000Z",
-      })
-    );
-    // Month 1: May → Jun
-    expect(mockCreateMetronomeCredit).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        startingAt: "2026-05-01T10:30:00.000Z",
-        endingBefore: "2026-06-01T10:30:00.000Z",
+        startingAt: "2026-04-01T10:00:00.000Z",
+        endingBefore: "2026-07-01T11:00:00.000Z",
       })
     );
   });
@@ -373,8 +413,8 @@ describe("createCouponCredit", () => {
 
     expect(mockCreateMetronomeCredit).toHaveBeenCalledWith(
       expect.objectContaining({
-        startingAt: "2026-04-01T10:30:00.000Z",
-        endingBefore: "2026-05-01T10:30:00.000Z",
+        startingAt: "2026-04-01T10:00:00.000Z",
+        endingBefore: "2026-05-01T11:00:00.000Z",
       })
     );
   });
@@ -450,7 +490,7 @@ describe("endCouponCredit", () => {
     );
   });
 
-  it("uses a floored hour boundary for accessEndingBefore", async () => {
+  it("uses a ceiled hour boundary for accessEndingBefore", async () => {
     await endCouponCredit({
       metronomeCustomerId: "cust-1",
       metronomeCreditIds: ["cid-1"],
@@ -459,7 +499,7 @@ describe("endCouponCredit", () => {
 
     expect(mockUpdateMetronomeCreditEndDate).toHaveBeenCalledWith(
       expect.objectContaining({
-        accessEndingBefore: "2026-05-15T14:00:00.000Z",
+        accessEndingBefore: "2026-05-15T15:00:00.000Z",
       })
     );
   });
@@ -519,30 +559,6 @@ describe("redeemCoupon", () => {
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({ action: "coupon.redeemed" })
     );
-  });
-
-  it("durationMonths=3 coupon → 3 credit IDs stored, status active", async () => {
-    const { auth } = await makeWorkspaceWithUserAuth();
-    const coupon = await CouponFactory.create({ durationMonths: 3 });
-    mockCreateMetronomeCredit
-      .mockResolvedValueOnce(new Ok({ id: "credit-1" }))
-      .mockResolvedValueOnce(new Ok({ id: "credit-2" }))
-      .mockResolvedValueOnce(new Ok({ id: "credit-3" }));
-
-    const result = await redeemCoupon(auth, { coupon });
-
-    expect(result.isOk()).toBe(true);
-    if (!result.isOk()) {
-      return;
-    }
-
-    expect(result.value.status).toBe("active");
-    expect(result.value.metronomeCreditIds).toEqual([
-      "credit-1",
-      "credit-2",
-      "credit-3",
-    ]);
-    expect(mockCreateMetronomeCredit).toHaveBeenCalledTimes(3);
   });
 
   it("no active contract → Err", async () => {
@@ -618,6 +634,49 @@ describe("redeemCoupon", () => {
     // blocks a second pending/active row for the same workspace+coupon.
     const second = await redeemCoupon(auth, { coupon });
     expect(second.isErr()).toBe(true);
+  });
+
+  it("metronomePackageAlias provided → resolves credit type from package, does not fetch contract", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create({ durationMonths: null });
+    mockListMetronomePackages.mockResolvedValueOnce(
+      new Ok([
+        makePackageSummary({ aliases: ["pro-monthly"], rateCardId: "rc-pkg" }),
+      ])
+    );
+    mockGetMetronomeRateCardById.mockResolvedValueOnce(
+      new Ok(makeRateCard(CREDIT_TYPE_EUR_ID))
+    );
+    mockCreateMetronomeCredit.mockResolvedValue(new Ok({ id: "credit-eur" }));
+
+    const result = await redeemCoupon(auth, {
+      coupon,
+      metronomePackageAlias: "pro-monthly",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockGetActiveContract).not.toHaveBeenCalled();
+    expect(mockGetMetronomeRateCardById).toHaveBeenCalledWith({
+      rateCardId: "rc-pkg",
+    });
+    expect(mockCreateMetronomeCredit).toHaveBeenCalledWith(
+      expect.objectContaining({ creditTypeId: CREDIT_TYPE_EUR_ID })
+    );
+  });
+
+  it("metronomePackageAlias provided but alias not found → Err, no credit created", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create();
+    mockListMetronomePackages.mockResolvedValueOnce(new Ok([]));
+
+    const result = await redeemCoupon(auth, {
+      coupon,
+      metronomePackageAlias: "nonexistent-alias",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(mockGetActiveContract).not.toHaveBeenCalled();
+    expect(mockCreateMetronomeCredit).not.toHaveBeenCalled();
   });
 
   it("Metronome failure → status failed, redemptionCount decremented, same workspace can retry", async () => {

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -9,6 +9,7 @@ import {
   createMetronomeCredit,
   floorToHourISO,
   getMetronomeRateCardById,
+  listMetronomePackages,
   updateMetronomeCreditEndDate,
 } from "@app/lib/metronome/client";
 import {
@@ -49,6 +50,46 @@ export async function getCreditTypeFromContract(
     return result;
   }
 
+  const fiat_credit_type_id = result.value.fiat_credit_type?.id;
+  if (!fiat_credit_type_id) {
+    return new Err(new Error("Rate card has no fiat_credit_type_id"));
+  }
+  const creditTypeIdToCurrency = Object.fromEntries(
+    Object.entries(CURRENCY_TO_CREDIT_TYPE_ID).map(([c, id]) => [id, c])
+  );
+  const currency = creditTypeIdToCurrency[fiat_credit_type_id];
+  if (!isSupportedCurrency(currency)) {
+    return new Err(
+      new Error(
+        `Unsupported currency for credit type id: ${fiat_credit_type_id}`
+      )
+    );
+  }
+  return new Ok({ creditTypeId: fiat_credit_type_id, currency });
+}
+
+export async function getCreditTypeFromPackage(
+  packageAlias: string
+): Promise<
+  Result<{ creditTypeId: string; currency: SupportedCurrency }, Error>
+> {
+  const packagesResult = await listMetronomePackages();
+  if (packagesResult.isErr()) {
+    return packagesResult;
+  }
+  const pkg = packagesResult.value.find((p) =>
+    p.aliases.includes(packageAlias)
+  );
+  if (!pkg) {
+    return new Err(new Error(`No package found for alias: ${packageAlias}`));
+  }
+  if (!pkg.rateCardId) {
+    return new Err(new Error(`Package ${packageAlias} has no rate_card_id`));
+  }
+  const result = await getMetronomeRateCardById({ rateCardId: pkg.rateCardId });
+  if (result.isErr()) {
+    return result;
+  }
   const fiat_credit_type_id = result.value.fiat_credit_type?.id;
   if (!fiat_credit_type_id) {
     return new Err(new Error("Rate card has no fiat_credit_type_id"));
@@ -147,7 +188,13 @@ export type RedeemCouponError =
 
 export async function redeemCoupon(
   auth: Authenticator,
-  { coupon }: { coupon: CouponResource }
+  {
+    coupon,
+    metronomePackageAlias,
+  }: {
+    coupon: CouponResource;
+    metronomePackageAlias?: string;
+  }
 ): Promise<Result<CouponRedemptionResource, RedeemCouponError | Error>> {
   const validation = coupon.validateRedemption();
   if (validation.isErr()) {
@@ -175,22 +222,22 @@ export async function redeemCoupon(
     });
   }
 
-  const contract = await getActiveContract(workspace.sId);
-  if (!contract) {
-    return new Err(
-      new Error("No active Metronome contract found for workspace")
-    );
+  let creditTypeIdResult;
+  if (metronomePackageAlias) {
+    creditTypeIdResult = await getCreditTypeFromPackage(metronomePackageAlias);
+  } else {
+    const contract = await getActiveContract(workspace.sId);
+    if (!contract) {
+      return new Err(
+        new Error("No active Metronome contract found for workspace")
+      );
+    }
+    creditTypeIdResult = await getCreditTypeFromContract(contract);
   }
-
-  const creditTypeIdResult = await getCreditTypeFromContract(contract);
   if (creditTypeIdResult.isErr()) {
     return creditTypeIdResult;
   }
   const { creditTypeId, currency } = creditTypeIdResult.value;
-  logger.info(
-    { creditTypeId, currency, workspaceId: workspace.sId },
-    "[Metronome] Resolved credit type for coupon redemption"
-  );
 
   let redemption: CouponRedemptionResource;
   try {

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -5,6 +5,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { metronomeAmount } from "@app/lib/metronome/amounts";
 import {
+  ceilToHourISO,
   createMetronomeCredit,
   floorToHourISO,
   getMetronomeRateCardById,
@@ -92,43 +93,27 @@ export async function createCouponCredit({
   creditTypeId: string;
   currency: SupportedCurrency;
 }): Promise<Result<string[], Error>> {
-  const scheduleItems =
-    coupon.durationMonths === null
-      ? [{ startingAt: redeemedAt, endingBefore: addMonths(redeemedAt, 1) }]
-      : Array.from({ length: coupon.durationMonths }, (_, i) => ({
-          startingAt: addMonths(redeemedAt, i),
-          endingBefore: addMonths(redeemedAt, i + 1),
-        }));
+  const durationMonths = coupon.durationMonths ?? 1;
+  const result = await createMetronomeCredit({
+    metronomeCustomerId,
+    productId: getProductSeatSubscriptionCreditsId(),
+    creditTypeId,
+    amount: metronomeAmount(coupon.amount * 100, currency),
+    startingAt: floorToHourISO(redeemedAt),
+    endingBefore: ceilToHourISO(addMonths(redeemedAt, durationMonths)),
+    name: `Coupon: ${coupon.code}`,
+    idempotencyKey: `coupon-${redemptionId}-0`,
+    priority: 0,
+    applicableProductIds: getApplicableProductIdsForDiscountType(
+      coupon.discountType
+    ),
+  });
 
-  const creditIds: string[] = [];
-
-  for (let i = 0; i < scheduleItems.length; i++) {
-    const item = scheduleItems[i];
-    const result = await createMetronomeCredit({
-      metronomeCustomerId,
-      productId: getProductSeatSubscriptionCreditsId(),
-      creditTypeId,
-      amount: metronomeAmount(coupon.amount * 100, currency),
-      startingAt: item.startingAt.toISOString(),
-      endingBefore: item.endingBefore.toISOString(),
-      name: `Coupon: ${coupon.code}`,
-      idempotencyKey: `coupon-${redemptionId}-${i}`,
-      priority: 0,
-      applicableProductIds: getApplicableProductIdsForDiscountType(
-        coupon.discountType
-      ),
-    });
-
-    if (result.isErr()) {
-      return new Err(result.error);
-    }
-
-    if (result.value !== null) {
-      creditIds.push(result.value.id);
-    }
+  if (result.isErr()) {
+    return new Err(result.error);
   }
 
-  return new Ok(creditIds);
+  return new Ok(result.value !== null ? [result.value.id] : []);
 }
 
 export async function endCouponCredit({
@@ -140,7 +125,7 @@ export async function endCouponCredit({
   metronomeCreditIds: string[];
   endAt: Date;
 }): Promise<Result<void, Error>> {
-  const accessEndingBefore = floorToHourISO(endAt);
+  const accessEndingBefore = ceilToHourISO(endAt);
 
   for (const creditId of metronomeCreditIds) {
     const result = await updateMetronomeCreditEndDate({

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -35,21 +35,15 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { addMonths } from "date-fns";
 
-export async function getCreditTypeFromContract(
-  contract: CachedContract
+async function getCreditTypeFromRateCardId(
+  rateCardId: string
 ): Promise<
   Result<{ creditTypeId: string; currency: SupportedCurrency }, Error>
 > {
-  if (!contract.rate_card_id) {
-    return new Err(new Error("Contract has no rate_card_id"));
-  }
-  const result = await getMetronomeRateCardById({
-    rateCardId: contract.rate_card_id,
-  });
+  const result = await getMetronomeRateCardById({ rateCardId });
   if (result.isErr()) {
     return result;
   }
-
   const fiat_credit_type_id = result.value.fiat_credit_type?.id;
   if (!fiat_credit_type_id) {
     return new Err(new Error("Rate card has no fiat_credit_type_id"));
@@ -66,6 +60,17 @@ export async function getCreditTypeFromContract(
     );
   }
   return new Ok({ creditTypeId: fiat_credit_type_id, currency });
+}
+
+export async function getCreditTypeFromContract(
+  contract: CachedContract
+): Promise<
+  Result<{ creditTypeId: string; currency: SupportedCurrency }, Error>
+> {
+  if (!contract.rate_card_id) {
+    return new Err(new Error("Contract has no rate_card_id"));
+  }
+  return getCreditTypeFromRateCardId(contract.rate_card_id);
 }
 
 export async function getCreditTypeFromPackage(
@@ -86,26 +91,7 @@ export async function getCreditTypeFromPackage(
   if (!pkg.rateCardId) {
     return new Err(new Error(`Package ${packageAlias} has no rate_card_id`));
   }
-  const result = await getMetronomeRateCardById({ rateCardId: pkg.rateCardId });
-  if (result.isErr()) {
-    return result;
-  }
-  const fiat_credit_type_id = result.value.fiat_credit_type?.id;
-  if (!fiat_credit_type_id) {
-    return new Err(new Error("Rate card has no fiat_credit_type_id"));
-  }
-  const creditTypeIdToCurrency = Object.fromEntries(
-    Object.entries(CURRENCY_TO_CREDIT_TYPE_ID).map(([c, id]) => [id, c])
-  );
-  const currency = creditTypeIdToCurrency[fiat_credit_type_id];
-  if (!isSupportedCurrency(currency)) {
-    return new Err(
-      new Error(
-        `Unsupported currency for credit type id: ${fiat_credit_type_id}`
-      )
-    );
-  }
-  return new Ok({ creditTypeId: fiat_credit_type_id, currency });
+  return getCreditTypeFromRateCardId(pkg.rateCardId);
 }
 
 function getApplicableProductIdsForDiscountType(


### PR DESCRIPTION
## Description

* change behavior of coupon redemption to fit better with Metronome: apply credit once but with a validity corresponding to the durationMonths of the coupon
* in preparation of the redemption of a coupon during checkout: redemption can also use a given metronomePackageAlias instead of a contract to deduce the currency to apply (as we will want to redeem a coupon in checkout before the contract has been created)

## Tests

Tested locally + update integration tests

## Risk

Low, only for Metronome billing and coupons are not used yet

## Deploy Plan

Deploy front