### PR TITLE
Move MCP action output items GCS paths under the workspace prefix

### DIFF
--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -13,9 +13,9 @@ import {
   getCreditPurchaseCouponId,
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
+  MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
   makeCreditPurchaseOneOffInvoiceForCustomer,
   makeCreditPurchaseOneOffInvoiceForSubscription,
-  MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
   payInvoice,
   voidInvoiceWithReason,
 } from "@app/lib/plans/stripe";

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -13,9 +13,9 @@ import {
   getCreditPurchaseCouponId,
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
-  MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
-  makeCreditPurchaseOneOffInvoiceForSubscription,
   makeCreditPurchaseOneOffInvoiceForCustomer,
+  makeCreditPurchaseOneOffInvoiceForSubscription,
+  MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
   payInvoice,
   voidInvoiceWithReason,
 } from "@app/lib/plans/stripe";

--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -2,7 +2,10 @@ import { REDIS_CACHE_CONCURRENCY } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import {
+  concurrentExecutor,
+  setTimeoutAsync,
+} from "@app/lib/utils/async_utils";
 import { cacheWithRedis, warmCacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -14,7 +17,35 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 const MCP_OUTPUT_ITEMS_PREFIX = "mcp_output_items";
 const GCS_CONCURRENCY = 4;
 
+// Retries for transient GCS failures on write. Total attempts = 1 + retries.
+const GCS_WRITE_MAX_RETRIES = 2;
+// TODO(2026-05-08 FLAV) Create proper withRetry helper to abstract this.
+const GCS_WRITE_RETRY_DELAYS_MS = [100, 500];
+
 export const GCS_CONTENT_CACHE_TTL_MS = 15 * 60 * 1000;
+
+async function writeOneToGcsWithRetry(
+  file: ReturnType<ReturnType<typeof getPrivateUploadBucket>["file"]>,
+  content: string
+): Promise<void> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= GCS_WRITE_MAX_RETRIES; attempt++) {
+    try {
+      await file.save(Buffer.from(content, "utf-8"), {
+        contentType: "application/json",
+      });
+      return;
+    } catch (err) {
+      lastErr = err;
+      if (attempt === GCS_WRITE_MAX_RETRIES) {
+        break;
+      }
+
+      await setTimeoutAsync(GCS_WRITE_RETRY_DELAYS_MS[attempt]);
+    }
+  }
+  throw lastErr;
+}
 
 type OutputContent = CallToolResult["content"][number];
 
