### PR TITLE
feat: add project page in poke with tasks section

### DIFF
--- a/front/components/poke/pages/ProjectPage.tsx
+++ b/front/components/poke/pages/ProjectPage.tsx
@@ -1,60 +1,36 @@
 import { DataSourceViewsDataTable } from "@app/components/poke/data_source_views/table";
-import { MCPServerViewsDataTable } from "@app/components/poke/mcp_server_views/table";
 import { MembersDataTable } from "@app/components/poke/members/table";
-import { ProjectPage } from "@app/components/poke/pages/ProjectPage";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { ProjectTasksDataTable } from "@app/components/poke/projects/tasks/table";
 import { ViewSpaceViewTable } from "@app/components/poke/spaces/view";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
-import { useRequiredPathParam } from "@app/lib/platform";
-import { usePokeSpaceDetails } from "@app/poke/swr/space_details";
-import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import type { PokeGetSpaceDetails } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details";
+import { LinkWrapper } from "@dust-tt/sparkle";
 
-export function SpacePage() {
+interface ProjectPageProps {
+  details: PokeGetSpaceDetails;
+}
+
+export function ProjectPage({ details }: ProjectPageProps) {
   const owner = useWorkspace();
-  useDocumentTitle(`Poke - ${owner.name} - Space`);
+  useDocumentTitle(`Poke - ${owner.name} - Project`);
 
-  const spaceId = useRequiredPathParam("spaceId");
-  const {
-    data: spaceDetails,
-    isLoading,
-    isError,
-  } = usePokeSpaceDetails({
-    owner,
-    spaceId,
-    disabled: false,
-  });
-
-  if (isLoading) {
-    return (
-      <div className="flex h-64 items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
-
-  if (isError || !spaceDetails) {
-    return (
-      <div className="flex h-64 items-center justify-center">
-        <p>Error loading space details.</p>
-      </div>
-    );
-  }
-
-  const { members, space } = spaceDetails;
-
-  if (spaceDetails.space.kind === "project") {
-    return <ProjectPage details={spaceDetails} />;
-  }
+  const { members, metadata, space } = details;
 
   return (
     <>
       <h3 className="text-xl font-bold">
-        Space {space.name} ({space.kind}) within workspace{" "}
+        Project {space.name} within workspace{" "}
         <LinkWrapper href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
         </LinkWrapper>
       </h3>
+      {metadata?.description && (
+        <p className="mt-2 text-sm text-muted-foreground">
+          {metadata.description}
+        </p>
+      )}
       <div className="flex flex-row gap-x-6">
         <ViewSpaceViewTable space={space} />
         <div className="mt-4 flex grow flex-col">
@@ -74,8 +50,8 @@ export function SpacePage() {
               workspace: owner,
             }}
           />
+          <ProjectTasksDataTable owner={owner} projectId={space.sId} />
           <DataSourceViewsDataTable owner={owner} spaceId={space.sId} />
-          <MCPServerViewsDataTable owner={owner} spaceId={space.sId} />
         </div>
       </div>
     </>

--- a/front/components/poke/projects/tasks/columns.tsx
+++ b/front/components/poke/projects/tasks/columns.tsx
@@ -1,0 +1,100 @@
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { ProjectTaskType } from "@app/types/project_task";
+import type { WorkspaceType } from "@app/types/user";
+import { Chip, LinkWrapper, Tooltip } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+
+function statusChip(task: ProjectTaskType) {
+  switch (task.status) {
+    case "todo":
+      return <Chip color="info" label="todo" size="xs" />;
+    case "in_progress":
+      return <Chip color="warning" label="in progress" size="xs" />;
+    case "done":
+      return <Chip color="success" label="done" size="xs" />;
+  }
+}
+
+export function makeColumnsForProjectTasks(
+  owner: WorkspaceType
+): ColumnDef<ProjectTaskType>[] {
+  return [
+    {
+      accessorKey: "sId",
+      cell: ({ row }) => <span className="font-mono">{row.original.sId}</span>,
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
+    },
+    {
+      accessorKey: "status",
+      cell: ({ row }) => statusChip(row.original),
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Status" />
+      ),
+    },
+    {
+      accessorKey: "text",
+      cell: ({ row }) => (
+        <Tooltip
+          label={row.original.text}
+          trigger={
+            <span className="line-clamp-2 max-w-md">{row.original.text}</span>
+          }
+        />
+      ),
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Text" />
+      ),
+    },
+    {
+      id: "assignedTo",
+      cell: ({ row }) => row.original.user?.fullName,
+      header: () => <span>Assigned to</span>,
+    },
+    {
+      accessorKey: "agentSuggestionStatus",
+      cell: ({ row }) => row.original.agentSuggestionStatus ?? "—",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Suggestion" />
+      ),
+    },
+    {
+      accessorKey: "conversationId",
+      cell: ({ row }) =>
+        row.original.conversationId ? (
+          <LinkWrapper
+            href={`/poke/${owner.sId}/conversation/${row.original.conversationId}`}
+          >
+            {row.original.conversationId}
+          </LinkWrapper>
+        ) : (
+          "—"
+        ),
+      header: () => <span>Conversation</span>,
+    },
+    {
+      accessorKey: "createdAt",
+      cell: ({ row }) =>
+        formatTimestampToFriendlyDate(
+          new Date(row.original.createdAt).getTime()
+        ),
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
+    },
+    {
+      accessorKey: "doneAt",
+      cell: ({ row }) =>
+        row.original.doneAt
+          ? formatTimestampToFriendlyDate(
+              new Date(row.original.doneAt).getTime()
+            )
+          : "—",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Done at" />
+      ),
+    },
+  ];
+}

