### PR TITLE
Surface .processed.<ext> files in the agent's files__list

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -23,7 +23,11 @@ export const FILES_TOOLS_METADATA = createToolsRecord({
       "Returns one entry per file with its scoped path (e.g. `conversation/chart.png`), " +
       "content type, and size in KB. " +
       "Scoped paths can be used to reference or display a file in a response, " +
-      "or passed to other tools that accept a file path.",
+      "or passed to other tools that accept a file path. " +
+      "Some files have an auto-generated `*.processed.<ext>` sibling carrying a " +
+      "model-friendly representation of their source: a resized version for images, " +
+      "a transcript for audio, or extracted text for PDFs and other documents. " +
+      `Read the sibling with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` to access the content of binary sources.`,
     schema: {},
     stake: "never_ask",
     displayLabels: {
@@ -37,7 +41,9 @@ export const FILES_TOOLS_METADATA = createToolsRecord({
       "For text files, returns lines with their line numbers." +
       "Use `offset` to start at a specific line and `limit` to control how many lines to return. " +
       "When the output is truncated, a footer indicates the next offset to use. " +
-      "For images (JPEG, PNG, GIF), returns a vision block the model can inspect directly.",
+      "For images (JPEG, PNG, GIF), returns a vision block the model can inspect directly. " +
+      "For binary sources such as PDFs, scanned documents, or audio files, prefer the " +
+      `\`*.processed.<ext>\` sibling listed in \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` — it carries the extracted text or transcript.`,
     schema: {
       path: z
         .string()
@@ -129,7 +135,11 @@ export const FILES_SERVER = {
       "exports, processed data produced by code run in the sandbox), and files produced " +
       "as results of tool use. " +
       "Files are identified by scoped paths such as `conversation/chart.png` that can " +
-      "be used to reference, display, or link files in agent responses.",
+      "be used to reference, display, or link files in agent responses. " +
+      "Files whose name follows the `*.processed.<ext>` pattern are auto-generated " +
+      "model-friendly representations of their source (resized image, audio transcript, " +
+      "or text extracted from a document). Read those siblings to access the content " +
+      "of binary uploads.",
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -4,9 +4,22 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
 import { listGCSMountFiles } from "@app/lib/api/files/gcs_mount/files";
+import { parseProcessedFilename } from "@app/lib/api/files/mount_path";
 import { stripMimeParameters } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import partition from "lodash/partition";
+
+function getDirAndFileName(path: string): { dir: string; fileName: string } {
+  const lastSlash = path.lastIndexOf("/");
+  if (lastSlash < 0) {
+    return { dir: "", fileName: path };
+  }
+
+  return {
+    dir: path.substring(0, lastSlash),
+    fileName: path.substring(lastSlash + 1),
+  };
+}
 
 export async function listHandler(
   _params: Record<string, never>,
@@ -20,7 +33,9 @@ export async function listHandler(
     return mountRes;
   }
 
-  const entries = await listGCSMountFiles(extra.auth, mountRes.value.scope);
+  const entries = await listGCSMountFiles(extra.auth, mountRes.value.scope, {
+    includeProcessed: true,
+  });
 
   const [dirs, files] = partition(entries, (e) => e.isDirectory);
 
@@ -38,6 +53,44 @@ export async function listHandler(
     }
   }
 
+  // Index sources by `<dir>/<basename-without-extension>` so we can look up the source for each
+  // `*.processed.<ext>` sibling.
+  const sourcePathByKey = new Map<string, string>();
+  for (const file of files) {
+    const { dir, fileName } = getDirAndFileName(file.path);
+    if (parseProcessedFilename(fileName).isProcessed) {
+      continue;
+    }
+
+    const lastDot = fileName.lastIndexOf(".");
+    const base = lastDot > 0 ? fileName.substring(0, lastDot) : fileName;
+    sourcePathByKey.set(`${dir}/${base}`, file.path);
+  }
+
+  // For each file, compute (sortKey, isProcessed) so that processed siblings sort right after
+  // their source. Falls back to the file's own path when no source is found (orphan processed file).
+  const annotated = files.map((file) => {
+    const { dir, fileName } = getDirAndFileName(file.path);
+    const parsed = parseProcessedFilename(fileName);
+    if (!parsed.isProcessed) {
+      return { file, sortKey: file.path, tieBreak: 0, sourcePath: null };
+    }
+
+    const sourcePath =
+      sourcePathByKey.get(`${dir}/${parsed.sourceBaseName}`) ?? null;
+
+    return {
+      file,
+      sortKey: sourcePath ?? file.path,
+      tieBreak: sourcePath ? 1 : 0,
+      sourcePath,
+    };
+  });
+
+  annotated.sort(
+    (a, b) => a.sortKey.localeCompare(b.sortKey) || a.tieBreak - b.tieBreak
+  );
+
   const lines: string[] = [];
 
   for (const dir of dirs) {
@@ -46,10 +99,13 @@ export async function listHandler(
     }
   }
 
-  for (const file of files) {
+  for (const { file, sourcePath } of annotated) {
     const mimeType = stripMimeParameters(file.contentType);
     const kb = Math.ceil(file.sizeBytes / 1024);
-    lines.push(`${file.path} (${mimeType}, ${kb} KB)`);
+    const annotation = sourcePath
+      ? ` — processed version of ${sourcePath}`
+      : "";
+    lines.push(`${file.path} (${mimeType}, ${kb} KB)${annotation}`);
   }
 
   return new Ok([{ type: "text", text: lines.join("\n") }]);

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -184,7 +184,10 @@ describe("listGCSMountFiles", () => {
 
     const paths = entries.filter((e) => !e.isDirectory).map((e) => e.path);
     expect(paths).toEqual(
-      expect.arrayContaining(["conversation/report.pdf", "conversation/photo.jpg"])
+      expect.arrayContaining([
+        "conversation/report.pdf",
+        "conversation/photo.jpg",
+      ])
     );
     expect(paths).not.toEqual(
       expect.arrayContaining([

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -2,6 +2,7 @@ import {
   createGCSMountFile,
   type GCSMountFileEntry,
   getConversationFileMountSignedUrl,
+  listGCSMountFiles,
 } from "@app/lib/api/files/gcs_mount/files";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -10,10 +11,6 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("@app/lib/file_storage", () => ({
-  getPrivateUploadBucket: vi.fn(),
-}));
 
 vi.mock("@app/lib/api/config", () => ({
   default: {
@@ -118,6 +115,105 @@ describe("createGCSMountFile", () => {
 
     assert(entryRes.isOk());
     expect(entryRes.value.thumbnailUrl).toBeNull();
+  });
+});
+
+describe("listGCSMountFiles", () => {
+  let auth: Authenticator;
+  let conversationId: string;
+  let workspaceId: string;
+  let getFilesMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    getFilesMock = vi.fn();
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      getFiles: getFilesMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator, conversationsSpace } = await createResourceTest({});
+    auth = authenticator;
+    workspaceId = auth.getNonNullableWorkspace().sId;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+    conversationId = conversation.sId;
+  });
+
+  function gcsFile({
+    name,
+    contentType = "text/plain",
+    size = 100,
+  }: {
+    name: string;
+    contentType?: string;
+    size?: number;
+  }) {
+    return {
+      name,
+      metadata: {
+        contentType,
+        size: String(size),
+        updated: new Date().toISOString(),
+      },
+    };
+  }
+
+  it("excludes *.processed.<ext> siblings by default", async () => {
+    const prefix = `w/${workspaceId}/conversations/${conversationId}/files/`;
+    getFilesMock.mockResolvedValue([
+      gcsFile({ name: `${prefix}report.pdf`, contentType: "application/pdf" }),
+      gcsFile({ name: `${prefix}report.processed.txt` }),
+      gcsFile({ name: `${prefix}photo.jpg`, contentType: "image/jpeg" }),
+      gcsFile({
+        name: `${prefix}photo.processed.jpg`,
+        contentType: "image/jpeg",
+      }),
+    ]);
+
+    const entries = await listGCSMountFiles(auth, {
+      useCase: "conversation",
+      conversationId,
+    });
+
+    const paths = entries.filter((e) => !e.isDirectory).map((e) => e.path);
+    expect(paths).toEqual(
+      expect.arrayContaining(["conversation/report.pdf", "conversation/photo.jpg"])
+    );
+    expect(paths).not.toEqual(
+      expect.arrayContaining([
+        "conversation/report.processed.txt",
+        "conversation/photo.processed.jpg",
+      ])
+    );
+  });
+
+  it("includes *.processed.<ext> siblings when includeProcessed is true", async () => {
+    const prefix = `w/${workspaceId}/conversations/${conversationId}/files/`;
+    getFilesMock.mockResolvedValue([
+      gcsFile({ name: `${prefix}report.pdf`, contentType: "application/pdf" }),
+      gcsFile({ name: `${prefix}report.processed.txt` }),
+    ]);
+
+    const entries = await listGCSMountFiles(
+      auth,
+      { useCase: "conversation", conversationId },
+      { includeProcessed: true }
+    );
+
+    const paths = entries.filter((e) => !e.isDirectory).map((e) => e.path);
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        "conversation/report.pdf",
+        "conversation/report.processed.txt",
+      ])
+    );
   });
 });
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -130,10 +130,16 @@ function makeFileEntry(
 
 /**
  * List files from a GCS mount point (mounted bucket as source of truth).
+ *
+ * `.processed.<ext>` siblings are filtered out by default — they are
+ * auto-generated artifacts (resized images, transcripts, extracted text) and
+ * the UI file panel should not surface them. The MCP `files__list` tool opts
+ * in via `includeProcessed: true` so the agent can read them directly.
  */
 export async function listGCSMountFiles(
   auth: Authenticator,
-  scope: GCSMountPoint
+  scope: GCSMountPoint,
+  { includeProcessed = false }: { includeProcessed?: boolean } = {}
 ): Promise<GCSMountEntry[]> {
   const owner = auth.getNonNullableWorkspace();
   const prefix = resolvePrefix(owner, scope);
@@ -147,6 +153,11 @@ export async function listGCSMountFiles(
     if (f.name.endsWith("/")) {
       return false;
     }
+
+    if (includeProcessed) {
+      return true;
+    }
+
     const name = f.name.split("/").pop() ?? "";
     return !name.includes(".processed.");
   });

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -4,6 +4,7 @@ import {
   getConversationFilePath,
   getConversationFilesBasePath,
   makeProcessedMountFileName,
+  parseProcessedFilename,
 } from "@app/lib/api/files/mount_path";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -84,6 +85,66 @@ describe("mount_path helpers", () => {
           processedContentType: "image/png",
         })
       ).toBe("dir/photo.processed.png");
+    });
+  });
+
+  describe("parseProcessedFilename", () => {
+    it("recognizes a processed file with a swapped extension (PDF → text)", () => {
+      expect(parseProcessedFilename("report.processed.txt")).toEqual({
+        isProcessed: true,
+        sourceBaseName: "report",
+      });
+    });
+
+    it("recognizes a processed image (same content type)", () => {
+      expect(parseProcessedFilename("photo.processed.jpg")).toEqual({
+        isProcessed: true,
+        sourceBaseName: "photo",
+      });
+    });
+
+    it("recognizes a processed file without an original extension", () => {
+      expect(parseProcessedFilename("Makefile.processed")).toEqual({
+        isProcessed: true,
+        sourceBaseName: "Makefile",
+      });
+    });
+
+    it("recognizes a processed file when the source name itself contains dots", () => {
+      expect(parseProcessedFilename("my.file.name.processed.txt")).toEqual({
+        isProcessed: true,
+        sourceBaseName: "my.file.name",
+      });
+    });
+
+    it("does not flag regular user files", () => {
+      expect(parseProcessedFilename("report.pdf")).toEqual({
+        isProcessed: false,
+      });
+      expect(parseProcessedFilename("notes.txt")).toEqual({
+        isProcessed: false,
+      });
+    });
+
+    it("does not flag user files that merely contain '.processed.' mid-name", () => {
+      // ".processed." is not the final segment-before-extension here.
+      expect(parseProcessedFilename("my.processed.report.pdf")).toEqual({
+        isProcessed: false,
+      });
+      // Multi-segment extension after ".processed." is not produced by our writer.
+      expect(parseProcessedFilename("data.processed.tar.gz")).toEqual({
+        isProcessed: false,
+      });
+    });
+
+    it("does not flag .processed-only or empty inputs", () => {
+      expect(parseProcessedFilename(".processed")).toEqual({
+        isProcessed: false,
+      });
+      expect(parseProcessedFilename(".processed.txt")).toEqual({
+        isProcessed: false,
+      });
+      expect(parseProcessedFilename("")).toEqual({ isProcessed: false });
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -79,6 +79,52 @@ export function makeProcessedMountFileName({
   return `${dirPart}${basename}.processed${ext}`;
 }
 
+/**
+ * Inverse of `makeProcessedMountFileName`: given a file name (no directory prefix), returns the
+ * original source's base name when the input is a processed sibling, or `{ isProcessed: false }`
+ * otherwise.
+ *
+ * Recognized shapes:
+ *   "report.processed.txt"    -> { isProcessed: true, sourceBaseName: "report" }
+ *   "photo.processed.jpg"     -> { isProcessed: true, sourceBaseName: "photo" }
+ *   "Makefile.processed"      -> { isProcessed: true, sourceBaseName: "Makefile" }
+ *
+ * Anything else (including user-named files that merely contain ".processed." somewhere) returns
+ * `{ isProcessed: false }`. The original extension is not recoverable from the processed name alone
+ * (the processed content type may differ). Callers that need the full source path should match by
+ * `sourceBaseName` against the listing.
+ */
+export function parseProcessedFilename(
+  fileName: string
+): { isProcessed: true; sourceBaseName: string } | { isProcessed: false } {
+  const PROCESSED = ".processed";
+
+  // Extension-less original: "<name>.processed".
+  if (fileName.endsWith(PROCESSED)) {
+    const sourceBaseName = fileName.slice(0, -PROCESSED.length);
+    if (sourceBaseName.length === 0) {
+      return { isProcessed: false };
+    }
+
+    return { isProcessed: true, sourceBaseName };
+  }
+
+  // Regular case: "<name>.processed.<ext>".
+  const marker = `${PROCESSED}.`;
+  const idx = fileName.lastIndexOf(marker);
+  if (idx <= 0) {
+    return { isProcessed: false };
+  }
+
+  const after = fileName.slice(idx + marker.length);
+  // The processed extension is always a single segment (no nested dots).
+  if (after.length === 0 || after.includes(".")) {
+    return { isProcessed: false };
+  }
+
+  return { isProcessed: true, sourceBaseName: fileName.slice(0, idx) };
+}
+
 export const scopedFilePathPrefixSchema = z.enum([
   "conversation",
   // TODO(20260428 FILE SYSTEM) Add support for project.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When an uploaded binary file enters the conversation file system we already write a model-friendly sibling next to it: a resized image for visual files, a transcript for audio, or extracted text for PDFs and other documents. Until now we filtered those siblings out of every listing, including the one the agent sees. The result was that the model knew report.pdf existed but had no idea its contents were already extracted and sitting at report.processed.txt. So it would either try
to read it through the sandbox (end goal, once sandbox is GA), or complain that it can't read it.

This change keeps the UI conversation file panel quiet (the user shouldn't see internal artifacts they didn't upload) but opens up the MCP `files__list` tool so the agent can see processed siblings. Each sibling is rendered right after its source with a small annotation pointing back at the original path, so the relationship is unambiguous, and the list, cat, and server-level descriptions now spell out the convention covering all three flavors.

The expected effect is that on a conversation with PDFs or audio uploads the model now cats the processed sibling directly instead of fumbling with the binary or asking for help.

<img width="1112" height="188" alt="image" src="https://github.com/user-attachments/assets/b39865ed-eea2-410f-808a-7222f6c10314" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
