### PR TITLE
[front] Fix branched conversation title in sidebar

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -6,7 +6,7 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import { EditConversationTitleDialog } from "@app/components/assistant/conversation/EditConversationTitleDialog";
 import { getParentConversationTitleLabel } from "@app/components/assistant/conversation/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { useConversation, useConversations } from "@app/hooks/conversations";
+import { useConversation } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
@@ -26,7 +26,7 @@ import {
   MoreIcon,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
 const BREADCRUMB_MIDDLE_TRUNCATE_LENGTH = 35;
 const DESKTOP_TITLE_TRUNCATE_LENGTH = 120;
@@ -44,7 +44,6 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     workspaceId: owner.sId,
     spaceId: conversation?.spaceId ?? null,
   });
-  const { mutateConversations } = useConversations({ workspaceId: owner.sId });
   const router = useAppRouter();
   const isMobile = useIsMobile();
 
@@ -56,9 +55,6 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     handleRightClick,
     handleMenuOpenChange,
   } = useConversationMenu();
-  const onConversationBranched = useCallback(() => {
-    void mutateConversations();
-  }, [mutateConversations]);
 
   const currentTitle = conversation
     ? getConversationDisplayTitle(conversation)
@@ -183,7 +179,6 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
           <ConversationMenu
             activeConversationId={activeConversationId}
             conversation={conversation}
