### PR TITLE
feat(project-task): thread runId as langfuse sessionId and drop scopedLogger

### DIFF
--- a/front/lib/project_task/analyze_document/index.ts
+++ b/front/lib/project_task/analyze_document/index.ts
@@ -20,7 +20,7 @@ import {
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { removeNulls } from "@app/types/shared/utils/general";
-import { startActiveObservation } from "@langfuse/tracing";
+import { startActiveObservation, updateActiveTrace } from "@langfuse/tracing";
 import type { Logger } from "pino";
 import { buildPromptForSourceType } from "./prompts";
 
@@ -50,25 +50,29 @@ async function callExtractActionItemsLLM(
   auth: Authenticator,
   {
     localLogger,
+    runId,
     model,
     specification,
     prompt,
     document,
   }: {
     localLogger: Logger;
+    runId: string;
     model: ModelConfigurationType;
     specification: AgentActionSpecification;
     prompt: string;
     document: TakeawaySourceDocument;
   }
-): Promise<{ extraction: ExtractionResult | null; scopedLogger: Logger }> {
+): Promise<ExtractionResult | null> {
   const owner = auth.getNonNullableWorkspace();
-  let scopedLogger = localLogger;
   const res = await startActiveObservation(
     "project-task-analyze-document",
     (span) => {
-      scopedLogger = localLogger.child({ langfuseSpanId: span.id });
-      scopedLogger.info("Document takeaway: LLM call started");
+      updateActiveTrace({ sessionId: runId });
+      localLogger.info(
+        { langfuseSpanId: span.id },
+        "Document takeaway: LLM call started"
+      );
 
       return runMultiActionsAgent(
         auth,
@@ -104,28 +108,28 @@ async function callExtractActionItemsLLM(
     }
   );
   if (res.isErr()) {
-    scopedLogger.error(
+    localLogger.error(
       { error: res.error },
       "Document takeaway: LLM call failed"
     );
-    return { extraction: null, scopedLogger };
+    return null;
   }
 
   const action = res.value.actions?.[0];
   if (!action?.arguments) {
-    scopedLogger.warn("Document takeaway: no tool call in LLM response");
-    return { extraction: null, scopedLogger };
+    localLogger.warn("Document takeaway: no tool call in LLM response");
+    return null;
   }
 
   const parsed = ExtractTakeawaysInputSchema.safeParse(action.arguments);
   if (!parsed.success) {
-    scopedLogger.warn(
+    localLogger.warn(
       { error: parsed.error, arguments: action.arguments },
       "Document takeaway: failed to parse LLM response"
     );
-    return { extraction: null, scopedLogger };
+    return null;
   }
-  return { extraction: parsed.data, scopedLogger };
+  return parsed.data;
 }
 
 // Maps raw LLM-extracted items to typed action items, reusing sIds from the
@@ -157,10 +161,12 @@ export async function extractDocumentTakeaways(
   auth: Authenticator,
   {
     localLogger: parentLogger,
+    runId,
     spaceId,
     document,
   }: {
     localLogger: Logger;
+    runId: string;
     spaceId: string;
     document: TakeawaySourceDocument;
   }
@@ -201,15 +207,16 @@ export async function extractDocumentTakeaways(
     .join("\n\n");
   const specification = buildSpec();
 
-  const { extraction, scopedLogger } = await callExtractActionItemsLLM(auth, {
+  const extraction = await callExtractActionItemsLLM(auth, {
     localLogger,
+    runId,
     model,
     specification,
     prompt,
     document,
   });
   if (!extraction) {
-    scopedLogger.error("Document takeaway: no extraction result");
+    localLogger.error("Document takeaway: no extraction result");
     return null;
   }
 
@@ -232,7 +239,7 @@ export async function extractDocumentTakeaways(
     },
     previousActionItems,
     validAssigneesUserIds,
-    scopedLogger
+    localLogger
   );
 
   const stats: ExtractedTakeawayStats = {
@@ -240,7 +247,7 @@ export async function extractDocumentTakeaways(
   };
 
   if (stats.actionItems === 0) {
-    scopedLogger.info("Document takeaway: no takeaways extracted");
+    localLogger.info("Document takeaway: no takeaways extracted");
     return stats;
   }
 
@@ -250,7 +257,7 @@ export async function extractDocumentTakeaways(
     actionItems,
   });
 
-  scopedLogger.info(
+  localLogger.info(
     {
       ...stats,
     },

--- a/front/lib/project_task/deduplicate_candidates.ts
+++ b/front/lib/project_task/deduplicate_candidates.ts
@@ -35,7 +35,7 @@ import type { ProjectTaskResource } from "@app/lib/resources/project_task_resour
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
-import { startActiveObservation } from "@langfuse/tracing";
+import { startActiveObservation, updateActiveTrace } from "@langfuse/tracing";
 import type { Logger } from "pino";
 import { z } from "zod";
 
@@ -47,22 +47,18 @@ export type DeduplicateCandidate = {
   text: string;
 };
 
-// One task that Phase 3 will touch. `scopedLogger` carries the langfuseSpanId
-// of the LLM call that produced the group (or the unscoped logger when no LLM
-// call was made).
+// One task that Phase 3 will touch.
 export type DeduplicatedGroup =
   | {
       kind: "existing";
       task: ProjectTaskResource;
       candidates: DeduplicateCandidate[];
-      scopedLogger: Logger;
     }
   | {
       kind: "new";
       // Non-empty. candidates[0] drives the new task's content; later entries
       // attach their sources to that task.
       candidates: DeduplicateCandidate[];
-      scopedLogger: Logger;
     };
 
 // ── LLM tool ─────────────────────────────────────────────────────────────────
@@ -154,16 +150,18 @@ export async function runDeduplicationLLMCall(
   auth: Authenticator,
   {
     localLogger,
+    runId,
     model,
     candidates,
     existingTasks,
   }: {
     localLogger: Logger;
+    runId: string;
     model: ModelConfigurationType;
     candidates: DeduplicateCandidate[];
     existingTasks: ProjectTaskResource[];
   }
-): Promise<{ groups: number[][]; scopedLogger: Logger }> {
+): Promise<number[][]> {
   const owner = auth.getNonNullableWorkspace();
   const prompt = buildDeduplicationPrompt(existingTasks, candidates);
   const specification = buildDeduplicationSpec();
@@ -178,13 +176,12 @@ export async function runDeduplicationLLMCall(
     ],
   };
 
-  let scopedLogger = localLogger;
   const res = await startActiveObservation(
     "project-task-deduplicate-candidates",
     (span) => {
-      scopedLogger = localLogger.child({ langfuseSpanId: span.id });
-      scopedLogger.info(
-        { workspaceId: owner.sId },
+      updateActiveTrace({ sessionId: runId });
+      localLogger.info(
+        { langfuseSpanId: span.id },
         "Project task dedup: LLM call started"
       );
 
@@ -215,32 +212,32 @@ export async function runDeduplicationLLMCall(
   );
 
   if (res.isErr()) {
-    scopedLogger.warn(
+    localLogger.warn(
       { error: res.error, workspaceId: owner.sId },
       "Project task dedup: LLM call failed, treating all candidates as new"
     );
-    return { groups: [], scopedLogger };
+    return [];
   }
 
   const action = res.value.actions?.[0];
   if (!action?.arguments) {
-    scopedLogger.warn(
+    localLogger.warn(
       { workspaceId: owner.sId },
       "Project task dedup: no tool call in LLM response, treating all as new"
     );
-    return { groups: [], scopedLogger };
+    return [];
   }
 
   const parsed = DeduplicationResultSchema.safeParse(action.arguments);
   if (!parsed.success) {
-    scopedLogger.warn(
+    localLogger.warn(
       { error: parsed.error, workspaceId: owner.sId },
       "Project task dedup: failed to parse LLM response, treating all as new"
     );
-    return { groups: [], scopedLogger };
+    return [];
   }
 
-  return { groups: parsed.data.groups, scopedLogger };
+  return parsed.data.groups;
 }
 
 // ── Group resolution ─────────────────────────────────────────────────────────
@@ -337,11 +334,13 @@ export async function batchDeduplicateCandidates(
   auth: Authenticator,
   {
     localLogger,
+    runId,
     model,
     candidates,
     existingTasks,
   }: {
     localLogger: Logger;
+    runId: string;
     model: ModelConfigurationType;
     candidates: DeduplicateCandidate[];
     existingTasks: ProjectTaskResource[];
@@ -355,7 +354,7 @@ export async function batchDeduplicateCandidates(
 
   // Fast path: single candidate with no existing tasks needs no LLM call.
   if (existingTasks.length === 0 && candidates.length === 1) {
-    return [{ kind: "new", candidates, scopedLogger: localLogger }];
+    return [{ kind: "new", candidates }];
   }
 
   const totalItems = existingTasks.length + candidates.length;
@@ -383,17 +382,13 @@ export async function batchDeduplicateCandidates(
     );
   }
 
-  const { groups: llmGroups, scopedLogger } = await runDeduplicationLLMCall(
-    auth,
-    {
-      localLogger,
-      model,
-      candidates,
-      existingTasks,
-    }
-  );
+  const llmGroups = await runDeduplicationLLMCall(auth, {
+    localLogger,
+    runId,
+    model,
+    candidates,
+    existingTasks,
+  });
 
-  return resolveDeduplicationGroups(candidates, existingTasks, llmGroups).map(
-    (group) => ({ ...group, scopedLogger })
-  );
+  return resolveDeduplicationGroups(candidates, existingTasks, llmGroups);
 }

--- a/front/lib/project_task/merge_into_project.test.ts
+++ b/front/lib/project_task/merge_into_project.test.ts
@@ -173,7 +173,6 @@ describe("createOrLinkTasks", () => {
       candidates: [
         { itemId: "item-x", userId: 1 as ModelId, text: "Do the thing" },
       ],
-      scopedLogger: fakeLogger,
     };
 
     const { deduplicated, createdNew } = await createOrLinkTasks(fakeAuth, {
@@ -220,7 +219,6 @@ describe("createOrLinkTasks", () => {
       candidates: [
         { itemId: "item-y", userId: 1 as ModelId, text: "Do the thing" },
       ],
-      scopedLogger: fakeLogger,
     };
 
     const { deduplicated, createdNew } = await createOrLinkTasks(fakeAuth, {

--- a/front/lib/project_task/merge_into_project.ts
+++ b/front/lib/project_task/merge_into_project.ts
@@ -95,10 +95,12 @@ function emptyMergeStats(): MergeStats {
 
 export async function mergeTakeawaysIntoProject({
   localLogger,
+  runId,
   workspaceId,
   spaceId,
 }: {
   localLogger: Logger;
+  runId: string;
   workspaceId: string;
   spaceId: string;
 }): Promise<MergeStats> {
@@ -160,6 +162,7 @@ export async function mergeTakeawaysIntoProject({
 
   const dedupGroups = await buildDeduplicationGroups(adminAuth, {
     localLogger,
+    runId,
     newCandidates: assignedCandidates,
     spaceModelId,
   });
@@ -295,10 +298,12 @@ async function buildDeduplicationGroups(
   auth: Authenticator,
   {
     localLogger,
+    runId,
     newCandidates,
     spaceModelId,
   }: {
     localLogger: Logger;
+    runId: string;
     newCandidates: PendingCandidate[];
     spaceModelId: ModelId;
   }
@@ -314,11 +319,7 @@ async function buildDeduplicationGroups(
     localLogger.warn(
       "Project task merge: no whitelisted model, skipping deduplication"
     );
-    return dedupInput.map((c) => ({
-      kind: "new",
-      candidates: [c],
-      scopedLogger: localLogger,
-    }));
+    return dedupInput.map((c) => ({ kind: "new", candidates: [c] }));
   }
 
   // Fetch all existing tasks for the space in one pass (including deleted).
@@ -330,6 +331,7 @@ async function buildDeduplicationGroups(
 
   return batchDeduplicateCandidates(auth, {
     localLogger,
+    runId,
     model,
     candidates: dedupInput,
     existingTasks,
@@ -393,7 +395,7 @@ export async function createOrLinkTasks(
           });
           deduplicated++;
 
-          group.scopedLogger.info(
+          localLogger.info(
             {
               existingTaskId: group.task.sId,
               itemId: pending.itemId,
@@ -432,7 +434,7 @@ export async function createOrLinkTasks(
       });
       createdNew++;
 
-      group.scopedLogger.info(
+      localLogger.info(
         {
           taskId: task.sId,
           itemId: primary.itemId,
@@ -453,7 +455,7 @@ export async function createOrLinkTasks(
         });
         deduplicated++;
 
-        group.scopedLogger.info(
+        localLogger.info(
           {
             taskId: task.sId,
             itemId: pending.itemId,

--- a/front/temporal/project_task/activities.ts
+++ b/front/temporal/project_task/activities.ts
@@ -78,14 +78,13 @@ function resultToTakeawaySourceDocument(
   return null;
 }
 
-async function runChecksAndGetValues({
+async function resolveProjectTaskContext({
   workspaceId,
   spaceId,
   localLogger,
 }: {
   workspaceId: string;
   spaceId: string;
-  runId: string;
   localLogger: typeof logger;
 }): Promise<
   Result<
@@ -135,10 +134,9 @@ export async function analyzeProjectTodosActivity({
 
   localLogger.info("Starting project todo analysis");
 
-  const checkResult = await runChecksAndGetValues({
+  const checkResult = await resolveProjectTaskContext({
     workspaceId,
     spaceId,
-    runId,
     localLogger,
   });
   if (checkResult.isErr()) {
@@ -243,6 +241,7 @@ export async function analyzeProjectTodosActivity({
     async (document) => {
       const result = await extractDocumentTakeaways(auth, {
         localLogger,
+        runId,
         spaceId,
         document,
       });
@@ -285,10 +284,9 @@ export async function mergeTasksForProjectActivity({
 
   localLogger.info("Starting merge of project todo takeaways");
 
-  const checkResult = await runChecksAndGetValues({
+  const checkResult = await resolveProjectTaskContext({
     workspaceId,
     spaceId,
-    runId,
     localLogger,
   });
   if (checkResult.isErr()) {
@@ -297,6 +295,7 @@ export async function mergeTasksForProjectActivity({
 
   const stats = await mergeTakeawaysIntoProject({
     localLogger,
+    runId,
     workspaceId,
     spaceId,
   });

--- a/front/tests/dedup-evals/lib/dedup-executor.ts
+++ b/front/tests/dedup-evals/lib/dedup-executor.ts
@@ -53,8 +53,9 @@ export async function executeDedup(
   const existingTodos = buildMockExistingTodos(testCase);
   const candidates = buildCandidates(testCase);
 
-  const { groups: llmGroups } = await runDeduplicationLLMCall(auth, {
+  const llmGroups = await runDeduplicationLLMCall(auth, {
     localLogger: logger,
+    runId: "eval-run",
     model,
     candidates,
     existingTasks: existingTodos,


### PR DESCRIPTION
## Description

Correlates all LLM calls within a single `projectTodoWorkflow` iteration under one Langfuse session ID, making it possible to trace a full iteration end-to-end in Langfuse.

**What changed:**
- `analyzeProjectTodosActivity` and `mergeTasksForProjectActivity` both receive `runId` (the `uuid4()` minted per iteration in the workflow). This ID is now passed all the way into the `startActiveObservation` callbacks via `updateActiveTrace({ sessionId: runId })`, so every LLM span for a given iteration shares the same Langfuse session.
- Removed the `scopedLogger` pattern (which carried `langfuseSpanId` back up the call stack). This was the mechanism used before to correlate log lines with Langfuse spans. It is no longer needed because the `runId` is already in the activity-level logger and is now also the Langfuse session ID.
- Same treatment applied to `runDeduplicationLLMCall` / `batchDeduplicateCandidates` (merge phase).
- `DeduplicatedGroup` type no longer carries `scopedLogger`.

## Tests

Existing unit tests updated (removed `scopedLogger` from `DeduplicatedGroup` fixtures). No functional behaviour changed.

## Risk

Low — pure observability/logging change. No production logic altered.
