### PR TITLE
[Branching] Ungate conversation branching

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -681,9 +681,7 @@ export function AgentMessage({
     !isProjectArchived;
 
   const canBranchConversation =
-    SHOW_BRANCH_FROM_HERE_ACTION &&
-    hasFeature("sessions_branching") &&
-    shouldShowCopy;
+    SHOW_BRANCH_FROM_HERE_ACTION && shouldShowCopy;
 
   const shouldShowFeedback =
     !isDeleted &&

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -680,8 +680,7 @@ export function AgentMessage({
     !isAgentMessageHandingOver &&
     !isProjectArchived;
 
-  const canBranchConversation =
-    SHOW_BRANCH_FROM_HERE_ACTION && shouldShowCopy;
+  const canBranchConversation = SHOW_BRANCH_FROM_HERE_ACTION && shouldShowCopy;
 
   const shouldShowFeedback =
     !isDeleted &&

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -403,19 +403,15 @@ export function ConversationMenu({
             onClick={() => setShowRenameDialog(true)}
             icon={PencilSquareIcon}
           />
-          {hasFeature("sessions_branching") && (
-            <>
-              <DropdownMenuItem
-                label="Branch conversation"
-                onClick={() => {
-                  void branchConversation();
-                }}
-                icon={ActionGitBranchIcon}
-                disabled={isBranching}
-              />
-              <DropdownMenuSeparator />
-            </>
-          )}
+          <DropdownMenuItem
+            label="Branch conversation"
+            onClick={() => {
+              void branchConversation();
+            }}
+            icon={ActionGitBranchIcon}
+            disabled={isBranching}
+          />
+          <DropdownMenuSeparator />
           {hasFeature("projects") && (
             <DropdownMenuSub>
               <DropdownMenuSubTrigger

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -240,8 +240,6 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
         method: "POST",
       });
 
-    await FeatureFlagFactory.basic(auth, "sessions_branching");
-
     const projectSpace = await SpaceFactory.project(workspace);
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -8,7 +8,6 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -120,26 +119,10 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     expect(res._getStatusCode()).toBe(405);
   });
 
-  it("returns 403 when the sessions branching feature flag is disabled", async () => {
-    const { req, res } = await createPrivateApiMockRequest({
-      method: "POST",
-    });
-
-    req.query.cId = "conv_test";
-    req.body = {};
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData().error.type).toBe("feature_flag_not_found");
-  });
-
   it("creates a fork and returns the child conversation id", async () => {
     const { req, res, auth, globalSpace } = await createPrivateApiMockRequest({
       method: "POST",
     });
-
-    await FeatureFlagFactory.basic(auth, "sessions_branching");
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
@@ -187,8 +170,6 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
       method: "POST",
     });
 
-    await FeatureFlagFactory.basic(auth, "sessions_branching");
-
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",
       visibility: "unlisted",
@@ -231,8 +212,6 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
     const { req, res, auth } = await createPrivateApiMockRequest({
       method: "POST",
     });
-
-    await FeatureFlagFactory.basic(auth, "sessions_branching");
 
     const parentConversation = await createConversation(auth, {
       title: "Parent conversation",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
@@ -2,7 +2,6 @@
 import { createConversationFork } from "@app/lib/api/assistant/conversation/forks";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -46,17 +45,6 @@ async function handler(
       api_error: {
         type: "method_not_supported_error",
         message: "The method passed is not supported, POST is expected.",
-      },
-    });
-  }
-
-  const featureFlags = await getFeatureFlags(auth);
-  if (!featureFlags.includes("sessions_branching")) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "feature_flag_not_found",
-        message: "The feature is not enabled for this workspace.",
       },
     });
   }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -241,6 +241,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     // Not really on_demand but we want to be able to enable it for customers
     stage: "on_demand",
   },
+  sessions_branching: {
+    description:
+      "Legacy flag kept temporarily so pre-release clients keep showing branching during rollout",
+    stage: "dust_only",
+  },
   reinforced_agents: {
     description:
       "Enable reinforcement: background analysis of conversations to suggest improvements to skills.",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -241,11 +241,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     // Not really on_demand but we want to be able to enable it for customers
     stage: "on_demand",
   },
-  sessions_branching: {
-    description:
-      "Legacy flag kept temporarily so pre-release clients keep showing branching during rollout",
-    stage: "dust_only",
-  },
   reinforced_agents: {
     description:
       "Enable reinforcement: background analysis of conversations to suggest improvements to skills.",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -241,10 +241,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     // Not really on_demand but we want to be able to enable it for customers
     stage: "on_demand",
   },
-  sessions_branching: {
-    description: "Enable sessions branching",
-    stage: "dust_only",
-  },
   reinforced_agents: {
     description:
       "Enable reinforcement: background analysis of conversations to suggest improvements to skills.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -690,6 +690,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "claude_4_5_opus_feature"
   | "claude_4_opus_feature"
   | "confluence_tool"
+  | "sessions_branching"
   | "projects"
   | "databricks_tool"
   | "deepseek_feature"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -690,7 +690,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "claude_4_5_opus_feature"
   | "claude_4_opus_feature"
   | "confluence_tool"
-  | "sessions_branching"
   | "projects"
   | "databricks_tool"
   | "deepseek_feature"


### PR DESCRIPTION
## Description
Removes the `sessions_branching` enforcement/UI gates and makes conversation forks available to all workspaces.

This removes the fork creation API gate, renders the conversation/message fork actions without the flag check, removes the runtime feature flag definition, and drops the stale disabled-flag route test. The SDK union value is kept for public type compatibility.

Fixes https://github.com/dust-tt/tasks/issues/7789

## Risks
Blast radius: conversation fork entry points and fork creation endpoint.
Risk: standard

## Tests
- `npx biome check --error-on-warnings front/components/assistant/conversation/AgentMessage.tsx front/components/assistant/conversation/ConversationMenu.tsx front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts front/types/shared/feature_flags.ts`
- `npx tsgo --noEmit` from `front`
- `git diff --check`

## Deploy Plan
- deploy front
