### PR TITLE
[SLACK] Fix intermittent blank consent page on Enterprise Grid for Slack Tools OAuth

### DIFF
--- a/core/src/oauth/providers/slack_tools.rs
+++ b/core/src/oauth/providers/slack_tools.rs
@@ -60,7 +60,7 @@ impl Provider for SlackToolsConnectionProvider {
 
         let req = self
             .reqwest_client()
-            .post("https://slack.com/api/oauth.v2.access")
+            .post("https://slack.com/api/oauth.v2.user.access")
             .header("Content-Type", "application/x-www-form-urlencoded")
             .header("Authorization", format!("Basic {}", self.basic_auth()))
             // Very important, this will *not* work with JSON body.
@@ -77,26 +77,12 @@ impl Provider for SlackToolsConnectionProvider {
             )));
         }
 
-        let (team_id, team_name) = match raw_json["team"].is_object() {
-            true => (
-                raw_json["team"]["id"]
-                    .as_str()
-                    .ok_or_else(|| anyhow!("Missing `team_id` in response from Slack"))?,
-                raw_json["team"]["name"]
-                    .as_str()
-                    .ok_or_else(|| anyhow!("Missing `team_name` in response from Slack"))?,
-            ),
-            false => {
-                return Err(ProviderError::UnknownError(format!(
-                    "Missing `team` in response from Slack"
-                )))
-            }
-        };
+        let team_id = raw_json["team"]["id"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing `team_id` in response from Slack"))?;
+        let team_name = raw_json["team"]["name"].as_str().unwrap_or(team_id);
 
-        // For both `platform_actions and `personal_actions we receive a user token.
-        // `platform_actions` are used to setup the MCP server while `personal_actions` are used by
-        // users at time of use.
-        let access_token = raw_json["authed_user"]["access_token"]
+        let access_token = raw_json["access_token"]
             .as_str()
             .ok_or_else(|| anyhow!("Missing `access_token` in response from Slack"))?;
 

--- a/core/src/oauth/providers/slack_tools.rs
+++ b/core/src/oauth/providers/slack_tools.rs
@@ -80,7 +80,10 @@ impl Provider for SlackToolsConnectionProvider {
         let team_id = raw_json["team"]["id"]
             .as_str()
             .ok_or_else(|| anyhow!("Missing `team_id` in response from Slack"))?;
-        let team_name = raw_json["team"]["name"].as_str().unwrap_or(team_id);
+        let team_name = match raw_json["team"]["name"].as_str() {
+            Some(name) => name,
+            None => team_id,
+        };
 
         let access_token = raw_json["access_token"]
             .as_str()

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -88,9 +88,9 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
     const clientId = config.getOAuthSlackToolsClientId();
 
     return (
-      `https://slack.com/oauth/v2/authorize?` +
+      `https://slack.com/oauth/v2_user/authorize?` +
       `client_id=${clientId}` +
-      `&user_scope=${encodeURIComponent(user_scopes.join(" "))}` +
+      `&scope=${encodeURIComponent(user_scopes.join(" "))}` +
       `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("slack_tools"))}` +
       // Force the team id to be the same as the admin-setup.
       // Edge-case: if the user is not in the team or not logged in, they might still connect to the wrong team.


### PR DESCRIPTION
## Description

Fixes [#8016](https://github.com/dust-tt/tasks/issues/8016) — intermittent blank Slack consent page during the Slack Tools user-auth flow on Enterprise Grid orgs (confirmed at Datadog and XM Cyber).

Migrates the Slack Tools OAuth flow from the standard `oauth/v2/authorize` + `oauth.v2.access` pair to the dedicated user-token-only `oauth/v2_user/authorize` + `oauth.v2.user.access` pair ([Slack docs](https://docs.slack.dev/authentication/installing-with-oauth/)). The standard endpoint mis-renders the consent page when only `user_scope` is requested on Enterprise Grid: Slack's redirect to the org subdomain (`<org>.slack.com/oauth`) injects an empty `scope=`, which the consent renderer then treats as "no scopes requested" and ignores `user_scope`. The user-token-only endpoint pair avoids that code path.

Front (`slack_tools.ts`) and core (`slack_tools.rs`) must change in lockstep — mismatching the two halves returns `oauth_authorization_url_mismatch`.

## Tests

No tests. 

## Risk

Medium — touches a working OAuth flow for all Slack Tools users (not just the affected ones). The new endpoint is documented and supported, but we have no production telemetry on it for our app config. Rollback is a clean revert of the two files; no data state to clean up. Note: `team.name` is now best-effort (falls back to `team_id`) since `oauth.v2.user.access` does not consistently return it — only used as a human-readable label, no functional impact.

## Deploy Plan

> ⚠️ Cross-service paired change — `core` must be deployed before/with `front`. Mismatched halves return `oauth_authorization_url_mismatch` from Slack and break the flow. `core` is **not** deployed via edge and requires a manual deploy.

1. Block `core` and `front` deployments on #deployments (❌)
2. Merge PR on main
3. Deploy `main` on `core` (manual — not edge) and wait for it to be live
4. Deploy `main` on `front`
5. Unlock #deployments (✅)
6. Monitor `OAuth: Failed to finalize connection` logs for `provider: "slack_tools"`