-            onConversationBranched={onConversationBranched}
             owner={owner}
             trigger={({ isPendingAction }) => (
               <Button

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1219,8 +1219,7 @@ export const ConversationViewer = ({
 
   const onConversationBranched = useCallback(() => {
     void mutateConversation();
-    void mutateConversations();
-  }, [mutateConversation, mutateConversations]);
+  }, [mutateConversation]);
 
   // After reversal in the hook, messages[0] is the oldest page. This only
   // returns the actual first conversation message when all pages are loaded

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -449,9 +449,6 @@ export function AgentSidebarMenu({
     loadMore,
     isLoadingMore,
   } = useConversations({ workspaceId: owner.sId });
-  const onConversationBranched = useCallback(() => {
-    void mutateConversations();
-  }, [mutateConversations]);
 
   const hasSpaceConversations = hasFeature("projects");
 
@@ -761,7 +758,6 @@ export function AgentSidebarMenu({
         selectedConversations={selectedConversations}
         toggleConversationSelection={toggleConversationSelection}
         activeConversationId={activeConversationId}
-        onConversationBranched={onConversationBranched}
         owner={owner}
         projectsSection={projectsSection}
         hasTriggeredConversations={hasTriggeredConversations}
@@ -782,7 +778,6 @@ export function AgentSidebarMenu({
     selectedConversations,
     toggleConversationSelection,
     activeConversationId,
-    onConversationBranched,
     owner,
     projectsSection,
     hasTriggeredConversations,
@@ -1087,7 +1082,6 @@ interface UnreadConversationsSectionProps {
   isMultiSelect: boolean;
   isMarkingAllAsRead: boolean;
   onMarkAllAsRead: (conversationIds: string[]) => void;
-  onConversationBranched?: () => Promise<void> | void;
   selectedConversations: ConversationListItemType[];
   toggleConversationSelection: (c: ConversationListItemType) => void;
   activeConversationId: string | null;
@@ -1116,7 +1110,6 @@ function UnreadConversationsSection({
   isMarkingAllAsRead,
   titleFilter,
   onMarkAllAsRead,
-  onConversationBranched,
   selectedConversations,
   toggleConversationSelection,
   activeConversationId,
@@ -1159,7 +1152,6 @@ function UnreadConversationsSection({
               <ConversationListItem
                 conversation={conversation}
                 isMultiSelect={isMultiSelect}
-                onConversationBranched={onConversationBranched}
                 selectedConversations={selectedConversations}
                 toggleConversationSelection={toggleConversationSelection}
                 activeConversationId={activeConversationId}
@@ -1184,7 +1176,6 @@ const ConversationList = ({
   selectedConversations: ConversationListItemType[];
   toggleConversationSelection: (c: ConversationListItemType) => void;
   activeConversationId: string | null;
-  onConversationBranched?: () => Promise<void> | void;
   owner: WorkspaceType;
 }) => {
   if (!conversations.length) {
@@ -1229,7 +1220,6 @@ const ConversationListItem = memo(
   ({
     conversation,
     isMultiSelect,
-    onConversationBranched,
     selectedConversations,
     toggleConversationSelection,
     activeConversationId,
@@ -1237,7 +1227,6 @@ const ConversationListItem = memo(
   }: {
     conversation: ConversationListItemType;
     isMultiSelect: boolean;
-    onConversationBranched?: () => Promise<void> | void;
     selectedConversations: ConversationListItemType[];
     toggleConversationSelection: (c: ConversationListItemType) => void;
     activeConversationId: string | null;
@@ -1314,7 +1303,6 @@ const ConversationListItem = memo(
           <ConversationMenu
             activeConversationId={conversation.sId}
             conversation={conversation}
-            onConversationBranched={onConversationBranched}
             owner={owner}
             trigger={() => <NavigationListItemAction />}
             isConversationDisplayed={activeConversationId === conversation.sId}
@@ -1344,7 +1332,6 @@ interface NavigationListWithInboxProps {
   selectedConversations: ConversationListItemType[];
   toggleConversationSelection: (conversation: ConversationListItemType) => void;
   activeConversationId: string | null;
-  onConversationBranched?: () => Promise<void> | void;
   owner: WorkspaceType;
   projectsSection?: React.ReactNode;
   hasTriggeredConversations: boolean;
@@ -1365,7 +1352,6 @@ function NavigationListWithInbox({
   selectedConversations,
   toggleConversationSelection,
   activeConversationId,
-  onConversationBranched,
   owner,
   projectsSection,
   hasTriggeredConversations,
@@ -1409,7 +1395,6 @@ function NavigationListWithInbox({
           conversations={conversationsByDate[dateLabel as GroupLabel]}
           dateLabel={dateLabel}
           isMultiSelect={isMultiSelect}
-          onConversationBranched={onConversationBranched}
           selectedConversations={selectedConversations}
           toggleConversationSelection={toggleConversationSelection}
           activeConversationId={activeConversationId}
@@ -1452,7 +1437,6 @@ function NavigationListWithInbox({
                 isMarkingAllAsRead={isMarkingAllAsRead}
                 titleFilter={titleFilter}
                 onMarkAllAsRead={markAllAsRead}
-                onConversationBranched={onConversationBranched}
                 selectedConversations={selectedConversations}
                 toggleConversationSelection={toggleConversationSelection}
                 activeConversationId={activeConversationId}
@@ -1477,7 +1461,6 @@ function NavigationListWithInbox({
                 isMarkingAllAsRead={isMarkingAllAsRead}
                 titleFilter={titleFilter}
                 onMarkAllAsRead={markAllAsRead}
-                onConversationBranched={onConversationBranched}
                 selectedConversations={selectedConversations}
                 toggleConversationSelection={toggleConversationSelection}
                 activeConversationId={activeConversationId}

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -19,7 +19,8 @@ function isPostConversationForkResponseBody(
     isRecord(value) &&
     isString(value.conversationId) &&
     (value.parentConversationTitle === null ||
-      isString(value.parentConversationTitle))
+      isString(value.parentConversationTitle)) &&
+    (value.spaceId === null || isString(value.spaceId))
   );
 }
 
@@ -105,7 +106,9 @@ export function useBranchConversation({
           nextWakeupAt: null,
           requestedSpaceIds: [],
           sId: responseBody.conversationId,
-          spaceId: null, // unknown at branch time; only affects sidebar draggability which is corrected on next SWR revalidation
+          // Inherited from the parent conversation — safe to return via the fork API
+          // because the caller already has access to the parent (they just branched it).
+          spaceId: responseBody.spaceId,
           title: displayTitle,
           triggerId: null,
           unread: false,

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -1,10 +1,11 @@
+import { useConversations } from "@app/hooks/conversations/useConversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { ConversationsUpdatedEvent } from "@app/lib/notifications/events";
 import { useAppRouter } from "@app/lib/platform";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { PostConversationForkResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/forks";
+import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import { isRecord, isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
@@ -16,7 +17,9 @@ function isPostConversationForkResponseBody(
     typeof value === "object" &&
     value !== null &&
     isRecord(value) &&
-    isString(value.conversationId)
+    isString(value.conversationId) &&
+    (value.parentConversationTitle === null ||
+      isString(value.parentConversationTitle))
   );
 }
 
@@ -31,12 +34,16 @@ export function useBranchConversation({
 }) {
   const sendNotification = useSendNotification();
   const router = useAppRouter();
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
 
   const [isBranching, setIsBranching] = useState(false);
 
   const branchConversation = useCallback(
     async (sourceMessageId?: string): Promise<boolean> => {
-      if (!conversationId) {
+      if (!conversationId || isBranching) {
         return false;
       }
 
@@ -79,9 +86,44 @@ export function useBranchConversation({
           return false;
         }
 
-        window.dispatchEvent(new ConversationsUpdatedEvent());
+        // Write directly into the SWR cache instead of dispatching ConversationsUpdatedEvent.
+        // ConversationsUpdatedEvent triggers an immediate refetch, but ES indexes conversations
+        // asynchronously via Temporal so the new conversation is not in ES yet at that point —
+        // the item would disappear from the sidebar. { revalidate: false } keeps the optimistic
+        // item until the next natural SWR revalidation, by which time ES has caught up.
+        const displayTitle = responseBody.parentConversationTitle
+          ? `Branched from '${responseBody.parentConversationTitle}'`
+          : "Branched conversation";
+
+        const nowMs = Date.now();
+        const optimisticConversationItem: ConversationListItemType = {
+          actionRequired: false,
+          created: nowMs,
+          hasError: false,
+          lastReadMs: nowMs,
+          metadata: {},
+          nextWakeupAt: null,
+          requestedSpaceIds: [],
+          sId: responseBody.conversationId,
+          spaceId: null, // unknown at branch time; only affects sidebar draggability which is corrected on next SWR revalidation
+          title: displayTitle,
+          triggerId: null,
+          unread: false,
+          updated: nowMs,
+        };
+
+        void mutateConversations(
+          (prevConversations) => {
+            if (!prevConversations) {
+              return prevConversations;
+            }
+            return [optimisticConversationItem, ...prevConversations];
+          },
+          { revalidate: false }
+        );
+
         void onConversationBranched?.();
-        void router.push(
+        await router.push(
           getConversationRoute(owner.sId, responseBody.conversationId)
         );
 
@@ -99,6 +141,8 @@ export function useBranchConversation({
     },
     [
       conversationId,
+      isBranching,
+      mutateConversations,
       onConversationBranched,
       owner.sId,
       router,

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -494,7 +494,7 @@ describe("createConversationFork", () => {
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     expect(childConversation.title).toBeNull();
@@ -689,7 +689,7 @@ describe("createConversationFork", () => {
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     expect(childConversation.forkingData?.forkedFrom?.sourceMessageId).toBe(
@@ -798,7 +798,7 @@ describe("createConversationFork", () => {
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     const childMCPServerViews = await ConversationResource.fetchMCPServerViews(
@@ -861,7 +861,7 @@ describe("createConversationFork", () => {
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     const childSkills = await SkillResource.listEnabledByConversation(auth, {
@@ -938,7 +938,7 @@ describe("createConversationFork", () => {
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     const childAttachments = await listAttachments(auth, {
@@ -1072,7 +1072,7 @@ const untouched = "prefix${referencedFile.sId}suffix";`
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     const childAttachments = await listAttachments(auth, {
@@ -1226,7 +1226,7 @@ const untouched = "prefix${referencedFile.sId}suffix";`
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     const childAttachments = await listAttachments(auth, {
@@ -1310,7 +1310,7 @@ const untouched = "prefix${referencedFile.sId}suffix";`
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     const childAttachments = await listAttachments(auth, {
@@ -1408,7 +1408,7 @@ const untouched = "prefix${referencedFile.sId}suffix";`
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     const childAttachments = await listAttachments(auth, {
@@ -1476,7 +1476,7 @@ const untouched = "prefix${referencedFile.sId}suffix";`
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     const childAttachments = await listAttachments(auth, {
@@ -1580,7 +1580,7 @@ const untouched = "prefix${referencedFile.sId}suffix";`
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     const childAttachments = await listAttachments(auth, {
@@ -1682,7 +1682,7 @@ const untouched = "prefix${referencedFile.sId}suffix";`
 
     const childConversation = await fetchConversationOrThrow(
       auth,
-      result.value
+      result.value.conversationId
     );
 
     expect(childConversation.requestedSpaceIds).toEqual([

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -551,6 +551,11 @@ async function carryOverConversationAttachments(
   return attachmentIdReplacements;
 }
 
+type ConversationForkResult = {
+  conversationId: string;
+  parentConversationTitle: string | null;
+};
+
 export async function createConversationFork(
   auth: Authenticator,
   {
@@ -560,7 +565,9 @@ export async function createConversationFork(
     conversationId: string;
     sourceMessageId?: string;
   }
-): Promise<Result<string, DustError<CreateConversationForkErrorCode>>> {
+): Promise<
+  Result<ConversationForkResult, DustError<CreateConversationForkErrorCode>>
+> {
   const parentConversation = await ConversationResource.fetchById(
     auth,
     conversationId
@@ -695,7 +702,10 @@ export async function createConversationFork(
       "Failed to reload child conversation for fork attachment carryover."
     );
 
-    return new Ok(childConversationId.value.childConversationId);
+    return new Ok({
+      conversationId: childConversationId.value.childConversationId,
+      parentConversationTitle: parentConversation.title,
+    });
   }
 
   const parentConversationWithContent = await getConversation(
@@ -746,8 +756,14 @@ export async function createConversationFork(
       },
       "Failed to initialize forked conversation compaction."
     );
-    return new Ok(childConversation.value.sId);
+    return new Ok({
+      conversationId: childConversation.value.sId,
+      parentConversationTitle: parentConversation.title,
+    });
   }
 
-  return new Ok(childConversation.value.sId);
+  return new Ok({
+    conversationId: childConversation.value.sId,
+    parentConversationTitle: parentConversation.title,
+  });
 }

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -554,6 +554,7 @@ async function carryOverConversationAttachments(
 type ConversationForkResult = {
   conversationId: string;
   parentConversationTitle: string | null;
+  spaceId: string | null;
 };
 
 export async function createConversationFork(
@@ -705,6 +706,7 @@ export async function createConversationFork(
     return new Ok({
       conversationId: childConversationId.value.childConversationId,
       parentConversationTitle: parentConversation.title,
+      spaceId: parentConversation.space?.sId ?? null,
     });
   }
 
@@ -759,11 +761,13 @@ export async function createConversationFork(
     return new Ok({
       conversationId: childConversation.value.sId,
       parentConversationTitle: parentConversation.title,
+      spaceId: parentConversation.space?.sId ?? null,
     });
   }
 
   return new Ok({
     conversationId: childConversation.value.sId,
     parentConversationTitle: parentConversation.title,
+    spaceId: parentConversation.space?.sId ?? null,
   });
 }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
@@ -18,6 +18,7 @@ const PostConversationForkBodySchema = t.partial({
 
 export type PostConversationForkResponseBody = {
   conversationId: string;
+  parentConversationTitle: string | null;
 };
 
 async function handler(
@@ -111,7 +112,8 @@ async function handler(
   }
 
   return res.status(200).json({
-    conversationId: createRes.value,
+    conversationId: createRes.value.conversationId,
+    parentConversationTitle: createRes.value.parentConversationTitle,
   });
 }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.ts
@@ -19,6 +19,7 @@ const PostConversationForkBodySchema = t.partial({
 export type PostConversationForkResponseBody = {
   conversationId: string;
   parentConversationTitle: string | null;
+  spaceId: string | null;
 };
 
 async function handler(
@@ -114,6 +115,7 @@ async function handler(
   return res.status(200).json({
     conversationId: createRes.value.conversationId,
     parentConversationTitle: createRes.value.parentConversationTitle,
+    spaceId: createRes.value.spaceId,
   });
 }
 


### PR DESCRIPTION
## Description

After branching a conversation, the sidebar was showing "New Conversation" instead of "Branched from '...'".

The fork API only returned conversationId, so the client had no way to compute the display title. The fix extends the response to include parentConversationTitle and spaceId, then writes directly into the SWR cache with { revalidate: false } so the correct title appears immediately without triggering a refetch.

The { revalidate: false } matters for the upcoming full ES rollout: ES indexes conversations asynchronously via Temporal, so an immediate refetch would return no result for the new conversation yet and erase the item. Adding a JOIN to the conversation list DB query was also considered but rejected since that query runs on every sidebar load.

All mutateConversations() calls in onConversationBranched callbacks in ConversationTitle, ConversationViewer, and SidebarMenu were removed for the same reason: they would trigger that exact refetch and break the fix.


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
