### PR TITLE
feat: add knowledge-from-connectors section to poke project page

### DIFF
--- a/front/components/poke/pages/ProjectPage.tsx
+++ b/front/components/poke/pages/ProjectPage.tsx
@@ -1,6 +1,7 @@
 import { DataSourceViewsDataTable } from "@app/components/poke/data_source_views/table";
 import { MembersDataTable } from "@app/components/poke/members/table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { ProjectConnectorKnowledgeDataTable } from "@app/components/poke/projects/connector_knowledge/table";
 import { ProjectTasksDataTable } from "@app/components/poke/projects/tasks/table";
 import { ViewProjectWorkflowTable } from "@app/components/poke/projects/workflow/view";
 import { ViewSpaceViewTable } from "@app/components/poke/spaces/view";
@@ -52,6 +53,10 @@ export function ProjectPage({ details }: ProjectPageProps) {
             }}
           />
           <ViewProjectWorkflowTable owner={owner} projectId={space.sId} />
+          <ProjectConnectorKnowledgeDataTable
+            owner={owner}
+            projectId={space.sId}
+          />
           <ProjectTasksDataTable owner={owner} projectId={space.sId} />
           <DataSourceViewsDataTable owner={owner} spaceId={space.sId} />
         </div>

--- a/front/components/poke/projects/connector_knowledge/columns.tsx
+++ b/front/components/poke/projects/connector_knowledge/columns.tsx
@@ -1,0 +1,111 @@
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { PokeProjectKnowledgeFromConnectorItem } from "@app/pages/api/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Chip, LinkWrapper, Tooltip } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+
+function sourceCell(
+  item: PokeProjectKnowledgeFromConnectorItem,
+  owner: LightWorkspaceType
+) {
+  const label =
+    item.sourceDataSourceName ??
+    item.sourceConnectorProvider ??
+    "unknown source";
+  if (!item.sourceDataSourceViewSpaceSId) {
+    return <span>{label}</span>;
+  }
+  return (
+    <LinkWrapper
+      href={`/poke/${owner.sId}/spaces/${item.sourceDataSourceViewSpaceSId}/data_source_views/${item.nodeDataSourceViewId}`}
+      className="text-highlight-400"
+    >
+      {label}
+    </LinkWrapper>
+  );
+}
+
+export function makeColumnsForProjectConnectorKnowledge(
+  owner: LightWorkspaceType
+): ColumnDef<PokeProjectKnowledgeFromConnectorItem>[] {
+  return [
+    {
+      id: "kind",
+      cell: ({ row }) => (
+        <Chip color="primary" label={row.original.nodeType} size="xs" />
+      ),
+      header: () => <span>Kind</span>,
+    },
+    {
+      accessorKey: "title",
+      cell: ({ row }) => {
+        const item = row.original;
+        const title = (
+          <Tooltip
+            label={item.title}
+            trigger={
+              <span className="line-clamp-2 max-w-md font-medium">
+                {item.title}
+              </span>
+            }
+          />
+        );
+        if (item.sourceUrl) {
+          return (
+            <LinkWrapper
+              href={item.sourceUrl}
+              target="_blank"
+              className="text-highlight-400"
+            >
+              {title}
+            </LinkWrapper>
+          );
+        }
+        return title;
+      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Title" />
+      ),
+    },
+    {
+      id: "source",
+      cell: ({ row }) => sourceCell(row.original, owner),
+      header: () => <span>Source</span>,
+    },
+    {
+      accessorKey: "contentType",
+      cell: ({ row }) => (
+        <span className="font-mono text-xs">{row.original.contentType}</span>
+      ),
+      header: () => <span>Content type</span>,
+    },
+    {
+      accessorKey: "lastUpdatedAt",
+      cell: ({ row }) => {
+        const ts = row.original.lastUpdatedAt;
+        if (!ts) {
+          return <span className="text-warning-500">never</span>;
+        }
+        return formatTimestampToFriendlyDate(ts);
+      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Last sync / update" />
+      ),
+    },
+    {
+      id: "creator",
+      cell: ({ row }) => row.original.creator ?? "—",
+      header: () => <span>Added by</span>,
+    },
+    {
+      accessorKey: "contentFragmentId",
+      cell: ({ row }) => (
+        <span className="font-mono text-xs">
+          {row.original.contentFragmentId}
+        </span>
+      ),
+      header: () => <span>Ref</span>,
+    },
+  ];
+}

--- a/front/components/poke/projects/connector_knowledge/table.tsx
+++ b/front/components/poke/projects/connector_knowledge/table.tsx
@@ -1,0 +1,34 @@
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
+import { makeColumnsForProjectConnectorKnowledge } from "@app/components/poke/projects/connector_knowledge/columns";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { usePokeProjectConnectorKnowledge } from "@app/poke/swr/project_connector_knowledge";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type { WorkspaceType } from "@app/types/user";
+
+interface ProjectConnectorKnowledgeDataTableProps {
+  owner: WorkspaceType;
+  projectId: string;
+}
+
+export function ProjectConnectorKnowledgeDataTable({
+  owner,
+  projectId,
+}: ProjectConnectorKnowledgeDataTableProps) {
+  const useConnectorKnowledgeForProject = (props: PokeConditionalFetchProps) =>
+    usePokeProjectConnectorKnowledge({ ...props, projectId });
+
+  return (
+    <PokeDataTableConditionalFetch
+      header="Knowledge from connectors"
+      owner={owner}
+      useSWRHook={useConnectorKnowledgeForProject}
+    >
+      {(items) => (
+        <PokeDataTable
+          columns={makeColumnsForProjectConnectorKnowledge(owner)}
+          data={items}
+        />
+      )}
+    </PokeDataTableConditionalFetch>
+  );
+}

