### PR TITLE
fix(voice): voice files and webm

### DIFF
--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -9,7 +9,12 @@ import {
   isReadableAsText,
   resolveConversationFile,
 } from "@app/lib/api/actions/servers/files/tools/utils";
-import { isLLMVisionSupportedImageContentType } from "@app/types/files";
+import { makeProcessedMountFileName } from "@app/lib/api/files/mount_path";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import {
+  isLLMVisionSupportedImageContentType,
+  isSupportedAudioContentType,
+} from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -48,6 +53,30 @@ function catImage(
         imageContentType: mimeType,
       },
     },
+  ]);
+}
+
+async function catAudio(
+  file: GCSFile,
+  path: string,
+  startLine: number,
+  maxLines: number
+): Promise<ToolHandlerResult> {
+  const processedGcsPath = makeProcessedMountFileName({
+    mountFilePath: file.name,
+    processedContentType: "text/plain",
+  });
+  const processedFile = getPrivateUploadBucket().file(processedGcsPath);
+  try {
+    const [exists] = await processedFile.exists();
+    if (exists) {
+      return catText(processedFile, path, startLine, maxLines);
+    }
+  } catch {
+    // Fall through to the empty transcript message.
+  }
+  return new Ok([
+    { type: "text", text: `\`${path}\` has no transcript available.` },
   ]);
 }
 
@@ -144,6 +173,10 @@ export async function catHandler(
 
   if (isLLMVisionSupportedImageContentType(mimeType)) {
     return catImage(file, { path, mimeType, sizeBytes });
+  }
+
+  if (isSupportedAudioContentType(mimeType)) {
+    return catAudio(file, path, offset ?? 1, limit ?? CAT_LINES_DEFAULT);
   }
 
   if (!isReadableAsText(mimeType)) {

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -419,6 +419,14 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
       processedContentType: "text/plain",
     },
   ],
+  // Chrome sometimes uses video/webm for audio files, and we can still process them as audio only files
+  [
+    "video/webm",
+    {
+      process: extractTextFromAudioAndUpload,
+      processedContentType: "text/plain",
+    },
+  ],
   [
     "audio/ogg",
     {

--- a/front/lib/api/files/use_cases/conversation.ts
+++ b/front/lib/api/files/use_cases/conversation.ts
@@ -14,6 +14,8 @@ const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
   "audio/wav",
   "audio/x-wav",
   "audio/webm",
+  // Chrome sometimes uses video/webm for audio files, and we can still process them as audio only files
+  "video/webm",
   "audio/ogg",
   "audio/x-m4a",
 

--- a/front/lib/api/files/use_cases/project_context.ts
+++ b/front/lib/api/files/use_cases/project_context.ts
@@ -14,6 +14,8 @@ const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
   "audio/wav",
   "audio/x-wav",
   "audio/webm",
+  // Chrome sometimes uses video/webm for audio files, and we can still process them as audio only files
+  "video/webm",
   "audio/ogg",
   "audio/x-m4a",
 

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -391,6 +391,8 @@ export const FILE_FORMATS = {
   "audio/x-wav": { cat: "audio", exts: [".wav"], isSafeToDisplay: true },
   "audio/ogg": { cat: "audio", exts: [".ogg"], isSafeToDisplay: true },
   "audio/webm": { cat: "audio", exts: [".webm"], isSafeToDisplay: true },
+  // Chrome sometimes uses video/webm for audio files, and we can still process them as audio only files
+  "video/webm": { cat: "audio", exts: [".webm"], isSafeToDisplay: true },
 
   // Unknown.
   "application/octet-stream": {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -230,6 +230,8 @@ export const supportedAudioFileFormats = {
   "audio/wav": [".wav"],
   "audio/x-wav": [".wav"],
   "audio/webm": [".webm"],
+  // Chrome sometimes uses video/webm for audio files, and we can still process them as audio only files
+  "video/webm": [".webm"],
 } as const;
 
 // Webhook trigger endpoint (skeleton) response type


### PR DESCRIPTION
## Description

Fix 2 audio issues:
1. handling of `video/webm` files
2. `cat` tool with audio files


For 1), Chrome seems to send `video/webm` files (and not `audio/webm`) when recording audio files. And we can still extract audio from it, so let's support them
For 2), the model was seeing audio files and not the transcription of it, making it fail to read

## Tests

Locally
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
