### PR TITLE
Fix version cache key for MCP action output items

### DIFF
--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -13,7 +13,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 const GCS_PREFIX = "mcp_output_items";
 const GCS_CONCURRENCY = 4;
-const GCS_CONTENT_CACHE_TTL_MS = 15 * 60 * 1000;
+export const GCS_CONTENT_CACHE_TTL_MS = 15 * 60 * 1000;
 
 type OutputContent = CallToolResult["content"][number];
 
@@ -92,11 +92,13 @@ async function fetchGcsContent(
   return JSON.parse(buffer.toString("utf-8"));
 }
 
-const gcsContentCacheKey = (
+// Bump the `:v1` suffix any time the cached value shape changes, so stale entries from previous
+// formats are orphaned instead of mis-parsed.
+export const gcsContentCacheKey = (
   auth: Authenticator,
   _gcsPath: string,
   itemId: ModelId
-) => `w:${auth.getNonNullableWorkspace().sId}:mcp_output:${itemId}`;
+) => `w:${auth.getNonNullableWorkspace().sId}:mcp_output:${itemId}:v1`;
 
 const fetchGcsContentCached = cacheWithRedis(
   fetchGcsContent,

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -676,12 +676,10 @@ describe("Output items with GCS storage", () => {
 });
 
 describe("warmGcsContentCache", () => {
-  let workspace: WorkspaceType;
   let auth: Authenticator;
 
   beforeEach(async () => {
     const setup = await createResourceTest({});
-    workspace = setup.workspace;
     auth = setup.authenticator;
 
     const redis = await getRedisCacheClient({ origin: "cache_with_redis" });

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -10,7 +10,11 @@ import {
   AgentMCPActionOutputItemModel,
 } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
-import { warmGcsContentCache } from "@app/lib/resources/agent_mcp_action/output_storage";
+import {
+  GCS_CONTENT_CACHE_TTL_MS,
+  gcsContentCacheKey,
+  warmGcsContentCache,
+} from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -471,9 +475,9 @@ describe("Output items with GCS storage", () => {
 
     for (const item of outputItems) {
       expect(setCalls).toContainEqual([
-        `cacheWithRedis-fetchGcsContent-w:${workspace.sId}:mcp_output:${item.id}`,
+        `cacheWithRedis-fetchGcsContent-${gcsContentCacheKey(auth, "", item.id)}`,
         JSON.stringify(item.content),
-        { PX: 15 * 60 * 1000 },
+        { PX: GCS_CONTENT_CACHE_TTL_MS },
       ]);
     }
   });
@@ -714,9 +718,9 @@ describe("warmGcsContentCache", () => {
 
     for (const item of items) {
       expect(setCalls).toContainEqual([
-        `cacheWithRedis-fetchGcsContent-w:${workspace.sId}:mcp_output:${item.itemId}`,
+        `cacheWithRedis-fetchGcsContent-${gcsContentCacheKey(auth, "", item.itemId)}`,
         JSON.stringify(item.content),
-        { PX: 15 * 60 * 1000 },
+        { PX: GCS_CONTENT_CACHE_TTL_MS },
       ]);
     }
   });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C09T7N4S6GG/p1778221721072109).

The endpoint call GET `/api/v1/w/.../spaces/.../conversations` was failing Zod validation in the SDK with:
```
Expected object, received string on actions[i].output[j].
```

## Investigation

Investigation showed the data on disk was healthy. Postgres held the output content as a JSONB object, the GCS file content tarted with `{` and parsed as an object, and the GCS write path in `createOutputItems` was producing correct bytes. The Redis cache, however, returned a JSON-encoded string for these specific items: a value beginning with `"`, which `JSON.parse` resolves to an inner string rather than an object. That string then propagated through
`fetchContentFromGcs` -> `batchFetchContentsFromGcs` -> `enrichActionsWithOutputItems` and ended up assigned back to `item.content`, ultimately landing in the API response and tripping the SDK schema.

The cause is a cache-format mismatch combined with cache entries that never expire. Until PR #25033, `fetchGcsContent` returned the raw GCS file as a UTF-8 string and `fetchContentFromGcs` did the `JSON.parse` itself.  `cacheWithRedis` therefore stored `JSON.stringify(rawString)`, a JSON-encoded JSON string. PR #25033 moved the parsing inside `fetchGcsContent` so the cache now stores `JSON.stringify(parsedObject)`. The cache key was not bumped, so old entries
written before #25033 still satisfy the same lookup, and the new reader does a single `JSON.parse` which correctly produces an object for new-format values but produces an inner string for legacy values. Worth flagging as well that the cache TTL was only added in PR #22653. Entries written between Feb 25 and Mar 6, 2026 (when the GCS storage path first shipped) were persisted to Redis without any expiration.

**Confirmed in production:** TTL on a poisoned key returned -1, and the affected output items were created on Mar 4, 2026, two days before TTL was introduced. Those entries have been sitting in Redis for ~2 months and only became user-visible when the format change a week ago.

This PR simply suffixes the cache key with a new version so all previous items are being orphaned. They will eventually be removed from Redis (cost is memory only) and will never be read again.

> [!WARNING]
> Going forward, the rule is to bump this version any time the cached value shape changes.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25430">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->