### PR TITLE
[front] Allow removal of groups with associated keys

### DIFF
--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -941,7 +941,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
   });
 
   describe("API key validation", () => {
-    it("should fail to delete a regular space with active API keys in non-global groups", async () => {
+    it("should be able to delete a regular space with active API keys in non-global groups", async () => {
       const result = await createSpaceAndGroup(adminAuth, {
         name: "Test Regular Space With Keys",
         isRestricted: true,
@@ -966,17 +966,12 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
             space,
             false
           );
-          expect(deleteResult.isErr()).toBe(true);
-          if (deleteResult.isErr()) {
-            expect(deleteResult.error.message).toContain(
-              "Cannot delete group with active API Keys"
-            );
-          }
+          expect(deleteResult.isOk()).toBe(true);
         }
       }
     });
 
-    it("should fail to delete a project space with active API keys in non-global groups", async () => {
+    it("should be able to delete a project space with active API keys in non-global groups", async () => {
       vi.spyOn(
         await import("@app/lib/api/projects/connector"),
         "createDataSourceAndConnectorForProject"
@@ -1006,12 +1001,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
             space,
             false
           );
-          expect(deleteResult.isErr()).toBe(true);
-          if (deleteResult.isErr()) {
-            expect(deleteResult.error.message).toContain(
-              "Cannot delete group with active API Keys"
-            );
-          }
+          expect(deleteResult.isOk()).toBe(true);
         }
       }
     });

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -11,7 +11,6 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
-import { KeyResource } from "@app/lib/resources/key_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -95,20 +94,6 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
     return new Err(
       new Error(
         `Cannot delete space with data source or app in use by agent(s): ${agentNames.join(", ")}. If you'd like to continue set the force query parameter to true.`
-      )
-    );
-  }
-
-  const groupHasKeys = await KeyResource.countActiveForGroups(
-    auth,
-    space.groups.filter(
-      (g) => (!space.isRegular() && !space.isProject()) || !g.isGlobal()
-    )
-  );
-  if (groupHasKeys > 0) {
-    return new Err(
-      new Error(
-        "Cannot delete group with active API Keys. Please revoke all keys before."
       )
     );
   }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -50,7 +50,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op, QueryTypes } from "sequelize";
+import { col, fn, Op, QueryTypes } from "sequelize";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const BUILDER_GROUP_NAME = "dust-builders";
@@ -1961,13 +1961,18 @@ export class GroupResource extends BaseResource<GroupModel> {
       });
       const memberUserIds = activeMemberships.map((m) => m.userId);
 
-      await KeyModel.destroy({
-        where: {
-          groupIds: { [Op.contains]: [this.id] },
-          workspaceId: owner.id,
+      await KeyModel.update(
+        {
+          groupIds: fn("array_remove", col("groupIds"), this.id),
         },
-        transaction,
-      });
+        {
+          where: {
+            groupIds: { [Op.contains]: [this.id] },
+            workspaceId: owner.id,
+          },
+          transaction,
+        }
+      );
 
       await GroupSpaceModel.destroy({
         where: {


### PR DESCRIPTION
## Description

Allow deletion of groups/spaced linked to a key. Don't delete the key when we delete group.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front