### PR TITLE
Add stripe/metronome info in poke

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -214,6 +214,7 @@ export function WorkspacePage() {
                   owner={owner}
                   membersCount={membersCount}
                   metronomeCustomerId={metronomeCustomerId}
+                  stripeCustomerId={stripeCustomerId}
                   workspaceVerifiedDomains={workspaceVerifiedDomains}
                   workspaceCreationDay={workspaceCreationDay}
                   extensionConfig={extensionConfig}

--- a/front/components/poke/subscriptions/columns.tsx
+++ b/front/components/poke/subscriptions/columns.tsx
@@ -5,6 +5,9 @@ export type SubscriptionsDisplayType = {
   id: string;
   name: string;
   status: string;
+  stripeSubscriptionId: string | null;
+  metronomeContractId: string | null;
+  metronomeContractUrl: string | null;
   startDate: string | null;
   endDate: string | null;
   startDateValue: number | null; // timestamp for sorting
@@ -65,6 +68,25 @@ export function makeColumnsForSubscriptions(): ColumnDef<SubscriptionsDisplayTyp
         );
       },
       header: "stripeSubscriptionId",
+    },
+    {
+      accessorKey: "metronomeContractId",
+      cell: ({ row }) => {
+        const contractId = row.original.metronomeContractId;
+        const url = row.original.metronomeContractUrl;
+        if (!contractId) {
+          return null;
+        }
+        if (!url) {
+          return contractId;
+        }
+        return (
+          <a className="font-bold hover:underline" target="_blank" href={url}>
+            {contractId}
+          </a>
+        );
+      },
+      header: "metronomeContractId",
     },
     {
       accessorKey: "startDate",

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -119,11 +119,13 @@ const STATUS_CONFIG: Record<
 
 interface SubscriptionsDataTableProps {
   owner: WorkspaceType;
+  metronomeCustomerId: string | null;
   subscriptions: SubscriptionType[];
 }
 
 function prepareSubscriptionsForDisplay(
   owner: WorkspaceType,
+  metronomeCustomerId: string | null,
   subscriptions: SubscriptionType[]
 ): SubscriptionsDisplayType[] {
   return subscriptions.map((s) => {
@@ -132,6 +134,11 @@ function prepareSubscriptionsForDisplay(
       name: s.plan.code,
       status: s.status,
       stripeSubscriptionId: s.stripeSubscriptionId,
+      metronomeContractId: s.metronomeContractId,
+      metronomeContractUrl:
+        s.metronomeContractId && metronomeCustomerId
+          ? getMetronomeContractUrl(metronomeCustomerId, s.metronomeContractId)
+          : null,
       startDate: s.startDate
         ? `${new Date(s.startDate).toLocaleDateString()} ${new Date(
             s.startDate
@@ -150,6 +157,7 @@ function prepareSubscriptionsForDisplay(
 
 export function SubscriptionsDataTable({
   owner,
+  metronomeCustomerId,
   subscriptions,
 }: SubscriptionsDataTableProps) {
   return (
@@ -157,7 +165,11 @@ export function SubscriptionsDataTable({
       <h2 className="text-md mb-4 font-bold">History of subscriptions:</h2>
       <PokeDataTable
         columns={makeColumnsForSubscriptions()}
-        data={prepareSubscriptionsForDisplay(owner, subscriptions)}
+        data={prepareSubscriptionsForDisplay(
+          owner,
+          metronomeCustomerId,
+          subscriptions
+        )}
       />
     </div>
   );
@@ -198,6 +210,7 @@ export function ActiveSubscriptionTable({
             </h2>
             <SubscriptionsHistoryModal
               owner={owner}
+              metronomeCustomerId={metronomeCustomerId}
               subscriptions={subscriptions}
             />
             <UpgradeDowngradeModal
@@ -606,9 +619,11 @@ function UpgradeDowngradeModal({
 
 function SubscriptionsHistoryModal({
   owner,
+  metronomeCustomerId,
   subscriptions,
 }: {
   owner: WorkspaceType;
+  metronomeCustomerId: string | null;
   subscriptions: SubscriptionType[];
 }) {
   return (
@@ -621,7 +636,11 @@ function SubscriptionsHistoryModal({
           <SheetTitle>Workspace subscriptions history</SheetTitle>
         </SheetHeader>
         <SheetContainer>
-          <SubscriptionsDataTable owner={owner} subscriptions={subscriptions} />
+          <SubscriptionsDataTable
+            owner={owner}
+            metronomeCustomerId={metronomeCustomerId}
+            subscriptions={subscriptions}
+          />
         </SheetContainer>
       </SheetContent>
     </Sheet>

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -10,6 +10,7 @@ import { getMetronomeCustomerUrl } from "@app/lib/metronome/urls";
 import { usePokeWorkOSDSyncStatus } from "@app/lib/swr/poke";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import type { ExtensionConfigurationType } from "@app/types/extension";
+import { isDevelopment } from "@app/types/shared/env";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import type { WorkspaceDomain } from "@app/types/workspace";
@@ -19,6 +20,7 @@ export function WorkspaceInfoTable({
   owner,
   membersCount,
   metronomeCustomerId,
+  stripeCustomerId,
   workspaceVerifiedDomains,
   workspaceCreationDay,
   extensionConfig,
@@ -30,6 +32,7 @@ export function WorkspaceInfoTable({
   owner: WorkspaceType;
   membersCount: number;
   metronomeCustomerId: string | null;
+  stripeCustomerId: string | null;
   workspaceVerifiedDomains: WorkspaceDomain[];
   workspaceCreationDay: string;
   extensionConfig: ExtensionConfigurationType | null;
@@ -113,6 +116,26 @@ export function WorkspaceInfoTable({
                   >
                     {owner.workOSOrganizationId}
                   </LinkWrapper>
+                )}
+              </PokeTableCell>
+            </PokeTableRow>
+            <PokeTableRow>
+              <PokeTableCell>Stripe customer</PokeTableCell>
+              <PokeTableCell>
+                {stripeCustomerId ? (
+                  <LinkWrapper
+                    href={
+                      isDevelopment()
+                        ? `https://dashboard.stripe.com/test/customers/${stripeCustomerId}`
+                        : `https://dashboard.stripe.com/customers/${stripeCustomerId}`
+                    }
+                    target="_blank"
+                    className="text-xs text-highlight-400"
+                  >
+                    {stripeCustomerId}
+                  </LinkWrapper>
+                ) : (
+                  "Not provisioned"
                 )}
               </PokeTableCell>
             </PokeTableRow>


### PR DESCRIPTION
## Description

Add link to stripe customer (useful when you don't have stripe subscriptions anymore) , link to metronome contracts in history.

## Tests

locally

## Risk

low

## Deploy Plan

deploy front
