### PR TITLE
Remove duplicated credits in db

### DIFF
--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -287,13 +287,19 @@ makeScript(
         "Optional workspace sId to process (processes all if omitted)",
       required: false,
     },
+    fromWorkspaceId: {
+      type: "number" as const,
+      description:
+        "Resume from this numeric workspace model id (skips workspaces with id < this value)",
+      required: false,
+    },
   },
-  async ({ workspaceId, execute }, logger) => {
+  async ({ workspaceId, fromWorkspaceId, execute }, logger) => {
     await runOnAllWorkspaces(
       async (workspace) => {
         await backfillFromMetronome(workspace, execute, logger);
       },
-      { concurrency: 4, wId: workspaceId }
+      { concurrency: 4, wId: workspaceId, fromWorkspaceId }
     );
   }
 );

--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -89,6 +89,7 @@ async function backfillFromMetronome(
     metronomeCustomerId,
     includeContractCredits: true,
     includeBalance: true,
+    coveringDate: new Date().toISOString(),
   });
 
   if (creditsResult.isErr()) {

--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -29,9 +29,9 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { makeScript } from "./helpers";
 import { runOnAllWorkspaces } from "./workspace_helpers";
 
-// Metronome publishes a 55 RPS API limit. Cap the script at 40 RPS to leave
+// Metronome publishes a 11 RPS API limit. Cap the script at 10 RPS to leave
 // headroom for concurrent production traffic on the same API key.
-const METRONOME_MAX_RPS = 40;
+const METRONOME_MAX_RPS = 10;
 const METRONOME_MIN_INTERVAL_MS = 1000 / METRONOME_MAX_RPS;
 let metronomeNextSlotAt = 0;
 

--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -29,6 +29,23 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { makeScript } from "./helpers";
 import { runOnAllWorkspaces } from "./workspace_helpers";
 
+// Metronome publishes a 55 RPS API limit. Cap the script at 40 RPS to leave
+// headroom for concurrent production traffic on the same API key.
+const METRONOME_MAX_RPS = 40;
+const METRONOME_MIN_INTERVAL_MS = 1000 / METRONOME_MAX_RPS;
+let metronomeNextSlotAt = 0;
+
+async function paceMetronome<T>(fn: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  const slot = Math.max(now, metronomeNextSlotAt);
+  metronomeNextSlotAt = slot + METRONOME_MIN_INTERVAL_MS;
+  const wait = slot - now;
+  if (wait > 0) {
+    await new Promise((r) => setTimeout(r, wait));
+  }
+  return fn();
+}
+
 type FreeCreditSubtype =
   | "free-poke"
   | "free-yearly-renewal"
@@ -85,12 +102,14 @@ async function backfillFromMetronome(
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   const programmaticUsdCreditTypeId = getCreditTypeProgrammaticUsdId();
 
-  const creditsResult = await listMetronomeCustomerCredits({
-    metronomeCustomerId,
-    includeContractCredits: true,
-    includeBalance: true,
-    coveringDate: new Date().toISOString(),
-  });
+  const creditsResult = await paceMetronome(() =>
+    listMetronomeCustomerCredits({
+      metronomeCustomerId,
+      includeContractCredits: true,
+      includeBalance: true,
+      coveringDate: new Date().toISOString(),
+    })
+  );
 
   if (creditsResult.isErr()) {
     logger.error(

--- a/front/scripts/backfill_db_free_credits_from_metronome.ts
+++ b/front/scripts/backfill_db_free_credits_from_metronome.ts
@@ -94,6 +94,7 @@ async function backfillFromMetronome(
   execute: boolean,
   logger: Logger
 ): Promise<void> {
+  logger.info({ workspaceId: workspace.sId }, "---- Starting ----");
   const { metronomeCustomerId } = workspace;
   if (!metronomeCustomerId) {
     return;

--- a/front/scripts/remove_duplicated_credits.ts
+++ b/front/scripts/remove_duplicated_credits.ts
@@ -287,13 +287,19 @@ makeScript(
         "Optional workspace sId to process (processes all if omitted)",
       required: false,
     },
+    fromWorkspaceId: {
+      type: "number" as const,
+      description:
+        "Resume from this numeric workspace model id (skips workspaces with id < this value)",
+      required: false,
+    },
   },
-  async ({ workspaceId, execute }, logger) => {
+  async ({ workspaceId, fromWorkspaceId, execute }, logger) => {
     await runOnAllWorkspaces(
       async (workspace) => {
         await removeDuplicatedCredits(workspace, execute, logger);
       },
-      { concurrency: 4, wId: workspaceId }
+      { concurrency: 4, wId: workspaceId, fromWorkspaceId }
     );
   }
 );

--- a/front/scripts/remove_duplicated_credits.ts
+++ b/front/scripts/remove_duplicated_credits.ts
@@ -57,7 +57,7 @@ async function removeDuplicatedCredits(
   // Group by (subtype, startDate, expirationDate).
   const groups = new Map<string, typeof renewalCredits>();
   for (const credit of renewalCredits) {
-    const key = `${credit.startDate!.toISOString().split("T")[0]}:${credit.expirationDate!.toISOString().split("T")[0]}`;
+    const key = `${credit.startDate!.toISOString().split("T")[0]}`;
     const group = groups.get(key) ?? [];
     group.push(credit);
     groups.set(key, group);
@@ -85,8 +85,22 @@ async function removeDuplicatedCredits(
 
     const contractsResponse = await client.v2.contracts.list({
       customer_id: metronomeCustomerId,
-      covering_date: representativeStartDate.toISOString(),
+      covering_date: new Date().toISOString(),
     });
+    const contracts = contractsResponse.data;
+    if (contracts.length > 1) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          groupKey,
+          metronomeCustomerId,
+          contractCount: contracts.length,
+          contractIds: contracts.map((c) => c.id),
+        },
+        "[Remove Duplicates] Multiple active Metronome contracts for one customer (should not happen), skipping group"
+      );
+      continue;
+    }
     const contract = contractsResponse.data[0];
 
     if (!contract) {

--- a/front/scripts/remove_duplicated_credits.ts
+++ b/front/scripts/remove_duplicated_credits.ts
@@ -30,14 +30,6 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { makeScript } from "./helpers";
 import { runOnAllWorkspaces } from "./workspace_helpers";
 
-type FreeRenewalSubtype = "free-renewal" | "free-yearly-renewal";
-
-function getRenewalSubtype(invoiceOrLineItemId: string): FreeRenewalSubtype {
-  return invoiceOrLineItemId.startsWith("free-renewal-yearly-")
-    ? "free-yearly-renewal"
-    : "free-renewal";
-}
-
 async function removeDuplicatedCredits(
   workspace: LightWorkspaceType,
   execute: boolean,
@@ -65,12 +57,7 @@ async function removeDuplicatedCredits(
   // Group by (subtype, startDate, expirationDate).
   const groups = new Map<string, typeof renewalCredits>();
   for (const credit of renewalCredits) {
-    const subtype = credit.invoiceOrLineItemId?.startsWith(
-      "free-renewal-yearly-"
-    )
-      ? "free-yearly-renewal"
-      : "free-renewal";
-    const key = `${subtype}:${credit.startDate!.toISOString().split("T")[0]}:${credit.expirationDate!.toISOString().split("T")[0]}`;
+    const key = `${credit.startDate!.toISOString().split("T")[0]}:${credit.expirationDate!.toISOString().split("T")[0]}`;
     const group = groups.get(key) ?? [];
     group.push(credit);
     groups.set(key, group);
@@ -123,21 +110,6 @@ async function removeDuplicatedCredits(
       continue;
     }
 
-    const isYearly = recurringCredit.recurrence_frequency === "ANNUAL";
-    const subtype = getRenewalSubtype(duplicates[0].invoiceOrLineItemId!);
-    const isAnnualCredit = subtype === "free-yearly-renewal";
-    if (isYearly !== isAnnualCredit) {
-      logger.warn(
-        {
-          workspaceId: workspace.sId,
-          groupKey,
-          recurrenceFrequency: recurringCredit.recurrence_frequency,
-        },
-        "[Remove Duplicates] Recurrence frequency mismatch between DB subtype and Metronome, skipping group"
-      );
-      continue;
-    }
-
     // Find the current credit instance generated from the recurring credit.
     const creditsResponse = await client.v1.customers.credits.list({
       customer_id: metronomeCustomerId,
@@ -171,6 +143,7 @@ async function removeDuplicatedCredits(
     );
 
     const periodStartSeconds = Math.floor(metronomeStartDate.getTime() / 1000);
+    const isYearly = recurringCredit.recurrence_frequency === "ANNUAL";
     const correctInvoiceOrLineItemId = isYearly
       ? `free-renewal-yearly-${contractId}-${periodStartSeconds}`
       : `free-renewal-${contractId}-${periodStartSeconds}`;

--- a/front/scripts/remove_duplicated_credits.ts
+++ b/front/scripts/remove_duplicated_credits.ts
@@ -1,0 +1,312 @@
+/**
+ * Remove duplicated free-renewal / free-renewal-yearly credits in the DB.
+ *
+ * Duplicates are detected by grouping free credits whose invoiceOrLineItemId
+ * starts with "free-renewal-" by (subtype, startDate, expirationDate).
+ * Any group with 2+ credits is a duplicate set.
+ *
+ * For each duplicate set:
+ * - Fetches the current recurring credit from Metronome (active at the group's start date).
+ * - Elects one surviving credit (the one with the most consumed amount).
+ * - If 2+ credits have consumed > 0, logs a warning and sums all consumed amounts.
+ * - Updates the survivor's startDate, expirationDate, initialAmountMicroUsd, metronomeCreditId,
+ *   and invoiceOrLineItemId from the Metronome credit.
+ * - Deletes all other duplicates.
+ *
+ * Idempotent when run in dry-run mode. Pass --execute to apply changes.
+ *
+ * Run with: npx tsx scripts/remove_duplicated_credits.ts [--execute] [--workspaceId <sId>]
+ */
+
+import { Authenticator } from "@app/lib/auth";
+import { getMetronomeClient } from "@app/lib/metronome/client";
+import { getProductFreeCreditId } from "@app/lib/metronome/constants";
+import { METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD } from "@app/lib/metronome/types";
+import { CreditResource } from "@app/lib/resources/credit_resource";
+import { CreditModel } from "@app/lib/resources/storage/models/credits";
+import type { Logger } from "@app/logger/logger";
+import type { LightWorkspaceType } from "@app/types/user";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+type FreeRenewalSubtype = "free-renewal" | "free-yearly-renewal";
+
+function getRenewalSubtype(invoiceOrLineItemId: string): FreeRenewalSubtype {
+  return invoiceOrLineItemId.startsWith("free-renewal-yearly-")
+    ? "free-yearly-renewal"
+    : "free-renewal";
+}
+
+async function removeDuplicatedCredits(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return;
+  }
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  const allCredits = await CreditResource.listAll(auth);
+  const renewalCredits = allCredits.filter(
+    (c) =>
+      c.type === "free" &&
+      c.invoiceOrLineItemId !== null &&
+      c.invoiceOrLineItemId.startsWith("free-renewal-")
+  );
+
+  if (renewalCredits.length === 0) {
+    return;
+  }
+
+  // Group by (subtype, startDate, expirationDate).
+  const groups = new Map<string, typeof renewalCredits>();
+  for (const credit of renewalCredits) {
+    const subtype = credit.invoiceOrLineItemId?.startsWith(
+      "free-renewal-yearly-"
+    )
+      ? "free-yearly-renewal"
+      : "free-renewal";
+    const key = `${subtype}:${credit.startDate!.toISOString().split("T")[0]}:${credit.expirationDate!.toISOString().split("T")[0]}`;
+    const group = groups.get(key) ?? [];
+    group.push(credit);
+    groups.set(key, group);
+  }
+
+  // Process only groups with duplicates.
+  for (const [groupKey, duplicates] of groups) {
+    if (duplicates.length < 2) {
+      continue;
+    }
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        groupKey,
+        count: duplicates.length,
+        creditIds: duplicates.map((c) => c.id),
+      },
+      "[Remove Duplicates] Found duplicate group"
+    );
+
+    // Fetch the active contract covering this group's start date.
+    const representativeStartDate = duplicates[0].startDate!;
+    const client = getMetronomeClient();
+
+    const contractsResponse = await client.v2.contracts.list({
+      customer_id: metronomeCustomerId,
+      covering_date: representativeStartDate.toISOString(),
+    });
+    const contract = contractsResponse.data[0];
+
+    if (!contract) {
+      logger.warn(
+        { workspaceId: workspace.sId, groupKey },
+        "[Remove Duplicates] No active Metronome contract found, skipping group"
+      );
+      continue;
+    }
+
+    const freeCreditProductId = getProductFreeCreditId();
+    const recurringCredit = contract.recurring_credits?.find(
+      (rc) => rc.product.id === freeCreditProductId
+    );
+
+    if (!recurringCredit) {
+      logger.warn(
+        { workspaceId: workspace.sId, groupKey, contractId: contract.id },
+        "[Remove Duplicates] No recurring credit on contract, skipping group"
+      );
+      continue;
+    }
+
+    const isYearly = recurringCredit.recurrence_frequency === "ANNUAL";
+    const subtype = getRenewalSubtype(duplicates[0].invoiceOrLineItemId!);
+    const isAnnualCredit = subtype === "free-yearly-renewal";
+    if (isYearly !== isAnnualCredit) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          groupKey,
+          recurrenceFrequency: recurringCredit.recurrence_frequency,
+        },
+        "[Remove Duplicates] Recurrence frequency mismatch between DB subtype and Metronome, skipping group"
+      );
+      continue;
+    }
+
+    // Find the current credit instance generated from the recurring credit.
+    const creditsResponse = await client.v1.customers.credits.list({
+      customer_id: metronomeCustomerId,
+      covering_date: representativeStartDate.toISOString(),
+      include_contract_credits: true,
+      include_balance: true,
+    });
+
+    const metronomeEntry = creditsResponse.data.find(
+      (c) => c.recurring_credit_id === recurringCredit.id
+    );
+
+    if (!metronomeEntry) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          groupKey,
+          recurringCreditId: recurringCredit.id,
+        },
+        "[Remove Duplicates] No active credit instance for recurring credit, skipping group"
+      );
+      continue;
+    }
+
+    const contractId = contract.id;
+    const item = metronomeEntry.access_schedule!.schedule_items![0];
+    const metronomeStartDate = new Date(item.starting_at);
+    const metronomeExpirationDate = new Date(item.ending_before);
+    const metronomeInitialAmountMicroUsd = Math.round(
+      item.amount * METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD
+    );
+
+    const periodStartSeconds = Math.floor(metronomeStartDate.getTime() / 1000);
+    const correctInvoiceOrLineItemId = isYearly
+      ? `free-renewal-yearly-${contractId}-${periodStartSeconds}`
+      : `free-renewal-${contractId}-${periodStartSeconds}`;
+
+    // Elect the surviving credit.
+    const withConsumed = duplicates.filter((c) => c.consumedAmountMicroUsd > 0);
+
+    if (withConsumed.length > 1) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          groupKey,
+          consumedCreditIds: withConsumed.map((c) => ({
+            id: c.id,
+            consumedMicroUsd: c.consumedAmountMicroUsd,
+          })),
+        },
+        "[Remove Duplicates] Multiple duplicates have consumed amount > 0"
+      );
+    }
+
+    // Survivor: among credits with consumed > 0 pick the one with the most initial amount
+    const sorted = [...duplicates].sort(
+      (a, b) => b.initialAmountMicroUsd - a.initialAmountMicroUsd
+    );
+    const survivor = sorted[0];
+    const toDelete = sorted.slice(1);
+
+    const totalConsumedAmountMicroUsd = duplicates.reduce(
+      (sum, c) => sum + c.consumedAmountMicroUsd,
+      0
+    );
+
+    if (totalConsumedAmountMicroUsd > survivor.initialAmountMicroUsd) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          groupKey,
+          survivorId: survivor.id,
+          survivorInitialAmountMicroUsd: survivor.initialAmountMicroUsd,
+          totalConsumedAmountMicroUsd,
+        },
+        "[Remove Duplicates] Total consumed exceeds survivor's initial amount, skipping group"
+      );
+      continue;
+    }
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        groupKey,
+        survivorId: survivor.id,
+        survivorConsumedMicroUsd: survivor.consumedAmountMicroUsd,
+        totalConsumedMicroUsd: totalConsumedAmountMicroUsd,
+        toDeleteIds: toDelete.map((c) => c.id),
+        metronomeId: metronomeEntry.id,
+        metronomeStartDate: metronomeStartDate.toISOString(),
+        metronomeExpirationDate: metronomeExpirationDate.toISOString(),
+        metronomeInitialAmountUsd: metronomeInitialAmountMicroUsd / 1_000_000,
+        correctInvoiceOrLineItemId,
+      },
+      execute
+        ? "[Remove Duplicates] Removing duplicates and updating survivor"
+        : "[Remove Duplicates] [DRY RUN] Would remove duplicates and update survivor"
+    );
+
+    if (!execute) {
+      continue;
+    }
+
+    // Delete non-surviving duplicates first.
+    for (const dup of toDelete) {
+      const result = await dup.delete(auth);
+      if (result.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            creditId: dup.id,
+            error: result.error.message,
+          },
+          "[Remove Duplicates] Failed to delete duplicate credit"
+        );
+      } else {
+        logger.info(
+          { workspaceId: workspace.sId, creditId: dup.id },
+          "[Remove Duplicates] Deleted duplicate credit"
+        );
+      }
+    }
+
+    // Update the survivor with values from Metronome.
+    try {
+      await CreditModel.update(
+        {
+          startDate: metronomeStartDate,
+          expirationDate: metronomeExpirationDate,
+          initialAmountMicroUsd: metronomeInitialAmountMicroUsd,
+          consumedAmountMicroUsd: totalConsumedAmountMicroUsd,
+          metronomeCreditId: metronomeEntry.id,
+          invoiceOrLineItemId: correctInvoiceOrLineItemId,
+        },
+        { where: { id: survivor.id } }
+      );
+
+      logger.info(
+        { workspaceId: workspace.sId, creditId: survivor.id },
+        "[Remove Duplicates] Updated survivor credit"
+      );
+    } catch (error) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          creditId: survivor.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "[Remove Duplicates] Failed to update survivor credit"
+      );
+    }
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string" as const,
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await removeDuplicatedCredits(workspace, execute, logger);
+      },
+      { concurrency: 4, wId: workspaceId }
+    );
+  }
+);


### PR DESCRIPTION
## Description

Adds a deduplication script for free renewal credits. Addresses duplicate credit entries created in the DB with the same start/expiration dates by keeping one survivor (the one with the highest initial amount), summing consumed amounts across duplicates, and updating the survivor with the correct Metronome credit ID and dates from the current active contract.

## Tests

Manually tested in dry-run and execute mode. The deduplication script logs all operations (duplicate detection, survivor selection, deletion, and updates) for audit trails.

## Risk

Low. Script is idempotent and default to dry-run mode.

## Deploy Plan

Deploy front