### PR TITLE
Upg: when doing a solo project, all new tasks (UI or mcp) are automatically assigned to me, even when unspecified.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer.tsx
@@ -24,7 +24,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export type AddTaskAssigneeChoice =
   | { kind: "default" }
@@ -133,7 +133,8 @@ function TodoRowAssigneeMenu({
   const assigneeSearchLabelNorm = removeDiacritics(
     PROJECT_TASK_NO_ASSIGNEE_LABEL
   ).toLowerCase();
-  const showNoAssigneeRow = q === "" || assigneeSearchLabelNorm.includes(q);
+  const showNoAssigneeRow =
+    members.length !== 1 && (q === "" || assigneeSearchLabelNorm.includes(q));
 
   let effectiveMemberSId: string | null;
   switch (choice.kind) {
@@ -303,6 +304,14 @@ export function AddTodoComposer({
       kind: "default",
     })
   );
+  useEffect(() => {
+    if (hideAssigneePicker || projectMembers.length !== 1) {
+      return;
+    }
+    setAssigneeChoice((c) =>
+      c.kind === "unassigned" ? { kind: "default" } : c
+    );
+  }, [hideAssigneePicker, projectMembers.length]);
   const [isAdding, setIsAdding] = useState(false);
   const [inputFocused, setInputFocused] = useState(false);
   const [assigneeMenuOpen, setAssigneeMenuOpen] = useState(false);

--- a/front/lib/api/actions/servers/project_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/project_tasks/metadata.ts
@@ -52,7 +52,7 @@ export const PROJECT_TASKS_TOOLS_METADATA = createToolsRecord({
   },
   create_tasks: {
     description:
-      "Create one or more new tasks at once in the project. Tasks are unassigned unless you pass userId — always set userId when a specific person should own the task.",
+      "Create one or more new tasks at once in the project. Omitting userId (or null) creates an unassigned task unless the project has exactly one assignable member, in which case that member is assigned. Pass userId when a specific person should own the task.",
     schema: {
       creatorType: z
         .enum(["user", "agent"])
@@ -75,7 +75,7 @@ export const PROJECT_TASKS_TOOLS_METADATA = createToolsRecord({
               .union([z.string(), z.null()])
               .optional()
               .describe(
-                "Project member's user sId to assign this task to. Omit userId entirely (or use null) to create an unassigned task. Never omit userId when the task must belong to someone — omitting defaults to unassigned, not the current user."
+                "Project member's user sId to assign this task to. Omit userId entirely (or use null) for an unassigned task, unless the project has exactly one assignable member (then that member is assigned)."
               ),
             doneRationale: z
               .string()

--- a/front/lib/api/actions/servers/project_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/project_tasks/tools/index.ts
@@ -131,6 +131,11 @@ export function createProjectTasksTools(
         }
         const { space } = contextRes.value;
 
+        const assignmentPool =
+          await space.fetchDistinctActiveManualGroupMembers(auth);
+        const soleAssigneeModelId =
+          assignmentPool.length === 1 ? assignmentPool[0]!.id : null;
+
         const currentUser = auth.getNonNullableUser();
         const agentConfigId =
           agentLoopContext?.runContext?.agentConfiguration?.sId ?? null;
@@ -151,8 +156,12 @@ export function createProjectTasksTools(
               continue;
             }
             newUserId = userAuth.getNonNullableUser().id;
+          } else if (
+            soleAssigneeModelId !== null &&
+            (item.userId === undefined || item.userId === null)
+          ) {
+            newUserId = soleAssigneeModelId;
           }
-          // Omit or null → unassigned (`newUserId` stays null).
 
           const row = await ProjectTaskResource.makeNew(auth, {
             spaceId: space.id,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1424,6 +1424,35 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     };
   }
 
+  /**
+   * Distinct active users across this space's manual regular + editor groups
+   * ({@link SpaceResource.fetchManualGroupsMemberships} with active memberships only).
+   * Same user set returned as `space.members` on GET /api/w/[wId]/spaces/[spaceId]
+   * when `includeAllMembers` is not `"true"` (dedupe is by numeric user id, equivalent
+   * to `uniqBy(..., "sId")` on serialized members).
+   */
+  async fetchDistinctActiveManualGroupMembers(
+    auth: Authenticator
+  ): Promise<UserResource[]> {
+    const { groupsToProcess } = await this.fetchManualGroupsMemberships(auth, {
+      shouldIncludeAllMembers: false,
+    });
+
+    const batches = await concurrentExecutor(
+      groupsToProcess,
+      async (group) => group.getActiveMembers(auth),
+      { concurrency: 10 }
+    );
+
+    const byId = new Map<ModelId, UserResource>();
+    for (const user of batches.flat()) {
+      if (!byId.has(user.id)) {
+        byId.set(user.id, user);
+      }
+    }
+    return [...byId.values()];
+  }
+
   toJSON(): SpaceType {
     return {
       createdAt: this.createdAt.getTime(),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
@@ -280,4 +280,51 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_tasks", () => {
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.message).toContain("member");
   });
+
+  it("should assign the sole assignable member when assigneeUserId is null", async () => {
+    const { user, req, res, workspace } = await setup("POST");
+    const project = await SpaceFactory.project(workspace, user.id);
+
+    req.query.spaceId = project.sId;
+    req.body = {
+      text: "Sole assignable member default",
+      assigneeUserId: null,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(201);
+    const data = res._getJSONData();
+    expect(data.task.user?.sId).toBe(user.sId);
+  });
+
+  it("should leave task unassigned when assigneeUserId is null with multiple assignable members", async () => {
+    const { user, req, res, workspace } = await setup("POST");
+    const project = await SpaceFactory.project(workspace, user.id);
+
+    const secondUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, secondUser, { role: "user" });
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const memberGroup = project.groups.find((g) => g.kind === "regular");
+    expect(memberGroup).toBeDefined();
+
+    const addRes = await memberGroup!.dangerouslyAddMember(adminAuth, {
+      user: secondUser.toJSON(),
+    });
+    expect(addRes.isOk()).toBe(true);
+
+    req.query.spaceId = project.sId;
+    req.body = {
+      text: "Null assignee stays unassigned with two members",
+      assigneeUserId: null,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(201);
+    expect(res._getJSONData().task.user).toBeNull();
+  });
 });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
@@ -73,7 +73,7 @@ const PostProjectTaskBodySchema = z.object({
     .trim()
     .min(1, "Text is required.")
     .max(256, "Text must be at most 256 characters."),
-  /** Omit to assign to the current user; pass `null` to leave the task unassigned. */
+  /** Omit to assign to the current user; pass `null` for unassigned (or the sole assignable member if the project has exactly one). */
   assigneeUserId: z.union([z.string().min(1), z.null()]).optional(),
 });
 
@@ -200,7 +200,10 @@ async function handler(
       if (assigneeUserId === undefined) {
         taskUserModelId = currentUser.id;
       } else if (assigneeUserId === null) {
-        taskUserModelId = null;
+        const assignable =
+          await space.fetchDistinctActiveManualGroupMembers(auth);
+        const soleModelId = assignable.length === 1 ? assignable[0]!.id : null;
+        taskUserModelId = soleModelId;
       } else {
         const assigneeAuth = await Authenticator.fromUserIdAndWorkspaceId(
           assigneeUserId,


### PR DESCRIPTION
## Description

In a solo project, leaving a task unassigned is rarely intentional — the only person who can work on it is the project owner. This PR makes `userId = null/undefined` auto-assign to the sole project member instead.

That way, if / when new members are added, the existing tasks are already set on the pre-exisiting member.

- Add `SpaceResource.fetchDistinctActiveManualGroupMembers` — deduplicates active users across the project's manual groups (same set as `space.members` in the GET endpoint)
- `POST /project_tasks` endpoint: when `assigneeUserId === null`, check the assignable member count; if exactly one member, assign to them; otherwise leave unassigned
- MCP `create_tasks` tool: same resolution using `fetchDistinctActiveManualGroupMembers`, resolved once and reused across all items in the batch
- `AddTodoComposer`: when `projectMembers.length === 1`, snap `assigneeChoice` from `unassigned` back to `default` via `useEffect`; hide the "No assignee" row in `TodoRowAssigneeMenu` when only one member exists
- MCP tool description updated to document the new fallback behavior
- New tests: sole member auto-assign, two-member project stays unassigned

## Tests

Green (2 new test cases)

## Risk

Low — only applies when the project has exactly one active member; multi-member projects behave identically to before

## Deploy Plan

Deploy `front`
