### PR TITLE
feat: update project conversation filter

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -147,6 +147,7 @@ export function SpaceConversationsTab({
   const isProjectEmpty = !isConversationsLoading && isSpaceEmpty;
   const isFilteredEmpty =
     !isConversationsLoading && !isSpaceEmpty && !hasHistory;
+  const isSingleMemberProject = spaceInfo.members.length === 1;
 
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
@@ -267,30 +268,32 @@ export function SpaceConversationsTab({
                   </div>
                 </div>
                 <div className="flex flex-row items-center justify-between gap-3">
-                  <ButtonsSwitchList
-                    key={conversationFilter}
-                    defaultValue={conversationFilter}
-                    size="xs"
-                  >
-                    <ButtonsSwitch
-                      value="group"
-                      label="Shared"
-                      tooltip="Show only threads where at least two people have sent messages."
-                      onClick={() => onConversationFilterChange("group")}
-                    />
-                    <ButtonsSwitch
-                      value="with_me"
-                      label="Just mine"
-                      tooltip="Show only conversations where you have sent a message."
-                      onClick={() => onConversationFilterChange("with_me")}
-                    />
-                    <ButtonsSwitch
-                      value="all"
-                      label="All project's"
-                      tooltip="Show every conversation in this project."
-                      onClick={() => onConversationFilterChange("all")}
-                    />
-                  </ButtonsSwitchList>
+                  {!isSingleMemberProject && (
+                    <ButtonsSwitchList
+                      key={conversationFilter}
+                      defaultValue={conversationFilter}
+                      size="xs"
+                    >
+                      <ButtonsSwitch
+                        value="with_me"
+                        label="Mine"
+                        tooltip="Conversations where you have sent a message."
+                        onClick={() => onConversationFilterChange("with_me")}
+                      />
+                      <ButtonsSwitch
+                        value="group"
+                        label="Group"
+                        tooltip="Conversations with more than one person"
+                        onClick={() => onConversationFilterChange("group")}
+                      />
+                      <ButtonsSwitch
+                        value="all"
+                        label="All"
+                        tooltip="Every conversation in this project."
+                        onClick={() => onConversationFilterChange("all")}
+                      />
+                    </ButtonsSwitchList>
+                  )}
                   <Button
                     size="xs"
                     variant="outline"

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -81,7 +81,10 @@ export function SpaceConversationsPage() {
       resourceId: spaceId,
       defaultValue: DEFAULT_SPACE_PROJECT_UI_PREFERENCES,
     });
-  const conversationFilter = projectUIPreferences.conversationsFilter;
+  const isSingleMemberProject = !!spaceInfo && spaceInfo.members.length === 1;
+  const conversationFilter: SpaceConversationListFilter = isSingleMemberProject
+    ? "all"
+    : projectUIPreferences.conversationsFilter;
 
   const {
     conversations,

--- a/front/hooks/useScopedUIPreferences.ts
+++ b/front/hooks/useScopedUIPreferences.ts
@@ -1,5 +1,5 @@
 import { normalizeTasksOwnerFilterFromPersistedBlob } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope";
-import { useCallback, useLayoutEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { z } from "zod";
 
 const SCOPED_UI_PREFERENCES_KEY_PREFIX = "scopedUIPreferences";
@@ -103,22 +103,24 @@ export function useScopedUIPreferences<
     return `${SCOPED_UI_PREFERENCES_KEY_PREFIX}:${scope}:${resourceId}`;
   }, [resourceId, scope]);
 
-  const readValue = useCallback((): ScopeValue<TScope> => {
+  const readValue = (): ScopeValue<TScope> => {
     if (!storageKey) {
       return defaultValue;
     }
     const candidateValue = readPersistedValue(storageKey);
     const parsedValue = schema.safeParse(candidateValue);
     return parsedValue.success ? parsedValue.data : defaultValue;
-  }, [defaultValue, schema, storageKey]);
+  };
 
   const [value, setValueState] = useState<ScopeValue<TScope>>(() =>
     readValue()
   );
+  const [seenStorageKey, setSeenStorageKey] = useState(storageKey);
 
-  useLayoutEffect(() => {
+  if (seenStorageKey !== storageKey) {
+    setSeenStorageKey(storageKey);
     setValueState(readValue());
-  }, [readValue]);
+  }
 
   const setValue = useCallback(
     (newValue: ScopeValue<TScope>) => {


### PR DESCRIPTION
## Description

This PR updates the conversation filter UI to match the new design.

- Hides the conversation filter buttons ("Mine", "Group", "All") when a project has only one member
- Updates filter button labels for clarity: "Shared" → "Mine", "Just mine" → "Group", "All project's" → "All"
- Refactors `useScopedUIPreferences` hook to remove unnecessary `useLayoutEffect` and convert `readValue` to a regular function

<img width="274" height="69" alt="Capture d’écran 2026-05-07 à 12 07 25" src="https://github.com/user-attachments/assets/e13fea00-5e0d-4470-bd62-81788b219487" />


## Tests

Manually

## Risks

Low

## Deploy Plan

Standard deployment - no special considerations needed.
