### PR TITLE
[front] Fix sidebar not updating after onboarding/branch conversation creation

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -10,6 +10,7 @@ import {
   sendOnboardingConversation,
   showDebugTools,
 } from "@app/lib/development";
+import { ConversationsUpdatedEvent } from "@app/lib/notifications/events";
 import { useAppRouter } from "@app/lib/platform";
 import type { SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
@@ -94,6 +95,7 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
     () => async () => {
       const result = await sendOnboardingConversation(owner, featureFlags);
       if (result.isOk) {
+        window.dispatchEvent(new ConversationsUpdatedEvent());
         sendNotification({
           title: "Success !",
           description: "Onboarding conversation created (redirecting...)",

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -1,5 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import { ConversationsUpdatedEvent } from "@app/lib/notifications/events";
 import { useAppRouter } from "@app/lib/platform";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -78,6 +79,7 @@ export function useBranchConversation({
           return false;
         }
 
+        window.dispatchEvent(new ConversationsUpdatedEvent());
         void onConversationBranched?.();
         void router.push(
           getConversationRoute(owner.sId, responseBody.conversationId)


### PR DESCRIPTION
## Description

Dispatch ConversationsUpdatedEvent after creating an onboarding conversation or branching, so the sidebar refreshes immediately without requiring a page reload.

## Tests

Locally, tested both use cases. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 