### PR TITLE
[front] enh: add explanatory message on space removal in skills

### DIFF
--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -15,7 +15,6 @@ export type ConfirmDataType = {
   validateLabel?: string;
   validateVariant?: "primary" | "warning";
   validateDisabled?: boolean;
-  hideValidateButton?: boolean;
   cancelLabel?: string;
 };
 
@@ -96,16 +95,12 @@ export function ConfirmDialog({
             variant: "outline",
             onClick: () => resolveConfirm(false),
           }}
-          rightButtonProps={
-            confirmData?.hideValidateButton
-              ? undefined
-              : {
-                  label: confirmData?.validateLabel ?? "OK",
-                  variant: confirmData?.validateVariant ?? "warning",
-                  disabled: confirmData?.validateDisabled ?? false,
-                  onClick: () => resolveConfirm(true),
-                }
-          }
+          rightButtonProps={{
+            label: confirmData?.validateLabel ?? "OK",
+            variant: confirmData?.validateVariant ?? "warning",
+            disabled: confirmData?.validateDisabled ?? false,
+            onClick: () => resolveConfirm(true),
+          }}
         />
       </DialogContent>
     </Dialog>

--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -15,6 +15,7 @@ export type ConfirmDataType = {
   validateLabel?: string;
   validateVariant?: "primary" | "warning";
   validateDisabled?: boolean;
+  hideValidateButton?: boolean;
   cancelLabel?: string;
 };
 
@@ -95,12 +96,16 @@ export function ConfirmDialog({
             variant: "outline",
             onClick: () => resolveConfirm(false),
           }}
