### PR TITLE
[front] phase 1 slice 2: admin API + UI for https_secret env vars

### DIFF
--- a/front/admin/audit_log_schemas/sandbox_env_var.allowed_domains_updated.json
+++ b/front/admin/audit_log_schemas/sandbox_env_var.allowed_domains_updated.json
@@ -1,10 +1,11 @@
 {
-  "action": "sandbox_env_var.created",
+  "action": "sandbox_env_var.allowed_domains_updated",
   "targets": [{ "type": "workspace" }, { "type": "sandbox_env_var" }],
   "metadata": {
     "name": "string",
     "kind": "string",
     "allowed_domains": "string",
+    "previous_allowed_domains": "string",
     "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/sandbox_env_var.deleted.json
+++ b/front/admin/audit_log_schemas/sandbox_env_var.deleted.json
@@ -3,6 +3,8 @@
   "targets": [{ "type": "workspace" }, { "type": "sandbox_env_var" }],
   "metadata": {
     "name": "string",
+    "kind": "string",
+    "allowed_domains": "string",
     "actor_type": "string"
   }
 }

--- a/front/admin/audit_log_schemas/sandbox_env_var.promoted_to_https_secret.json
+++ b/front/admin/audit_log_schemas/sandbox_env_var.promoted_to_https_secret.json
@@ -1,8 +1,9 @@
 {
-  "action": "sandbox_env_var.created",
+  "action": "sandbox_env_var.promoted_to_https_secret",
   "targets": [{ "type": "workspace" }, { "type": "sandbox_env_var" }],
   "metadata": {
     "name": "string",
+    "previous_name": "string",
     "kind": "string",
     "allowed_domains": "string",
     "actor_type": "string"

--- a/front/admin/audit_log_schemas/sandbox_env_var.updated.json
+++ b/front/admin/audit_log_schemas/sandbox_env_var.updated.json
@@ -3,6 +3,8 @@
   "targets": [{ "type": "workspace" }, { "type": "sandbox_env_var" }],
   "metadata": {
     "name": "string",
+    "kind": "string",
+    "allowed_domains": "string",
     "previously_existed": "string",
     "actor_type": "string"
   }

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -26,6 +26,7 @@ import {
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   Button,
+  Chip,
   ContentMessage,
   cn,
   Dialog,
@@ -38,6 +39,8 @@ import {
   InformationCircleIcon,
   Input,
   Label,
+  ListGroup,
+  ListItem,
   LockIcon,
   Page,
   PencilSquareIcon,
@@ -492,17 +495,18 @@ export function EnvironmentSection() {
             No environment variables yet.
           </ContentMessage>
         ) : (
-          <div className="flex w-full flex-col divide-y divide-separator dark:divide-separator-night">
+          <ListGroup>
             {envVars.map((envVar) => {
               const updatedBy =
                 envVar.lastUpdatedByName ?? envVar.createdByName ?? "Unknown";
+              const isAnyMutationPending =
+                isUpsertingWorkspaceSandboxEnvVar ||
+                isDeletingWorkspaceSandboxEnvVar ||
+                isPatchingWorkspaceSandboxEnvVar;
 
               return (
-                <div
-                  key={envVar.name}
-                  className="flex items-center justify-between gap-3 py-3"
-                >
-                  <div className="flex min-w-0 flex-col gap-1">
+                <ListItem key={envVar.name} itemsAlignment="center">
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
                     <pre
                       title={envVar.name}
                       className="min-w-0 self-start overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2 text-sm text-foreground dark:bg-muted-background-night dark:text-foreground-night"
@@ -514,12 +518,23 @@ export function EnvironmentSection() {
                       {timeAgoFrom(envVar.updatedAt, { useLongFormat: true })}{" "}
                       ago by {updatedBy}
                     </div>
-                    <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                      {labelForKind(envVar.kind)}
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <Chip
+                        size="xs"
+                        color={
+                          envVar.kind === "https_secret" ? "warning" : "info"
+                        }
+                        label={labelForKind(envVar.kind)}
+                      />
                       {envVar.kind === "https_secret" &&
-                      envVar.allowedDomains?.length
-                        ? ` - ${envVar.allowedDomains.join(", ")}`
-                        : ""}
+                        envVar.allowedDomains?.map((domain) => (
+                          <Chip
+                            key={domain}
+                            size="xs"
+                            color="white"
+                            label={domain}
+                          />
+                        ))}
                     </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
@@ -532,11 +547,7 @@ export function EnvironmentSection() {
                           ? `Promote ${envVar.name} to HTTPS secret`
                           : `Edit allowed domains for ${envVar.name}`
                       }
-                      disabled={
-                        isUpsertingWorkspaceSandboxEnvVar ||
-                        isDeletingWorkspaceSandboxEnvVar ||
-                        isPatchingWorkspaceSandboxEnvVar
-                      }
+                      disabled={isAnyMutationPending}
                       onClick={() => openConfigureDomainsDialog(envVar)}
                     />
                     <Button
@@ -544,11 +555,7 @@ export function EnvironmentSection() {
                       size="mini"
                       icon={PencilSquareIcon}
                       tooltip={`Replace value of ${envVar.name}`}
-                      disabled={
-                        isUpsertingWorkspaceSandboxEnvVar ||
-                        isDeletingWorkspaceSandboxEnvVar ||
-                        isPatchingWorkspaceSandboxEnvVar
-                      }
+                      disabled={isAnyMutationPending}
                       onClick={() => openReplaceDialog(envVar)}
                     />
                     <Button
@@ -556,18 +563,14 @@ export function EnvironmentSection() {
                       size="mini"
                       icon={TrashIcon}
                       tooltip={`Delete ${envVar.name}`}
-                      disabled={
-                        isDeletingWorkspaceSandboxEnvVar ||
-                        isUpsertingWorkspaceSandboxEnvVar ||
-                        isPatchingWorkspaceSandboxEnvVar
-                      }
+                      disabled={isAnyMutationPending}
                       onClick={() => setEnvVarToDelete(envVar)}
                     />
                   </div>
-                </div>
+                </ListItem>
               );
             })}
-          </div>
+          </ListGroup>
         )}
       </Page.Vertical>
     );

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -1,5 +1,7 @@
 import {
   ENV_VAR_NAME_SUFFIX_REGEX,
+  envVarPrefixForKind,
+  MAX_HTTPS_SECRET_VALUE_BYTES,
   MAX_VALUE_BYTES,
   SANDBOX_ENV_VAR_PREFIX,
 } from "@app/lib/api/sandbox/env_vars";
@@ -10,11 +12,18 @@ import {
 } from "@app/lib/auth/AuthContext";
 import {
   useDeleteWorkspaceSandboxEnvVar,
+  usePatchWorkspaceSandboxEnvVar,
   useUpsertWorkspaceSandboxEnvVar,
   useWorkspaceSandboxEnvVars,
 } from "@app/lib/swr/sandbox";
 import { timeAgoFrom } from "@app/lib/utils";
-import type { WorkspaceSandboxEnvVarType } from "@app/types/sandbox/env_var";
+import { normalizeEgressPolicyDomains } from "@app/types/sandbox/egress_policy";
+import {
+  WORKSPACE_SANDBOX_ENV_VAR_KINDS,
+  type WorkspaceSandboxEnvVarKind,
+  type WorkspaceSandboxEnvVarType,
+} from "@app/types/sandbox/env_var";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   Button,
   ContentMessage,
@@ -25,12 +34,16 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  GlobeAltIcon,
   InformationCircleIcon,
+  Input,
   Label,
   LockIcon,
   Page,
   PencilSquareIcon,
   PlusIcon,
+  RadioGroup,
+  RadioGroupItem,
   Spinner,
   TextArea,
   TrashIcon,
@@ -41,32 +54,121 @@ import { useController, useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 
 const NAME_HELPER_TEXT =
-  "Uppercase letters, digits and underscores. Up to 64 characters after the DST_ prefix.";
+  "Uppercase letters, digits and underscores. Up to 64 characters after the prefix.";
 
-const formSchema = z.object({
-  name: z
-    .string()
-    .min(1, NAME_HELPER_TEXT)
-    .regex(
-      ENV_VAR_NAME_SUFFIX_REGEX,
-      "Suffix must start with A-Z and then use only A-Z, 0-9, or underscore, up to 64 characters."
-    ),
-  value: z
-    .string()
-    .min(1, "Value is required.")
-    .refine(
-      (value) => !value.includes("\u0000"),
-      "Values cannot contain NUL bytes."
-    )
-    .refine(
-      (value) => new TextEncoder().encode(value).length <= MAX_VALUE_BYTES,
-      "Values cannot exceed 32 KiB."
-    ),
-});
+const ALLOWED_DOMAINS_HELPER_TEXT =
+  "Use exact domains such as api.github.com or wildcards such as *.github.com.";
+
+function parseAllowedDomainsText(value: string): string[] {
+  return value
+    .split(",")
+    .map((domain) => domain.trim())
+    .filter((domain) => domain.length > 0);
+}
+
+function getEnvVarSuffix(envVar: WorkspaceSandboxEnvVarType): string {
+  const prefix = envVarPrefixForKind(envVar.kind);
+  return envVar.name.startsWith(prefix)
+    ? envVar.name.slice(prefix.length)
+    : envVar.name;
+}
+
+function labelForKind(kind: WorkspaceSandboxEnvVarKind): string {
+  switch (kind) {
+    case "config":
+      return "Config";
+    case "https_secret":
+      return "HTTPS secret";
+    default:
+      assertNeverAndIgnore(kind);
+      return "";
+  }
+}
+
+const formSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, NAME_HELPER_TEXT)
+      .regex(
+        ENV_VAR_NAME_SUFFIX_REGEX,
+        "Suffix must start with A-Z and then use only A-Z, 0-9, or underscore, up to 64 characters."
+      ),
+    value: z.string().min(1, "Value is required."),
+    kind: z.enum(WORKSPACE_SANDBOX_ENV_VAR_KINDS),
+    allowedDomainsText: z.string(),
+  })
+  .superRefine((data, ctx) => {
+    const valueBytes = new TextEncoder().encode(data.value).length;
+
+    switch (data.kind) {
+      case "config": {
+        if (data.value.includes("\u0000")) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["value"],
+            message: "Values cannot contain NUL bytes.",
+          });
+        }
+        if (valueBytes > MAX_VALUE_BYTES) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["value"],
+            message: "Values cannot exceed 32 KiB.",
+          });
+        }
+        return;
+      }
+
+      case "https_secret": {
+        if (/[\u0000-\u001F\u007F]/.test(data.value)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["value"],
+            message: "HTTPS secret values cannot contain ASCII control bytes.",
+          });
+        }
+        if (valueBytes > MAX_HTTPS_SECRET_VALUE_BYTES) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["value"],
+            message: `HTTPS secret values cannot exceed ${
+              MAX_HTTPS_SECRET_VALUE_BYTES / 1_024
+            } KiB.`,
+          });
+        }
+
+        const allowedDomains = parseAllowedDomainsText(data.allowedDomainsText);
+        if (allowedDomains.length === 0) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["allowedDomainsText"],
+            message: "HTTPS secrets require at least one allowed domain.",
+          });
+          return;
+        }
+
+        const normalizedDomains = normalizeEgressPolicyDomains(allowedDomains);
+        if (normalizedDomains.isErr()) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["allowedDomainsText"],
+            message: normalizedDomains.error.message,
+          });
+        }
+        return;
+      }
+    }
+  });
 
 type FormValues = z.infer<typeof formSchema>;
 
