### PR TITLE
[front] feat: add Skill Builder space selection

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -1,5 +1,5 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { SpaceSelectionPageContent } from "@app/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage";
+import { SpaceSelectionSheet } from "@app/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActionsMap";
 import { useRemoveSpaceConfirm } from "@app/components/shared/RemoveSpaceDialog";
@@ -10,19 +10,7 @@ import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
-import {
-  Button,
-  ContentMessage,
-  PlanetIcon,
-  SearchInput,
-  Sheet,
-  SheetContainer,
-  SheetContent,
-  SheetDescription,
-  SheetFooter,
-  SheetHeader,
-  SheetTitle,
-} from "@dust-tt/sparkle";
+import { Button, ContentMessage, PlanetIcon } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
@@ -65,7 +53,6 @@ export function AgentBuilderSpacesBlock({
 
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [draftSelectedSpaces, setDraftSelectedSpaces] = useState<string[]>([]);
-  const [spaceSearchQuery, setSpaceSearchQuery] = useState("");
 
   const selectedSkills = useWatch<AgentBuilderFormData, "skills">({
     name: "skills",
@@ -217,52 +204,16 @@ export function AgentBuilderSpacesBlock({
       )}
       <SpaceChips spaces={spacesToDisplay} onRemoveSpace={handleRemoveSpace} />
 
-      <Sheet open={isSheetOpen} onOpenChange={handleCloseSheet}>
-        <SheetContent>
-          <SheetHeader>
-            <SheetTitle>
-              {isProjectsEnabled ? "Add Spaces and Projects" : "Add Spaces"}
-            </SheetTitle>
-            <SheetDescription>
-              {isProjectsEnabled
-                ? "Choose the spaces and projects you want the agent to have access to."
-                : "Choose the spaces you want the agent to have access to."}
-            </SheetDescription>
-            <SearchInput
-              name="space"
-              onChange={(s) => setSpaceSearchQuery(s)}
-              value={spaceSearchQuery}
-              placeholder={
-                isProjectsEnabled
-                  ? "Search spaces and projects"
-                  : "Search spaces"
-              }
-              className="mt-4"
-            />
-          </SheetHeader>
-          <SheetContainer isListSelector>
-            <SpaceSelectionPageContent
-              alreadyRequestedSpaceIds={actionsAndSkillsRequestedSpaceIds}
-              selectedSpaces={draftSelectedSpaces}
-              setSelectedSpaces={setDraftSelectedSpaces}
-              searchQuery={spaceSearchQuery}
-              missingSpaceIds={missingSpaceIds}
-            />
-          </SheetContainer>
-          <SheetFooter
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-              onClick: handleCloseSheet,
-            }}
-            rightButtonProps={{
-              label: "Save",
-              variant: "primary",
-              onClick: handleSaveSpaces,
-            }}
-          />
-        </SheetContent>
-      </Sheet>
+      <SpaceSelectionSheet
+        alreadyRequestedSpaceIds={actionsAndSkillsRequestedSpaceIds}
+        entityName="agent"
+        missingSpaceIds={missingSpaceIds}
+        onClose={handleCloseSheet}
+        onSave={handleSaveSpaces}
+        open={isSheetOpen}
+        selectedSpaces={draftSelectedSpaces}
+        setSelectedSpaces={setDraftSelectedSpaces}
+      />
     </div>
   );
 }

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -36,6 +36,7 @@ type SpaceRowData = {
 
 interface SpaceSelectionPageProps {
   alreadyRequestedSpaceIds: Set<string>;
+  includeProjects?: boolean;
   selectedSpaces: string[];
   setSelectedSpaces: React.Dispatch<React.SetStateAction<string[]>>;
   searchQuery?: string;
@@ -53,6 +54,7 @@ interface SpaceSelectionSheetProps
 export function SpaceSelectionSheet({
   alreadyRequestedSpaceIds,
   entityName,
+  includeProjects = true,
   missingSpaceIds,
   onClose,
   onSave,
@@ -62,7 +64,7 @@ export function SpaceSelectionSheet({
 }: SpaceSelectionSheetProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const { hasFeature } = useFeatureFlags();
-  const isProjectsEnabled = hasFeature("projects");
+  const isProjectsEnabled = includeProjects && hasFeature("projects");
 
   const handleClose = () => {
     setSearchQuery("");
@@ -106,6 +108,7 @@ export function SpaceSelectionSheet({
         <SheetContainer isListSelector>
           <SpaceSelectionPageContent
             alreadyRequestedSpaceIds={alreadyRequestedSpaceIds}
+            includeProjects={includeProjects}
             selectedSpaces={selectedSpaces}
             setSelectedSpaces={setSelectedSpaces}
             searchQuery={searchQuery}
@@ -131,6 +134,7 @@ export function SpaceSelectionSheet({
 
 export function SpaceSelectionPageContent({
   alreadyRequestedSpaceIds,
+  includeProjects = true,
   selectedSpaces,
   setSelectedSpaces,
   searchQuery = "",
@@ -148,13 +152,14 @@ export function SpaceSelectionPageContent({
 
   const { hasFeature } = useFeatureFlags();
 
-  const isProjectsEnabled = hasFeature("projects");
+  const isProjectsEnabled = includeProjects && hasFeature("projects");
 
   const selectableSpaces = useMemo(() => {
     return allSpaces
       .filter(
         (s) =>
           s.kind !== "global" &&
+          (includeProjects || s.kind !== "project") &&
           s.name.toLowerCase().includes(searchQuery.toLowerCase())
       )
       .sort((a, b) => {
@@ -167,7 +172,7 @@ export function SpaceSelectionPageContent({
         }
         return getSpaceName(a).localeCompare(getSpaceName(b));
       });
-  }, [allSpaces, searchQuery]);
+  }, [allSpaces, includeProjects, searchQuery]);
 
   const selectedSpaceIds = useMemo(
     () => new Set(selectedSpaces),
@@ -344,7 +349,9 @@ export function SpaceSelectionPageContent({
         <div className="py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
           {searchQuery.length > 0
             ? "No results found for your search"
-            : "No spaces and projects available"}
+            : isProjectsEnabled
+              ? "No spaces and projects available"
+              : "No spaces available"}
         </div>
       )}
     </div>

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -10,10 +10,18 @@ import {
   ListGroup,
   ListItem,
   ListItemSection,
+  SearchInput,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
   Tooltip,
 } from "@dust-tt/sparkle";
 import type React from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 type SpaceRowData = {
   sId: string;
@@ -32,6 +40,93 @@ interface SpaceSelectionPageProps {
   setSelectedSpaces: React.Dispatch<React.SetStateAction<string[]>>;
   searchQuery?: string;
   missingSpaceIds?: string[];
+}
+
+interface SpaceSelectionSheetProps
+  extends Omit<SpaceSelectionPageProps, "searchQuery"> {
+  entityName: "agent" | "skill";
+  onClose: () => void;
+  onSave: () => void;
+  open: boolean;
+}
+
+export function SpaceSelectionSheet({
+  alreadyRequestedSpaceIds,
+  entityName,
+  missingSpaceIds,
+  onClose,
+  onSave,
+  open,
+  selectedSpaces,
+  setSelectedSpaces,
+}: SpaceSelectionSheetProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const { hasFeature } = useFeatureFlags();
+  const isProjectsEnabled = hasFeature("projects");
+
+  const handleClose = () => {
+    setSearchQuery("");
+    onClose();
+  };
+
+  const handleSave = () => {
+    setSearchQuery("");
+    onSave();
+  };
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          handleClose();
+        }
+      }}
+    >
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>
+            {isProjectsEnabled ? "Add Spaces and Projects" : "Add Spaces"}
+          </SheetTitle>
+          <SheetDescription>
+            {isProjectsEnabled
+              ? `Choose the spaces and projects you want the ${entityName} to have access to.`
+              : `Choose the spaces you want the ${entityName} to have access to.`}
+          </SheetDescription>
+          <SearchInput
+            name="space"
+            onChange={(query) => setSearchQuery(query)}
+            value={searchQuery}
+            placeholder={
+              isProjectsEnabled ? "Search spaces and projects" : "Search spaces"
+            }
+            className="mt-4"
+          />
+        </SheetHeader>
+        <SheetContainer isListSelector>
+          <SpaceSelectionPageContent
+            alreadyRequestedSpaceIds={alreadyRequestedSpaceIds}
+            selectedSpaces={selectedSpaces}
+            setSelectedSpaces={setSelectedSpaces}
+            searchQuery={searchQuery}
+            missingSpaceIds={missingSpaceIds}
+          />
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: handleClose,
+          }}
+          rightButtonProps={{
+            label: "Save",
+            variant: "primary",
+            onClick: handleSave,
+          }}
+        />
+      </SheetContent>
+    </Sheet>
+  );
 }
 
 export function SpaceSelectionPageContent({

--- a/front/components/shared/SpaceChips.tsx
+++ b/front/components/shared/SpaceChips.tsx
@@ -5,9 +5,14 @@ import { Chip } from "@dust-tt/sparkle";
 interface SpaceChipsProps {
   spaces: SpaceType[];
   onRemoveSpace: (space: SpaceType) => void;
+  canRemoveSpace?: (space: SpaceType) => boolean;
 }
 
-export function SpaceChips({ spaces, onRemoveSpace }: SpaceChipsProps) {
+export function SpaceChips({
+  spaces,
+  onRemoveSpace,
+  canRemoveSpace,
+}: SpaceChipsProps) {
   return (
     <div className="flex flex-wrap gap-2">
       {spaces.map((space) => (
@@ -17,7 +22,9 @@ export function SpaceChips({ spaces, onRemoveSpace }: SpaceChipsProps) {
           label={getSpaceName(space)}
           icon={getSpaceIcon(space)}
           onRemove={
-            space.kind !== "global" ? () => onRemoveSpace(space) : undefined
+            space.kind !== "global" && (canRemoveSpace?.(space) ?? true)
+              ? () => onRemoveSpace(space)
+              : undefined
           }
         />
       ))}

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -228,7 +228,9 @@ export default function SkillBuilder({
               specific needs before saving.
             </ContentMessage>
           )}
-          <SkillBuilderRequestedSpacesSection />
+          <SkillBuilderRequestedSpacesSection
+            initialRequestedSpaceIds={skill?.requestedSpaceIds}
+          />
           <SkillBuilderAgentFacingDescriptionSection />
           <SkillBuilderInstructionsSection />
           {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -42,6 +42,7 @@ export const skillBuilderFormSchema = z.object({
   reinforcement: z.enum(SKILL_REINFORCEMENT_MODES),
   fileAttachments: z.array(fileAttachmentSchema),
   attachedKnowledge: z.array(attachedKnowledgeSchema).optional(),
+  additionalSpaces: z.array(z.string()),
 });
 
 export type SkillBuilderFormData = z.infer<typeof skillBuilderFormSchema>;

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -21,7 +21,7 @@ import type { Editor } from "@tiptap/react";
 import type { Config } from "dompurify";
 import DOMPurify from "dompurify";
 import debounce from "lodash/debounce";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 const INSTRUCTIONS_FIELD_NAME = "instructions";
@@ -73,7 +73,8 @@ export function SkillBuilderInstructionsEditor({
   onAddKnowledge,
 }: SkillBuilderInstructionsEditorProps) {
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
-  const { setValue } = useFormContext<SkillBuilderFormData>();
+  const { resetField } = useFormContext<SkillBuilderFormData>();
+  const initializedAttachedKnowledgeEditorRef = useRef<Editor | null>(null);
 
   const { field: instructionsField, fieldState: instructionsFieldState } =
     useController<SkillBuilderFormData, typeof INSTRUCTIONS_FIELD_NAME>({
@@ -99,28 +100,40 @@ export function SkillBuilderInstructionsEditor({
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
 
+  const syncAttachedKnowledgeFromEditor = useCallback(
+    (editor: Editor) => {
+      attachedKnowledgeField.onChange(
+        toAttachedKnowledge(collectKnowledgeItems(editor))
+      );
+    },
+    [attachedKnowledgeField.onChange]
+  );
+
+  const syncInstructionsFromEditor = useCallback(
+    (editor: Editor) => {
+      instructionsField.onChange(
+        postProcessMarkdown(editor.getMarkdown()).trim()
+      );
+      instructionsHtmlField.onChange(
+        sanitizeSkillInstructionsHtml(editor.getHTML())
+      );
+      syncAttachedKnowledgeFromEditor(editor);
+    },
+    [
+      instructionsField.onChange,
+      instructionsHtmlField.onChange,
+      syncAttachedKnowledgeFromEditor,
+    ]
+  );
+
   const debouncedUpdate = useMemo(
     () =>
       debounce((editor: Editor) => {
         if (!isDiffMode && !editor.isDestroyed) {
-          setValue(
-            INSTRUCTIONS_FIELD_NAME,
-            postProcessMarkdown(editor.getMarkdown()).trim(),
-            { shouldDirty: true }
-          );
-          setValue(
-            INSTRUCTIONS_HTML_FIELD_NAME,
-            sanitizeSkillInstructionsHtml(editor.getHTML()),
-            { shouldDirty: true }
-          );
-          setValue(
-            ATTACHED_KNOWLEDGE_FIELD_NAME,
-            toAttachedKnowledge(collectKnowledgeItems(editor)),
-            { shouldDirty: true }
-          );
+          syncInstructionsFromEditor(editor);
         }
       }, 250),
-    [isDiffMode, setValue]
+    [isDiffMode, syncInstructionsFromEditor]
   );
 
   const handleUpdate = useCallback(
@@ -140,13 +153,9 @@ export function SkillBuilderInstructionsEditor({
 
   const handleDelete = useCallback(
     (editorInstance: Editor) => {
-      setValue(
-        ATTACHED_KNOWLEDGE_FIELD_NAME,
-        toAttachedKnowledge(collectKnowledgeItems(editorInstance)),
-        { shouldDirty: true }
-      );
+      syncAttachedKnowledgeFromEditor(editorInstance);
     },
-    [setValue]
+    [syncAttachedKnowledgeFromEditor]
   );
 
   const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
@@ -243,25 +252,31 @@ export function SkillBuilderInstructionsEditor({
         }
       }
 
-      // Sync the editor's new content back to the form.
-      setValue(
-        INSTRUCTIONS_HTML_FIELD_NAME,
-        sanitizeSkillInstructionsHtml(editor.getHTML()),
-        { shouldDirty: true }
-      );
-      setValue(
-        INSTRUCTIONS_FIELD_NAME,
-        postProcessMarkdown(editor.getMarkdown()).trim(),
-        {
-          shouldDirty: true,
-        }
-      );
+      syncInstructionsFromEditor(editor);
     });
 
     return () => {
       setAcceptInstructionEdits(null);
     };
-  }, [editor, setValue, setAcceptInstructionEdits]);
+  }, [editor, syncInstructionsFromEditor, setAcceptInstructionEdits]);
+
+  useEffect(() => {
+    if (
+      !editor ||
+      !isContentReady ||
+      isDiffMode ||
+      initializedAttachedKnowledgeEditorRef.current === editor
+    ) {
+      return;
+    }
+
+    initializedAttachedKnowledgeEditorRef.current = editor;
+    resetField(ATTACHED_KNOWLEDGE_FIELD_NAME, {
+      defaultValue: toAttachedKnowledge(collectKnowledgeItems(editor)),
+      keepError: true,
+      keepTouched: true,
+    });
+  }, [editor, isContentReady, isDiffMode, resetField]);
 
   // Apply pending instruction suggestions as inline diff decorations.
   // "Reject all + re-apply current" on every change so that accepts and

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -9,7 +9,7 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
 import { Button, ContentMessage, PlanetIcon } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
-import { useFormContext, useWatch } from "react-hook-form";
+import { useController, useFormContext, useWatch } from "react-hook-form";
 
 interface SkillBuilderRequestedSpacesSectionProps {
   initialRequestedSpaceIds?: string[];
@@ -18,11 +18,7 @@ interface SkillBuilderRequestedSpacesSectionProps {
 export function SkillBuilderRequestedSpacesSection({
   initialRequestedSpaceIds,
 }: SkillBuilderRequestedSpacesSectionProps) {
-  const {
-    resetField,
-    setValue,
-    formState: { dirtyFields },
-  } = useFormContext<SkillBuilderFormData>();
+  const { resetField } = useFormContext<SkillBuilderFormData>();
 
   const tools = useWatch<SkillBuilderFormData, "tools">({ name: "tools" });
   const attachedKnowledge = useWatch<SkillBuilderFormData, "attachedKnowledge">(
@@ -30,10 +26,14 @@ export function SkillBuilderRequestedSpacesSection({
       name: "attachedKnowledge",
     }
   );
-  const additionalSpaces = useWatch<SkillBuilderFormData, "additionalSpaces">({
+
+  const {
+    field: additionalSpacesField,
+    fieldState: additionalSpacesFieldState,
+  } = useController<SkillBuilderFormData, "additionalSpaces">({
     name: "additionalSpaces",
   });
-  const selectedAdditionalSpaces = additionalSpaces ?? [];
+  const selectedAdditionalSpaces = additionalSpacesField.value ?? [];
 
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
@@ -100,7 +100,7 @@ export function SkillBuilderRequestedSpacesSection({
     if (
       !areSpaceRequirementsReady ||
       !initialRequestedSpaceIds ||
-      dirtyFields.additionalSpaces
+      additionalSpacesFieldState.isDirty
     ) {
       return;
     }
@@ -110,7 +110,7 @@ export function SkillBuilderRequestedSpacesSection({
     });
   }, [
     areSpaceRequirementsReady,
-    dirtyFields.additionalSpaces,
+    additionalSpacesFieldState.isDirty,
     initialAdditionalSpaces,
     initialRequestedSpaceIds,
     resetField,
@@ -130,10 +130,8 @@ export function SkillBuilderRequestedSpacesSection({
   }, [additionalSpaceIds, allSpaces, spaceIdsUsedBySkill]);
 
   const handleRemoveSpace = (space: SpaceType) => {
-    setValue(
-      "additionalSpaces",
-      selectedAdditionalSpaces.filter((spaceId) => spaceId !== space.sId),
-      { shouldDirty: true }
+    additionalSpacesField.onChange(
+      selectedAdditionalSpaces.filter((spaceId) => spaceId !== space.sId)
     );
   };
 
@@ -164,7 +162,7 @@ export function SkillBuilderRequestedSpacesSection({
   };
 
   const handleSaveSpaces = () => {
-    setValue("additionalSpaces", draftSelectedSpaces, { shouldDirty: true });
+    additionalSpacesField.onChange(draftSelectedSpaces);
     handleCloseSheet();
   };
 

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -1,115 +1,227 @@
+import { SpaceSelectionSheet } from "@app/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActionsMap";
-import { useRemoveSpaceConfirm } from "@app/components/shared/RemoveSpaceDialog";
 import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import { removeNulls } from "@app/types/shared/utils/general";
-import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { SpaceType } from "@app/types/space";
-import { ContentMessage } from "@dust-tt/sparkle";
-import { useMemo } from "react";
-import { useFormContext } from "react-hook-form";
+import { Button, ContentMessage, PlanetIcon } from "@dust-tt/sparkle";
+import { useEffect, useMemo, useState } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 
-export function SkillBuilderRequestedSpacesSection() {
-  const { watch, setValue } = useFormContext<SkillBuilderFormData>();
+interface SkillBuilderRequestedSpacesSectionProps {
+  initialRequestedSpaceIds?: string[];
+}
 
-  const tools = watch("tools");
-  const attachedKnowledge = watch("attachedKnowledge");
+export function SkillBuilderRequestedSpacesSection({
+  initialRequestedSpaceIds,
+}: SkillBuilderRequestedSpacesSectionProps) {
+  const {
+    setValue,
+    formState: { isDirty },
+  } = useFormContext<SkillBuilderFormData>();
 
-  const { mcpServerViews } = useMCPServerViewsContext();
-  const { spaces } = useSpacesContext();
+  const tools = useWatch<SkillBuilderFormData, "tools">({ name: "tools" });
+  const attachedKnowledge = useWatch<SkillBuilderFormData, "attachedKnowledge">(
+    {
+      name: "attachedKnowledge",
+    }
+  );
+  const additionalSpaces = useWatch<SkillBuilderFormData, "additionalSpaces">({
+    name: "additionalSpaces",
+  });
+  const selectedAdditionalSpaces = additionalSpaces ?? [];
 
-  const confirmRemoveSpace = useRemoveSpaceConfirm({
-    entityName: "skill",
-    mcpServerViews,
+  const { hasFeature } = useFeatureFlags();
+  const { mcpServerViews, isMCPServerViewsLoading } =
+    useMCPServerViewsContext();
+  const { spaces, owner, isSpacesLoading } = useSpacesContext();
+
+  const isProjectsEnabled = hasFeature("projects");
+
+  const missingSpaceIds = useMemo(() => {
+    if (isSpacesLoading || !initialRequestedSpaceIds?.length) {
+      return [];
+    }
+
+    const existingSpaceIds = new Set(spaces.map((space) => space.sId));
+    return initialRequestedSpaceIds.filter((id) => !existingSpaceIds.has(id));
+  }, [isSpacesLoading, initialRequestedSpaceIds, spaces]);
+
+  const { spaces: missingSpaces } = useSpaceProjectsLookup({
+    workspaceId: owner.sId,
+    spaceIds: missingSpaceIds,
   });
 
+  const allSpaces = useMemo(() => {
+    return [...spaces, ...missingSpaces];
+  }, [spaces, missingSpaces]);
+
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [draftSelectedSpaces, setDraftSelectedSpaces] = useState<string[]>([]);
+
   const spaceIdToActions = useMemo(() => {
-    return getSpaceIdToActionsMap(tools, mcpServerViews);
+    return getSpaceIdToActionsMap(tools ?? [], mcpServerViews);
   }, [tools, mcpServerViews]);
 
   const spaceIdsFromKnowledge = useMemo(() => {
     return new Set(attachedKnowledge?.map((k) => k.spaceId) ?? []);
   }, [attachedKnowledge]);
 
-  const nonGlobalSpacesUsedInActions = useMemo(() => {
-    return spaces.filter(
-      (s) =>
-        s.kind !== "global" &&
-        (spaceIdToActions[s.sId]?.length > 0 ||
-          spaceIdsFromKnowledge.has(s.sId))
+  const spaceIdsUsedBySkill = useMemo(() => {
+    const actionRequestedSpaceIds = Object.keys(spaceIdToActions).filter(
+      (spaceId) => spaceIdToActions[spaceId]?.length > 0
     );
-  }, [spaceIdToActions, spaceIdsFromKnowledge, spaces]);
 
-  const knowledgeToRemoveBySpaceId = useMemo(() => {
-    const map: Record<string, NonNullable<typeof attachedKnowledge>> = {};
-    for (const k of attachedKnowledge ?? []) {
-      if (!map[k.spaceId]) {
-        map[k.spaceId] = [];
-      }
-      map[k.spaceId].push(k);
+    return new Set([...actionRequestedSpaceIds, ...spaceIdsFromKnowledge]);
+  }, [spaceIdToActions, spaceIdsFromKnowledge]);
+
+  const areSpaceRequirementsReady =
+    !isMCPServerViewsLoading &&
+    (!initialRequestedSpaceIds || attachedKnowledge !== undefined);
+
+  const initialAdditionalSpaces = useMemo(() => {
+    if (!areSpaceRequirementsReady || !initialRequestedSpaceIds?.length) {
+      return [];
     }
-    return map;
-  }, [attachedKnowledge]);
 
-  const handleRemoveSpace = async (space: SpaceType) => {
-    const actionsToRemove = spaceIdToActions[space.sId] || [];
-    const knowledgeInSpace = knowledgeToRemoveBySpaceId[space.sId] || [];
+    return initialRequestedSpaceIds.filter(
+      (spaceId) => !spaceIdsUsedBySkill.has(spaceId)
+    );
+  }, [
+    areSpaceRequirementsReady,
+    initialRequestedSpaceIds,
+    spaceIdsUsedBySkill,
+  ]);
 
-    // Don't show confirmation if nothing to remove.
-    if (actionsToRemove.length === 0 && knowledgeInSpace.length === 0) {
+  useEffect(() => {
+    if (!areSpaceRequirementsReady || !initialRequestedSpaceIds || isDirty) {
       return;
     }
 
-    const confirmed = await confirmRemoveSpace({
-      space,
-      actions: actionsToRemove,
-      knowledgeInInstructions: knowledgeInSpace,
+    setValue("additionalSpaces", initialAdditionalSpaces, {
+      shouldDirty: false,
     });
+  }, [
+    areSpaceRequirementsReady,
+    initialAdditionalSpaces,
+    initialRequestedSpaceIds,
+    isDirty,
+    setValue,
+  ]);
 
-    if (!confirmed) {
+  const additionalSpaceIds = useMemo(() => {
+    return new Set(selectedAdditionalSpaces);
+  }, [selectedAdditionalSpaces]);
+
+  const nonGlobalSpacesWithRestrictions = useMemo(() => {
+    return allSpaces.filter(
+      (space) =>
+        space.kind !== "global" &&
+        (spaceIdsUsedBySkill.has(space.sId) ||
+          additionalSpaceIds.has(space.sId))
+    );
+  }, [additionalSpaceIds, allSpaces, spaceIdsUsedBySkill]);
+
+  const handleRemoveSpace = (space: SpaceType) => {
+    setValue(
+      "additionalSpaces",
+      selectedAdditionalSpaces.filter((spaceId) => spaceId !== space.sId),
+      { shouldDirty: true }
+    );
+  };
+
+  const canRemoveSpace = (space: SpaceType) => {
+    return (
+      areSpaceRequirementsReady &&
+      additionalSpaceIds.has(space.sId) &&
+      !spaceIdsUsedBySkill.has(space.sId)
+    );
+  };
+
+  const handleOpenSheet = () => {
+    if (!areSpaceRequirementsReady) {
       return;
     }
 
-    const actionIdsToRemove = new Set(actionsToRemove.map((a) => a.id));
+    setDraftSelectedSpaces(
+      selectedAdditionalSpaces.filter(
+        (spaceId) => !spaceIdsUsedBySkill.has(spaceId)
+      )
+    );
+    setIsSheetOpen(true);
+  };
 
-    // Filter out the tools to remove and set the new value.
-    const newTools = tools.filter((t) => !actionIdsToRemove.has(t.id));
-    setValue("tools", newTools, { shouldDirty: true });
+  const handleCloseSheet = () => {
+    setIsSheetOpen(false);
+    setDraftSelectedSpaces([]);
+  };
+
+  const handleSaveSpaces = () => {
+    setValue("additionalSpaces", draftSelectedSpaces, { shouldDirty: true });
+    handleCloseSheet();
   };
 
   const globalSpace = useMemo(() => {
-    return spaces.find((s) => s.kind === "global");
-  }, [spaces]);
+    return allSpaces.find((s) => s.kind === "global");
+  }, [allSpaces]);
+
   const spacesToDisplay = useMemo(() => {
-    return removeNulls([globalSpace, ...nonGlobalSpacesUsedInActions]);
-  }, [globalSpace, nonGlobalSpacesUsedInActions]);
+    return removeNulls([globalSpace, ...nonGlobalSpacesWithRestrictions]);
+  }, [globalSpace, nonGlobalSpacesWithRestrictions]);
 
   return (
     <div className="space-y-3">
-      <div>
-        <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-          Spaces
-        </h3>
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Sets what knowledge and tools the skill can access.
-        </p>
+      <div className="flex items-start justify-between">
+        <div>
+          <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
+            {isProjectsEnabled ? "Spaces and Projects" : "Spaces"}
+          </h3>
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Set what knowledge and tools the skill can access.
+          </p>
+        </div>
+        <Button
+          label="Manage"
+          icon={PlanetIcon}
+          variant="outline"
+          disabled={!areSpaceRequirementsReady}
+          onClick={handleOpenSheet}
+        />
       </div>
-      {nonGlobalSpacesUsedInActions.length > 0 && (
+      {nonGlobalSpacesWithRestrictions.length > 0 && (
         <div className="mb-4 w-full">
           <ContentMessage variant="golden" size="lg">
-            Based on your selection of knowledge and tools, this skill can only
-            be used by users with access to space
-            {pluralize(nonGlobalSpacesUsedInActions.length)} :{" "}
+            Based on your selection of spaces, knowledge, and tools, this skill
+            can only be used by users with access to:{" "}
             <strong>
-              {nonGlobalSpacesUsedInActions.map((v) => v.name).join(", ")}
+              {nonGlobalSpacesWithRestrictions
+                .map((space) => space.name)
+                .join(", ")}
             </strong>
             .
           </ContentMessage>
         </div>
       )}
-      <SpaceChips spaces={spacesToDisplay} onRemoveSpace={handleRemoveSpace} />
+      <SpaceChips
+        spaces={spacesToDisplay}
+        onRemoveSpace={handleRemoveSpace}
+        canRemoveSpace={canRemoveSpace}
+      />
+
+      <SpaceSelectionSheet
+        alreadyRequestedSpaceIds={spaceIdsUsedBySkill}
+        entityName="skill"
+        missingSpaceIds={missingSpaceIds}
+        onClose={handleCloseSheet}
+        onSave={handleSaveSpaces}
+        open={isSheetOpen}
+        selectedSpaces={draftSelectedSpaces}
+        setSelectedSpaces={setDraftSelectedSpaces}
+      />
     </div>
   );
 }

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -4,7 +4,6 @@ import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActio
 import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
@@ -35,12 +34,9 @@ export function SkillBuilderRequestedSpacesSection({
   });
   const selectedAdditionalSpaces = additionalSpaces ?? [];
 
-  const { hasFeature } = useFeatureFlags();
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
   const { spaces, owner, isSpacesLoading } = useSpacesContext();
-
-  const isProjectsEnabled = hasFeature("projects");
 
   const missingSpaceIds = useMemo(() => {
     if (isSpacesLoading || !initialRequestedSpaceIds?.length) {
@@ -57,7 +53,9 @@ export function SkillBuilderRequestedSpacesSection({
   });
 
   const allSpaces = useMemo(() => {
-    return [...spaces, ...missingSpaces];
+    return [...spaces, ...missingSpaces].filter(
+      (space) => space.kind !== "project"
+    );
   }, [spaces, missingSpaces]);
 
   const [isSheetOpen, setIsSheetOpen] = useState(false);
@@ -178,7 +176,7 @@ export function SkillBuilderRequestedSpacesSection({
       <div className="flex items-start justify-between">
         <div>
           <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-            {isProjectsEnabled ? "Spaces and Projects" : "Spaces"}
+            Spaces
           </h3>
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             Set what knowledge and tools the skill can access.
@@ -215,6 +213,7 @@ export function SkillBuilderRequestedSpacesSection({
       <SpaceSelectionSheet
         alreadyRequestedSpaceIds={spaceIdsUsedBySkill}
         entityName="skill"
+        includeProjects={false}
         missingSpaceIds={missingSpaceIds}
         onClose={handleCloseSheet}
         onSave={handleSaveSpaces}

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -19,8 +19,9 @@ export function SkillBuilderRequestedSpacesSection({
   initialRequestedSpaceIds,
 }: SkillBuilderRequestedSpacesSectionProps) {
   const {
+    resetField,
     setValue,
-    formState: { isDirty },
+    formState: { dirtyFields },
   } = useFormContext<SkillBuilderFormData>();
 
   const tools = useWatch<SkillBuilderFormData, "tools">({ name: "tools" });
@@ -96,19 +97,23 @@ export function SkillBuilderRequestedSpacesSection({
   ]);
 
   useEffect(() => {
-    if (!areSpaceRequirementsReady || !initialRequestedSpaceIds || isDirty) {
+    if (
+      !areSpaceRequirementsReady ||
+      !initialRequestedSpaceIds ||
+      dirtyFields.additionalSpaces
+    ) {
       return;
     }
 
-    setValue("additionalSpaces", initialAdditionalSpaces, {
-      shouldDirty: false,
+    resetField("additionalSpaces", {
+      defaultValue: initialAdditionalSpaces,
     });
   }, [
     areSpaceRequirementsReady,
+    dirtyFields.additionalSpaces,
     initialAdditionalSpaces,
     initialRequestedSpaceIds,
-    isDirty,
-    setValue,
+    resetField,
   ]);
 
   const additionalSpaceIds = useMemo(() => {

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -23,6 +23,7 @@ export function transformSkillTypeToFormData(
     extendedSkillId: skill.extendedSkillId,
     isDefault: skill.isDefault,
     reinforcement: skill.reinforcement,
+    additionalSpaces: [],
   };
 }
 
@@ -49,5 +50,6 @@ export function getDefaultSkillFormData({
     extendedSkillId,
     isDefault: false,
     reinforcement: "on",
+    additionalSpaces: [],
   };
 }

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -55,6 +55,7 @@ export async function submitSkillBuilderForm({
           fileId: f.fileId,
         })),
         attachedKnowledge: formData.attachedKnowledge ?? [],
+        additionalRequestedSpaceIds: formData.additionalSpaces,
       }),
     });
 


### PR DESCRIPTION
## Description

- Adds a Skill Builder space selector so builders can grant a skill access to spaces beyond those required by selected tools and attached knowledge.
- Reuses the Agent Builder space selection sheet while keeping Skill Builder scoped to spaces only, without project-specific labels or rows.
- Separates dependency-required spaces from manually selected spaces: required spaces stay visible and locked, while only manually selected spaces are submitted as `additionalRequestedSpaceIds`.
- Keeps the blocked-removal explanation flow out of this PR; that remains in the follow-up PR.

## Tests

- Tested locally

## Risk

- Low

## Deploy Plan

- Deploy front