-          rightButtonProps={{
-            label: confirmData?.validateLabel ?? "OK",
-            variant: confirmData?.validateVariant ?? "warning",
-            disabled: confirmData?.validateDisabled ?? false,
-            onClick: () => resolveConfirm(true),
-          }}
+          rightButtonProps={
+            confirmData?.hideValidateButton
+              ? undefined
+              : {
+                  label: confirmData?.validateLabel ?? "OK",
+                  variant: confirmData?.validateVariant ?? "warning",
+                  disabled: confirmData?.validateDisabled ?? false,
+                  onClick: () => resolveConfirm(true),
+                }
+          }
         />
       </DialogContent>
     </Dialog>

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -188,7 +188,8 @@ export function useBlockedSkillSpaceRemovalConfirm({
             ))}
           </div>
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Update the skill to stop relying on these items, then remove the{" "}
+            Update the skill to stop relying on these items, then remove
+            the&nbsp;
             {spaceKind}.
           </p>
         </div>

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -6,7 +6,7 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceName } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types/space";
-import { DocumentIcon, Icon } from "@dust-tt/sparkle";
+import { Chip, DocumentIcon, Icon, ToolsIcon } from "@dust-tt/sparkle";
 import React, { useContext } from "react";
 
 function getActionDisplayName(
@@ -66,6 +66,12 @@ interface ConfirmRemoveSpaceParams {
   actions: BuilderAction[];
   knowledgeInInstructions?: KnowledgeToRemove[];
   skills?: SkillToRemove[];
+}
+
+interface ConfirmBlockedSkillSpaceRemovalParams {
+  space: SpaceType;
+  actions: BuilderAction[];
+  knowledgeInInstructions: KnowledgeToRemove[];
 }
 
 export function useRemoveSpaceConfirm({
@@ -135,6 +141,62 @@ export function useRemoveSpaceConfirm({
       validateLabel: "OK",
       validateVariant: "warning",
       validateDisabled: hasKnowledge,
+    });
+  };
+}
+
+export function useBlockedSkillSpaceRemovalConfirm({
+  mcpServerViews,
+}: {
+  mcpServerViews: MCPServerViewType[];
+}) {
+  const confirm = useContext(ConfirmContext);
+
+  return async ({
+    space,
+    actions,
+    knowledgeInInstructions,
+  }: ConfirmBlockedSkillSpaceRemovalParams): Promise<void> => {
+    const spaceKind = space.kind === "project" ? "project" : "space";
+
+    await confirm({
+      title: `${getSpaceName(space)} can't be removed`,
+      message: (
+        <div className="space-y-3">
+          <p className="text-sm">
+            This {spaceKind} can't be removed from the skill because the skill
+            uses knowledge or tools that belong to it.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {knowledgeInInstructions.map((knowledge) => (
+              <Chip
+                key={`knowledge-${knowledge.nodeId}`}
+                size="xs"
+                color="info"
+                icon={DocumentIcon}
+                label={knowledge.title}
+              />
+            ))}
+            {actions.map((action) => (
+              <Chip
+                key={`action-${action.id}`}
+                size="xs"
+                color="warning"
+                icon={ToolsIcon}
+                label={getActionDisplayName(action, mcpServerViews)}
+              />
+            ))}
+          </div>
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Update the skill to stop relying on these items, then remove the{" "}
+            {spaceKind}.
+          </p>
+        </div>
+      ),
+      cancelLabel: "Close",
+      validateLabel: "Remove",
+      validateVariant: "warning",
+      validateDisabled: true,
     });
   };
 }

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -1,4 +1,5 @@
 import { ConfirmContext } from "@app/components/Confirm";
+import { getIcon } from "@app/components/resources/resources_icons";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
@@ -6,7 +7,7 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceName } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types/space";
-import { Chip, DocumentIcon, Icon, ToolsIcon } from "@dust-tt/sparkle";
+import { BookOpenIcon, Chip, DocumentIcon, Icon } from "@dust-tt/sparkle";
 import React, { useContext } from "react";
 
 function getActionDisplayName(
@@ -33,6 +34,20 @@ function getActionIcon(
     return getAvatar(mcpServerView.server, "xs");
   }
   return null;
+}
+
+function getActionChipIcon(
+  action: BuilderAction,
+  mcpServerViews: MCPServerViewType[]
+) {
+  const mcpServerView = mcpServerViews.find(
+    (view) => view.sId === action.configuration.mcpServerViewId
+  );
+  if (!mcpServerView?.server) {
+    return BookOpenIcon;
+  }
+
+  return getIcon(mcpServerView.server.icon);
 }
 
 function getSkillIcon(skill: SkillToRemove): React.ReactNode {
@@ -182,7 +197,7 @@ export function useBlockedSkillSpaceRemovalConfirm({
                 key={`action-${action.id}`}
                 size="xs"
                 color="primary"
-                icon={ToolsIcon}
+                icon={getActionChipIcon(action, mcpServerViews)}
                 label={getActionDisplayName(action, mcpServerViews)}
               />
             ))}

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -172,15 +172,13 @@ export function useBlockedSkillSpaceRemovalConfirm({
     actions,
     knowledgeInInstructions,
   }: ConfirmBlockedSkillSpaceRemovalParams): Promise<boolean> => {
-    const spaceKind = space.kind === "project" ? "project" : "space";
-
     return confirm({
       title: `${getSpaceName(space)} can't be removed`,
       message: (
         <div className="space-y-3">
           <p className="text-sm">
-            This {spaceKind} can't be removed from the skill because the skill
-            uses knowledge or tools that belong to it.
+            This space can't be removed from the skill because the skill uses
+            knowledge or tools that belong to it.
           </p>
           <div className="flex flex-wrap gap-2">
             {knowledgeInInstructions.map((knowledge) => (
@@ -203,9 +201,8 @@ export function useBlockedSkillSpaceRemovalConfirm({
             ))}
           </div>
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Update the skill to stop relying on these items, then remove
-            the&nbsp;
-            {spaceKind}.
+            Update the skill to stop relying on these items, then remove the
+            space.
           </p>
         </div>
       ),

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -195,9 +195,7 @@ export function useBlockedSkillSpaceRemovalConfirm({
         </div>
       ),
       cancelLabel: "Close",
-      validateLabel: "Remove",
-      validateVariant: "warning",
-      validateDisabled: true,
+      hideValidateButton: true,
     });
   };
 }

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -172,7 +172,7 @@ export function useBlockedSkillSpaceRemovalConfirm({
               <Chip
                 key={`knowledge-${knowledge.nodeId}`}
                 size="xs"
-                color="info"
+                color="primary"
                 icon={DocumentIcon}
                 label={knowledge.title}
               />
@@ -181,7 +181,7 @@ export function useBlockedSkillSpaceRemovalConfirm({
               <Chip
                 key={`action-${action.id}`}
                 size="xs"
-                color="warning"
+                color="primary"
                 icon={ToolsIcon}
                 label={getActionDisplayName(action, mcpServerViews)}
               />

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -7,7 +7,7 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceName } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types/space";
-import { BookOpenIcon, Chip, DocumentIcon, Icon } from "@dust-tt/sparkle";
+import { Chip, DocumentIcon, Icon, ToolsIcon } from "@dust-tt/sparkle";
 import React, { useContext } from "react";
 
 function getActionDisplayName(
@@ -44,7 +44,7 @@ function getActionChipIcon(
     (view) => view.sId === action.configuration.mcpServerViewId
   );
   if (!mcpServerView?.server) {
-    return BookOpenIcon;
+    return ToolsIcon;
   }
 
   return getIcon(mcpServerView.server.icon);

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -195,7 +195,9 @@ export function useBlockedSkillSpaceRemovalConfirm({
         </div>
       ),
       cancelLabel: "Close",
-      hideValidateButton: true,
+      validateLabel: "Remove",
+      validateVariant: "warning",
+      validateDisabled: true,
     });
   };
 }

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -79,14 +79,14 @@ interface UseRemoveSpaceConfirmParams {
 interface ConfirmRemoveSpaceParams {
   space: SpaceType;
   actions: BuilderAction[];
-  knowledgeInInstructions?: KnowledgeToRemove[];
+  knowledge?: KnowledgeToRemove[];
   skills?: SkillToRemove[];
 }
 
 interface ConfirmBlockedSkillSpaceRemovalParams {
   space: SpaceType;
   actions: BuilderAction[];
-  knowledgeInInstructions: KnowledgeToRemove[];
+  knowledge: KnowledgeToRemove[];
 }
 
 export function useRemoveSpaceConfirm({
@@ -98,11 +98,11 @@ export function useRemoveSpaceConfirm({
   return ({
     space,
     actions,
-    knowledgeInInstructions = [],
+    knowledge = [],
     skills = [],
   }: ConfirmRemoveSpaceParams): Promise<boolean> => {
     const allItems: ItemToRemove[] = [
-      ...knowledgeInInstructions.map((k) => ({
+      ...knowledge.map((k) => ({
         id: k.nodeId,
         name: k.title,
         icon: <Icon visual={DocumentIcon} size="xs" />,
@@ -119,7 +119,7 @@ export function useRemoveSpaceConfirm({
       })),
     ];
 
-    const hasKnowledge = knowledgeInInstructions.length > 0;
+    const hasKnowledge = knowledge.length > 0;
 
     return confirm({
       title: `Remove ${getSpaceName(space)} ${space.kind === "project" ? "project" : "space"}`,
@@ -170,7 +170,7 @@ export function useBlockedSkillSpaceRemovalConfirm({
   return ({
     space,
     actions,
-    knowledgeInInstructions,
+    knowledge,
   }: ConfirmBlockedSkillSpaceRemovalParams): Promise<boolean> => {
     return confirm({
       title: `${getSpaceName(space)} can't be removed`,
@@ -181,13 +181,13 @@ export function useBlockedSkillSpaceRemovalConfirm({
             knowledge or tools that belong to it.
           </p>
           <div className="flex flex-wrap gap-2">
-            {knowledgeInInstructions.map((knowledge) => (
+            {knowledge.map((knowledgeItem) => (
               <Chip
-                key={`knowledge-${knowledge.nodeId}`}
+                key={`knowledge-${knowledgeItem.nodeId}`}
                 size="xs"
                 color="primary"
                 icon={DocumentIcon}
-                label={knowledge.title}
+                label={knowledgeItem.title}
               />
             ))}
             {actions.map((action) => (

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -80,7 +80,7 @@ export function useRemoveSpaceConfirm({
 }: UseRemoveSpaceConfirmParams) {
   const confirm = useContext(ConfirmContext);
 
-  return async ({
+  return ({
     space,
     actions,
     knowledgeInInstructions = [],

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -152,14 +152,14 @@ export function useBlockedSkillSpaceRemovalConfirm({
 }) {
   const confirm = useContext(ConfirmContext);
 
-  return async ({
+  return ({
     space,
     actions,
     knowledgeInInstructions,
-  }: ConfirmBlockedSkillSpaceRemovalParams): Promise<void> => {
+  }: ConfirmBlockedSkillSpaceRemovalParams): Promise<boolean> => {
     const spaceKind = space.kind === "project" ? "project" : "space";
 
-    await confirm({
+    return confirm({
       title: `${getSpaceName(space)} can't be removed`,
       message: (
         <div className="space-y-3">

--- a/front/components/shared/SpaceChips.tsx
+++ b/front/components/shared/SpaceChips.tsx
@@ -5,14 +5,9 @@ import { Chip } from "@dust-tt/sparkle";
 interface SpaceChipsProps {
   spaces: SpaceType[];
   onRemoveSpace: (space: SpaceType) => void;
-  canRemoveSpace?: (space: SpaceType) => boolean;
 }
 
-export function SpaceChips({
-  spaces,
-  onRemoveSpace,
-  canRemoveSpace,
-}: SpaceChipsProps) {
+export function SpaceChips({ spaces, onRemoveSpace }: SpaceChipsProps) {
   return (
     <div className="flex flex-wrap gap-2">
       {spaces.map((space) => (
@@ -22,9 +17,7 @@ export function SpaceChips({
           label={getSpaceName(space)}
           icon={getSpaceIcon(space)}
           onRemove={
-            space.kind !== "global" && (canRemoveSpace?.(space) ?? true)
-              ? () => onRemoveSpace(space)
-              : undefined
+            space.kind !== "global" ? () => onRemoveSpace(space) : undefined
           }
         />
       ))}

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -13,6 +13,7 @@ export const attachedKnowledgeSchema = z.object({
   spaceId: z.string(),
   title: z.string(),
 });
+export type AttachedKnowledgeFormData = z.infer<typeof attachedKnowledgeSchema>;
 
 const fileAttachmentSchema = z.object({
   fileId: z.string(),

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -4,7 +4,10 @@ import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActio
 import { useBlockedSkillSpaceRemovalConfirm } from "@app/components/shared/RemoveSpaceDialog";
 import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import type {
+  AttachedKnowledgeFormData,
+  SkillBuilderFormData,
+} from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { Button, ContentMessage, PlanetIcon } from "@dust-tt/sparkle";
@@ -86,10 +89,7 @@ export function SkillBuilderRequestedSpacesSection({
     (!initialRequestedSpaceIds || attachedKnowledge !== undefined);
 
   const knowledgeBySpaceId = useMemo(() => {
-    const knowledgeBySpace: Record<
-      string,
-      NonNullable<typeof attachedKnowledge>
-    > = {};
+    const knowledgeBySpace: Record<string, AttachedKnowledgeFormData[]> = {};
 
     for (const knowledge of attachedKnowledge ?? []) {
       knowledgeBySpace[knowledge.spaceId] = (

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -157,7 +157,7 @@ export function SkillBuilderRequestedSpacesSection({
       await confirmBlockedSpaceRemoval({
         space,
         actions: actionsBySpaceId[space.sId] ?? [],
-        knowledgeInInstructions: knowledgeBySpaceId[space.sId] ?? [],
+        knowledge: knowledgeBySpaceId[space.sId] ?? [],
       });
       return;
     }

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -201,7 +201,7 @@ export function SkillBuilderRequestedSpacesSection({
         <div className="mb-4 w-full">
           <ContentMessage variant="golden" size="lg">
             Based on your selection of spaces, knowledge, and tools, this skill
-            can only be used by users with access to:{" "}
+            can only be used by users with access to:&nbsp;
             <strong>
               {nonGlobalSpacesWithRestrictions
                 .map((space) => space.name)

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -167,13 +167,6 @@ export function SkillBuilderRequestedSpacesSection({
     );
   };
 
-  const canRemoveSpace = (space: SpaceType) => {
-    return (
-      areSpaceRequirementsReady &&
-      (additionalSpaceIds.has(space.sId) || spaceIdsUsedBySkill.has(space.sId))
-    );
-  };
-
   const handleOpenSheet = () => {
     if (!areSpaceRequirementsReady) {
       return;
@@ -238,11 +231,7 @@ export function SkillBuilderRequestedSpacesSection({
           </ContentMessage>
         </div>
       )}
-      <SpaceChips
-        spaces={spacesToDisplay}
-        onRemoveSpace={handleRemoveSpace}
-        canRemoveSpace={canRemoveSpace}
-      />
+      <SpaceChips spaces={spacesToDisplay} onRemoveSpace={handleRemoveSpace} />
 
       <SpaceSelectionSheet
         alreadyRequestedSpaceIds={spaceIdsUsedBySkill}

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -69,7 +69,7 @@ export function SkillBuilderRequestedSpacesSection({
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [draftSelectedSpaces, setDraftSelectedSpaces] = useState<string[]>([]);
 
-  const spaceIdToActions = useMemo(() => {
+  const actionsBySpaceId = useMemo(() => {
     return getSpaceIdToActionsMap(tools ?? [], mcpServerViews);
   }, [tools, mcpServerViews]);
 
@@ -78,12 +78,12 @@ export function SkillBuilderRequestedSpacesSection({
   }, [attachedKnowledge]);
 
   const spaceIdsUsedBySkill = useMemo(() => {
-    const actionRequestedSpaceIds = Object.keys(spaceIdToActions).filter(
-      (spaceId) => spaceIdToActions[spaceId]?.length > 0
+    const actionRequestedSpaceIds = Object.keys(actionsBySpaceId).filter(
+      (spaceId) => actionsBySpaceId[spaceId]?.length > 0
     );
 
     return new Set([...actionRequestedSpaceIds, ...spaceIdsFromKnowledge]);
-  }, [spaceIdToActions, spaceIdsFromKnowledge]);
+  }, [actionsBySpaceId, spaceIdsFromKnowledge]);
 
   const areSpaceRequirementsReady =
     !isMCPServerViewsLoading &&
@@ -156,7 +156,7 @@ export function SkillBuilderRequestedSpacesSection({
     if (spaceIdsUsedBySkill.has(space.sId)) {
       await confirmBlockedSpaceRemoval({
         space,
-        actions: spaceIdToActions[space.sId] ?? [],
+        actions: actionsBySpaceId[space.sId] ?? [],
         knowledgeInInstructions: knowledgeBySpaceId[space.sId] ?? [],
       });
       return;

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -10,6 +10,7 @@ import type {
 } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import { removeNulls } from "@app/types/shared/utils/general";
+import type { SpaceType } from "@app/types/space";
 import { Button, ContentMessage, PlanetIcon } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
 import { useController, useFormContext, useWatch } from "react-hook-form";
@@ -147,6 +148,32 @@ export function SkillBuilderRequestedSpacesSection({
     );
   }, [additionalSpaceIds, allSpaces, spaceIdsUsedBySkill]);
 
+  const handleRemoveSpace = async (space: SpaceType) => {
+    if (!areSpaceRequirementsReady) {
+      return;
+    }
+
+    if (spaceIdsUsedBySkill.has(space.sId)) {
+      await confirmBlockedSpaceRemoval({
+        space,
+        actions: spaceIdToActions[space.sId] ?? [],
+        knowledgeInInstructions: knowledgeBySpaceId[space.sId] ?? [],
+      });
+      return;
+    }
+
+    additionalSpacesField.onChange(
+      selectedAdditionalSpaces.filter((spaceId) => spaceId !== space.sId)
+    );
+  };
+
+  const canRemoveSpace = (space: SpaceType) => {
+    return (
+      areSpaceRequirementsReady &&
+      (additionalSpaceIds.has(space.sId) || spaceIdsUsedBySkill.has(space.sId))
+    );
+  };
+
   const handleOpenSheet = () => {
     if (!areSpaceRequirementsReady) {
       return;
@@ -213,29 +240,8 @@ export function SkillBuilderRequestedSpacesSection({
       )}
       <SpaceChips
         spaces={spacesToDisplay}
-        onRemoveSpace={async (space) => {
-          if (!areSpaceRequirementsReady) {
-            return;
-          }
-
-          if (spaceIdsUsedBySkill.has(space.sId)) {
-            await confirmBlockedSpaceRemoval({
-              space,
-              actions: spaceIdToActions[space.sId] ?? [],
-              knowledgeInInstructions: knowledgeBySpaceId[space.sId] ?? [],
-            });
-            return;
-          }
-
-          additionalSpacesField.onChange(
-            selectedAdditionalSpaces.filter((spaceId) => spaceId !== space.sId)
-          );
-        }}
-        canRemoveSpace={(space) =>
-          areSpaceRequirementsReady &&
-          (additionalSpaceIds.has(space.sId) ||
-            spaceIdsUsedBySkill.has(space.sId))
-        }
+        onRemoveSpace={handleRemoveSpace}
+        canRemoveSpace={canRemoveSpace}
       />
 
       <SpaceSelectionSheet

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -1,12 +1,12 @@
 import { SpaceSelectionSheet } from "@app/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActionsMap";
+import { useBlockedSkillSpaceRemovalConfirm } from "@app/components/shared/RemoveSpaceDialog";
 import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { SpaceType } from "@app/types/space";
 import { Button, ContentMessage, PlanetIcon } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
 import { useController, useFormContext, useWatch } from "react-hook-form";
@@ -38,6 +38,9 @@ export function SkillBuilderRequestedSpacesSection({
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
   const { spaces, owner, isSpacesLoading } = useSpacesContext();
+  const confirmBlockedSpaceRemoval = useBlockedSkillSpaceRemovalConfirm({
+    mcpServerViews,
+  });
 
   const missingSpaceIds = useMemo(() => {
     if (isSpacesLoading || !initialRequestedSpaceIds?.length) {
@@ -81,6 +84,21 @@ export function SkillBuilderRequestedSpacesSection({
   const areSpaceRequirementsReady =
     !isMCPServerViewsLoading &&
     (!initialRequestedSpaceIds || attachedKnowledge !== undefined);
+
+  const knowledgeBySpaceId = useMemo(() => {
+    const knowledgeBySpace: Record<
+      string,
+      NonNullable<typeof attachedKnowledge>
+    > = {};
+
+    for (const knowledge of attachedKnowledge ?? []) {
+      knowledgeBySpace[knowledge.spaceId] = (
+        knowledgeBySpace[knowledge.spaceId] ?? []
+      ).concat(knowledge);
+    }
+
+    return knowledgeBySpace;
+  }, [attachedKnowledge]);
 
   const initialAdditionalSpaces = useMemo(() => {
     if (!areSpaceRequirementsReady || !initialRequestedSpaceIds?.length) {
@@ -128,20 +146,6 @@ export function SkillBuilderRequestedSpacesSection({
           additionalSpaceIds.has(space.sId))
     );
   }, [additionalSpaceIds, allSpaces, spaceIdsUsedBySkill]);
-
-  const handleRemoveSpace = (space: SpaceType) => {
-    additionalSpacesField.onChange(
-      selectedAdditionalSpaces.filter((spaceId) => spaceId !== space.sId)
-    );
-  };
-
-  const canRemoveSpace = (space: SpaceType) => {
-    return (
-      areSpaceRequirementsReady &&
-      additionalSpaceIds.has(space.sId) &&
-      !spaceIdsUsedBySkill.has(space.sId)
-    );
-  };
 
   const handleOpenSheet = () => {
     if (!areSpaceRequirementsReady) {
@@ -209,8 +213,29 @@ export function SkillBuilderRequestedSpacesSection({
       )}
       <SpaceChips
         spaces={spacesToDisplay}
-        onRemoveSpace={handleRemoveSpace}
-        canRemoveSpace={canRemoveSpace}
+        onRemoveSpace={async (space) => {
+          if (!areSpaceRequirementsReady) {
+            return;
+          }
+
+          if (spaceIdsUsedBySkill.has(space.sId)) {
+            await confirmBlockedSpaceRemoval({
+              space,
+              actions: spaceIdToActions[space.sId] ?? [],
+              knowledgeInInstructions: knowledgeBySpaceId[space.sId] ?? [],
+            });
+            return;
+          }
+
+          additionalSpacesField.onChange(
+            selectedAdditionalSpaces.filter((spaceId) => spaceId !== space.sId)
+          );
+        }}
+        canRemoveSpace={(space) =>
+          areSpaceRequirementsReady &&
+          (additionalSpaceIds.has(space.sId) ||
+            spaceIdsUsedBySkill.has(space.sId))
+        }
       />
 
       <SpaceSelectionSheet


### PR DESCRIPTION
## Description

- Adds the Skill Builder follow-up flow for spaces required by a skill’s tools or knowledge.
- When a builder clicks the X on a required space chip, opens a dialog explaining that the space cannot be removed while the skill still depends on items from it.
- Shows the blocking knowledge and tool chips so builders can identify what to change before trying again.

<img width="1107" height="1214" alt="Screenshot 2026-05-19 at 11 15 03 AM" src="https://github.com/user-attachments/assets/f250ca21-77e1-4328-ab7f-f08172b36879" />

## Tests

- Tested locally.

## Risk

- Low, UI-only. Safe to rollback.

## Deploy Plan

- Deploy front
