### PR TITLE
[front] CheckoutPage: support coupons

### DIFF
--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -46,6 +46,8 @@ function getStripePromise() {
   return stripePromise;
 }
 
+const COUPONS_ENABLED = false;
+
 const couponFormSchema = z.object({
   couponCode: z.string().min(1, "Please enter a promotion code"),
 });
@@ -255,7 +257,8 @@ export function CheckoutPage() {
             </div>
 
             {/* Promotion code: toggle button → input field */}
-            {!appliedCoupon &&
+            {COUPONS_ENABLED &&
+              !appliedCoupon &&
               (showCouponInput ? (
                 <div className="mt-4 flex flex-col gap-2">
                   <div className="flex gap-2">
@@ -292,7 +295,7 @@ export function CheckoutPage() {
               ))}
 
             {/* Applied coupon: pill + description */}
-            {appliedCoupon && (
+            {COUPONS_ENABLED && appliedCoupon && (
               <div className="mt-4 flex flex-col gap-1">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-sm text-muted-foreground">

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -11,11 +11,21 @@ import { isWhitelistedBusinessPlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import {
   useCreateCheckoutSession,
+  useValidateCoupon,
   useWorkspaceSeatsCount,
 } from "@app/lib/swr/workspaces";
+import type { CouponType } from "@app/types/coupon";
 import type { BillingPeriod } from "@app/types/plan";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { DustLogoSquare, Icon, Spinner } from "@dust-tt/sparkle";
+import {
+  Button,
+  DustLogoSquare,
+  Icon,
+  Input,
+  Spinner,
+  TagIcon,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
 import {
   EmbeddedCheckout,
   EmbeddedCheckoutProvider,
@@ -51,8 +61,15 @@ export function CheckoutPage() {
   const { createSession, isCreating } = useCreateCheckoutSession({
     workspaceId: owner.sId,
   });
+  const { validateCoupon } = useValidateCoupon({ workspaceId: owner.sId });
 
   const [clientSecret, setClientSecret] = useState<string | null>(null);
+  const [isSessionRefreshing, setIsSessionRefreshing] = useState(false);
+  const [showCouponInput, setShowCouponInput] = useState(false);
+  const [couponCode, setCouponCode] = useState("");
+  const [appliedCoupon, setAppliedCoupon] = useState<CouponType | null>(null);
+  const [couponError, setCouponError] = useState<string | null>(null);
+  const [isApplyingCoupon, setIsApplyingCoupon] = useState(false);
 
   const initSession = useCallback(
     async (couponCodeArg?: string) => {
@@ -113,6 +130,37 @@ export function CheckoutPage() {
     void initSession();
   }, [initSession]);
 
+  const handleRemoveCoupon = async () => {
+    setAppliedCoupon(null);
+    setCouponCode("");
+    setIsSessionRefreshing(true);
+    await initSession();
+    setIsSessionRefreshing(false);
+  };
+
+  const handleApplyCoupon = async () => {
+    if (!couponCode.trim()) {
+      return;
+    }
+    setIsApplyingCoupon(true);
+    setCouponError(null);
+    try {
+      const result = await validateCoupon(couponCode.trim());
+      if (!result.ok) {
+        setCouponError(result.message);
+        return;
+      }
+      setAppliedCoupon(result.coupon);
+      setShowCouponInput(false);
+      // Re-create session with the coupon code so it's stored in metadata.
+      setIsSessionRefreshing(true);
+      await initSession(couponCode.trim());
+      setIsSessionRefreshing(false);
+    } finally {
+      setIsApplyingCoupon(false);
+    }
+  };
+
   // Full-page spinner only on initial load; coupon re-creation keeps the left pane visible.
   const isInitialLoading = (isSeatsCountLoading || isCreating) && !clientSecret;
 
@@ -131,9 +179,13 @@ export function CheckoutPage() {
   const seatPriceCents = seatPricePerMonthCents * monthsInPeriod;
   const subtotalCents = seatPriceCents * seats;
 
-  const totalDueTodayCents = subtotalCents;
+  const couponDiscountCents =
+    appliedCoupon !== null
+      ? Math.min(appliedCoupon.amount * 100, subtotalCents)
+      : 0;
+  const totalDueTodayCents = subtotalCents - couponDiscountCents;
 
-  if (isInitialLoading || !clientSecret) {
+  if (!isSessionRefreshing && (isInitialLoading || !clientSecret)) {
     return (
       <main className="flex min-h-screen items-center justify-center">
         <Spinner size="xl" />
@@ -190,6 +242,80 @@ export function CheckoutPage() {
                 })}
               </span>
             </div>
+
+            {/* Promotion code: toggle button → input field */}
+            {!appliedCoupon &&
+              (showCouponInput ? (
+                <div className="mt-4 flex flex-col gap-2">
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder="Enter promotion code"
+                      value={couponCode}
+                      onChange={(e) => {
+                        setCouponCode(e.target.value);
+                        setCouponError(null);
+                      }}
+                      disabled={isApplyingCoupon}
+                      className="flex-1"
+                    />
+                    <Button
+                      label={isApplyingCoupon ? "Applying…" : "Apply"}
+                      disabled={isApplyingCoupon || !couponCode.trim()}
+                      onClick={handleApplyCoupon}
+                      size="sm"
+                      variant="outline"
+                    />
+                  </div>
+                  {couponError && (
+                    <p className="text-sm text-warning-500">{couponError}</p>
+                  )}
+                </div>
+              ) : (
+                <div className="mt-4 flex flex-col gap-2">
+                  <Button
+                    label="Add promotion code"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowCouponInput(true)}
+                    className="self-start bg-muted"
+                  />
+                </div>
+              ))}
+
+            {/* Applied coupon: pill + description */}
+            {appliedCoupon && (
+              <div className="mt-4 flex flex-col gap-1">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-sm text-muted-foreground">
+                    <Icon visual={TagIcon} size="xs" />
+                    <span className="font-medium">{appliedCoupon.code}</span>
+                    <button
+                      type="button"
+                      onClick={handleRemoveCoupon}
+                      className="ml-0.5 hover:text-foreground"
+                    >
+                      <Icon visual={XMarkIcon} size="xs" />
+                    </button>
+                  </div>
+                  <span className="text-sm text-success-500">
+                    −
+                    {getPriceAsString({
+                      currency,
+                      priceInCents: couponDiscountCents,
+                    })}
+                  </span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {getPriceAsString({
+                    currency,
+                    priceInCents: appliedCoupon.amount * 100,
+                  })}
+                  {appliedCoupon.durationMonths !== null
+                    ? ` for ${appliedCoupon.durationMonths} month${appliedCoupon.durationMonths > 1 ? "s" : ""}`
+                    : " valid once"}
+                </p>
+              </div>
+            )}
 
             {/* Total due today — always visible */}
             <div className="mt-6 flex justify-between border-t border-separator pt-3 text-base font-semibold">

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -26,12 +26,15 @@ import {
   TagIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
 import {
   EmbeddedCheckout,
   EmbeddedCheckoutProvider,
 } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
 // Lazily initialised at module level so Stripe.js is loaded only when the embedded
 // checkout is actually rendered, and never re-loaded on re-renders.
@@ -42,6 +45,12 @@ function getStripePromise() {
   }
   return stripePromise;
 }
+
+const couponFormSchema = z.object({
+  couponCode: z.string().min(1, "Please enter a promotion code"),
+});
+
+type CouponFormValues = z.infer<typeof couponFormSchema>;
 
 function useBillingPeriodParam(): BillingPeriod {
   const raw = useSearchParam("billingPeriod");
@@ -66,10 +75,21 @@ export function CheckoutPage() {
   const [clientSecret, setClientSecret] = useState<string | null>(null);
   const [isSessionRefreshing, setIsSessionRefreshing] = useState(false);
   const [showCouponInput, setShowCouponInput] = useState(false);
-  const [couponCode, setCouponCode] = useState("");
   const [appliedCoupon, setAppliedCoupon] = useState<CouponType | null>(null);
-  const [couponError, setCouponError] = useState<string | null>(null);
-  const [isApplyingCoupon, setIsApplyingCoupon] = useState(false);
+
+  const {
+    register: registerCoupon,
+    handleSubmit: handleCouponSubmit,
+    watch: watchCoupon,
+    reset: resetCoupon,
+    setError: setCouponError,
+    formState: { errors: couponErrors, isSubmitting: isApplyingCoupon },
+  } = useForm<CouponFormValues>({
+    resolver: zodResolver(couponFormSchema),
+    defaultValues: { couponCode: "" },
+  });
+
+  const couponCodeValue = watchCoupon("couponCode");
 
   const initSession = useCallback(
     async (couponCodeArg?: string) => {
@@ -132,34 +152,25 @@ export function CheckoutPage() {
 
   const handleRemoveCoupon = async () => {
     setAppliedCoupon(null);
-    setCouponCode("");
+    resetCoupon();
     setIsSessionRefreshing(true);
     await initSession();
     setIsSessionRefreshing(false);
   };
 
-  const handleApplyCoupon = async () => {
-    if (!couponCode.trim()) {
+  const handleApplyCoupon = handleCouponSubmit(async ({ couponCode }) => {
+    const result = await validateCoupon(couponCode.trim());
+    if (!result.ok) {
+      setCouponError("couponCode", { message: result.message });
       return;
     }
-    setIsApplyingCoupon(true);
-    setCouponError(null);
-    try {
-      const result = await validateCoupon(couponCode.trim());
-      if (!result.ok) {
-        setCouponError(result.message);
-        return;
-      }
-      setAppliedCoupon(result.coupon);
-      setShowCouponInput(false);
-      // Re-create session with the coupon code so it's stored in metadata.
-      setIsSessionRefreshing(true);
-      await initSession(couponCode.trim());
-      setIsSessionRefreshing(false);
-    } finally {
-      setIsApplyingCoupon(false);
-    }
-  };
+    setAppliedCoupon(result.coupon);
+    setShowCouponInput(false);
+    // Re-create session with the coupon code so it's stored in metadata.
+    setIsSessionRefreshing(true);
+    await initSession(couponCode.trim());
+    setIsSessionRefreshing(false);
+  });
 
   // Full-page spinner only on initial load; coupon re-creation keeps the left pane visible.
   const isInitialLoading = (isSeatsCountLoading || isCreating) && !clientSecret;
@@ -250,24 +261,22 @@ export function CheckoutPage() {
                   <div className="flex gap-2">
                     <Input
                       placeholder="Enter promotion code"
-                      value={couponCode}
-                      onChange={(e) => {
-                        setCouponCode(e.target.value);
-                        setCouponError(null);
-                      }}
+                      {...registerCoupon("couponCode")}
                       disabled={isApplyingCoupon}
                       className="flex-1"
                     />
                     <Button
                       label={isApplyingCoupon ? "Applying…" : "Apply"}
-                      disabled={isApplyingCoupon || !couponCode.trim()}
+                      disabled={isApplyingCoupon || !couponCodeValue.trim()}
                       onClick={handleApplyCoupon}
                       size="sm"
                       variant="outline"
                     />
                   </div>
-                  {couponError && (
-                    <p className="text-sm text-warning-500">{couponError}</p>
+                  {couponErrors.couponCode && (
+                    <p className="text-sm text-warning-500">
+                      {couponErrors.couponCode.message}
+                    </p>
                   )}
                 </div>
               ) : (

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -65,7 +65,8 @@ export type DustErrorCode =
   | "subscription_already_exists"
   | "workspace_not_found"
   | "plan_not_found"
-  | "metronome_error";
+  | "metronome_error"
+  | "coupon_redemption_error";
 
 export class DustError<T extends DustErrorCode = DustErrorCode> extends Error {
   constructor(

--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -187,9 +187,11 @@ export async function handleMetronomeSetupCheckout({
   if (couponCode) {
     const coupon = await CouponResource.findByCode(couponCode);
     if (!coupon) {
-      logger.warn(
-        { couponCode, workspaceId },
-        "Coupon not found during checkout; skipping redemption."
+      return new Err(
+        new DustError(
+          "coupon_redemption_error",
+          `Coupon ${couponCode} not found.`
+        )
       );
     } else {
       const redeemResult = await redeemCoupon(authUser ?? authAdmin, {
@@ -197,9 +199,11 @@ export async function handleMetronomeSetupCheckout({
         metronomePackageAlias: resolvedPackageAlias,
       });
       if (redeemResult.isErr()) {
-        logger.warn(
-          { couponCode, workspaceId, error: redeemResult.error },
-          "Failed to redeem coupon during checkout; skipping."
+        return new Err(
+          new DustError(
+            "coupon_redemption_error",
+            `Could not apply coupon ${couponCode}.`
+          )
         );
       }
     }

--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -6,12 +6,14 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
+import { redeemCoupon } from "@app/lib/metronome/coupons";
 import { PlanModel } from "@app/lib/models/plan";
 import {
   resolveCurrencyFromStripe,
   resolvePackageAliasForCurrency,
 } from "@app/lib/plans/billing_currency";
 import { getStripeClient, getStripeCustomer } from "@app/lib/plans/stripe";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -31,6 +33,7 @@ const StripeSetupSessionSchema = z.object({
     planCode: z.string(),
     userId: z.string().optional(),
     metronomePackageAlias: z.string(),
+    couponCode: z.string().optional(),
   }),
   customer: z.string(),
   setup_intent: z.string().nullable().optional(),
@@ -89,7 +92,7 @@ export async function handleMetronomeSetupCheckout({
   const {
     id: sessionId,
     client_reference_id: workspaceId,
-    metadata: { planCode, userId, metronomePackageAlias },
+    metadata: { planCode, userId, metronomePackageAlias, couponCode },
     customer: stripeCustomerId,
     customer_details: customerDetails,
     setup_intent: setupIntentId,
@@ -174,6 +177,34 @@ export async function handleMetronomeSetupCheckout({
   }
   const { metronomeCustomerId } = customerResult.value;
 
+  const authAdmin = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const authUser = userId
+    ? await Authenticator.fromUserIdAndWorkspaceId(userId, workspace.sId)
+    : null;
+
+  if (couponCode) {
+    const coupon = await CouponResource.findByCode(couponCode);
+    if (!coupon) {
+      logger.warn(
+        { couponCode, workspaceId },
+        "Coupon not found during checkout; skipping redemption."
+      );
+    } else {
+      const redeemResult = await redeemCoupon(authUser ?? authAdmin, {
+        coupon,
+        metronomePackageAlias: resolvedPackageAlias,
+      });
+      if (redeemResult.isErr()) {
+        logger.warn(
+          { couponCode, workspaceId, error: redeemResult.error },
+          "Failed to redeem coupon during checkout; skipping."
+        );
+      }
+    }
+  }
+
   const contractResult = await provisionMetronomeContract({
     metronomeCustomerId,
     workspace: lightWorkspace,
@@ -200,8 +231,6 @@ export async function handleMetronomeSetupCheckout({
     return subscriptionResult;
   }
 
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
   if (userId) {
     const workspaceSeats = await MembershipResource.countActiveSeatsInWorkspace(
       workspace.sId
@@ -215,7 +244,7 @@ export async function handleMetronomeSetupCheckout({
     });
   }
 
-  await restoreWorkspaceAfterSubscription(auth);
+  await restoreWorkspaceAfterSubscription(authAdmin);
 
   await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({ workspaceId });
 

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -278,12 +278,14 @@ export const createStripeSubscriptionCheckoutSession = async ({
  */
 export const createEmbeddedMetronomeSetupCheckoutSession = async ({
   allowedPaymentMethods = ["card"],
+  couponCode,
   metronomePackageAlias,
   owner,
   planCode,
   user,
 }: {
   allowedPaymentMethods?: SupportedPaymentMethod[];
+  couponCode?: string;
   metronomePackageAlias: string;
   owner: WorkspaceType;
   planCode: string;
@@ -296,6 +298,9 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
     userId: `${user.id}`,
     metronomePackageAlias,
   };
+  if (couponCode) {
+    metadata.couponCode = couponCode;
+  }
 
   const session = await stripe.checkout.sessions.create({
     ui_mode: "embedded",

--- a/front/lib/resources/coupon_redemption_resource.ts
+++ b/front/lib/resources/coupon_redemption_resource.ts
@@ -72,12 +72,12 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<CouponRedemptionResource> {
     const workspace = auth.getNonNullableWorkspace();
-    const user = auth.getNonNullableUser();
+    const user = auth.user();
     const redemption = await CouponRedemptionModel.create(
       {
         couponId: coupon.id,
         workspaceId: workspace.id,
-        redeemedByUserId: user.id,
+        redeemedByUserId: user ? user.id : null,
         redeemedAt: new Date(),
         status: "pending",
         metronomeCreditIds: [],
@@ -87,7 +87,7 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
     return new this(this.model, redemption.get(), {
       workspaceSId: workspace.sId,
       couponSId: coupon.sId,
-      redeemedByUserSId: user.sId,
+      redeemedByUserSId: user ? user.sId : null,
     });
   }
 

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1132,8 +1132,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     billingPeriod: BillingPeriod,
     {
       useMetronomeBilling,
+      couponCode,
     }: {
       useMetronomeBilling: boolean;
+      couponCode?: string;
     }
   ): Promise<CheckoutUrlResult> {
     const isBusiness = !!owner.metadata?.isBusiness;
@@ -1174,6 +1176,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
           planCode,
           metronomePackageAlias,
           allowedPaymentMethods,
+          couponCode,
         });
       return {
         mode: "embedded",

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -25,6 +25,7 @@ import type { GetWorkspaceTopAgentsResponse } from "@app/pages/api/w/[wId]/analy
 import type { GetWorkspaceTopUsersResponse } from "@app/pages/api/w/[wId]/analytics/top-users";
 import type { GetWorkspaceUsageMetricsResponse } from "@app/pages/api/w/[wId]/analytics/usage-metrics";
 import type { GetWorkspaceAuthContextResponseType } from "@app/pages/api/w/[wId]/auth-context";
+import type { GetCouponValidateResponseBody } from "@app/pages/api/w/[wId]/coupon/validate";
 import type { GetJoinResponseBody } from "@app/pages/api/w/[wId]/join";
 import type { GetMetronomeContractResponseBody } from "@app/pages/api/w/[wId]/metronome/contract";
 import type { GetMetronomeInvoiceResponseBody } from "@app/pages/api/w/[wId]/metronome/invoice";
@@ -1054,4 +1055,30 @@ export function useCreateCheckoutSession({
   );
 
   return { createSession, isCreating };
+}
+
+export function useValidateCoupon({ workspaceId }: { workspaceId: string }) {
+  const validateCoupon = useCallback(
+    async (
+      code: string
+    ): Promise<
+      | { ok: true; coupon: GetCouponValidateResponseBody["coupon"] }
+      | { ok: false; message: string }
+    > => {
+      const res = await clientFetch(
+        `/api/w/${workspaceId}/coupon/validate?code=${encodeURIComponent(code)}`
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        const message =
+          body?.error?.message ?? "Invalid or expired coupon code.";
+        return { ok: false, message };
+      }
+      const body = (await res.json()) as GetCouponValidateResponseBody;
+      return { ok: true, coupon: body.coupon };
+    },
+    [workspaceId]
+  );
+
+  return { validateCoupon };
 }

--- a/front/pages/api/w/[wId]/coupon/validate.test.ts
+++ b/front/pages/api/w/[wId]/coupon/validate.test.ts
@@ -1,0 +1,133 @@
+import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { CouponFactory } from "@app/tests/utils/CouponFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { describe, expect, it } from "vitest";
+
+import handler from "./validate";
+
+describe("GET /api/w/[wId]/coupon/validate", () => {
+  it("returns 400 when code query param is missing", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 for unknown coupon code", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    req.query = { ...req.query, code: "UNKNOWN_CODE" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("coupon_not_found");
+  });
+
+  it("returns 200 and coupon for a valid code", async () => {
+    const coupon = await CouponFactory.create({ code: "VALID10" });
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    req.query = { ...req.query, code: coupon.code };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.coupon.code).toBe("VALID10");
+    expect(data.coupon.amount).toBeDefined();
+  });
+
+  it("returns 400 for an expired coupon", async () => {
+    const expired = await CouponFactory.create({
+      expirationDate: new Date("2020-01-01"),
+    });
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    req.query = { ...req.query, code: expired.code };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("coupon_not_redeemable");
+  });
+
+  it("returns 400 for an exhausted coupon", async () => {
+    const exhausted = await CouponFactory.create({
+      maxRedemptions: 1,
+      redemptionCount: 1,
+    });
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    req.query = { ...req.query, code: exhausted.code };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("coupon_not_redeemable");
+  });
+
+  it("returns 400 for an archived coupon", async () => {
+    const archived = await CouponFactory.create({
+      archivedAt: new Date("2023-01-01"),
+    });
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    req.query = { ...req.query, code: archived.code };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("coupon_not_redeemable");
+  });
+
+  it("returns 400 when coupon already redeemed by this workspace", async () => {
+    const coupon = await CouponFactory.create({ code: "ALREADYUSED" });
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await CouponRedemptionResource.makeNew(auth, { coupon });
+
+    req.query = { ...req.query, code: coupon.code };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("coupon_already_redeemed");
+  });
+
+  it("returns 405 for non-GET methods", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    req.query = { ...req.query, code: "ANYCODE" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+});

--- a/front/pages/api/w/[wId]/coupon/validate.ts
+++ b/front/pages/api/w/[wId]/coupon/validate.ts
@@ -1,0 +1,85 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { CouponType } from "@app/types/coupon";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetCouponValidateResponseBody = {
+  coupon: CouponType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetCouponValidateResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported.",
+      },
+    });
+  }
+
+  const { code } = req.query;
+  if (!isString(code)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid `code` query parameter.",
+      },
+    });
+  }
+
+  const coupon = await CouponResource.findByCode(code);
+  if (!coupon) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "coupon_not_found",
+        message: "Coupon not found.",
+      },
+    });
+  }
+
+  const validationResult = coupon.validateRedemption();
+  if (validationResult.isErr()) {
+    const { code: errorCode } = validationResult.error;
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "coupon_not_redeemable",
+        message: `Coupon is not redeemable: ${errorCode}.`,
+      },
+    });
+  }
+
+  const existingRedemption =
+    await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
+      auth,
+      { coupon }
+    );
+  if (existingRedemption) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "coupon_already_redeemed",
+        message: "This coupon has already been redeemed by this workspace.",
+      },
+    });
+  }
+
+  return res.status(200).json({ coupon: coupon.toJSON() });
+}
+
+export default withSessionAuthenticationForWorkspace(handler, {
+  doesNotRequireCanUseProduct: true,
+});

--- a/front/pages/api/w/[wId]/coupon/validate.ts
+++ b/front/pages/api/w/[wId]/coupon/validate.ts
@@ -28,6 +28,17 @@ async function handler(
     });
   }
 
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
+      },
+    });
+  }
+
   const { code } = req.query;
   if (!isString(code)) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -30,6 +30,7 @@ export type GetSubscriptionsResponseBody = {
 
 export const PostSubscriptionRequestBody = z.object({
   billingPeriod: z.enum(["monthly", "yearly"]),
+  couponCode: z.string().optional(),
 });
 
 export const PatchSubscriptionRequestBody = z.object({
@@ -99,7 +100,10 @@ async function handler(
           owner,
           user,
           bodyValidation.data.billingPeriod,
-          { useMetronomeBilling }
+          {
+            useMetronomeBilling,
+            couponCode: bodyValidation.data.couponCode,
+          }
         );
 
         return res.status(200).json(checkoutUrlResult);

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -123,6 +123,8 @@ const API_ERROR_TYPES = [
   "group_not_found",
   // Coupons:
   "coupon_not_found",
+  "coupon_not_redeemable",
+  "coupon_already_redeemed",
   // Plugins:
   "plugin_not_found",
   "plugin_execution_failed",


### PR DESCRIPTION
## Description

Coupon support at checkout

Closes https://github.com/dust-tt/tasks/issues/7926 (last step)
=> Adds end-to-end coupon redemption to the checkout flow:
* GET /api/w/[wId]/coupon/validate: new endpoint that validates a coupon code (checks existence, expiry, and whether it has already been redeemed by the workspace). Includes unit tests.
* useValidateCoupon SWR hook : client-side hook to call the validation endpoint with debouncing.
* Checkout page : coupon input field added to the UI; on a valid coupon the discount is displayed and the coupon code is passed through to the subscription creation flow.
* Subscription creation (/api/w/[wId]/subscriptions) : wires the validated coupon into the Metronome checkout and marks it as redeemed on success via CouponRedemptionResource, the coupon redemption is done before the contract is created so that the credits corresponding to the coupon can be taken into account in the invoice generated at contract creation
<img width="1466" height="714" alt="Screenshot 2026-05-06 at 21 12 57" src="https://github.com/user-attachments/assets/d93b7080-3045-483a-bc3f-5f0856413bca" />
<img width="1429" height="681" alt="Screenshot 2026-05-06 at 21 13 12" src="https://github.com/user-attachments/assets/efaa4e66-f386-4fb7-9003-f94df8663af1" />

<img width="1438" height="685" alt="Screenshot 2026-05-06 at 21 13 27" src="https://github.com/user-attachments/assets/89efbadf-0a98-4e1f-9052-cc4935488692" />


For the moment coupons are not displayed using COUPONS_ENABLED, will be enabled later after with full coupons release

## Tests

Tested locally with coupons and a checkout with Metronome => the coupon/credits are applied on the first invoice generated on contract creation

## Risk

Low, only for checkout with metronome_billing feature flag

## Deploy Plan

Deploy front