--- a/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
@@ -1,0 +1,142 @@
+/** @ignoreswagger */
+
+import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { listProjectContextAttachments } from "@app/lib/api/projects/context";
+import { Authenticator } from "@app/lib/auth";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { ContentNodeType } from "@app/types/core/content_node";
+import type { ConnectorProvider } from "@app/types/data_source";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type PokeProjectKnowledgeFromConnectorItem = {
+  contentFragmentId: string;
+  nodeId: string;
+  nodeType: ContentNodeType;
+  nodeDataSourceViewId: string;
+  title: string;
+  contentType: string;
+  sourceUrl: string | null;
+  lastUpdatedAt: number | null;
+  creator: string | null;
+  sourceDataSourceViewSpaceSId: string | null;
+  sourceDataSourceName: string | null;
+  sourceConnectorProvider: ConnectorProvider | null;
+};
+
+export type PokeListProjectKnowledgeFromConnectors = {
+  items: PokeProjectKnowledgeFromConnectorItem[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PokeListProjectKnowledgeFromConnectors>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, projectId } = req.query;
+  if (!isString(wId) || !isString(projectId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or project ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const space = await SpaceResource.fetchById(auth, projectId);
+  if (!space || !space.isProject()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "Project not found.",
+      },
+    });
+  }
+
+  const attachments = await listProjectContextAttachments(auth, space);
+  const contentNodes = attachments.filter(isContentNodeAttachmentType);
+
+  const dsvSIds = Array.from(
+    new Set(contentNodes.map((a) => a.nodeDataSourceViewId))
+  );
+
+  const dsvBySId = new Map<
+    string,
+    {
+      spaceSId: string;
+      dataSourceName: string;
+      connectorProvider: ConnectorProvider | null;
+    }
+  >();
+  if (dsvSIds.length > 0) {
+    const dsvs = await DataSourceViewResource.fetchByIds(auth, dsvSIds);
+    for (const dsv of dsvs) {
+      const json = dsv.toJSON();
+      dsvBySId.set(dsv.sId, {
+        spaceSId: json.spaceId,
+        dataSourceName: getDisplayNameForDataSource(json.dataSource),
+        connectorProvider: json.dataSource.connectorProvider,
+      });
+    }
+  }
+
+  const items: PokeProjectKnowledgeFromConnectorItem[] = contentNodes.map(
+    (a) => {
+      const creator = a.creator
+        ? `${a.creator.type === "agent" ? "agent: " : ""}${a.creator.name}`
+        : null;
+      const dsv = dsvBySId.get(a.nodeDataSourceViewId);
+      return {
+        contentFragmentId: a.contentFragmentId,
+        nodeId: a.nodeId,
+        nodeType: a.nodeType,
+        nodeDataSourceViewId: a.nodeDataSourceViewId,
+        title: a.title,
+        contentType: a.contentType,
+        sourceUrl: a.sourceUrl,
+        lastUpdatedAt: a.lastUpdatedAt ?? null,
+        creator,
+        sourceDataSourceViewSpaceSId: dsv?.spaceSId ?? null,
+        sourceDataSourceName: dsv?.dataSourceName ?? null,
+        sourceConnectorProvider: dsv?.connectorProvider ?? null,
+      };
+    }
+  );
+
+  return res.status(200).json({ items });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/project_connector_knowledge.ts
+++ b/front/poke/swr/project_connector_knowledge.ts
@@ -1,0 +1,34 @@
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeListProjectKnowledgeFromConnectors } from "@app/pages/api/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Fetcher } from "swr";
+
+interface UsePokeProjectConnectorKnowledgeProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  projectId: string;
+}
+
+export function usePokeProjectConnectorKnowledge({
+  disabled,
+  owner,
+  projectId,
+}: UsePokeProjectConnectorKnowledgeProps) {
+  const { fetcher } = useFetcher();
+  const connectorKnowledgeFetcher: Fetcher<PokeListProjectKnowledgeFromConnectors> =
+    fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/projects/${projectId}/connector-knowledge`,
+    connectorKnowledgeFetcher,
+    { disabled }
+  );
+
+  return {
+    data:
+      data?.items ??
+      emptyArray<PokeListProjectKnowledgeFromConnectors["items"][number]>(),
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Description

This PR adds a "Knowledge from connectors" section to the poke project page displaying content nodes that have been added to a project from external data sources.

- Creates a new API endpoint to fetch and resolve connector knowledge items with their source metadata
- Adds a table component showing node type, title, source, content type, last sync time, and creator

## Tests

Manually.

## Risks

## Deploy Plan
