### PR TITLE
Add members usage table to workspace usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1,15 +1,31 @@
-import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
+import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
+import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
+import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
+import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
+import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import { useAwuPoolSummary } from "@app/lib/swr/credits";
+import { useMembersUsage } from "@app/lib/swr/memberships";
+import {
+  usePerSeatPricing,
+  useWorkspaceSeatAvailability,
+} from "@app/lib/swr/workspaces";
+import { isAdmin } from "@app/types/user";
 import {
   ActionPieChartIcon,
   ContentMessage,
   ExclamationCircleIcon,
   Icon,
   Page,
+  SearchInput,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 function formatAmount(amountMicroUsd: number): string {
   const amountDollars = amountMicroUsd / 1_000_000;
@@ -105,8 +121,12 @@ function CreditPoolUsageBar({
 
 export function UsagePage() {
   const owner = useWorkspace();
+  const { subscription } = useAuth();
   const { hasFeature } = useFeatureFlags();
   const router = useAppRouter();
+  const [searchTerm, setSearchTerm] = useState("");
+  const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
+    useState<WorkspaceLimit | null>(null);
 
   useEffect(() => {
     if (!hasFeature("metronome_billing_usage_page")) {
@@ -124,6 +144,38 @@ export function UsagePage() {
   } = useAwuPoolSummary({
     workspaceId: owner.sId,
   });
+
+  const { membersUsage, isMembersUsageLoading } = useMembersUsage({
+    workspaceId: owner.sId,
+  });
+
+  const { hasAvailableSeats } = useWorkspaceSeatAvailability({
+    workspaceId: owner.sId,
+  });
+
+  const { perSeatPricing } = usePerSeatPricing({
+    workspaceId: owner.sId,
+  });
+
+  const plan = subscription.plan;
+  const isManualInvitationsEnabled =
+    owner.metadata?.disableManualInvitations !== true;
+
+  const onInviteClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (!isUpgraded(plan)) {
+        setInviteBlockedPopupReason("cant_invite_free_plan");
+        event.preventDefault();
+      } else if (subscription.paymentFailingSince) {
+        setInviteBlockedPopupReason("cant_invite_payment_failure");
+        event.preventDefault();
+      } else if (!hasAvailableSeats) {
+        setInviteBlockedPopupReason("cant_invite_no_seats_available");
+        event.preventDefault();
+      }
+    },
+    [plan, subscription.paymentFailingSince, hasAvailableSeats]
+  );
 
   const totalConsumedMicroUsd =
     consumedByUsersMicroUsd + consumedByProgrammaticMicroUsd;
@@ -193,13 +245,49 @@ export function UsagePage() {
         )}
       </Page.Vertical>
 
+      <Page.Vertical gap="sm" align="stretch">
+        <span className="text-[16px] font-medium leading-[24px] tracking-[-0.32px] text-foreground dark:text-foreground-night">
+          Members
+        </span>
+        <div className="flex flex-row gap-2">
+          <SearchInput
+            placeholder="Search members (email)"
+            value={searchTerm}
+            name="search"
+            onChange={setSearchTerm}
+            className="w-full"
+          />
+          {isManualInvitationsEnabled && (
+            <InviteEmailButtonWithModal
+              owner={owner}
+              prefillText=""
+              perSeatPricing={perSeatPricing}
+              onInviteClick={onInviteClick}
+            />
+          )}
+        </div>
+        <MembersUsageTable
+          members={membersUsage}
+          isLoading={isMembersUsageLoading}
+          searchTerm={searchTerm}
+        />
+      </Page.Vertical>
+
+      {inviteBlockedPopupReason && (
+        <ReachedLimitPopup
+          isAdmin={isAdmin(owner)}
+          isOpened={!!inviteBlockedPopupReason}
+          onClose={() => setInviteBlockedPopupReason(null)}
+          subscription={subscription}
+          owner={owner}
+          code={inviteBlockedPopupReason}
+        />
+      )}
+
       {/* TODO: Settings section*/}
       <div />
 
       {/* TODO: Notifications section */}
-      <div />
-
-      {/* TODO: Members section */}
       <div />
     </Page.Vertical>
   );

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -1,0 +1,101 @@
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import { DataTable, LoadingBlock } from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+
+type RowData = {
+  sId: string;
+  name: string;
+  email: string | null;
+  image: string | null;
+  consumedMicroUsd: number;
+  onClick?: () => void;
+};
+
+type Info = CellContext<RowData, string>;
+
+function formatMicroUsd(amountMicroUsd: number): string {
+  const dollars = amountMicroUsd / 1_000_000;
+  return `$${dollars.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+const columns: ColumnDef<RowData, string>[] = [
+  {
+    id: "name" as const,
+    header: "Name",
+    accessorFn: (row) => row.name,
+    cell: (info: Info) => (
+      <DataTable.CellContent
+        avatarUrl={info.row.original.image ?? undefined}
+        roundedAvatar
+      >
+        <div>
+          <div>{info.row.original.name}</div>
+          {info.row.original.email && (
+            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {info.row.original.email}
+            </div>
+          )}
+        </div>
+      </DataTable.CellContent>
+    ),
+  },
+  {
+    id: "consumedMicroUsd" as const,
+    header: "Workspace usage",
+    accessorFn: (row) => row.consumedMicroUsd.toString(),
+    cell: (info: Info) => (
+      <DataTable.CellContent>
+        <span className="text-sm tabular-nums text-muted-foreground dark:text-muted-foreground-night">
+          {formatMicroUsd(info.row.original.consumedMicroUsd)}
+        </span>
+      </DataTable.CellContent>
+    ),
+    meta: {
+      className: "w-36 text-right",
+    },
+    enableSorting: true,
+    sortingFn: (a, b) =>
+      a.original.consumedMicroUsd - b.original.consumedMicroUsd,
+  },
+];
+
+interface MembersUsageTableProps {
+  members: MemberUsageType[];
+  isLoading: boolean;
+  searchTerm: string;
+}
+
+export function MembersUsageTable({
+  members,
+  isLoading,
+  searchTerm,
+}: MembersUsageTableProps) {
+  if (isLoading) {
+    return (
+      <div className="flex w-full flex-col space-y-2">
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  const lowerSearch = searchTerm.toLowerCase();
+  const filtered = searchTerm
+    ? members.filter(
+        (m) =>
+          m.name.toLowerCase().includes(lowerSearch) ||
+          (m.email ?? "").toLowerCase().includes(lowerSearch)
+      )
+    : members;
+
+  const rows: RowData[] = filtered.map((m) => ({
+    sId: m.sId,
+    name: m.name,
+    email: m.email,
+    image: m.image,
+    consumedMicroUsd: m.consumedMicroUsd,
+  }));
+
+  return <DataTable data={rows} columns={columns} />;
+}

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,0 +1,199 @@
+import { getMembers } from "@app/lib/api/workspace";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
+  listMetronomeDraftInvoices,
+  listMetronomeUsageWithGroups,
+} from "@app/lib/metronome/client";
+import { getMetricLlmCostAwuUserId } from "@app/lib/metronome/constants";
+import { METRONOME_USER_CREDIT_TO_MICRO_USD } from "@app/lib/metronome/types";
+import type { MembershipsPaginationParams } from "@app/lib/resources/membership_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+export type MemberUsageType = {
+  sId: string;
+  name: string;
+  email: string | null;
+  image: string | null;
+  consumedMicroUsd: number;
+};
+
+export type GetMembersUsageResponseBody = {
+  members: MemberUsageType[];
+  total: number;
+  nextPageUrl?: string;
+};
+
+export const DEFAULT_MEMBERS_USAGE_PAGE_LIMIT = 50;
+export const MAX_MEMBERS_USAGE_PAGE_LIMIT = 150;
+
+const MembersUsagePaginationSchema = z.object({
+  limit: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(MAX_MEMBERS_USAGE_PAGE_LIMIT)
+    .catch(DEFAULT_MEMBERS_USAGE_PAGE_LIMIT),
+  orderColumn: z.literal("createdAt").catch("createdAt"),
+  orderDirection: z.enum(["asc", "desc"]).catch("desc"),
+  lastValue: z.coerce.number().optional().catch(undefined),
+});
+
+function buildUrlWithParams(
+  req: NextApiRequest,
+  newParams: MembershipsPaginationParams | undefined
+) {
+  if (!newParams) {
+    return undefined;
+  }
+  const url = new URL(req.url!, `http://${req.headers.host}`);
+  Object.entries(newParams).forEach(([key, value]) => {
+    if (value === null || value === undefined) {
+      url.searchParams.delete(key);
+    } else {
+      url.searchParams.set(key, value.toString());
+    }
+  });
+  return url.pathname + url.search;
+}
+
+async function fetchPerUserUsageMicroUsd({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string | null;
+  metronomeContractId: string | null;
+}): Promise<Map<string, number>> {
+  if (!metronomeCustomerId || !metronomeContractId) {
+    return new Map();
+  }
+
+  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
+  if (invoicesResult.isErr()) {
+    return new Map();
+  }
+
+  const now = Date.now();
+  const currentInvoice = invoicesResult.value.find((inv) => {
+    if (inv.contract_id !== metronomeContractId) {
+      return false;
+    }
+    if (!inv.start_timestamp || !inv.end_timestamp) {
+      return false;
+    }
+    const startMs = new Date(inv.start_timestamp).getTime();
+    const endMs = new Date(inv.end_timestamp).getTime();
+    return startMs <= now && now < endMs;
+  });
+
+  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+    return new Map();
+  }
+
+  const startingOn = floorToMidnightUTC(
+    new Date(currentInvoice.start_timestamp)
+  ).toISOString();
+  const endingBefore = ceilToMidnightUTC(
+    new Date(currentInvoice.end_timestamp)
+  ).toISOString();
+
+  const usageResult = await listMetronomeUsageWithGroups({
+    customerId: metronomeCustomerId,
+    billableMetricId: getMetricLlmCostAwuUserId(),
+    startingOn,
+    endingBefore,
+    windowSize: "NONE",
+    groupKey: ["user_id"],
+  });
+
+  if (usageResult.isErr()) {
+    return new Map();
+  }
+
+  const perUser = new Map<string, number>();
+  for (const entry of usageResult.value) {
+    const userId = entry.group?.["user_id"];
+    if (!userId || entry.value === null) {
+      continue;
+    }
+    const existing = perUser.get(userId) ?? 0;
+    perUser.set(
+      userId,
+      existing + entry.value * METRONOME_USER_CREDIT_TO_MICRO_USD
+    );
+  }
+  return perUser;
+}
+
+export async function handleGetMembersUsageRequest(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMembersUsageResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access the members usage list.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const paginationRes = MembersUsagePaginationSchema.safeParse(req.query);
+      if (!paginationRes.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid pagination parameters: ${fromError(paginationRes.error).toString()}`,
+          },
+        });
+      }
+
+      const paginationParams = paginationRes.data;
+      const workspace = auth.getNonNullableWorkspace();
+      const subscription = auth.subscription();
+      const { metronomeCustomerId } = workspace;
+
+      const [membersResult, perUserUsageMicroUsd] = await Promise.all([
+        getMembers(auth, { activeOnly: true }, paginationParams),
+        fetchPerUserUsageMicroUsd({
+          metronomeCustomerId: metronomeCustomerId ?? null,
+          metronomeContractId: subscription?.metronomeContractId ?? null,
+        }),
+      ]);
+
+      const { members, total, nextPageParams } = membersResult;
+
+      const membersUsage: MemberUsageType[] = members.map((m) => ({
+        sId: m.sId,
+        name: m.fullName,
+        email: m.email ?? null,
+        image: m.image ?? null,
+        consumedMicroUsd: perUserUsageMicroUsd.get(m.sId) ?? 0,
+      }));
+
+      return res.status(200).json({
+        members: membersUsage,
+        total,
+        nextPageUrl: buildUrlWithParams(req, nextPageParams),
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -14,8 +14,8 @@ import {
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
   MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
-  makeCreditPurchaseOneOffInvoiceForSubscription,
   makeCreditPurchaseOneOffInvoiceForCustomer,
+  makeCreditPurchaseOneOffInvoiceForSubscription,
   payInvoice,
   voidInvoiceWithReason,
 } from "@app/lib/plans/stripe";

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,10 +1,10 @@
+import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 import type { MembersLookupResponseBody } from "@app/pages/api/w/[wId]/members/lookup";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
-import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import type { GroupKind } from "@app/types/groups";
 import { isGroupKind } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -4,6 +4,7 @@ import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 import type { MembersLookupResponseBody } from "@app/pages/api/w/[wId]/members/lookup";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
+import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import type { GroupKind } from "@app/types/groups";
 import { isGroupKind } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -182,5 +183,34 @@ export function useMembersLookup({
     members: data?.users ?? emptyArray(),
     isMembersLookupLoading: !error && !data && !!query && !disabled,
     isMembersLookupError: !!error,
+  };
+}
+
+export function useMembersUsage({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const defaultUrl = `/api/w/${workspaceId}/credits/members-usage`;
+  const [url, setUrl] = useState(defaultUrl);
+
+  const membersUsageFetcher: Fetcher<GetMembersUsageResponseBody> = fetcher;
+  const { data, error } = useSWRWithDefaults(url, membersUsageFetcher, {
+    disabled,
+  });
+
+  return {
+    membersUsage: data?.members ?? emptyArray(),
+    isMembersUsageLoading: !error && !data && !disabled,
+    isMembersUsageError: !!error,
+    totalMembersUsage: data?.total ?? 0,
+    hasNextPage: !!data?.nextPageUrl,
+    loadNextPage: useCallback(
+      () => data?.nextPageUrl && setUrl(data.nextPageUrl),
+      [data?.nextPageUrl]
+    ),
   };
 }

--- a/front/pages/api/w/[wId]/credits/members-usage.ts
+++ b/front/pages/api/w/[wId]/credits/members-usage.ts
@@ -1,0 +1,17 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
+import { handleGetMembersUsageRequest } from "@app/lib/api/credits/members_usage";
+import type { Authenticator } from "@app/lib/auth";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMembersUsageResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  return handleGetMembersUsageRequest(req, res, auth);
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## What

Adds a **Members** section to the workspace Usage page (behind `metronome_billing_usage_page` feature flag) showing each member's current-period AWU spend from the workspace credit pool.

Note, this is a simplified version of displaying the usage compared to the mock-up. We do not have seat-based usage/allocation on the current Metronome contract which is a prerequisite to wire that up. We also do not yet have workspace limits defined per user yet

## Changes

- **`/api/w/[wId]/credits/members-usage`** — New paginated endpoint returning workspace members enriched with `consumedMicroUsd`. Uses cursor-based pagination matching the core members API. Fetches per-user AWU spend from Metronome via `listMetronomeUsageWithGroups` with `group_key: ["user_id"]`, scoped to the current billing period (derived from the contract's draft invoice). Gracefully returns zeros if Metronome is not configured.
- **`MembersUsageTable`** — New table component with Name and Workspace usage columns. Usage column is sortable and formatted as `$X.XX`. Includes client-side search by name/email.
- **`UsagePage`** — Wires in the members table alongside the existing credit pool bar, with search input and invite button.
- **`useMembersUsage`** — New SWR hook in `lib/swr/memberships.ts` with cursor-based pagination (`hasNextPage` / `loadNextPage`), matching the pattern of `useMembers`.

## Testing
<img width="999" height="396" alt="Screenshot 2026-05-08 at 4 33 29 PM" src="https://github.com/user-attachments/assets/f9369082-7460-40df-9afa-930ef5609dd6" />

## Risk
Low

## Deploy Steps
* Deploy front