### PR TITLE
[front] fix biome import order in lib/credits/committed.ts

### DIFF
--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -14,8 +14,8 @@ import {
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
   MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
-  makeCreditPurchaseOneOffInvoiceForSubscription,
   makeCreditPurchaseOneOffInvoiceForCustomer,
+  makeCreditPurchaseOneOffInvoiceForSubscription,
   payInvoice,
   voidInvoiceWithReason,
 } from "@app/lib/plans/stripe";


### PR DESCRIPTION
## Description

Main has been red on \`format-check\` since #25427. Biome's organize-imports flags \`makeCreditPurchaseOneOffInvoiceFor{Subscription,Customer}\` as out of order in \`front/lib/credits/committed.ts\`. One-line auto-fix.

## Tests

Standard deploy.

## Risk

None, import-order only.

## Deploy Plan

Standard deploy.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25433">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->