### PR TITLE
feat: update tasks filter ui

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskLocalSearch.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskLocalSearch.tsx
@@ -18,7 +18,7 @@ export function ProjectTaskLocalSearch() {
   return (
     <SearchInput
       name="project-tasks-filter"
-      placeholder="Search tasks..."
+      placeholder="Filter tasks..."
       value={inputValue}
       onChange={setValue}
       className="w-full"

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskLocalSearch.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskLocalSearch.tsx
@@ -18,7 +18,7 @@ export function ProjectTaskLocalSearch() {
   return (
     <SearchInput
       name="project-tasks-filter"
-      placeholder="Filter tasks..."
+      placeholder="Search tasks..."
       value={inputValue}
       onChange={setValue}
       className="w-full"

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskScopeFilter.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskScopeFilter.tsx
@@ -1,121 +1,92 @@
 import { useProjectTasksPanel } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelContext";
-import type {
-  ProjectTaskPeopleScope,
-  ProjectTaskPeriodScope,
+import {
+  peopleScopeLabel,
+  periodScopeLabel,
 } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
+  isProjectTaskPeopleScope,
+  isProjectTaskPeriodScope,
+  PROJECT_TASK_PEOPLE_SCOPES,
+  PROJECT_TASK_PERIOD_SCOPES,
+} from "@app/types/project_task";
+import {
   Button,
-  ClockIcon,
-  cn,
+  ButtonsSwitch,
+  ButtonsSwitchList,
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
+  EyeIcon,
 } from "@dust-tt/sparkle";
 
-const PERIOD_OPTIONS: Array<{
-  value: ProjectTaskPeriodScope;
-  label: string;
-}> = [
-  { value: "active", label: "Open" },
-  { value: "last_24h", label: "Done today" },
-  { value: "last_7d", label: "Done in the last 7 days" },
-  { value: "last_30d", label: "Done in the last 30 days" },
-];
-
-const PEOPLE_OPTIONS: Array<{
-  value: ProjectTaskPeopleScope;
-  label: string;
-  description: string;
-}> = [
-  {
-    value: "just_mine",
-    label: "Mine",
-    description: "Your tasks only",
-  },
-  {
-    value: "unassigned",
-    label: "Unassigned",
-    description: "Tasks with no assignee",
-  },
-  {
-    value: "all_project",
-    label: "Everyone",
-    description: "All tasks in this project",
-  },
-];
-
 export function ProjectTaskScopeFilter() {
+  const { taskOwnerFilter, onTaskOwnerFilterChange } = useProjectTasksPanel();
   const isMobile = useIsMobile();
-  const {
-    isScopeMenuOpen,
-    setIsScopeMenuOpen,
-    taskOwnerFilter,
-    onTaskOwnerFilterChange,
-    taskScopeLabel,
-  } = useProjectTasksPanel();
+  const periodLabel = periodScopeLabel(taskOwnerFilter.periodScope);
 
   return (
-    <DropdownMenu
-      modal={false}
-      open={isScopeMenuOpen}
-      onOpenChange={setIsScopeMenuOpen}
-    >
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          isSelect
-          label={isMobile ? undefined : taskScopeLabel}
-          tooltip={isMobile ? taskScopeLabel : undefined}
-          icon={ClockIcon}
-          className={cn(!isMobile && "max-w-[min(100vw-3rem,24rem)]")}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-80" align="start">
-        <DropdownMenuLabel label="Status" />
-        <DropdownMenuRadioGroup
-          value={taskOwnerFilter.periodScope}
-          className="mb-2"
-        >
-          {PERIOD_OPTIONS.map(({ value, label }) => (
-            <DropdownMenuRadioItem
-              key={value}
-              value={value}
-              label={label}
-              onClick={() => {
+    <div className="flex items-center gap-2">
+      <ButtonsSwitchList
+        size="xs"
+        defaultValue={taskOwnerFilter.peopleScope}
+        onValueChange={(value) => {
+          if (isProjectTaskPeopleScope(value)) {
+            onTaskOwnerFilterChange({
+              ...taskOwnerFilter,
+              peopleScope: value,
+            });
+          }
+        }}
+      >
+        {PROJECT_TASK_PEOPLE_SCOPES.map((scope) => (
+          <ButtonsSwitch
+            key={scope}
+            value={scope}
+            label={peopleScopeLabel(scope)}
+          />
+        ))}
+      </ButtonsSwitchList>
+
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            icon={EyeIcon}
+            isSelect
+            label={isMobile ? undefined : periodLabel}
+            tooltip={isMobile ? periodLabel : undefined}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+            Status
+          </div>
+          <DropdownMenuRadioGroup
+            value={taskOwnerFilter.periodScope}
+            onValueChange={(value) => {
+              if (isProjectTaskPeriodScope(value)) {
                 onTaskOwnerFilterChange({
                   ...taskOwnerFilter,
                   periodScope: value,
                 });
-              }}
-            />
-          ))}
-        </DropdownMenuRadioGroup>
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel label="People" />
-        <DropdownMenuRadioGroup value={taskOwnerFilter.peopleScope}>
-          {PEOPLE_OPTIONS.map(({ value, label, description }) => (
-            <DropdownMenuRadioItem
-              key={value}
-              value={value}
-              label={label}
-              description={description}
-              onClick={() => {
-                onTaskOwnerFilterChange({
-                  ...taskOwnerFilter,
-                  peopleScope: value,
-                });
-              }}
-            />
-          ))}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+              }
+            }}
+          >
+            {PROJECT_TASK_PERIOD_SCOPES.map((scope) => (
+              <DropdownMenuRadioItem
+                key={scope}
+                value={scope}
+                label={periodScopeLabel(scope)}
+              />
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }

--- a/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope.ts
@@ -1,12 +1,10 @@
+import {
+  isProjectTaskPeriodScope,
+  type ProjectTaskPeopleScope,
+  type ProjectTaskPeriodScope,
+} from "@app/types/project_task";
+import { isString } from "@app/types/shared/utils/general";
 import { z } from "zod";
-
-export type ProjectTaskPeriodScope =
-  | "active"
-  | "last_24h"
-  | "last_7d"
-  | "last_30d";
-
-export type ProjectTaskPeopleScope = "all_project" | "just_mine" | "unassigned";
 
 /** Filter for project task list fetching + persisted project UI prefs. */
 export interface TaskOwnerFilter {
@@ -29,26 +27,19 @@ const PERIOD_SCOPE_LABELS: Record<ProjectTaskPeriodScope, string> = {
 const PEOPLE_SCOPE_LABELS: Record<ProjectTaskPeopleScope, string> = {
   all_project: "Everyone",
   just_mine: "Mine",
-  unassigned: "Unassigned",
 };
 
-export function formatTaskScopeLabel(filter: TaskOwnerFilter): string {
-  return `${PERIOD_SCOPE_LABELS[filter.periodScope]} · ${PEOPLE_SCOPE_LABELS[filter.peopleScope]}`;
+export function periodScopeLabel(scope: ProjectTaskPeriodScope): string {
+  return PERIOD_SCOPE_LABELS[scope];
 }
 
-const PERIOD_SCOPES: ProjectTaskPeriodScope[] = [
-  "active",
-  "last_24h",
-  "last_7d",
-  "last_30d",
-];
+export function peopleScopeLabel(scope: ProjectTaskPeopleScope): string {
+  return PEOPLE_SCOPE_LABELS[scope];
+}
 
 function coercePeriodScope(raw: unknown): ProjectTaskPeriodScope {
-  if (
-    typeof raw === "string" &&
-    PERIOD_SCOPES.includes(raw as ProjectTaskPeriodScope)
-  ) {
-    return raw as ProjectTaskPeriodScope;
+  if (isString(raw) && isProjectTaskPeriodScope(raw)) {
+    return raw;
   }
   return "active";
 }
@@ -56,9 +47,7 @@ function coercePeriodScope(raw: unknown): ProjectTaskPeriodScope {
 const tasksOwnerFilterPersistedBlobSchema = z
   .object({
     periodScope: z.string().optional(),
-    peopleScope: z.enum(["all_project", "just_mine", "unassigned"]).optional(),
-    assigneeScope: z.enum(["mine", "all", "users"]).optional(),
-    selectedUserSIds: z.array(z.string()).optional(),
+    peopleScope: z.enum(["all_project", "just_mine"]).optional(),
   })
   .passthrough();
 
@@ -71,20 +60,9 @@ export function normalizeTasksOwnerFilterFromPersistedBlob(
   }
   const blob = parsed.data;
 
-  let peopleScope: ProjectTaskPeopleScope = "all_project";
-  if (
-    blob.peopleScope === "just_mine" ||
-    blob.peopleScope === "unassigned" ||
-    blob.peopleScope === "all_project"
-  ) {
-    peopleScope = blob.peopleScope;
-  } else if (blob.assigneeScope === "mine") {
-    peopleScope = "just_mine";
-  }
-
   return {
     periodScope: coercePeriodScope(blob.periodScope),
-    peopleScope,
+    peopleScope: blob.peopleScope ?? "all_project",
   };
 }
 
@@ -94,14 +72,7 @@ export function taskOwnerFilterToSearchParams(
 ): URLSearchParams {
   const params = new URLSearchParams();
   params.set("period", filter.periodScope);
-  params.set(
-    "people",
-    filter.peopleScope === "just_mine"
-      ? "mine"
-      : filter.peopleScope === "unassigned"
-        ? "unassigned"
-        : "all"
-  );
+  params.set("people", filter.peopleScope === "just_mine" ? "mine" : "all");
   return params;
 }
 

--- a/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksPanelTypes.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksPanelTypes.ts
@@ -5,7 +5,6 @@ import type {
   ProjectTaskType,
 } from "@app/types/project_task";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
-import type { Dispatch, SetStateAction } from "react";
 
 export type GroupedTasksByAssignee = Array<{
   user: ProjectTaskAssigneeType | null;
@@ -19,12 +18,9 @@ export type CombinedGroupedTasksByUser = Array<{
 }>;
 
 export type ProjectTasksPanelData = {
-  isScopeMenuOpen: boolean;
-  setIsScopeMenuOpen: Dispatch<SetStateAction<boolean>>;
   taskOwnerFilter: TaskOwnerFilter;
   onTaskOwnerFilterChange: (value: TaskOwnerFilter) => void;
   viewerUserId: string | null;
-  taskScopeLabel: string;
   isReadOnly?: boolean;
   owner: LightWorkspaceType;
   combinedGroupedTasksByUser: CombinedGroupedTasksByUser;

--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -1,4 +1,3 @@
-import { formatTaskScopeLabel } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope";
 import type {
   ProjectTasksPanelData,
   UseProjectTasksPanelArgs,
@@ -50,7 +49,6 @@ export function useProjectTasksPanelState({
   onTaskOwnerFilterChange,
 }: UseProjectTasksPanelArgs): ProjectTasksPanelData {
   const [debouncedTaskSearchQuery, setDebouncedTaskSearchQuery] = useState("");
-  const [isScopeMenuOpen, setIsScopeMenuOpen] = useState(false);
   const {
     tasks,
     viewerUserId,
@@ -156,8 +154,6 @@ export function useProjectTasksPanelState({
     isTasksLoading,
     markRead,
   });
-
-  const taskScopeLabel = formatTaskScopeLabel(taskOwnerFilter);
 
   const assigneeScopedTasks = tasks;
 
@@ -529,7 +525,6 @@ export function useProjectTasksPanelState({
     hideAssigneeHeaders,
     isAgentsLoading,
     isReadOnly,
-    isScopeMenuOpen,
     isSoleProjectMember,
     isSpaceInfoLoading,
     isTasksError,
@@ -545,11 +540,9 @@ export function useProjectTasksPanelState({
     projectMembers,
     requestDelete,
     setDebouncedTaskSearchQuery,
-    setIsScopeMenuOpen,
     startingTaskIds,
     taskOwnerFilter,
     tasks,
-    taskScopeLabel,
     viewerUserId,
   };
 }

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -359,13 +359,10 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
       spaceId,
       timeScope,
       assigneeUserId = null,
-      onlyUnassigned = false,
     }: {
       spaceId: ModelId;
       timeScope: "active" | "last_24h" | "last_7d" | "last_30d" | "all";
       assigneeUserId?: ModelId | null;
-      /** When true, returns only todos with no assignee (`userId` IS NULL). */
-      onlyUnassigned?: boolean;
     }
   ): Promise<ProjectTaskResource[]> {
     const MS_PER_HOUR = 60 * 60 * 1000;
@@ -386,9 +383,7 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
 
     const clauses: WhereOptions<ProjectTaskModel>[] = [{ spaceId }];
 
-    if (onlyUnassigned) {
-      clauses.push({ userId: null });
-    } else if (assigneeUserId != null) {
+    if (assigneeUserId != null) {
       clauses.push({ userId: assigneeUserId });
     }
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
@@ -7,37 +7,37 @@ import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import { ProjectTaskStateResource } from "@app/lib/resources/project_task_state_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import {
+  isProjectTaskPeriodScope,
+  type ProjectTaskPeriodScope,
+  type ProjectTaskType,
+} from "@app/types/project_task";
 import type { ModelId } from "@app/types/shared/model_id";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 
 function parseSingleQueryValue(
   value: NextApiRequest["query"][string] | undefined
 ): string | undefined {
   const v = Array.isArray(value) ? value[0] : value;
-  return typeof v === "string" && v.trim().length > 0 ? v.trim() : undefined;
+  return isString(v) && v.trim().length > 0 ? v.trim() : undefined;
 }
-
-const PROJECT_TODO_TIME_SCOPE_VALUES = [
-  "active",
-  "last_24h",
-  "last_7d",
-  "last_30d",
-] as const;
-
-type ProjectTaskFetchTimeScope =
-  (typeof PROJECT_TODO_TIME_SCOPE_VALUES)[number];
 
 function parseProjectTaskTimeScope(
   req: NextApiRequest
-): ProjectTaskFetchTimeScope {
+): ProjectTaskPeriodScope {
   const raw =
     parseSingleQueryValue(req.query.period)?.toLowerCase() ?? "active";
-  if ((PROJECT_TODO_TIME_SCOPE_VALUES as readonly string[]).includes(raw)) {
-    return raw as ProjectTaskFetchTimeScope;
+  if (isProjectTaskPeriodScope(raw)) {
+    return raw;
   }
   return "active";
 }
 
-type ProjectTasksPeopleFetchMode = "all" | "mine" | "unassigned";
+type ProjectTasksPeopleFetchMode = "all" | "mine";
 
 function parseProjectTasksPeopleMode(
   req: NextApiRequest
@@ -49,17 +49,8 @@ function parseProjectTasksPeopleMode(
   if (token === "mine") {
     return "mine";
   }
-  if (token === "unassigned") {
-    return "unassigned";
-  }
   return "all";
 }
-
-import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types/error";
-import type { ProjectTaskType } from "@app/types/project_task";
-import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 
 export interface GetProjectTasksResponseBody {
   tasks: ProjectTaskType[];
@@ -109,19 +100,13 @@ async function handler(
       });
       const timeScope = parseProjectTaskTimeScope(req);
       const peopleMode = parseProjectTasksPeopleMode(req);
-      let assigneeUserId: ModelId | null = null;
-      let onlyUnassigned = false;
-      if (peopleMode === "mine") {
-        assigneeUserId = currentUser.id;
-      } else if (peopleMode === "unassigned") {
-        onlyUnassigned = true;
-      }
+      const assigneeUserId: ModelId | null =
+        peopleMode === "mine" ? currentUser.id : null;
 
       const todos = await ProjectTaskResource.fetchBySpace(auth, {
         spaceId: space.id,
         timeScope,
         assigneeUserId,
-        onlyUnassigned,
       });
 
       const todoIds = todos.map((t) => t.sId);

--- a/front/types/project_task.ts
+++ b/front/types/project_task.ts
@@ -29,6 +29,31 @@ export const AGENT_SUGGESTION_STATUSES = [
 ] as const;
 export type AgentSuggestionStatus = (typeof AGENT_SUGGESTION_STATUSES)[number];
 
+export const PROJECT_TASK_PERIOD_SCOPES = [
+  "active",
+  "last_24h",
+  "last_7d",
+  "last_30d",
+] as const;
+export type ProjectTaskPeriodScope =
+  (typeof PROJECT_TASK_PERIOD_SCOPES)[number];
+
+export function isProjectTaskPeriodScope(
+  v: string
+): v is ProjectTaskPeriodScope {
+  return PROJECT_TASK_PERIOD_SCOPES.includes(v as ProjectTaskPeriodScope);
+}
+
+export const PROJECT_TASK_PEOPLE_SCOPES = ["just_mine", "all_project"] as const;
+export type ProjectTaskPeopleScope =
+  (typeof PROJECT_TASK_PEOPLE_SCOPES)[number];
+
+export function isProjectTaskPeopleScope(
+  v: string
+): v is ProjectTaskPeopleScope {
+  return PROJECT_TASK_PEOPLE_SCOPES.includes(v as ProjectTaskPeopleScope);
+}
+
 export type ProjectTaskSourceInfo = {
   sourceType: ProjectTaskSourceType;
   sourceId: string;


### PR DESCRIPTION
## Description

This PR updates the tasks filter UI to match the new design.

- Replaced the combined dropdown filter with separate controls: a `ButtonsSwitchList` for people scope (Mine/Everyone) and a dedicated dropdown for period/status filters (Open/Done today/Done in the last 7 days/Done in the last 30 days)
- Removed the "Unassigned" filter option
- Updated the search input placeholder
- Cleaned up the API endpoint to remove `onlyUnassigned` parameter and simplified people mode parsing

<img width="950" height="250" alt="Capture d’écran 2026-05-07 à 16 55 35" src="https://github.com/user-attachments/assets/0bd7cf3c-2e6f-4df9-8980-758d2b253db3" />


## Tests

Manually

## Risks

Low - Users who were previously using the "Unassigned" filter will now see all tasks by default.

## Deploy Plan

Standard deployment - no migration needed.
