### PR TITLE
Setup default payment method + webhooks

### DIFF
--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -1,11 +1,7 @@
 import { MetronomeSubscriptionPanel } from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
 import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
 import { useSendNotification } from "@app/hooks/useNotification";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
@@ -16,7 +12,6 @@ import {
   isWhitelistedBusinessPlan,
 } from "@app/lib/plans/plan_codes";
 import { LinkWrapper, useAppRouter, useSearchParam } from "@app/lib/platform";
-import { useKillSwitches } from "@app/lib/swr/kill";
 import {
   usePerSeatPricing,
   useSubscriptionTrialInfo,
@@ -29,7 +24,7 @@ import type {
   SubscriptionPerSeatPricing,
   SubscriptionType,
 } from "@app/types/plan";
-import { isSubscriptionStripeBilled } from "@app/types/plan";
+import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import {
   Button,
   ButtonsSwitch,
@@ -196,13 +191,7 @@ function CancelFreeTrialDialog({
 export function SubscriptionPage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
-  const { hasFeature } = useFeatureFlags();
-  const { killSwitches } = useKillSwitches();
-  const isMetronomeBillingEnabled =
-    hasFeature("metronome_billing") ||
-    !killSwitches?.includes("global_disable_metronome_billing");
-  const useMetronomePanel =
-    isMetronomeBillingEnabled && !isSubscriptionStripeBilled(subscription);
+  const useMetronomePanel = isSubscriptionMetronomeBilled(subscription);
   const router = useAppRouter();
   const sendNotification = useSendNotification();
   const type = useSearchParam("type");

--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -47,28 +47,26 @@ const StripeSetupSessionSchema = z.object({
     .optional(),
 });
 
-async function resolveCheckoutCountry({
+async function getSetupIntentDetails({
   setupIntentId,
-  customerCountry,
 }: {
-  setupIntentId: string | null | undefined;
-  customerCountry: string | null | undefined;
-}): Promise<string | null> {
-  if (customerCountry) {
-    return customerCountry;
-  }
-  if (!setupIntentId) {
-    return null;
-  }
+  setupIntentId: string;
+}): Promise<{ paymentMethodId: string | null; country: string | null }> {
   const stripe = getStripeClient();
   const setupIntent = await stripe.setupIntents.retrieve(setupIntentId, {
     expand: ["payment_method"],
   });
   const pm = setupIntent.payment_method;
   if (pm && typeof pm !== "string") {
-    return pm.billing_details.address?.country ?? null;
+    return {
+      paymentMethodId: pm.id,
+      country: pm.billing_details.address?.country ?? null,
+    };
   }
-  return null;
+  if (typeof pm === "string") {
+    return { paymentMethodId: pm, country: null };
+  }
+  return { paymentMethodId: null, country: null };
 }
 
 export async function handleMetronomeSetupCheckout({
@@ -109,14 +107,40 @@ export async function handleMetronomeSetupCheckout({
     "[Metronome] Handle metronome checkout"
   );
 
-  // Resolve the package alias based on the customer's billing country.
-  // With billing_address_collection: "auto", Stripe may not populate
-  // customer_details.address — fall back to the SetupIntent's payment method
-  // billing details, which is reliably set for card sessions.
-  const customerCountry = await resolveCheckoutCountry({
-    setupIntentId,
-    customerCountry: customerDetails?.address?.country,
+  // Stripe setup mode attaches the saved PaymentMethod to the customer but
+  // does NOT set it as the default for invoicing. Without setting it here,
+  // Metronome-generated invoices stay "Incomplete: customer hasn't attempted
+  // to pay yet" because Stripe has no default PM to charge off-session.
+  // We also reuse the SetupIntent's billing country as a fallback when
+  // billing_address_collection: "auto" leaves customer_details.address empty.
+  const setupIntentDetails = setupIntentId
+    ? await getSetupIntentDetails({ setupIntentId })
+    : { paymentMethodId: null, country: null };
+
+  // Stamp workspace_id on the Stripe customer so Stripe webhooks for
+  // Metronome-pushed invoices (which carry no Stripe subscription id) can
+  // resolve the invoice back to a workspace.
+  const stripe = getStripeClient();
+  await stripe.customers.update(stripeCustomerId, {
+    metadata: { workspace_id: workspaceId },
+    ...(setupIntentDetails.paymentMethodId
+      ? {
+          invoice_settings: {
+            default_payment_method: setupIntentDetails.paymentMethodId,
+          },
+        }
+      : {}),
   });
+
+  if (!setupIntentDetails.paymentMethodId) {
+    logger.warn(
+      { sessionId, workspaceId, stripeCustomerId, setupIntentId },
+      "[Metronome] No payment method on setup intent; default payment method not set. Future invoices may fail to auto-charge."
+    );
+  }
+
+  const customerCountry =
+    customerDetails?.address?.country ?? setupIntentDetails.country;
 
   const stripeCustomer = await getStripeCustomer(stripeCustomerId);
   const billingCurrency = resolveCurrencyFromStripe({

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -42,6 +42,7 @@ import {
   assertStripeSubscriptionIsValid,
   createCustomerPortalSession,
   getStripeClient,
+  getStripeCustomer,
   getStripeSubscription,
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
@@ -158,6 +159,64 @@ async function provisionShadowMetronome({
       { workspaceId: workspace.sId, error: normalizeError(err) },
       "[Stripe Webhook] Failed to shadow-provision Metronome"
     );
+  }
+}
+
+/**
+ * Shared payment-failure handling for a workspace subscription. Skips
+ * enterprise plans (paid by wire on 30-day terms), flags the subscription as
+ * payment-failing, and emails admins + the Stripe customer email.
+ * Used by both the Stripe-subscription and Metronome-subscription paths.
+ */
+async function notifyAdminsOfPaymentFailure({
+  auth,
+  subscription,
+  invoice,
+  now,
+}: {
+  auth: Authenticator;
+  subscription: SubscriptionResource;
+  invoice: Stripe.Invoice;
+  now: Date;
+}): Promise<void> {
+  const owner = auth.workspace();
+  const subscriptionType = auth.subscription();
+  if (!owner || !subscriptionType) {
+    throw new Error(
+      "notifyAdminsOfPaymentFailure: missing owner or subscription on auth"
+    );
+  }
+  if (isEntreprisePlanPrefix(subscriptionType.plan.code)) {
+    logger.info(
+      {
+        workspaceId: owner.sId,
+        invoiceId: invoice.id,
+        planCode: subscriptionType.plan.code,
+      },
+      "[Stripe Webhook] Skipping payment_failed handling for enterprise workspace."
+    );
+    return;
+  }
+  if (subscription.paymentFailingSince === null) {
+    await subscription.setPaymentFailingStatus({
+      paymentFailingSince: now,
+    });
+  }
+  const { members } = await getMembers(auth, {
+    roles: ["admin"],
+    activeOnly: true,
+  });
+  const adminEmails = members.map((u) => u.email);
+  const customerEmail = invoice.customer_email;
+  if (customerEmail && !adminEmails.includes(customerEmail)) {
+    adminEmails.push(customerEmail);
+  }
+  const portalUrl = await createCustomerPortalSession({
+    owner,
+    subscription: subscriptionType,
+  });
+  for (const adminEmail of adminEmails) {
+    await sendAdminSubscriptionPaymentFailedEmail(adminEmail, portalUrl);
   }
 }
 
@@ -502,12 +561,16 @@ async function handler(
               }
               return res.status(200).json({ success: true });
             }
-            return _returnStripeApiError(
-              req,
-              res,
-              "invoice.paid",
-              "Subscription in event is not a string."
+            // Metronome subscription invoices are pushed to Stripe via
+            // direct_to_billing_provider delivery and have no Stripe
+            // subscription attached. Subscription/credit state is driven
+            // by Metronome's own credit_segment events, so we just
+            // acknowledge the payment here.
+            logger.info(
+              { invoiceId: invoice.id, customer: invoice.customer },
+              "[Stripe Webhook] Metronome subscription invoice paid"
             );
+            return res.status(200).json({ success: true });
           }
           // Setting subscription payment status to succeeded.
           const subscription = await SubscriptionResource.fetchByStripeId(
@@ -602,6 +665,52 @@ async function handler(
           break;
         }
 
+        case "invoice.finalized": {
+          // Metronome-billed subscription invoices are pushed to Stripe via
+          // direct_to_billing_provider delivery. They sometimes finalize with
+          // the PaymentIntent in "incomplete" state (no payment method on the
+          // PI), so Stripe never auto-charges. Force a charge here using the
+          // customer's default payment method. Stripe-subscription invoices
+          // and credit-purchase invoices are charged through their own flows.
+          const finalizedInvoice = event.data.object as Stripe.Invoice;
+          if (typeof finalizedInvoice.subscription === "string") {
+            return res.status(200).json({ success: true });
+          }
+          if (isCreditPurchaseInvoice(finalizedInvoice)) {
+            return res.status(200).json({ success: true });
+          }
+          if (
+            finalizedInvoice.status !== "open" ||
+            finalizedInvoice.amount_due <= 0 ||
+            finalizedInvoice.collection_method !== "charge_automatically"
+          ) {
+            return res.status(200).json({ success: true });
+          }
+          if (!finalizedInvoice.id) {
+            return res.status(200).json({ success: true });
+          }
+          try {
+            await stripe.invoices.pay(finalizedInvoice.id);
+            logger.info(
+              {
+                invoiceId: finalizedInvoice.id,
+                customer: finalizedInvoice.customer,
+              },
+              "[Stripe Webhook] Charged Metronome subscription invoice on finalize"
+            );
+          } catch (err) {
+            logger.warn(
+              {
+                error: normalizeError(err),
+                invoiceId: finalizedInvoice.id,
+                customer: finalizedInvoice.customer,
+              },
+              "[Stripe Webhook] Failed to charge Metronome subscription invoice on finalize; Stripe dunning will retry"
+            );
+          }
+          return res.status(200).json({ success: true });
+        }
+
         case "invoice.payment_failed":
           // Occurs when payment failed or the user does not have a valid payment method.
           // The stripe subscription becomes "past_due".
@@ -655,12 +764,76 @@ async function handler(
               }
               return res.status(200).json({ success: true });
             }
-            return _returnStripeApiError(
-              req,
-              res,
-              "invoice.payment_failed",
-              "Subscription in event is not a string."
+            // Metronome subscription invoice failure (no Stripe subscription,
+            // not a credit purchase). Resolve workspace via the Stripe
+            // customer's `workspace_id` metadata, then mirror the Stripe
+            // subscription failure path: set payment failing status and email
+            // admins.
+            const customerId = isString(invoice.customer)
+              ? invoice.customer
+              : invoice.customer?.id;
+            if (!customerId) {
+              logger.error(
+                { invoiceId: invoice.id },
+                "[Stripe Webhook] Metronome subscription invoice missing customer"
+              );
+              return res.status(200).json({ success: true });
+            }
+            const stripeCustomer = await getStripeCustomer(customerId);
+            if (!stripeCustomer) {
+              return apiError(req, res, {
+                status_code: 500,
+                api_error: {
+                  type: "internal_server_error",
+                  message: "Failed to fetch customer from Stripe.",
+                },
+              });
+            }
+            const metronomeWorkspaceId =
+              stripeCustomer?.metadata?.workspace_id ?? null;
+            if (!metronomeWorkspaceId) {
+              logger.error(
+                {
+                  invoiceId: invoice.id,
+                  stripeCustomerId: customerId,
+                  stripeError: true,
+                },
+                "[Stripe Webhook] Metronome subscription invoice: Stripe customer missing workspace_id metadata"
+              );
+              return res.status(200).json({ success: true });
+            }
+            const metronomeWorkspace =
+              await WorkspaceResource.fetchById(metronomeWorkspaceId);
+            if (!metronomeWorkspace) {
+              logger.warn(
+                {
+                  invoiceId: invoice.id,
+                  workspaceId: metronomeWorkspaceId,
+                },
+                "[Stripe Webhook] Metronome subscription invoice: workspace not found"
+              );
+              return res.status(200).json({ success: true });
+            }
+            const metronomeSubscription =
+              await SubscriptionResource.fetchActiveByWorkspaceModelId(
+                metronomeWorkspace.id
+              );
+            if (
+              !metronomeSubscription ||
+              metronomeSubscription.status === "ended"
+            ) {
+              return res.status(200).json({ success: true });
+            }
+            const metronomeAuth = await Authenticator.internalAdminForWorkspace(
+              metronomeWorkspace.sId
             );
+            await notifyAdminsOfPaymentFailure({
+              auth: metronomeAuth,
+              subscription: metronomeSubscription,
+              invoice,
+              now,
+            });
+            return res.status(200).json({ success: true });
           }
 
           // Logging that we have a failed payment
@@ -753,61 +926,12 @@ async function handler(
               }
             }
           } else {
-            const owner = auth.workspace();
-            const subscriptionType = auth.subscription();
-
-            if (!owner || !subscriptionType) {
-              return _returnStripeApiError(
-                req,
-                res,
-                "invoice.payment_failed",
-                "Couldn't get owner or subscription from `auth`."
-              );
-            }
-
-            // Enterprise workspaces are paid by wire on 30-day invoice terms,
-            // so a Stripe payment_failed event does not reflect an actual
-            // billing problem. We also use the workspace's current active
-            // plan (not the plan attached to the failing invoice) so that a
-            // legacy non-enterprise subscription still tied to the same
-            // Stripe customer cannot trigger the past-due flow.
-            if (isEntreprisePlanPrefix(subscriptionType.plan.code)) {
-              logger.info(
-                {
-                  workspaceId: owner.sId,
-                  stripeSubscriptionId: invoice.subscription,
-                  planCode: subscriptionType.plan.code,
-                },
-                "[Stripe Webhook] Skipping payment_failed handling for enterprise workspace."
-              );
-              return res.status(200).json({ success: true });
-            }
-
-            if (subscription.paymentFailingSince === null) {
-              await subscription.setPaymentFailingStatus({
-                paymentFailingSince: now,
-              });
-            }
-
-            const { members } = await getMembers(auth, {
-              roles: ["admin"],
-              activeOnly: true,
+            await notifyAdminsOfPaymentFailure({
+              auth,
+              subscription,
+              invoice,
+              now,
             });
-            const adminEmails = members.map((u) => u.email);
-            const customerEmail = invoice.customer_email;
-            if (customerEmail && !adminEmails.includes(customerEmail)) {
-              adminEmails.push(customerEmail);
-            }
-            const portalUrl = await createCustomerPortalSession({
-              owner,
-              subscription: subscriptionType,
-            });
-            for (const adminEmail of adminEmails) {
-              await sendAdminSubscriptionPaymentFailedEmail(
-                adminEmail,
-                portalUrl
-              );
-            }
           }
           break;
 


### PR DESCRIPTION
## Description

Three fixes for the Metronome subscription payment flow that together get the customer's card actually charged when their first invoice is generated.

1. **Set default payment method on the Stripe customer** (`front/lib/metronome/checkout.ts`). Stripe Checkout in `mode="setup"` saves the PaymentMethod and attaches it to the customer, but does **not** set `customer.invoice_settings.default_payment_method`. Without this, Metronome-generated invoices land in Stripe with no PM to charge — they show as "Incomplete: customer hasn't attempted to pay yet". Now we explicitly set the default PM right after `checkout.session.completed`. Also stamps `workspace_id` on the Stripe customer metadata so Metronome-pushed invoices (which have no Stripe subscription) can be resolved back to a workspace by webhook handlers.

2. **Force-charge the finalized Metronome invoice** (`front/pages/api/stripe/webhook.ts`, `invoice.finalized`). Metronome pushes its subscription invoices to Stripe via `direct_to_billing_provider` with the `charge_automatically` collection method, but Stripe sometimes finalizes them with the PaymentIntent in "incomplete" state (no PM on the PI itself), so it never auto-charges. We now intercept `invoice.finalized`, skip Stripe-subscription and credit-purchase invoices, and call `stripe.invoices.pay(invoiceId)` to force a charge using the customer's default PM. Stripe's existing dunning handles real declines / SCA fallthrough.

3. **Handle Metronome subscription payment failures** (`front/pages/api/stripe/webhook.ts`, `invoice.payment_failed` and `invoice.paid`).
    - `invoice.payment_failed`: Metronome subscription invoices have no Stripe subscription id, so the existing handler bailed with `"Subscription in event is not a string."`. Added a Metronome path that resolves the workspace via `customer.metadata.workspace_id`, then mirrors the Stripe-subscription failure flow (set `paymentFailingSince`, email admins, skip enterprise plans). Refactored both branches onto a shared `notifyAdminsOfPaymentFailure` helper.
    - `invoice.paid`: Same root cause — silently acknowledge Metronome subscription invoices instead of erroring; subscription state is driven by Metronome's `credit_segment` events, not Stripe events.

## Tests

Manual testing on the billing hive:
- New Metronome subscription via the upgrade flow with €34.80 / €69.60 plans.
- Verified card was set as default on the Stripe customer.
- Verified `invoice.finalized` triggered an immediate charge of the Metronome-pushed invoice.
- Verified `invoice.paid` no longer logs the spurious "Subscription in event is not a string" error.

## Risk

- Low. The default-PM update is idempotent and only runs on Metronome setup checkouts. The `invoice.finalized` charge call is gated to non-subscription / non-credit-purchase invoices and catches errors as warnings (Stripe dunning still handles legit failures). The `invoice.payment_failed` Metronome path bails gracefully on missing metadata.
- Stripe webhook subscriptions: this code expects `invoice.finalized` to be subscribed on the webhook endpoint — needs to be enabled in the Stripe Dashboard if not already.

## Deploy Plan

1. Make sure `invoice.finalized` is enabled on the production Stripe webhook endpoint.
2. Merge and deploy.
3. Smoke-test by creating a new Metronome subscription on a test workspace; confirm the card is charged immediately when Metronome's invoice finalizes.