### PR TITLE
Fix microsoft connector worker OOM from leaked GCS read streams

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -74,6 +74,7 @@ import {
 } from "@connectors/types";
 import type { LoggerInterface } from "@dust-tt/client";
 import { removeNulls } from "@dust-tt/client";
+import type { Bucket } from "@google-cloud/storage";
 import { Storage } from "@google-cloud/storage";
 import type { Client } from "@microsoft/microsoft-graph-client";
 import { GraphError } from "@microsoft/microsoft-graph-client";
@@ -91,6 +92,21 @@ interface DeltaDataInGCS {
   rootNodeIds: string[];
   sortedChangedItems: DriveItem[];
   totalItems: number;
+}
+
+let _deltaSyncBucket: Bucket | null = null;
+function getDeltaSyncBucket(): Bucket {
+  if (!_deltaSyncBucket) {
+    const storage = new Storage({
+      keyFilename: isDevelopment()
+        ? connectorsConfig.getServiceAccount()
+        : undefined,
+    });
+    _deltaSyncBucket = storage.bucket(
+      connectorsConfig.getDustTmpSyncBucketName()
+    );
+  }
+  return _deltaSyncBucket;
 }
 
 // Creates a readable stream that yields JSON chunks for DeltaDataInGCS.
@@ -146,22 +162,31 @@ function createDeltaJsonStream(
 // for very large files (JavaScript string limit ~512MB).
 // Uses stream-json's Assembler to reconstruct the object from a token stream.
 async function readDeltaFromGCSStream(
-  file: ReturnType<ReturnType<Storage["bucket"]>["file"]>
+  file: ReturnType<Bucket["file"]>
 ): Promise<DeltaDataInGCS> {
-  return new Promise((resolve, reject) => {
-    const readStream = file.createReadStream();
-    const jsonParser = parser();
-    const assembler = Assembler.connectTo(jsonParser);
+  const readStream = file.createReadStream();
+  const jsonParser = parser();
 
-    assembler.on("done", (asm: Assembler) => {
-      resolve(asm.current as DeltaDataInGCS);
+  try {
+    const assembler = Assembler.connectTo(jsonParser);
+    const done = new Promise<DeltaDataInGCS>((resolve, reject) => {
+      assembler.on("done", (asm: Assembler) =>
+        resolve(asm.current as DeltaDataInGCS)
+      );
+      jsonParser.on("error", reject);
     });
 
-    readStream.on("error", reject);
-    jsonParser.on("error", reject);
-
-    readStream.pipe(jsonParser);
-  });
+    // `pipeline()` ensures both streams are torn down on error or completion, releasing the
+    // underlying TLS socket back to the agent pool.
+    const [, result] = await Promise.all([
+      pipeline(readStream, jsonParser),
+      done,
+    ]);
+    return result;
+  } finally {
+    readStream.destroy();
+    jsonParser.destroy();
+  }
 }
 
 const FILES_SYNC_CONCURRENCY = 10;
@@ -1409,13 +1434,7 @@ export async function fetchDeltaForRootNodesInDrive({
   const gcsFilePath = `microsoft-delta-sync/${connectorId}/${driveId}/${timestamp}_delta.json`;
 
   // Upload the delta data to GCS
-  const storage = new Storage({
-    keyFilename: isDevelopment()
-      ? connectorsConfig.getServiceAccount()
-      : undefined,
-  });
-  const bucket = storage.bucket(connectorsConfig.getDustTmpSyncBucketName());
-  const file = bucket.file(gcsFilePath);
+  const file = getDeltaSyncBucket().file(gcsFilePath);
 
   // Process changes in batches of 1000
   const uniqueChangedItems = removeAllButLastOccurences(results);
@@ -1550,13 +1569,7 @@ export async function cleanupDeltaGCSFile({
   const logger = getActivityLogger(connector);
 
   try {
-    const storage = new Storage({
-      keyFilename: isDevelopment()
-        ? connectorsConfig.getServiceAccount()
-        : undefined,
-    });
-    const bucket = storage.bucket(connectorsConfig.getDustTmpSyncBucketName());
-    const file = bucket.file(gcsFilePath);
+    const file = getDeltaSyncBucket().file(gcsFilePath);
 
     await file.delete();
     logger.info(
@@ -2277,13 +2290,7 @@ export async function processDeltaChangesFromGCS({
   const logger = getActivityLogger(connector);
 
   // Read the GCS file to get the list of changed items
-  const storage = new Storage({
-    keyFilename: isDevelopment()
-      ? connectorsConfig.getServiceAccount()
-      : undefined,
-  });
-  const bucket = storage.bucket(connectorsConfig.getDustTmpSyncBucketName());
-  const file = bucket.file(gcsFilePath);
+  const file = getDeltaSyncBucket().file(gcsFilePath);
 
   // Use streaming JSON parse to avoid "Invalid string length" error
   // when the file is too large to convert to a string.

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -9,12 +9,7 @@ import {
   isReadableAsText,
   resolveConversationFile,
 } from "@app/lib/api/actions/servers/files/tools/utils";
-import { makeProcessedMountFileName } from "@app/lib/api/files/mount_path";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import {
-  isLLMVisionSupportedImageContentType,
-  isSupportedAudioContentType,
-} from "@app/types/files";
+import { isLLMVisionSupportedImageContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -53,30 +48,6 @@ function catImage(
         imageContentType: mimeType,
       },
     },
-  ]);
-}
-
-async function catAudio(
-  file: GCSFile,
-  path: string,
-  startLine: number,
-  maxLines: number
-): Promise<ToolHandlerResult> {
-  const processedGcsPath = makeProcessedMountFileName({
-    mountFilePath: file.name,
-    processedContentType: "text/plain",
-  });
-  const processedFile = getPrivateUploadBucket().file(processedGcsPath);
-  try {
-    const [exists] = await processedFile.exists();
-    if (exists) {
-      return catText(processedFile, path, startLine, maxLines);
-    }
-  } catch {
-    // Fall through to the empty transcript message.
-  }
-  return new Ok([
-    { type: "text", text: `\`${path}\` has no transcript available.` },
   ]);
 }
 
@@ -173,10 +144,6 @@ export async function catHandler(
 
   if (isLLMVisionSupportedImageContentType(mimeType)) {
     return catImage(file, { path, mimeType, sizeBytes });
-  }
-
-  if (isSupportedAudioContentType(mimeType)) {
-    return catAudio(file, path, offset ?? 1, limit ?? CAT_LINES_DEFAULT);
   }
 
   if (!isReadableAsText(mimeType)) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We have observed frequent OOM-killed pods on `connectors-worker-microsoft`deployment. Profiling the heap revealed that  significant part of the retained memory (~958MB) was held by a single HTTPS `Agent`, with ~739MB on its in-use `sockets` map keyed by `storage.googleapis.com:443`. The amount on `freeSockets` was negligible (~33KB), confirming the sockets were in-use, not idle keep-alive entries.

<img width="2853" height="216" alt="image" src="https://github.com/user-attachments/assets/7431d7ba-b46f-40ba-aeb1-62dd4506cc1d" />

## Findings

The `readDeltaFromGCSStream` function resolved its returned promise on `assembler.on("done")`. Which fires as soon as
`stream-json`'s `Assembler` finishes reconstructing the JSON object. At that
point:
- The underlying GCS `readStream` was never destroyed. Its TLS socket stayed referenced via `https.globalAgent.sockets`. (`@google-cloud/storage` 7.19.0 -> `google-auth-library` -> `gaxios` does not set a custom
`agent` for plain HTTPS) (verified in `node_modules/gaxios/build/src/gaxios.js:435-463` so all requests share Node's process-wide `https.globalAgent`.)
- The chain used raw `.pipe()` instead of `pipeline()`, so errors on one side did not tear down the other side.
- Only one of `readStream` / `jsonParser` rejected on error. The other was left dangling.

Each invocation of the activity therefore leaked one socket onto the shared agent. They accumulated across the worker's lifetime until OOM.

## Fixes

1. **`readDeltaFromGCSStream`**
- Replaces `.pipe()` with `pipeline()` so both streams are torn down on error or completion.
- Awaits both `pipeline()` resolution and the assembler `done` event before returning.
- Destroys both streams in a `finally` block as a final safety net.

2. **`getDeltaSyncBucket()` singleton**
- Replaces three per-activity `new Storage({...}).bucket(...)`  with a memoized bucket handle. Avoids
redundant `GoogleAuth` + gaxios construction + fs read for the SA per activity invocation. Purely an hygiene move, not solving the leak.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
