### PR TITLE
fix: skip task conversation notification

### DIFF
--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -95,7 +95,7 @@ const triggerProjectNewConversationNotifications = async (
   }
 
   // Skip notification for conversations created from a todo.
-  if (conversation.metadata?.projectTodoId) {
+  if (conversation.metadata?.projectTaskId) {
     return new Ok(undefined);
   }
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -448,7 +448,7 @@ export const CONVERSATION_METADATA_URL_ACCESS_MODE_KEY = "urlAccessMode";
 
 export type ConversationMetadata = Record<string, unknown> & {
   urlAccessMode?: ConversationUrlAccessMode;
-  projectTodoId?: string;
+  projectTaskId?: string;
   useFileSystem?: boolean;
 };
 


### PR DESCRIPTION
## Description

This PR fixes the notification skip logic for task-created conversations by checking the metadata field `projectTaskId` instead of `projectTodoId`.


## Tests

Manually

## Risks

Low

## Deploy Plan

Standard deployment.