### PR TITLE
[front] PaymentProcessingPage: use SWR hook + clean redis + use polling in page

### DIFF
--- a/front/components/pages/onboarding/PaymentProcessingPage.tsx
+++ b/front/components/pages/onboarding/PaymentProcessingPage.tsx
@@ -16,31 +16,18 @@ export function PaymentProcessingPage() {
   const sessionId = useSearchParam("session_id");
   const planCode = useSearchParam("plan_code");
   const [error, setError] = useState<string | null>(null);
+  const [shouldPoll, setShouldPoll] = useState(true);
   const pollCountRef = useRef(0);
 
   const { mutateAuthContext } = useAuthContext({ workspaceId: owner.sId });
 
-  const { checkoutStatus, mutateCheckoutStatus } = useCheckoutStatus({
+  const { checkoutStatus } = useCheckoutStatus({
     workspaceId: owner.sId,
     sessionId: sessionId ?? "",
     planCode: planCode ?? "",
     disabled: type !== "succeeded" || !sessionId || !planCode,
+    pollIntervalMs: shouldPoll ? CHECKOUT_POLL_INTERVAL_MS : 0,
   });
-
-  useEffect(() => {
-    if (checkoutStatus?.status !== "pending") {
-      return;
-    }
-    if (pollCountRef.current >= MAX_CHECKOUT_POLL_ATTEMPTS) {
-      setError("Payment processing timed out.");
-      return;
-    }
-    pollCountRef.current += 1;
-    const timeoutId = setTimeout(() => {
-      void mutateCheckoutStatus();
-    }, CHECKOUT_POLL_INTERVAL_MS);
-    return () => clearTimeout(timeoutId);
-  }, [checkoutStatus, mutateCheckoutStatus]);
 
   useEffect(() => {
     if (!checkoutStatus) {
@@ -48,6 +35,7 @@ export function PaymentProcessingPage() {
     }
     switch (checkoutStatus.status) {
       case "success":
+        setShouldPoll(false);
         void (async () => {
           await mutateAuthContext();
           void router.replace(
@@ -56,9 +44,15 @@ export function PaymentProcessingPage() {
         })();
         break;
       case "error":
+        setShouldPoll(false);
         setError(checkoutStatus.message);
         break;
       case "pending":
+        pollCountRef.current += 1;
+        if (pollCountRef.current >= MAX_CHECKOUT_POLL_ATTEMPTS) {
+          setShouldPoll(false);
+          setError("Payment processing timed out.");
+        }
         break;
       default:
         assertNeverAndIgnore(checkoutStatus);

--- a/front/components/pages/onboarding/PaymentProcessingPage.tsx
+++ b/front/components/pages/onboarding/PaymentProcessingPage.tsx
@@ -1,9 +1,13 @@
 import { useWorkspace } from "@app/lib/auth/AuthContext";
-import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
+import { useAuthContext, useCheckoutStatus } from "@app/lib/swr/workspaces";
 import { getConversationRoute } from "@app/lib/utils/router";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { BarHeader, Button, Page, Spinner } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+const MAX_CHECKOUT_POLL_ATTEMPTS = 15;
+const CHECKOUT_POLL_INTERVAL_MS = 2000;
 
 export function PaymentProcessingPage() {
   const owner = useWorkspace();
@@ -12,37 +16,54 @@ export function PaymentProcessingPage() {
   const sessionId = useSearchParam("session_id");
   const planCode = useSearchParam("plan_code");
   const [error, setError] = useState<string | null>(null);
+  const pollCountRef = useRef(0);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally runs once
+  const { mutateAuthContext } = useAuthContext({ workspaceId: owner.sId });
+
+  const { checkoutStatus, mutateCheckoutStatus } = useCheckoutStatus({
+    workspaceId: owner.sId,
+    sessionId: sessionId ?? "",
+    planCode: planCode ?? "",
+    disabled: type !== "succeeded" || !sessionId || !planCode,
+  });
+
   useEffect(() => {
-    if (type !== "succeeded") {
+    if (checkoutStatus?.status !== "pending") {
       return;
     }
+    if (pollCountRef.current >= MAX_CHECKOUT_POLL_ATTEMPTS) {
+      setError("Payment processing timed out.");
+      return;
+    }
+    pollCountRef.current += 1;
+    const timeoutId = setTimeout(() => {
+      void mutateCheckoutStatus();
+    }, CHECKOUT_POLL_INTERVAL_MS);
+    return () => clearTimeout(timeoutId);
+  }, [checkoutStatus, mutateCheckoutStatus]);
 
-    const checkStatus = async () => {
-      const res = await clientFetch(
-        `/api/w/${owner.sId}/subscriptions/checkout-status?session_id=${sessionId}&plan_code=${planCode}`
-      );
-      const data = (await res.json()) as
-        | { status: "success" }
-        | { status: "error"; message: string }
-        | { status: "pending" };
-
-      if (data.status === "success") {
-        void router.replace(
-          getConversationRoute(owner.sId, "new", "welcome=true")
-        );
-      } else if (data.status === "error") {
-        setError(data.message);
-      } else {
-        setTimeout(() => {
-          void router.reload();
-        }, 5000);
-      }
-    };
-
-    void checkStatus();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (!checkoutStatus) {
+      return;
+    }
+    switch (checkoutStatus.status) {
+      case "success":
+        void (async () => {
+          await mutateAuthContext();
+          void router.replace(
+            getConversationRoute(owner.sId, "new", "welcome=true")
+          );
+        })();
+        break;
+      case "error":
+        setError(checkoutStatus.message);
+        break;
+      case "pending":
+        break;
+      default:
+        assertNeverAndIgnore(checkoutStatus);
+    }
+  }, [checkoutStatus, mutateAuthContext, owner.sId, router]);
 
   return (
     <>

--- a/front/lib/metronome/checkout_error.ts
+++ b/front/lib/metronome/checkout_error.ts
@@ -1,7 +1,9 @@
 import { getRedisCacheClient } from "@app/lib/api/redis";
+import { z } from "zod";
 
-const CHECKOUT_ERROR_TTL_SECONDS = 3600;
+const CHECKOUT_ERROR_TTL_SECONDS = 60;
 const CHECKOUT_ERROR_KEY_PREFIX = "metronome:checkout:error:";
+const CheckoutErrorSchema = z.object({ message: z.string() });
 
 export async function storeMetronomeCheckoutError({
   sessionId,
@@ -26,9 +28,12 @@ export async function getMetronomeCheckoutError(
   const redis = await getRedisCacheClient({
     origin: "metronome_checkout_error",
   });
-  const raw = await redis.get(`${CHECKOUT_ERROR_KEY_PREFIX}${sessionId}`);
+  const key = `${CHECKOUT_ERROR_KEY_PREFIX}${sessionId}`;
+  const raw = await redis.get(key);
   if (!raw) {
     return null;
   }
-  return JSON.parse(raw) as { message: string };
+  await redis.del(key);
+  const parsed = CheckoutErrorSchema.safeParse(JSON.parse(raw));
+  return parsed.success ? parsed.data : null;
 }

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -34,6 +34,7 @@ import type {
   GetSubscriptionsResponseBody,
   PostSubscriptionResponseBody,
 } from "@app/pages/api/w/[wId]/subscriptions";
+import type { GetCheckoutStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/checkout-status";
 import type { GetSubscriptionPricingResponseBody } from "@app/pages/api/w/[wId]/subscriptions/pricing";
 import type { GetSubscriptionStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/status";
 import type { GetSubscriptionTrialInfoResponseBody } from "@app/pages/api/w/[wId]/subscriptions/trial-info";
@@ -819,6 +820,35 @@ export function useAuthContext(
     isAuthContextLoading: isFetching || !!isRegionRedirectResponse,
     authContextError: error,
     mutateAuthContext: mutate,
+  };
+}
+
+export function useCheckoutStatus({
+  workspaceId,
+  sessionId,
+  planCode,
+  disabled,
+}: {
+  workspaceId: string;
+  sessionId: string;
+  planCode: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const checkoutFetcher: Fetcher<GetCheckoutStatusResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    disabled
+      ? null
+      : `/api/w/${workspaceId}/subscriptions/checkout-status?session_id=${sessionId}&plan_code=${planCode}`,
+    checkoutFetcher
+  );
+
+  return {
+    checkoutStatus: data ?? null,
+    isCheckoutStatusLoading: !error && !data && !disabled,
+    isCheckoutStatusError: error,
+    mutateCheckoutStatus: mutate,
   };
 }
 

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -828,11 +828,13 @@ export function useCheckoutStatus({
   sessionId,
   planCode,
   disabled,
+  pollIntervalMs = 0,
 }: {
   workspaceId: string;
   sessionId: string;
   planCode: string;
   disabled?: boolean;
+  pollIntervalMs?: number;
 }) {
   const { fetcher } = useFetcher();
   const checkoutFetcher: Fetcher<GetCheckoutStatusResponseBody> = fetcher;
@@ -841,7 +843,8 @@ export function useCheckoutStatus({
     disabled
       ? null
       : `/api/w/${workspaceId}/subscriptions/checkout-status?session_id=${sessionId}&plan_code=${planCode}`,
-    checkoutFetcher
+    checkoutFetcher,
+    { refreshInterval: pollIntervalMs }
   );
 
   return {


### PR DESCRIPTION
## Description

* Replace the manual clientFetch + router.reload() polling in PaymentProcessingPage with a proper useCheckoutStatus SWR hook that polls the checkout-status endpoint up to 15 times (every 2s)
* Invalidates the auth context on success before routing to the conversation page (needed)
* Clean usage of Redis with a TTL of 60 seconds and key deletion

## Tests

Tested locally, with success with Stripe (legacy) and success and error with Metronome checkout (new pricing)

## Risk

Medium, impacts the whole subscription flow with Metronome, to be properly redirected to conversation page after successful checkout

## Deploy Plan

Deploy front