### PR TITLE
Dust-hive: set env to dev to init pro plans

### DIFF
--- a/x/henry/dust-hive/src/lib/init.ts
+++ b/x/henry/dust-hive/src/lib/init.ts
@@ -365,11 +365,17 @@ async function runFrontDbInit(env: Environment): Promise<boolean> {
   // Commands and their expected completion markers
   // Both init_db.sh and init_plans.sh print "Done" when they complete successfully
   const commands = [
-    { cmd: "./admin/init_db.sh --unsafe", name: "init_db", expectDone: true },
-    { cmd: "./admin/init_plans.sh", name: "init_plans", expectDone: true },
+    { cmd: "./admin/init_db.sh --unsafe", name: "init_db", expectDone: true, env: {} },
+    {
+      cmd: "./admin/init_plans.sh",
+      name: "init_plans",
+      expectDone: true,
+      // pro plans are empty if not in development/test mode
+      env: { NODE_ENV: "development" },
+    },
   ];
 
-  for (const { cmd, name, expectDone } of commands) {
+  for (const { cmd, name, expectDone, env } of commands) {
     const command = buildShell({
       sourceEnv: envShPath,
       sourceNvm: true,
@@ -378,6 +384,7 @@ async function runFrontDbInit(env: Environment): Promise<boolean> {
 
     const proc = Bun.spawn(["bash", "-c", command], {
       cwd: `${worktreePath}/front`,
+      env: { ...process.env, ...env },
       stdout: "pipe",
       stderr: "pipe",
     });


### PR DESCRIPTION
## Description

See

https://github.com/dust-tt/dust/blob/a0862a91a71927f5f7a75a1e59bc878f49400e64/front/lib/plans/pro_plans.ts#L31-L33

We only get the free plans otherwise

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low, it's dust-hive

## Deploy Plan

none
