### PR TITLE
feat: move create task input

### DIFF
--- a/front/components/assistant/conversation/space/SpaceTasksTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTasksTab.tsx
@@ -1,4 +1,5 @@
 import {
+  ProjectTaskCreateBar,
   ProjectTasksPanelMain,
   ProjectTasksPanelProvider,
   ProjectTasksToolbar,
@@ -36,6 +37,7 @@ export function SpaceTasksTab({
           onTaskOwnerFilterChange={onTaskOwnerFilterChange}
         >
           <div className="flex flex-col gap-3">
+            <ProjectTaskCreateBar />
             <ProjectTasksToolbar />
             <ProjectTasksPanelMain />
           </div>

--- a/front/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer.tsx
@@ -27,13 +27,13 @@ export type AddTaskAssigneeChoice =
 
 export function resolveSubmitAssigneeSId(
   choice: AddTaskAssigneeChoice,
-  defaultAssigneeSId: string
+  defaultAssigneeId: string
 ): string | null {
   switch (choice.kind) {
     case "unassigned":
       return null;
     case "default":
-      return defaultAssigneeSId;
+      return defaultAssigneeId;
     case "member":
       return choice.sId;
     default:
@@ -45,13 +45,13 @@ export function resolveSubmitAssigneeSId(
 function memberRowAssigneeChecked(
   choice: AddTaskAssigneeChoice,
   memberSId: string,
-  defaultAssigneeSId: string
+  defaultAssigneeId: string
 ): boolean {
   switch (choice.kind) {
     case "unassigned":
       return false;
     case "default":
-      return defaultAssigneeSId === memberSId;
+      return defaultAssigneeId === memberSId;
     case "member":
       return choice.sId === memberSId;
     default:
@@ -63,7 +63,7 @@ function memberRowAssigneeChecked(
 interface TaskRowAssigneeMenuProps {
   members: SpaceUserType[];
   viewerUserId: string | null;
-  defaultAssigneeSId: string;
+  defaultAssigneeId: string;
   choice: AddTaskAssigneeChoice;
   onChoiceChange: (next: AddTaskAssigneeChoice) => void;
   disabled?: boolean;
@@ -72,7 +72,7 @@ interface TaskRowAssigneeMenuProps {
 function TaskRowAssigneeMenu({
   members,
   viewerUserId,
-  defaultAssigneeSId,
+  defaultAssigneeId,
   choice,
   onChoiceChange,
   disabled,
@@ -97,7 +97,7 @@ function TaskRowAssigneeMenu({
 
   const effectiveMemberSId = resolveSubmitAssigneeSId(
     choice,
-    defaultAssigneeSId
+    defaultAssigneeId
   );
   const selectedUser = effectiveMemberSId
     ? members.find((m) => m.sId === effectiveMemberSId)
@@ -177,11 +177,11 @@ function TaskRowAssigneeMenu({
                   checked={memberRowAssigneeChecked(
                     choice,
                     member.sId,
-                    defaultAssigneeSId
+                    defaultAssigneeId
                   )}
                   onClick={() =>
                     onChoiceChange(
-                      member.sId === defaultAssigneeSId
+                      member.sId === defaultAssigneeId
                         ? { kind: "default" }
                         : { kind: "member", sId: member.sId }
                     )
@@ -203,8 +203,8 @@ function TaskRowAssigneeMenu({
 interface AddTaskComposerProps {
   projectMembers: SpaceUserType[];
   viewerUserId: string | null;
-  defaultAssigneeSId: string;
-  /** When true, always assigns to `defaultAssigneeSId` with no picker. */
+  defaultAssigneeId: string;
+  /** When true, always assigns to `defaultAssigneeId` with no picker. */
   hideAssigneePicker?: boolean;
   onAdd: (text: string, assigneeSId: string | null) => Promise<boolean>;
 }
@@ -212,7 +212,7 @@ interface AddTaskComposerProps {
 export function AddTaskComposer({
   projectMembers,
   viewerUserId,
-  defaultAssigneeSId,
+  defaultAssigneeId,
   hideAssigneePicker = false,
   onAdd,
 }: AddTaskComposerProps) {
@@ -233,8 +233,8 @@ export function AddTaskComposer({
   }, [hideAssigneePicker, projectMembers.length]);
 
   const submitAssigneeSId = hideAssigneePicker
-    ? defaultAssigneeSId
-    : resolveSubmitAssigneeSId(assigneeChoice, defaultAssigneeSId);
+    ? defaultAssigneeId
+    : resolveSubmitAssigneeSId(assigneeChoice, defaultAssigneeId);
 
   const handleSubmit = async () => {
     const trimmed = text.trim();
@@ -256,7 +256,7 @@ export function AddTaskComposer({
         <TaskRowAssigneeMenu
           members={projectMembers}
           viewerUserId={viewerUserId}
-          defaultAssigneeSId={defaultAssigneeSId}
+          defaultAssigneeId={defaultAssigneeId}
           choice={assigneeChoice}
           onChoiceChange={setAssigneeChoice}
           disabled={isAdding}

--- a/front/components/assistant/conversation/space/conversations/project_tasks/EditableProjectTasksPanel.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/EditableProjectTasksPanel.tsx
@@ -1,8 +1,10 @@
+import { ProjectTaskCreateBar } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskCreateBar";
 import { ProjectTasksPanelProvider } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelContext";
 import { ProjectTasksPanelMain } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelMain";
 import { ProjectTasksToolbar } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksToolbar";
 import type { UseProjectTasksPanelArgs } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksPanelTypes";
 
+export { ProjectTaskCreateBar } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskCreateBar";
 export { ProjectTaskLocalSearch } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskLocalSearch";
 export { ProjectTaskScopeFilter } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskScopeFilter";
 export {
@@ -20,6 +22,7 @@ export function EditableProjectTasksPanel(props: UseProjectTasksPanelArgs) {
   return (
     <ProjectTasksPanelProvider {...props}>
       <div className="flex flex-col gap-3">
+        <ProjectTaskCreateBar />
         <ProjectTasksToolbar />
         <ProjectTasksPanelMain />
       </div>

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskCreateBar.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskCreateBar.tsx
@@ -8,7 +8,7 @@ export function ProjectTaskCreateBar() {
     projectMembers,
     isReadOnly,
     isSpaceInfoLoading,
-    defaultNewAssigneeSId,
+    defaultNewAssigneeId,
     handleAddTask,
   } = useProjectTasksPanel();
 
@@ -24,7 +24,7 @@ export function ProjectTaskCreateBar() {
     );
   }
 
-  if (projectMembers.length === 0) {
+  if (projectMembers.length === 0 || !defaultNewAssigneeId) {
     return (
       <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
         No project members available to assign.
@@ -36,7 +36,7 @@ export function ProjectTaskCreateBar() {
     <AddTaskComposer
       projectMembers={projectMembers}
       viewerUserId={viewerUserId}
-      defaultAssigneeSId={defaultNewAssigneeSId!}
+      defaultAssigneeId={defaultNewAssigneeId}
       onAdd={handleAddTask}
     />
   );

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskCreateBar.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskCreateBar.tsx
@@ -1,0 +1,43 @@
+import { AddTaskComposer } from "@app/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer";
+import { useProjectTasksPanel } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelContext";
+import { Spinner } from "@dust-tt/sparkle";
+
+export function ProjectTaskCreateBar() {
+  const {
+    viewerUserId,
+    projectMembers,
+    isReadOnly,
+    isSpaceInfoLoading,
+    defaultNewAssigneeSId,
+    handleAddTask,
+  } = useProjectTasksPanel();
+
+  if (isReadOnly) {
+    return null;
+  }
+
+  if (isSpaceInfoLoading) {
+    return (
+      <div className="flex h-7 items-center">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (projectMembers.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        No project members available to assign.
+      </p>
+    );
+  }
+
+  return (
+    <AddTaskComposer
+      projectMembers={projectMembers}
+      viewerUserId={viewerUserId}
+      defaultAssigneeSId={defaultNewAssigneeSId!}
+      onAdd={handleAddTask}
+    />
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelMain.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelMain.tsx
@@ -1,4 +1,3 @@
-import { AddTaskComposer } from "@app/components/assistant/conversation/space/conversations/project_tasks/AddTaskComposer";
 import { useProjectTasksPanel } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTasksPanelContext";
 import { ProjectTaskUserSection } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskUserSection";
 import { normalizeProjectTaskSearchNeedle } from "@app/components/assistant/conversation/space/conversations/project_tasks/utils";
@@ -7,12 +6,6 @@ import { Spinner } from "@dust-tt/sparkle";
 
 export function ProjectTasksPanelMain() {
   const {
-    viewerUserId,
-    projectMembers,
-    isReadOnly,
-    isSpaceInfoLoading,
-    defaultNewAssigneeSId,
-    handleAddTask,
     isTasksLoading,
     isTasksError,
     frozenLastReadAt,
@@ -28,24 +21,6 @@ export function ProjectTasksPanelMain() {
 
   return (
     <div className="flex flex-col gap-3">
-      {!isReadOnly &&
-        (isSpaceInfoLoading ? (
-          <div className="flex h-7 items-center">
-            <Spinner size="sm" />
-          </div>
-        ) : projectMembers.length === 0 ? (
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            No project members available to assign.
-          </p>
-        ) : (
-          <AddTaskComposer
-            projectMembers={projectMembers}
-            viewerUserId={viewerUserId}
-            defaultAssigneeSId={defaultNewAssigneeSId!}
-            onAdd={handleAddTask}
-          />
-        ))}
-
       {isTasksLoading || frozenLastReadAt === undefined ? (
         <div className="flex justify-center py-4">
           <Spinner size="sm" />

--- a/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksPanelTypes.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksPanelTypes.ts
@@ -51,7 +51,7 @@ export type ProjectTasksPanelData = {
     updates: { text?: string; assigneeUserId?: string | null }
   ) => Promise<void>;
   isSpaceInfoLoading: boolean;
-  defaultNewAssigneeSId: string | null;
+  defaultNewAssigneeId: string | null;
   handleAddTask: (text: string, assigneeSId: string | null) => Promise<boolean>;
   isTasksLoading: boolean;
   isTasksError: boolean;

--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -120,7 +120,7 @@ export function useProjectTasksPanelState({
     return ids;
   }, [tasks]);
 
-  const defaultNewAssigneeSId = useMemo(() => {
+  const defaultNewAssigneeId = useMemo(() => {
     if (projectMembers.length === 0) {
       return null;
     }
@@ -514,7 +514,7 @@ export function useProjectTasksPanelState({
     assigneeScopedTasks,
     combinedGroupedTasksByUser,
     debouncedTaskSearchQuery,
-    defaultNewAssigneeSId,
+    defaultNewAssigneeId,
     doneFlashKeys,
     filteredTasks,
     firstOnboardingTaskId,


### PR DESCRIPTION
## Description

This PR refactors the project task creation input by extracting it into a dedicated component and moving it above the filters.

<img width="950" height="198" alt="Capture d’écran 2026-05-07 à 16 56 02" src="https://github.com/user-attachments/assets/8f0cb40a-18c4-452f-9ef5-495cbb64d37b" />


## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment - no special considerations needed.
