### PR TITLE
Remove support to explicitly cat audio file

### DIFF
--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -9,12 +9,7 @@ import {
   isReadableAsText,
   resolveConversationFile,
 } from "@app/lib/api/actions/servers/files/tools/utils";
-import { makeProcessedMountFileName } from "@app/lib/api/files/mount_path";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import {
-  isLLMVisionSupportedImageContentType,
-  isSupportedAudioContentType,
-} from "@app/types/files";
+import { isLLMVisionSupportedImageContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -53,30 +48,6 @@ function catImage(
         imageContentType: mimeType,
       },
     },
-  ]);
-}
-
-async function catAudio(
-  file: GCSFile,
-  path: string,
-  startLine: number,
-  maxLines: number
-): Promise<ToolHandlerResult> {
-  const processedGcsPath = makeProcessedMountFileName({
-    mountFilePath: file.name,
-    processedContentType: "text/plain",
-  });
-  const processedFile = getPrivateUploadBucket().file(processedGcsPath);
-  try {
-    const [exists] = await processedFile.exists();
-    if (exists) {
-      return catText(processedFile, path, startLine, maxLines);
-    }
-  } catch {
-    // Fall through to the empty transcript message.
-  }
-  return new Ok([
-    { type: "text", text: `\`${path}\` has no transcript available.` },
   ]);
 }
 
@@ -173,10 +144,6 @@ export async function catHandler(
 
   if (isLLMVisionSupportedImageContentType(mimeType)) {
     return catImage(file, { path, mimeType, sizeBytes });
-  }
-
-  if (isSupportedAudioContentType(mimeType)) {
-    return catAudio(file, path, offset ?? 1, limit ?? CAT_LINES_DEFAULT);
   }
 
   if (!isReadableAsText(mimeType)) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Since https://github.com/dust-tt/dust/pull/25348, all processed files (including audio files) can now be listed and read by the LLMs. A "tir-croisé" explicitly added support for this in https://github.com/dust-tt/dust/pull/25346, this isn't required anymore.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
