### PR TITLE
Allow starting on a task directly from the task popup

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
@@ -1,4 +1,4 @@
-import { Card, CardGrid, Icon, ListCheckIcon } from "@dust-tt/sparkle";
+import { Card, CardGrid, CheckIcon, Icon } from "@dust-tt/sparkle";
 
 interface SpaceConversationsActionsProps {
   isEditor: boolean;
@@ -13,7 +13,7 @@ export function SpaceConversationsActions({
     {
       id: "onboarding-tasks",
       label: "Get your project off the ground",
-      icon: ListCheckIcon,
+      icon: CheckIcon,
       description:
         "Add context, connect your knowledge, and bring the right people in. Flying solo? It still keeps everything in one place.",
       variant: "highlight" as const,

--- a/front/components/assistant/conversation/space/conversations/project_tasks/EditableTaskItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/EditableTaskItem.tsx
@@ -1,5 +1,5 @@
-import { AgentPicker } from "@app/components/assistant/AgentPicker";
 import { ConversationSidebarStatusDot } from "@app/components/assistant/conversation/ConversationSidebarStatusDot";
+import { ProjectTaskStartWorkingDropdown } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskStartWorkingDropdown";
 import { useProjectTasksPanel } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelContext";
 import {
   TaskMetadataTooltip,
@@ -15,8 +15,6 @@ import { useAppRouter } from "@app/lib/platform";
 import { removeDiacritics } from "@app/lib/utils";
 import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   PROJECT_TASK_NO_ASSIGNEE_LABEL,
   type ProjectTaskType,
@@ -25,12 +23,8 @@ import {
   AnimatedText,
   Avatar,
   Button,
-  ButtonGroup,
-  ButtonGroupDropdown,
   ChatBubbleLeftRightIcon,
   Checkbox,
-  CheckIcon,
-  ChevronDownIcon,
   cn,
   DropdownMenu,
   DropdownMenuContent,
@@ -42,11 +36,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-  Icon,
   MoreIcon,
-  PlayIcon,
-  RobotIcon,
-  TextArea,
   Tooltip,
   TrashIcon,
   TypingAnimation,
@@ -88,12 +78,6 @@ export function EditableTaskItem({ task }: EditableTaskItemProps) {
 
   const router = useAppRouter();
   const [startMenuOpen, setStartMenuOpen] = useState(false);
-  const [startCustomMessage, setStartCustomMessage] = useState("");
-  const [goToConversationAfterStart, setGoToConversationAfterStart] = useState(
-    () => !!task.agentInstructions?.trim()
-  );
-  const [selectedStartAgent, setSelectedStartAgent] =
-    useState<LightAgentConfigurationType | null>(null);
 
   const isDone = task.status === "done";
   const hasConversationLink =
@@ -252,39 +236,6 @@ export function EditableTaskItem({ task }: EditableTaskItemProps) {
       setIsEditing(true);
     },
     [canEdit, task.text]
-  );
-
-  const handleStartMenuOpenChange = (open: boolean) => {
-    setStartMenuOpen(open);
-    if (open) {
-      setStartCustomMessage("");
-      const defaultAgent =
-        activeAgents.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST) ??
-        activeAgents[0] ??
-        null;
-      setSelectedStartAgent(defaultAgent);
-    }
-  };
-
-  const handleConfirmStart = async () => {
-    setStartMenuOpen(false);
-    const agentConfigurationId =
-      selectedStartAgent && selectedStartAgent.sId !== GLOBAL_AGENTS_SID.DUST
-        ? selectedStartAgent.sId
-        : undefined;
-    await handleStartWorking(task, {
-      customMessage: startCustomMessage.trim() || undefined,
-      agentConfigurationId,
-      goToConversation: goToConversationAfterStart,
-    });
-  };
-
-  const checkIcon = (
-    <Icon
-      size="xs"
-      visual={CheckIcon}
-      className="text-muted-foreground dark:text-muted-foreground-night"
-    />
   );
 
   const startMenuKeepsActionsVisible =
@@ -458,134 +409,21 @@ export function EditableTaskItem({ task }: EditableTaskItemProps) {
                   : "opacity-100 md:opacity-0 md:group-hover/task:opacity-100 md:focus-within:opacity-100"
               )}
             >
-              {isDoneWithoutConversation ? (
-                <Tooltip
-                  label="Reopen this task before starting work."
-                  trigger={
-                    <Button
-                      icon={PlayIcon}
-                      size="xs"
-                      variant="outline"
-                      disabled
-                    />
-                  }
-                />
-              ) : (
-                <DropdownMenu
-                  modal={false}
-                  open={startMenuOpen}
-                  onOpenChange={handleStartMenuOpenChange}
-                >
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      icon={PlayIcon}
-                      size="xs"
-                      variant="outline"
-                      isLoading={isStarting}
-                      disabled={isStarting}
-                      isPulsing={isFirstOnboardingTask && !startMenuOpen}
-                      tooltip="Start working on task"
-                    />
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-96">
-                    <div className="flex flex-col gap-3 p-3">
-                      <TextArea
-                        id={`task-start-msg-${task.sId}`}
-                        aria-label="Additional instructions for the agent"
-                        placeholder="(optional) Add a custom message for the agent..."
-                        value={startCustomMessage}
-                        rows={4}
-                        onChange={(
-                          event: React.ChangeEvent<HTMLTextAreaElement>
-                        ) => setStartCustomMessage(event.target.value)}
-                      />
-                      <div className="flex items-end justify-between gap-2">
-                        <div className="min-w-0 flex-1">
-                          <AgentPicker
-                            owner={owner}
-                            agents={activeAgents}
-                            disabled={isAgentsLoading}
-                            isLoading={isAgentsLoading}
-                            mountPortal
-                            showDropdownArrow
-                            showFooterButtons={false}
-                            side="bottom"
-                            size="xs"
-                            onItemClick={(agent) =>
-                              setSelectedStartAgent(agent)
-                            }
-                            pickerButton={
-                              <Button
-                                variant="ghost-secondary"
-                                size="xs"
-                                isSelect
-                                icon={
-                                  selectedStartAgent
-                                    ? () => (
-                                        <Avatar
-                                          size="xxs"
-                                          visual={selectedStartAgent.pictureUrl}
-                                        />
-                                      )
-                                    : RobotIcon
-                                }
-                                label={selectedStartAgent?.name ?? "Agent"}
-                                className="max-w-full min-w-0"
-                              />
-                            }
-                          />
-                        </div>
-                        <ButtonGroup className="shrink-0">
-                          <Button
-                            label="Start working"
-                            variant="outline"
-                            size="sm"
-                            className={isFirstOnboardingTask ? "z-10" : ""}
-                            isLoading={isStarting}
-                            isPulsing={isFirstOnboardingTask}
-                            disabled={isStarting || !selectedStartAgent}
-                            onClick={() => void handleConfirmStart()}
-                          />
-                          <ButtonGroupDropdown
-                            align="end"
-                            items={[
-                              {
-                                label: "Redirect to conversation",
-                                onSelect: (e) => {
-                                  e.preventDefault();
-                                  setGoToConversationAfterStart(true);
-                                },
-                                endComponent: goToConversationAfterStart
-                                  ? checkIcon
-                                  : undefined,
-                              },
-                              {
-                                label: "Stay on tasks",
-                                onSelect: (e) => {
-                                  e.preventDefault();
-                                  setGoToConversationAfterStart(false);
-                                },
-                                endComponent: !goToConversationAfterStart
-                                  ? checkIcon
-                                  : undefined,
-                              },
-                            ]}
-                            trigger={
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                icon={ChevronDownIcon}
-                                disabled={isStarting || !selectedStartAgent}
-                                aria-label="After start: open conversation or stay on tasks"
-                              />
-                            }
-                          />
-                        </ButtonGroup>
-                      </div>
-                    </div>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
+              <ProjectTaskStartWorkingDropdown
+                owner={owner}
+                taskSId={task.sId}
+                activeAgents={activeAgents}
+                agentsLoading={isAgentsLoading}
+                disabled={isDoneWithoutConversation}
+                disabledReason="Reopen this task before starting work."
+                isStarting={isStarting}
+                isFirstOnboardingTask={isFirstOnboardingTask}
+                defaultGoToConversation={!!task.agentInstructions?.trim()}
+                onOpenChange={setStartMenuOpen}
+                onStart={async (opts) => {
+                  await handleStartWorking(task, opts);
+                }}
+              />
             </div>
           )}
           {canEdit && (

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskStartWorkingDropdown.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskStartWorkingDropdown.tsx
@@ -1,0 +1,233 @@
+import { AgentPicker } from "@app/components/assistant/AgentPicker";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Avatar,
+  Button,
+  ButtonGroup,
+  ButtonGroupDropdown,
+  CheckIcon,
+  ChevronDownIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  type DropdownMenuItemProps,
+  DropdownMenuTrigger,
+  Icon,
+  PlayIcon,
+  RobotIcon,
+  TextArea,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import type React from "react";
+import { useEffect, useMemo, useState } from "react";
+
+export type ProjectTaskStartWorkingOptions = {
+  customMessage?: string;
+  agentConfigurationId?: string;
+  goToConversation: boolean;
+};
+
+export function ProjectTaskStartWorkingDropdown({
+  owner,
+  taskSId,
+  activeAgents,
+  agentsLoading,
+  disabled,
+  disabledReason,
+  isStarting,
+  isFirstOnboardingTask = false,
+  defaultGoToConversation = false,
+  onOpenChange,
+  onStart,
+  triggerClassName,
+  /** Default `xs`. Use `icon-xs` for a compact icon-only trigger (e.g. inline in metadata). */
+  triggerSize = "xs",
+}: {
+  owner: LightWorkspaceType;
+  taskSId: string;
+  activeAgents: LightAgentConfigurationType[];
+  agentsLoading: boolean;
+  disabled: boolean;
+  disabledReason?: string;
+  isStarting: boolean;
+  isFirstOnboardingTask?: boolean;
+  defaultGoToConversation?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onStart: (options: ProjectTaskStartWorkingOptions) => Promise<void>;
+  triggerClassName?: string;
+  triggerSize?: "xs" | "icon-xs";
+}) {
+  const [startMenuOpen, setStartMenuOpen] = useState(false);
+  const [startCustomMessage, setStartCustomMessage] = useState("");
+  const [goToConversationAfterStart, setGoToConversationAfterStart] = useState(
+    defaultGoToConversation
+  );
+  const [selectedStartAgent, setSelectedStartAgent] =
+    useState<LightAgentConfigurationType | null>(null);
+
+  useEffect(() => {
+    setGoToConversationAfterStart(defaultGoToConversation);
+  }, [defaultGoToConversation]);
+
+  const handleStartMenuOpenChange = (open: boolean) => {
+    setStartMenuOpen(open);
+    onOpenChange?.(open);
+    if (open) {
+      setStartCustomMessage("");
+      const defaultAgent =
+        activeAgents.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST) ??
+        activeAgents[0] ??
+        null;
+      setSelectedStartAgent(defaultAgent);
+    }
+  };
+
+  const handleConfirmStart = async () => {
+    setStartMenuOpen(false);
+    onOpenChange?.(false);
+    const agentConfigurationId =
+      selectedStartAgent && selectedStartAgent.sId !== GLOBAL_AGENTS_SID.DUST
+        ? selectedStartAgent.sId
+        : undefined;
+    await onStart({
+      customMessage: startCustomMessage.trim() || undefined,
+      agentConfigurationId,
+      goToConversation: goToConversationAfterStart,
+    });
+  };
+
+  const startRedirectMenuItems = useMemo((): DropdownMenuItemProps[] => {
+    const check = (
+      <Icon
+        size="xs"
+        visual={CheckIcon}
+        className="text-muted-foreground dark:text-muted-foreground-night"
+      />
+    );
+    return [
+      {
+        label: "Redirect to conversation",
+        onSelect: (e: Event) => {
+          e.preventDefault();
+          setGoToConversationAfterStart(true);
+        },
+        endComponent: goToConversationAfterStart ? check : undefined,
+      },
+      {
+        label: "Stay on tasks",
+        onSelect: (e: Event) => {
+          e.preventDefault();
+          setGoToConversationAfterStart(false);
+        },
+        endComponent: !goToConversationAfterStart ? check : undefined,
+      },
+    ];
+  }, [goToConversationAfterStart]);
+
+  const triggerButton = disabled ? (
+    <Tooltip
+      label={
+        disabledReason ?? "Can't start work on this task in this state yet."
+      }
+      trigger={
+        <Button icon={PlayIcon} size={triggerSize} variant="outline" disabled />
+      }
+    />
+  ) : (
+    <DropdownMenu
+      modal={false}
+      open={startMenuOpen}
+      onOpenChange={handleStartMenuOpenChange}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          icon={PlayIcon}
+          size={triggerSize}
+          variant="outline"
+          className={triggerClassName}
+          isLoading={isStarting}
+          disabled={isStarting}
+          isPulsing={isFirstOnboardingTask && !startMenuOpen}
+          tooltip="Start working on task"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-96">
+        <div className="flex flex-col gap-3 p-3">
+          <TextArea
+            id={`task-start-msg-${taskSId}`}
+            aria-label="Additional instructions for the agent"
+            placeholder="(optional) Add a custom message for the agent..."
+            value={startCustomMessage}
+            rows={4}
+            onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setStartCustomMessage(event.target.value)
+            }
+          />
+          <div className="flex items-end justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <AgentPicker
+                owner={owner}
+                agents={activeAgents}
+                disabled={agentsLoading}
+                isLoading={agentsLoading}
+                mountPortal
+                showDropdownArrow
+                showFooterButtons={false}
+                side="bottom"
+                size="xs"
+                onItemClick={(agent) => setSelectedStartAgent(agent)}
+                pickerButton={
+                  <Button
+                    variant="ghost-secondary"
+                    size="xs"
+                    isSelect
+                    icon={
+                      selectedStartAgent
+                        ? () => (
+                            <Avatar
+                              size="xxs"
+                              visual={selectedStartAgent.pictureUrl}
+                            />
+                          )
+                        : RobotIcon
+                    }
+                    label={selectedStartAgent?.name ?? "Agent"}
+                    className="max-w-full min-w-0"
+                  />
+                }
+              />
+            </div>
+            <ButtonGroup className="shrink-0">
+              <Button
+                label="Start working"
+                variant="outline"
+                size="sm"
+                className={isFirstOnboardingTask ? "z-10" : ""}
+                isLoading={isStarting}
+                isPulsing={isFirstOnboardingTask}
+                disabled={isStarting || !selectedStartAgent}
+                onClick={() => void handleConfirmStart()}
+              />
+              <ButtonGroupDropdown
+                align="end"
+                items={startRedirectMenuItems}
+                trigger={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    icon={ChevronDownIcon}
+                    disabled={isStarting || !selectedStartAgent}
+                    aria-label="After start: open conversation or stay on tasks"
+                  />
+                }
+              />
+            </ButtonGroup>
+          </div>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  return triggerButton;
+}

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -1,17 +1,26 @@
 import { ConversationSidebarStatusDot } from "@app/components/assistant/conversation/ConversationSidebarStatusDot";
+import { ProjectTaskStartWorkingDropdown } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskStartWorkingDropdown";
+import { useAppRouter } from "@app/lib/platform";
+import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
+import { useStartProjectTaskConversation } from "@app/lib/swr/projects";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
 import type { GetWorkspaceProjectTaskResponseBody } from "@app/pages/api/w/[wId]/project_tasks/[taskSId]/index";
-import type { ProjectTaskStatus } from "@app/types/project_task";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { compareAgentsForSort } from "@app/types/assistant/assistant";
+import type {
+  ProjectTaskStatus,
+  ProjectTaskType,
+} from "@app/types/project_task";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   AttachmentChip,
   Avatar,
+  CheckIcon,
   LinkWrapper,
-  ListCheckIcon,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
@@ -19,7 +28,7 @@ import {
   Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 import { visit } from "unist-util-visit";
 
@@ -61,36 +70,97 @@ function conversationActivityCaption(
   }
 }
 
-function TaskDirectivePopoverBody({
+/** Start control inside the task popover only (parent mounts when popover opens). */
+function TaskMarkdownPopoverStartChrome({
   owner,
   taskSId,
+  spaceId,
+  task,
+  activeAgents,
+  agentsLoading,
+  onStarted,
+  triggerSize = "xs",
 }: {
   owner: LightWorkspaceType;
   taskSId: string;
+  spaceId: string;
+  task: ProjectTaskType;
+  activeAgents: LightAgentConfigurationType[];
+  agentsLoading: boolean;
+  onStarted?: () => void;
+  triggerSize?: "xs" | "icon-xs";
 }) {
-  const { fetcher } = useFetcher();
-  const url = `/api/w/${owner.sId}/project_tasks/${encodeURIComponent(taskSId)}`;
-  const { data, error, isLoading } = useSWRWithDefaults(
-    url,
-    fetcher as Fetcher<GetWorkspaceProjectTaskResponseBody, string>
+  const router = useAppRouter();
+  const doStart = useStartProjectTaskConversation({ owner, spaceId });
+  const [isStarting, setIsStarting] = useState(false);
+
+  const hasConversationLink =
+    (task.status === "in_progress" || task.status === "done") &&
+    !!task.conversationId;
+  const isDoneWithoutConversation =
+    task.status === "done" && !hasConversationLink;
+
+  if (hasConversationLink) {
+    return null;
+  }
+
+  return (
+    <ProjectTaskStartWorkingDropdown
+      owner={owner}
+      taskSId={taskSId}
+      activeAgents={activeAgents}
+      agentsLoading={agentsLoading}
+      disabled={isDoneWithoutConversation}
+      disabledReason="Reopen this task before starting work."
+      isStarting={isStarting}
+      isFirstOnboardingTask={false}
+      defaultGoToConversation={false}
+      triggerClassName="shrink-0"
+      triggerSize={triggerSize}
+      onStart={async (opts) => {
+        setIsStarting(true);
+        try {
+          const result = await doStart(taskSId, {
+            customMessage: opts.customMessage,
+            agentConfigurationId: opts.agentConfigurationId,
+          });
+          if (
+            result.isOk() &&
+            opts.goToConversation &&
+            result.value.conversationId
+          ) {
+            void router.push(
+              getConversationRoute(owner.sId, result.value.conversationId),
+              undefined,
+              { shallow: true }
+            );
+          }
+          if (result.isOk()) {
+            onStarted?.();
+          }
+        } finally {
+          setIsStarting(false);
+        }
+      }}
+    />
   );
+}
 
-  if (isLoading) {
-    return (
-      <div className="flex min-h-[7rem] items-center justify-center p-3">
-        <Spinner size="sm" />
-      </div>
-    );
-  }
-
-  if (error || !data) {
-    return (
-      <div className="p-3 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
-        Could not load this task.
-      </div>
-    );
-  }
-
+function TaskDirectivePopoverBodyLoaded({
+  owner,
+  taskSId,
+  data,
+  activeAgents,
+  agentsLoading,
+  onTaskUpdated,
+}: {
+  owner: LightWorkspaceType;
+  taskSId: string;
+  data: GetWorkspaceProjectTaskResponseBody;
+  activeAgents: LightAgentConfigurationType[];
+  agentsLoading: boolean;
+  onTaskUpdated?: () => void;
+}) {
   const { task, space } = data;
   const projectHref = getProjectRoute(owner.sId, space.sId);
   const assignee = task.user;
@@ -102,6 +172,10 @@ function TaskDirectivePopoverBody({
     hasConversation
   );
 
+  const showStartInPopover =
+    (task.status !== "in_progress" && task.status !== "done") ||
+    !task.conversationId;
+
   return (
     <div className="flex flex-col p-3">
       <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground dark:text-foreground-night">
@@ -110,11 +184,18 @@ function TaskDirectivePopoverBody({
 
       <Separator className="-mx-3 my-3 shrink-0 bg-border/60 dark:bg-border-night/60" />
 
-      <dl className="grid grid-cols-[minmax(0,7.5rem)_1fr] gap-x-3 gap-y-2.5 pb-2 text-xs">
-        <dt className="text-muted-foreground dark:text-muted-foreground-night">
+      <dl className="grid grid-cols-[minmax(0,7.5rem)_1fr] gap-x-3 gap-y-2 pb-2 text-xs [grid-auto-rows:minmax(2rem,max-content)]">
+        <dt className="flex items-center text-muted-foreground dark:text-muted-foreground-night">
+          ID
+        </dt>
+        <dd className="flex min-h-8 min-w-0 items-center justify-end font-mono text-[11px] font-medium tabular-nums text-foreground dark:text-foreground-night">
+          <span className="break-all select-text">{task.sId}</span>
+        </dd>
+
+        <dt className="flex items-center text-muted-foreground dark:text-muted-foreground-night">
           Assignee
         </dt>
-        <dd className="flex min-w-0 items-center justify-end">
+        <dd className="flex min-h-8 min-w-0 items-center justify-end">
           {assignee ? (
             <Tooltip
               label={assignee.fullName}
@@ -140,38 +221,45 @@ function TaskDirectivePopoverBody({
           )}
         </dd>
 
-        <dt className="text-muted-foreground dark:text-muted-foreground-night">
+        <dt className="flex items-center text-muted-foreground dark:text-muted-foreground-night">
           Created
         </dt>
-        <dd className="text-right font-medium text-foreground dark:text-foreground-night">
+        <dd className="flex min-h-8 min-w-0 items-center justify-end text-right font-medium text-foreground dark:text-foreground-night">
           {formatRelativeAgo(task.createdAt)}
         </dd>
 
-        <dt className="text-muted-foreground dark:text-muted-foreground-night">
+        <dt className="flex items-center text-muted-foreground dark:text-muted-foreground-night">
           Status
         </dt>
-        <dd className="text-right font-medium text-foreground dark:text-foreground-night">
-          {formatTaskStatusLabel(task.status)}
-          {task.status === "done" && task.doneAt ? (
-            <span className="block text-[11px] font-normal text-muted-foreground dark:text-muted-foreground-night">
-              Completed {formatRelativeAgo(task.doneAt)}
-            </span>
+        <dd className="flex min-h-8 min-w-0 flex-wrap items-center justify-end gap-2 font-medium text-foreground dark:text-foreground-night">
+          <span className="text-right leading-tight">
+            {formatTaskStatusLabel(task.status)}
+            {task.status === "done" && task.doneAt ? (
+              <span className="mt-1 block text-[11px] font-normal leading-tight text-muted-foreground dark:text-muted-foreground-night">
+                Completed {formatRelativeAgo(task.doneAt)}
+              </span>
+            ) : null}
+          </span>
+          {showStartInPopover ? (
+            <TaskMarkdownPopoverStartChrome
+              owner={owner}
+              taskSId={taskSId}
+              spaceId={space.sId}
+              task={task}
+              activeAgents={activeAgents}
+              agentsLoading={agentsLoading}
+              onStarted={onTaskUpdated}
+              triggerSize="icon-xs"
+            />
           ) : null}
-        </dd>
-
-        <dt className="text-muted-foreground dark:text-muted-foreground-night">
-          ID
-        </dt>
-        <dd className="min-w-0 text-right font-mono text-[11px] font-medium tabular-nums text-foreground dark:text-foreground-night">
-          <span className="break-all select-text">{task.sId}</span>
         </dd>
 
         {hasConversation && task.conversationId && activityCaption ? (
           <>
-            <dt className="text-muted-foreground dark:text-muted-foreground-night">
+            <dt className="flex items-center text-muted-foreground dark:text-muted-foreground-night">
               Conversation
             </dt>
-            <dd className="flex min-w-0 items-center justify-end gap-2 text-right">
+            <dd className="flex min-h-8 min-w-0 items-center justify-end gap-2 text-right">
               <ConversationSidebarStatusDot
                 status={dotStatus}
                 className="m-0 shrink-0"
@@ -208,6 +296,63 @@ function TaskDirectivePopoverBody({
   );
 }
 
+/**
+ * Fetches task + agents only while this tree is mounted (popover open).
+ */
+function TaskDirectivePopoverContent({
+  owner,
+  taskSId,
+}: {
+  owner: LightWorkspaceType;
+  taskSId: string;
+}) {
+  const { fetcher } = useFetcher();
+  const url = `/api/w/${owner.sId}/project_tasks/${encodeURIComponent(taskSId)}`;
+  const { data, error, isLoading, mutate } = useSWRWithDefaults(
+    url,
+    fetcher as Fetcher<GetWorkspaceProjectTaskResponseBody, string>
+  );
+
+  const { agentConfigurations, isLoading: agentsLoading } =
+    useUnifiedAgentConfigurations({
+      workspaceId: owner.sId,
+      disabled: false,
+    });
+
+  const activeAgents = useMemo(() => {
+    const agents = agentConfigurations.filter((a) => a.status === "active");
+    agents.sort(compareAgentsForSort);
+    return agents;
+  }, [agentConfigurations]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[7rem] items-center justify-center p-3">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="p-3 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Could not load this task.
+      </div>
+    );
+  }
+
+  return (
+    <TaskDirectivePopoverBodyLoaded
+      owner={owner}
+      taskSId={taskSId}
+      data={data}
+      activeAgents={activeAgents}
+      agentsLoading={agentsLoading}
+      onTaskUpdated={() => void mutate()}
+    />
+  );
+}
+
 function TaskDirectiveChipInner({
   owner,
   label,
@@ -234,20 +379,22 @@ function TaskDirectiveChipInner({
           >
             <AttachmentChip
               label={displayLabel}
-              icon={{ visual: ListCheckIcon }}
+              icon={{ visual: CheckIcon }}
               color="green"
               className="min-w-0 max-w-full transition-opacity group-hover:opacity-90"
             />
           </button>
         </PopoverTrigger>
+        {/* Prevent moving focus to the first control (Start). Radix Tooltip opens on focus → instant tooltip */}
         <PopoverContent
           align="start"
           sideOffset={6}
           collisionPadding={16}
           className="w-[min(22rem,calc(100vw-1.5rem))] overflow-hidden rounded-xl border border-border/70 p-0 shadow-xl ring-1 ring-black/[0.04] dark:border-border-night/70 dark:ring-white/[0.06]"
+          onOpenAutoFocus={(e) => e.preventDefault()}
         >
           {open ? (
-            <TaskDirectivePopoverBody owner={owner} taskSId={sId} />
+            <TaskDirectivePopoverContent owner={owner} taskSId={sId} />
           ) : null}
         </PopoverContent>
       </PopoverRoot>

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -40,8 +40,8 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import {
   BookOpenIcon,
   ChatBubbleLeftRightIcon,
+  CheckIcon,
   Cog6ToothIcon,
-  ListCheckIcon,
   Spinner,
   Tabs,
   TabsContent,
@@ -308,7 +308,7 @@ export function SpaceConversationsPage() {
               value="tasks"
               label={compactProjectTabs ? undefined : "Tasks"}
               tooltip={compactProjectTabs ? "Tasks" : undefined}
-              icon={ListCheckIcon}
+              icon={CheckIcon}
             />
             <TabsTrigger
               value="knowledge"


### PR DESCRIPTION
## Description

Two improvements: the start-working UI is extracted into a reusable component and surfaced directly from the task chip popup.

**Extract `ProjectTaskStartWorkingDropdown`**

The agent picker, custom message textarea, and go/stay split button were inlined in `EditableTaskItem`, making the component large and the logic hard to reuse. All start-related state and handlers are moved into a new `ProjectTaskStartWorkingDropdown` component; `EditableTaskItem` simply renders it.

**Start from the task popup**

Users clicking a `:project_task` chip in a message had to navigate to the tasks tab to start working. `ProjectTaskStartWorkingDropdown` is now also rendered inside `TaskDirectivePopoverBody`, so users can kick off a conversation on a task directly from the popup wherever the chip appears.

**Minor**

- `SpaceConversationsActions` onboarding card icon: `ListCheckIcon` → `CheckIcon`

## Tests

Local

## Risk

Low — pure refactor for `EditableTaskItem`; popup integration is additive

## Deploy Plan

Deploy `front`
