### PR TITLE
[front] - feat(analytics): interactive skill series selection

### DIFF
--- a/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/SkillUsageChart.tsx
@@ -130,7 +130,10 @@ export function SkillUsageChart({
       ? versionData.chartData.length === 0
       : filteredSourceItems.length === 0;
 
-  const { selectedKey, isDimmed, decorate } = useSelectableSeries();
+  const visibleSeriesKeys =
+    skillMode === "version" ? versionData.topTools : filteredSkillNames;
+  const { selectedKey, isDimmed, decorate } =
+    useSelectableSeries(visibleSeriesKeys);
 
   const legendItems = useMemo(() => {
     if (skillMode === "version") {

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -76,7 +76,7 @@ export function ToolUsageChart({
     configurationNames,
   });
 
-  const { selectedKey, isDimmed, decorate } = useSelectableSeries();
+  const { selectedKey, isDimmed, decorate } = useSelectableSeries(topTools);
 
   const legendItems = useMemo(
     () =>

--- a/front/components/charts/useSelectableSeries.ts
+++ b/front/components/charts/useSelectableSeries.ts
@@ -3,11 +3,24 @@ import type {
   LegendItem,
 } from "@app/components/charts/ChartLegend";
 import { useHoveredSeries } from "@app/components/charts/useHoveredSeries";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-export function useSelectableSeries() {
+export function useSelectableSeries(visibleKeys?: readonly string[]) {
   const { hoveredKey, hoverHandlers } = useHoveredSeries();
   const [selectedKey, setSelectedKey] = useState<string | undefined>(undefined);
+
+  // Clear the selection when the selected series is no longer visible (e.g. the
+  // user removed it from a series picker), otherwise every remaining line would
+  // be dimmed.
+  useEffect(() => {
+    if (
+      selectedKey !== undefined &&
+      visibleKeys !== undefined &&
+      !visibleKeys.includes(selectedKey)
+    ) {
+      setSelectedKey(undefined);
+    }
+  }, [selectedKey, visibleKeys]);
 
   const activeKey = hoveredKey ?? selectedKey;
 

--- a/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
@@ -264,7 +264,7 @@ export function WorkspaceSkillUsageChart({
     lineActiveDot,
     decorate,
     hoverHandlers,
-  } = useSelectableSeries();
+  } = useSelectableSeries(skillsWithData);
 
   const legendItems = decorate(
     skillsWithData.map((skill) => ({

--- a/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSkillUsageChart.tsx
@@ -5,8 +5,8 @@ import {
   getIndexedColor,
 } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
-import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { useSelectableSeries } from "@app/components/charts/useSelectableSeries";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import {
@@ -18,6 +18,7 @@ import {
   Button,
   ButtonsSwitch,
   ButtonsSwitchList,
+  cn,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -72,6 +73,8 @@ function getSkillSelectorLabel(selectedSkills: string[]): string {
 interface SkillUsageTooltipProps extends TooltipContentProps<number, string> {
   displayMode: SkillUsageDisplayMode;
   skillsWithData: string[];
+  activeKey?: string;
+  selectedKey?: string;
 }
 
 function SkillUsageTooltip({
@@ -79,6 +82,8 @@ function SkillUsageTooltip({
   skillsWithData,
   active,
   payload,
+  activeKey,
+  selectedKey,
 }: SkillUsageTooltipProps) {
   if (!active || !payload || payload.length === 0) {
     return null;
@@ -99,6 +104,7 @@ function SkillUsageTooltip({
 
   const values = skillsWithData.map((skill) => point.values[skill] ?? 0);
   const rows = skillsWithData.map((skill, idx) => ({
+    key: skill,
     label: skill,
     value: values[idx].toLocaleString(),
     colorClassName: getIndexedColor(skill, skillsWithData),
@@ -107,13 +113,21 @@ function SkillUsageTooltip({
   if (skillsWithData.length > 1) {
     const total = values.reduce((sum, v) => sum + v, 0);
     rows.push({
+      key: "__total__",
       label: `Total ${label}`,
       value: total.toLocaleString(),
       colorClassName: "",
     });
   }
 
-  return <ChartTooltipCard title={title} rows={rows} />;
+  return (
+    <ChartTooltipCard
+      title={title}
+      rows={rows}
+      activeKey={activeKey}
+      selectedKey={selectedKey}
+    />
+  );
 }
 
 interface WorkspaceSkillUsageChartProps {
@@ -243,11 +257,22 @@ export function WorkspaceSkillUsageChart({
     }
   };
 
-  const legendItems: LegendItem[] = skillsWithData.map((skill) => ({
-    key: skill,
-    label: skill,
-    colorClassName: getIndexedColor(skill, skillsWithData),
-  }));
+  const {
+    selectedKey,
+    activeKey,
+    isDimmed,
+    lineActiveDot,
+    decorate,
+    hoverHandlers,
+  } = useSelectableSeries();
+
+  const legendItems = decorate(
+    skillsWithData.map((skill) => ({
+      key: skill,
+      label: skill,
+      colorClassName: getIndexedColor(skill, skillsWithData),
+    }))
+  );
 
   const skillSelector = (
     <DropdownMenu modal={false}>
@@ -363,6 +388,8 @@ export function WorkspaceSkillUsageChart({
               {...props}
               displayMode={displayMode}
               skillsWithData={skillsWithData}
+              activeKey={activeKey}
+              selectedKey={selectedKey}
             />
           )}
           cursor={false}
@@ -381,9 +408,16 @@ export function WorkspaceSkillUsageChart({
             strokeWidth={2}
             dataKey={(point: SkillUsageChartPoint) => point.values[skill] ?? 0}
             name={skill}
-            className={getIndexedColor(skill, skillsWithData)}
+            className={cn(
+              getIndexedColor(skill, skillsWithData),
+              "transition-opacity",
+              isDimmed(skill) && "opacity-25"
+            )}
             stroke="currentColor"
             dot={false}
+            activeDot={lineActiveDot(skill)}
+            isAnimationActive={false}
+            {...hoverHandlers(skill)}
           />
         ))}
       </LineChart>

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -256,7 +256,7 @@ export function WorkspaceToolUsageChart({
     lineActiveDot,
     decorate,
     hoverHandlers,
-  } = useSelectableSeries();
+  } = useSelectableSeries(toolsWithData);
 
   const legendItems = decorate(
     toolsWithData.map((tool) => ({


### PR DESCRIPTION
## Description

Adds interactive series selection to the workspace-level skill usage chart. Users can now click on legend items to focus on specific skills—selected series remain highlighted while others are dimmed. The implementation uses the `useSelectableSeries` hook (introduced in #24601) to manage hover and selection state, and updates the tooltip to filter rows when a skill is selected.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front