### PR TITLE
fix(front): resolve billing currency from Stripe for Metronome contracts

### DIFF
--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -8,10 +8,10 @@ import {
 } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import {
-  getBillingCurrencyForCountry,
+  resolveCurrencyFromStripe,
   resolvePackageAliasForCurrency,
 } from "@app/lib/plans/billing_currency";
-import { getStripeClient } from "@app/lib/plans/stripe";
+import { getStripeClient, getStripeCustomer } from "@app/lib/plans/stripe";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -105,9 +105,11 @@ export async function handleMetronomeSetupCheckout({
     customerCountry: customerDetails?.address?.country,
   });
 
-  const billingCurrency = customerCountry
-    ? getBillingCurrencyForCountry(customerCountry, true)
-    : "usd";
+  const stripeCustomer = await getStripeCustomer(stripeCustomerId);
+  const billingCurrency = resolveCurrencyFromStripe({
+    stripeCustomer,
+    countryFallback: customerCountry,
+  });
   const resolvedPackageAlias = resolvePackageAliasForCurrency(
     metronomePackageAlias,
     billingCurrency

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -3,23 +3,23 @@ import {
   buildEnterpriseOverrides,
   extractEnterprisePricing,
   provisionMetronomeContract,
+  resolveCurrencyForExistingMetronomeCustomer,
   switchMetronomeContractPackage,
 } from "@app/lib/metronome/contracts";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-// ---------------------------------------------------------------------------
-// Mocks
-// ---------------------------------------------------------------------------
 
 const {
   mockCreateMetronomeContract,
   mockCreateMetronomeCustomer,
   mockFindMetronomeCustomerByAlias,
   mockGetMetronomeContractById,
+  mockGetMetronomeCustomerStripeCustomerId,
   mockGetSeatSubscriptionIdFromContract,
+  mockGetStripeCustomer,
+  mockGetStripeSubscription,
   mockHasMauSubscriptionInContract,
   mockPrices,
   mockScheduleMetronomeContractEnd,
@@ -33,7 +33,10 @@ const {
     mockCreateMetronomeCustomer: vi.fn(),
     mockFindMetronomeCustomerByAlias: vi.fn(),
     mockGetMetronomeContractById: vi.fn(),
+    mockGetMetronomeCustomerStripeCustomerId: vi.fn(),
     mockGetSeatSubscriptionIdFromContract: vi.fn(),
+    mockGetStripeCustomer: vi.fn(),
+    mockGetStripeSubscription: vi.fn(),
     mockHasMauSubscriptionInContract: vi.fn(),
     mockPrices,
     mockScheduleMetronomeContractEnd: vi.fn(),
@@ -50,6 +53,8 @@ vi.mock("@app/lib/metronome/client", () => ({
   findMetronomeCustomerByAlias: mockFindMetronomeCustomerByAlias,
   getMetronomeClient: vi.fn(),
   getMetronomeContractById: mockGetMetronomeContractById,
+  getMetronomeCustomerStripeCustomerId:
+    mockGetMetronomeCustomerStripeCustomerId,
   scheduleMetronomeContractEnd: mockScheduleMetronomeContractEnd,
 }));
 
@@ -72,6 +77,8 @@ vi.mock("@app/lib/metronome/seats", () => ({
 
 vi.mock("@app/lib/plans/stripe", () => ({
   getStripeClient: () => ({ prices: mockPrices }),
+  getStripeCustomer: mockGetStripeCustomer,
+  getStripeSubscription: mockGetStripeSubscription,
 }));
 
 vi.mock("@app/lib/metronome/constants", () => ({
@@ -147,10 +154,6 @@ beforeEach(() => {
   mockSyncMauCount.mockResolvedValue(new Ok(undefined));
 });
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 function makeSubscription(
   items: Array<{
     priceId: string;
@@ -186,10 +189,6 @@ function findOverride(
       o.override_specifiers?.some((s) => s.product_id === productId)
   );
 }
-
-// ---------------------------------------------------------------------------
-// extractEnterprisePricing
-// ---------------------------------------------------------------------------
 
 describe("extractEnterprisePricing", () => {
   it("extracts FIXED pricing", async () => {
@@ -382,10 +381,6 @@ describe("extractEnterprisePricing", () => {
     expect(result).toBeUndefined();
   });
 });
-
-// ---------------------------------------------------------------------------
-// buildEnterpriseOverrides
-// ---------------------------------------------------------------------------
 
 describe("buildEnterpriseOverrides", () => {
   it("FIXED: disables all MAU and tier products", () => {
@@ -668,10 +663,6 @@ describe("buildEnterpriseOverrides", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Contract provisioning / switching
-// ---------------------------------------------------------------------------
-
 describe("provisionMetronomeContract", () => {
   it("syncs seats and MAU when the contract has both subscriptions", async () => {
     const result = await provisionMetronomeContract({
@@ -795,5 +786,148 @@ describe("switchMetronomeContractPackage", () => {
     expect(result.isOk()).toBe(true);
     expect(mockSyncSeatCount).toHaveBeenCalledTimes(1);
     expect(mockSyncMauCount).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveCurrencyForExistingMetronomeCustomer", () => {
+  beforeEach(() => {
+    mockGetStripeSubscription.mockReset();
+    mockGetStripeCustomer.mockReset();
+    mockGetMetronomeCustomerStripeCustomerId.mockReset();
+  });
+
+  it("uses the Stripe subscription currency on the Stripe-billed path", async () => {
+    mockGetStripeSubscription.mockResolvedValue({ currency: "eur" });
+
+    const result = await resolveCurrencyForExistingMetronomeCustomer({
+      metronomeCustomerId: "cust_1",
+      stripeSubscriptionId: "sub_1",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toBe("eur");
+    expect(mockGetMetronomeCustomerStripeCustomerId).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the Metronome-linked Stripe customer when no sub", async () => {
+    mockGetMetronomeCustomerStripeCustomerId.mockResolvedValue(
+      new Ok("cus_eu")
+    );
+    mockGetStripeCustomer.mockResolvedValue({
+      currency: "eur",
+      address: null,
+    });
+
+    const result = await resolveCurrencyForExistingMetronomeCustomer({
+      metronomeCustomerId: "cust_1",
+      stripeSubscriptionId: null,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toBe("eur");
+    expect(mockGetStripeSubscription).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the customer's address country when currency is unset", async () => {
+    mockGetMetronomeCustomerStripeCustomerId.mockResolvedValue(
+      new Ok("cus_fr")
+    );
+    mockGetStripeCustomer.mockResolvedValue({
+      currency: null,
+      address: { country: "FR" },
+    });
+
+    const result = await resolveCurrencyForExistingMetronomeCustomer({
+      metronomeCustomerId: "cust_1",
+      stripeSubscriptionId: null,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toBe("eur");
+  });
+
+  it("returns an error when no Stripe sub and Metronome has no Stripe billing config", async () => {
+    mockGetMetronomeCustomerStripeCustomerId.mockResolvedValue(new Ok(null));
+
+    const result = await resolveCurrencyForExistingMetronomeCustomer({
+      metronomeCustomerId: "cust_1",
+      stripeSubscriptionId: null,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("no Stripe billing config found");
+    }
+    expect(mockGetStripeCustomer).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the Metronome customer when getStripeSubscription returns null", async () => {
+    mockGetStripeSubscription.mockResolvedValue(null);
+    mockGetMetronomeCustomerStripeCustomerId.mockResolvedValue(
+      new Ok("cus_fr")
+    );
+    mockGetStripeCustomer.mockResolvedValue({
+      currency: null,
+      address: { country: "FR" },
+    });
+
+    const result = await resolveCurrencyForExistingMetronomeCustomer({
+      metronomeCustomerId: "cust_1",
+      stripeSubscriptionId: "sub_dead",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toBe("eur");
+    expect(mockGetMetronomeCustomerStripeCustomerId).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an error when getMetronomeCustomerStripeCustomerId errs", async () => {
+    mockGetMetronomeCustomerStripeCustomerId.mockResolvedValue(
+      new Err(new Error("boom"))
+    );
+
+    const result = await resolveCurrencyForExistingMetronomeCustomer({
+      metronomeCustomerId: "cust_1",
+      stripeSubscriptionId: null,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "could not read Stripe billing config: boom"
+      );
+    }
+    expect(mockGetStripeCustomer).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the linked Stripe customer cannot be retrieved", async () => {
+    mockGetMetronomeCustomerStripeCustomerId.mockResolvedValue(
+      new Ok("cus_missing")
+    );
+    mockGetStripeCustomer.mockResolvedValue(null);
+
+    const result = await resolveCurrencyForExistingMetronomeCustomer({
+      metronomeCustomerId: "cust_1",
+      stripeSubscriptionId: null,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "Stripe customer cus_missing could not be retrieved"
+      );
+    }
   });
 });

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -7,6 +7,7 @@ import {
   floorToHourISO,
   getMetronomeClient,
   getMetronomeContractById,
+  getMetronomeCustomerStripeCustomerId,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
 import {
@@ -27,8 +28,15 @@ import {
   syncSeatCount,
 } from "@app/lib/metronome/seats";
 import { LEGACY_ENTERPRISE_PACKAGE_ALIAS } from "@app/lib/metronome/types";
-import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
-import { getStripeClient } from "@app/lib/plans/stripe";
+import {
+  resolveCurrencyFromStripe,
+  resolvePackageAliasForCurrency,
+} from "@app/lib/plans/billing_currency";
+import {
+  getStripeClient,
+  getStripeCustomer,
+  getStripeSubscription,
+} from "@app/lib/plans/stripe";
 import { countActiveUsersForPeriodInWorkspace } from "@app/lib/plans/usage/mau";
 import {
   isEnterpriseReportUsage,
@@ -167,6 +175,69 @@ export async function ensureMetronomeCustomerForWorkspace({
   }
 
   return new Ok({ metronomeCustomerId });
+}
+
+/**
+ * Resolve the billing currency for a workspace whose Metronome customer
+ * already exists. Tries the Stripe subscription first (when the workspace
+ * is Stripe-billed); falls back to the Stripe customer that's wired into
+ * the Metronome billing configuration (Metronome-only billing path).
+ *
+ * Returns an error when neither path yields a usable signal — existing
+ * customers are expected to have either a Stripe subscription or a linked
+ * Stripe billing config on the Metronome customer.
+ */
+export async function resolveCurrencyForExistingMetronomeCustomer({
+  metronomeCustomerId,
+  stripeSubscriptionId,
+}: {
+  metronomeCustomerId: string;
+  stripeSubscriptionId: string | null;
+}): Promise<Result<SupportedCurrency, Error>> {
+  const stripeSubscription = stripeSubscriptionId
+    ? await getStripeSubscription(stripeSubscriptionId)
+    : null;
+  if (stripeSubscription) {
+    return new Ok(resolveCurrencyFromStripe({ stripeSubscription }));
+  }
+
+  // Metronome-only billing path: no Stripe sub. Read the Stripe customer
+  // through the Metronome billing config, then derive currency from its
+  // currency / address.country.
+  const stripeCustomerIdResult =
+    await getMetronomeCustomerStripeCustomerId(metronomeCustomerId);
+  if (stripeCustomerIdResult.isErr()) {
+    return new Err(
+      new Error(
+        "Failed to resolve billing currency for Metronome customer " +
+          `${metronomeCustomerId}: could not read Stripe billing config: ` +
+          stripeCustomerIdResult.error.message
+      )
+    );
+  }
+
+  const stripeCustomerId = stripeCustomerIdResult.value;
+  if (!stripeCustomerId) {
+    return new Err(
+      new Error(
+        "Failed to resolve billing currency for Metronome customer " +
+          `${metronomeCustomerId}: no Stripe billing config found.`
+      )
+    );
+  }
+
+  const stripeCustomer = await getStripeCustomer(stripeCustomerId);
+  if (!stripeCustomer) {
+    return new Err(
+      new Error(
+        "Failed to resolve billing currency for Metronome customer " +
+          `${metronomeCustomerId}: Stripe customer ${stripeCustomerId} could ` +
+          "not be retrieved."
+      )
+    );
+  }
+
+  return new Ok(resolveCurrencyFromStripe({ stripeCustomer }));
 }
 
 /**

--- a/front/lib/plans/billing_currency.test.ts
+++ b/front/lib/plans/billing_currency.test.ts
@@ -1,0 +1,79 @@
+import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
+import { describe, expect, it } from "vitest";
+
+const sub = (currency: string) => ({ currency });
+
+const customer = (
+  fields: Partial<{ currency: string | null; country: string | null }>
+) => ({
+  currency: fields.currency ?? null,
+  address: fields.country ? { country: fields.country } : null,
+});
+
+describe("resolveCurrencyFromStripe", () => {
+  it("returns the Stripe subscription currency when set and supported", () => {
+    expect(resolveCurrencyFromStripe({ stripeSubscription: sub("eur") })).toBe(
+      "eur"
+    );
+    expect(resolveCurrencyFromStripe({ stripeSubscription: sub("usd") })).toBe(
+      "usd"
+    );
+  });
+
+  it("falls through to customer when subscription currency is unsupported", () => {
+    expect(
+      resolveCurrencyFromStripe({
+        stripeSubscription: sub("gbp"),
+        stripeCustomer: customer({ currency: "eur" }),
+      })
+    ).toBe("eur");
+  });
+
+  it("uses the Stripe customer currency when no subscription is provided", () => {
+    expect(
+      resolveCurrencyFromStripe({
+        stripeCustomer: customer({ currency: "eur" }),
+      })
+    ).toBe("eur");
+  });
+
+  it("prefers the customer's address country over countryFallback", () => {
+    expect(
+      resolveCurrencyFromStripe({
+        stripeCustomer: customer({ country: "US" }),
+        countryFallback: "FR",
+      })
+    ).toBe("usd");
+  });
+
+  it("uses countryFallback when the customer has no address", () => {
+    expect(
+      resolveCurrencyFromStripe({
+        stripeCustomer: customer({}),
+        countryFallback: "FR",
+      })
+    ).toBe("eur");
+  });
+
+  it("falls back to the customer's address country when no other signal", () => {
+    expect(
+      resolveCurrencyFromStripe({ stripeCustomer: customer({ country: "FR" }) })
+    ).toBe("eur");
+    expect(
+      resolveCurrencyFromStripe({ stripeCustomer: customer({ country: "US" }) })
+    ).toBe("usd");
+  });
+
+  it("defaults to usd when nothing is provided", () => {
+    expect(resolveCurrencyFromStripe({})).toBe("usd");
+  });
+
+  it("ignores null customer and uses countryFallback", () => {
+    expect(
+      resolveCurrencyFromStripe({
+        stripeCustomer: null,
+        countryFallback: "FR",
+      })
+    ).toBe("eur");
+  });
+});

--- a/front/lib/plans/billing_currency.ts
+++ b/front/lib/plans/billing_currency.ts
@@ -1,4 +1,8 @@
-import type { SupportedCurrency } from "@app/types/currency";
+import {
+  isSupportedCurrency,
+  type SupportedCurrency,
+} from "@app/types/currency";
+import type Stripe from "stripe";
 
 /**
  * ISO 3166-1 alpha-2 country codes that map to EUR billing.
@@ -92,4 +96,50 @@ export function resolvePackageAliasForCurrency(
   };
 
   return eurAliases[baseAlias] ?? baseAlias;
+}
+
+type StripeSubscriptionCurrencySource = Pick<Stripe.Subscription, "currency">;
+type StripeCustomerCurrencySource = {
+  currency?: Stripe.Customer["currency"];
+  address?: Pick<Stripe.Address, "country"> | null;
+};
+
+/**
+ * Resolve the billing currency for a new Metronome contract from Stripe.
+ *
+ * Order of precedence:
+ * 1. Stripe subscription currency (set as soon as the sub exists).
+ * 2. Stripe customer currency (set on first invoice; may be null on a fresh
+ *    customer).
+ * 3. Country code via getBillingCurrencyForCountry(_, true) — either the
+ *    explicit fallback, or the customer's billing address country.
+ * 4. Default "usd".
+ *
+ * Stripe is the only billing source of truth: every prior Metronome
+ * contract's currency was itself derived from Stripe, so re-reading it
+ * adds no new signal.
+ */
+export function resolveCurrencyFromStripe({
+  stripeSubscription,
+  stripeCustomer,
+  countryFallback,
+}: {
+  stripeSubscription?: StripeSubscriptionCurrencySource | null;
+  stripeCustomer?: StripeCustomerCurrencySource | null;
+  countryFallback?: string | null;
+}): SupportedCurrency {
+  if (stripeSubscription && isSupportedCurrency(stripeSubscription.currency)) {
+    return stripeSubscription.currency;
+  }
+  if (
+    stripeCustomer?.currency &&
+    isSupportedCurrency(stripeCustomer.currency)
+  ) {
+    return stripeCustomer.currency;
+  }
+  const country = stripeCustomer?.address?.country ?? countryFallback ?? null;
+  if (country) {
+    return getBillingCurrencyForCountry(country, true);
+  }
+  return "usd";
 }

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -8,6 +8,7 @@ import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
   provisionShadowEnterpriseMetronomeContract,
+  resolveCurrencyForExistingMetronomeCustomer,
   switchMetronomeContractPackage,
   syncContractQuantities,
 } from "@app/lib/metronome/contracts";
@@ -20,6 +21,7 @@ import {
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
+import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
 import type { PlanAttributes } from "@app/lib/plans/free_plans";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import {
@@ -999,11 +1001,24 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     // Switch Metronome contract to Business package.
     let newMetronomeContractId: string | null = null;
     if (this.metronomeContractId && owner.metronomeCustomerId) {
+      const billingCurrencyResult =
+        await resolveCurrencyForExistingMetronomeCustomer({
+          metronomeCustomerId: owner.metronomeCustomerId,
+          stripeSubscriptionId: newStripeSubscriptionId,
+        });
+      if (billingCurrencyResult.isErr()) {
+        return new Err(billingCurrencyResult.error);
+      }
+
+      const packageAlias = resolvePackageAliasForCurrency(
+        LEGACY_BUSINESS_PACKAGE_ALIAS,
+        billingCurrencyResult.value
+      );
       const result = await switchMetronomeContractPackage({
         metronomeCustomerId: owner.metronomeCustomerId,
         oldContractId: this.metronomeContractId,
         workspace: owner,
-        packageAlias: LEGACY_BUSINESS_PACKAGE_ALIAS,
+        packageAlias,
         enableStripeBilling: isSubscriptionMetronomeBilled(this.toJSON()),
       });
       if (result.isErr() && !this.isMetronomeShadowBilled) {

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -30,7 +30,10 @@ import {
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
-import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
+import {
+  resolveCurrencyFromStripe,
+  resolvePackageAliasForCurrency,
+} from "@app/lib/plans/billing_currency";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
@@ -415,12 +418,12 @@ async function handler(
                 checkoutStripeSubscription.current_period_start * 1000
               );
 
-              // Resolve EUR variant based on Stripe subscription currency.
-              const subscriptionCurrency =
-                checkoutStripeSubscription.currency === "eur" ? "eur" : "usd";
+              const billingCurrency = resolveCurrencyFromStripe({
+                stripeSubscription: checkoutStripeSubscription,
+              });
               const resolvedAlias = resolvePackageAliasForCurrency(
                 metronomePackageAlias,
-                subscriptionCurrency
+                billingCurrency
               );
               void provisionShadowMetronome({
                 workspace,


### PR DESCRIPTION
## Description

Read currency from the Stripe subscription/customer instead of inferring it from country alone, so EUR-billed customers get the correct package alias on plan switches and shadow Metronome provisioning.

Gather currency logic in billing_currency.ts

Existing Metronome customers without a usable Stripe signal (no Stripe subscription and no Stripe billing config on the Metronome customer) now return an error instead of silently defaulting to USD, surfacing misconfigurations rather than billing in the wrong currency.
## Tests

Unit + local

## Risk

Low

## Deploy Plan

front