@@ -30,10 +61,7 @@ function getGcsPath(
 
 /**
  * Writes multiple output items to GCS concurrently.
- * Returns Ok with a map of itemId → gcsPath, or Err on failure.
- *
- * TODO(2026-03-15): Add retry with exponential backoff to handle transient
- * GCS failures.
+ * Returns Ok with a map of itemId -> gcsPath, or Err on failure.
  */
 export async function batchWriteContentsToGcs(
   auth: Authenticator,
@@ -53,9 +81,9 @@ export async function batchWriteContentsToGcs(
         const bucket = getPrivateUploadBucket();
         const file = bucket.file(gcsPath);
         const json = JSON.stringify(content);
-        await file.save(Buffer.from(json, "utf-8"), {
-          contentType: "application/json",
-        });
+
+        await writeOneToGcsWithRetry(file, json);
+
         results.set(itemId, gcsPath);
       },
       { concurrency: GCS_CONCURRENCY }

--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -11,21 +11,21 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-const GCS_PREFIX = "mcp_output_items";
+const MCP_OUTPUT_ITEMS_PREFIX = "mcp_output_items";
 const GCS_CONCURRENCY = 4;
+
 export const GCS_CONTENT_CACHE_TTL_MS = 15 * 60 * 1000;
 
 type OutputContent = CallToolResult["content"][number];
 
+// Writes live under the workspace prefix `w/<wsId>/...` so they are included by the
+// workspace-relocation file transfer.
 function getGcsPath(
   auth: Authenticator,
   action: AgentMCPActionResource,
   itemId: ModelId
 ): string {
-  const workspaceId = auth.getNonNullableWorkspace().sId;
-  const actionId = action.sId;
-
-  return `${GCS_PREFIX}/w/${workspaceId}/${actionId}/${itemId}.json`;
+  return `w/${auth.getNonNullableWorkspace().sId}/${MCP_OUTPUT_ITEMS_PREFIX}/${action.sId}/${itemId}.json`;
 }
 
 /**

--- a/front/lib/resources/agent_mcp_action/output_storage.ts
+++ b/front/lib/resources/agent_mcp_action/output_storage.ts
@@ -2,10 +2,7 @@ import { REDIS_CACHE_CONCURRENCY } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import {
-  concurrentExecutor,
-  setTimeoutAsync,
-} from "@app/lib/utils/async_utils";
+import { concurrentExecutor, withRetry } from "@app/lib/utils/async_utils";
 import { cacheWithRedis, warmCacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -17,35 +14,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 const MCP_OUTPUT_ITEMS_PREFIX = "mcp_output_items";
 const GCS_CONCURRENCY = 4;
 
-// Retries for transient GCS failures on write. Total attempts = 1 + retries.
-const GCS_WRITE_MAX_RETRIES = 2;
-// TODO(2026-05-08 FLAV) Create proper withRetry helper to abstract this.
-const GCS_WRITE_RETRY_DELAYS_MS = [100, 500];
-
 export const GCS_CONTENT_CACHE_TTL_MS = 15 * 60 * 1000;
-
-async function writeOneToGcsWithRetry(
-  file: ReturnType<ReturnType<typeof getPrivateUploadBucket>["file"]>,
-  content: string
-): Promise<void> {
-  let lastErr: unknown;
-  for (let attempt = 0; attempt <= GCS_WRITE_MAX_RETRIES; attempt++) {
-    try {
-      await file.save(Buffer.from(content, "utf-8"), {
-        contentType: "application/json",
-      });
-      return;
-    } catch (err) {
-      lastErr = err;
-      if (attempt === GCS_WRITE_MAX_RETRIES) {
-        break;
-      }
-
-      await setTimeoutAsync(GCS_WRITE_RETRY_DELAYS_MS[attempt]);
-    }
-  }
-  throw lastErr;
-}
 
 type OutputContent = CallToolResult["content"][number];
 
@@ -73,31 +42,44 @@ export async function batchWriteContentsToGcs(
 ): Promise<Result<Map<ModelId, string>, Error>> {
   const results = new Map<ModelId, string>();
 
-  try {
-    await concurrentExecutor(
-      items,
-      async ({ itemId, content }) => {
-        const gcsPath = getGcsPath(auth, action, itemId);
-        const bucket = getPrivateUploadBucket();
-        const file = bucket.file(gcsPath);
-        const json = JSON.stringify(content);
+  let firstError: Error | null = null;
 
-        await writeOneToGcsWithRetry(file, json);
+  await concurrentExecutor(
+    items,
+    async ({ itemId, content }) => {
+      const gcsPath = getGcsPath(auth, action, itemId);
+      const bucket = getPrivateUploadBucket();
+      const file = bucket.file(gcsPath);
+      const json = JSON.stringify(content);
 
-        results.set(itemId, gcsPath);
-      },
-      { concurrency: GCS_CONCURRENCY }
-    );
-  } catch (err) {
+      const writeResult = await withRetry(() =>
+        file.save(Buffer.from(json, "utf-8"), {
+          contentType: "application/json",
+        })
+      );
+
+      if (writeResult.isErr()) {
+        if (!firstError) {
+          firstError = writeResult.error;
+        }
+        return;
+      }
+      results.set(itemId, gcsPath);
+    },
+    { concurrency: GCS_CONCURRENCY }
+  );
+
+  if (firstError) {
     logger.error(
       {
-        err: normalizeError(err),
+        err: firstError,
         itemCount: items.length,
         successCount: results.size,
       },
       "Failed to write MCP output items to GCS"
     );
-    return new Err(normalizeError(err));
+
+    return new Err(firstError);
   }
 
   return new Ok(results);

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -696,10 +696,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       }))
     );
 
-    // On GCS failure during migration period, items remain as legacy rows (content read from DB).
-    // Once content column is dropped, this must become a hard error.
+    // GCS write is retried internally. If it still fails we surface the error rather than leaving
+    // rows with no `contentGcsPath`. There is no acceptable degraded state.
     if (gcsResult.isErr()) {
-      return outputItems;
+      // TODO(2026-05-08 FLAV) Return a result and refactor all call sites.
+      throw gcsResult.error;
     }
 
     await warmGcsContentCache(

--- a/front/lib/utils/async_utils.ts
+++ b/front/lib/utils/async_utils.ts
@@ -1,3 +1,7 @@
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
 /**
  * Executes an array of tasks concurrently with controlled parallelism.
  *
@@ -53,3 +57,45 @@ export async function concurrentExecutor<T, V>(
 
 export const setTimeoutAsync = (ms: number): Promise<"timeout"> =>
   new Promise((resolve) => setTimeout(() => resolve("timeout"), ms));
+
+interface WithRetryOptions {
+  // Total attempts = 1 + maxRetries.
+  maxRetries?: number;
+  // Delay before the first retry. Subsequent retries multiply by `backoffMultiplier`.
+  initialDelayMs?: number;
+  backoffMultiplier?: number;
+  shouldRetry?: (err: unknown, attempt: number) => boolean;
+}
+
+/**
+ * Retries an async operation with exponential backoff. Returns a `Result`:
+ * `Ok` with the operation's value, or `Err` with the last error after retries
+ * are exhausted (or when `shouldRetry` returns false).
+ */
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  {
+    maxRetries = 2,
+    initialDelayMs = 200,
+    backoffMultiplier = 2,
+    shouldRetry = () => true,
+  }: WithRetryOptions = {}
+): Promise<Result<T, Error>> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return new Ok(await operation());
+    } catch (err) {
+      lastErr = err;
+      if (attempt === maxRetries || !shouldRetry(err, attempt)) {
+        break;
+      }
+
+      await setTimeoutAsync(
+        initialDelayMs * Math.pow(backoffMultiplier, attempt)
+      );
+    }
+  }
+
+  return new Err(normalizeError(lastErr));
+}

