### PR TITLE
[front] feat: allow skills to request additional spaces

### DIFF
--- a/front/lib/api/skills/space_requirements.ts
+++ b/front/lib/api/skills/space_requirements.ts
@@ -1,0 +1,46 @@
+import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import uniq from "lodash/uniq";
+
+export async function resolveAdditionalRequestedSpaceModelIds(
+  auth: Authenticator,
+  additionalRequestedSpaceIds: string[] | undefined
+): Promise<Result<ModelId[], Error>> {
+  const requestedSpaceIds = uniq(additionalRequestedSpaceIds ?? []);
+
+  if (requestedSpaceIds.length === 0) {
+    return new Ok([]);
+  }
+
+  const spaces = await SpaceResource.fetchByIds(auth, requestedSpaceIds);
+  const readableSpacesById = new Map(
+    spaces
+      .filter((space) => space.canRead(auth))
+      .map((space) => [space.sId, space])
+  );
+
+  const inaccessibleSpaceIds = requestedSpaceIds.filter(
+    (spaceId) => !readableSpacesById.has(spaceId)
+  );
+
+  if (inaccessibleSpaceIds.length > 0) {
+    return new Err(
+      new Error(
+        `User does not have access to the following spaces: ${inaccessibleSpaceIds.join(", ")}`
+      )
+    );
+  }
+
+  const additionalRequestedSpaceModelIds: ModelId[] = [];
+  for (const spaceId of requestedSpaceIds) {
+    const space = readableSpacesById.get(spaceId);
+    if (space) {
+      additionalRequestedSpaceModelIds.push(space.id);
+    }
+  }
+
+  return new Ok(additionalRequestedSpaceModelIds);
+}

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -7,7 +7,6 @@ import {
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
@@ -1164,15 +1163,69 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       );
       expect(deleteResult.isOk()).toBe(true);
 
-      // Verify the skill's requestedSpaceIds no longer contains the deleted space
-      // Note: We query the model directly because the MCP server views are cleaned up
-      // asynchronously by the scrub workflow and would fail permission checks
-      const skillAfter = await SkillConfigurationModel.findOne({
-        where: { id: skill.id, workspaceId: workspace.id },
-      });
+      const skillAfter = await SkillResource.fetchById(adminAuth, skill.sId);
       expect(skillAfter).not.toBeNull();
       expect(skillAfter!.requestedSpaceIds).not.toContain(space!.id);
       expect(skillAfter!.requestedSpaceIds).toHaveLength(0);