--- a/front/components/poke/projects/tasks/table.tsx
+++ b/front/components/poke/projects/tasks/table.tsx
@@ -1,0 +1,34 @@
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
+import { makeColumnsForProjectTasks } from "@app/components/poke/projects/tasks/columns";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { usePokeProjectTasks } from "@app/poke/swr/project_tasks";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type { WorkspaceType } from "@app/types/user";
+
+interface ProjectTasksDataTableProps {
+  owner: WorkspaceType;
+  projectId: string;
+}
+
+export function ProjectTasksDataTable({
+  owner,
+  projectId,
+}: ProjectTasksDataTableProps) {
+  const useTasksForProject = (props: PokeConditionalFetchProps) =>
+    usePokeProjectTasks({ ...props, projectId });
+
+  return (
+    <PokeDataTableConditionalFetch
+      header="Tasks"
+      owner={owner}
+      useSWRHook={useTasksForProject}
+    >
+      {(tasks) => (
+        <PokeDataTable
+          columns={makeColumnsForProjectTasks(owner)}
+          data={tasks}
+        />
+      )}
+    </PokeDataTableConditionalFetch>
+  );
+}

--- a/front/lib/api/poke/plugins/spaces/import_app.ts
+++ b/front/lib/api/poke/plugins/spaces/import_app.ts
@@ -20,6 +20,7 @@ export const importAppPlugin = createPlugin({
       },
     },
   },
+  isApplicableTo: (_auth, space) => !space?.isProject(),
   execute: async (auth, space, args) => {
     if (!space) {
       return new Err(new Error("Space not found"));

--- a/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
@@ -1,0 +1,79 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ProjectTaskType } from "@app/types/project_task";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type PokeListProjectTasks = {
+  tasks: ProjectTaskType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeListProjectTasks>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, projectId } = req.query;
+  if (!isString(wId) || !isString(projectId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or project ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const space = await SpaceResource.fetchById(auth, projectId);
+      if (!space || !space.isProject()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "space_not_found",
+            message: "Project not found.",
+          },
+        });
+      }
+
+      const tasks = await ProjectTaskResource.fetchBySpace(auth, {
+        spaceId: space.id,
+        timeScope: "all",
+      });
+
+      return res.status(200).json({
+        tasks: tasks.map((t) => t.toJSON()),
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -4,15 +4,18 @@ import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { spaceToPokeJSON } from "@app/lib/poke/utils";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PokeSpaceType } from "@app/types/poke";
+import type { ProjectMetadataType } from "@app/types/project_metadata";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type PokeGetSpaceDetails = {
   members: Record<string, UserTypeWithWorkspaces[]>;
+  metadata: ProjectMetadataType | null;
   space: PokeSpaceType;
 };
 
@@ -77,8 +80,13 @@ async function handler(
         });
       }
 
+      const metadata = space.isProject()
+        ? await ProjectMetadataResource.fetchBySpace(auth, space)
+        : null;
+
       return res.status(200).json({
         members,
+        metadata: metadata ? metadata.toJSON() : null,
         space: spaceToPokeJSON(space),
       });
 

--- a/front/poke/swr/project_tasks.ts
+++ b/front/poke/swr/project_tasks.ts
@@ -1,0 +1,31 @@
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeListProjectTasks } from "@app/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+interface UsePokeProjectTasksProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+export function usePokeProjectTasks({
+  disabled,
+  owner,
+  projectId,
+}: UsePokeProjectTasksProps) {
+  const { fetcher } = useFetcher();
+  const tasksFetcher: Fetcher<PokeListProjectTasks> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/projects/${projectId}/tasks`,
+    tasksFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data?.tasks ?? emptyArray(),
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Description

This PR adds a dedicated project page in the poke interface with a tasks section.

- Created a new `ProjectPage` component that renders project-specific information including a tasks table
- Updated `SpacePage` to conditionally render `ProjectPage` when the space is of kind "project"
- Added a new API endpoint `/api/poke/workspaces/[wId]/projects/[projectId]/tasks` to fetch tasks for a given project
- Updated the import_app plugin to only be applicable to non-project spaces

## Tests

Manually

## Risks

Low risk - this is an additive change to the poke interface that adds new functionality without modifying existing behavior for non-project spaces.

## Deploy Plan

Standard deployment - no special steps required.
