### PR TITLE
[IMAGE-GENERATION] EU fallback to gpt-image-1.5 + custom OpenAI base URL

### DIFF
--- a/front/lib/api/llm/clients/openai/imageGeneration.ts
+++ b/front/lib/api/llm/clients/openai/imageGeneration.ts
@@ -74,7 +74,7 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
       credentials,
     }: {
       modelId: ImageModelIdType;
-      credentials: { OPENAI_API_KEY?: string };
+      credentials: { OPENAI_API_KEY?: string; OPENAI_BASE_URL?: string };
     }
   ) {
     super(auth, { modelId, credentials });
@@ -82,7 +82,10 @@ export class ImageGenerationOpenAILLM extends ImageGenerationLLM {
     this.supportedContentTypes = ["image/jpeg", "image/png", "image/webp"];
 
     assert(credentials.OPENAI_API_KEY, "OPENAI_API_KEY credential is required");
-    this.client = new OpenAI({ apiKey: credentials.OPENAI_API_KEY });
+    this.client = new OpenAI({
+      apiKey: credentials.OPENAI_API_KEY,
+      baseURL: credentials.OPENAI_BASE_URL,
+    });
   }
 
   async generateImage(

--- a/front/lib/api/llm/getImageGenerationLLM.test.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.test.ts
@@ -34,7 +34,10 @@ vi.mock("@app/lib/api/regions/config", () => ({
 
 import { Authenticator } from "@app/lib/auth";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
-import { GPT_IMAGE_2_MODEL_ID } from "@app/types/assistant/models/openai";
+import {
+  GPT_IMAGE_1_5_MODEL_ID,
+  GPT_IMAGE_2_MODEL_ID,
+} from "@app/types/assistant/models/openai";
 
 import { getImageGenerationLLM } from "./getImageGenerationLLM";
 
@@ -189,7 +192,7 @@ describe("getImageGenerationLLM", () => {
     });
   });
 
-  it("returns null in the EU region when only openai is whitelisted", async () => {
+  it("falls back to OpenAI gpt-image-1.5 in the EU region when only openai is whitelisted", async () => {
     mockGetCurrentRegion.mockReturnValue("europe-west1");
     mockIsProviderWhitelisted.mockImplementation(
       (_auth, providerId) => providerId === "openai"
@@ -197,8 +200,14 @@ describe("getImageGenerationLLM", () => {
 
     const llm = await getImageGenerationLLM(auth);
 
-    expect(llm).toBeNull();
-    expect(mockOpenAIImageGenerationLLM).not.toHaveBeenCalled();
+    expect(mockOpenAIImageGenerationLLM).toHaveBeenCalledWith(auth, {
+      modelId: GPT_IMAGE_1_5_MODEL_ID,
+      credentials: CREDENTIALS,
+    });
     expect(mockGoogleImageGenerationLLM).not.toHaveBeenCalled();
+    expect(llm).toEqual({
+      provider: "openai",
+      args: { modelId: GPT_IMAGE_1_5_MODEL_ID, credentials: CREDENTIALS },
+    });
   });
 });

--- a/front/lib/api/llm/getImageGenerationLLM.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.ts
@@ -6,7 +6,10 @@ import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
-import { GPT_IMAGE_2_MODEL_ID } from "@app/types/assistant/models/openai";
+import {
+  GPT_IMAGE_1_5_MODEL_ID,
+  GPT_IMAGE_2_MODEL_ID,
+} from "@app/types/assistant/models/openai";
 
 export async function getImageGenerationLLM(
   auth: Authenticator
@@ -15,8 +18,8 @@ export async function getImageGenerationLLM(
     skipEmbeddingApiKeyRequirement: true,
   });
 
-  // gpt-image-2 is not available from the EU region, so EU workspaces fall
-  // back to Gemini for image generation.
+  // gpt-image-2 is not eligible to EU data residency yet, so EU workspaces fall
+  // back to Gemini for image generation if workspace-enabled, or image 1.5.
   const isEuRegion = regionConfig.getCurrentRegion() === "europe-west1";
 
   if (!isEuRegion && isProviderWhitelisted(auth, "openai")) {
@@ -29,6 +32,13 @@ export async function getImageGenerationLLM(
   if (isProviderWhitelisted(auth, "google_ai_studio")) {
     return new ImageGenerationGoogleLLM(auth, {
       modelId: GEMINI_3_PRO_IMAGE_MODEL_ID,
+      credentials,
+    });
+  }
+
+  if (isProviderWhitelisted(auth, "openai")) {
+    return new ImageGenerationOpenAILLM(auth, {
+      modelId: GPT_IMAGE_1_5_MODEL_ID,
       credentials,
     });
   }


### PR DESCRIPTION
## Description

EU workspaces couldn't generate images via OpenAI because `gpt-image-2` is not yet eligible to EU data residency, and they only had a fallback to Gemini (which requires the Google AI Studio provider to be whitelisted). This PR adds a final fallback to `gpt-image-1.5` (which is EU-eligible) when only OpenAI is whitelisted, and threads `OPENAI_BASE_URL` through the OpenAI image client so EU OpenAI traffic can be routed to a region-specific endpoint.

Resolution order is now:
1. Non-EU + OpenAI whitelisted → `gpt-image-2`
2. Google AI Studio whitelisted → `gemini-3-pro-image`
3. OpenAI whitelisted → `gpt-image-1.5` (new EU fallback)

## Tests

Tested in front-edge with Dust (EU) workspace

## Risk

Low. Additive change — it only introduces a new fallback branch for workspaces that previously returned `null` from `getImageGenerationLLM`. `OPENAI_BASE_URL` is optional and defaults to the standard OpenAI endpoint when unset.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`