### PR TITLE
Rename tool outputs folder to .tool_outputs/

### DIFF
--- a/front/components/assistant/conversation/files_panel/FileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/FileExplorer.tsx
@@ -12,6 +12,7 @@ import { buildSandboxTree } from "@app/components/assistant/conversation/files_p
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { downloadSandboxFile } from "@app/lib/swr/files";
 import logger from "@app/logger/logger";
 import type {
@@ -149,7 +150,7 @@ export function NewFileExplorer({
     const filesAtLevel: GCSMountFileEntry[] = [];
 
     for (const node of currentNodes) {
-      if (node.name.startsWith(".")) {
+      if (node.name.startsWith(".") && node.name !== TOOL_OUTPUTS_FOLDER_NAME) {
         continue;
       }
       if (node.isDirectory) {

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -6,6 +6,7 @@ import {
 import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { processToolResults } from "@app/lib/actions/mcp_execution";
 import type { DataSourceNodeContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -227,7 +228,7 @@ describe("processToolResults", () => {
     }
   });
 
-  it("should persist DATA_SOURCE_NODE_CONTENT block to results/", async () => {
+  it(`should persist DATA_SOURCE_NODE_CONTENT block to ${TOOL_OUTPUTS_FOLDER_NAME}/`, async () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
     await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
@@ -272,18 +273,18 @@ describe("processToolResults", () => {
       );
 
     const toolOutputWrite = uploadCalls.find((call) =>
-      call[0].filePath.includes("results/")
+      call[0].filePath.includes(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
     );
     expect(toolOutputWrite).toBeDefined();
     expect(toolOutputWrite?.[0].filePath).toMatch(
-      /results\/\d+_my_notion_page\.md$/
+      new RegExp(`${TOOL_OUTPUTS_FOLDER_NAME}/\\d+_my_notion_page\\.md$`)
     );
     expect(toolOutputWrite?.[0].content).toBe(
       "# My Notion Page\n\nSome content here."
     );
   });
 
-  it("should persist large plain text block to results/ as .txt", async () => {
+  it(`should persist large plain text block to ${TOOL_OUTPUTS_FOLDER_NAME}/ as .txt`, async () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
     await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
@@ -308,16 +309,16 @@ describe("processToolResults", () => {
       );
 
     const toolOutputWrite = uploadCalls.find((call) =>
-      call[0].filePath.includes("results/")
+      call[0].filePath.includes(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
     );
 
     expect(toolOutputWrite).toBeDefined();
     expect(toolOutputWrite?.[0].filePath).toMatch(
-      /results\/\d+_test_tool\.txt$/
+      new RegExp(`${TOOL_OUTPUTS_FOLDER_NAME}/\\d+_test_tool\\.txt$`)
     );
   });
 
-  it("should persist large JSON text block to results/ as .json", async () => {
+  it(`should persist large JSON text block to ${TOOL_OUTPUTS_FOLDER_NAME}/ as .json`, async () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
     await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
@@ -344,11 +345,11 @@ describe("processToolResults", () => {
       );
 
     const toolOutputWrite = uploadCalls.find((call) =>
-      call[0].filePath.includes("results/")
+      call[0].filePath.includes(`${TOOL_OUTPUTS_FOLDER_NAME}/`)
     );
     expect(toolOutputWrite).toBeDefined();
     expect(toolOutputWrite?.[0].filePath).toMatch(
-      /results\/\d+_test_tool\.json$/
+      new RegExp(`${TOOL_OUTPUTS_FOLDER_NAME}/\\d+_test_tool\\.json$`)
     );
   });
 });

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -13,9 +13,10 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 // Action output file system.
 //
-// Writes qualifying tool output blocks to the conversation's results GCS path as a side effect
-// of processToolResults. Files are conversation-scoped and are not tracked in the database. They
-// are cleaned up when the conversation is scrubbed.
+// Writes qualifying tool output blocks to the conversation's tool outputs GCS path (see
+// `getConversationToolOutputsBasePath`) as a side effect of processToolResults. Files are
+// conversation-scoped and are not tracked in the database. They are cleaned up when the
+// conversation is scrubbed.
 //
 // Two cases are handled:
 //   1. Resource blocks whose mimeType is registered in resolveResourceOutput.
@@ -23,12 +24,12 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 //      file extension).
 
 export interface PersistedToolOutput {
-  // Filename within results/ — what the model and sandbox use.
+  // Filename within the tool outputs folder — what the model and sandbox use.
   fileName: string;
 }
 
 /**
- * Attempts to persist a tool output block to the conversation's results GCS path.
+ * Attempts to persist a tool output block to the conversation's tool outputs GCS path.
  * Returns null if the block does not qualify for persistence.
  *
  * Call this as a side effect from processToolResults.

--- a/front/lib/api/files/action_output_fs/naming.ts
+++ b/front/lib/api/files/action_output_fs/naming.ts
@@ -14,7 +14,7 @@ export function uriToSlug(uri: string): string {
 
 /**
  * Builds a tool output filename. The timestamp prefix is mandatory so that files are naturally
- * ordered when listing the results/ folder and are never silently overwritten across runs.
+ * ordered when listing the tool outputs folder and are never silently overwritten across runs.
  */
 export function makeFileName({
   ext,

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -1,5 +1,8 @@
 import config from "@app/lib/api/config";
-import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import {
+  getConversationFilesBasePath,
+  TOOL_OUTPUTS_FOLDER_NAME,
+} from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -167,8 +170,12 @@ export async function listGCSMountFiles(
     (f) => {
       const trimmed = f.name.replace(/\/$/, "");
       const name = trimmed.split("/").pop() ?? "";
-      // Skip hidden folders (name starting with ".").
-      if (!name || name.startsWith(".")) {
+      // Skip hidden folders (name starting with "."), except the tool outputs folder which is
+      // surfaced to users despite its dot prefix.
+      if (
+        !name ||
+        (name.startsWith(".") && name !== TOOL_OUTPUTS_FOLDER_NAME)
+      ) {
         return [];
       }
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -23,7 +23,7 @@ export function getConversationFilesBasePath({
   return `${getBaseMountPathForWorkspace({ workspaceId })}conversations/${conversationId}/files/`;
 }
 
-export const TOOL_OUTPUTS_FOLDER_NAME = "tool_outputs";
+export const TOOL_OUTPUTS_FOLDER_NAME = ".tool_outputs";
 
 export function getConversationToolOutputsBasePath({
   workspaceId,

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -23,7 +23,7 @@ export function getConversationFilesBasePath({
   return `${getBaseMountPathForWorkspace({ workspaceId })}conversations/${conversationId}/files/`;
 }
 
-export const TOOL_OUTPUTS_FOLDER_NAME = ".tool_outputs";
+export const TOOL_OUTPUTS_FOLDER_NAME = "tool_outputs";
 
 export function getConversationToolOutputsBasePath({
   workspaceId,

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -23,6 +23,8 @@ export function getConversationFilesBasePath({
   return `${getBaseMountPathForWorkspace({ workspaceId })}conversations/${conversationId}/files/`;
 }
 
+export const TOOL_OUTPUTS_FOLDER_NAME = ".tool_outputs";
+
 export function getConversationToolOutputsBasePath({
   workspaceId,
   conversationId,
@@ -30,7 +32,7 @@ export function getConversationToolOutputsBasePath({
   workspaceId: string;
   conversationId: string;
 }): string {
-  return `${getConversationFilesBasePath({ workspaceId, conversationId })}results/`;
+  return `${getConversationFilesBasePath({ workspaceId, conversationId })}${TOOL_OUTPUTS_FOLDER_NAME}/`;
 }
 
 export function getConversationFilePath({

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -1,3 +1,4 @@
+import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { readWorkspacePolicy } from "@app/lib/api/sandbox/egress_policy";
 import {
   createToolManifest,
@@ -49,8 +50,8 @@ Layout:
   for the user (scripts, exports, reports, charts). Anything you write here
   is delivered to the user as a conversation file. Put deliverables
   directly in this directory; do not write your own files into
-  \`results/\`, that path is managed automatically.
-- \`/files/conversation/results/\` — **tool outputs are automatically
+  \`${TOOL_OUTPUTS_FOLDER_NAME}/\`, that path is managed automatically.
+- \`/files/conversation/${TOOL_OUTPUTS_FOLDER_NAME}/\` — **tool outputs are automatically
   persisted here as a side effect of every tool call you make.** Two cases
   qualify:
   1. Output blocks that represent fetched content (the contents of a
@@ -65,7 +66,7 @@ Layout:
 
 The exact same files are also exposed by the \`files\` MCP server (tools
 \`list\`, \`cat\`, \`grep\`, \`create\`) under scoped paths like
-\`conversation/results/<file>\`. The MCP server and the mount are two views
+\`conversation/${TOOL_OUTPUTS_FOLDER_NAME}/<file>\`. The MCP server and the mount are two views
 on the same underlying conversation storage: a write through one is
 immediately visible through the other.
 
@@ -78,10 +79,10 @@ conversation context, and lets you compose pipelines. Reach for the
 \`files\` MCP server only for a trivial one-shot read where spinning up a
 shell command would be heavier than needed. Never re-call a tool just to
 re-read its output: the previous result is already on disk under
-\`/files/conversation/results/\`.
+\`/files/conversation/${TOOL_OUTPUTS_FOLDER_NAME}/\`.
 
 Typical workflow when a prior tool returned a large output: locate the most
-recent matching file under \`/files/conversation/results/\`, then use
+recent matching file under \`/files/conversation/${TOOL_OUTPUTS_FOLDER_NAME}/\`, then use
 \`jq\` / \`rg\` / \`grep\` to extract just the fields or lines you need,
 instead of paging the whole blob back through \`files__cat\` or re-running
 the tool.`;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C0AGY9MTNJV/p1778140736215479).

We renamed to `results/` in https://github.com/dust-tt/dust/pull/25172. `results/` ends up not being a great name, and we don't want to override it on the UI side, as model and human could reference the same folder with different names.  

This PR renames the conversation tool-outputs folder from `results/` to `.tool_outputs/`.

For now it will remain visible in the UI, just under a different name.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
