### PR TITLE
Enable metronome billing

### DIFF
--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -16,6 +16,7 @@ import {
   isWhitelistedBusinessPlan,
 } from "@app/lib/plans/plan_codes";
 import { LinkWrapper, useAppRouter, useSearchParam } from "@app/lib/platform";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import {
   usePerSeatPricing,
   useSubscriptionTrialInfo,
@@ -196,9 +197,12 @@ export function SubscriptionPage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
   const { hasFeature } = useFeatureFlags();
+  const { killSwitches } = useKillSwitches();
+  const isMetronomeBillingEnabled =
+    hasFeature("metronome_billing") ||
+    !killSwitches?.includes("global_disable_metronome_billing");
   const useMetronomePanel =
-    hasFeature("metronome_billing") &&
-    !isSubscriptionStripeBilled(subscription);
+    isMetronomeBillingEnabled && !isSubscriptionStripeBilled(subscription);
   const router = useAppRouter();
   const sendNotification = useSendNotification();
   const type = useSearchParam("type");

--- a/front/pages/api/w/[wId]/subscriptions/index.test.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.test.ts
@@ -1,7 +1,8 @@
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import type { Stripe } from "stripe";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
 
@@ -32,6 +33,12 @@ describe("POST /api/w/[wId]/subscriptions", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(async () => {
+    await KillSwitchResource.disableKillSwitch(
+      "global_disable_metronome_billing"
+    );
+  });
+
   it("returns 400 on invalid request body", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
@@ -48,11 +55,15 @@ describe("POST /api/w/[wId]/subscriptions", () => {
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
   });
 
-  it("returns hosted checkoutUrl and plan details for legacy subscription", async () => {
+  it("returns hosted checkoutUrl and plan details for legacy subscription when metronome billing is killed", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
+
+    await KillSwitchResource.enableKillSwitch(
+      "global_disable_metronome_billing"
+    );
 
     req.body = {
       billingPeriod: "monthly",
@@ -78,11 +89,15 @@ describe("POST /api/w/[wId]/subscriptions", () => {
     );
   });
 
-  it("handles yearly billing period", async () => {
+  it("handles yearly billing period for legacy subscription when metronome billing is killed", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
+
+    await KillSwitchResource.enableKillSwitch(
+      "global_disable_metronome_billing"
+    );
 
     req.body = {
       billingPeriod: "yearly",
@@ -97,13 +112,11 @@ describe("POST /api/w/[wId]/subscriptions", () => {
     expect(data.plan).toBeDefined();
   });
 
-  it("returns embedded clientSecret and sessionId when metronome_billing flag is enabled", async () => {
-    const { req, res, auth } = await createPrivateApiMockRequest({
+  it("returns embedded clientSecret and sessionId by default", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
-
-    await FeatureFlagFactory.basic(auth, "metronome_billing");
 
     req.body = {
       billingPeriod: "monthly",
@@ -122,6 +135,30 @@ describe("POST /api/w/[wId]/subscriptions", () => {
         name: expect.any(String),
       })
     );
+  });
+
+  it("returns embedded clientSecret when metronome_billing flag overrides the kill switch", async () => {
+    const { req, res, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    await KillSwitchResource.enableKillSwitch(
+      "global_disable_metronome_billing"
+    );
+    await FeatureFlagFactory.basic(auth, "metronome_billing");
+
+    req.body = {
+      billingPeriod: "monthly",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.mode).toEqual("embedded");
+    expect(data.clientSecret).toEqual(TEST_CLIENT_SECRET);
+    expect(data.sessionId).toEqual(TEST_SESSION_ID);
   });
 
   it("returns 403 when user is not admin", async () => {

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -7,6 +7,7 @@ import {
   cancelSubscriptionAtPeriodEnd,
   skipSubscriptionFreeTrial,
 } from "@app/lib/plans/stripe";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -94,10 +95,7 @@ async function handler(
       }
 
       try {
-        const useMetronomeBilling = await hasFeatureFlag(
-          auth,
-          "metronome_billing"
-        );
+        const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
         const owner = auth.getNonNullableWorkspace();
         const user = auth.getNonNullableUser().toJSON();
         const subscription = auth.getNonNullableSubscriptionResource();
@@ -160,10 +158,7 @@ async function handler(
           }
 
           const owner = auth.getNonNullableWorkspace();
-          const useMetronomeBilling = await hasFeatureFlag(
-            auth,
-            "metronome_billing"
-          );
+          const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
 
           if (!subscription.stripeSubscriptionId && !useMetronomeBilling) {
             return apiError(req, res, {
@@ -269,6 +264,19 @@ async function handler(
         },
       });
   }
+}
+
+// Metronome billing is enabled by default for all workspaces. The
+// `global_disable_metronome_billing` kill switch turns it off globally; the
+// `metronome_billing` feature flag re-enables it for individual workspaces.
+async function isMetronomeBillingEnabled(
+  auth: Authenticator
+): Promise<boolean> {
+  const [hasFlag, killed] = await Promise.all([
+    hasFeatureFlag(auth, "metronome_billing"),
+    KillSwitchResource.isKillSwitchEnabled("global_disable_metronome_billing"),
+  ]);
+  return hasFlag || !killed;
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {


### PR DESCRIPTION
## Description

Enable new subscriptions based on metronome unless kill switch is enabled
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

kill switch can restore stripe subs

## Deploy Plan

deploy
