### PR TITLE
Gong: retryAfer is in seconds

### DIFF
--- a/connectors/src/connectors/gong/lib/errors.ts
+++ b/connectors/src/connectors/gong/lib/errors.ts
@@ -24,7 +24,7 @@ export class GongAPIError extends Error {
   readonly errors?: string[];
   readonly pathErrors?: string[];
   readonly requestId?: string;
-  readonly retryAfterMs?: number;
+  readonly retryAfterSeconds?: number;
   readonly status?: number;
 
   constructor(
@@ -35,7 +35,7 @@ export class GongAPIError extends Error {
       errors,
       pathErrors,
       requestId,
-      retryAfterMs,
+      retryAfterSeconds,
       status,
       type,
     }: {
@@ -44,7 +44,7 @@ export class GongAPIError extends Error {
       errors?: string[];
       pathErrors?: string[];
       requestId?: string;
-      retryAfterMs?: number;
+      retryAfterSeconds?: number;
       status?: number;
       type: GongAPIErrorType;
     }
@@ -57,7 +57,7 @@ export class GongAPIError extends Error {
     this.errors = errors;
     this.pathErrors = pathErrors;
     this.requestId = requestId;
-    this.retryAfterMs = retryAfterMs;
+    this.retryAfterSeconds = retryAfterSeconds;
     this.status = status;
   }
 
@@ -68,13 +68,13 @@ export class GongAPIError extends Error {
       connectorId,
       endpoint,
       pathErrors,
-      retryAfterMs,
+      retryAfterSeconds,
     }: {
       body: string;
       connectorId: ModelId;
       endpoint: string;
       pathErrors?: string[];
-      retryAfterMs?: number;
+      retryAfterSeconds?: number;
     }
   ) {
     // Attempt to parse the body as JSON.
@@ -103,7 +103,7 @@ export class GongAPIError extends Error {
         pathErrors,
         requestId,
         status: response.status,
-        retryAfterMs,
+        retryAfterSeconds,
       }
     );
   }

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -237,18 +237,23 @@ const GongPermissionProfilesResponseCodec = t.intersection([
   CatchAllCodec,
 ]);
 
-// Gong's documented Retry-After unit is seconds, we have observerd it to be in anything betwee 1 to 55k,
-// which indicates that it's in miliseconds, or in seconds, but with a bug
-// if you remove oultiers, the distribution is centered around 10 (which we treat a seconds)
-// so flooring the retry after to 10.
-const RETRY_AFTER_FLOOR_MS = 10_000;
-const RETRY_AFTER_CEILING_MS = 60 * 60_000;
+// Gong's documented Retry-After unit is seconds, we have observerd it to be in anything betwee 1 to
+// 55k.  We thought before that it was milliseconds but we've observed in the while a decrease of
+// that value with following a second pattern (spolu). We floor at 10s and ceil at 1h to avoid
+// outliers.
+const RETRY_AFTER_FLOOR_SECONDS = 10;
+const RETRY_AFTER_CEILING_SECONDS = 3600;
 
-export function clampRetryAfterMs(raw: number | undefined): number | undefined {
+export function clampRetryAfterSeconds(
+  raw: number | undefined
+): number | undefined {
   if (raw === undefined || Number.isNaN(raw)) {
     return undefined;
   }
-  return Math.min(Math.max(raw, RETRY_AFTER_FLOOR_MS), RETRY_AFTER_CEILING_MS);
+  return Math.min(
+    Math.max(raw, RETRY_AFTER_FLOOR_SECONDS),
+    RETRY_AFTER_CEILING_SECONDS
+  );
 }
 
 export class GongClient {
@@ -295,9 +300,8 @@ export class GongClient {
           )
         );
 
-        // Gong docs says the Retry-After header is in seconds, our findings show it is actually
-        // in milliseconds.
-        const retryAfterMs = response.headers.get("Retry-After")
+        // Gong docs says the Retry-After header is in seconds. It is indeed seconds
+        const retryAfterSeconds = response.headers.get("Retry-After")
           ? parseInt(response.headers.get("Retry-After")!, 10)
           : undefined;
 
@@ -307,7 +311,7 @@ export class GongClient {
             endpoint,
             headers,
             provider: "gong",
-            retryAfterMs,
+            retryAfterSeconds,
           },
           "Rate limit hit on Gong API."
         );
@@ -324,7 +328,7 @@ export class GongClient {
           body,
           connectorId: this.connectorId,
           endpoint,
-          retryAfterMs,
+          retryAfterSeconds,
         });
       }
 

--- a/connectors/src/connectors/gong/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/gong/temporal/cast_known_errors.ts
@@ -1,5 +1,5 @@
 import { GongAPIError } from "@connectors/connectors/gong/lib/errors";
-import { clampRetryAfterMs } from "@connectors/connectors/gong/lib/gong_api";
+import { clampRetryAfterSeconds } from "@connectors/connectors/gong/lib/gong_api";
 import {
   DustConnectorWorkflowError,
   ProviderRateLimitError,
@@ -24,12 +24,14 @@ export class GongCastKnownErrorsInterceptor
       if (err instanceof GongAPIError) {
         switch (err.status) {
           case 429: {
-            const clampedMs = clampRetryAfterMs(err.retryAfterMs);
-            if (clampedMs !== undefined) {
+            const clampedSeconds = clampRetryAfterSeconds(
+              err.retryAfterSeconds
+            );
+            if (clampedSeconds !== undefined) {
               // Override the default retry delay of the activity policy.
               throw ApplicationFailure.create({
-                message: `${err.message}. Retry after ${clampedMs}ms`,
-                nextRetryDelay: clampedMs,
+                message: `${err.message}. Retry after ${clampedSeconds * 1000}ms`,
+                nextRetryDelay: 1000 * clampedSeconds,
                 cause: err,
               });
             }


### PR DESCRIPTION
## Description

Refactor retryAfter from Gong as seconds.

We can see them decreasing as seconds here: https://app.datadoghq.eu/logs?query=%22Rate%20limit%20hit%20on%20Gong%20API.%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1778235707600&to_ts=1778235925943&live=false

## Tests

N/A

## Risk

Low can be reverted

## Deploy Plan

- deploy `connectors`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->