### PR TITLE
Fixed credit purchase on metronome only flow

### DIFF
--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -26,6 +26,7 @@ import {
   Button,
   ButtonsSwitch,
   ButtonsSwitchList,
+  CardIcon,
   Chip,
   Dialog,
   DialogContainer,
@@ -365,6 +366,36 @@ export function MetronomeSubscriptionPanel({
         <div>
           <Page.Horizontal gap="sm">
             <Chip size="sm" color={chipColor} label={plan.name} />
+            {!isEnterprise &&
+              (isCancellationScheduled ? (
+                <Button
+                  size="sm"
+                  label="Resume subscription"
+                  variant="highlight"
+                  disabled={isReactivating}
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "subscription_reactivate",
+                    () => {
+                      void reactivateSubscription();
+                    }
+                  )}
+                />
+              ) : (
+                <Button
+                  size="sm"
+                  label="Cancel subscription"
+                  variant="warning"
+                  disabled={isCancelling}
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "subscription_cancel",
+                    () => {
+                      setShowCancelDialog(true);
+                    }
+                  )}
+                />
+              ))}
           </Page.Horizontal>
         </div>
 
@@ -411,35 +442,19 @@ export function MetronomeSubscriptionPanel({
               No billing information available for this period yet.
             </Page.P>
           )}
-          <div className="my-5 flex flex-row gap-2">
-            {!isEnterprise &&
-              (isCancellationScheduled ? (
-                <Button
-                  label="Resume subscription"
-                  variant="highlight"
-                  disabled={isReactivating}
-                  onClick={withTracking(
-                    TRACKING_AREAS.AUTH,
-                    "subscription_reactivate",
-                    () => {
-                      void reactivateSubscription();
-                    }
-                  )}
-                />
-              ) : (
-                <Button
-                  label="Cancel subscription"
-                  variant="warning"
-                  disabled={isCancelling}
-                  onClick={withTracking(
-                    TRACKING_AREAS.AUTH,
-                    "subscription_cancel",
-                    () => {
-                      setShowCancelDialog(true);
-                    }
-                  )}
-                />
-              ))}
+          <div className="my-5">
+            <Button
+              icon={CardIcon}
+              label="Your billing dashboard on Stripe"
+              variant="ghost"
+              onClick={withTracking(
+                TRACKING_AREAS.AUTH,
+                "subscription_stripe_portal",
+                () => {
+                  window.open(`/w/${owner.sId}/subscription/manage`, "_blank");
+                }
+              )}
+            />
           </div>
         </Page.Vertical>
 

--- a/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/buy_programmatic_usage_credits.ts
@@ -1,11 +1,17 @@
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { createPlugin } from "@app/lib/api/poke/types";
+import type { CreditPurchaseBillingTarget } from "@app/lib/credits/committed";
 import { createEnterpriseCreditPurchase } from "@app/lib/credits/committed";
-import { createMetronomeCredit } from "@app/lib/metronome/client";
+import {
+  createMetronomeCredit,
+  getMetronomeCustomerStripeCustomerId,
+} from "@app/lib/metronome/client";
 import {
   getCreditTypeProgrammaticUsdId,
   getProductFreeCreditId,
 } from "@app/lib/metronome/constants";
+import { resolveCurrencyForExistingMetronomeCustomer } from "@app/lib/metronome/contracts";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import {
   getStripeSubscription,
   isEnterpriseSubscription,
@@ -239,24 +245,35 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
     }
 
     // Handle committed credit creation (with Stripe invoice).
-    const subscription = auth.subscription();
+    const subscription = auth.subscriptionResource();
 
-    if (!subscription?.stripeSubscriptionId) {
+    if (
+      !subscription?.stripeSubscriptionId &&
+      !subscription?.isMetronomeOnlyBilled
+    ) {
       return new Err(
         new Error(
-          `Workspace "${workspace.name}" does not have a Stripe subscription.`
+          `Workspace "${workspace.name}" does not have an active subscription.`
         )
       );
     }
 
-    const stripeSubscription = await getStripeSubscription(
-      subscription.stripeSubscriptionId
-    );
-    if (!stripeSubscription) {
-      return new Err(new Error("Failed to retrieve Stripe subscription."));
+    // Determine enterprise + Pro-override gate, identical for both billing
+    // paths. For Stripe-billed we read it off the Stripe subscription; for
+    // Metronome-only we read it off the plan code.
+    let isEnterprise: boolean;
+    if (subscription.stripeSubscriptionId) {
+      const stripeSubscription = await getStripeSubscription(
+        subscription.stripeSubscriptionId
+      );
+      if (!stripeSubscription) {
+        return new Err(new Error("Failed to retrieve Stripe subscription."));
+      }
+      isEnterprise = isEnterpriseSubscription(stripeSubscription);
+    } else {
+      isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
     }
 
-    const isEnterprise = isEnterpriseSubscription(stripeSubscription);
     if (!isEnterprise && !validatedArgs.confirmProOverride) {
       return new Err(
         new Error(
@@ -278,18 +295,63 @@ export const buyProgrammaticUsageCreditsPlugin = createPlugin({
       discountPercent = defaultDiscount > 0 ? defaultDiscount : undefined;
     }
 
+    const customerFacingInfo = validatedArgs.purchaseOrderId
+      ? { purchaseOrderId: validatedArgs.purchaseOrderId }
+      : undefined;
+
+    let billingTarget: CreditPurchaseBillingTarget;
+
+    if (subscription.isMetronomeOnlyBilled) {
+      // Metronome-only: issue the invoice on the linked Stripe customer.
+      if (!workspace.metronomeCustomerId) {
+        return new Err(
+          new Error(
+            `Workspace "${workspace.name}" is not provisioned in Metronome.`
+          )
+        );
+      }
+      const stripeCustomerIdResult = await getMetronomeCustomerStripeCustomerId(
+        workspace.metronomeCustomerId
+      );
+      if (stripeCustomerIdResult.isErr() || !stripeCustomerIdResult.value) {
+        return new Err(
+          new Error(
+            `No Stripe billing configuration found for workspace "${workspace.name}".`
+          )
+        );
+      }
+      const currencyResult = await resolveCurrencyForExistingMetronomeCustomer({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        stripeSubscriptionId: null,
+      });
+      if (currencyResult.isErr()) {
+        return new Err(
+          new Error(
+            `Failed to resolve billing currency: ${currencyResult.error.message}`
+          )
+        );
+      }
+      billingTarget = {
+        type: "metronome",
+        stripeCustomerId: stripeCustomerIdResult.value,
+        currency: currencyResult.value,
+      };
+    } else {
+      billingTarget = {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscription.stripeSubscriptionId!,
+      };
+    }
+
     const result = await createEnterpriseCreditPurchase({
       auth,
-      stripeSubscriptionId: subscription.stripeSubscriptionId,
+      billingTarget,
       amountMicroUsd,
       discountPercent,
       startDate,
       expirationDate,
-      customerFacingInfo: validatedArgs.purchaseOrderId
-        ? { purchaseOrderId: validatedArgs.purchaseOrderId }
-        : undefined,
+      customerFacingInfo,
     });
-
     if (result.isErr()) {
       return result;
     }

--- a/front/lib/credits/committed.test.ts
+++ b/front/lib/credits/committed.test.ts
@@ -15,7 +15,7 @@ import {
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
   MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
-  makeCreditPurchaseOneOffInvoice,
+  makeCreditPurchaseOneOffInvoiceForSubscription,
   payInvoice,
   voidInvoiceWithReason,
 } from "@app/lib/plans/stripe";
@@ -37,7 +37,7 @@ vi.mock("@app/lib/plans/stripe", async () => {
     getCreditAmountFromInvoice: vi.fn(),
     voidInvoiceWithReason: vi.fn(),
     getCreditPurchaseCouponId: vi.fn(),
-    makeCreditPurchaseOneOffInvoice: vi.fn(),
+    makeCreditPurchaseOneOffInvoiceForSubscription: vi.fn(),
     finalizeInvoice: vi.fn(),
     payInvoice: vi.fn(),
   };
@@ -449,7 +449,7 @@ describe("createEnterpriseCreditPurchase", () => {
   });
 
   it("should create invoice with send_invoice collection method and N+30 days", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_enterprise" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -465,18 +465,20 @@ describe("createEnterpriseCreditPurchase", () => {
       amountMicroUsd: 5_000_000_000,
     });
 
-    expect(makeCreditPurchaseOneOffInvoice).toHaveBeenCalledWith({
-      stripeSubscriptionId: subscriptionId,
-      amountMicroUsd: 5_000_000_000,
-      couponId: undefined,
-      collectionMethod: "send_invoice",
-      daysUntilDue: ENTERPRISE_N30_PAYMENTS_DAYS,
-    });
+    expect(makeCreditPurchaseOneOffInvoiceForSubscription).toHaveBeenCalledWith(
+      {
+        stripeSubscriptionId: subscriptionId,
+        amountMicroUsd: 5_000_000_000,
+        couponId: undefined,
+        collectionMethod: "send_invoice",
+        daysUntilDue: ENTERPRISE_N30_PAYMENTS_DAYS,
+      }
+    );
   });
 
   it("should create coupon when discountPercent is provided", async () => {
     vi.mocked(getCreditPurchaseCouponId).mockResolvedValue(new Ok("coupon_15"));
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_enterprise" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -494,13 +496,13 @@ describe("createEnterpriseCreditPurchase", () => {
     });
 
     expect(getCreditPurchaseCouponId).toHaveBeenCalledWith(15);
-    expect(makeCreditPurchaseOneOffInvoice).toHaveBeenCalledWith(
+    expect(makeCreditPurchaseOneOffInvoiceForSubscription).toHaveBeenCalledWith(
       expect.objectContaining({ couponId: "coupon_15" })
     );
   });
 
   it("should create credit resource with correct type and amounts", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_enterprise" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -528,7 +530,7 @@ describe("createEnterpriseCreditPurchase", () => {
 
   it("should finalize invoice after creation", async () => {
     const mockInvoice = { id: "in_enterprise" } as Stripe.Invoice;
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok(mockInvoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(new Ok(mockInvoice));
@@ -546,7 +548,7 @@ describe("createEnterpriseCreditPurchase", () => {
   });
 
   it("should start credit immediately with custom dates", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_enterprise" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -592,11 +594,13 @@ describe("createEnterpriseCreditPurchase", () => {
     if (result.isErr()) {
       expect(result.error.message).toBe("Coupon API error");
     }
-    expect(makeCreditPurchaseOneOffInvoice).not.toHaveBeenCalled();
+    expect(
+      makeCreditPurchaseOneOffInvoiceForSubscription
+    ).not.toHaveBeenCalled();
   });
 
   it("should return error if invoice creation fails", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Err({ error_type: "other", error_message: "Invoice creation failed" })
     );
 
@@ -616,7 +620,7 @@ describe("createEnterpriseCreditPurchase", () => {
   });
 
   it("should return error if finalize fails", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_enterprise" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -651,7 +655,7 @@ describe("createProCreditPurchase", () => {
   });
 
   it("should create invoice with charge_automatically collection method", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_pro" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -668,18 +672,20 @@ describe("createProCreditPurchase", () => {
       amountMicroUsd: 100_000_000,
     });
 
-    expect(makeCreditPurchaseOneOffInvoice).toHaveBeenCalledWith({
-      stripeSubscriptionId: subscriptionId,
-      amountMicroUsd: 100_000_000,
-      couponId: undefined,
-      collectionMethod: "charge_automatically",
-      requestThreeDSecure: "challenge",
-    });
+    expect(makeCreditPurchaseOneOffInvoiceForSubscription).toHaveBeenCalledWith(
+      {
+        stripeSubscriptionId: subscriptionId,
+        amountMicroUsd: 100_000_000,
+        couponId: undefined,
+        collectionMethod: "charge_automatically",
+        requestThreeDSecure: "challenge",
+      }
+    );
   });
 
   it("should create coupon when discountPercent is provided", async () => {
     vi.mocked(getCreditPurchaseCouponId).mockResolvedValue(new Ok("coupon_20"));
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_pro" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -698,13 +704,13 @@ describe("createProCreditPurchase", () => {
     });
 
     expect(getCreditPurchaseCouponId).toHaveBeenCalledWith(20);
-    expect(makeCreditPurchaseOneOffInvoice).toHaveBeenCalledWith(
+    expect(makeCreditPurchaseOneOffInvoiceForSubscription).toHaveBeenCalledWith(
       expect.objectContaining({ couponId: "coupon_20" })
     );
   });
 
   it("should create credit resource before finalizing", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_pro" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -734,7 +740,7 @@ describe("createProCreditPurchase", () => {
       id: "in_pro",
       status: "open",
     } as Stripe.Invoice;
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok(mockInvoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(new Ok(mockFinalizedInvoice));
@@ -754,7 +760,7 @@ describe("createProCreditPurchase", () => {
   });
 
   it("should return invoiceId and null paymentUrl on successful auto-charge", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_pro" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -779,7 +785,7 @@ describe("createProCreditPurchase", () => {
   });
 
   it("should return paymentUrl when payment requires additional action (3DS)", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_pro" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -823,11 +829,13 @@ describe("createProCreditPurchase", () => {
     if (result.isErr()) {
       expect(result.error.message).toBe("Coupon API error");
     }
-    expect(makeCreditPurchaseOneOffInvoice).not.toHaveBeenCalled();
+    expect(
+      makeCreditPurchaseOneOffInvoiceForSubscription
+    ).not.toHaveBeenCalled();
   });
 
   it("should return error if invoice creation fails", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Err({ error_type: "other", error_message: "Invoice creation failed" })
     );
 