-const DEFAULT_FORM_VALUES: FormValues = { name: "", value: "" };
+const DEFAULT_FORM_VALUES: FormValues = {
+  name: "",
+  value: "",
+  kind: "config",
+  allowedDomainsText: "",
+};
 
 export function EnvironmentSection() {
   const owner = useWorkspace();
@@ -77,8 +179,13 @@ export function EnvironmentSection() {
     featureFlags.includes("sandbox_workspace_admin");
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isNameLocked, setIsNameLocked] = useState(false);
+  const [envVarToReplace, setEnvVarToReplace] =
+    useState<WorkspaceSandboxEnvVarType | null>(null);
   const [envVarToDelete, setEnvVarToDelete] =
     useState<WorkspaceSandboxEnvVarType | null>(null);
+  const [envVarToConfigureDomains, setEnvVarToConfigureDomains] =
+    useState<WorkspaceSandboxEnvVarType | null>(null);
+  const [domainsText, setDomainsText] = useState("");
 
   const {
     envVars,
@@ -90,6 +197,8 @@ export function EnvironmentSection() {
   });
   const { upsertWorkspaceSandboxEnvVar, isUpsertingWorkspaceSandboxEnvVar } =
     useUpsertWorkspaceSandboxEnvVar({ owner });
+  const { patchWorkspaceSandboxEnvVar, isPatchingWorkspaceSandboxEnvVar } =
+    usePatchWorkspaceSandboxEnvVar({ owner });
   const { deleteWorkspaceSandboxEnvVar, isDeletingWorkspaceSandboxEnvVar } =
     useDeleteWorkspaceSandboxEnvVar({ owner });
 
@@ -106,11 +215,25 @@ export function EnvironmentSection() {
     reset,
   } = form;
   const { field: nameField } = useController({ control, name: "name" });
+  const { field: kindField } = useController({ control, name: "kind" });
   const nameValue = nameField.value;
   const valueValue = useWatch({ control, name: "value" });
+  const kindValue = useWatch({ control, name: "kind" });
+  const allowedDomainsTextValue = useWatch({
+    control,
+    name: "allowedDomainsText",
+  });
 
-  const fullName = nameValue ? `${SANDBOX_ENV_VAR_PREFIX}${nameValue}` : "";
-  const isReplacing = envVars.some((envVar) => envVar.name === fullName);
+  const namePrefix = envVarPrefixForKind(kindValue);
+  const fullName = nameValue ? `${namePrefix}${nameValue}` : "";
+  const existingEnvVarForSuffix = envVars.find(
+    (envVar) => getEnvVarSuffix(envVar) === nameValue
+  );
+  const isReplacing = existingEnvVarForSuffix?.name === fullName;
+  const isNameTakenByOtherKind =
+    !isNameLocked &&
+    existingEnvVarForSuffix !== undefined &&
+    existingEnvVarForSuffix.name !== fullName;
   const nameMessage = (() => {
     if (errors.name) {
       return {
@@ -120,6 +243,14 @@ export function EnvironmentSection() {
     }
     if (nameValue.length === 0) {
       return { message: NAME_HELPER_TEXT, isError: false };
+    }
+    if (isNameTakenByOtherKind) {
+      return {
+        message: `A variable with this suffix already exists as ${
+          existingEnvVarForSuffix?.name ?? fullName
+        }.`,
+        isError: true,
+      };
     }
     return {
       message: isReplacing
@@ -133,8 +264,42 @@ export function EnvironmentSection() {
       return { message: errors.value.message ?? "", isError: true };
     }
     const valueBytes = new TextEncoder().encode(valueValue).length;
+    const maxBytes =
+      kindValue === "https_secret"
+        ? MAX_HTTPS_SECRET_VALUE_BYTES
+        : MAX_VALUE_BYTES;
+    const suffix =
+      kindValue === "https_secret"
+        ? "ASCII control bytes are not allowed."
+        : "Multiline values are allowed.";
     return {
-      message: `${valueBytes} / ${MAX_VALUE_BYTES} bytes. Multiline values are allowed.`,
+      message: `${valueBytes} / ${maxBytes} bytes. ${suffix}`,
+      isError: false,
+    };
+  })();
+  const allowedDomainsMessage = (() => {
+    if (kindValue !== "https_secret") {
+      return null;
+    }
+    if (errors.allowedDomainsText) {
+      return {
+        message: errors.allowedDomainsText.message ?? "",
+        isError: true,
+      };
+    }
+
+    const allowedDomains = parseAllowedDomainsText(allowedDomainsTextValue);
+    if (allowedDomains.length === 0) {
+      return { message: ALLOWED_DOMAINS_HELPER_TEXT, isError: false };
+    }
+
+    const normalizedDomains = normalizeEgressPolicyDomains(allowedDomains);
+    if (normalizedDomains.isErr()) {
+      return { message: normalizedDomains.error.message, isError: true };
+    }
+
+    return {
+      message: `Will be saved as ${normalizedDomains.value.join(", ")}.`,
       isError: false,
     };
   })();
@@ -143,36 +308,98 @@ export function EnvironmentSection() {
     valueValue.length > 0 &&
     !errors.name &&
     !errors.value &&
+    !errors.allowedDomainsText &&
+    !isNameTakenByOtherKind &&
     !isUpsertingWorkspaceSandboxEnvVar;
+
+  const domainsDialogParsed = parseAllowedDomainsText(domainsText);
+  const domainsDialogNormalized =
+    domainsDialogParsed.length > 0
+      ? normalizeEgressPolicyDomains(domainsDialogParsed)
+      : null;
+  const domainsDialogMessage =
+    domainsDialogNormalized?.isErr() === true
+      ? domainsDialogNormalized.error.message
+      : domainsDialogNormalized?.isOk() === true
+        ? `Will be saved as ${domainsDialogNormalized.value.join(", ")}.`
+        : ALLOWED_DOMAINS_HELPER_TEXT;
+  const isDomainsDialogInvalid = domainsDialogNormalized?.isErr() === true;
+  const canSaveDomains =
+    domainsDialogNormalized?.isOk() === true &&
+    domainsDialogNormalized.value.length > 0 &&
+    !isPatchingWorkspaceSandboxEnvVar;
 
   const closeDialog = () => {
     setIsDialogOpen(false);
     setIsNameLocked(false);
+    setEnvVarToReplace(null);
     reset(DEFAULT_FORM_VALUES);
   };
 
   const openAddDialog = () => {
     reset(DEFAULT_FORM_VALUES);
+    setEnvVarToReplace(null);
     setIsNameLocked(false);
     setIsDialogOpen(true);
   };
 
   const openReplaceDialog = (envVar: WorkspaceSandboxEnvVarType) => {
-    const suffix = envVar.name.startsWith(SANDBOX_ENV_VAR_PREFIX)
-      ? envVar.name.slice(SANDBOX_ENV_VAR_PREFIX.length)
-      : envVar.name;
-    reset({ name: suffix, value: "" });
+    reset({
+      name: getEnvVarSuffix(envVar),
+      value: "",
+      kind: envVar.kind,
+      allowedDomainsText: envVar.allowedDomains?.join(", ") ?? "",
+    });
+    setEnvVarToReplace(envVar);
     setIsNameLocked(true);
     setIsDialogOpen(true);
   };
 
+  const openConfigureDomainsDialog = (envVar: WorkspaceSandboxEnvVarType) => {
+    setDomainsText(envVar.allowedDomains?.join(", ") ?? "");
+    setEnvVarToConfigureDomains(envVar);
+  };
+
   const onSubmit = async (data: FormValues) => {
+    const shouldCreateSecretWithDomains =
+      data.kind === "https_secret" && envVarToReplace === null;
+    const normalizedDomains = shouldCreateSecretWithDomains
+      ? normalizeEgressPolicyDomains(
+          parseAllowedDomainsText(data.allowedDomainsText)
+        )
+      : null;
+    if (normalizedDomains?.isErr() === true) {
+      return;
+    }
+
     const success = await upsertWorkspaceSandboxEnvVar({
-      name: `${SANDBOX_ENV_VAR_PREFIX}${data.name}`,
+      name: `${envVarPrefixForKind(data.kind)}${data.name}`,
       value: data.value,
+      kind: data.kind,
+      allowedDomains:
+        normalizedDomains?.isOk() === true
+          ? normalizedDomains.value
+          : undefined,
     });
     if (success) {
       closeDialog();
+    }
+  };
+
+  const handleConfigureDomains = async () => {
+    if (!envVarToConfigureDomains || domainsDialogNormalized?.isOk() !== true) {
+      return;
+    }
+
+    const success = await patchWorkspaceSandboxEnvVar({
+      envVar: envVarToConfigureDomains,
+      kind:
+        envVarToConfigureDomains.kind === "config" ? "https_secret" : undefined,
+      allowedDomains: domainsDialogNormalized.value,
+    });
+    if (success) {
+      setEnvVarToConfigureDomains(null);
+      setDomainsText("");
     }
   };
 
@@ -287,8 +514,31 @@ export function EnvironmentSection() {
                       {timeAgoFrom(envVar.updatedAt, { useLongFormat: true })}{" "}
                       ago by {updatedBy}
                     </div>
+                    <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                      {labelForKind(envVar.kind)}
+                      {envVar.kind === "https_secret" &&
+                      envVar.allowedDomains?.length
+                        ? ` - ${envVar.allowedDomains.join(", ")}`
+                        : ""}
+                    </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="mini"
+                      icon={envVar.kind === "config" ? LockIcon : GlobeAltIcon}
+                      tooltip={
+                        envVar.kind === "config"
+                          ? `Promote ${envVar.name} to HTTPS secret`
+                          : `Edit allowed domains for ${envVar.name}`
+                      }
+                      disabled={
+                        isUpsertingWorkspaceSandboxEnvVar ||
+                        isDeletingWorkspaceSandboxEnvVar ||
+                        isPatchingWorkspaceSandboxEnvVar
+                      }
+                      onClick={() => openConfigureDomainsDialog(envVar)}
+                    />
                     <Button
                       variant="outline"
                       size="mini"
@@ -296,7 +546,8 @@ export function EnvironmentSection() {
                       tooltip={`Replace value of ${envVar.name}`}
                       disabled={
                         isUpsertingWorkspaceSandboxEnvVar ||
-                        isDeletingWorkspaceSandboxEnvVar
+                        isDeletingWorkspaceSandboxEnvVar ||
+                        isPatchingWorkspaceSandboxEnvVar
                       }
                       onClick={() => openReplaceDialog(envVar)}
                     />
@@ -307,7 +558,8 @@ export function EnvironmentSection() {
                       tooltip={`Delete ${envVar.name}`}
                       disabled={
                         isDeletingWorkspaceSandboxEnvVar ||
-                        isUpsertingWorkspaceSandboxEnvVar
+                        isUpsertingWorkspaceSandboxEnvVar ||
+                        isPatchingWorkspaceSandboxEnvVar
                       }
                       onClick={() => setEnvVarToDelete(envVar)}
                     />
@@ -339,6 +591,36 @@ export function EnvironmentSection() {
           </DialogHeader>
           <DialogContainer>
             <Page.Vertical align="stretch" gap="md">
+              {!isNameLocked ? (
+                <div className="flex flex-col gap-2">
+                  <Label>Type</Label>
+                  <RadioGroup
+                    value={kindField.value}
+                    onValueChange={(value) => {
+                      switch (value) {
+                        case "config":
+                        case "https_secret":
+                          kindField.onChange(value);
+                          return;
+                      }
+                    }}
+                    className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+                  >
+                    <RadioGroupItem
+                      id="sandbox-env-var-kind-config"
+                      value="config"
+                      label="Config"
+                      disabled={isUpsertingWorkspaceSandboxEnvVar}
+                    />
+                    <RadioGroupItem
+                      id="sandbox-env-var-kind-https-secret"
+                      value="https_secret"
+                      label="HTTPS secret"
+                      disabled={isUpsertingWorkspaceSandboxEnvVar}
+                    />
+                  </RadioGroup>
+                </div>
+              ) : null}
               <div className="flex flex-col gap-1">
                 <Label htmlFor="sandbox-env-var-name">Name</Label>
                 <div
@@ -356,9 +638,9 @@ export function EnvironmentSection() {
                   <span
                     className="select-none text-muted-foreground dark:text-muted-foreground-night"
                     aria-hidden="true"
-                    title="The DST_ prefix is reserved and cannot be removed."
+                    title={`The ${namePrefix} prefix is reserved and cannot be removed.`}
                   >
-                    {SANDBOX_ENV_VAR_PREFIX}
+                    {namePrefix}
                   </span>
                   <input
                     id="sandbox-env-var-name"
@@ -385,6 +667,18 @@ export function EnvironmentSection() {
                   {nameMessage.message}
                 </div>
               </div>
+              {kindValue === "https_secret" && envVarToReplace === null ? (
+                <Input
+                  label="Allowed domains"
+                  placeholder="api.github.com, *.github.com"
+                  message={allowedDomainsMessage?.message}
+                  messageStatus={
+                    allowedDomainsMessage?.isError ? "error" : "info"
+                  }
+                  disabled={isUpsertingWorkspaceSandboxEnvVar}
+                  {...register("allowedDomainsText")}
+                />
+              ) : null}
               <div className="flex flex-col gap-1">
                 <Label htmlFor="sandbox-env-var-value">Value</Label>
                 <TextArea
@@ -433,6 +727,80 @@ export function EnvironmentSection() {
           />
         </DialogContent>
       </Dialog>
+
+      {envVarToConfigureDomains ? (
+        <Dialog
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) {
+              setEnvVarToConfigureDomains(null);
+              setDomainsText("");
+            }
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>
+                {envVarToConfigureDomains.kind === "config"
+                  ? `Promote ${envVarToConfigureDomains.name}`
+                  : `Allowed domains for ${envVarToConfigureDomains.name}`}
+              </DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
+              <Page.Vertical align="stretch" gap="md">
+                {envVarToConfigureDomains.kind === "config" ? (
+                  <ContentMessage
+                    variant="warning"
+                    icon={InformationCircleIcon}
+                    title="Promotion only takes effect on next wake"
+                  >
+                    Running sandboxes keep the previous {SANDBOX_ENV_VAR_PREFIX}
+                    -prefixed value until they are restarted, and the
+                    secrets-file substitution path is not live yet, so promoted
+                    variables will not be available to new sandboxes either
+                    until that ships.
+                  </ContentMessage>
+                ) : null}
+                <Input
+                  label="Allowed domains"
+                  name="sandbox-env-var-allowed-domains"
+                  placeholder="api.github.com, *.github.com"
+                  value={domainsText}
+                  message={domainsDialogMessage}
+                  messageStatus={isDomainsDialogInvalid ? "error" : "info"}
+                  disabled={isPatchingWorkspaceSandboxEnvVar}
+                  onChange={(event) => setDomainsText(event.target.value)}
+                />
+              </Page.Vertical>
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: () => {
+                  setEnvVarToConfigureDomains(null);
+                  setDomainsText("");
+                },
+              }}
+              rightButtonProps={{
+                label:
+                  envVarToConfigureDomains.kind === "config"
+                    ? "Promote"
+                    : "Save",
+                icon:
+                  envVarToConfigureDomains.kind === "config"
+                    ? LockIcon
+                    : GlobeAltIcon,
+                onClick: () => {
+                  void handleConfigureDomains();
+                },
+                disabled: !canSaveDomains,
+                isLoading: isPatchingWorkspaceSandboxEnvVar,
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+      ) : null}
 
       {envVarToDelete ? (
         <Dialog

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -28,7 +28,6 @@ import {
   Button,
   Chip,
   ContentMessage,
-  cn,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -45,8 +44,7 @@ import {
   Page,
   PencilSquareIcon,
   PlusIcon,
-  RadioGroup,
-  RadioGroupItem,
+  SliderToggle,
   Spinner,
   TextArea,
   TrashIcon,
@@ -60,7 +58,7 @@ const NAME_HELPER_TEXT =
   "Uppercase letters, digits and underscores. Up to 64 characters after the prefix.";
 
 const ALLOWED_DOMAINS_HELPER_TEXT =
-  "Use exact domains such as api.github.com or wildcards such as *.github.com.";
+  "Use exact domains such as api.openai.com or wildcards such as *.mistral.ai.";
 
 function parseAllowedDomainsText(value: string): string[] {
   return value
@@ -216,6 +214,7 @@ export function EnvironmentSection() {
     handleSubmit,
     register,
     reset,
+    trigger,
   } = form;
   const { field: nameField } = useController({ control, name: "name" });
   const { field: kindField } = useController({ control, name: "kind" });
@@ -456,29 +455,35 @@ export function EnvironmentSection() {
         />
 
         <ContentMessage
-          variant="warning"
-          icon={InformationCircleIcon}
-          size="lg"
-          title="Handle as write-only secrets"
-        >
-          These values are mounted on every future sandbox in this workspace.
-          The agent is instructed not to print or echo them, and bash output is
-          redacted on a best-effort basis. This is defense-in-depth, not a
-          guarantee: encoded output, network calls from sandbox code, and short
-          or dictionary-like values may still leak. Use least-privilege,
-          high-entropy credentials and rotate often. Values cannot be viewed
-          after saving, only overwritten or deleted.
-        </ContentMessage>
-
-        <ContentMessage
           variant="info"
           icon={InformationCircleIcon}
           size="lg"
-          title="Changes apply to new sandboxes only"
+          title="Choose the right kind for each value"
         >
-          Env vars are snapshotted at sandbox boot. Running sandboxes keep their
-          original values; new sandboxes (new conversations, restarts) pick up
-          the latest.
+          <div className="flex flex-col gap-2">
+            <div>
+              <strong>HTTPS secrets (DSEC_)</strong> — for credentials and
+              anything sensitive. Stored encrypted on the host. The dsbx
+              forwarder injects the value only into outbound HTTPS requests to
+              the domains you whitelist; sandbox code never sees the raw value.
+              Safe for API keys, tokens, and other secrets bound to a known
+              external service.
+            </div>
+            <div>
+              <strong>Config ({SANDBOX_ENV_VAR_PREFIX})</strong> — for
+              non-sensitive configuration: feature flags, identifiers, public
+              endpoints, model names. Mounted as plain env vars on every new
+              sandbox and read directly by the agent and the code it runs.
+              Anything you put here should be safe to log; do not use for
+              credentials.
+            </div>
+            <div>
+              Values are write-only: they cannot be viewed after saving, only
+              overwritten or deleted. Env vars are snapshotted at sandbox boot,
+              so running sandboxes keep their original values; new sandboxes
+              (new conversations, restarts) pick up the latest.
+            </div>
+          </div>
         </ContentMessage>
 
         <div className="flex justify-end">
@@ -596,60 +601,68 @@ export function EnvironmentSection() {
             <Page.Vertical align="stretch" gap="md">
               {!isNameLocked ? (
                 <div className="flex flex-col gap-2">
-                  <Label>Type</Label>
-                  <RadioGroup
-                    value={kindField.value}
-                    onValueChange={(value) => {
-                      switch (value) {
-                        case "config":
-                        case "https_secret":
-                          kindField.onChange(value);
-                          return;
-                      }
-                    }}
-                    className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="flex flex-col">
+                      <Label>HTTPS secret</Label>
+                      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                        Keep the value out of the sandbox environment.
+                      </span>
+                    </div>
+                    <SliderToggle
+                      size="sm"
+                      selected={kindField.value === "https_secret"}
+                      disabled={isUpsertingWorkspaceSandboxEnvVar}
+                      onClick={() => {
+                        kindField.onChange(
+                          kindField.value === "https_secret"
+                            ? "config"
+                            : "https_secret"
+                        );
+                        void trigger(["value", "allowedDomainsText"]);
+                      }}
+                    />
+                  </div>
+                  <ContentMessage
+                    variant={kindValue === "https_secret" ? "info" : "warning"}
+                    icon={
+                      kindValue === "https_secret" ? LockIcon : GlobeAltIcon
+                    }
+                    size="sm"
                   >
-                    <RadioGroupItem
-                      id="sandbox-env-var-kind-config"
-                      value="config"
-                      label="Config"
-                      disabled={isUpsertingWorkspaceSandboxEnvVar}
-                    />
-                    <RadioGroupItem
-                      id="sandbox-env-var-kind-https-secret"
-                      value="https_secret"
-                      label="HTTPS secret"
-                      disabled={isUpsertingWorkspaceSandboxEnvVar}
-                    />
-                  </RadioGroup>
+                    {kindValue === "https_secret" ? (
+                      <>
+                        Stored securely. The dsbx forwarder injects it only into
+                        outbound HTTPS requests to whitelisted domains; sandbox
+                        code never reads it.
+                      </>
+                    ) : (
+                      <>
+                        Mounted as a prefixed env var on every new sandbox and
+                        read directly by the agent and any code it runs. Use for
+                        non-sensitive values.
+                      </>
+                    )}
+                  </ContentMessage>
                 </div>
               ) : null}
               <div className="flex flex-col gap-1">
                 <Label htmlFor="sandbox-env-var-name">Name</Label>
-                <div
-                  aria-disabled={
-                    isUpsertingWorkspaceSandboxEnvVar || isNameLocked
-                  }
-                  className={cn(
-                    "flex h-9 w-full items-center rounded-xl border bg-muted-background pl-3 text-sm focus-within:ring focus-within:ring-inset dark:bg-muted-background-night",
-                    nameMessage.isError &&
-                      "border-border-warning dark:border-border-warning-night",
-                    (isUpsertingWorkspaceSandboxEnvVar || isNameLocked) &&
-                      "cursor-not-allowed opacity-50"
-                  )}
-                >
+                <div className="relative">
                   <span
-                    className="select-none text-muted-foreground dark:text-muted-foreground-night"
+                    className="pointer-events-none absolute left-3 top-0 flex h-9 select-none items-center text-sm text-muted-foreground dark:text-muted-foreground-night"
                     aria-hidden="true"
                     title={`The ${namePrefix} prefix is reserved and cannot be removed.`}
                   >
                     {namePrefix}
                   </span>
-                  <input
+                  <Input
                     id="sandbox-env-var-name"
                     type="text"
                     placeholder="API_TOKEN"
-                    className="h-full w-full flex-1 border-0 bg-transparent pl-1 pr-3 text-foreground outline-none placeholder:text-muted-foreground dark:text-foreground-night dark:placeholder:text-muted-foreground-night"
+                    className={namePrefix === "DSEC_" ? "pl-14" : "pl-11"}
+                    isError={nameMessage.isError}
+                    message={nameMessage.message}
+                    messageStatus={nameMessage.isError ? "error" : "info"}
                     disabled={isUpsertingWorkspaceSandboxEnvVar || isNameLocked}
                     ref={nameField.ref}
                     name={nameField.name}
@@ -660,27 +673,37 @@ export function EnvironmentSection() {
                     }
                   />
                 </div>
+              </div>
+              {envVarToReplace === null ? (
                 <div
                   className={
-                    nameMessage.isError
-                      ? "text-xs text-foreground-warning dark:text-foreground-warning-night"
-                      : "text-xs text-muted-foreground dark:text-muted-foreground-night"
+                    kindValue === "https_secret"
+                      ? undefined
+                      : "pointer-events-none opacity-40"
                   }
+                  aria-disabled={kindValue !== "https_secret"}
                 >
-                  {nameMessage.message}
+                  <Input
+                    label="Allowed domains"
+                    placeholder="e.g. api.openai.com, *.mistral.ai"
+                    message={
+                      kindValue === "https_secret"
+                        ? allowedDomainsMessage?.message
+                        : "Only used when HTTPS secret is on."
+                    }
+                    messageStatus={
+                      kindValue === "https_secret" &&
+                      allowedDomainsMessage?.isError
+                        ? "error"
+                        : "info"
+                    }
+                    disabled={
+                      isUpsertingWorkspaceSandboxEnvVar ||
+                      kindValue !== "https_secret"
+                    }
+                    {...register("allowedDomainsText")}
+                  />
                 </div>
-              </div>
-              {kindValue === "https_secret" && envVarToReplace === null ? (
-                <Input
-                  label="Allowed domains"
-                  placeholder="api.github.com, *.github.com"
-                  message={allowedDomainsMessage?.message}
-                  messageStatus={
-                    allowedDomainsMessage?.isError ? "error" : "info"
-                  }
-                  disabled={isUpsertingWorkspaceSandboxEnvVar}
-                  {...register("allowedDomainsText")}
-                />
               ) : null}
               <div className="flex flex-col gap-1">
                 <Label htmlFor="sandbox-env-var-value">Value</Label>
@@ -758,16 +781,15 @@ export function EnvironmentSection() {
                     title="Promotion only takes effect on next wake"
                   >
                     Running sandboxes keep the previous {SANDBOX_ENV_VAR_PREFIX}
-                    -prefixed value until they are restarted, and the
-                    secrets-file substitution path is not live yet, so promoted
-                    variables will not be available to new sandboxes either
-                    until that ships.
+                    -prefixed value in their env until they are restarted. New
+                    sandboxes will receive the promoted secret only via
+                    egress-time substitution to the allowed domains.
                   </ContentMessage>
                 ) : null}
                 <Input
                   label="Allowed domains"
                   name="sandbox-env-var-allowed-domains"
-                  placeholder="api.github.com, *.github.com"
+                  placeholder="e.g. api.openai.com, *.mistral.ai"
                   value={domainsText}
                   message={domainsDialogMessage}
                   messageStatus={isDomainsDialogInvalid ? "error" : "info"}

--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -71,7 +71,7 @@ export function NetworkSection() {
         ? "This domain is already allowed."
         : normalizedDomain
           ? `Will be saved as ${normalizedDomain}.`
-          : "Use an exact domain such as api.github.com or a wildcard such as *.github.com.";
+          : "Use an exact domain such as api.openai.com or a wildcard such as *.mistral.ai.";
   const isDomainInputInvalid =
     domainInputResult?.isErr() === true || isDuplicate;
   const canAddDomain =
@@ -188,7 +188,7 @@ export function NetworkSection() {
             <Input
               label="Domain"
               name="domain"
-              placeholder="api.github.com or *.github.com"
+              placeholder="e.g. api.openai.com or *.mistral.ai"
               value={domainInput}
               message={domainInputMessage}
               messageStatus={isDomainInputInvalid ? "error" : "info"}

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -60,8 +60,10 @@ type AuditAction =
   | "sandbox_egress_policy.agent_requests_setting_updated"
   | "sandbox_egress_policy.sandbox_updated"
   | "sandbox_egress_policy.updated"
+  | "sandbox_env_var.allowed_domains_updated"
   | "sandbox_env_var.created"
   | "sandbox_env_var.deleted"
+  | "sandbox_env_var.promoted_to_https_secret"
   | "sandbox_env_var.updated"
   // SCIM / Directory Sync.
   | "scim.user_provisioned"
@@ -125,7 +127,7 @@ export type EmitAuditLogEventParams = {
  * schema definitions, which declare every metadata value as `"string"`.
  */
 function serializeMetadata(
-  metadata: Record<string, string | number | boolean> | undefined
+  metadata: Record<string, string | number | boolean> | undefined,
 ): Record<string, string> | undefined {
   if (!metadata) {
     return undefined;
@@ -142,7 +144,7 @@ function serializeMetadata(
  * either via feature flag or plan setting.
  */
 export async function isAuditLogsEnabled(
-  auth: Authenticator
+  auth: Authenticator,
 ): Promise<boolean> {
   if (await hasFeatureFlag(auth, "audit_logs")) {
     return true;
@@ -196,7 +198,7 @@ export async function emitAuditLogEvent({
         ...normalizeError(error),
         auditEvent: { action, targets, metadata },
       },
-      "Failed to emit audit log event"
+      "Failed to emit audit log event",
     );
   }
 }
@@ -263,7 +265,7 @@ export async function emitAuditLogEventDirect({
         ...normalizeError(error),
         auditEvent: { action, targets, metadata },
       },
-      "Failed to emit audit log event"
+      "Failed to emit audit log event",
     );
   }
 }
@@ -333,7 +335,7 @@ type AuditTargetResourceMap = {
  */
 export function buildAuditLogTarget<T extends AuditTargetType>(
   type: T,
-  resource: AuditTargetResourceMap[T]
+  resource: AuditTargetResourceMap[T],
 ): AuditLogTarget {
   return { type, id: resource.sId, name: resource.name };
 }
@@ -348,7 +350,7 @@ export function getAuditLogContext(
   req?: {
     headers: Record<string, string | string[] | undefined>;
     socket?: { remoteAddress?: string };
-  }
+  },
 ): AuditLogContext {
   if (req) {
     return { location: getClientIp(req) };

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -127,7 +127,7 @@ export type EmitAuditLogEventParams = {
  * schema definitions, which declare every metadata value as `"string"`.
  */
 function serializeMetadata(
-  metadata: Record<string, string | number | boolean> | undefined,
+  metadata: Record<string, string | number | boolean> | undefined
 ): Record<string, string> | undefined {
   if (!metadata) {
     return undefined;
@@ -144,7 +144,7 @@ function serializeMetadata(
  * either via feature flag or plan setting.
  */
 export async function isAuditLogsEnabled(
-  auth: Authenticator,
+  auth: Authenticator
 ): Promise<boolean> {
   if (await hasFeatureFlag(auth, "audit_logs")) {
     return true;
@@ -198,7 +198,7 @@ export async function emitAuditLogEvent({
         ...normalizeError(error),
         auditEvent: { action, targets, metadata },
       },
-      "Failed to emit audit log event",
+      "Failed to emit audit log event"
     );
   }
 }
@@ -265,7 +265,7 @@ export async function emitAuditLogEventDirect({
         ...normalizeError(error),
         auditEvent: { action, targets, metadata },
       },
-      "Failed to emit audit log event",
+      "Failed to emit audit log event"
     );
   }
 }
@@ -335,7 +335,7 @@ type AuditTargetResourceMap = {
  */
 export function buildAuditLogTarget<T extends AuditTargetType>(
   type: T,
-  resource: AuditTargetResourceMap[T],
+  resource: AuditTargetResourceMap[T]
 ): AuditLogTarget {
   return { type, id: resource.sId, name: resource.name };
 }
@@ -350,7 +350,7 @@ export function getAuditLogContext(
   req?: {
     headers: Record<string, string | string[] | undefined>;
     socket?: { remoteAddress?: string };
-  },
+  }
 ): AuditLogContext {
   if (req) {
     return { location: getClientIp(req) };

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -306,6 +306,20 @@ describe("SandboxResource.ensureActive", () => {
         createdByUserId: user.id,
         lastUpdatedByUserId: user.id,
       },
+      {
+        workspaceId: workspace.id,
+        name: "SECRET_TOKEN",
+        kind: "https_secret",
+        placeholderNonce: Buffer.alloc(16, 1),
+        allowedDomains: ["api.example.com"],
+        encryptedValue: encrypt({
+          text: "workspace-secret-token",
+          key: workspace.sId,
+          useCase: "developer_secret",
+        }),
+        createdByUserId: user.id,
+        lastUpdatedByUserId: user.id,
+      },
     ]);
 
     const result = await SandboxResource.ensureActive(
@@ -324,6 +338,9 @@ describe("SandboxResource.ensureActive", () => {
         }),
       }),
       { workspaceId: workspace.sId }
+    );
+    expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
+      "DSEC_SECRET_TOKEN"
     );
   });
 });

--- a/front/lib/resources/workspace_sandbox_env_var_resource.test.ts
+++ b/front/lib/resources/workspace_sandbox_env_var_resource.test.ts
@@ -93,7 +93,7 @@ describe("WorkspaceSandboxEnvVarResource", () => {
   it("creates HTTPS secrets with stable nonce and normalized allowed domains", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
 
-    const createResult = await WorkspaceSandboxEnvVarResource.create(
+    const createResult = await WorkspaceSandboxEnvVarResource.makeNew(
       authenticator,
       {
         name: "API_TOKEN",
@@ -141,7 +141,7 @@ describe("WorkspaceSandboxEnvVarResource", () => {
       allowedDomains: ["api.openai.com"],
     });
 
-    const configResult = await WorkspaceSandboxEnvVarResource.create(
+    const configResult = await WorkspaceSandboxEnvVarResource.makeNew(
       authenticator,
       {
         name: "CONFIG_TOKEN",
@@ -164,7 +164,7 @@ describe("WorkspaceSandboxEnvVarResource", () => {
   it("promotes config vars to HTTPS secrets without injecting plaintext env", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
 
-    const createResult = await WorkspaceSandboxEnvVarResource.create(
+    const createResult = await WorkspaceSandboxEnvVarResource.makeNew(
       authenticator,
       {
         name: "API_TOKEN",
@@ -207,7 +207,7 @@ describe("WorkspaceSandboxEnvVarResource", () => {
   it("rotates HTTPS secret value and allowed domains in a single upsert", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
 
-    const createResult = await WorkspaceSandboxEnvVarResource.create(
+    const createResult = await WorkspaceSandboxEnvVarResource.makeNew(
       authenticator,
       {
         name: "API_TOKEN",
@@ -247,7 +247,7 @@ describe("WorkspaceSandboxEnvVarResource", () => {
   it("validates HTTPS secret values and allowed domains without changing config multiline values", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
 
-    const multilineConfig = await WorkspaceSandboxEnvVarResource.create(
+    const multilineConfig = await WorkspaceSandboxEnvVarResource.makeNew(
       authenticator,
       {
         name: "MULTILINE_CONFIG",
@@ -263,7 +263,7 @@ describe("WorkspaceSandboxEnvVarResource", () => {
       "a".repeat(8 * 1024 + 1),
     ];
     for (const [index, value] of invalidValues.entries()) {
-      const result = await WorkspaceSandboxEnvVarResource.create(
+      const result = await WorkspaceSandboxEnvVarResource.makeNew(
         authenticator,
         {
           name: `SECRET_VALUE_${index}`,
@@ -277,7 +277,7 @@ describe("WorkspaceSandboxEnvVarResource", () => {
 
     const invalidAllowedDomains = [undefined, [], ["127.0.0.1"]];
     for (const [index, allowedDomains] of invalidAllowedDomains.entries()) {
-      const result = await WorkspaceSandboxEnvVarResource.create(
+      const result = await WorkspaceSandboxEnvVarResource.makeNew(
         authenticator,
         {
           name: `SECRET_DOMAIN_${index}`,

--- a/front/lib/resources/workspace_sandbox_env_var_resource.test.ts
+++ b/front/lib/resources/workspace_sandbox_env_var_resource.test.ts
@@ -141,6 +141,15 @@ describe("WorkspaceSandboxEnvVarResource", () => {
       allowedDomains: ["api.openai.com"],
     });
 
+    const configResult = await WorkspaceSandboxEnvVarResource.create(
+      authenticator,
+      {
+        name: "CONFIG_TOKEN",
+        value: "config-token",
+      }
+    );
+    expect(configResult.isOk()).toBe(true);
+
     const envResult =
       await WorkspaceSandboxEnvVarResource.loadEnv(authenticator);
     expect(envResult.isOk()).toBe(true);
@@ -148,7 +157,90 @@ describe("WorkspaceSandboxEnvVarResource", () => {
       throw envResult.error;
     }
     expect(envResult.value).toEqual({
-      DSEC_API_TOKEN: "rotated-token",
+      DST_CONFIG_TOKEN: "config-token",
+    });
+  });
+
+  it("promotes config vars to HTTPS secrets without injecting plaintext env", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const createResult = await WorkspaceSandboxEnvVarResource.create(
+      authenticator,
+      {
+        name: "API_TOKEN",
+        value: "super-secret-token",
+      }
+    );
+    expect(createResult.isOk()).toBe(true);
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+
+    const promotedResult = await createResult.value.promoteToHttpsSecret(
+      authenticator,
+      {
+        allowedDomains: [" API.GitHub.COM. "],
+      }
+    );
+    expect(promotedResult.isOk()).toBe(true);
+    if (promotedResult.isErr()) {
+      throw promotedResult.error;
+    }
+    expect(promotedResult.value.toJSON()).toMatchObject({
+      name: "DSEC_API_TOKEN",
+      kind: "https_secret",
+      allowedDomains: ["api.github.com"],
+    });
+    expect(promotedResult.value.toJSON().placeholderNonce).toMatch(
+      /^[0-9a-f]{32}$/
+    );
+
+    const envResult =
+      await WorkspaceSandboxEnvVarResource.loadEnv(authenticator);
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value).toEqual({});
+  });
+
+  it("rotates HTTPS secret value and allowed domains in a single upsert", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const createResult = await WorkspaceSandboxEnvVarResource.create(
+      authenticator,
+      {
+        name: "API_TOKEN",
+        kind: "https_secret",
+        value: "super-secret-token",
+        allowedDomains: ["api.github.com"],
+      }
+    );
+    expect(createResult.isOk()).toBe(true);
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+    const initialNonce = createResult.value.toJSON().placeholderNonce;
+
+    const upsertResult = await WorkspaceSandboxEnvVarResource.upsert(
+      authenticator,
+      {
+        name: "API_TOKEN",
+        kind: "https_secret",
+        value: "rotated-token",
+        allowedDomains: ["api.openai.com"],
+      }
+    );
+    expect(upsertResult.isOk()).toBe(true);
+    if (upsertResult.isErr()) {
+      throw upsertResult.error;
+    }
+    expect(upsertResult.value.created).toBe(false);
+    expect(upsertResult.value.resource.toJSON()).toMatchObject({
+      name: "DSEC_API_TOKEN",
+      kind: "https_secret",
+      allowedDomains: ["api.openai.com"],
+      placeholderNonce: initialNonce,
     });
   });
 

--- a/front/lib/resources/workspace_sandbox_env_var_resource.ts
+++ b/front/lib/resources/workspace_sandbox_env_var_resource.ts
@@ -14,13 +14,16 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { makeSId } from "@app/lib/resources/string_ids";
+import {
+  getResourceIdFromSId,
+  isResourceSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
 import { normalizeEgressPolicyDomains } from "@app/types/sandbox/egress_policy";
 import type {
   WorkspaceSandboxEnvVarKind,
   WorkspaceSandboxEnvVarType,
 } from "@app/types/sandbox/env_var";
-import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -155,8 +158,15 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
 
   static async fetchById(
     auth: Authenticator,
-    id: ModelId
+    sId: string
   ): Promise<WorkspaceSandboxEnvVarResource | null> {
+    if (!isResourceSId("sandbox_env_var", sId)) {
+      return null;
+    }
+    const id = getResourceIdFromSId(sId);
+    if (id === null) {
+      return null;
+    }
     const rows = await this.baseFetch(auth, { id });
     return rows[0] ?? null;
   }
@@ -366,7 +376,7 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
   // Create-only entry point for callers that must not replace an existing
   // value. Implementation defers to upsert() and rejects when the row already
   // existed — relies on the unique index to catch concurrent creates.
-  static async create(
+  static async makeNew(
     auth: Authenticator,
     {
       name,
@@ -470,34 +480,26 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
       lastUpdatedByUserId: user.id,
     });
 
-    const updated = await WorkspaceSandboxEnvVarResource.fetchById(
-      auth,
-      this.id
-    );
-    if (!updated) {
-      return new Err(new Error("Sandbox environment variable not found."));
-    }
-
     void emitAuditLogEvent({
       auth,
       action: "sandbox_env_var.promoted_to_https_secret",
       targets: [
         buildAuditLogTarget("workspace", owner),
         buildAuditLogTarget("sandbox_env_var", {
-          sId: updated.sId,
-          name: updated.envName,
+          sId: this.sId,
+          name: this.envName,
         }),
       ],
       context,
       metadata: {
-        name: updated.envName,
+        name: this.envName,
         previous_name: previousEnvName,
-        kind: updated.kind,
-        allowed_domains: formatAllowedDomainsForAudit(updated.allowedDomains),
+        kind: this.kind,
+        allowed_domains: formatAllowedDomainsForAudit(this.allowedDomains),
       },
     });
 
-    return new Ok(updated);
+    return new Ok(this);
   }
 
   async updateValue(
@@ -532,34 +534,26 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
       lastUpdatedByUserId: user.id,
     });
 
-    const updated = await WorkspaceSandboxEnvVarResource.fetchById(
-      auth,
-      this.id
-    );
-    if (!updated) {
-      return new Err(new Error("Sandbox environment variable not found."));
-    }
-
     void emitAuditLogEvent({
       auth,
       action: "sandbox_env_var.updated",
       targets: [
         buildAuditLogTarget("workspace", owner),
         buildAuditLogTarget("sandbox_env_var", {
-          sId: updated.sId,
-          name: updated.envName,
+          sId: this.sId,
+          name: this.envName,
         }),
       ],
       context,
       metadata: {
-        name: updated.envName,
-        kind: updated.kind,
-        allowed_domains: formatAllowedDomainsForAudit(updated.allowedDomains),
+        name: this.envName,
+        kind: this.kind,
+        allowed_domains: formatAllowedDomainsForAudit(this.allowedDomains),
         previously_existed: "true",
       },
     });
 
-    return new Ok(updated);
+    return new Ok(this);
   }
 
   async updateAllowedDomains(
@@ -612,36 +606,28 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
       lastUpdatedByUserId: user.id,
     });
 
-    const updated = await WorkspaceSandboxEnvVarResource.fetchById(
-      auth,
-      this.id
-    );
-    if (!updated) {
-      return new Err(new Error("Sandbox environment variable not found."));
-    }
-
     void emitAuditLogEvent({
       auth,
       action: "sandbox_env_var.allowed_domains_updated",
       targets: [
         buildAuditLogTarget("workspace", owner),
         buildAuditLogTarget("sandbox_env_var", {
-          sId: updated.sId,
-          name: updated.envName,
+          sId: this.sId,
+          name: this.envName,
         }),
       ],
       context,
       metadata: {
-        name: updated.envName,
-        kind: updated.kind,
-        allowed_domains: formatAllowedDomainsForAudit(updated.allowedDomains),
+        name: this.envName,
+        kind: this.kind,
+        allowed_domains: formatAllowedDomainsForAudit(this.allowedDomains),
         previous_allowed_domains: formatAllowedDomainsForAudit(
           previousAllowedDomains
         ),
       },
     });
 
-    return new Ok(updated);
+    return new Ok(this);
   }
 
   private static normalizeAllowedDomainsForKind({

--- a/front/lib/resources/workspace_sandbox_env_var_resource.ts
+++ b/front/lib/resources/workspace_sandbox_env_var_resource.ts
@@ -44,6 +44,34 @@ const USER_JOIN_INCLUDES: Includeable[] = [
 
 type NormalizedAllowedDomains = string[] | null | undefined;
 
+function formatAllowedDomainsForAudit(
+  allowedDomains: string[] | null | undefined
+): string {
+  return JSON.stringify(allowedDomains ?? []);
+}
+
+// Domains are compared as sets so reordering the same domains does not
+// trigger an `allowed_domains_updated` audit emission.
+function areAllowedDomainsEqual(
+  left: string[] | null | undefined,
+  right: string[] | null | undefined
+): boolean {
+  const leftSet = new Set(left ?? []);
+  const rightSet = new Set(right ?? []);
+
+  if (leftSet.size !== rightSet.size) {
+    return false;
+  }
+
+  for (const domain of leftSet) {
+    if (!rightSet.has(domain)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface WorkspaceSandboxEnvVarResource
   extends ReadonlyAttributesType<WorkspaceSandboxEnvVarModel> {}
@@ -94,7 +122,7 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
 
   private static async baseFetch(
     auth: Authenticator,
-    where?: Partial<Pick<WorkspaceSandboxEnvVarModel, "id" | "name">>,
+    where?: Partial<Pick<WorkspaceSandboxEnvVarModel, "id" | "kind" | "name">>,
     { withUserJoins = true }: { withUserJoins?: boolean } = {}
   ): Promise<WorkspaceSandboxEnvVarResource[]> {
     const isPointLookup = Boolean(where?.id ?? where?.name);
@@ -133,9 +161,11 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
     return rows[0] ?? null;
   }
 
-  // `kind` and `allowedDomains` are reachable in slice 2 once the API/admin
-  // UI accept them. Slice 1 callers stick to `kind = 'config'` defaults and
-  // never pass `allowedDomains`.
+  // Rejects kind transitions: the one-way config -> https_secret promotion
+  // goes through `promoteToHttpsSecret`. For an existing https_secret row,
+  // callers may pass `allowedDomains` alongside the new value to rotate both
+  // in one call; this emits both `sandbox_env_var.updated` and
+  // `sandbox_env_var.allowed_domains_updated`.
   static async upsert(
     auth: Authenticator,
     {
@@ -187,6 +217,8 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
 
     let row: WorkspaceSandboxEnvVarModel;
     let created: boolean;
+    let allowedDomainsChanged = false;
+    let previousAllowedDomains: string[] | null = null;
     if (existing) {
       if (existing.kind !== kind) {
         return new Err(
@@ -204,6 +236,14 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
       if (normalizedAllowedDomains.isErr()) {
         return normalizedAllowedDomains;
       }
+      previousAllowedDomains = existing.allowedDomains;
+      allowedDomainsChanged =
+        allowedDomains !== undefined &&
+        allowedDomains !== null &&
+        !areAllowedDomainsEqual(
+          previousAllowedDomains,
+          normalizedAllowedDomains.value
+        );
 
       // `existing` is a Sequelize model instance (we found it via `findOne`
       // above), not a Resource — that's why we call its `update()` directly
@@ -278,17 +318,53 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
       ],
       context,
       metadata: created
-        ? { name: resource.envName }
-        : { name: resource.envName, previously_existed: "true" },
+        ? {
+            name: resource.envName,
+            kind: resource.kind,
+            allowed_domains: formatAllowedDomainsForAudit(
+              resource.allowedDomains
+            ),
+          }
+        : {
+            name: resource.envName,
+            kind: resource.kind,
+            allowed_domains: formatAllowedDomainsForAudit(
+              resource.allowedDomains
+            ),
+            previously_existed: "true",
+          },
     });
+
+    if (!created && allowedDomainsChanged) {
+      void emitAuditLogEvent({
+        auth,
+        action: "sandbox_env_var.allowed_domains_updated",
+        targets: [
+          buildAuditLogTarget("workspace", owner),
+          buildAuditLogTarget("sandbox_env_var", {
+            sId: resource.sId,
+            name: resource.envName,
+          }),
+        ],
+        context,
+        metadata: {
+          name: resource.envName,
+          kind: resource.kind,
+          allowed_domains: formatAllowedDomainsForAudit(
+            resource.allowedDomains
+          ),
+          previous_allowed_domains: formatAllowedDomainsForAudit(
+            previousAllowedDomains
+          ),
+        },
+      });
+    }
 
     return new Ok({ resource, created });
   }
 
-  // Slice-2-callable. Slice 1's API still routes through `upsert()`; this
-  // helper exists so future callers (admin promotion flow, scripts) get a
-  // create-only entry point without piggybacking on upsert's update branch.
-  // Implementation defers to upsert() and rejects when the row already
+  // Create-only entry point for callers that must not replace an existing
+  // value. Implementation defers to upsert() and rejects when the row already
   // existed — relies on the unique index to catch concurrent creates.
   static async create(
     auth: Authenticator,
@@ -322,6 +398,106 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
     }
 
     return new Ok(result.value.resource);
+  }
+
+  async promoteToHttpsSecret(
+    auth: Authenticator,
+    {
+      allowedDomains,
+      context,
+    }: {
+      allowedDomains: string[];
+      context?: AuditLogContext;
+    }
+  ): Promise<Result<WorkspaceSandboxEnvVarResource, Error>> {
+    if (this.kind !== "config") {
+      return new Err(
+        new Error(
+          "Only config sandbox environment variables can be promoted to HTTPS secrets."
+        )
+      );
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+    const previousEnvName = this.envName;
+
+    const normalizedAllowedDomains =
+      WorkspaceSandboxEnvVarResource.normalizeAllowedDomainsForKind({
+        kind: "https_secret",
+        allowedDomains,
+        requiredForSecret: true,
+      });
+    if (normalizedAllowedDomains.isErr()) {
+      return normalizedAllowedDomains;
+    }
+    const normalizedAllowedDomainsValue = normalizedAllowedDomains.value;
+    if (!normalizedAllowedDomainsValue) {
+      return new Err(
+        new Error("HTTPS secrets require at least one allowed domain.")
+      );
+    }
+
+    let currentValue: string;
+    try {
+      currentValue = decrypt({
+        encrypted: this.encryptedValue,
+        key: owner.sId,
+        useCase: "developer_secret",
+      });
+    } catch (error) {
+      return new Err(
+        new Error(
+          `Failed to decrypt sandbox environment variable ${previousEnvName}: ${
+            normalizeError(error).message
+          }`
+        )
+      );
+    }
+
+    const valueValidation = validateEnvVarValueForKind({
+      kind: "https_secret",
+      value: currentValue,
+    });
+    if (valueValidation.isErr()) {
+      return new Err(new Error(valueValidation.error));
+    }
+
+    await this.update({
+      kind: "https_secret",
+      placeholderNonce: randomBytes(16),
+      allowedDomains: normalizedAllowedDomainsValue,
+      lastUpdatedByUserId: user.id,
+    });
+
+    const updated = await WorkspaceSandboxEnvVarResource.fetchById(
+      auth,
+      this.id
+    );
+    if (!updated) {
+      return new Err(new Error("Sandbox environment variable not found."));
+    }
+
+    void emitAuditLogEvent({
+      auth,
+      action: "sandbox_env_var.promoted_to_https_secret",
+      targets: [
+        buildAuditLogTarget("workspace", owner),
+        buildAuditLogTarget("sandbox_env_var", {
+          sId: updated.sId,
+          name: updated.envName,
+        }),
+      ],
+      context,
+      metadata: {
+        name: updated.envName,
+        previous_name: previousEnvName,
+        kind: updated.kind,
+        allowed_domains: formatAllowedDomainsForAudit(updated.allowedDomains),
+      },
+    });
+
+    return new Ok(updated);
   }
 
   async updateValue(
@@ -375,7 +551,12 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
         }),
       ],
       context,
-      metadata: { name: updated.envName, previously_existed: "true" },
+      metadata: {
+        name: updated.envName,
+        kind: updated.kind,
+        allowed_domains: formatAllowedDomainsForAudit(updated.allowedDomains),
+        previously_existed: "true",
+      },
     });
 
     return new Ok(updated);
@@ -391,8 +572,15 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
       context?: AuditLogContext;
     }
   ): Promise<Result<WorkspaceSandboxEnvVarResource, Error>> {
+    if (this.kind !== "https_secret") {
+      return new Err(
+        new Error("Allowed domains can only be updated for HTTPS secrets.")
+      );
+    }
+
     const owner = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
+    const previousAllowedDomains = this.allowedDomains;
 
     const normalizedAllowedDomains =
       WorkspaceSandboxEnvVarResource.normalizeAllowedDomainsForKind({
@@ -403,9 +591,24 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
     if (normalizedAllowedDomains.isErr()) {
       return normalizedAllowedDomains;
     }
+    const normalizedAllowedDomainsValue = normalizedAllowedDomains.value;
+    if (!normalizedAllowedDomainsValue) {
+      return new Err(
+        new Error("HTTPS secrets require at least one allowed domain.")
+      );
+    }
+
+    if (
+      areAllowedDomainsEqual(
+        previousAllowedDomains,
+        normalizedAllowedDomainsValue
+      )
+    ) {
+      return new Ok(this);
+    }
 
     await this.update({
-      allowedDomains: normalizedAllowedDomains.value,
+      allowedDomains: normalizedAllowedDomainsValue,
       lastUpdatedByUserId: user.id,
     });
 
@@ -419,7 +622,7 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
 
     void emitAuditLogEvent({
       auth,
-      action: "sandbox_env_var.updated",
+      action: "sandbox_env_var.allowed_domains_updated",
       targets: [
         buildAuditLogTarget("workspace", owner),
         buildAuditLogTarget("sandbox_env_var", {
@@ -428,7 +631,14 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
         }),
       ],
       context,
-      metadata: { name: updated.envName, previously_existed: "true" },
+      metadata: {
+        name: updated.envName,
+        kind: updated.kind,
+        allowed_domains: formatAllowedDomainsForAudit(updated.allowedDomains),
+        previous_allowed_domains: formatAllowedDomainsForAudit(
+          previousAllowedDomains
+        ),
+      },
     });
 
     return new Ok(updated);
@@ -524,7 +734,11 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
         }),
       ],
       context,
-      metadata: { name: this.envName },
+      metadata: {
+        name: this.envName,
+        kind: this.kind,
+        allowed_domains: formatAllowedDomainsForAudit(this.allowedDomains),
+      },
     });
 
     return new Ok(undefined);
@@ -543,17 +757,16 @@ export class WorkspaceSandboxEnvVarResource extends BaseResource<WorkspaceSandbo
   ): Promise<Result<Record<string, string>, Error>> {
     const owner = auth.getNonNullableWorkspace();
     // Hot path on every sandbox mount — skip the user joins, we only need
-    // name + encryptedValue here.
-    //
-    // TODO(2026-05-05 SLICE_2): skip `kind = 'https_secret'` rows here.
-    // Their real value must NOT land in the agent env as `DSEC_<name>`
-    // plaintext — substitution is supposed to happen on the wire from
-    // the secrets file. Slice 1 leaves them in for symmetry; the
-    // production-user gate (no admin promotes rows in prod until the
-    // last slice) keeps this safe in the meantime.
-    const resources = await this.baseFetch(auth, undefined, {
-      withUserJoins: false,
-    });
+    // name + encryptedValue here. HTTPS secrets are intentionally absent from
+    // the agent env until Slice 3 injects placeholders backed by the secrets
+    // file; injecting their real value here would defeat the MITM swap.
+    const resources = await this.baseFetch(
+      auth,
+      { kind: "config" },
+      {
+        withUserJoins: false,
+      }
+    );
 
     const env: Record<string, string> = {};
     for (const resource of resources) {

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -14,9 +14,13 @@ import type {
   GetWorkspaceSandboxEnvVarsResponseBody,
   PostWorkspaceSandboxEnvVarsResponseBody,
 } from "@app/pages/api/w/[wId]/sandbox/env-vars";
+import type { PatchWorkspaceSandboxEnvVarResponseBody } from "@app/pages/api/w/[wId]/sandbox/env-vars/[id]";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import { EMPTY_EGRESS_POLICY } from "@app/types/sandbox/egress_policy";
-import type { WorkspaceSandboxEnvVarType } from "@app/types/sandbox/env_var";
+import type {
+  WorkspaceSandboxEnvVarKind,
+  WorkspaceSandboxEnvVarType,
+} from "@app/types/sandbox/env_var";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useState } from "react";
@@ -30,6 +34,13 @@ function workspaceSandboxEnvVarsUrl(workspaceId: string) {
   return `/api/w/${workspaceId}/sandbox/env-vars`;
 }
 
+type WorkspaceSandboxEnvVarWritePayload = {
+  name: string;
+  value: string;
+  kind?: WorkspaceSandboxEnvVarKind;
+  allowedDomains?: string[] | null;
+};
+
 export function useWorkspaceEgressPolicy({
   owner,
   disabled = false,
@@ -42,7 +53,7 @@ export function useWorkspaceEgressPolicy({
   const { data, error, mutate, isLoading } = useSWRWithDefaults(
     workspaceEgressPolicyUrl(owner.sId),
     policyFetcher,
-    { disabled }
+    { disabled },
   );
 
   return {
@@ -66,7 +77,7 @@ export function useWorkspaceSandboxEnvVars({
   const { data, error, mutate, isLoading } = useSWRWithDefaults(
     workspaceSandboxEnvVarsUrl(owner.sId),
     envVarsFetcher,
-    { disabled }
+    { disabled },
   );
 
   return {
@@ -90,12 +101,11 @@ export function useUpsertWorkspaceSandboxEnvVar({
   });
 
   const upsertWorkspaceSandboxEnvVar = async ({
+    allowedDomains,
+    kind,
     name,
     value,
-  }: {
-    name: string;
-    value: string;
-  }): Promise<boolean> => {
+  }: WorkspaceSandboxEnvVarWritePayload): Promise<boolean> => {
     setIsUpserting(true);
     try {
       const response = await clientFetch(
@@ -105,8 +115,8 @@ export function useUpsertWorkspaceSandboxEnvVar({
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ name, value }),
-        }
+          body: JSON.stringify({ allowedDomains, kind, name, value }),
+        },
       );
 
       if (!response.ok) {
@@ -148,6 +158,80 @@ export function useUpsertWorkspaceSandboxEnvVar({
   };
 }
 
+export function usePatchWorkspaceSandboxEnvVar({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isPatching, setIsPatching] = useState(false);
+  const { mutateWorkspaceSandboxEnvVars } = useWorkspaceSandboxEnvVars({
+    owner,
+    disabled: true,
+  });
+
+  const patchWorkspaceSandboxEnvVar = async ({
+    allowedDomains,
+    envVar,
+    kind,
+  }: {
+    envVar: WorkspaceSandboxEnvVarType;
+    kind?: WorkspaceSandboxEnvVarKind;
+    allowedDomains?: string[] | null;
+  }): Promise<boolean> => {
+    setIsPatching(true);
+    try {
+      const response = await clientFetch(
+        `${workspaceSandboxEnvVarsUrl(owner.sId)}/${envVar.sId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ allowedDomains, kind }),
+        },
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to update environment variable",
+          description: error.message,
+        });
+        return false;
+      }
+
+      const data: PatchWorkspaceSandboxEnvVarResponseBody =
+        await response.json();
+      await mutateWorkspaceSandboxEnvVars();
+      sendNotification({
+        type: "success",
+        title:
+          data.envVar.kind === "https_secret"
+            ? "Environment variable secured"
+            : "Environment variable updated",
+        description: `${data.envVar.name} has been updated.`,
+      });
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update environment variable",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsPatching(false);
+    }
+  };
+
+  return {
+    patchWorkspaceSandboxEnvVar,
+    isPatchingWorkspaceSandboxEnvVar: isPatching,
+  };
+}
+
 export function useDeleteWorkspaceSandboxEnvVar({
   owner,
 }: {
@@ -161,7 +245,7 @@ export function useDeleteWorkspaceSandboxEnvVar({
   });
 
   const deleteWorkspaceSandboxEnvVar = async (
-    envVar: WorkspaceSandboxEnvVarType
+    envVar: WorkspaceSandboxEnvVarType,
   ): Promise<boolean> => {
     setIsDeleting(true);
     try {
@@ -169,7 +253,7 @@ export function useDeleteWorkspaceSandboxEnvVar({
         `${workspaceSandboxEnvVarsUrl(owner.sId)}/${envVar.sId}`,
         {
           method: "DELETE",
-        }
+        },
       );
 
       if (!response.ok) {
@@ -215,11 +299,11 @@ export function useUpdateWorkspaceSandboxAgentEgressRequests({
   const sendNotification = useSendNotification();
   const [isUpdating, setIsUpdating] = useState(false);
   const [isEnabled, setIsEnabled] = useState(
-    owner.metadata?.sandboxAllowAgentEgressRequests === true
+    owner.metadata?.sandboxAllowAgentEgressRequests === true,
   );
 
   const updateWorkspaceSandboxAgentEgressRequests = async (
-    enabled: boolean
+    enabled: boolean,
   ): Promise<boolean> => {
     setIsUpdating(true);
     try {
@@ -273,7 +357,7 @@ export function useUpdateWorkspaceEgressPolicy({
   });
 
   const updateWorkspaceEgressPolicy = async (
-    policy: EgressPolicy
+    policy: EgressPolicy,
   ): Promise<boolean> => {
     setIsUpdating(true);
     try {

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -53,7 +53,7 @@ export function useWorkspaceEgressPolicy({
   const { data, error, mutate, isLoading } = useSWRWithDefaults(
     workspaceEgressPolicyUrl(owner.sId),
     policyFetcher,
-    { disabled },
+    { disabled }
   );
 
   return {
@@ -77,7 +77,7 @@ export function useWorkspaceSandboxEnvVars({
   const { data, error, mutate, isLoading } = useSWRWithDefaults(
     workspaceSandboxEnvVarsUrl(owner.sId),
     envVarsFetcher,
-    { disabled },
+    { disabled }
   );
 
   return {
@@ -116,7 +116,7 @@ export function useUpsertWorkspaceSandboxEnvVar({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ allowedDomains, kind, name, value }),
-        },
+        }
       );
 
       if (!response.ok) {
@@ -189,7 +189,7 @@ export function usePatchWorkspaceSandboxEnvVar({
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ allowedDomains, kind }),
-        },
+        }
       );
 
       if (!response.ok) {
@@ -245,7 +245,7 @@ export function useDeleteWorkspaceSandboxEnvVar({
   });
 
   const deleteWorkspaceSandboxEnvVar = async (
-    envVar: WorkspaceSandboxEnvVarType,
+    envVar: WorkspaceSandboxEnvVarType
   ): Promise<boolean> => {
     setIsDeleting(true);
     try {
@@ -253,7 +253,7 @@ export function useDeleteWorkspaceSandboxEnvVar({
         `${workspaceSandboxEnvVarsUrl(owner.sId)}/${envVar.sId}`,
         {
           method: "DELETE",
-        },
+        }
       );
 
       if (!response.ok) {
@@ -299,11 +299,11 @@ export function useUpdateWorkspaceSandboxAgentEgressRequests({
   const sendNotification = useSendNotification();
   const [isUpdating, setIsUpdating] = useState(false);
   const [isEnabled, setIsEnabled] = useState(
-    owner.metadata?.sandboxAllowAgentEgressRequests === true,
+    owner.metadata?.sandboxAllowAgentEgressRequests === true
   );
 
   const updateWorkspaceSandboxAgentEgressRequests = async (
-    enabled: boolean,
+    enabled: boolean
   ): Promise<boolean> => {
     setIsUpdating(true);
     try {
@@ -357,7 +357,7 @@ export function useUpdateWorkspaceEgressPolicy({
   });
 
   const updateWorkspaceEgressPolicy = async (
-    policy: EgressPolicy,
+    policy: EgressPolicy
   ): Promise<boolean> => {
     setIsUpdating(true);
     try {

--- a/front/pages/api/w/[wId]/sandbox/env-vars/[id].ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/[id].ts
@@ -39,7 +39,7 @@ async function handler(
       | PatchWorkspaceSandboxEnvVarResponseBody
     >
   >,
-  auth: Authenticator,
+  auth: Authenticator
 ): Promise<void> {
   if (!auth.isAdmin()) {
     return apiError(req, res, {
@@ -117,7 +117,7 @@ async function handler(
 
       const envVar = await WorkspaceSandboxEnvVarResource.fetchById(
         auth,
-        envVarModelId,
+        envVarModelId
       );
       if (!envVar) {
         return apiError(req, res, {
@@ -195,7 +195,7 @@ async function handler(
     case "DELETE": {
       const envVar = await WorkspaceSandboxEnvVarResource.fetchById(
         auth,
-        envVarModelId,
+        envVarModelId
       );
       if (!envVar) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/sandbox/env-vars/[id].ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/[id].ts
@@ -10,19 +10,36 @@ import {
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import {
+  WORKSPACE_SANDBOX_ENV_VAR_KINDS,
+  type WorkspaceSandboxEnvVarType,
+} from "@app/types/sandbox/env_var";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 export type DeleteWorkspaceSandboxEnvVarResponseBody = {
   success: true;
 };
 
+export type PatchWorkspaceSandboxEnvVarResponseBody = {
+  envVar: WorkspaceSandboxEnvVarType;
+};
+
+const PatchWorkspaceSandboxEnvVarBodySchema = z.object({
+  kind: z.enum(WORKSPACE_SANDBOX_ENV_VAR_KINDS).optional(),
+  allowedDomains: z.array(z.string()).optional(),
+});
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorResponse<DeleteWorkspaceSandboxEnvVarResponseBody>
+    WithAPIErrorResponse<
+      | DeleteWorkspaceSandboxEnvVarResponseBody
+      | PatchWorkspaceSandboxEnvVarResponseBody
+    >
   >,
-  auth: Authenticator
+  auth: Authenticator,
 ): Promise<void> {
   if (!auth.isAdmin()) {
     return apiError(req, res, {
@@ -73,10 +90,112 @@ async function handler(
   }
 
   switch (req.method) {
+    case "PATCH": {
+      const parsed = PatchWorkspaceSandboxEnvVarBodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: parsed.error.issues
+              .map((i) => `${i.path.join(".") || "body"}: ${i.message}`)
+              .join("; "),
+          },
+        });
+      }
+
+      const { allowedDomains, kind } = parsed.data;
+      if (kind === undefined && allowedDomains === undefined) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "At least one field must be provided.",
+          },
+        });
+      }
+
+      const envVar = await WorkspaceSandboxEnvVarResource.fetchById(
+        auth,
+        envVarModelId,
+      );
+      if (!envVar) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Sandbox environment variable not found.",
+          },
+        });
+      }
+
+      // Phase 1 only permits one-way promotion. Demoting an HTTPS secret back
+      // to config would put the real value back into the agent environment.
+      if (kind === "config" && envVar.kind === "https_secret") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Demoting an HTTPS secret to a config environment variable is not supported.",
+          },
+        });
+      }
+
+      if (kind === "https_secret" && envVar.kind === "config") {
+        if (allowedDomains === undefined) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "allowedDomains is required when promoting to an HTTPS secret.",
+            },
+          });
+        }
+
+        const promoteResult = await envVar.promoteToHttpsSecret(auth, {
+          allowedDomains,
+          context: getAuditLogContext(auth, req),
+        });
+        if (promoteResult.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: promoteResult.error.message,
+            },
+          });
+        }
+
+        return res.status(200).json({ envVar: promoteResult.value.toJSON() });
+      }
+
+      if (allowedDomains !== undefined) {
+        const updateResult = await envVar.updateAllowedDomains(auth, {
+          allowedDomains,
+          context: getAuditLogContext(auth, req),
+        });
+        if (updateResult.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: updateResult.error.message,
+            },
+          });
+        }
+
+        return res.status(200).json({ envVar: updateResult.value.toJSON() });
+      }
+
+      return res.status(200).json({ envVar: envVar.toJSON() });
+    }
+
     case "DELETE": {
       const envVar = await WorkspaceSandboxEnvVarResource.fetchById(
         auth,
-        envVarModelId
+        envVarModelId,
       );
       if (!envVar) {
         return apiError(req, res, {
@@ -109,7 +228,8 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, DELETE is expected.",
+          message:
+            "The method passed is not supported, DELETE or PATCH is expected.",
         },
       });
   }

--- a/front/pages/api/w/[wId]/sandbox/env-vars/[id].ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/[id].ts
@@ -3,10 +3,6 @@ import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
-import {
-  getResourceIdFromSId,
-  isResourceSId,
-} from "@app/lib/resources/string_ids";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -74,12 +70,7 @@ async function handler(
   }
 
   const { id } = req.query;
-
-  const envVarModelId =
-    isString(id) && isResourceSId("sandbox_env_var", id)
-      ? getResourceIdFromSId(id)
-      : null;
-  if (envVarModelId === null) {
+  if (!isString(id)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -115,10 +106,7 @@ async function handler(
         });
       }
 
-      const envVar = await WorkspaceSandboxEnvVarResource.fetchById(
-        auth,
-        envVarModelId
-      );
+      const envVar = await WorkspaceSandboxEnvVarResource.fetchById(auth, id);
       if (!envVar) {
         return apiError(req, res, {
           status_code: 404,
@@ -193,10 +181,7 @@ async function handler(
     }
 
     case "DELETE": {
-      const envVar = await WorkspaceSandboxEnvVarResource.fetchById(
-        auth,
-        envVarModelId
-      );
+      const envVar = await WorkspaceSandboxEnvVarResource.fetchById(auth, id);
       if (!envVar) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/sandbox/env-vars/delete.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/delete.test.ts
@@ -2,29 +2,54 @@ import { makeSId } from "@app/lib/resources/string_ids";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return {
+    ...actual,
+    emitAuditLogEvent: mockEmitAuditLogEvent,
+  };
+});
 
 process.env.DUST_DEVELOPERS_SECRETS_SECRET ??= "test-developer-secret";
 
 import handler from "./[id]";
 
-async function createDeleteRequest({
+async function createEnvVarIdRequest({
+  method,
   role = "admin",
+  body,
 }: {
+  method: "DELETE" | "PATCH";
   role?: "admin" | "builder" | "user";
-} = {}) {
+  body?: unknown;
+}) {
   const request = await createPrivateApiMockRequest({
-    method: "DELETE",
+    method,
     role,
   });
   await FeatureFlagFactory.basic(request.auth, "sandbox_tools");
   await FeatureFlagFactory.basic(request.auth, "sandbox_workspace_admin");
+  request.req.body = body;
   return request;
 }
 
-describe("DELETE /api/w/[wId]/sandbox/env-vars/[id]", () => {
+describe("PATCH/DELETE /api/w/[wId]/sandbox/env-vars/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("deletes an existing sandbox environment variable", async () => {
-    const { req, res, auth } = await createDeleteRequest();
+    const { req, res, auth } = await createEnvVarIdRequest({
+      method: "DELETE",
+    });
 
     const upsertResult = await WorkspaceSandboxEnvVarResource.upsert(auth, {
       name: "API_TOKEN",
@@ -46,7 +71,9 @@ describe("DELETE /api/w/[wId]/sandbox/env-vars/[id]", () => {
   });
 
   it("returns 404 for a missing sandbox environment variable", async () => {
-    const { req, res, auth } = await createDeleteRequest();
+    const { req, res, auth } = await createEnvVarIdRequest({
+      method: "DELETE",
+    });
 
     const upsertResult = await WorkspaceSandboxEnvVarResource.upsert(auth, {
       name: "API_TOKEN",
@@ -67,11 +94,132 @@ describe("DELETE /api/w/[wId]/sandbox/env-vars/[id]", () => {
   });
 
   it("rejects non-admin deletes", async () => {
-    const { req, res } = await createDeleteRequest({ role: "user" });
+    const { req, res } = await createEnvVarIdRequest({
+      method: "DELETE",
+      role: "user",
+    });
     req.query.id = makeSId("sandbox_env_var", { id: 1, workspaceId: 1 });
 
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(403);
+  });
+
+  it("promotes config variables to HTTPS secrets", async () => {
+    const { req, res, auth } = await createEnvVarIdRequest({
+      method: "PATCH",
+      body: {
+        kind: "https_secret",
+        allowedDomains: [" API.GitHub.COM. "],
+      },
+    });
+
+    const createResult = await WorkspaceSandboxEnvVarResource.create(auth, {
+      name: "API_TOKEN",
+      value: "super-secret-token",
+    });
+    expect(createResult.isOk()).toBe(true);
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+    req.query.id = createResult.value.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseBody = JSON.parse(res._getData());
+    expect(responseBody).toEqual({
+      envVar: expect.objectContaining({
+        name: "DSEC_API_TOKEN",
+        kind: "https_secret",
+        allowedDomains: ["api.github.com"],
+      }),
+    });
+    expect(responseBody.envVar.placeholderNonce).toMatch(/^[0-9a-f]{32}$/);
+
+    const envResult = await WorkspaceSandboxEnvVarResource.loadEnv(auth);
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value).toEqual({});
+
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sandbox_env_var.promoted_to_https_secret",
+        metadata: expect.objectContaining({
+          name: "DSEC_API_TOKEN",
+          previous_name: "DST_API_TOKEN",
+          allowed_domains: JSON.stringify(["api.github.com"]),
+        }),
+      })
+    );
+  });
+
+  it("updates HTTPS secret allowed domains", async () => {
+    const setup = await createEnvVarIdRequest({
+      method: "PATCH",
+      body: {
+        allowedDomains: ["api.openai.com"],
+      },
+    });
+
+    const createResult = await WorkspaceSandboxEnvVarResource.create(
+      setup.auth,
+      {
+        name: "API_TOKEN",
+        kind: "https_secret",
+        value: "super-secret-token",
+        allowedDomains: ["api.github.com"],
+      }
+    );
+    expect(createResult.isOk()).toBe(true);
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+    setup.req.query.id = createResult.value.sId;
+
+    await handler(setup.req, setup.res);
+
+    expect(setup.res._getStatusCode()).toBe(200);
+    expect(JSON.parse(setup.res._getData())).toEqual({
+      envVar: expect.objectContaining({
+        name: "DSEC_API_TOKEN",
+        allowedDomains: ["api.openai.com"],
+      }),
+    });
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sandbox_env_var.allowed_domains_updated",
+        metadata: expect.objectContaining({
+          name: "DSEC_API_TOKEN",
+          allowed_domains: JSON.stringify(["api.openai.com"]),
+          previous_allowed_domains: JSON.stringify(["api.github.com"]),
+        }),
+      })
+    );
+  });
+
+  it("rejects demoting an HTTPS secret to a config variable", async () => {
+    const { req, res, auth } = await createEnvVarIdRequest({
+      method: "PATCH",
+      body: { kind: "config" },
+    });
+
+    const createResult = await WorkspaceSandboxEnvVarResource.create(auth, {
+      name: "API_TOKEN",
+      kind: "https_secret",
+      value: "super-secret-token",
+      allowedDomains: ["api.github.com"],
+    });
+    expect(createResult.isOk()).toBe(true);
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+    req.query.id = createResult.value.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
   });
 });

--- a/front/pages/api/w/[wId]/sandbox/env-vars/delete.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/delete.test.ts
@@ -114,7 +114,7 @@ describe("PATCH/DELETE /api/w/[wId]/sandbox/env-vars/[id]", () => {
       },
     });
 
-    const createResult = await WorkspaceSandboxEnvVarResource.create(auth, {
+    const createResult = await WorkspaceSandboxEnvVarResource.makeNew(auth, {
       name: "API_TOKEN",
       value: "super-secret-token",
     });
@@ -164,7 +164,7 @@ describe("PATCH/DELETE /api/w/[wId]/sandbox/env-vars/[id]", () => {
       },
     });
 
-    const createResult = await WorkspaceSandboxEnvVarResource.create(
+    const createResult = await WorkspaceSandboxEnvVarResource.makeNew(
       setup.auth,
       {
         name: "API_TOKEN",
@@ -206,7 +206,7 @@ describe("PATCH/DELETE /api/w/[wId]/sandbox/env-vars/[id]", () => {
       body: { kind: "config" },
     });
 
-    const createResult = await WorkspaceSandboxEnvVarResource.create(auth, {
+    const createResult = await WorkspaceSandboxEnvVarResource.makeNew(auth, {
       name: "API_TOKEN",
       kind: "https_secret",
       value: "super-secret-token",

--- a/front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/index.test.ts
@@ -85,6 +85,24 @@ describe("GET/POST /api/w/[wId]/sandbox/env-vars", () => {
       { name: "_API_TOKEN", value: "super-secret-token" },
       { name: "API-TOKEN", value: "super-secret-token" },
       { name: "DSEC_API_TOKEN", value: "super-secret-token" },
+      {
+        name: "DST_API_TOKEN",
+        value: "super-secret-token",
+        kind: "https_secret",
+        allowedDomains: ["api.example.com"],
+      },
+      {
+        name: "DSEC_API_TOKEN",
+        value: "line one\nline two",
+        kind: "https_secret",
+        allowedDomains: ["api.example.com"],
+      },
+      {
+        name: "DSEC_API_TOKEN",
+        value: "super-secret-token",
+        kind: "https_secret",
+        allowedDomains: [],
+      },
       { name: "DST_API_TOKEN", value: "" },
       { name: "DST_API_TOKEN", value: "abc\u0000def" },
       { name: "DST_API_TOKEN", value: "a".repeat(32 * 1024 + 1) },
@@ -243,20 +261,69 @@ describe("GET/POST /api/w/[wId]/sandbox/env-vars", () => {
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "sandbox_env_var.created",
-        metadata: { name: "DST_API_TOKEN" },
+        metadata: expect.objectContaining({ name: "DST_API_TOKEN" }),
       })
     );
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "sandbox_env_var.updated",
-        metadata: {
+        metadata: expect.objectContaining({
           name: "DST_API_TOKEN",
           previously_existed: "true",
-        },
+        }),
       })
     );
     expect(JSON.stringify(mockEmitAuditLogEvent.mock.calls)).not.toContain(
       "rotated-secret-token"
+    );
+  });
+
+  it("creates HTTPS secrets with allowed domains and omits them from loadEnv", async () => {
+    const request = await createEnvVarRequest({
+      method: "POST",
+      body: {
+        name: "DSEC_API_TOKEN",
+        value: "super-secret-token",
+        kind: "https_secret",
+        allowedDomains: [" API.GitHub.COM. ", "*.Example.com"],
+      },
+    });
+
+    await handler(request.req, request.res);
+
+    expect(request.res._getStatusCode()).toBe(201);
+    const responseBody = JSON.parse(request.res._getData());
+    expect(responseBody).toEqual({
+      envVar: expect.objectContaining({
+        name: "DSEC_API_TOKEN",
+        kind: "https_secret",
+        allowedDomains: ["api.github.com", "*.example.com"],
+      }),
+      created: true,
+    });
+    expect(responseBody.envVar.placeholderNonce).toMatch(/^[0-9a-f]{32}$/);
+
+    const envResult = await WorkspaceSandboxEnvVarResource.loadEnv(
+      request.auth
+    );
+    expect(envResult.isOk()).toBe(true);
+    if (envResult.isErr()) {
+      throw envResult.error;
+    }
+    expect(envResult.value).toEqual({});
+
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sandbox_env_var.created",
+        metadata: expect.objectContaining({
+          name: "DSEC_API_TOKEN",
+          kind: "https_secret",
+          allowed_domains: JSON.stringify(["api.github.com", "*.example.com"]),
+        }),
+      })
+    );
+    expect(JSON.stringify(mockEmitAuditLogEvent.mock.calls)).not.toContain(
+      "super-secret-token"
     );
   });
 });

--- a/front/pages/api/w/[wId]/sandbox/env-vars/index.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/index.ts
@@ -10,18 +10,18 @@ import { hasFeatureFlag } from "@app/lib/auth";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { WorkspaceSandboxEnvVarType } from "@app/types/sandbox/env_var";
+import {
+  WORKSPACE_SANDBOX_ENV_VAR_KINDS,
+  type WorkspaceSandboxEnvVarType,
+} from "@app/types/sandbox/env_var";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-// TODO(2026-05-05 SLICE_2): accept optional `kind` ("config" | "https_secret")
-// and `allowedDomains` here, plumb them through to the resource layer, and
-// emit dedicated audit actions (`sandbox_env_var.promoted_to_https_secret`,
-// `sandbox_env_var.allowed_domains_updated`). Slice 1 keeps the schema
-// strictly config-only so the API contract stays unchanged on this slice.
 const PostWorkspaceSandboxEnvVarBodySchema = z.object({
   name: z.string(),
   value: z.string(),
+  kind: z.enum(WORKSPACE_SANDBOX_ENV_VAR_KINDS).optional(),
+  allowedDomains: z.array(z.string()).nullable().optional(),
 });
 
 export type GetWorkspaceSandboxEnvVarsResponseBody = {
@@ -99,12 +99,13 @@ async function handler(
         });
       }
 
+      const kind = parsed.data.kind ?? "config";
       const parsedName = parseWorkspaceSandboxEnvVarNameForKind({
-        kind: "config",
+        kind,
         name: parsed.data.name,
       });
       const parsedValue = validateEnvVarValueForKind({
-        kind: "config",
+        kind,
         value: parsed.data.value,
       });
       if (parsedName.isErr() || parsedValue.isErr()) {
@@ -125,6 +126,8 @@ async function handler(
       const result = await WorkspaceSandboxEnvVarResource.upsert(auth, {
         name: parsedName.value,
         value: parsed.data.value,
+        kind,
+        allowedDomains: parsed.data.allowedDomains,
         context: getAuditLogContext(auth, req),
       });
       if (result.isErr()) {


### PR DESCRIPTION
## Description

Slice 2 of the phase 1 secret-swap plan. Admins can now mint or promote sandbox env vars to `kind: 'https_secret'` with an `allowedDomains` policy.

- POST accepts optional `kind` and `allowedDomains`. Existing config-only callers unaffected.
- PATCH supports promotion `config -> https_secret` (one way per the plan, demotion is rejected) and rotation of `allowedDomains` on existing secrets.
- `loadEnv` skips `kind: 'https_secret'` rows so promoted vars do not leak into the agent env as `DSEC_*` plaintext. Substitution from the secrets file lands in slice 3.
- New audit actions `sandbox_env_var.promoted_to_https_secret` and `sandbox_env_var.allowed_domains_updated`. Create / update / delete metadata picks up `kind` and `allowed_domains`.
- Admin UI: kind radio on create, allowed-domains input for secrets, promote dialog with a wake-time warning (running sandboxes keep the previous DST_-prefixed value, and the secrets-file path is not live yet, so promoted vars will not be available to new sandboxes either until that ships).

<img width="1866" height="1241" alt="Screenshot 2026-05-07 at 16 13 36" src="https://github.com/user-attachments/assets/e8faf272-a441-466f-a24a-fafdb28af5d6" />

<img width="580" height="720" alt="Screenshot 2026-05-07 at 16 13 46" src="https://github.com/user-attachments/assets/ee27c2c7-ce2d-4a4e-bb55-c5083d243e6c" />

<img width="580" height="720" alt="Screenshot 2026-05-07 at 16 13 54" src="https://github.com/user-attachments/assets/80743fdd-8065-49a9-b0ec-58900afd86de" />

<img width="578" height="723" alt="Screenshot 2026-05-07 at 16 14 26" src="https://github.com/user-attachments/assets/16f288f9-1af3-4e4b-9dcc-e06388deae39" />

## Tests

7 resource tests, 5 GET/POST tests, 6 PATCH/DELETE tests, plus a regression in `sandbox_resource.test.ts` asserting `DSEC_SECRET_TOKEN` does not appear in the provider env. New test exercises rotating value + allowedDomains in a single upsert.

## Risk

Low. No prod consumer of the new path yet.

## Deploy Plan

Standard deploy.