### PR TITLE
Self-improving skills: add DB fields for per skill cap + lock mode for reinforcement toggle

### DIFF
--- a/front/components/skill_builder/SkillBuilderEnableSuggestionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderEnableSuggestionsSection.tsx
@@ -13,7 +13,7 @@ export function SkillBuilderEnableSuggestionsSection() {
   const enabled = reinforcement !== "off";
 
   const handleToggle = () => {
-    setValue("reinforcement", enabled ? "off" : "auto", { shouldDirty: true });
+    setValue("reinforcement", enabled ? "off" : "on", { shouldDirty: true });
   };
 
   return (

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -48,6 +48,6 @@ export function getDefaultSkillFormData({
     icon: null,
     extendedSkillId,
     isDefault: false,
-    reinforcement: "auto",
+    reinforcement: "on",
   };
 }

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -118,6 +118,9 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
 
   declare reinforcement: CreationOptional<SkillReinforcementMode>;
   declare lastReinforcementAnalysisAt: CreationOptional<Date | null>;
+  declare selfImprovementCostsCapMicroUsd: CreationOptional<number>;
+  // Lock toggling of self-improvement to admin only.
+  declare selfImprovementLock: CreationOptional<boolean>;
 
   declare requestedSpaceIds: number[];
 }
@@ -128,12 +131,22 @@ SkillConfigurationModel.init(
     reinforcement: {
       type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: "auto",
+      defaultValue: "on",
     },
     lastReinforcementAnalysisAt: {
       type: DataTypes.DATE,
       allowNull: true,
       defaultValue: null,
+    },
+    selfImprovementCostsCapMicroUsd: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      defaultValue: 0,
+    },
+    selfImprovementLock: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/front/lib/reinforcement/consumption.test.ts
+++ b/front/lib/reinforcement/consumption.test.ts
@@ -48,15 +48,15 @@ describe("getReinforcementMonthlyCapMicroUsd", () => {
 
 describe("getSelfImprovementCapPerSkillMicroUsd", () => {
   it("returns default cap when workspace has no metadata", () => {
-    expect(getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(makeWorkspace())).toBe(
-      DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD
-    );
+    expect(
+      getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(makeWorkspace())
+    ).toBe(DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD);
   });
 
   it("returns default cap when metadata has no selfImprovementCapPerSkillMicroUsd", () => {
-    expect(getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(makeWorkspace({}))).toBe(
-      DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD
-    );
+    expect(
+      getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(makeWorkspace({}))
+    ).toBe(DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD);
   });
 
   it("returns workspace override when set", () => {

--- a/front/lib/reinforcement/consumption.test.ts
+++ b/front/lib/reinforcement/consumption.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@app/lib/reinforcement/constants";
 import {
   getReinforcementMonthlyCapMicroUsd,
-  getSelfImprovementCapPerSkillMicroUsd,
+  getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";
 import type { LightWorkspaceType } from "@app/types/user";
 import { describe, expect, it } from "vitest";
@@ -48,20 +48,20 @@ describe("getReinforcementMonthlyCapMicroUsd", () => {
 
 describe("getSelfImprovementCapPerSkillMicroUsd", () => {
   it("returns default cap when workspace has no metadata", () => {
-    expect(getSelfImprovementCapPerSkillMicroUsd(makeWorkspace())).toBe(
+    expect(getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(makeWorkspace())).toBe(
       DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD
     );
   });
 
   it("returns default cap when metadata has no selfImprovementCapPerSkillMicroUsd", () => {
-    expect(getSelfImprovementCapPerSkillMicroUsd(makeWorkspace({}))).toBe(
+    expect(getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(makeWorkspace({}))).toBe(
       DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD
     );
   });
 
   it("returns workspace override when set", () => {
     expect(
-      getSelfImprovementCapPerSkillMicroUsd(
+      getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(
         makeWorkspace({ selfImprovementCapPerSkillMicroUsd: 10_000_000 })
       )
     ).toBe(10_000_000);
@@ -69,7 +69,7 @@ describe("getSelfImprovementCapPerSkillMicroUsd", () => {
 
   it("allows cap of 0", () => {
     expect(
-      getSelfImprovementCapPerSkillMicroUsd(
+      getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(
         makeWorkspace({ selfImprovementCapPerSkillMicroUsd: 0 })
       )
     ).toBe(0);

--- a/front/lib/reinforcement/consumption.ts
+++ b/front/lib/reinforcement/consumption.ts
@@ -20,7 +20,7 @@ export function getReinforcementMonthlyCapMicroUsd(
  * Return the workspace's self-improvement cost cap per skill in microUSD.
  * Uses the workspace metadata override if set, otherwise the default ($20).
  */
-export function getSelfImprovementCapPerSkillMicroUsd(
+export function getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(
   workspace: LightWorkspaceType
 ): number {
   return typeof workspace.metadata?.selfImprovementCapPerSkillMicroUsd ===

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1,11 +1,14 @@
+import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { SkillDataSourceConfigurationModel } from "@app/lib/models/skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
+import { DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD } from "@app/lib/reinforcement/constants";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
@@ -1155,6 +1158,42 @@ describe("SkillResource", () => {
       expect(results[0].skill.id).toEqual(skillA.id);
       expect(results[0].conversationModelId).toEqual(conv1.id);
       expect(results[0].agentConfigurationId).toEqual(agent.sId);
+    });
+  });
+
+  describe("makeNew - selfImprovementCostsCapMicroUsd", () => {
+    it("defaults to the workspace self-improvement cap (20 USD) when no metadata is set", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator);
+
+      expect(skill.selfImprovementCostsCapMicroUsd).toBe(
+        DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD
+      );
+      expect(skill.selfImprovementLock).toBe(false);
+    });
+
+    it("uses the workspace-level cap override when set", async () => {
+      const customCapMicroUsd = 7_000_000; // $7
+
+      const workspaceResource = await WorkspaceResource.fetchByModelId(
+        testContext.workspace.id
+      );
+      if (!workspaceResource) {
+        throw new Error("Workspace not found");
+      }
+      await workspaceResource.updateWorkspaceSettings({
+        metadata: {
+          ...(testContext.workspace.metadata ?? {}),
+          selfImprovementCapPerSkillMicroUsd: customCapMicroUsd,
+        },
+      });
+
+      const freshAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        testContext.user.sId,
+        testContext.workspace.sId
+      );
+      const skill = await SkillFactory.create(freshAuth);
+
+      expect(skill.selfImprovementCostsCapMicroUsd).toBe(customCapMicroUsd);
     });
   });
 });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -21,6 +21,7 @@ import {
 } from "@app/lib/models/skill/conversation_skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
+import { getSelfImprovementCapPerSkillMicroUsd } from "@app/lib/reinforcement/consumption";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -370,6 +371,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const skill = await this.model.create(
         {
           ...blob,
+          selfImprovementCostsCapMicroUsd:
+            getSelfImprovementCapPerSkillMicroUsd(owner),
           workspaceId: owner.id,
         },
         {
@@ -1551,6 +1554,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         isDefault: !SystemSkillsRegistry.isSystemSkill(def.sId),
         reinforcement: "auto",
         lastReinforcementAnalysisAt: null,
+        selfImprovementCostsCapMicroUsd: 0,
+        selfImprovementLock: false,
       },
       {
         // Global skills do not have data source configurations.
@@ -1810,6 +1815,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           isDefault: versionModel.isDefault,
           reinforcement: "auto",
           lastReinforcementAnalysisAt: null,
+          selfImprovementCostsCapMicroUsd:
+            versionModel.selfImprovementCostsCapMicroUsd,
+          selfImprovementLock: versionModel.selfImprovementLock,
         },
         {
           // We ignore data source configurations for historical versions.

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -21,7 +21,7 @@ import {
 } from "@app/lib/models/skill/conversation_skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
-import { getSelfImprovementCapPerSkillMicroUsd } from "@app/lib/reinforcement/consumption";
+import { getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd } from "@app/lib/reinforcement/consumption";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -372,7 +372,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         {
           ...blob,
           selfImprovementCostsCapMicroUsd:
-            getSelfImprovementCapPerSkillMicroUsd(owner),
+            getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(owner),
           workspaceId: owner.id,
         },
         {

--- a/front/lib/swr/useReinforcementToggle.ts
+++ b/front/lib/swr/useReinforcementToggle.ts
@@ -2,7 +2,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   getReinforcementMonthlyCapMicroUsd,
-  getSelfImprovementCapPerSkillMicroUsd,
+  getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -164,7 +164,7 @@ export function useSelfImprovementCapPerSkillSetting({
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
 
-  const capDollars = getSelfImprovementCapPerSkillMicroUsd(owner) / 1_000_000;
+  const capDollars = getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(owner) / 1_000_000;
 
   const saveCapDollars = async (dollars: number): Promise<boolean> => {
     setIsSaving(true);

--- a/front/lib/swr/useReinforcementToggle.ts
+++ b/front/lib/swr/useReinforcementToggle.ts
@@ -164,7 +164,8 @@ export function useSelfImprovementCapPerSkillSetting({
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
 
-  const capDollars = getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(owner) / 1_000_000;
+  const capDollars =
+    getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(owner) / 1_000_000;
 
   const saveCapDollars = async (dollars: number): Promise<boolean> => {
     setIsSaving(true);

--- a/front/migrations/db/migration_628.sql
+++ b/front/migrations/db/migration_628.sql
@@ -1,0 +1,9 @@
+-- Migration created on May 07, 2026
+ALTER TABLE "skill_configurations"
+ADD COLUMN "selfImprovementCostsCapMicroUsd" BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE "skill_configurations"
+ADD COLUMN "selfImprovementLock" BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE "skill_configurations"
+ALTER COLUMN "reinforcement" SET DEFAULT 'on';


### PR DESCRIPTION
## Description

All the db changes needed for the self improving skill control:
 - add a new column: cost limit per skill
 - add a new column: lock self improv for skills
 - change default value of reinforcement to be on (auto is already considered as on, we will drop auto)

## Tests

 - unit tests

## Risk

 low

## Deploy Plan

lock front
merge
migrate
deploy
unlock
