### PR TITLE
[Branching] Harden project conversation forks

### DIFF
--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -50,6 +50,7 @@ import type { Transaction } from "sequelize";
 
 export type CreateConversationForkErrorCode =
   | "conversation_not_found"
+  | "unauthorized"
   | "invalid_request_error"
   | "internal_error";
 
@@ -569,6 +570,13 @@ export async function createConversationFork(
   if (!parentConversation) {
     return new Err(
       new DustError("conversation_not_found", "Conversation not found.")
+    );
+  }
+
+  const parentSpace = parentConversation.space;
+  if (parentSpace?.isProject() && !parentSpace.isMember(auth)) {
+    return new Err(
+      new DustError("unauthorized", "You are not a member of the project.")
     );
   }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -1,13 +1,16 @@
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { describe, expect, it, vi } from "vitest";
@@ -250,5 +253,49 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
 
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 403 when creating a fork in a project where the user is not a member", async () => {
+    const { req, res, auth, workspace, globalGroup } =
+      await createPrivateApiMockRequest({
+        method: "POST",
+      });
+
+    await FeatureFlagFactory.basic(auth, "sessions_branching");
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await GroupSpaceMemberResource.makeNew(internalAdminAuth, {
+      group: globalGroup,
+      space: projectSpace,
+    });
+
+    const parentConversation = await createConversation(auth, {
+      title: "Parent conversation",
+      visibility: "unlisted",
+      spaceId: projectSpace.id,
+    });
+
+    const userMessage = await createUserMessage(auth, {
+      conversation: parentConversation,
+      rank: 0,
+      content: "Please continue from here.",
+    });
+    const sourceMessage = await createAgentMessage(auth, {
+      conversation: parentConversation,
+      rank: 1,
+      parentId: userMessage.id,
+      status: "succeeded",
+    });
+
+    req.query.cId = parentConversation.sId;
+    req.body = { sourceMessageId: sourceMessage.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error.type).toBe("workspace_auth_error");
   });
 });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
@@ -89,6 +89,14 @@ async function handler(
             message: createRes.error.message,
           },
         });
+      case "unauthorized":
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: createRes.error.message,
+          },
+        });
       case "invalid_request_error":
         return apiError(req, res, {
           status_code: 400,


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/25395

Project conversations can be readable by non-project members when the project is open, but fork creation writes a new child conversation back into the project. Today, the fork path only requires read access, so a non-project member can create a fork inside the project.

This blocks fork creation in `createConversationFork` when the parent conversation belongs to a project and the current user is not a project member. The API handler maps that to a 403 `workspace_auth_error`.

## Risks
Blast radius: conversation fork creation for project conversations.
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Tests
- [ ] `NODE_ENV=test npm test -- forks/index.test.ts` (blocked locally by test DB sync error before tests ran: `agent_suggestions_agentConfigurationId_fkey` has incompatible column types)