### PR TITLE
[front] fix: update tests on `reinforcement` to mirror default value changes

### DIFF
--- a/front/pages/api/w/[wId]/skills/[sId]/reinforcement.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/reinforcement.test.ts
@@ -96,7 +96,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]/reinforcement", () => {
       requestUserRole: "admin",
     });
 
-    expect(skill.reinforcement).toBe("auto");
+    expect(skill.reinforcement).toBe("on");
 
     req.body = { reinforcement: "off" };
 


### PR DESCRIPTION
## Description

- This PR updates the tests on skill reinforcement following the default value changes in https://github.com/dust-tt/dust/pull/25377

## Tests

- Yes

## Risk

- N/A

## Deploy Plan

- No deploy.
