### PR TITLE
[front] Show block tooltip on Enter when agent switch is pending

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1235,8 +1235,8 @@ const InputBarContainer = ({
                 />
               )}
           </div>
-          <TooltipProvider delayDuration={0}>
-            <TooltipRoot open={isBlockTooltipOpen}>
+          <TooltipProvider>
+            <TooltipRoot open={isBlockTooltipOpen && submitBlockMessage !== null}>
               <TooltipTrigger asChild>
                 <Button
                   size={buttonSize}
@@ -1247,10 +1247,6 @@ const InputBarContainer = ({
                   icon={ArrowUpIcon}
                   variant={isSubmitBlocked ? "ghost-secondary" : "highlight"}
                   disabled={isSubmitDisabled}
-                  className={cn(
-                    isSubmitBlocked &&
-                      "hover:s-bg-transparent dark:hover:s-bg-transparent hover:s-text-muted-foreground dark:hover:s-text-muted-foreground-night"
-                  )}
                   onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {
                     e.preventDefault();
                     e.stopPropagation();

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1236,8 +1236,24 @@ const InputBarContainer = ({
               )}
           </div>
           <TooltipProvider>
-            <TooltipRoot open={isBlockTooltipOpen && submitBlockMessage !== null}>
-              <TooltipTrigger asChild>
+            <TooltipRoot
+              open={isBlockTooltipOpen && submitBlockMessage !== null}
+            >
+              <TooltipTrigger
+                asChild
+                onPointerEnter={() => {
+                  if (submitBlockMessage) {
+                    setIsBlockTooltipOpen(true);
+                  }
+                }}
+                onPointerLeave={() => {
+                  if (blockTooltipTimerRef.current) {
+                    clearTimeout(blockTooltipTimerRef.current);
+                    blockTooltipTimerRef.current = null;
+                  }
+                  setIsBlockTooltipOpen(false);
+                }}
+              >
                 <Button
                   size={buttonSize}
                   isLoading={
@@ -1261,7 +1277,7 @@ const InputBarContainer = ({
                         editorService.setLoading(false);
                       }
                     }
-                    onEnterKeyDown(
+                    onEnterKeyDownWithShake(
                       editorService.isEmpty() && !canSubmitEmpty,
                       editorService.getMarkdownAndMentions(),
                       () => {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -61,6 +61,10 @@ import {
   PlusIcon,
   TextIcon,
   Toolbar,
+  TooltipContent,
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
   VoicePicker,
 } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
@@ -197,6 +201,17 @@ const InputBarContainer = ({
 
   const [hasUserMention, setHasUserMention] = useState(false);
   const canSubmitEmpty = !!selectedSingleAgent;
+  const [isBlockTooltipOpen, setIsBlockTooltipOpen] = useState(false);
+  const blockTooltipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  useEffect(() => {
+    return () => {
+      if (blockTooltipTimerRef.current) {
+        clearTimeout(blockTooltipTimerRef.current);
+      }
+    };
+  }, []);
 
   const agentsById = useMemo(
     () => new Map(allAgents.map((a) => [a.sId, a])),
@@ -407,6 +422,14 @@ const InputBarContainer = ({
     (isEmpty, markdownAndMentions, resetEditorText, setLoading) => {
       if (isSubmitBlocked) {
         onShake();
+        if (blockTooltipTimerRef.current) {
+          clearTimeout(blockTooltipTimerRef.current);
+        }
+        setIsBlockTooltipOpen(true);
+        blockTooltipTimerRef.current = setTimeout(
+          () => setIsBlockTooltipOpen(false),
+          2000
+        );
         return;
       }
       onEnterKeyDown(
@@ -1212,41 +1235,52 @@ const InputBarContainer = ({
                 />
               )}
           </div>
-          <Button
-            size={buttonSize}
-            isLoading={
-              isSubmitting && voiceTranscriberService.status !== "transcribing"
-            }
-            icon={ArrowUpIcon}
-            variant={isSubmitBlocked ? "ghost-secondary" : "highlight"}
-            disabled={isSubmitDisabled}
-            tooltip={submitBlockMessage ?? undefined}
-            className={cn(
-              isSubmitBlocked &&
-                "hover:s-bg-transparent dark:hover:s-bg-transparent hover:s-text-muted-foreground dark:hover:s-text-muted-foreground-night"
-            )}
-            onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (disableAutoFocus) {
-                editorService.blur();
-                // wait a bit for the keyboard to be closed on mobile
-                if (isMobile) {
-                  editorService.setLoading(true);
-                  await new Promise((resolve) => setTimeout(resolve, 500));
-                  editorService.setLoading(false);
-                }
-              }
-              onEnterKeyDown(
-                editorService.isEmpty() && !canSubmitEmpty,
-                editorService.getMarkdownAndMentions(),
-                () => {
-                  editorService.clearEditor();
-                },
-                editorService.setLoading
-              );
-            }}
-          />
+          <TooltipProvider delayDuration={0}>
+            <TooltipRoot open={isBlockTooltipOpen}>
+              <TooltipTrigger asChild>
+                <Button
+                  size={buttonSize}
+                  isLoading={
+                    isSubmitting &&
+                    voiceTranscriberService.status !== "transcribing"
+                  }
+                  icon={ArrowUpIcon}
+                  variant={isSubmitBlocked ? "ghost-secondary" : "highlight"}
+                  disabled={isSubmitDisabled}
+                  className={cn(
+                    isSubmitBlocked &&
+                      "hover:s-bg-transparent dark:hover:s-bg-transparent hover:s-text-muted-foreground dark:hover:s-text-muted-foreground-night"
+                  )}
+                  onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (disableAutoFocus) {
+                      editorService.blur();
+                      // wait a bit for the keyboard to be closed on mobile
+                      if (isMobile) {
+                        editorService.setLoading(true);
+                        await new Promise((resolve) =>
+                          setTimeout(resolve, 500)
+                        );
+                        editorService.setLoading(false);
+                      }
+                    }
+                    onEnterKeyDown(
+                      editorService.isEmpty() && !canSubmitEmpty,
+                      editorService.getMarkdownAndMentions(),
+                      () => {
+                        editorService.clearEditor();
+                      },
+                      editorService.setLoading
+                    );
+                  }}
+                />
+              </TooltipTrigger>
+              {submitBlockMessage && (
+                <TooltipContent>{submitBlockMessage}</TooltipContent>
+              )}
+            </TooltipRoot>
+          </TooltipProvider>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

Before: When you send a message to @soupinou and soupinou is processing and you switch to @pistache, when you click on the submit button in the input bar, you get a tooltip: "Resolve the pending action from @soupinou before switching agents".

Goal: have the same behavior if instead of clicking on the send button you hit the Enter key to send. 

To do this, the Button's built-in tooltip prop is replaced with a manual controlled TooltipRoot, driven by a boolean state that is set to true for 2 seconds on a blocked Enter attempt.

I know it's a lot of code and annoying to manually deal with the tooltip state just for that, but we thought it was important that the user would understand why hitting enter would not send the message. Is there a better solution? 

## Tests

Locally. 

## Risk

Break this tooltip? 
Can be rolled back. 

## Deploy Plan

Deploy front. 