+    });
+
+    it("should preserve additional skill requestedSpaceIds when deleting a dependency space", async () => {
+      const toolSpaceResult = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Test Space With Tool",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(toolSpaceResult.isOk()).toBe(true);
+      const toolSpace = toolSpaceResult.isOk() ? toolSpaceResult.value : null;
+
+      const additionalSpaceResult = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Test Additional Skill Space",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(additionalSpaceResult.isOk()).toBe(true);
+      const additionalSpace = additionalSpaceResult.isOk()
+        ? additionalSpaceResult.value
+        : null;
+
+      const server = await RemoteMCPServerFactory.create(workspace, {
+        name: "Test Server",
+      });
+      const serverView = await MCPServerViewFactory.create(
+        workspace,
+        server.sId,
+        toolSpace!
+      );
+
+      const skill = await SkillFactory.create(adminAuth, {
+        name: "Test Skill With Tool And Additional Space",
+        requestedSpaceIds: [toolSpace!.id, additionalSpace!.id],
+        mcpServerViews: [serverView],
+      });
+
+      const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+        adminAuth,
+        toolSpace!,
+        true
+      );
+      expect(deleteResult.isOk()).toBe(true);
+
+      const skillAfter = await SkillResource.fetchById(adminAuth, skill.sId);
+      expect(skillAfter).not.toBeNull();
+      expect(skillAfter!.requestedSpaceIds).not.toContain(toolSpace!.id);
+      expect(skillAfter!.requestedSpaceIds).toEqual([additionalSpace!.id]);
     });
 
     it("should only remove deleted space from agent requestedSpaceIds, keeping other spaces", async () => {

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -196,14 +196,30 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
         (k) => !dataSourceViewIdSet.has(k.dataSourceView.id)
       );
 
+      const previousComputedRequestedSpaceIds =
+        await SkillResource.computeRequestedSpaceIds(auth, {
+          mcpServerViews: skill.mcpServerViews,
+          attachedKnowledge,
+        });
+      const previousComputedRequestedSpaceIdSet = new Set(
+        previousComputedRequestedSpaceIds
+      );
+      const additionalRequestedSpaceIds = skill.requestedSpaceIds.filter(
+        (spaceId) =>
+          spaceId !== space.id &&
+          !previousComputedRequestedSpaceIdSet.has(spaceId)
+      );
+
       // Compute the new requestedSpaceIds from the filtered tools and knowledge.
-      const requestedSpaceIds = await SkillResource.computeRequestedSpaceIds(
-        auth,
-        {
+      const computedRequestedSpaceIds =
+        await SkillResource.computeRequestedSpaceIds(auth, {
           mcpServerViews: filteredMCPServerViews,
           attachedKnowledge: filteredAttachedKnowledge,
-        }
-      );
+        });
+      const requestedSpaceIds = uniq([
+        ...computedRequestedSpaceIds,
+        ...additionalRequestedSpaceIds,
+      ]);
 
       // Log an error if the deleted space is still in requestedSpaceIds.
       if (requestedSpaceIds.includes(space.id)) {

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -8,6 +8,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -37,6 +38,7 @@ async function setupTest(
     auth,
     req,
     res,
+    globalGroup,
     workspace,
     globalSpace,
     user: requestUser,
@@ -120,6 +122,7 @@ async function setupTest(
     skillOwner,
     skillOwnerAuth,
     globalSpace,
+    globalGroup,
     workspace,
   };
 }
@@ -380,6 +383,84 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.requestedSpaceIds).toHaveLength(2);
+  });
+
+  it("should include additionalRequestedSpaceIds when updating a skill", async () => {
+    const { req, res, skill, workspace, requestUserAuth, globalGroup } =
+      await setupTest({
+        requestUserRole: "admin",
+        method: "PATCH",
+      });
+
+    const openSpace = await SpaceFactory.regular(workspace);
+    await GroupSpaceFactory.associate(openSpace, globalGroup);
+
+    req.body = {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [openSpace.sId],
+    };
+
+    await handler(req, res);
+
+    const data = res._getJSONData();
+    expect(data).not.toHaveProperty("error");
+    expect(res._getStatusCode()).toBe(200);
+    expect(data.skill.requestedSpaceIds).toContain(openSpace.sId);
+
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill).not.toBeNull();
+    expect(updatedSkill?.requestedSpaceIds).toContain(openSpace.id);
+  });
+
+  it("should preserve existing additional requested spaces when omitted", async () => {
+    const { req, res, skill, workspace, requestUserAuth, globalGroup } =
+      await setupTest({
+        requestUserRole: "admin",
+        method: "PATCH",
+      });
+
+    const openSpace = await SpaceFactory.regular(workspace);
+    await GroupSpaceFactory.associate(openSpace, globalGroup);
+
+    await skill.updateSkill(requestUserAuth, {
+      agentFacingDescription: skill.agentFacingDescription,
+      attachedKnowledge: [],
+      icon: skill.icon,
+      instructions: skill.instructions,
+      instructionsHtml: skill.instructionsHtml,
+      mcpServerViews: [],
+      name: skill.name,
+      requestedSpaceIds: [openSpace.id],
+      userFacingDescription: skill.userFacingDescription,
+    });
+
+    req.body = {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: skill.instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    };
+
+    await handler(req, res);
+
+    const data = res._getJSONData();
+    expect(data).not.toHaveProperty("error");
+    expect(res._getStatusCode()).toBe(200);
+    expect(data.skill.requestedSpaceIds).toContain(openSpace.sId);
   });
 
   it("should correctly reflect updated tools in the response", async () => {

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -1,5 +1,6 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -15,6 +16,7 @@ import type {
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import type { ModelId } from "@app/types/shared/model_id";
 import { isString } from "@app/types/shared/utils/general";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
@@ -63,6 +65,7 @@ const PatchSkillRequestBodySchema = t.intersection([
     instructionsHtml: t.union([t.string, t.null]),
   }),
   t.partial({
+    additionalRequestedSpaceIds: t.array(t.string),
     fileAttachments: t.array(t.type({ fileId: t.string })),
     isDefault: t.boolean,
     reinforcement: t.union([
@@ -255,13 +258,53 @@ async function handler(
         })
       );
 
-      const requestedSpaceIds = await SkillResource.computeRequestedSpaceIds(
-        auth,
-        {
+      const computedRequestedSpaceIds =
+        await SkillResource.computeRequestedSpaceIds(auth, {
           mcpServerViews,
           attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+        });
+
+      let additionalRequestedSpaceIds: ModelId[];
+
+      if (body.additionalRequestedSpaceIds !== undefined) {
+        const additionalRequestedSpaceIdsRes =
+          await resolveAdditionalRequestedSpaceModelIds(
+            auth,
+            body.additionalRequestedSpaceIds
+          );
+
+        if (additionalRequestedSpaceIdsRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: additionalRequestedSpaceIdsRes.error.message,
+            },
+          });
         }
-      );
+
+        additionalRequestedSpaceIds = additionalRequestedSpaceIdsRes.value;
+      } else {
+        const previousAttachedKnowledge =
+          await skill.getAttachedKnowledge(auth);
+        const previousComputedRequestedSpaceIds =
+          await SkillResource.computeRequestedSpaceIds(auth, {
+            mcpServerViews: skill.mcpServerViews,
+            attachedKnowledge: previousAttachedKnowledge,
+          });
+        const previousComputedRequestedSpaceIdsSet = new Set(
+          previousComputedRequestedSpaceIds
+        );
+
+        additionalRequestedSpaceIds = skill.requestedSpaceIds.filter(
+          (spaceId) => !previousComputedRequestedSpaceIdsSet.has(spaceId)
+        );
+      }
+
+      const requestedSpaceIds = uniq([
+        ...computedRequestedSpaceIds,
+        ...additionalRequestedSpaceIds,
+      ]);
 
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -1,8 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
-import {
-  SkillConfigurationModel,
-  SkillMCPServerConfigurationModel,
-} from "@app/lib/models/skill";
+import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -10,6 +7,8 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
@@ -493,7 +492,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
 
 describe("POST /api/w/[wId]/skills", () => {
   it("creates a simple skill configuration", async () => {
-    const { req, res, workspace } = await setupTest("POST", "admin");
+    const { auth, req, res } = await setupTest("POST", "admin");
 
     req.body = {
       name: "Simple Skill",
@@ -520,14 +519,79 @@ describe("POST /api/w/[wId]/skills", () => {
       tools: [],
     });
 
-    // Verify skill was created in the database
-    const skillConfiguration = await SkillConfigurationModel.findOne({
-      where: {
-        workspaceId: workspace.id,
-        name: "Simple Skill",
+    const createdSkill = await SkillResource.fetchById(
+      auth,
+      responseData.skill.sId
+    );
+    expect(createdSkill).not.toBeNull();
+  });
+
+  it("creates a skill configuration with additional requested spaces", async () => {
+    const { auth, req, res, workspace, globalGroup } = await setupTest(
+      "POST",
+      "admin"
+    );
+
+    const openSpace = await SpaceFactory.regular(workspace);
+    await GroupSpaceFactory.associate(openSpace, globalGroup);
+
+    req.body = {
+      name: "Skill With Additional Space",
+      agentFacingDescription: "To use with an additional space",
+      userFacingDescription: "A skill with a selected space",
+      instructions: "Simple instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [openSpace.sId],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData.skill).toMatchObject({
+      name: "Skill With Additional Space",
+      requestedSpaceIds: [openSpace.sId],
+    });
+
+    const createdSkill = await SkillResource.fetchById(
+      auth,
+      responseData.skill.sId
+    );
+    expect(createdSkill).not.toBeNull();
+    expect(createdSkill!.requestedSpaceIds).toContain(openSpace.id);
+  });
+
+  it("rejects additional requested spaces the user cannot access", async () => {
+    const { req, res, workspace } = await setupTest("POST", "builder");
+
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+
+    req.body = {
+      name: "Skill With Restricted Additional Space",
+      agentFacingDescription: "To use with a restricted space",
+      userFacingDescription: "A skill with a selected space",
+      instructions: "Simple instructions",
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+      instructionsHtml: null,
+      additionalRequestedSpaceIds: [restrictedSpace.sId],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: `User does not have access to the following spaces: ${restrictedSpace.sId}`,
       },
     });
-    expect(skillConfiguration).not.toBeNull();
   });
 
   it("creates a skill configuration with 2 tools", async () => {
@@ -582,27 +646,22 @@ describe("POST /api/w/[wId]/skills", () => {
       tools: [serverView1.toJSON(), serverView2.toJSON()],
     });
 
-    // Verify skill was created in the database
-    const skillConfiguration = await SkillConfigurationModel.findOne({
-      where: {
-        workspaceId: workspace.id,
-        name: "Test Skill",
-      },
-    });
-    expect(skillConfiguration).not.toBeNull();
-    expect(skillConfiguration!.agentFacingDescription).toBe(
+    const createdSkill = await SkillResource.fetchById(
+      auth,
+      responseData.skill.sId
+    );
+    expect(createdSkill).not.toBeNull();
+    expect(createdSkill!.agentFacingDescription).toBe(
       "Use this skill all the time"
     );
-    expect(skillConfiguration!.instructions).toBe(
-      "Test instructions for the skill"
-    );
-    expect(skillConfiguration!.editedBy).toBe(user.id);
+    expect(createdSkill!.instructions).toBe("Test instructions for the skill");
+    expect(createdSkill!.editedBy).toBe(user.id);
 
     // Verify tools were created in the database
     const toolConfigurations = await SkillMCPServerConfigurationModel.findAll({
       where: {
         workspaceId: workspace.id,
-        skillConfigurationId: skillConfiguration!.id,
+        skillConfigurationId: createdSkill!.id,
       },
     });
     expect(toolConfigurations).toHaveLength(2);
@@ -615,10 +674,23 @@ describe("POST /api/w/[wId]/skills", () => {
   });
 
   it("creates a skill configuration with requestedSpaceIds derived from tool's space", async () => {
-    const { req, res, workspace } = await setupTest("POST", "admin");
+    const { auth, req, res, workspace, user } = await setupTest(
+      "POST",
+      "admin"
+    );
 
     // Create a regular space where the tool will be placed
     const regularSpace = await SpaceFactory.regular(workspace);
+    const memberGroup = await GroupFactory.regular(
+      workspace,
+      "Tool Space Members"
+    );
+    await GroupFactory.withMembers(auth, memberGroup, [user]);
+    await GroupSpaceFactory.associate(regularSpace, memberGroup);
+    const spaceMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
 
     // Create a remote MCP server and view in the regular space
     const server = await RemoteMCPServerFactory.create(workspace, {
@@ -651,14 +723,12 @@ describe("POST /api/w/[wId]/skills", () => {
       requestedSpaceIds: [regularSpace.sId],
     });
 
-    const skillConfiguration = await SkillConfigurationModel.findOne({
-      where: {
-        workspaceId: workspace.id,
-        name: "Skill With Space Restrictions",
-      },
-    });
-    expect(skillConfiguration).not.toBeNull();
-    expect(skillConfiguration!.requestedSpaceIds).toEqual([regularSpace.id]);
+    const createdSkill = await SkillResource.fetchById(
+      spaceMemberAuth,
+      responseData.skill.sId
+    );
+    expect(createdSkill).not.toBeNull();
+    expect(createdSkill!.requestedSpaceIds).toEqual([regularSpace.id]);
   });
 
   it("creates a skill with attached knowledge", async () => {
@@ -718,10 +788,23 @@ describe("POST /api/w/[wId]/skills", () => {
   });
 
   it("creates a skill with requestedSpaceIds derived from attached knowledge's space", async () => {
-    const { req, res, workspace, user } = await setupTest("POST", "admin");
+    const { auth, req, res, workspace, user } = await setupTest(
+      "POST",
+      "admin"
+    );
 
     // Create a regular space where the knowledge will be placed.
     const regularSpace = await SpaceFactory.regular(workspace);
+    const memberGroup = await GroupFactory.regular(
+      workspace,
+      "Knowledge Space Members"
+    );
+    await GroupFactory.withMembers(auth, memberGroup, [user]);
+    await GroupSpaceFactory.associate(regularSpace, memberGroup);
+    const spaceMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
 
     // Create a data source view in the regular space.
     const dataSourceView = await DataSourceViewFactory.folder(
@@ -762,15 +845,12 @@ describe("POST /api/w/[wId]/skills", () => {
       requestedSpaceIds: [regularSpace.sId],
     });
 
-    // Verify in database.
-    const skillConfiguration = await SkillConfigurationModel.findOne({
-      where: {
-        workspaceId: workspace.id,
-        name: "Skill With Knowledge From Restricted Space",
-      },
-    });
-    expect(skillConfiguration).not.toBeNull();
-    expect(skillConfiguration!.requestedSpaceIds).toEqual([regularSpace.id]);
+    const createdSkill = await SkillResource.fetchById(
+      spaceMemberAuth,
+      responseData.skill.sId
+    );
+    expect(createdSkill).not.toBeNull();
+    expect(createdSkill!.requestedSpaceIds).toEqual([regularSpace.id]);
   });
 });
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -78,6 +79,7 @@ const PostSkillRequestBodySchema = t.intersection([
     instructionsHtml: t.union([t.string, t.null]),
   }),
   t.partial({
+    additionalRequestedSpaceIds: t.array(t.string),
     fileAttachments: t.array(t.type({ fileId: t.string })),
     isDefault: t.boolean,
   }),
@@ -319,19 +321,31 @@ async function handler(
         })
       );
 
-      const spaceIdsFromMcpServerViews =
-        await MCPServerViewResource.listSpaceRequirementsByIds(
+      const computedRequestedSpaceIds =
+        await SkillResource.computeRequestedSpaceIds(auth, {
+          mcpServerViews,
+          attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+        });
+
+      const additionalRequestedSpaceIdsRes =
+        await resolveAdditionalRequestedSpaceModelIds(
           auth,
-          mcpServerViewIds
+          body.additionalRequestedSpaceIds
         );
 
-      const spaceIdsFromAttachedKnowledge = dataSourceViews.map(
-        (dsv) => dsv.space.id
-      );
+      if (additionalRequestedSpaceIdsRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: additionalRequestedSpaceIdsRes.error.message,
+          },
+        });
+      }
 
       const requestedSpaceIds = uniq([
-        ...spaceIdsFromMcpServerViews,
-        ...spaceIdsFromAttachedKnowledge,
+        ...computedRequestedSpaceIds,
+        ...additionalRequestedSpaceIdsRes.value,
       ]);
 
       const extendedSkill = body.extendedSkillId


### PR DESCRIPTION
## Description

- The end goal is to let skills persist spaces that are explicitly selected by the builder instead of only storing spaces inferred from tools and attached knowledge. Same pattern as for agents.
- Adds optional `additionalRequestedSpaceIds` handling to skill creation and updates.
- Keeps PATCH backward-compatible by preserving existing explicit requested spaces when older clients omit the new field.

## Tests

- Added a few tests.

## Risk

- Low.

## Deploy Plan

- Deploy front
