### PR TITLE
feat: add task generation workflow section to poke project page

### DIFF
--- a/front/components/poke/pages/ProjectPage.tsx
+++ b/front/components/poke/pages/ProjectPage.tsx
@@ -2,6 +2,7 @@ import { DataSourceViewsDataTable } from "@app/components/poke/data_source_views
 import { MembersDataTable } from "@app/components/poke/members/table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { ProjectTasksDataTable } from "@app/components/poke/projects/tasks/table";
+import { ViewProjectWorkflowTable } from "@app/components/poke/projects/workflow/view";
 import { ViewSpaceViewTable } from "@app/components/poke/spaces/view";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -50,6 +51,7 @@ export function ProjectPage({ details }: ProjectPageProps) {
               workspace: owner,
             }}
           />
+          <ViewProjectWorkflowTable owner={owner} projectId={space.sId} />
           <ProjectTasksDataTable owner={owner} projectId={space.sId} />
           <DataSourceViewsDataTable owner={owner} spaceId={space.sId} />
         </div>

--- a/front/components/poke/projects/workflow/view.tsx
+++ b/front/components/poke/projects/workflow/view.tsx
@@ -1,0 +1,182 @@
+import {
+  PokeTable,
+  PokeTableBody,
+  PokeTableCell,
+  PokeTableCellWithCopy,
+  PokeTableHead,
+  PokeTableRow,
+} from "@app/components/poke/shadcn/ui/table";
+import { formatTimestampToFriendlyDate, timeAgoFrom } from "@app/lib/utils";
+import { usePokeProjectWorkflow } from "@app/poke/swr/project_tasks_workflow";
+import type { WorkspaceType } from "@app/types/user";
+import { Chip, LinkWrapper, Spinner } from "@dust-tt/sparkle";
+
+interface ViewProjectWorkflowTableProps {
+  owner: WorkspaceType;
+  projectId: string;
+}
+
+export function ViewProjectWorkflowTable({
+  owner,
+  projectId,
+}: ViewProjectWorkflowTableProps) {
+  const { data, isLoading, isError } = usePokeProjectWorkflow({
+    owner,
+    projectId,
+  });
+
+  return (
+    <div className="border-material-200 my-4 flex min-h-24 flex-col rounded-lg border bg-muted-background dark:bg-muted-background-night">
+      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4 dark:bg-primary-300-night">
+        <h2 className="text-md font-bold">Task generation workflow</h2>
+      </div>
+      <div className="flex flex-grow flex-col justify-center p-4">
+        {isLoading ? (
+          <div className="flex h-32 items-center justify-center">
+            <Spinner />
+          </div>
+        ) : isError || !data ? (
+          <div className="flex h-32 items-center justify-center">
+            <p>Error loading workflow.</p>
+          </div>
+        ) : (
+          <ViewProjectWorkflowTableContent data={data} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RunIdCell({
+  runId,
+  status,
+  href,
+}: {
+  runId: string;
+  status: string;
+  href: string | null;
+}) {
+  const label = `${runId} (${status})`;
+  if (!href) {
+    return <span className="font-mono">{label}</span>;
+  }
+  return (
+    <LinkWrapper
+      href={href}
+      target="_blank"
+      className="font-mono text-highlight-400"
+    >
+      {label}
+    </LinkWrapper>
+  );
+}
+
+function ViewProjectWorkflowTableContent({
+  data,
+}: {
+  data: NonNullable<ReturnType<typeof usePokeProjectWorkflow>["data"]>;
+}) {
+  const { metadata, temporalNamespace, workflowId, latestWorkflow } = data;
+  const generationEnabled = metadata?.todoGenerationEnabled ?? false;
+
+  const temporalSearchUrl = temporalNamespace
+    ? `https://cloud.temporal.io/namespaces/${temporalNamespace}/workflows?query=WorkflowId%3D%22${encodeURIComponent(
+        workflowId
+      )}%22`
+    : null;
+  const temporalRunUrl = (runId: string) =>
+    temporalNamespace
+      ? `https://cloud.temporal.io/namespaces/${temporalNamespace}/workflows/${encodeURIComponent(
+          workflowId
+        )}/${encodeURIComponent(runId)}/history`
+      : null;
+
+  return (
+    <PokeTable>
+      <PokeTableBody>
+        <PokeTableRow>
+          <PokeTableHead>Generation enabled</PokeTableHead>
+          <PokeTableCell>
+            {generationEnabled ? (
+              <Chip color="success" label="Yes" size="xs" />
+            ) : (
+              <Chip color="warning" label="No" size="xs" />
+            )}
+          </PokeTableCell>
+        </PokeTableRow>
+        <PokeTableRow>
+          <PokeTableHead>Last analysis at</PokeTableHead>
+          <PokeTableCell>
+            {metadata?.lastTodoAnalysisAt ? (
+              <>
+                {formatTimestampToFriendlyDate(metadata.lastTodoAnalysisAt)} (
+                {timeAgoFrom(metadata.lastTodoAnalysisAt, {
+                  useLongFormat: true,
+                })}{" "}
+                ago)
+              </>
+            ) : (
+              <span className="font-bold text-warning-500">never</span>
+            )}
+          </PokeTableCell>
+        </PokeTableRow>
+        <PokeTableRow>
+          <PokeTableHead>Workflow ID</PokeTableHead>
+          <PokeTableCellWithCopy label={workflowId} />
+        </PokeTableRow>
+        <PokeTableRow>
+          <PokeTableHead>Latest run</PokeTableHead>
+          <PokeTableCell>
+            {latestWorkflow ? (
+              <span>
+                <RunIdCell
+                  runId={latestWorkflow.runId}
+                  status={latestWorkflow.status}
+                  href={temporalRunUrl(latestWorkflow.runId)}
+                />
+                {latestWorkflow.closeTime && (
+                  <>
+                    {" "}
+                    — closed{" "}
+                    {timeAgoFrom(latestWorkflow.closeTime, {
+                      useLongFormat: true,
+                    })}{" "}
+                    ago
+                  </>
+                )}
+              </span>
+            ) : (
+              <span className="font-bold text-warning-500">no executions</span>
+            )}
+          </PokeTableCell>
+        </PokeTableRow>
+        <PokeTableRow>
+          <PokeTableHead>Links</PokeTableHead>
+          <PokeTableCell>
+            {temporalSearchUrl && (
+              <>
+                <LinkWrapper
+                  href={temporalSearchUrl}
+                  target="_blank"
+                  className="text-sm text-highlight-400"
+                >
+                  Temporal (all runs)
+                </LinkWrapper>{" "}
+                /{" "}
+              </>
+            )}
+            <LinkWrapper
+              href={`https://app.datadoghq.eu/logs?query=%40workflowId%3A${encodeURIComponent(
+                workflowId
+              )}`}
+              target="_blank"
+              className="text-sm text-highlight-400"
+            >
+              Datadog
+            </LinkWrapper>
+          </PokeTableCell>
+        </PokeTableRow>
+      </PokeTableBody>
+    </PokeTable>
+  );
+}

--- a/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -1,0 +1,107 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ProjectMetadataType } from "@app/types/project_metadata";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type PokeProjectWorkflowInfo = {
+  workflowId: string;
+  runId: string;
+  status: string;
+  startTime: number | null;
+  closeTime: number | null;
+};
+
+export type PokeGetProjectWorkflow = {
+  metadata: ProjectMetadataType | null;
+  temporalNamespace: string;
+  workflowId: string;
+  latestWorkflow: PokeProjectWorkflowInfo | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetProjectWorkflow>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, projectId } = req.query;
+  if (!isString(wId) || !isString(projectId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or project ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const space = await SpaceResource.fetchById(auth, projectId);
+      if (!space || !space.isProject()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "space_not_found",
+            message: "Project not found.",
+          },
+        });
+      }
+
+      const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+      const workflowId = `project-todo-${owner.sId}-${space.sId}`;
+
+      const temporalClient = await getTemporalClientForFrontNamespace();
+
+      let latestWorkflow: PokeProjectWorkflowInfo | null = null;
+      const description = await temporalClient.workflow
+        .getHandle(workflowId)
+        .describe();
+      latestWorkflow = {
+        workflowId,
+        runId: description.runId,
+        status: description.status.name,
+        startTime: description.startTime?.getTime() ?? null,
+        closeTime: description.closeTime?.getTime() ?? null,
+      };
+
+      return res.status(200).json({
+        metadata: metadata ? metadata.toJSON() : null,
+        temporalNamespace: config.getTemporalFrontNamespace() ?? "",
+        workflowId,
+        latestWorkflow,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/project_tasks_workflow.ts
+++ b/front/poke/swr/project_tasks_workflow.ts
@@ -1,0 +1,31 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetProjectWorkflow } from "@app/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+interface UsePokeProjectWorkflowProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+export function usePokeProjectWorkflow({
+  disabled,
+  owner,
+  projectId,
+}: UsePokeProjectWorkflowProps) {
+  const { fetcher } = useFetcher();
+  const workflowFetcher: Fetcher<PokeGetProjectWorkflow> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/projects/${projectId}/tasks-workflow`,
+    workflowFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Description

This PR adds a task generation workflow section to the poke project page, displaying Temporal workflow status and metadata.

- Creates a new `ViewProjectWorkflowTable` component showing workflow execution details (run ID, status, timestamps, links to Temporal/Datadog)
- Adds endpoint that fetches workflow info from Temporal and project metadata

## Tests

Manually.

## Risks

## Deploy Plan
