### PR TITLE
feat(slack): add email in connector

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -8,7 +8,7 @@ import { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stre
 import { streamConversationToSlack } from "@connectors/connectors/slack/chat/stream_conversation_handler";
 import {
   getBotUserIdResponse,
-  getUserName,
+  getUserInfo,
 } from "@connectors/connectors/slack/lib/bot_user_helpers";
 import {
   isSlackWebAPIPlatformError,
@@ -970,8 +970,13 @@ async function answerMessage(
         }
         message = message.replace(m, "");
       } else {
-        const userName = await getUserName(userId, connector.id, slackClient);
-        message = message.replace(m, `@${userName}`);
+        const { name: userName, email } = await getUserInfo(
+          userId,
+          connector.id,
+          slackClient
+        );
+        const replaceValue = email ? `@${userName} (${email})` : `@${userName}`;
+        message = message.replace(m, replaceValue);
       }
     }
   }

--- a/connectors/src/connectors/slack/lib/bot_user_helpers.ts
+++ b/connectors/src/connectors/slack/lib/bot_user_helpers.ts
@@ -59,24 +59,21 @@ export async function getBotUserIdResponse(
   }
 }
 
-export async function getUserName(
+export async function getUserInfo(
   slackUserId: string,
   connectorId: ModelId,
   slackClient: WebClient
-): Promise<string | null> {
+): Promise<{ name: string | null; email: string | null }> {
   try {
     const info = await getSlackUserInfoMemoized(
       connectorId,
       slackClient,
       slackUserId
     );
-
-    const userName = info.display_name || info.real_name || info.name;
-
-    if (userName) {
-      return userName;
-    }
-    return null;
+    return {
+      name: info.display_name || info.real_name || info.name || null,
+      email: info.email,
+    };
   } catch (err) {
     if (isSlackWebAPIPlatformError(err)) {
       if (err.data.error === "user_not_found") {
@@ -84,7 +81,7 @@ export async function getUserName(
           { provider: "slack", connectorId, slackUserId },
           "Slack user not found."
         );
-        return null;
+        return { name: null, email: null };
       }
     }
     throw err;
@@ -204,5 +201,7 @@ export async function getBotOrUserName(
 ): Promise<string | null> {
   return message.bot_id
     ? getBotNameMemoized({ botId: message.bot_id, connectorId, slackClient })
-    : getUserName(message.user as string, connectorId, slackClient);
+    : getUserInfo(message.user as string, connectorId, slackClient).then(
+        ({ name }) => name
+      );
 }

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -1,6 +1,6 @@
 import {
   getBotOrUserName,
-  getUserName,
+  getUserInfo,
 } from "@connectors/connectors/slack/lib/bot_user_helpers";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
 import { renderDocumentTitleAndContent } from "@connectors/lib/data_sources";
@@ -21,7 +21,11 @@ async function processMessageForMentions(
   }
   for (const m of matches) {
     const userId = m.replace(/<|@|>/g, "");
-    const userName = await getUserName(userId, connectorId, slackClient);
+    const { name: userName } = await getUserInfo(
+      userId,
+      connectorId,
+      slackClient
+    );
     if (!userName) {
       continue;
     }
@@ -55,11 +59,17 @@ export async function formatMessagesForUpsert({
         slackClient
       );
 
-      const authorName = await getBotOrUserName(
-        message,
-        connectorId,
-        slackClient
-      );
+      let authorName: string | null;
+      let authorEmail: string | null = null;
+      if (message.bot_id) {
+        authorName = await getBotOrUserName(message, connectorId, slackClient);
+      } else {
+        ({ name: authorName, email: authorEmail } = await getUserInfo(
+          message.user as string,
+          connectorId,
+          slackClient
+        ));
+      }
       const messageDate = new Date(parseInt(message.ts as string, 10) * 1000);
       const messageDateStr = formatDateForUpsert(messageDate);
 
@@ -76,6 +86,7 @@ export async function formatMessagesForUpsert({
         messageDate,
         dateStr: messageDateStr,
         authorName,
+        authorEmail,
         text: text + filesInfo,
         content: text + "\n",
         sections: [],
@@ -104,7 +115,7 @@ export async function formatMessagesForUpsert({
       prefix: null,
       content: null,
       sections: data.map((d) => ({
-        prefix: `>> @${d.authorName} [${d.dateStr}]:\n`,
+        prefix: `>> @${d.authorName}${d.authorEmail ? ` (${d.authorEmail})` : ""} [${d.dateStr}]:\n`,
         content: d.text + "\n",
         sections: [],
       })),


### PR DESCRIPTION
## Description

Add the user email when we get data from slack. It'll allow to store it in core, and in the conversations.

That would help model to match the users from slack to dust
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
