### PR TITLE
Handle: unassigned tasks in the project's ui.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer.tsx
@@ -10,6 +10,8 @@ import {
   stripNewlines,
 } from "@app/components/assistant/conversation/space/conversations/project_tasks/utils";
 import { removeDiacritics } from "@app/lib/utils";
+import { PROJECT_TASK_NO_ASSIGNEE_LABEL } from "@app/types/project_task";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { SpaceUserType } from "@app/types/user";
 import {
   Avatar,
@@ -24,43 +26,139 @@ import {
 } from "@dust-tt/sparkle";
 import { useCallback, useMemo, useRef, useState } from "react";
 
+export type AddTaskAssigneeChoice =
+  | { kind: "default" }
+  | { kind: "unassigned" }
+  | { kind: "member"; sId: string };
+
+export function resolveSubmitAssigneeSId(
+  choice: AddTaskAssigneeChoice,
+  defaultAssigneeSId: string
+): string | null {
+  switch (choice.kind) {
+    case "unassigned":
+      return null;
+    case "default":
+      return defaultAssigneeSId;
+    case "member":
+      return choice.sId;
+    default:
+      assertNeverAndIgnore(choice);
+      return null;
+  }
+}
+
+function memberRowAssigneeChecked(
+  choice: AddTaskAssigneeChoice,
+  memberSId: string,
+  defaultAssigneeSId: string
+): boolean {
+  switch (choice.kind) {
+    case "unassigned":
+      return false;
+    case "default":
+      return defaultAssigneeSId === memberSId;
+    case "member":
+      return choice.sId === memberSId;
+    default:
+      assertNeverAndIgnore(choice);
+      return false;
+  }
+}
+
+function assigneeTriggerTitleAndAria(
+  choice: AddTaskAssigneeChoice,
+  selectedUser: SpaceUserType | null | undefined,
+  viewerUserId: string | null
+): { title: string; ariaLabel: string } {
+  if (selectedUser) {
+    const youSuffix = viewerUserId === selectedUser.sId ? " (you)" : "";
+    return {
+      title: `Assign to ${selectedUser.fullName}${youSuffix} — click to change`,
+      ariaLabel: `Assign to ${selectedUser.fullName}${youSuffix}, open menu to change`,
+    };
+  }
+  switch (choice.kind) {
+    case "unassigned":
+      return {
+        title: `${PROJECT_TASK_NO_ASSIGNEE_LABEL} — click to change assignee`,
+        ariaLabel: `${PROJECT_TASK_NO_ASSIGNEE_LABEL}, open menu to change assignee`,
+      };
+    case "default":
+    case "member":
+      return {
+        title: "Choose assignee",
+        ariaLabel: "Choose assignee",
+      };
+    default:
+      assertNeverAndIgnore(choice);
+      return {
+        title: "Choose assignee",
+        ariaLabel: "Choose assignee",
+      };
+  }
+}
+
 function TodoRowAssigneeMenu({
   ariaNamePrefix,
   members,
   viewerUserId,
-  selectedSId,
-  onSelect,
+  defaultAssigneeSId,
+  choice,
+  onChoiceChange,
   onMenuOpenChange,
   disabled,
 }: {
   ariaNamePrefix: string;
   members: SpaceUserType[];
   viewerUserId: string | null;
-  selectedSId: string | null;
-  onSelect: (userSId: string) => void;
+  defaultAssigneeSId: string;
+  choice: AddTaskAssigneeChoice;
+  onChoiceChange: (next: AddTaskAssigneeChoice) => void;
   onMenuOpenChange?: (open: boolean) => void;
   disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const q = removeDiacritics(search.trim()).toLowerCase();
   const filteredMembers = useMemo(() => {
-    const q = removeDiacritics(search.trim()).toLowerCase();
     if (!q) {
       return [...members];
     }
     return members.filter((m) =>
       removeDiacritics(m.fullName).toLowerCase().includes(q)
     );
-  }, [search, members]);
-  const selectedUser = members.find((m) => m.sId === selectedSId);
-  const assigneeTriggerVisual =
-    selectedUser?.image ?? "/static/humanavatar/anonymous.png";
-  const title = selectedUser
-    ? `Assign to ${selectedUser.fullName}${viewerUserId === selectedUser.sId ? " (you)" : ""} — click to change`
-    : "Choose assignee";
-  const ariaLabel = selectedUser
-    ? `Assign to ${selectedUser.fullName}${viewerUserId === selectedUser.sId ? " (you)" : ""}, open menu to change`
-    : "Choose assignee";
+  }, [q, members]);
+
+  const assigneeSearchLabelNorm = removeDiacritics(
+    PROJECT_TASK_NO_ASSIGNEE_LABEL
+  ).toLowerCase();
+  const showNoAssigneeRow = q === "" || assigneeSearchLabelNorm.includes(q);
+
+  let effectiveMemberSId: string | null;
+  switch (choice.kind) {
+    case "unassigned":
+      effectiveMemberSId = null;
+      break;
+    case "default":
+      effectiveMemberSId = defaultAssigneeSId;
+      break;
+    case "member":
+      effectiveMemberSId = choice.sId;
+      break;
+    default:
+      assertNeverAndIgnore(choice);
+      effectiveMemberSId = null;
+  }
+  const selectedUser = effectiveMemberSId
+    ? members.find((m) => m.sId === effectiveMemberSId)
+    : null;
+
+  const { title, ariaLabel } = assigneeTriggerTitleAndAria(
+    choice,
+    selectedUser,
+    viewerUserId
+  );
 
   return (
     <DropdownMenu
@@ -88,7 +186,18 @@ function TodoRowAssigneeMenu({
             "disabled:pointer-events-none disabled:opacity-40"
           )}
         >
-          <Avatar size="xs" isRounded visual={assigneeTriggerVisual} />
+          {selectedUser ? (
+            <Avatar
+              size="xs"
+              isRounded
+              visual={selectedUser.image ?? "/static/humanavatar/anonymous.png"}
+            />
+          ) : (
+            <span
+              className="block size-[1.625rem] shrink-0 rounded-full ring-1 ring-inset ring-border/70 dark:ring-border-night/60"
+              aria-hidden
+            />
+          )}
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -104,29 +213,65 @@ function TodoRowAssigneeMenu({
         />
         <DropdownMenuSeparator />
         <div className="max-h-64 overflow-auto">
-          {filteredMembers.length > 0 ? (
-            filteredMembers.map((member) => (
-              <DropdownMenuCheckboxItem
-                key={`${ariaNamePrefix}-member-${member.sId}`}
-                icon={() => (
-                  <Avatar
-                    size="xxs"
-                    isRounded
-                    visual={member.image ?? "/static/humanavatar/anonymous.png"}
+          {showNoAssigneeRow || filteredMembers.length > 0 ? (
+            <>
+              {showNoAssigneeRow && (
+                <DropdownMenuCheckboxItem
+                  key={`${ariaNamePrefix}-no-assignee`}
+                  label={PROJECT_TASK_NO_ASSIGNEE_LABEL}
+                  checked={choice.kind === "unassigned"}
+                  onClick={() => {
+                    onChoiceChange({ kind: "unassigned" });
+                    setOpen(false);
+                    onMenuOpenChange?.(false);
+                  }}
+                  onSelect={(event) => {
+                    event.preventDefault();
+                  }}
+                />
+              )}
+              {showNoAssigneeRow && filteredMembers.length > 0 ? (
+                <DropdownMenuSeparator />
+              ) : null}
+              {filteredMembers.length > 0 ? (
+                filteredMembers.map((member) => (
+                  <DropdownMenuCheckboxItem
+                    key={`${ariaNamePrefix}-member-${member.sId}`}
+                    icon={() => (
+                      <Avatar
+                        size="xxs"
+                        isRounded
+                        visual={
+                          member.image ?? "/static/humanavatar/anonymous.png"
+                        }
+                      />
+                    )}
+                    label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
+                    checked={memberRowAssigneeChecked(
+                      choice,
+                      member.sId,
+                      defaultAssigneeSId
+                    )}
+                    onClick={() => {
+                      onChoiceChange(
+                        member.sId === defaultAssigneeSId
+                          ? { kind: "default" }
+                          : { kind: "member", sId: member.sId }
+                      );
+                      setOpen(false);
+                      onMenuOpenChange?.(false);
+                    }}
+                    onSelect={(event) => {
+                      event.preventDefault();
+                    }}
                   />
-                )}
-                label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
-                checked={selectedSId === member.sId}
-                onClick={() => {
-                  onSelect(member.sId);
-                  setOpen(false);
-                  onMenuOpenChange?.(false);
-                }}
-                onSelect={(event) => {
-                  event.preventDefault();
-                }}
-              />
-            ))
+                ))
+              ) : !showNoAssigneeRow ? (
+                <div className="px-3 py-2 text-sm text-muted-foreground">
+                  No members found
+                </div>
+              ) : null}
+            </>
           ) : (
             <div className="px-3 py-2 text-sm text-muted-foreground">
               No members found
@@ -148,19 +293,25 @@ export function AddTodoComposer({
   projectMembers: SpaceUserType[];
   viewerUserId: string | null;
   defaultAssigneeSId: string;
-  /** When true, assignee is implicit (e.g. sole project member); no avatar control. */
+  /** When true, always assigns to `defaultAssigneeSId` with no picker. */
   hideAssigneePicker?: boolean;
-  onAdd: (text: string, assigneeSId: string) => Promise<boolean>;
+  onAdd: (text: string, assigneeSId: string | null) => Promise<boolean>;
 }) {
   const [text, setText] = useState("");
-  const [assigneeSId, setAssigneeSId] = useState<string | null>(null);
+  const [assigneeChoice, setAssigneeChoice] = useState<AddTaskAssigneeChoice>(
+    () => ({
+      kind: "default",
+    })
+  );
   const [isAdding, setIsAdding] = useState(false);
   const [inputFocused, setInputFocused] = useState(false);
   const [assigneeMenuOpen, setAssigneeMenuOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const selectedSId = assigneeSId ?? defaultAssigneeSId;
+  const submitAssigneeSId = hideAssigneePicker
+    ? defaultAssigneeSId
+    : resolveSubmitAssigneeSId(assigneeChoice, defaultAssigneeSId);
 
   const isExpanded =
     inputFocused ||
@@ -169,11 +320,11 @@ export function AddTodoComposer({
 
   const handleSubmit = useCallback(async () => {
     const trimmed = stripNewlines(text).trim();
-    if (!trimmed || !selectedSId || isAdding) {
+    if (!trimmed || isAdding) {
       return;
     }
     setIsAdding(true);
-    const ok = await onAdd(trimmed, selectedSId);
+    const ok = await onAdd(trimmed, submitAssigneeSId);
     setIsAdding(false);
     if (ok) {
       setText("");
@@ -187,7 +338,7 @@ export function AddTodoComposer({
         }
       });
     }
-  }, [text, selectedSId, isAdding, onAdd]);
+  }, [text, submitAssigneeSId, isAdding, onAdd]);
 
   const sideChromeToneClass = cn(
     "transition-opacity duration-300 ease-in-out motion-reduce:transition-none motion-reduce:duration-75",
@@ -218,8 +369,9 @@ export function AddTodoComposer({
                 ariaNamePrefix="add-task"
                 members={projectMembers}
                 viewerUserId={viewerUserId}
-                selectedSId={selectedSId}
-                onSelect={setAssigneeSId}
+                defaultAssigneeSId={defaultAssigneeSId}
+                choice={assigneeChoice}
+                onChoiceChange={setAssigneeChoice}
                 onMenuOpenChange={setAssigneeMenuOpen}
                 disabled={isAdding}
               />
@@ -287,7 +439,7 @@ export function AddTodoComposer({
               variant="highlight"
               label="Add"
               isLoading={isAdding}
-              disabled={isAdding || !stripNewlines(text).trim() || !selectedSId}
+              disabled={isAdding || !stripNewlines(text).trim()}
               onMouseDown={(e) => e.preventDefault()}
               onClick={() => void handleSubmit()}
             />

--- a/front/components/assistant/conversation/space/conversations/project_tasks/EditableTaskItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/EditableTaskItem.tsx
@@ -16,7 +16,10 @@ import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_stat
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { ProjectTaskType } from "@app/types/project_task";
+import {
+  PROJECT_TASK_NO_ASSIGNEE_LABEL,
+  type ProjectTaskType,
+} from "@app/types/project_task";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
 import {
   AnimatedText,
@@ -79,7 +82,7 @@ export interface EditableTaskItemProps {
   membersWithActiveTaskIds: Set<string>;
   onPatchTask: (
     taskId: string,
-    updates: { text?: string; assigneeUserId?: string }
+    updates: { text?: string; assigneeUserId?: string | null }
   ) => Promise<void>;
   allowAssigneeReassign?: boolean;
 }
@@ -177,6 +180,16 @@ export const EditableTaskItem = memo(function EditableTaskItem({
       return aActive - bActive;
     });
   }, [reassignSearch, projectMembers, membersWithActiveTaskIds]);
+
+  const showNoAssigneeReassignOption =
+    task.user !== null &&
+    (() => {
+      const q = removeDiacritics(reassignSearch.trim()).toLowerCase();
+      const labelNorm = removeDiacritics(
+        PROJECT_TASK_NO_ASSIGNEE_LABEL
+      ).toLowerCase();
+      return q === "" || labelNorm.includes(q);
+    })();
 
   useEffect(() => {
     if (!isNewlyDone) {
@@ -659,7 +672,9 @@ export const EditableTaskItem = memo(function EditableTaskItem({
                       <DropdownMenuSubTrigger
                         label="Reassign"
                         icon={UserIcon}
-                        disabled={projectMembers.length === 0}
+                        disabled={
+                          projectMembers.length === 0 && task.user === null
+                        }
                       />
                       <DropdownMenuPortal>
                         <DropdownMenuSubContent
@@ -675,37 +690,62 @@ export const EditableTaskItem = memo(function EditableTaskItem({
                           />
                           <DropdownMenuSeparator />
                           <div className="max-h-64 overflow-auto">
-                            {filteredReassignMembers.length > 0 ? (
-                              filteredReassignMembers.map((member) => (
-                                <DropdownMenuItem
-                                  key={`reassign-task-${task.sId}-${member.sId}`}
-                                  label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
-                                  disabled={member.sId === task.user?.sId}
-                                  icon={() => (
-                                    <Avatar
-                                      size="xxs"
-                                      isRounded
-                                      visual={
-                                        member.image ??
-                                        "/static/humanavatar/anonymous.png"
-                                      }
+                            {showNoAssigneeReassignOption ||
+                            filteredReassignMembers.length > 0 ? (
+                              <>
+                                {showNoAssigneeReassignOption && (
+                                  <>
+                                    <DropdownMenuItem
+                                      key={`reassign-task-${task.sId}-none`}
+                                      label={PROJECT_TASK_NO_ASSIGNEE_LABEL}
+                                      onClick={() => {
+                                        void (async () => {
+                                          try {
+                                            await onPatchTask(task.sId, {
+                                              assigneeUserId: null,
+                                            });
+                                          } finally {
+                                            setOverflowMenuOpen(false);
+                                          }
+                                        })();
+                                      }}
                                     />
-                                  )}
-                                  onClick={() => {
-                                    void (async () => {
-                                      try {
-                                        if (member.sId !== task.user?.sId) {
-                                          await onPatchTask(task.sId, {
-                                            assigneeUserId: member.sId,
-                                          });
+                                    {filteredReassignMembers.length > 0 ? (
+                                      <DropdownMenuSeparator />
+                                    ) : null}
+                                  </>
+                                )}
+                                {filteredReassignMembers.map((member) => (
+                                  <DropdownMenuItem
+                                    key={`reassign-task-${task.sId}-${member.sId}`}
+                                    label={`${member.fullName}${viewerUserId === member.sId ? " (you)" : ""}`}
+                                    disabled={member.sId === task.user?.sId}
+                                    icon={() => (
+                                      <Avatar
+                                        size="xxs"
+                                        isRounded
+                                        visual={
+                                          member.image ??
+                                          "/static/humanavatar/anonymous.png"
                                         }
-                                      } finally {
-                                        setOverflowMenuOpen(false);
-                                      }
-                                    })();
-                                  }}
-                                />
-                              ))
+                                      />
+                                    )}
+                                    onClick={() => {
+                                      void (async () => {
+                                        try {
+                                          if (member.sId !== task.user?.sId) {
+                                            await onPatchTask(task.sId, {
+                                              assigneeUserId: member.sId,
+                                            });
+                                          }
+                                        } finally {
+                                          setOverflowMenuOpen(false);
+                                        }
+                                      })();
+                                    }}
+                                  />
+                                ))}
+                              </>
                             ) : (
                               <div className="px-3 py-2 text-sm text-muted-foreground">
                                 No members found

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskScopeFilter.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskScopeFilter.tsx
@@ -35,12 +35,17 @@ const PEOPLE_OPTIONS: Array<{
   {
     value: "just_mine",
     label: "Mine",
-    description: "Your to-dos only",
+    description: "Your tasks only",
+  },
+  {
+    value: "unassigned",
+    label: "Unassigned",
+    description: "Tasks with no assignee",
   },
   {
     value: "all_project",
     label: "Everyone",
-    description: "All to-dos in this project",
+    description: "All tasks in this project",
   },
 ];
 

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksDataTable.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksDataTable.tsx
@@ -3,9 +3,10 @@ import {
   ProjectTasksDataTableHeaderTitle,
   ProjectTasksDataTableUiProvider,
 } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksDataTableCell";
-import type {
-  ProjectTaskAssigneeType,
-  ProjectTaskType,
+import {
+  PROJECT_TASK_UNASSIGNED_GROUP_KEY,
+  type ProjectTaskAssigneeType,
+  type ProjectTaskType,
 } from "@app/types/project_task";
 import { DataTable, type MenuItem } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -46,8 +47,7 @@ function flattenGroupedTasks(
   let groupIndex = 0;
 
   for (const group of groups) {
-    const groupKey =
-      group.user?.sId ?? `unknown-${group.tasks[0]?.id ?? "empty"}`;
+    const groupKey = group.user?.sId ?? PROJECT_TASK_UNASSIGNED_GROUP_KEY;
     rows.push({
       kind: "assignee_header",
       groupKey,

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelMain.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelMain.tsx
@@ -21,7 +21,6 @@ export function ProjectTasksPanelMain() {
     filteredTasks,
     assigneeScopedTasks,
     debouncedTaskSearchQuery,
-    isSoleProjectMember,
     hideRegularTaskAssigneeHeaders,
   } = useProjectTasksPanel();
 
@@ -54,7 +53,6 @@ export function ProjectTasksPanelMain() {
               projectMembers={projectMembers}
               viewerUserId={viewerUserId}
               defaultAssigneeSId={defaultNewAssigneeSId!}
-              hideAssigneePicker={isSoleProjectMember}
               onAdd={handleAddTask}
             />
           ))}

--- a/front/components/assistant/conversation/space/conversations/project_tasks/TaskSubComponents.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/TaskSubComponents.tsx
@@ -2,10 +2,11 @@ import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useUser } from "@app/lib/swr/user";
 import { timeAgoFrom } from "@app/lib/utils";
-import type {
-  ProjectTaskActorType,
-  ProjectTaskAssigneeType,
-  ProjectTaskType,
+import {
+  PROJECT_TASK_NO_ASSIGNEE_LABEL,
+  type ProjectTaskActorType,
+  type ProjectTaskAssigneeType,
+  type ProjectTaskType,
 } from "@app/types/project_task";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type {
@@ -280,22 +281,35 @@ export function TaskAssigneeHeader({
   className?: string;
 }) {
   const isYou = viewerUserId !== null && user?.sId === viewerUserId;
+  const displayName =
+    user === null ? PROJECT_TASK_NO_ASSIGNEE_LABEL : user.fullName;
 
   return (
     <div className={cn("mb-1 mt-2 flex items-center gap-2", className)}>
       <Tooltip
-        label={user?.fullName ?? "Unknown user"}
+        label={displayName}
         trigger={
-          <Avatar
-            size="xxs"
-            isRounded
-            visual={user?.image ?? "/static/humanavatar/anonymous.png"}
-          />
+          <span className="inline-flex shrink-0 items-center justify-center">
+            {user !== null ? (
+              <Avatar
+                size="xxs"
+                isRounded
+                visual={user.image ?? "/static/humanavatar/anonymous.png"}
+              />
+            ) : (
+              <Avatar
+                size="xxs"
+                isRounded
+                visual={null}
+                className="bg-background dark:bg-background-night"
+              />
+            )}
+          </span>
         }
       />
       <span className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
-        {user?.fullName ?? "Unknown user"}
-        {isYou ? " (you)" : ""}
+        {displayName}
+        {user !== null && isYou ? " (you)" : ""}
       </span>
     </div>
   );

--- a/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope.ts
@@ -6,7 +6,7 @@ export type ProjectTaskPeriodScope =
   | "last_7d"
   | "last_30d";
 
-export type ProjectTaskPeopleScope = "all_project" | "just_mine";
+export type ProjectTaskPeopleScope = "all_project" | "just_mine" | "unassigned";
 
 /** Filter for project task list fetching + persisted project UI prefs. */
 export interface TaskOwnerFilter {
@@ -29,6 +29,7 @@ const PERIOD_SCOPE_LABELS: Record<ProjectTaskPeriodScope, string> = {
 const PEOPLE_SCOPE_LABELS: Record<ProjectTaskPeopleScope, string> = {
   all_project: "Everyone",
   just_mine: "Mine",
+  unassigned: "Unassigned",
 };
 
 export function formatTaskScopeLabel(filter: TaskOwnerFilter): string {
@@ -55,7 +56,7 @@ function coercePeriodScope(raw: unknown): ProjectTaskPeriodScope {
 const tasksOwnerFilterPersistedBlobSchema = z
   .object({
     periodScope: z.string().optional(),
-    peopleScope: z.enum(["all_project", "just_mine"]).optional(),
+    peopleScope: z.enum(["all_project", "just_mine", "unassigned"]).optional(),
     assigneeScope: z.enum(["mine", "all", "users"]).optional(),
     selectedUserSIds: z.array(z.string()).optional(),
   })
@@ -70,13 +71,20 @@ export function normalizeTasksOwnerFilterFromPersistedBlob(
   }
   const blob = parsed.data;
 
-  const peopleScope: ProjectTaskPeopleScope =
-    blob.peopleScope ??
-    (blob.assigneeScope === "mine" ? "just_mine" : "all_project");
+  let peopleScope: ProjectTaskPeopleScope = "all_project";
+  if (
+    blob.peopleScope === "just_mine" ||
+    blob.peopleScope === "unassigned" ||
+    blob.peopleScope === "all_project"
+  ) {
+    peopleScope = blob.peopleScope;
+  } else if (blob.assigneeScope === "mine") {
+    peopleScope = "just_mine";
+  }
 
   return {
     periodScope: coercePeriodScope(blob.periodScope),
-    peopleScope: peopleScope === "just_mine" ? "just_mine" : "all_project",
+    peopleScope,
   };
 }
 
@@ -86,7 +94,14 @@ export function taskOwnerFilterToSearchParams(
 ): URLSearchParams {
   const params = new URLSearchParams();
   params.set("period", filter.periodScope);
-  params.set("people", filter.peopleScope === "just_mine" ? "mine" : "all");
+  params.set(
+    "people",
+    filter.peopleScope === "just_mine"
+      ? "mine"
+      : filter.peopleScope === "unassigned"
+        ? "unassigned"
+        : "all"
+  );
   return params;
 }
 

--- a/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksPanelTypes.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksPanelTypes.ts
@@ -49,11 +49,11 @@ export type ProjectTasksPanelData = {
   ) => Promise<void>;
   patchTaskItem: (
     taskId: string,
-    updates: { text?: string; assigneeUserId?: string }
+    updates: { text?: string; assigneeUserId?: string | null }
   ) => Promise<void>;
   isSpaceInfoLoading: boolean;
   defaultNewAssigneeSId: string | null;
-  handleAddTask: (text: string, assigneeSId: string) => Promise<boolean>;
+  handleAddTask: (text: string, assigneeSId: string | null) => Promise<boolean>;
   isTasksLoading: boolean;
   isTasksError: boolean;
   frozenLastReadAt: string | null | undefined;

--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -38,10 +38,11 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import type { BulkActionsBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions";
 import type { GetProjectTasksResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
-import type {
-  ProjectTaskAssigneeType,
-  ProjectTaskStatus,
-  ProjectTaskType,
+import {
+  PROJECT_TASK_UNASSIGNED_GROUP_KEY,
+  type ProjectTaskAssigneeType,
+  type ProjectTaskStatus,
+  type ProjectTaskType,
 } from "@app/types/project_task";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
@@ -198,7 +199,7 @@ export function useProjectTasksPanelState({
 
     for (const task of filteredTasks) {
       const user = task.user ?? null;
-      const key = user?.sId ?? `unknown-${task.id}`;
+      const key = user?.sId ?? PROJECT_TASK_UNASSIGNED_GROUP_KEY;
       const existing = groups.get(key);
       if (existing) {
         existing.tasks.push(task);
@@ -353,7 +354,7 @@ export function useProjectTasksPanelState({
   const patchTaskItem = useCallback(
     async (
       taskId: string,
-      updates: { text?: string; assigneeUserId?: string }
+      updates: { text?: string; assigneeUserId?: string | null }
     ) => {
       const result = await doUpdate(taskId, updates);
       if (result.isErr()) {
@@ -444,7 +445,7 @@ export function useProjectTasksPanelState({
   );
 
   const handleAddTask = useCallback(
-    async (text: string, assigneeSId: string): Promise<boolean> => {
+    async (text: string, assigneeSId: string | null): Promise<boolean> => {
       const result = await doCreateTask({
         text,
         assigneeUserId: assigneeSId,

--- a/front/lib/api/actions/servers/project_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/project_tasks/metadata.ts
@@ -51,7 +51,8 @@ export const PROJECT_TASKS_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_tasks: {
-    description: "Create one or more new tasks at once in the project.",
+    description:
+      "Create one or more new tasks at once in the project. Tasks are unassigned unless you pass userId — always set userId when a specific person should own the task.",
     schema: {
       creatorType: z
         .enum(["user", "agent"])
@@ -71,10 +72,10 @@ export const PROJECT_TASKS_TOOLS_METADATA = createToolsRecord({
                   "assignee with 'you'/'your' pronouns when needed."
               ),
             userId: z
-              .string()
+              .union([z.string(), z.null()])
               .optional()
               .describe(
-                "The sId of the user to assign the task to; must be a member of the project. Defaults to the current user."
+                "Project member's user sId to assign this task to. Omit userId entirely (or use null) to create an unassigned task. Never omit userId when the task must belong to someone — omitting defaults to unassigned, not the current user."
               ),
             doneRationale: z
               .string()

--- a/front/lib/api/actions/servers/project_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/project_tasks/tools/index.ts
@@ -16,6 +16,7 @@ import { Authenticator } from "@app/lib/auth";
 import { startAgentForProjectTask } from "@app/lib/project_task/start_agent";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
+import { PROJECT_TASK_NO_ASSIGNEE_LABEL } from "@app/types/project_task";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -23,9 +24,12 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 function formatTaskListingLine(row: ProjectTaskResource): string {
   const json = row.toJSON();
+  const assigneePart = json.user
+    ? `${json.user.fullName} (${json.user.sId})`
+    : PROJECT_TASK_NO_ASSIGNEE_LABEL;
   const lines = [
     `- [${json.sId}] ${json.text}`,
-    ` Assignee: ${json.user?.fullName} (${json.user?.sId}) | Status: ${json.status} | Created: ${json.createdAt.toISOString().slice(0, 10)}`,
+    ` Assignee: ${assigneePart} | Status: ${json.status} | Created: ${json.createdAt.toISOString().slice(0, 10)}`,
   ];
   if (row.doneAt) {
     lines.push(`  Done: ${row.doneAt.toISOString().slice(0, 10)}`);
@@ -134,8 +138,8 @@ export function createProjectTasksTools(
         const created: string[] = [];
         const errors: string[] = [];
         for (const item of tasks) {
-          let newUserId: ModelId | undefined = currentUser.id;
-          if (item.userId) {
+          let newUserId: ModelId | null = null;
+          if (typeof item.userId === "string") {
             const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
               item.userId,
               owner.sId
@@ -148,6 +152,7 @@ export function createProjectTasksTools(
             }
             newUserId = userAuth.getNonNullableUser().id;
           }
+          // Omit or null → unassigned (`newUserId` stays null).
 
           const row = await ProjectTaskResource.makeNew(auth, {
             spaceId: space.id,

--- a/front/lib/project_task/display_order.ts
+++ b/front/lib/project_task/display_order.ts
@@ -1,7 +1,9 @@
-import type {
-  ProjectTaskAssigneeType,
-  ProjectTaskStatus,
-  ProjectTaskType,
+import {
+  PROJECT_TASK_NO_ASSIGNEE_LABEL,
+  PROJECT_TASK_UNASSIGNED_GROUP_KEY,
+  type ProjectTaskAssigneeType,
+  type ProjectTaskStatus,
+  type ProjectTaskType,
 } from "@app/types/project_task";
 
 const PROJECT_TODO_STATUS_SORT_RANK: Record<ProjectTaskStatus, number> = {
@@ -71,13 +73,18 @@ export function compareProjectTaskAssigneeGroups(
   b: { user: ProjectTaskAssigneeType | null },
   viewerUserId: string | null
 ): number {
+  const aUnassigned = a.user === null;
+  const bUnassigned = b.user === null;
+  if (aUnassigned !== bUnassigned) {
+    return aUnassigned ? -1 : 1;
+  }
   const aIsViewer = viewerUserId !== null && a.user?.sId === viewerUserId;
   const bIsViewer = viewerUserId !== null && b.user?.sId === viewerUserId;
   if (aIsViewer !== bIsViewer) {
     return aIsViewer ? -1 : 1;
   }
-  const aName = a.user?.fullName ?? "";
-  const bName = b.user?.fullName ?? "";
+  const aName = a.user?.fullName ?? PROJECT_TASK_NO_ASSIGNEE_LABEL;
+  const bName = b.user?.fullName ?? PROJECT_TASK_NO_ASSIGNEE_LABEL;
   return aName.localeCompare(bName, undefined, { sensitivity: "base" });
 }
 
@@ -97,7 +104,7 @@ export function flattenProjectTasksWithStableAssigneeOrder(
 
   for (const task of rawTasks) {
     const user = task.user ?? null;
-    const key = user?.sId ?? `unknown-${task.id}`;
+    const key = user?.sId ?? PROJECT_TASK_UNASSIGNED_GROUP_KEY;
     const existing = groups.get(key);
     if (existing) {
       existing.todos.push(task);
@@ -112,7 +119,7 @@ export function flattenProjectTasksWithStableAssigneeOrder(
 
   const flattened: ProjectTaskType[] = [];
   for (const group of sortedGroups) {
-    const key = group.user?.sId ?? `unknown-${group.todos[0]?.id}`;
+    const key = group.user?.sId ?? PROJECT_TASK_UNASSIGNED_GROUP_KEY;
     const prev = stableOrderByAssigneeKey.get(key);
     const mergedIds = mergeProjectTodoStableOrder(prev, group.todos);
     stableOrderByAssigneeKey.set(key, mergedIds);

--- a/front/lib/project_task/start_agent.ts
+++ b/front/lib/project_task/start_agent.ts
@@ -203,7 +203,7 @@ export async function startAgentForProjectTask(
 
   if (!conversationId) {
     conversation = await createConversation(auth, {
-      title: `Project task · ${task.text.slice(0, 80)}`,
+      title: `Task · ${task.text.slice(0, 80)}`,
       visibility: "unlisted",
       spaceId: space.id,
       metadata: {

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -355,10 +355,13 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
       spaceId,
       timeScope,
       assigneeUserId = null,
+      onlyUnassigned = false,
     }: {
       spaceId: ModelId;
       timeScope: "active" | "last_24h" | "last_7d" | "last_30d" | "all";
       assigneeUserId?: ModelId | null;
+      /** When true, returns only todos with no assignee (`userId` IS NULL). */
+      onlyUnassigned?: boolean;
     }
   ): Promise<ProjectTaskResource[]> {
     const MS_PER_HOUR = 60 * 60 * 1000;
@@ -379,7 +382,9 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
 
     const clauses: WhereOptions<ProjectTaskModel>[] = [{ spaceId }];
 
-    if (assigneeUserId != null) {
+    if (onlyUnassigned) {
+      clauses.push({ userId: null });
+    } else if (assigneeUserId != null) {
       clauses.push({ userId: assigneeUserId });
     }
 

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -459,7 +459,7 @@ export function useCreateProjectTask({
     assigneeUserId,
   }: {
     text: string;
-    assigneeUserId: string;
+    assigneeUserId: string | null;
   }): Promise<Result<ProjectTaskType, Error>> => {
     try {
       const res = await clientFetch(
@@ -509,7 +509,7 @@ export function useUpdateProjectTask({
     updates: {
       text?: string;
       status?: ProjectTaskStatus;
-      assigneeUserId?: string;
+      assigneeUserId?: string | null;
     }
   ): Promise<Result<ProjectTaskType, Error>> => {
     try {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.test.ts
@@ -177,6 +177,26 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]", () => {
     expect(updated.text).toBe("Hand off this");
   });
 
+  it("should clear a todo assignee when assigneeUserId is null", async () => {
+    const { user } = await setup();
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTaskFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Unassign me",
+    });
+
+    req.query.spaceId = project.sId;
+    req.query.taskId = todo.sId;
+    req.body = { assigneeUserId: null };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { task: updated } = res._getJSONData();
+    expect(updated.user).toBeNull();
+    expect(updated.text).toBe("Unassign me");
+  });
+
   it("should return 400 when no update fields are provided", async () => {
     const { user } = await setup();
     const project = await SpaceFactory.project(workspace, user.id);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.ts
@@ -22,7 +22,7 @@ const PatchProjectTaskBodySchema = z
       .max(256, "Text must be at most 256 characters.")
       .optional(),
     status: z.enum(PROJECT_TASK_STATUSES).optional(),
-    assigneeUserId: z.string().min(1).optional(),
+    assigneeUserId: z.union([z.string().min(1), z.null()]).optional(),
   })
   .refine(
     (data) =>
@@ -124,30 +124,34 @@ async function handler(
       }
 
       if (assigneeUserId !== undefined) {
-        const assigneeAuth = await Authenticator.fromUserIdAndWorkspaceId(
-          assigneeUserId,
-          workspace.sId
-        );
-        const assigneeUser = assigneeAuth.user();
-        if (!assigneeUser) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Assignee user not found.",
-            },
-          });
+        if (assigneeUserId === null) {
+          updates.userId = null;
+        } else {
+          const assigneeAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            assigneeUserId,
+            workspace.sId
+          );
+          const assigneeUser = assigneeAuth.user();
+          if (!assigneeUser) {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Assignee user not found.",
+              },
+            });
+          }
+          if (!space.isMember(assigneeAuth)) {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Assignee must be a member of this project.",
+              },
+            });
+          }
+          updates.userId = assigneeUser.id;
         }
-        if (!space.isMember(assigneeAuth)) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Assignee must be a member of this project.",
-            },
-          });
-        }
-        updates.userId = assigneeUser.id;
       }
 
       const updatedTask = await task.updateWithVersion(auth, updates);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
@@ -37,12 +37,22 @@ function parseProjectTaskTimeScope(
   return "active";
 }
 
-function parsePeopleMineOnly(req: NextApiRequest): boolean {
+type ProjectTasksPeopleFetchMode = "all" | "mine" | "unassigned";
+
+function parseProjectTasksPeopleMode(
+  req: NextApiRequest
+): ProjectTasksPeopleFetchMode {
   const legacy = parseSingleQueryValue(req.query.assignee)?.toLowerCase();
   const explicit = parseSingleQueryValue(req.query.people)?.toLowerCase();
 
   const token = explicit ?? legacy ?? "all";
-  return token === "mine";
+  if (token === "mine") {
+    return "mine";
+  }
+  if (token === "unassigned") {
+    return "unassigned";
+  }
+  return "all";
 }
 
 import { apiError } from "@app/logger/withlogging";
@@ -63,7 +73,8 @@ const PostProjectTaskBodySchema = z.object({
     .trim()
     .min(1, "Text is required.")
     .max(256, "Text must be at most 256 characters."),
-  assigneeUserId: z.string().min(1, "Assignee is required."),
+  /** Omit to assign to the current user; pass `null` to leave the task unassigned. */
+  assigneeUserId: z.union([z.string().min(1), z.null()]).optional(),
 });
 
 export interface PostProjectTaskResponseBody {
@@ -97,16 +108,20 @@ async function handler(
         spaceId: space.id,
       });
       const timeScope = parseProjectTaskTimeScope(req);
-      const viewerOnlyMine = parsePeopleMineOnly(req);
+      const peopleMode = parseProjectTasksPeopleMode(req);
       let assigneeUserId: ModelId | null = null;
-      if (viewerOnlyMine) {
+      let onlyUnassigned = false;
+      if (peopleMode === "mine") {
         assigneeUserId = currentUser.id;
+      } else if (peopleMode === "unassigned") {
+        onlyUnassigned = true;
       }
 
       const todos = await ProjectTaskResource.fetchBySpace(auth, {
         spaceId: space.id,
         timeScope,
         assigneeUserId,
+        onlyUnassigned,
       });
 
       const todoIds = todos.map((t) => t.sId);
@@ -181,34 +196,43 @@ async function handler(
       const workspace = auth.getNonNullableWorkspace();
       const currentUser = auth.getNonNullableUser();
 
-      const assigneeAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        assigneeUserId,
-        workspace.sId
-      );
-      const assigneeUser = assigneeAuth.user();
-      if (!assigneeUser) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Assignee user not found.",
-          },
-        });
-      }
+      let taskUserModelId: ModelId | null;
+      if (assigneeUserId === undefined) {
+        taskUserModelId = currentUser.id;
+      } else if (assigneeUserId === null) {
+        taskUserModelId = null;
+      } else {
+        const assigneeAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          assigneeUserId,
+          workspace.sId
+        );
+        const assigneeUser = assigneeAuth.user();
+        if (!assigneeUser) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Assignee user not found.",
+            },
+          });
+        }
 
-      if (!space.isMember(assigneeAuth)) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Assignee must be a member of this project.",
-          },
-        });
+        if (!space.isMember(assigneeAuth)) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Assignee must be a member of this project.",
+            },
+          });
+        }
+
+        taskUserModelId = assigneeUser.id;
       }
 
       const newTodo = await ProjectTaskResource.makeNew(auth, {
         spaceId: space.id,
-        userId: assigneeUser.id,
+        userId: taskUserModelId,
         createdByType: "user",
         createdByUserId: currentUser.id,
         createdByAgentConfigurationId: null,

--- a/front/types/project_task.ts
+++ b/front/types/project_task.ts
@@ -42,6 +42,12 @@ export type ProjectTaskAssigneeType = {
   image: string | null;
 };
 
+/** Stable row / stable-order key when grouping tasks with no assignee. */
+export const PROJECT_TASK_UNASSIGNED_GROUP_KEY = "__unassigned__";
+
+/** Header and menu copy for tasks with no assignee. */
+export const PROJECT_TASK_NO_ASSIGNEE_LABEL = "No assignee";
+
 export type ProjectTaskType = {
   id: ModelId;
   sId: string;


### PR DESCRIPTION
## Description

The task composer only accepted a member sId; there was no way to create an unassigned task from the UI, and unassigned tasks created by agents had no visual treatment.

- Add `AddTaskAssigneeChoice` discriminated union (`"default"` | `"unassigned"` | `{ kind: "member"; sId }`) to replace the raw `selectedSId: string | null` throughout `AddTaskComposer`; `resolveSubmitAssigneeSId` maps it to `string | null` at submission time
- `TodoRowAssigneeMenu` gains a `PROJECT_TASK_NO_ASSIGNEE_LABEL` row at the top of the dropdown, shown when the search query matches; selecting it renders an empty circle-ring avatar trigger and updates aria labels accordingly
- Unassigned tasks are grouped under a `PROJECT_TASK_NO_ASSIGNEE_LABEL` header in the list with the same empty circle-ring avatar in the leading slot

## Tests

Local

## Risk

Low — additive; existing tasks with a userId are unaffected

## Deploy Plan

Deploy `front`