--- a/front/scripts/backfill_mcp_action_output_item_gcs_paths.ts
+++ b/front/scripts/backfill_mcp_action_output_item_gcs_paths.ts
@@ -1,0 +1,226 @@
+import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
+import { batchWriteContentsToGcs } from "@app/lib/resources/agent_mcp_action/output_storage";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { ModelId } from "@app/types/shared/model_id";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { WhereOptions } from "sequelize";
+import { Op } from "sequelize";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+const BATCH_SIZE_DEFAULT = 200;
+
+// New paths live under `w/<workspaceId>/...`. Anything else (`mcp_output_items/...`
+// or NULL) needs to be migrated.
+function isMigratedPath(p: string | null): boolean {
+  return p !== null && p.startsWith("w/");
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      describe: "Restrict the backfill to a single workspace sId",
+    },
+    fromWorkspaceId: {
+      type: "number",
+      describe:
+        "Resume: skip workspaces with model id < this value (used when iterating all workspaces)",
+    },
+    batchSize: {
+      type: "number",
+      default: BATCH_SIZE_DEFAULT,
+      describe: "Number of output items to process per DB batch per workspace",
+    },
+    concurrency: {
+      type: "number",
+      default: 4,
+      describe: "Concurrent items processed per batch",
+    },
+    deleteOldGcs: {
+      type: "boolean",
+      default: false,
+      describe:
+        "Delete the legacy `mcp_output_items/...` GCS object after a successful row update",
+    },
+  },
+  async (
+    {
+      execute,
+      workspaceId,
+      fromWorkspaceId,
+      batchSize,
+      concurrency,
+      deleteOldGcs,
+    },
+    scriptLogger
+  ) => {
+    scriptLogger.info(
+      { workspaceId, fromWorkspaceId, batchSize, execute },
+      "[Backfill MCP output GCS paths] Starting"
+    );
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const workspaceModelId = workspace.id;
+
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+        const bucket = getPrivateUploadBucket();
+
+        let lastId: ModelId | null = null;
+        let migrated = 0;
+        let skipped = 0;
+        let errors = 0;
+
+        while (true) {
+          const where: WhereOptions<AgentMCPActionOutputItemModel> = {
+            workspaceId: workspaceModelId,
+          };
+
+          if (lastId !== null) {
+            where.id = { [Op.gt]: lastId };
+          }
+
+          const items = await AgentMCPActionOutputItemModel.findAll({
+            where,
+            order: [["id", "ASC"]],
+            limit: batchSize,
+          });
+
+          if (items.length === 0) {
+            break;
+          }
+          lastId = items[items.length - 1].id;
+
+          // Pre-fetch action resources for this batch.
+          const uniqueActionModelIds = [
+            ...new Set(items.map((i) => i.agentMCPActionId)),
+          ];
+          const actionResources = await AgentMCPActionResource.fetchByModelIds(
+            auth,
+            uniqueActionModelIds
+          );
+          const actionByModelId = new Map(
+            actionResources.map((a) => [a.id, a])
+          );
+
+          await concurrentExecutor(
+            items,
+            async (item) => {
+              if (isMigratedPath(item.contentGcsPath)) {
+                skipped += 1;
+                return;
+              }
+
+              const action = actionByModelId.get(item.agentMCPActionId);
+              if (!action) {
+                // Orphan output item. The action it belongs to was deleted but this row wasn't
+                // (FK cascade should prevent this, log and skip).
+                scriptLogger.error(
+                  {
+                    workspaceId: workspaceId,
+                    itemId: item.id,
+                    agentMCPActionId: item.agentMCPActionId,
+                  },
+                  "[Backfill MCP output GCS paths] Orphan item with no action; skipping"
+                );
+                errors += 1;
+                return;
+              }
+
+              const oldPath = item.contentGcsPath;
+
+              if (!execute) {
+                return;
+              }
+
+              // Re-write content from DB to the new GCS path. The DB column is NOT NULL during the
+              // migration period, so it's available even for items that already have a
+              // (legacy-prefix) GCS object.
+              const writeResult = await batchWriteContentsToGcs(auth, action, [
+                { itemId: item.id, content: item.content },
+              ]);
+              if (writeResult.isErr()) {
+                scriptLogger.error(
+                  {
+                    workspaceId: workspaceId,
+                    itemId: item.id,
+                    err: writeResult.error.message,
+                  },
+                  "[Backfill MCP output GCS paths] GCS write failed; skipping item"
+                );
+                errors += 1;
+                return;
+              }
+
+              const newPath = writeResult.value.get(item.id);
+              if (!newPath) {
+                scriptLogger.error(
+                  { workspaceId: workspaceId, itemId: item.id },
+                  "[Backfill MCP output GCS paths] GCS write returned no path; skipping"
+                );
+                errors += 1;
+                return;
+              }
+
+              await AgentMCPActionOutputItemModel.update(
+                { contentGcsPath: newPath },
+                { where: { id: item.id, workspaceId: workspaceModelId } }
+              );
+
+              // Best-effort cleanup of the legacy object. Do not fail the row if delete errors
+              // The new path is already authoritative.
+              if (deleteOldGcs && oldPath && !isMigratedPath(oldPath)) {
+                try {
+                  await bucket.delete(oldPath, { ignoreNotFound: true });
+                } catch (err) {
+                  logger.error(
+                    {
+                      workspaceId: workspaceId,
+                      itemId: item.id,
+                      oldPath,
+                      err: normalizeError(err),
+                    },
+                    "[Backfill MCP output GCS paths] Failed to delete legacy GCS object"
+                  );
+                }
+              }
+
+              migrated += 1;
+            },
+            { concurrency }
+          );
+
+          scriptLogger.info(
+            {
+              workspaceId: workspaceId,
+              lastId,
+              migrated,
+              skipped,
+              errors,
+              execute,
+            },
+            execute
+              ? "[Backfill MCP output GCS paths] Batch processed"
+              : "[Backfill MCP output GCS paths] [DRY RUN] Batch processed"
+          );
+        }
+
+        scriptLogger.info(
+          { workspaceId: workspaceId, migrated, skipped, errors, execute },
+          "[Backfill MCP output GCS paths] Workspace done"
+        );
+      },
+      { wId: workspaceId, fromWorkspaceId }
+    );
+
+    scriptLogger.info("[Backfill MCP output GCS paths] All workspaces done.");
+  }
+);

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -59,8 +59,10 @@ class FileStorageMock {
           return new PassThrough();
         }),
       delete: vi.fn().mockResolvedValue(undefined),
+      download: vi.fn().mockResolvedValue([Buffer.from("", "utf-8")]),
       getSignedUrl: vi.fn().mockResolvedValue(["https://signed-url.test"]),
       publicUrl: vi.fn().mockReturnValue("https://public-url.test"),
+      save: vi.fn().mockResolvedValue(undefined),
     };
   }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Workspace relocation only transfers GCS objects under the per-workspace prefix, but MCP action output items have been writing to a separate top-level path until we build conviction. The DB rows are relocated correctly, but the underlying content files aren't. Today this is masked by a fallback that reads content from the DB column we kept during the GCS migration. As we want to drop that column soon, relocated workspaces would lose access to their tool outputs.

Phase 1 of the fix: new writes go under the workspace prefix, and a one-shot script backfills existing rows. The path stored on each row is absolute, so old objects keep resolving correctly until the backfill rewrites them. No read-path change needed. We also make the writes to GCS more robust by retrying a second time.

Phase 2, in a follow-up: drop the GCS read fallback and remove the content column.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25431">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->