### PR TITLE
[sandbox] dev-only escape hatch for unrestricted egress

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -552,6 +552,20 @@ const config = {
       "SBX_DEV_FRONT_URL"
     )?.replace(/^https?:\/\//, "");
   },
+  // Dev-only switch to fully unrestrict sandbox network egress: skips the
+  // dsbx forwarder, tears down in-sandbox nftables redirect, and lets E2B
+  // allow all outbound traffic. Only honored when isDevelopment() to avoid
+  // accidental enablement in production.
+  getSandboxDevUnrestrictedEgress: (): boolean => {
+    if (!isDevelopment()) {
+      return false;
+    }
+    return (
+      EnvironmentConfig.getOptionalEnvVariable(
+        "SBX_DEV_UNRESTRICTED_EGRESS"
+      ) === "true"
+    );
+  },
   getSandboxGcpArtifactServiceAccountPath: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(
       "SBX_GCP_ARTIFACT_SERVICE_ACCOUNT"

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -1,6 +1,6 @@
 import { Err, Ok } from "@app/types/shared/result";
 import jwt from "jsonwebtoken";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockGetEgressProxyHost,
@@ -58,6 +58,7 @@ import {
   mintEgressJwt,
   readNewDenyLogEntries,
   setupEgressForwarder,
+  teardownInSandboxEgressRedirect,
 } from "./egress";
 
 describe("sandbox egress helpers", () => {
@@ -306,5 +307,89 @@ describe("sandbox egress helpers", () => {
     const startCall = sandbox.exec.mock.calls[1][1] as string;
     expect(startCall).not.toContain("--mitm-experiment-host");
     expect(startCall).not.toContain("--mitm-ca-path");
+  });
+
+  describe("teardownInSandboxEgressRedirect", () => {
+    const originalIsDev = process.env.IS_DEVELOPMENT;
+
+    beforeEach(() => {
+      process.env.IS_DEVELOPMENT = "true";
+    });
+
+    afterEach(() => {
+      if (originalIsDev === undefined) {
+        delete process.env.IS_DEVELOPMENT;
+      } else {
+        process.env.IS_DEVELOPMENT = originalIsDev;
+      }
+    });
+
+    it("tears down the in-sandbox nftables redirect", async () => {
+      const sandbox = {
+        providerId: "provider-sandbox-id",
+        sId: "sandbox-id",
+        exec: vi
+          .fn()
+          .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
+      };
+
+      const result = await teardownInSandboxEgressRedirect(
+        auth,
+        sandbox as never
+      );
+
+      expect(result).toEqual(new Ok(undefined));
+      expect(sandbox.exec).toHaveBeenCalledTimes(1);
+      const command = sandbox.exec.mock.calls[0][1] as string;
+      expect(command).toContain(
+        "systemctl disable --now dust-egress-nftables.service"
+      );
+      expect(command).toContain("nft delete table ip dust-egress");
+      expect(command).toContain("nft delete table ip6 dust-egress");
+      expect(sandbox.exec).toHaveBeenCalledWith(auth, expect.any(String), {
+        user: "root",
+      });
+    });
+
+    it("propagates exec failures as Err", async () => {
+      const sandbox = {
+        providerId: "provider-sandbox-id",
+        sId: "sandbox-id",
+        exec: vi
+          .fn()
+          .mockResolvedValue(new Err(new Error("sandbox command failed"))),
+      };
+
+      const result = await teardownInSandboxEgressRedirect(
+        auth,
+        sandbox as never
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("sandbox command failed");
+      }
+    });
+
+    it("refuses to run outside dev mode", async () => {
+      delete process.env.IS_DEVELOPMENT;
+
+      const sandbox = {
+        providerId: "provider-sandbox-id",
+        sId: "sandbox-id",
+        exec: vi.fn(),
+      };
+
+      const result = await teardownInSandboxEgressRedirect(
+        auth,
+        sandbox as never
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("dev-only");
+      }
+      expect(sandbox.exec).not.toHaveBeenCalled();
+    });
   });
 });

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -4,6 +4,7 @@ import { config as regionConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
+import { isDevelopment } from "@app/types/shared/env";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import jwt from "jsonwebtoken";
 
@@ -140,6 +141,84 @@ export async function checkEgressForwarderHealth(
   }
 
   return new Ok(healthResult.value.exitCode === 0);
+}
+
+// Egress prep that runs before GCS mounts: in prod, starts the forwarder; in
+// dev-unrestricted mode, tears down the in-sandbox nftables redirect so
+// traffic flows direct out of the (now permissive) E2B network. Pairs with
+// the network policy chosen in getSandboxImage().
+export async function prepareSandboxEgressBeforeMount(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<void, Error>> {
+  if (config.getSandboxDevUnrestrictedEgress()) {
+    return teardownInSandboxEgressRedirect(auth, sandbox);
+  }
+  return setupEgressForwarder(auth, sandbox);
+}
+
+// Egress check that runs after GCS mounts on every exec: in prod, verifies
+// the forwarder is still healthy and restarts it if not. In dev-unrestricted
+// mode, re-runs the teardown when resuming from sleep (where systemd may have
+// re-enabled the unit on the next boot); otherwise no-op.
+export async function ensureSandboxEgressOnExec(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  { wokeFromSleep }: { wokeFromSleep: boolean }
+): Promise<Result<void, Error>> {
+  if (config.getSandboxDevUnrestrictedEgress()) {
+    if (wokeFromSleep) {
+      return teardownInSandboxEgressRedirect(auth, sandbox);
+    }
+    return new Ok(undefined);
+  }
+
+  const healthResult = await checkEgressForwarderHealth(auth, sandbox);
+  if (healthResult.isErr()) {
+    return healthResult;
+  }
+
+  const logContext = {
+    event: healthResult.value ? "egress.health_ok" : "egress.health_fail",
+    providerId: sandbox.providerId,
+    sandboxId: sandbox.sId,
+  };
+
+  if (healthResult.value) {
+    logger.info(logContext, "Sandbox egress forwarder health check succeeded");
+    return new Ok(undefined);
+  }
+
+  logger.warn(
+    logContext,
+    "Sandbox egress forwarder health check failed, restarting"
+  );
+  return setupEgressForwarder(auth, sandbox);
+}
+
+// Dev-only: tear down the in-sandbox nftables redirect baked into the image
+// (see egress-nftables.sh in the image registry) so agent-proxied traffic
+// flows direct out of the (now permissive) E2B network, instead of being
+// redirected to the local forwarder port that has no listener in this mode.
+// Idempotent: safe to call on every fresh sandbox.
+export async function teardownInSandboxEgressRedirect(
+  auth: Authenticator,
+  sandbox: SandboxResource
+): Promise<Result<void, Error>> {
+  if (!isDevelopment()) {
+    return new Err(
+      new Error(
+        "teardownInSandboxEgressRedirect is dev-only and must not be called in production"
+      )
+    );
+  }
+
+  const command =
+    "systemctl disable --now dust-egress-nftables.service >/dev/null 2>&1 || true; " +
+    "nft delete table ip dust-egress >/dev/null 2>&1 || true; " +
+    "nft delete table ip6 dust-egress >/dev/null 2>&1 || true";
+
+  return runSuccessfulSandboxCommand(auth, sandbox, command, "root");
 }
 
 export async function setupEgressForwarder(

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -72,12 +72,19 @@ export function getSandboxImage(
     return imageResult;
   }
 
-  const devHost = config.getSandboxDevFrontHostName();
-  if (!devHost) {
-    return imageResult;
+  const image = imageResult.value;
+
+  // Dev-only: bypass all egress restrictions. Pairs with skipping the dsbx
+  // forwarder + tearing down in-sandbox nftables in tools/index.ts.
+  if (config.getSandboxDevUnrestrictedEgress()) {
+    return new Ok(image.withNetwork({ mode: "allow_all" }));
   }
 
-  const image = imageResult.value;
+  const devHost = config.getSandboxDevFrontHostName();
+  if (!devHost) {
+    return new Ok(image);
+  }
+
   return new Ok(
     image.withNetwork({
       mode: image.network.mode,

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -120,9 +120,9 @@ describe("ensureSandboxReady", () => {
     expect(
       mockPrepareSandboxEgressBeforeMount.mock.invocationCallOrder[0]
     ).toBeLessThan(mockMountConversationFiles.mock.invocationCallOrder[0]);
-    expect(
-      mockMountConversationFiles.mock.invocationCallOrder[0]
-    ).toBeLessThan(mockEnsureSandboxEgressOnExec.mock.invocationCallOrder[0]);
+    expect(mockMountConversationFiles.mock.invocationCallOrder[0]).toBeLessThan(
+      mockEnsureSandboxEgressOnExec.mock.invocationCallOrder[0]
+    );
   });
 
   it("only refreshes the token (no remount) when the sandbox woke from sleep", async () => {

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -2,32 +2,32 @@ import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  mockCheckEgressForwarderHealth,
   mockEnsureActive,
+  mockEnsureSandboxEgressOnExec,
   mockGetSandboxImage,
   mockLoggerError,
   mockLoggerInfo,
   mockLoggerWarn,
   mockMountConversationFiles,
+  mockPrepareSandboxEgressBeforeMount,
   mockRefreshGcsToken,
-  mockSetupEgressForwarder,
   mockStartTelemetry,
 } = vi.hoisted(() => ({
-  mockCheckEgressForwarderHealth: vi.fn(),
   mockEnsureActive: vi.fn(),
+  mockEnsureSandboxEgressOnExec: vi.fn(),
   mockGetSandboxImage: vi.fn(),
   mockLoggerError: vi.fn(),
   mockLoggerInfo: vi.fn(),
   mockLoggerWarn: vi.fn(),
   mockMountConversationFiles: vi.fn(),
+  mockPrepareSandboxEgressBeforeMount: vi.fn(),
   mockRefreshGcsToken: vi.fn(),
-  mockSetupEgressForwarder: vi.fn(),
   mockStartTelemetry: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/sandbox/egress", () => ({
-  checkEgressForwarderHealth: mockCheckEgressForwarderHealth,
-  setupEgressForwarder: mockSetupEgressForwarder,
+  ensureSandboxEgressOnExec: mockEnsureSandboxEgressOnExec,
+  prepareSandboxEgressBeforeMount: mockPrepareSandboxEgressBeforeMount,
 }));
 
 vi.mock("@app/lib/api/sandbox/gcs/mount", () => ({
@@ -78,15 +78,15 @@ describe("ensureSandboxReady", () => {
         wokeFromSleep: false,
       })
     );
-    mockSetupEgressForwarder.mockResolvedValue(new Ok(undefined));
+    mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Ok(undefined));
+    mockEnsureSandboxEgressOnExec.mockResolvedValue(new Ok(undefined));
     mockGetSandboxImage.mockReturnValue(new Ok(image));
     mockStartTelemetry.mockResolvedValue(new Ok(undefined));
     mockMountConversationFiles.mockResolvedValue(new Ok(undefined));
     mockRefreshGcsToken.mockResolvedValue(new Ok(undefined));
-    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(true));
   });
 
-  it("sets up egress, mounts files, and checks health for freshly-created sandboxes", async () => {
+  it("preps egress, mounts files, and ensures egress on exec for freshly-created sandboxes", async () => {
     mockEnsureActive.mockResolvedValue(
       new Ok({
         freshlyCreated: true,
@@ -101,7 +101,11 @@ describe("ensureSandboxReady", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockSetupEgressForwarder).toHaveBeenCalledTimes(1);
+    expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledTimes(1);
+    expect(mockPrepareSandboxEgressBeforeMount).toHaveBeenCalledWith(
+      auth,
+      sandbox
+    );
     expect(mockMountConversationFiles).toHaveBeenCalledWith(
       auth,
       sandbox,
@@ -109,19 +113,21 @@ describe("ensureSandboxReady", () => {
       image
     );
     expect(mockRefreshGcsToken).not.toHaveBeenCalled();
-    expect(mockCheckEgressForwarderHealth).toHaveBeenCalledWith(auth, sandbox);
+    expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
+      wokeFromSleep: false,
+    });
 
-    expect(mockSetupEgressForwarder.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(
+      mockPrepareSandboxEgressBeforeMount.mock.invocationCallOrder[0]
+    ).toBeLessThan(mockMountConversationFiles.mock.invocationCallOrder[0]);
+    expect(
       mockMountConversationFiles.mock.invocationCallOrder[0]
-    );
-    expect(mockMountConversationFiles.mock.invocationCallOrder[0]).toBeLessThan(
-      mockCheckEgressForwarderHealth.mock.invocationCallOrder[0]
-    );
+    ).toBeLessThan(mockEnsureSandboxEgressOnExec.mock.invocationCallOrder[0]);
   });
 
   it("only refreshes the token (no remount) when the sandbox woke from sleep", async () => {
     // e2b preserves the FUSE mount and the token server across betaPause +
-    // connect, so on wake we must NOT remount — that would fail with EBUSY.
+    // connect, so on wake we must NOT remount, that would fail with EBUSY.
     mockEnsureActive.mockResolvedValue(
       new Ok({
         freshlyCreated: false,
@@ -136,7 +142,7 @@ describe("ensureSandboxReady", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockSetupEgressForwarder).not.toHaveBeenCalled();
+    expect(mockPrepareSandboxEgressBeforeMount).not.toHaveBeenCalled();
     expect(mockMountConversationFiles).not.toHaveBeenCalled();
     expect(mockRefreshGcsToken).toHaveBeenCalledWith(
       auth,
@@ -144,6 +150,9 @@ describe("ensureSandboxReady", () => {
       conversation,
       image
     );
+    expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledWith(auth, sandbox, {
+      wokeFromSleep: true,
+    });
   });
 
   it("refreshes the GCS token for already-running sandboxes", async () => {
@@ -153,7 +162,7 @@ describe("ensureSandboxReady", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockSetupEgressForwarder).not.toHaveBeenCalled();
+    expect(mockPrepareSandboxEgressBeforeMount).not.toHaveBeenCalled();
     expect(mockMountConversationFiles).not.toHaveBeenCalled();
     expect(mockRefreshGcsToken).toHaveBeenCalledWith(
       auth,
@@ -162,38 +171,8 @@ describe("ensureSandboxReady", () => {
       image
     );
     expect(mockRefreshGcsToken.mock.invocationCallOrder[0]).toBeLessThan(
-      mockCheckEgressForwarderHealth.mock.invocationCallOrder[0]
+      mockEnsureSandboxEgressOnExec.mock.invocationCallOrder[0]
     );
-  });
-
-  it("restarts egress when the post-setup health check fails", async () => {
-    mockEnsureActive.mockResolvedValue(
-      new Ok({
-        freshlyCreated: true,
-        sandbox,
-        wokeFromSleep: false,
-      })
-    );
-    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(false));
-
-    const result = await ensureSandboxReady(
-      auth as never,
-      conversation as never
-    );
-
-    expect(result.isOk()).toBe(true);
-    expect(mockSetupEgressForwarder).toHaveBeenCalledTimes(2);
-    expect(mockLoggerWarn).toHaveBeenCalledWith(
-      {
-        event: "egress.health_fail",
-        providerId: "provider-id",
-        sandboxId: "sandbox-id",
-      },
-      "Sandbox egress forwarder health check failed, restarting"
-    );
-    expect(
-      mockCheckEgressForwarderHealth.mock.invocationCallOrder[0]
-    ).toBeLessThan(mockSetupEgressForwarder.mock.invocationCallOrder[1]);
   });
 
   it("short-circuits when the sandbox image lookup fails", async () => {
@@ -209,7 +188,7 @@ describe("ensureSandboxReady", () => {
     expect(mockStartTelemetry).not.toHaveBeenCalled();
     expect(mockMountConversationFiles).not.toHaveBeenCalled();
     expect(mockRefreshGcsToken).not.toHaveBeenCalled();
-    expect(mockCheckEgressForwarderHealth).not.toHaveBeenCalled();
+    expect(mockEnsureSandboxEgressOnExec).not.toHaveBeenCalled();
     expect(mockLoggerError).toHaveBeenCalledWith(
       { err: imageError },
       "Failed to get sandbox image for GCS mount"
@@ -225,11 +204,11 @@ describe("ensureSandboxReady", () => {
     );
 
     expect(result.isErr()).toBe(true);
-    expect(mockSetupEgressForwarder).not.toHaveBeenCalled();
+    expect(mockPrepareSandboxEgressBeforeMount).not.toHaveBeenCalled();
     expect(mockGetSandboxImage).not.toHaveBeenCalled();
   });
 
-  it("short-circuits when initial egress setup fails", async () => {
+  it("short-circuits when initial egress prep fails", async () => {
     mockEnsureActive.mockResolvedValue(
       new Ok({
         freshlyCreated: true,
@@ -237,7 +216,7 @@ describe("ensureSandboxReady", () => {
         wokeFromSleep: false,
       })
     );
-    mockSetupEgressForwarder.mockResolvedValue(
+    mockPrepareSandboxEgressBeforeMount.mockResolvedValue(
       new Err(new Error("setup failed"))
     );
 
@@ -269,7 +248,7 @@ describe("ensureSandboxReady", () => {
     );
 
     expect(result.isErr()).toBe(true);
-    expect(mockCheckEgressForwarderHealth).not.toHaveBeenCalled();
+    expect(mockEnsureSandboxEgressOnExec).not.toHaveBeenCalled();
   });
 
   it("short-circuits when refreshing the GCS token fails", async () => {
@@ -281,12 +260,12 @@ describe("ensureSandboxReady", () => {
     );
 
     expect(result.isErr()).toBe(true);
-    expect(mockCheckEgressForwarderHealth).not.toHaveBeenCalled();
+    expect(mockEnsureSandboxEgressOnExec).not.toHaveBeenCalled();
   });
 
-  it("short-circuits when the egress health check fails", async () => {
-    mockCheckEgressForwarderHealth.mockResolvedValue(
-      new Err(new Error("health failed"))
+  it("short-circuits when ensure-on-exec fails", async () => {
+    mockEnsureSandboxEgressOnExec.mockResolvedValue(
+      new Err(new Error("ensure-egress failed"))
     );
 
     const result = await ensureSandboxReady(
@@ -295,21 +274,6 @@ describe("ensureSandboxReady", () => {
     );
 
     expect(result.isErr()).toBe(true);
-    expect(mockSetupEgressForwarder).not.toHaveBeenCalled();
-  });
-
-  it("short-circuits when egress restart fails after an unhealthy check", async () => {
-    mockCheckEgressForwarderHealth.mockResolvedValue(new Ok(false));
-    mockSetupEgressForwarder.mockResolvedValue(
-      new Err(new Error("restart failed"))
-    );
-
-    const result = await ensureSandboxReady(
-      auth as never,
-      conversation as never
-    );
-
-    expect(result.isErr()).toBe(true);
-    expect(mockSetupEgressForwarder).toHaveBeenCalledTimes(1);
+    expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledTimes(1);
   });
 });

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -1,6 +1,6 @@
 import {
-  checkEgressForwarderHealth,
-  setupEgressForwarder,
+  ensureSandboxEgressOnExec,
+  prepareSandboxEgressBeforeMount,
 } from "@app/lib/api/sandbox/egress";
 import {
   mountConversationFiles,
@@ -26,18 +26,18 @@ export async function ensureSandboxReady(
     return ensureResult;
   }
 
-  const { sandbox, freshlyCreated } = ensureResult.value;
+  const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
 
-  // Egress forwarder setup must run BEFORE GCS mounts. When the MITM
-  // experiment is enabled, sandbox_resource.buildSandboxEnvVars exports
-  // SSL_CERT_FILE / CURL_CA_BUNDLE pointing at /etc/dust/ca-bundle.pem, which
-  // setupEgressForwarder is responsible for creating. Mounting (gcsfuse and
-  // friends) makes HTTPS calls that read the trust bundle via those env vars,
-  // so the bundle has to exist first.
+  // Egress prep must run BEFORE GCS mounts. When the MITM experiment is
+  // enabled, sandbox_resource.buildSandboxEnvVars exports SSL_CERT_FILE /
+  // CURL_CA_BUNDLE pointing at /etc/dust/ca-bundle.pem, which the forwarder
+  // setup is responsible for creating. Mounting (gcsfuse and friends) makes
+  // HTTPS calls that read the trust bundle via those env vars, so the bundle
+  // has to exist first.
   if (freshlyCreated) {
-    const setupResult = await setupEgressForwarder(auth, sandbox);
-    if (setupResult.isErr()) {
-      return setupResult;
+    const prepResult = await prepareSandboxEgressBeforeMount(auth, sandbox);
+    if (prepResult.isErr()) {
+      return prepResult;
     }
   }
 
@@ -57,8 +57,8 @@ export async function ensureSandboxReady(
 
   // Only mount on first creation. e2b preserves the FUSE mount and the
   // token server across betaPause + connect (verified empirically), so on
-  // wake we just need a fresh GCS access token in /tmp/token.json — the
-  // running token server will hand it to gcsfuse on the next request.
+  // wake we just need a fresh GCS access token in /tmp/token.json (the
+  // running token server will hand it to gcsfuse on the next request).
   if (freshlyCreated) {
     const mountResult = await mountConversationFiles(
       auth,
@@ -81,33 +81,11 @@ export async function ensureSandboxReady(
     }
   }
 
-  const healthResult = await checkEgressForwarderHealth(auth, sandbox);
-  if (healthResult.isErr()) {
-    return healthResult;
-  }
-
-  if (!healthResult.value) {
-    logger.warn(
-      {
-        event: "egress.health_fail",
-        providerId: sandbox.providerId,
-        sandboxId: sandbox.sId,
-      },
-      "Sandbox egress forwarder health check failed, restarting"
-    );
-    const setupResult = await setupEgressForwarder(auth, sandbox);
-    if (setupResult.isErr()) {
-      return setupResult;
-    }
-  } else {
-    logger.info(
-      {
-        event: "egress.health_ok",
-        providerId: sandbox.providerId,
-        sandboxId: sandbox.sId,
-      },
-      "Sandbox egress forwarder health check succeeded"
-    );
+  const ensureEgressResult = await ensureSandboxEgressOnExec(auth, sandbox, {
+    wokeFromSleep,
+  });
+  if (ensureEgressResult.isErr()) {
+    return ensureEgressResult;
   }
 
   return new Ok(sandbox);

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -48,9 +48,12 @@ function toE2BNetworkOpts(policy: NetworkPolicy): E2BNetworkOpts {
       return {
         allowOut: policy.allowlist ? [...policy.allowlist] : [],
         denyOut: [ALL_TRAFFIC],
+        allowPublicTraffic: false,
       };
     case "allow_all":
-      return {};
+      // Fully unrestricted: lift the public-traffic block too. Only reachable
+      // in dev via SBX_DEV_UNRESTRICTED_EGRESS.
+      return { allowPublicTraffic: true };
     default:
       assertNever(policy.mode);
   }
@@ -113,10 +116,9 @@ export class E2BSandboxProvider implements SandboxProvider {
             envs: hasEnvVars ? envVars : undefined,
             timeoutMs: SANDBOX_LIFETIME_MS,
             requestTimeoutMs: REQUEST_TIMEOUT_MS,
-            network: {
-              ...(config.network ? toE2BNetworkOpts(config.network) : {}),
-              allowPublicTraffic: false,
-            },
+            network: config.network
+              ? toE2BNetworkOpts(config.network)
+              : { allowPublicTraffic: false },
           });
         } catch (err) {
           return new Err(normalizeError(err));


### PR DESCRIPTION
## Description

Adds `SBX_DEV_UNRESTRICTED_EGRESS=true`, only honored when `isDevelopment()`. When on:

- E2B network policy is set to `allow_all` with `allowPublicTraffic: true` (was hardcoded `false`).
- The dsbx forwarder is not started.
- The in-sandbox nftables redirect (`dust-egress-nftables.service`) is disabled and the tables dropped on first exec, so agent-proxied traffic flows direct out instead of hitting a non-existent local forwarder.

The branching lives behind two helpers in `egress.ts` (`prepareSandboxEgressBeforeMount`, `ensureSandboxEgressOnExec`), so `tools/index.ts` stays linear. The teardown helper itself also asserts `isDevelopment()` as defense in depth.

Useful when running `front` locally where the regional egress proxy is not reachable and the per-workspace policy plumbing is overkill.

## Tests

12 unit tests in `egress.test.ts`, including the teardown happy path, an Err-propagation case, and a "refuses to run outside dev mode" case.

## Risk

Low. The flag returns false unless `NODE_ENV=development` (or `IS_DEVELOPMENT=true`) AND the env var is `"true"`. The teardown function additionally refuses to run outside dev. No behavior change on the prod path beyond making the previously-hardcoded `allowPublicTraffic: false` explicit per branch in `toE2BNetworkOpts`. Safe to rollback.

## Deploy Plan

Standard deploy.