@@ -847,7 +855,7 @@ describe("createProCreditPurchase", () => {
   });
 
   it("should return error if finalize fails", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_pro" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(
@@ -870,7 +878,7 @@ describe("createProCreditPurchase", () => {
   });
 
   it("should return error if pay fails", async () => {
-    vi.mocked(makeCreditPurchaseOneOffInvoice).mockResolvedValue(
+    vi.mocked(makeCreditPurchaseOneOffInvoiceForSubscription).mockResolvedValue(
       new Ok({ id: "in_pro" } as Stripe.Invoice)
     );
     vi.mocked(finalizeInvoice).mockResolvedValue(

--- a/front/lib/credits/committed.test.ts
+++ b/front/lib/credits/committed.test.ts
@@ -458,7 +458,10 @@ describe("createEnterpriseCreditPurchase", () => {
 
     await createEnterpriseCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 5_000_000_000,
     });
 
@@ -482,7 +485,10 @@ describe("createEnterpriseCreditPurchase", () => {
 
     await createEnterpriseCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 5_000_000_000,
       discountPercent: 15,
     });
@@ -503,7 +509,10 @@ describe("createEnterpriseCreditPurchase", () => {
 
     const result = await createEnterpriseCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 5_000_000_000,
       discountPercent: 10,
     });
@@ -526,7 +535,10 @@ describe("createEnterpriseCreditPurchase", () => {
 
     await createEnterpriseCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 5_000_000_000,
     });
 
@@ -546,7 +558,10 @@ describe("createEnterpriseCreditPurchase", () => {
 
     const result = await createEnterpriseCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 5_000_000_000,
       startDate,
       expirationDate,
@@ -565,7 +580,10 @@ describe("createEnterpriseCreditPurchase", () => {
 
     const result = await createEnterpriseCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 5_000_000_000,
       discountPercent: 15,
     });
@@ -584,7 +602,10 @@ describe("createEnterpriseCreditPurchase", () => {
 
     const result = await createEnterpriseCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 5_000_000_000,
     });
 
@@ -604,7 +625,10 @@ describe("createEnterpriseCreditPurchase", () => {
 
     const result = await createEnterpriseCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 5_000_000_000,
     });
 
@@ -637,7 +661,10 @@ describe("createProCreditPurchase", () => {
 
     await createProCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 100_000_000,
     });
 
@@ -662,7 +689,10 @@ describe("createProCreditPurchase", () => {
 
     await createProCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 100_000_000,
       discountPercent: 20,
     });
@@ -684,7 +714,10 @@ describe("createProCreditPurchase", () => {
 
     await createProCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 100_000_000,
     });
 
@@ -709,7 +742,10 @@ describe("createProCreditPurchase", () => {
 
     await createProCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 100_000_000,
     });
 
@@ -728,7 +764,10 @@ describe("createProCreditPurchase", () => {
 
     const result = await createProCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 100_000_000,
     });
 
@@ -752,7 +791,10 @@ describe("createProCreditPurchase", () => {
 
     const result = await createProCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 100_000_000,
     });
 
@@ -769,7 +811,10 @@ describe("createProCreditPurchase", () => {
 
     const result = await createProCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 100_000_000,
       discountPercent: 20,
     });
@@ -788,7 +833,10 @@ describe("createProCreditPurchase", () => {
 
     const result = await createProCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 100_000_000,
     });
 
@@ -808,7 +856,10 @@ describe("createProCreditPurchase", () => {
 
     const result = await createProCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 100_000_000,
     });
 
@@ -831,7 +882,10 @@ describe("createProCreditPurchase", () => {
 
     const result = await createProCreditPurchase({
       auth,
-      stripeSubscriptionId: subscriptionId,
+      billingTarget: {
+        type: "stripe-subscription",
+        stripeSubscriptionId: subscriptionId,
+      },
       amountMicroUsd: 100_000_000,
     });
 

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -14,7 +14,7 @@ import {
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
   MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
-  makeCreditPurchaseOneOffInvoice,
+  makeCreditPurchaseOneOffInvoiceForSubscription,
   makeCreditPurchaseOneOffInvoiceForCustomer,
   payInvoice,
   voidInvoiceWithReason,
@@ -372,7 +372,7 @@ export async function createEnterpriseCreditPurchase({
 
   const invoiceResult =
     billingTarget.type === "stripe-subscription"
-      ? await makeCreditPurchaseOneOffInvoice({
+      ? await makeCreditPurchaseOneOffInvoiceForSubscription({
           stripeSubscriptionId: billingTarget.stripeSubscriptionId,
           amountMicroUsd,
           couponId,
@@ -645,7 +645,7 @@ export async function createProCreditPurchase({
 
   const invoiceResult =
     billingTarget.type === "stripe-subscription"
-      ? await makeCreditPurchaseOneOffInvoice({
+      ? await makeCreditPurchaseOneOffInvoiceForSubscription({
           stripeSubscriptionId: billingTarget.stripeSubscriptionId,
           amountMicroUsd,
           couponId,

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -15,12 +15,14 @@ import {
   isEnterpriseSubscription,
   MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
   makeCreditPurchaseOneOffInvoice,
+  makeCreditPurchaseOneOffInvoiceForCustomer,
   payInvoice,
   voidInvoiceWithReason,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
+import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
@@ -319,7 +321,7 @@ export async function voidFailedProCreditPurchaseInvoice({
 
 export async function createEnterpriseCreditPurchase({
   auth,
-  stripeSubscriptionId,
+  billingTarget,
   amountMicroUsd,
   discountPercent,
   startDate,
@@ -328,7 +330,7 @@ export async function createEnterpriseCreditPurchase({
   customerFacingInfo,
 }: {
   auth: Authenticator;
-  stripeSubscriptionId: string;
+  billingTarget: CreditPurchaseBillingTarget;
   amountMicroUsd: number;
   discountPercent?: number;
   startDate?: Date;
@@ -368,14 +370,26 @@ export async function createEnterpriseCreditPurchase({
     couponId = undefined;
   }
 
-  const invoiceResult = await makeCreditPurchaseOneOffInvoice({
-    stripeSubscriptionId,
-    amountMicroUsd,
-    couponId,
-    customerFacingInfo,
-    collectionMethod: "send_invoice",
-    daysUntilDue: ENTERPRISE_N30_PAYMENTS_DAYS,
-  });
+  const invoiceResult =
+    billingTarget.type === "stripe-subscription"
+      ? await makeCreditPurchaseOneOffInvoice({
+          stripeSubscriptionId: billingTarget.stripeSubscriptionId,
+          amountMicroUsd,
+          couponId,
+          customerFacingInfo,
+          collectionMethod: "send_invoice",
+          daysUntilDue: ENTERPRISE_N30_PAYMENTS_DAYS,
+        })
+      : await makeCreditPurchaseOneOffInvoiceForCustomer({
+          stripeCustomerId: billingTarget.stripeCustomerId,
+          workspaceId: workspace.sId,
+          currency: billingTarget.currency,
+          amountMicroUsd,
+          couponId,
+          customerFacingInfo,
+          collectionMethod: "send_invoice",
+          daysUntilDue: ENTERPRISE_N30_PAYMENTS_DAYS,
+        });
 
   if (invoiceResult.isErr()) {
     logger.error(
@@ -384,6 +398,7 @@ export async function createEnterpriseCreditPurchase({
         workspaceId: workspace.sId,
         amountMicroUsd,
         discountPercent,
+        billingTarget: billingTarget.type,
       },
       "[Credit Purchase] Failed to create enterprise credit purchase invoice"
     );
@@ -467,15 +482,135 @@ export async function createEnterpriseCreditPurchase({
   return new Ok({ credit, invoiceOrLineItemId: invoice.id });
 }
 
+/**
+ * Webhook-side credit activation for Metronome-only Pro purchases. Mirrors
+ * `startCreditFromProOneOffInvoice` but doesn't take a Stripe subscription —
+ * the workspace is resolved upstream from the invoice metadata.
+ */
+export async function startCreditFromMetronomeOneOffInvoice({
+  auth,
+  invoice,
+}: {
+  auth: Authenticator;
+  invoice: Stripe.Invoice;
+}): Promise<Result<undefined, Error>> {
+  if (!isCreditPurchaseInvoice(invoice)) {
+    throw new Error(
+      `Cannot process this invoice for credit purchase: ${invoice.id}`
+    );
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const creditAmountCents = getCreditAmountFromInvoice(invoice);
+
+  if (creditAmountCents === null) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+        creditAmountCents: invoice.metadata?.credit_amount_cents,
+      },
+      "[Credit Purchase] Invalid credit amount in invoice metadata"
+    );
+    getStatsDClient().increment("credits.top_up.error", 1, [
+      `workspace_id:${workspace.sId}`,
+      "type:committed",
+      "customer:metronome",
+    ]);
+    return new Err(new Error("Invalid credit amount in invoice metadata"));
+  }
+
+  const credit = await CreditResource.fetchByInvoiceOrLineItemId(
+    auth,
+    invoice.id
+  );
+
+  if (!credit) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+      },
+      "[Credit Purchase] Credit not found for invoice"
+    );
+    getStatsDClient().increment("credits.top_up.error", 1, [
+      `workspace_id:${workspace.sId}`,
+      "type:committed",
+      "customer:metronome",
+    ]);
+    return new Err(new Error("Credit not found for invoice"));
+  }
+
+  const startResult = await credit.start(auth);
+  if (startResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        creditAmountCents,
+        invoiceId: invoice.id,
+        creditId: credit.id,
+        expirationDate: credit.expirationDate,
+      },
+      "[Credit Purchase] Error starting credit"
+    );
+    getStatsDClient().increment("credits.top_up.error", 1, [
+      `workspace_id:${workspace.sId}`,
+      "type:committed",
+      "customer:metronome",
+    ]);
+    return new Err(startResult.error);
+  }
+
+  getStatsDClient().increment("credits.top_up.success", 1, [
+    `workspace_id:${workspace.sId}`,
+    "type:committed",
+    "customer:metronome",
+  ]);
+
+  const metronomeResult = await addMetronomeCommitsForWorkspace({
+    auth,
+    credit,
+    amountCredits: creditAmountCents / 100,
+    startDate: startResult.value.startDate,
+    expirationDate: startResult.value.expirationDate,
+  });
+  if (metronomeResult.isErr()) {
+    return new Err(metronomeResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      creditAmountCents,
+      invoiceId: invoice.id,
+      creditId: credit.id,
+    },
+    "[Credit Purchase] Successfully activated credit for Metronome-only subscription"
+  );
+  return new Ok(undefined);
+}
+
+// Where the Stripe one-off credit-purchase invoice lives:
+// - `stripe-subscription`: attached to the workspace's Stripe subscription.
+// - `metronome`: issued directly on the Stripe customer linked through the
+//   Metronome billing config (no Stripe subscription).
+export type CreditPurchaseBillingTarget =
+  | { type: "stripe-subscription"; stripeSubscriptionId: string }
+  | {
+      type: "metronome";
+      stripeCustomerId: string;
+      currency: SupportedCurrency;
+    };
+
 export async function createProCreditPurchase({
   auth,
-  stripeSubscriptionId,
+  billingTarget,
   amountMicroUsd,
   discountPercent,
   boughtByUserId,
 }: {
   auth: Authenticator;
-  stripeSubscriptionId: string;
+  billingTarget: CreditPurchaseBillingTarget;
   amountMicroUsd: number;
   discountPercent?: number;
   boughtByUserId?: number;
@@ -508,13 +643,24 @@ export async function createProCreditPurchase({
     couponId = couponResult.value;
   }
 
-  const invoiceResult = await makeCreditPurchaseOneOffInvoice({
-    stripeSubscriptionId,
-    amountMicroUsd,
-    couponId,
-    collectionMethod: "charge_automatically",
-    requestThreeDSecure: "challenge",
-  });
+  const invoiceResult =
+    billingTarget.type === "stripe-subscription"
+      ? await makeCreditPurchaseOneOffInvoice({
+          stripeSubscriptionId: billingTarget.stripeSubscriptionId,
+          amountMicroUsd,
+          couponId,
+          collectionMethod: "charge_automatically",
+          requestThreeDSecure: "challenge",
+        })
+      : await makeCreditPurchaseOneOffInvoiceForCustomer({
+          stripeCustomerId: billingTarget.stripeCustomerId,
+          workspaceId: workspace.sId,
+          currency: billingTarget.currency,
+          amountMicroUsd,
+          couponId,
+          collectionMethod: "charge_automatically",
+          requestThreeDSecure: "challenge",
+        });
 
   if (invoiceResult.isErr()) {
     logger.warn(
@@ -522,6 +668,7 @@ export async function createProCreditPurchase({
         error: invoiceResult.error.error_message,
         workspaceId: workspace.sId,
         amountMicroUsd,
+        billingTarget: billingTarget.type,
       },
       "[Credit Purchase] Failed to process credit purchase"
     );
@@ -577,6 +724,7 @@ export async function createProCreditPurchase({
       discountPercent,
       invoiceId: invoice.id,
       requiresAction: paymentUrl !== null,
+      billingTarget: billingTarget.type,
     },
     "[Credit Purchase] Credit purchase invoice created, credit will be started via webhook"
   );

--- a/front/lib/credits/limits.test.ts
+++ b/front/lib/credits/limits.test.ts
@@ -92,7 +92,10 @@ describe("getCreditPurchaseLimits", () => {
     it("should allow purchase with $1000 minimum limit when no payg cap", async () => {
       fetchProgrammaticConfigSpy.mockResolvedValue(null);
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -105,7 +108,10 @@ describe("getCreditPurchaseLimits", () => {
         paygCapMicroUsd: 1_000_000_000, // $1000 payg cap -> $500 half
       });
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -118,7 +124,10 @@ describe("getCreditPurchaseLimits", () => {
         paygCapMicroUsd: 10_000_000_000, // $10,000 payg cap -> $5,000 half
       });
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -127,7 +136,10 @@ describe("getCreditPurchaseLimits", () => {
     });
 
     it("should not call getCustomerPaymentStatus for enterprise", async () => {
-      await getCreditPurchaseLimits(auth, makeSubscription());
+      await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(getCustomerPaymentStatus).not.toHaveBeenCalled();
     });
@@ -136,7 +148,10 @@ describe("getCreditPurchaseLimits", () => {
       fetchProgrammaticConfigSpy.mockResolvedValue(null);
       sumCommittedCreditsSpy.mockResolvedValue(300_000_000); // $300 already purchased
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -150,7 +165,10 @@ describe("getCreditPurchaseLimits", () => {
       });
       sumCommittedCreditsSpy.mockResolvedValue(2_000_000_000); // $2000 already purchased
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -162,7 +180,10 @@ describe("getCreditPurchaseLimits", () => {
       fetchProgrammaticConfigSpy.mockResolvedValue(null);
       sumCommittedCreditsSpy.mockResolvedValue(1_000_000_000); // $1000 already purchased
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -176,7 +197,10 @@ describe("getCreditPurchaseLimits", () => {
       vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
       vi.mocked(getCustomerPaymentStatus).mockResolvedValue("trialing");
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: false,
@@ -190,7 +214,10 @@ describe("getCreditPurchaseLimits", () => {
       vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
       vi.mocked(getCustomerPaymentStatus).mockResolvedValue("not_paying");
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: false,
@@ -208,7 +235,10 @@ describe("getCreditPurchaseLimits", () => {
     it("should calculate limit based on user count ($50/user)", async () => {
       countEligibleUsersSpy.mockResolvedValue(10);
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -219,7 +249,10 @@ describe("getCreditPurchaseLimits", () => {
     it("should cap at $1000 for large teams", async () => {
       countEligibleUsersSpy.mockResolvedValue(100);
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -230,7 +263,10 @@ describe("getCreditPurchaseLimits", () => {
     it("should allow $50 for single user", async () => {
       countEligibleUsersSpy.mockResolvedValue(1);
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -241,7 +277,10 @@ describe("getCreditPurchaseLimits", () => {
     it("should allow $250 for 5 users", async () => {
       countEligibleUsersSpy.mockResolvedValue(5);
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -252,7 +291,10 @@ describe("getCreditPurchaseLimits", () => {
     it("should cap exactly at $1000 for 20 users", async () => {
       countEligibleUsersSpy.mockResolvedValue(20);
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -263,7 +305,10 @@ describe("getCreditPurchaseLimits", () => {
     it("should cap at $1000 for more than 20 users", async () => {
       countEligibleUsersSpy.mockResolvedValue(25);
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -275,7 +320,10 @@ describe("getCreditPurchaseLimits", () => {
       countEligibleUsersSpy.mockResolvedValue(10); // $500 limit
       sumCommittedCreditsSpy.mockResolvedValue(200_000_000); // $200 already purchased
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -287,7 +335,10 @@ describe("getCreditPurchaseLimits", () => {
       countEligibleUsersSpy.mockResolvedValue(5); // $250 limit
       sumCommittedCreditsSpy.mockResolvedValue(250_000_000); // $250 already purchased
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: true,
@@ -298,7 +349,10 @@ describe("getCreditPurchaseLimits", () => {
     it("should not allow purchase when pending committed credits exist", async () => {
       listPendingCommittedSpy.mockResolvedValue([{ id: 1 } as CreditResource]);
 
-      const result = await getCreditPurchaseLimits(auth, makeSubscription());
+      const result = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription: makeSubscription(),
+      });
 
       expect(result).toEqual({
         canPurchase: false,

--- a/front/lib/credits/limits.ts
+++ b/front/lib/credits/limits.ts
@@ -1,9 +1,12 @@
 import type { Authenticator } from "@app/lib/auth";
+import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import { countEligibleUsersForCredits } from "@app/lib/credits/common";
 import { getCustomerPaymentStatus } from "@app/lib/credits/free";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { isEnterpriseSubscription } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import type { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import type Stripe from "stripe";
 
 // $50 per user per month for Pro subscriptions.
@@ -125,4 +128,75 @@ async function getAlreadyPurchasedInCycle(
     periodStart,
     periodEnd
   );
+}
+
+/**
+ * Limits for Metronome-only billed workspaces (no Stripe subscription).
+ *
+ * Mirrors `getCreditPurchaseLimits`, but:
+ * - Enterprise vs Pro is read from `subscription.getPlan().code` (no Stripe sub).
+ * - The billing cycle is anchored to `subscription.startDate`'s day-of-month.
+ * - Trial / Stripe payment-issue checks are skipped — Metronome contracts
+ *   don't trial, and payment is on N+30 invoice (not card-on-file). The
+ *   Pro pending-credit guard is preserved.
+ */
+export async function getCreditPurchaseLimitsMetronome(
+  auth: Authenticator,
+  subscription: SubscriptionResource
+): Promise<CreditPurchaseLimits> {
+  const isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
+
+  const startDate = subscription.startDate;
+  const billingCycleStartDay = startDate ? new Date(startDate).getUTCDate() : 1;
+  const { cycleStart, cycleEnd } = getBillingCycleFromDay(
+    billingCycleStartDay,
+    new Date(),
+    true
+  );
+
+  if (isEnterprise) {
+    const programmaticConfig =
+      await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+    const paygCapMicroUsd = programmaticConfig?.paygCapMicroUsd ?? 0;
+    const enterpriseMaxMicroUsd = Math.max(
+      MIN_ENTERPRISE_CREDIT_MICRO_USD,
+      Math.floor(paygCapMicroUsd / 2)
+    );
+
+    const alreadyPurchased =
+      await CreditResource.sumCommittedCreditsPurchasedInPeriod(
+        auth,
+        cycleStart,
+        cycleEnd
+      );
+    return {
+      canPurchase: true,
+      maxAmountMicroUsd: Math.max(0, enterpriseMaxMicroUsd - alreadyPurchased),
+    };
+  }
+
+  // Pro on Metronome: same per-user / total caps as Stripe path.
+  const pendingCredits = await CreditResource.listPendingCommitted(auth);
+  if (pendingCredits.length > 0) {
+    return { canPurchase: false, reason: "pending_payment" };
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const userCount = await countEligibleUsersForCredits(workspace);
+  const cycleMaxMicroUsd = Math.min(
+    userCount * MAX_PRO_CREDIT_PER_USER_MICRO_USD,
+    MAX_PRO_CREDIT_TOTAL_MICRO_USD
+  );
+
+  const alreadyPurchased =
+    await CreditResource.sumCommittedCreditsPurchasedInPeriod(
+      auth,
+      cycleStart,
+      cycleEnd
+    );
+
+  return {
+    canPurchase: true,
+    maxAmountMicroUsd: Math.max(0, cycleMaxMicroUsd - alreadyPurchased),
+  };
 }

--- a/front/lib/credits/limits.ts
+++ b/front/lib/credits/limits.ts
@@ -23,138 +23,41 @@ export type CreditPurchaseLimits =
     }
   | { canPurchase: true; maxAmountMicroUsd: number };
 
+// Where the workspace is billed from. Drives Enterprise detection, the
+// billing-cycle bounds, and the Stripe-only trial / payment-issue guard.
+export type CreditPurchaseLimitsContext =
+  | { type: "stripe-subscription"; stripeSubscription: Stripe.Subscription }
+  | { type: "metronome"; subscription: SubscriptionResource };
+
 /**
  * Computes the maximum amount of credits a workspace can purchase in the
  * current billing cycle.
  *
  * Rules:
- * - Pro in trial: cannot purchase credits
- * - Pro with payment issues: cannot purchase credits
+ * - Pro in trial: cannot purchase credits (Stripe-billed only)
+ * - Pro with payment issues: cannot purchase credits (Stripe-billed only)
  * - Pro paying: $50/user/month, capped at $1000 per billing cycle
  * - Enterprise: max($1000, half of pay-as-you-go cap) per billing cycle
+ *
+ * Metronome-only workspaces skip the trial / payment-issue checks (no Stripe
+ * subscription state to read; payment is on Stripe N+30 dunning).
  *
  * The limits are per billing cycle. Already purchased committed credits
  * in the current billing cycle are subtracted from the maximum.
  */
 export async function getCreditPurchaseLimits(
   auth: Authenticator,
-  stripeSubscription: Stripe.Subscription
+  context: CreditPurchaseLimitsContext
 ): Promise<CreditPurchaseLimits> {
-  const isEnterprise = isEnterpriseSubscription(stripeSubscription);
+  const isEnterprise =
+    context.type === "stripe-subscription"
+      ? isEnterpriseSubscription(context.stripeSubscription)
+      : isEntreprisePlanPrefix(context.subscription.getPlan().code);
+
+  const { cycleStart, cycleEnd } = getCycleBounds(context);
 
   if (isEnterprise) {
     // Enterprise limit: max($1000, half of pay-as-you-go cap).
-    const programmaticConfig =
-      await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-    const paygCapMicroUsd = programmaticConfig?.paygCapMicroUsd ?? 0;
-    const enterpriseMaxMicroUsd = Math.max(
-      MIN_ENTERPRISE_CREDIT_MICRO_USD,
-      Math.floor(paygCapMicroUsd / 2)
-    );
-
-    const alreadyPurchased = await getAlreadyPurchasedInCycle(
-      auth,
-      stripeSubscription
-    );
-    const remainingMicroUsd = Math.max(
-      0,
-      enterpriseMaxMicroUsd - alreadyPurchased
-    );
-    return {
-      canPurchase: true,
-      maxAmountMicroUsd: remainingMicroUsd,
-    };
-  }
-
-  // For Pro subscriptions, check if they're paying or trialing.
-  const customerStatus = await getCustomerPaymentStatus(stripeSubscription);
-
-  if (customerStatus === "trialing") {
-    return {
-      canPurchase: false,
-      reason: "trialing",
-    };
-  }
-
-  if (customerStatus === "not_paying") {
-    return {
-      canPurchase: false,
-      reason: "payment_issue",
-    };
-  }
-
-  // Check for any pending committed credits first
-  const pendingCredits = await CreditResource.listPendingCommitted(auth);
-  if (pendingCredits.length > 0) {
-    return {
-      canPurchase: false,
-      reason: "pending_payment",
-    };
-  }
-
-  // Pro paying: $50/user/month, capped at $1000 per billing cycle.
-  const workspace = auth.getNonNullableWorkspace();
-  const userCount = await countEligibleUsersForCredits(workspace);
-  const cycleMaxMicroUsd = Math.min(
-    userCount * MAX_PRO_CREDIT_PER_USER_MICRO_USD,
-    MAX_PRO_CREDIT_TOTAL_MICRO_USD
-  );
-
-  const alreadyPurchased = await getAlreadyPurchasedInCycle(
-    auth,
-    stripeSubscription
-  );
-  const remainingMicroUsd = Math.max(0, cycleMaxMicroUsd - alreadyPurchased);
-
-  return {
-    canPurchase: true,
-    maxAmountMicroUsd: remainingMicroUsd,
-  };
-}
-
-/**
- * Gets the total amount of committed credits already purchased in the current
- * billing cycle.
- */
-async function getAlreadyPurchasedInCycle(
-  auth: Authenticator,
-  stripeSubscription: Stripe.Subscription
-): Promise<number> {
-  const periodStart = new Date(stripeSubscription.current_period_start * 1000);
-  const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
-
-  return CreditResource.sumCommittedCreditsPurchasedInPeriod(
-    auth,
-    periodStart,
-    periodEnd
-  );
-}
-
-/**
- * Limits for Metronome-only billed workspaces (no Stripe subscription).
- *
- * Mirrors `getCreditPurchaseLimits`, but:
- * - Enterprise vs Pro is read from `subscription.getPlan().code` (no Stripe sub).
- * - The billing cycle is anchored to `subscription.startDate`'s day-of-month.
- * - Trial / Stripe payment-issue checks are skipped — Metronome contracts
- *   don't trial, and payment is on N+30 invoice (not card-on-file). The
- *   Pro pending-credit guard is preserved.
- */
-export async function getCreditPurchaseLimitsMetronome(
-  auth: Authenticator,
-  subscription: SubscriptionResource
-): Promise<CreditPurchaseLimits> {
-  const isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
-
-  const startDate = subscription.startDate;
-  const billingCycleStartDay = startDate ? new Date(startDate).getUTCDate() : 1;
-  const { cycleStart, cycleEnd } = getBillingCycleFromDay(
-    billingCycleStartDay,
-    new Date(),
-    true
-  );
-
-  if (isEnterprise) {
     const programmaticConfig =
       await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
     const paygCapMicroUsd = programmaticConfig?.paygCapMicroUsd ?? 0;
@@ -175,12 +78,26 @@ export async function getCreditPurchaseLimitsMetronome(
     };
   }
 
-  // Pro on Metronome: same per-user / total caps as Stripe path.
+  // Pro path. Stripe-billed gates on Stripe customer payment status; Metronome
+  // contracts don't trial and are dunned via N+30 invoices.
+  if (context.type === "stripe-subscription") {
+    const customerStatus = await getCustomerPaymentStatus(
+      context.stripeSubscription
+    );
+    if (customerStatus === "trialing") {
+      return { canPurchase: false, reason: "trialing" };
+    }
+    if (customerStatus === "not_paying") {
+      return { canPurchase: false, reason: "payment_issue" };
+    }
+  }
+
   const pendingCredits = await CreditResource.listPendingCommitted(auth);
   if (pendingCredits.length > 0) {
     return { canPurchase: false, reason: "pending_payment" };
   }
 
+  // Pro paying: $50/user/month, capped at $1000 per billing cycle.
   const workspace = auth.getNonNullableWorkspace();
   const userCount = await countEligibleUsersForCredits(workspace);
   const cycleMaxMicroUsd = Math.min(
@@ -199,4 +116,23 @@ export async function getCreditPurchaseLimitsMetronome(
     canPurchase: true,
     maxAmountMicroUsd: Math.max(0, cycleMaxMicroUsd - alreadyPurchased),
   };
+}
+
+function getCycleBounds(context: CreditPurchaseLimitsContext): {
+  cycleStart: Date;
+  cycleEnd: Date;
+} {
+  if (context.type === "stripe-subscription") {
+    return {
+      cycleStart: new Date(
+        context.stripeSubscription.current_period_start * 1000
+      ),
+      cycleEnd: new Date(context.stripeSubscription.current_period_end * 1000),
+    };
+  }
+  // Metronome-only: anchor to subscription.startDate's day-of-month.
+  const billingCycleStartDay = new Date(
+    context.subscription.startDate
+  ).getUTCDate();
+  return getBillingCycleFromDay(billingCycleStartDay, new Date(), true);
 }

--- a/front/lib/plans/stripe.test.ts
+++ b/front/lib/plans/stripe.test.ts
@@ -7,7 +7,7 @@ import {
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
   makeAndFinalizeCreditsPAYGInvoice,
-  makeCreditPurchaseOneOffInvoice,
+  makeCreditPurchaseOneOffInvoiceForSubscription,
   payInvoice,
   voidInvoiceWithReason,
 } from "@app/lib/plans/stripe";
@@ -347,7 +347,7 @@ describe("makeOneOffInvoice - Pro credit purchase", () => {
     mockInvoices.create.mockResolvedValue({ id: "in_pro" });
     mockInvoiceItems.create.mockResolvedValue({ id: "ii_1" });
 
-    const result = await makeCreditPurchaseOneOffInvoice({
+    const result = await makeCreditPurchaseOneOffInvoiceForSubscription({
       stripeSubscriptionId: "sub_pro",
       amountMicroUsd: 100_000_000,
       collectionMethod: "charge_automatically",
@@ -390,7 +390,7 @@ describe("makeOneOffInvoice - Pro credit purchase", () => {
     mockInvoices.create.mockResolvedValue({ id: "in_pro" });
     mockInvoiceItems.create.mockResolvedValue({ id: "ii_1" });
 
-    await makeCreditPurchaseOneOffInvoice({
+    await makeCreditPurchaseOneOffInvoiceForSubscription({
       stripeSubscriptionId: "sub_pro",
       amountMicroUsd: 100_000_000,
       couponId: "programmatic-usage-credits-once-20",
@@ -407,7 +407,7 @@ describe("makeOneOffInvoice - Pro credit purchase", () => {
   it("should return Err when subscription not found", async () => {
     mockSubscriptions.retrieve.mockResolvedValue(null);
 
-    const result = await makeCreditPurchaseOneOffInvoice({
+    const result = await makeCreditPurchaseOneOffInvoiceForSubscription({
       stripeSubscriptionId: "sub_invalid",
       amountMicroUsd: 100_000_000,
       collectionMethod: "charge_automatically",
@@ -427,7 +427,7 @@ describe("makeOneOffInvoice - Pro credit purchase", () => {
     mockInvoices.create.mockResolvedValue({ id: "in_pro" });
     mockInvoiceItems.create.mockResolvedValue({ id: "ii_1" });
 
-    const result = await makeCreditPurchaseOneOffInvoice({
+    const result = await makeCreditPurchaseOneOffInvoiceForSubscription({
       stripeSubscriptionId: "sub_pro",
       amountMicroUsd: 100_000_000,
       collectionMethod: "charge_automatically",
@@ -461,7 +461,7 @@ describe("makeOneOffInvoice - Enterprise credit purchase", () => {
     mockInvoices.create.mockResolvedValue({ id: "in_enterprise" });
     mockInvoiceItems.create.mockResolvedValue({ id: "ii_1" });
 
-    const result = await makeCreditPurchaseOneOffInvoice({
+    const result = await makeCreditPurchaseOneOffInvoiceForSubscription({
       stripeSubscriptionId: "sub_enterprise",
       amountMicroUsd: 5_000_000_000,
       collectionMethod: "send_invoice",

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1036,7 +1036,7 @@ export async function reportActiveSeats(
   );
 }
 
-export async function makeCreditPurchaseOneOffInvoice({
+export async function makeCreditPurchaseOneOffInvoiceForSubscription({
   stripeSubscriptionId,
   amountMicroUsd,
   couponId,
@@ -1160,6 +1160,11 @@ async function makeInvoiceForCustomer({
   }
 }
 
+/**
+ * Variant for Metronome-only billed customers: no Stripe subscription, just a
+ * Stripe customer (linked via the Metronome billing config). Issues a one-off
+ * invoice directly on the customer in the requested currency.
+ */
 export async function makeCreditPurchaseOneOffInvoiceForCustomer({
   stripeCustomerId,
   workspaceId,

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { PHONE_TRIAL_ENABLED } from "@app/lib/plans/trial/constants";
@@ -10,6 +11,7 @@ import {
 } from "@app/lib/plans/usage/types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
+import type { SupportedCurrency } from "@app/types/currency";
 import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import type { BillingPeriod, SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
@@ -339,27 +341,45 @@ export const createCustomerPortalSession = async ({
 }): Promise<string | null> => {
   const stripe = getStripeClient();
 
-  if (!subscription.stripeSubscriptionId) {
-    throw new Error(
-      `No stripeSubscriptionId ID found for the workspace: ${owner.sId}`
+  // Resolve the Stripe customer: prefer the Stripe subscription's customer
+  // when available; for Metronome-only billed workspaces (no Stripe sub),
+  // read the linked Stripe customer from the Metronome billing config.
+  let stripeCustomerId: string | null = null;
+
+  if (subscription.stripeSubscriptionId) {
+    const stripeSubscription = await getStripeSubscription(
+      subscription.stripeSubscriptionId
     );
-  }
-
-  const stripeSubscription = await getStripeSubscription(
-    subscription.stripeSubscriptionId
-  );
-
-  if (!stripeSubscription) {
-    throw new Error(
-      `No stripeSubscription found for the workspace: ${owner.sId}`
+    if (!stripeSubscription) {
+      throw new Error(
+        `No stripeSubscription found for the workspace: ${owner.sId}`
+      );
+    }
+    const customer = stripeSubscription.customer;
+    if (typeof customer !== "string") {
+      throw new Error(
+        `No stripeCustomerId found for the workspace: ${owner.sId}`
+      );
+    }
+    stripeCustomerId = customer;
+  } else if (owner.metronomeCustomerId) {
+    const result = await getMetronomeCustomerStripeCustomerId(
+      owner.metronomeCustomerId
     );
-  }
-
-  const stripeCustomerId = stripeSubscription.customer;
-
-  if (!stripeCustomerId || typeof stripeCustomerId !== "string") {
+    if (result.isErr()) {
+      throw new Error(
+        `Failed to resolve Stripe customer for Metronome-only workspace ${owner.sId}: ${result.error.message}`
+      );
+    }
+    if (!result.value) {
+      throw new Error(
+        `No Stripe billing configuration found for Metronome customer of workspace ${owner.sId}`
+      );
+    }
+    stripeCustomerId = result.value;
+  } else {
     throw new Error(
-      `No stripeCustomerId found for the workspace: ${owner.sId}`
+      `No Stripe subscription or Metronome customer for the workspace: ${owner.sId}`
     );
   }
 
@@ -1045,6 +1065,133 @@ export async function makeCreditPurchaseOneOffInvoice({
     metadata: {
       credit_purchase: "true",
       credit_amount_cents: amountCents.toString(),
+    },
+    lineItem: {
+      priceId: getCreditPurchasePriceId(),
+      quantity: amountCents,
+      description: `Programmatic usage credit: $${amountDollars.toFixed(2)}`,
+      couponId,
+    },
+    customerFacingInfo,
+    ...collectionParams,
+  });
+}
+
+// Variant for Metronome-only billed customers: no Stripe subscription, just a
+// Stripe customer (linked via the Metronome billing config). Issues a one-off
+// invoice directly on the customer in the requested currency.
+async function makeInvoiceForCustomer({
+  stripeCustomerId,
+  currency,
+  metadata,
+  lineItem,
+  customerFacingInfo,
+  ...collectionParams
+}: {
+  stripeCustomerId: string;
+  // Required for the customer-only path: prices are multi-currency, but with
+  // no subscription Stripe has no anchor to pick from — pass it explicitly so
+  // the issued invoice matches the contract / customer's billing currency.
+  currency: SupportedCurrency;
+  metadata: Record<string, string>;
+  lineItem: InvoiceLineItem;
+  customerFacingInfo?: CustomerFacingInvoiceInfo;
+} & InvoiceCollectionParams): Promise<
+  Result<Stripe.Invoice, { error_message: string }>
+> {
+  const stripe = getStripeClient();
+
+  const invoiceParams: Stripe.InvoiceCreateParams = {
+    customer: stripeCustomerId,
+    currency,
+    collection_method: collectionParams.collectionMethod,
+    metadata,
+    auto_advance: true,
+    automatic_tax: { enabled: true },
+    custom_fields: customerFacingInfo?.purchaseOrderId
+      ? [{ name: "Purchase Order", value: customerFacingInfo.purchaseOrderId }]
+      : undefined,
+  };
+
+  switch (collectionParams.collectionMethod) {
+    case "charge_automatically":
+      invoiceParams.payment_settings = {
+        payment_method_options: {
+          card: {
+            request_three_d_secure: (collectionParams.requestThreeDSecure ??
+              "automatic") as Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Card.RequestThreeDSecure,
+          },
+        },
+      };
+      break;
+    case "send_invoice":
+      invoiceParams.days_until_due = collectionParams.daysUntilDue;
+      break;
+    default:
+      assertNever(collectionParams);
+  }
+
+  try {
+    const invoice = await stripe.invoices.create(invoiceParams);
+
+    await stripe.invoiceItems.create({
+      customer: stripeCustomerId,
+      price: lineItem.priceId,
+      currency,
+      quantity: lineItem.quantity,
+      description: lineItem.description,
+      invoice: invoice.id,
+      ...(lineItem.couponId && { discounts: [{ coupon: lineItem.couponId }] }),
+    });
+
+    return new Ok(invoice);
+  } catch (error) {
+    logger.error(
+      {
+        stripeCustomerId,
+        stripeError: true,
+        error: normalizeError(error).message,
+      },
+      "[Stripe] Failed to create invoice for customer"
+    );
+    return new Err({
+      error_message: `Failed to create invoice: ${normalizeError(error).message}`,
+    });
+  }
+}
+
+export async function makeCreditPurchaseOneOffInvoiceForCustomer({
+  stripeCustomerId,
+  workspaceId,
+  currency,
+  amountMicroUsd,
+  couponId,
+  customerFacingInfo,
+  ...collectionParams
+}: {
+  stripeCustomerId: string;
+  // Stamped on the invoice metadata so the Stripe webhook can route
+  // subscription-less invoice events (paid / payment_failed / voided)
+  // back to the originating workspace without going through Metronome.
+  workspaceId: string;
+  // Currency to bill in — must match the contract / Stripe customer.
+  currency: SupportedCurrency;
+  amountMicroUsd: number;
+  couponId?: string;
+  customerFacingInfo?: CustomerFacingInvoiceInfo;
+} & InvoiceCollectionParams): Promise<
+  Result<Stripe.Invoice, { error_message: string }>
+> {
+  const amountCents = Math.ceil(amountMicroUsd / 10_000);
+  const amountDollars = amountCents / 100;
+
+  return makeInvoiceForCustomer({
+    stripeCustomerId,
+    currency,
+    metadata: {
+      credit_purchase: "true",
+      credit_amount_cents: amountCents.toString(),
+      workspace_id: workspaceId,
     },
     lineItem: {
       priceId: getCreditPurchasePriceId(),

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -11,6 +11,7 @@ import { Authenticator } from "@app/lib/auth";
 import {
   deleteCreditFromVoidedInvoice,
   startCreditFromEnterpriseOneOffInvoice,
+  startCreditFromMetronomeOneOffInvoice,
   startCreditFromProOneOffInvoice,
   voidFailedProCreditPurchaseInvoice,
 } from "@app/lib/credits/committed";
@@ -470,6 +471,37 @@ async function handler(
           );
           const invoice = event.data.object as Stripe.Invoice;
           if (typeof invoice.subscription !== "string") {
+            // Metronome-only billed workspaces issue credit-purchase invoices
+            // directly on the Stripe customer (no subscription). Activate the
+            // credit now that payment has cleared. The originating workspace
+            // is stamped on `invoice.metadata.workspace_id`.
+            if (isCreditPurchaseInvoice(invoice)) {
+              const workspaceId = invoice.metadata?.workspace_id;
+              if (!workspaceId) {
+                logger.error(
+                  { invoiceId: invoice.id, customer: invoice.customer },
+                  "[Stripe Webhook] Metronome-only credit purchase invoice missing workspace_id metadata"
+                );
+                return res.status(200).json({ success: true });
+              }
+              const metronomeAuth =
+                await Authenticator.internalAdminForWorkspace(workspaceId);
+              const startResult = await startCreditFromMetronomeOneOffInvoice({
+                auth: metronomeAuth,
+                invoice,
+              });
+              if (startResult.isErr()) {
+                logger.error(
+                  {
+                    error: startResult.error,
+                    invoiceId: invoice.id,
+                    workspaceId,
+                  },
+                  "[Stripe Webhook] Error processing Metronome-only credit purchase"
+                );
+              }
+              return res.status(200).json({ success: true });
+            }
             return _returnStripeApiError(
               req,
               res,
@@ -586,6 +618,43 @@ async function handler(
           }
 
           if (typeof invoice.subscription !== "string") {
+            // Metronome-only credit purchase: no subscription on the invoice.
+            // Reuse the Pro void-after-N-attempts flow — it's keyed off the
+            // invoice id, not the subscription.
+            if (isCreditPurchaseInvoice(invoice)) {
+              const workspaceId = invoice.metadata?.workspace_id;
+              if (!workspaceId) {
+                logger.error(
+                  { invoiceId: invoice.id, customer: invoice.customer },
+                  "[Stripe Webhook] Metronome-only failed credit purchase invoice missing workspace_id metadata"
+                );
+                return res.status(200).json({ success: true });
+              }
+              const metronomeAuth =
+                await Authenticator.internalAdminForWorkspace(workspaceId);
+              const result = await voidFailedProCreditPurchaseInvoice({
+                auth: metronomeAuth,
+                invoice,
+              });
+              if (result.isErr()) {
+                logger.error(
+                  {
+                    error: result.error,
+                    panic: true,
+                    stripeError: true,
+                    invoiceId: invoice.id,
+                    workspaceId,
+                  },
+                  "[Stripe Webhook] Error handling failed Metronome-only credit purchase"
+                );
+              } else if (result.value.voided) {
+                logger.warn(
+                  { invoiceId: invoice.id, workspaceId },
+                  "[Stripe Webhook] Voided Metronome-only credit purchase invoice after 3 failures"
+                );
+              }
+              return res.status(200).json({ success: true });
+            }
             return _returnStripeApiError(
               req,
               res,
@@ -862,10 +931,60 @@ async function handler(
           }
 
           if (!isString(voidedInvoice.subscription)) {
-            logger.warn(
-              { invoiceId: voidedInvoice.id, stripeError: true },
-              "[Stripe Webhook] Voided credit purchase invoice has no subscription."
-            );
+            // Metronome-only credit purchase: no subscription. Resolve the
+            // workspace via the metadata stamp and route to the same delete
+            // helper used for Pro voids.
+            const workspaceId = voidedInvoice.metadata?.workspace_id;
+            if (!workspaceId) {
+              logger.warn(
+                { invoiceId: voidedInvoice.id, stripeError: true },
+                "[Stripe Webhook] Voided credit purchase invoice has no subscription and no workspace_id metadata."
+              );
+              break;
+            }
+
+            const metronomeAuth =
+              await Authenticator.internalAdminForWorkspace(workspaceId);
+            const deleteResult = await deleteCreditFromVoidedInvoice({
+              auth: metronomeAuth,
+              invoice: voidedInvoice,
+            });
+            if (deleteResult.isOk()) {
+              logger.info(
+                { invoiceId: voidedInvoice.id, workspaceId },
+                "[Stripe Webhook] Successfully deleted Metronome-only credit for voided invoice."
+              );
+              break;
+            }
+            const error = deleteResult.error;
+            if (error.type === "credit_already_started") {
+              const freezeResult = await error.credit.freeze(metronomeAuth);
+              if (freezeResult.isErr()) {
+                logger.warn(
+                  {
+                    invoiceId: voidedInvoice.id,
+                    creditId: error.credit.id,
+                    workspaceId,
+                    error: freezeResult.error.message,
+                  },
+                  "[Stripe Webhook] Failed to freeze started Metronome-only credit for voided invoice."
+                );
+              } else {
+                logger.warn(
+                  {
+                    invoiceId: voidedInvoice.id,
+                    creditId: error.credit.id,
+                    workspaceId,
+                  },
+                  "[Stripe Webhook] Froze started Metronome-only credit for voided invoice"
+                );
+              }
+            } else {
+              logger.warn(
+                { invoiceId: voidedInvoice.id, workspaceId },
+                "[Stripe Webhook] Metronome-only credit not found for voided invoice (likely already voided)."
+              );
+            }
             break;
           }
 

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -2,12 +2,19 @@
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import type { CreditPurchaseBillingTarget } from "@app/lib/credits/committed";
 import {
   createEnterpriseCreditPurchase,
   createProCreditPurchase,
 } from "@app/lib/credits/committed";
 import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
-import { getCreditPurchaseLimits } from "@app/lib/credits/limits";
+import {
+  getCreditPurchaseLimits,
+  getCreditPurchaseLimitsMetronome,
+} from "@app/lib/credits/limits";
+import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
+import { resolveCurrencyForExistingMetronomeCustomer } from "@app/lib/metronome/contracts";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import {
   getCreditPurchasePriceId,
   getStripePricingData,
@@ -17,6 +24,7 @@ import {
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
+import type { SupportedCurrency } from "@app/types/currency";
 import { isSupportedCurrency } from "@app/types/currency";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { StripePricingData } from "@app/types/stripe/pricing";
@@ -66,48 +74,86 @@ async function handler(
     });
   }
 
-  const subscription = auth.subscription();
-  if (!subscription || !subscription.stripeSubscriptionId) {
+  const subscription = auth.subscriptionResource();
+  if (
+    !subscription?.stripeSubscriptionId &&
+    !subscription?.isMetronomeOnlyBilled
+  ) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "subscription_not_found",
         message:
-          "No active Stripe subscription found. Please subscribe to a plan first.",
+          "No active xsubscription found. Please subscribe to a plan first.",
       },
     });
   }
 
+  const isMetronomeOnly = subscription.isMetronomeOnlyBilled;
+
   switch (req.method) {
     case "GET": {
-      const stripeSubscription = await getStripeSubscription(
-        subscription.stripeSubscriptionId
-      );
-
       let isEnterprise = false;
       let currency = "usd";
       let creditPurchaseLimits: CreditPurchaseLimits | null = null;
       let billingCycleStartDay: number | null = null;
 
-      if (stripeSubscription) {
-        isEnterprise = isEnterpriseSubscription(stripeSubscription);
-        currency = isSupportedCurrency(stripeSubscription.currency)
-          ? stripeSubscription.currency
-          : "usd";
-        creditPurchaseLimits = await getCreditPurchaseLimits(
+      if (isMetronomeOnly) {
+        isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
+        creditPurchaseLimits = await getCreditPurchaseLimitsMetronome(
           auth,
-          stripeSubscription
+          subscription
         );
-      }
 
-      // Get billingCycleStartDay from subscription start date (use UTC to match client-side).
-      // Prioritize subscription.startDate to align with getBillingCycle used in the header.
-      if (subscription.startDate) {
-        billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
-      } else if (stripeSubscription?.current_period_start) {
-        billingCycleStartDay = new Date(
-          stripeSubscription.current_period_start * 1000
-        ).getUTCDate();
+        // Bill in the same currency as the contract / Stripe customer.
+        const workspace = auth.getNonNullableWorkspace();
+        if (workspace.metronomeCustomerId) {
+          const currencyResult =
+            await resolveCurrencyForExistingMetronomeCustomer({
+              metronomeCustomerId: workspace.metronomeCustomerId,
+              stripeSubscriptionId: null,
+            });
+          if (currencyResult.isOk()) {
+            currency = currencyResult.value;
+          } else {
+            logger.warn(
+              {
+                workspaceId: workspace.sId,
+                error: currencyResult.error.message,
+              },
+              "[Credit Purchase] Failed to resolve currency for Metronome-only workspace, defaulting to usd"
+            );
+          }
+        }
+
+        if (subscription.startDate) {
+          billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
+        }
+      } else {
+        const stripeSubscription = await getStripeSubscription(
+          subscription.stripeSubscriptionId!
+        );
+
+        if (stripeSubscription) {
+          isEnterprise = isEnterpriseSubscription(stripeSubscription);
+          currency = isSupportedCurrency(stripeSubscription.currency)
+            ? stripeSubscription.currency
+            : "usd";
+          creditPurchaseLimits = await getCreditPurchaseLimits(
+            auth,
+            stripeSubscription
+          );
+        }
+
+        // Get billingCycleStartDay from subscription start date (use UTC to match client-side).
+        // Prioritize subscription.startDate to align with getBillingCycle used in the header.
+        if (subscription.startDate) {
+          billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
+        } else if (stripeSubscription?.current_period_start) {
+          billingCycleStartDay = new Date(
+            stripeSubscription.current_period_start * 1000
+          ).getUTCDate();
+        }
       }
 
       const programmaticConfig =
@@ -155,33 +201,108 @@ async function handler(
         });
       }
 
-      // Get Stripe subscription and determine if Enterprise.
-      const stripeSubscription = await getStripeSubscription(
-        subscription.stripeSubscriptionId
-      );
-      if (!stripeSubscription) {
-        logger.error(
-          {
-            workspaceId: workspace.sId,
-            stripeError: true,
-            stripeSubscriptionId: subscription.stripeSubscriptionId,
-          },
-          "Failed to retrieve Stripe subscription"
-        );
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "subscription_not_found",
-            message: "[Credit Purchase] Stripe subscription not found.",
-          },
-        });
-      }
       // Convert dollars to micro USD for internal storage.
       const amountMicroUsd = Math.round(amountDollars * 1_000_000);
-      const isEnterprise = isEnterpriseSubscription(stripeSubscription);
 
-      // Validate against purchase limits.
-      const limits = await getCreditPurchaseLimits(auth, stripeSubscription);
+      // Resolve enterprise + limits depending on the billing path.
+      let isEnterprise: boolean;
+      let limits: CreditPurchaseLimits;
+      let metronomeStripeCustomerId: string | null = null;
+      let metronomeCurrency: SupportedCurrency = "usd";
+
+      if (isMetronomeOnly) {
+        isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
+        limits = await getCreditPurchaseLimitsMetronome(auth, subscription);
+
+        // Resolve the Stripe customer linked to the Metronome customer's
+        // billing config — this is where we'll issue the one-off invoice.
+        if (!workspace.metronomeCustomerId) {
+          logger.error(
+            { workspaceId: workspace.sId },
+            "[Credit Purchase] Metronome-only workspace has no metronomeCustomerId"
+          );
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Workspace is not provisioned in Metronome.",
+            },
+          });
+        }
+        const stripeCustomerIdResult =
+          await getMetronomeCustomerStripeCustomerId(
+            workspace.metronomeCustomerId
+          );
+        if (stripeCustomerIdResult.isErr() || !stripeCustomerIdResult.value) {
+          logger.error(
+            {
+              workspaceId: workspace.sId,
+              metronomeCustomerId: workspace.metronomeCustomerId,
+              error: stripeCustomerIdResult.isErr()
+                ? stripeCustomerIdResult.error.message
+                : "no stripe billing config",
+            },
+            "[Credit Purchase] Failed to resolve Stripe customer for Metronome-only workspace"
+          );
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message:
+                "No Stripe billing configuration found for this workspace.",
+            },
+          });
+        }
+        metronomeStripeCustomerId = stripeCustomerIdResult.value;
+
+        // Bill in the same currency as the contract / Stripe customer.
+        const currencyResult =
+          await resolveCurrencyForExistingMetronomeCustomer({
+            metronomeCustomerId: workspace.metronomeCustomerId,
+            stripeSubscriptionId: null,
+          });
+        if (currencyResult.isErr()) {
+          logger.error(
+            {
+              workspaceId: workspace.sId,
+              error: currencyResult.error.message,
+            },
+            "[Credit Purchase] Failed to resolve currency for Metronome-only workspace"
+          );
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to resolve billing currency for this workspace.",
+            },
+          });
+        }
+        metronomeCurrency = currencyResult.value;
+      } else {
+        const stripeSubscription = await getStripeSubscription(
+          subscription.stripeSubscriptionId!
+        );
+        if (!stripeSubscription) {
+          logger.error(
+            {
+              workspaceId: workspace.sId,
+              stripeError: true,
+              stripeSubscriptionId: subscription.stripeSubscriptionId,
+            },
+            "Failed to retrieve Stripe subscription"
+          );
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "subscription_not_found",
+              message: "[Credit Purchase] Stripe subscription not found.",
+            },
+          });
+        }
+        isEnterprise = isEnterpriseSubscription(stripeSubscription);
+        limits = await getCreditPurchaseLimits(auth, stripeSubscription);
+      }
+
       if (!limits.canPurchase) {
         const message =
           limits.reason === "trialing"
@@ -233,10 +354,22 @@ async function handler(
 
       const user = auth.getNonNullableUser();
 
+      const billingTarget: CreditPurchaseBillingTarget =
+        isMetronomeOnly && metronomeStripeCustomerId
+          ? {
+              type: "metronome",
+              stripeCustomerId: metronomeStripeCustomerId,
+              currency: metronomeCurrency,
+            }
+          : {
+              type: "stripe-subscription",
+              stripeSubscriptionId: subscription.stripeSubscriptionId!,
+            };
+
       if (isEnterprise) {
         const result = await createEnterpriseCreditPurchase({
           auth,
-          stripeSubscriptionId: subscription.stripeSubscriptionId,
+          billingTarget,
           amountMicroUsd,
           discountPercent,
           boughtByUserId: user.id,
@@ -259,9 +392,10 @@ async function handler(
           paymentUrl: null,
         });
       }
+
       const result = await createProCreditPurchase({
         auth,
-        stripeSubscriptionId: subscription.stripeSubscriptionId,
+        billingTarget,
         amountMicroUsd,
         discountPercent,
         boughtByUserId: user.id,

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -8,10 +8,7 @@ import {
   createProCreditPurchase,
 } from "@app/lib/credits/committed";
 import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
-import {
-  getCreditPurchaseLimits,
-  getCreditPurchaseLimitsMetronome,
-} from "@app/lib/credits/limits";
+import { getCreditPurchaseLimits } from "@app/lib/credits/limits";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
 import { resolveCurrencyForExistingMetronomeCustomer } from "@app/lib/metronome/contracts";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
@@ -84,7 +81,7 @@ async function handler(
       api_error: {
         type: "subscription_not_found",
         message:
-          "No active xsubscription found. Please subscribe to a plan first.",
+          "No active subscription found. Please subscribe to a plan first.",
       },
     });
   }
@@ -100,10 +97,10 @@ async function handler(
 
       if (isMetronomeOnly) {
         isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
-        creditPurchaseLimits = await getCreditPurchaseLimitsMetronome(
-          auth,
-          subscription
-        );
+        creditPurchaseLimits = await getCreditPurchaseLimits(auth, {
+          type: "metronome",
+          subscription,
+        });
 
         // Bill in the same currency as the contract / Stripe customer.
         const workspace = auth.getNonNullableWorkspace();
@@ -113,9 +110,7 @@ async function handler(
               metronomeCustomerId: workspace.metronomeCustomerId,
               stripeSubscriptionId: null,
             });
-          if (currencyResult.isOk()) {
-            currency = currencyResult.value;
-          } else {
+          if (currencyResult.isErr()) {
             logger.warn(
               {
                 workspaceId: workspace.sId,
@@ -123,7 +118,16 @@ async function handler(
               },
               "[Credit Purchase] Failed to resolve currency for Metronome-only workspace, defaulting to usd"
             );
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message:
+                  "Failed to resolve billing currency for this workspace.",
+              },
+            });
           }
+          currency = currencyResult.value;
         }
 
         if (subscription.startDate) {
@@ -139,10 +143,10 @@ async function handler(
           currency = isSupportedCurrency(stripeSubscription.currency)
             ? stripeSubscription.currency
             : "usd";
-          creditPurchaseLimits = await getCreditPurchaseLimits(
-            auth,
-            stripeSubscription
-          );
+          creditPurchaseLimits = await getCreditPurchaseLimits(auth, {
+            type: "stripe-subscription",
+            stripeSubscription,
+          });
         }
 
         // Get billingCycleStartDay from subscription start date (use UTC to match client-side).
@@ -212,7 +216,10 @@ async function handler(
 
       if (isMetronomeOnly) {
         isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
-        limits = await getCreditPurchaseLimitsMetronome(auth, subscription);
+        limits = await getCreditPurchaseLimits(auth, {
+          type: "metronome",
+          subscription,
+        });
 
         // Resolve the Stripe customer linked to the Metronome customer's
         // billing config — this is where we'll issue the one-off invoice.
@@ -300,7 +307,10 @@ async function handler(
           });
         }
         isEnterprise = isEnterpriseSubscription(stripeSubscription);
-        limits = await getCreditPurchaseLimits(auth, stripeSubscription);
+        limits = await getCreditPurchaseLimits(auth, {
+          type: "stripe-subscription",
+          stripeSubscription,
+        });
       }
 
       if (!limits.canPurchase) {


### PR DESCRIPTION
## Description

Enable programmatic-usage credit purchases for **Metronome-only billed workspaces** — those with a Metronome contract but no Stripe subscription. Previously, the credit-purchase endpoint and Poke plugin both bailed on `!stripeSubscriptionId`. Stripe is still the payment processor; we just issue the one-off invoice directly on the linked Stripe customer (resolved through the Metronome billing config) instead of attaching it to a subscription.

### Server flow

The Pro and Enterprise credit-purchase functions take a `billingTarget` discriminated union — same code path for Stripe-billed and Metronome-only workspaces, only the invoice creation step branches.

```ts
type CreditPurchaseBillingTarget =
  | { type: "stripe-subscription"; stripeSubscriptionId: string }
  | { type: "metronome"; stripeCustomerId: string; currency: SupportedCurrency };
```

- **`createProCreditPurchase`** / **`createEnterpriseCreditPurchase`** (`lib/credits/committed.ts`): both now take `billingTarget`. The invoice creation step routes to either `makeCreditPurchaseOneOffInvoice` (sub-attached) or `makeCreditPurchaseOneOffInvoiceForCustomer` (customer-only); everything else — discount validation, coupon resolution, DB credit creation, finalize, pay/start, Metronome commit, statsd — is shared.
- **`makeCreditPurchaseOneOffInvoiceForCustomer`** (`lib/plans/stripe.ts`): new helper that creates a one-off Stripe invoice on a customer (no subscription). Stamps `workspace_id` on `invoice.metadata` so the webhook can route subscription-less events back to the originating workspace, and forces an explicit `currency` because there's no subscription anchor for the multi-currency credit price.
- **`startCreditFromMetronomeOneOffInvoice`** (`lib/credits/committed.ts`): webhook-side activation; mirrors `startCreditFromProOneOffInvoice` without a Stripe subscription dep — workspace is resolved upstream from `invoice.metadata.workspace_id`.
- **`getCreditPurchaseLimitsMetronome`** (`lib/credits/limits.ts`): same $50/user/cycle Pro caps and $1k Enterprise floor as the Stripe path. Plan code drives Enterprise-ness; `subscription.startDate` drives the billing cycle. No trialing/payment-issue checks (Metronome contracts don't trial; payment is on Stripe N+30 dunning).

### Stripe webhook (`pages/api/stripe/webhook.ts`)

For `invoice.paid` / `invoice.payment_failed` / `invoice.voided` with `subscription === null` and `isCreditPurchaseInvoice`:

- Resolve workspace via `invoice.metadata.workspace_id` and call the matching helper (`startCreditFromMetronomeOneOffInvoice`, `voidFailedProCreditPurchaseInvoice`, `deleteCreditFromVoidedInvoice`).
- Same dunning behavior as Pro: void after 3 failed attempts, freeze if a started credit's invoice is later voided.

### Currency

Bill in the currency of the contract / Stripe customer. `pages/api/w/[wId]/credits/purchase.ts` resolves currency via `resolveCurrencyForExistingMetronomeCustomer` and threads it into invoice creation. Both the GET (UI display) and POST (invoice creation) paths use it. Metronome-only POST hard-fails on resolution error rather than silently billing in USD.

### UI

- **Buy Credits dialog** (`pages/api/w/[wId]/credits/purchase.ts`): branch on `subscriptionResource.isMetronomeOnlyBilled`; build the `billingTarget` once and pass it to either `createProCreditPurchase` or `createEnterpriseCreditPurchase`. Consume `paymentUrl` from the result so the dialog correctly transitions to the "Payment confirmation required" state on 3DS.
- **`createCustomerPortalSession`** (`lib/plans/stripe.ts`): now also resolves `stripeCustomerId` from the Metronome billing config when there's no Stripe subscription. Unblocks the existing `/subscription/manage` → `/api/stripe/portal` chain for Metronome-only workspaces.
- **`MetronomeSubscriptionPanel`** (`components/pages/workspace/subscription/`): adds the same `CardIcon` "Your billing dashboard on Stripe" button as the Stripe-billed page (tracks `subscription_stripe_portal`); moves Cancel/Resume inline next to the plan Chip.

### Poke plugin

`buy_programmatic_usage_credits.ts` (the "Buy Committed Credits" plugin) now accepts Metronome-only workspaces. Same Pro-override gate applies; builds a `CreditPurchaseBillingTarget` and routes through the unified `createEnterpriseCreditPurchase`.

## Tests

- `npx tsgo --noEmit` clean across the touched files.
- `committed.test.ts` updated to pass `billingTarget` and continues to pass (38/38).
- Manually exercised end-to-end in dev (Metronome-only Pro workspace, EUR currency):
  - Self-serve credit purchase → Stripe invoice issued in EUR → `invoice.paid` webhook → credit + Metronome commit activated.
  - Self-serve credit purchase with insufficient funds → 3DS / payment failure → repeated attempts → invoice voided → pending DB credit deleted.
  - Pending payment state → "Manage my subscription" → Stripe Customer Portal → invoice paid → credit activates.
  - Poke "Buy Committed Credits" plugin with Pro override → enterprise N+30 invoice issued → optimistic credit start.

## Risk

Medium. New money-moving paths, but they reuse the existing Pro/Enterprise primitives (the merged functions are the same code, just with one extra branch in invoice creation), share dunning behavior with Pro, and are gated to `isMetronomeOnlyBilled` workspaces only.

- **Subscription-less webhook routing relies on `invoice.metadata.workspace_id`.** Set at invoice creation in this PR. Pre-existing Metronome-only credit-purchase invoices created before this PR (none in production today) would have no `workspace_id` metadata and the webhook would log an error and 200; the credit would not auto-activate. Acceptable since this is a new flow.
- **Stripe Customer Portal config** must have **Invoice history** and **Payment methods** enabled in the Stripe dashboard for the `Manage my subscription` button to be useful for Metronome-only workspaces. One-time setting in Stripe, no code dependency. Worth verifying in production before deploy.

Rollback is a clean revert — no schema migration, no destructive Stripe operation.

## Deploy Plan

1. Verify the Stripe Customer Portal config (Settings → Customer portal) exposes Invoice history + Payment methods in production.
2. Deploy `front`.
3. Smoke-test with a dev Metronome-only workspace: buy credits → confirm `invoice.paid` activates the credit; click "Your billing dashboard on Stripe" → confirm portal loads.
4. No coordinated client/server release needed — the dialog already handles a `paymentUrl` field, so older clients will keep working with the new POST response.