### PR TITLE
[front] stripe sessions: clean userId (use sId)

### DIFF
--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -235,18 +235,15 @@ export async function handleMetronomeSetupCheckout({
     return subscriptionResult;
   }
 
-  if (userId) {
-    const workspaceSeats = await MembershipResource.countActiveSeatsInWorkspace(
-      workspace.sId
-    );
-    await ServerSideTracking.trackSubscriptionCreated({
-      userId,
-      workspace: renderLightWorkspaceType({ workspace }),
-      planCode,
-      workspaceSeats,
-      subscriptionStartAt: now,
-    });
-  }
+  const workspaceSeats = await MembershipResource.countActiveSeatsInWorkspace(
+    workspace.sId
+  );
+  await ServerSideTracking.trackSubscriptionCreated({
+    workspace: lightWorkspace,
+    planCode,
+    workspaceSeats,
+    subscriptionStartAt: now,
+  });
 
   await restoreWorkspaceAfterSubscription(authAdmin);
 

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -236,7 +236,7 @@ export const createStripeSubscriptionCheckoutSession = async ({
     },
     metadata: {
       planCode: planCode,
-      userId: `${user.id}`,
+      userId: user.sId,
       ...(metronomePackageAlias ? { metronomePackageAlias } : {}),
     },
     line_items: [
@@ -295,7 +295,7 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
 
   const metadata: Record<string, string> = {
     planCode,
-    userId: `${user.id}`,
+    userId: user.sId,
     metronomePackageAlias,
   };
   if (couponCode) {

--- a/front/lib/tracking/server.ts
+++ b/front/lib/tracking/server.ts
@@ -169,7 +169,6 @@ export class ServerSideTracking {
     workspaceSeats,
     subscriptionStartAt,
   }: {
-    userId: string;
     workspace: LightWorkspaceType;
     planCode: string;
     workspaceSeats: number;

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -562,7 +562,6 @@ async function handleStripeCheckoutCompleted({
   planCode,
   stripeSubscriptionId,
   metronomePackageAlias,
-  userId,
   stripe,
   now,
 }: {
@@ -571,7 +570,6 @@ async function handleStripeCheckoutCompleted({
   planCode: string | null;
   stripeSubscriptionId: string | Stripe.Subscription | null;
   metronomePackageAlias: string | null;
-  userId: string | null;
   stripe: Stripe;
   now: Date;
 }): Promise<void> {
@@ -668,17 +666,15 @@ async function handleStripeCheckoutCompleted({
 
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    if (userId) {
-      const workspaceSeats =
-        await MembershipResource.countActiveSeatsInWorkspace(workspace.sId);
-      await ServerSideTracking.trackSubscriptionCreated({
-        userId,
-        workspace: renderLightWorkspaceType({ workspace }),
-        planCode,
-        workspaceSeats,
-        subscriptionStartAt: now,
-      });
-    }
+    const workspaceSeats = await MembershipResource.countActiveSeatsInWorkspace(
+      workspace.sId
+    );
+    await ServerSideTracking.trackSubscriptionCreated({
+      workspace: renderLightWorkspaceType({ workspace }),
+      planCode,
+      workspaceSeats,
+      subscriptionStartAt: now,
+    });
     await restoreWorkspaceAfterSubscription(auth);
 
     if (
@@ -787,7 +783,6 @@ async function handler(
           const planCode = session?.metadata?.planCode || null;
           const metronomePackageAlias =
             session?.metadata?.metronomePackageAlias || null;
-          const userId = session?.metadata?.userId || null;
 
           if (session.status === "open" || session.status === "expired") {
             // Open: still in progress, payment processing has not started.
@@ -827,7 +822,6 @@ async function handler(
               planCode,
               stripeSubscriptionId,
               metronomePackageAlias,
-              userId,
               stripe,
               now,
             });


### PR DESCRIPTION
## Description

Multiple cleaning for userId sent in stripe session metadata
* ServerSideTracking.trackSubscriptionCreated was already not using userId (dead code)
* removed the check on userId in the checkout as not used by ServerSideTracking.trackSubscriptionCreated
* changed the userId to a sId (as pere convention for external calls)
* userId kept as it is needed for coupons redemptions in metronome case

## Tests

Tested locally

## Risk

Low as userId was not actually used anymore

## Deploy Plan

Deploy front