### PR TITLE
Gong: withLocalRateLimitRetries for transcripts endpoints

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -4,6 +4,7 @@ import {
   HTTPError,
   isNotFoundError,
 } from "@connectors/lib/error";
+import { setTimeoutAsync } from "@connectors/lib/async_utils";
 import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import type { ModelId } from "@connectors/types";
@@ -243,6 +244,8 @@ const GongPermissionProfilesResponseCodec = t.intersection([
 // outliers.
 const RETRY_AFTER_FLOOR_SECONDS = 10;
 const RETRY_AFTER_CEILING_SECONDS = 3600;
+const GET_TRANSCRIPTS_RATE_LIMIT_MAX_LOCAL_RETRIES = 3;
+const GET_TRANSCRIPTS_MAX_LOCAL_RETRY_AFTER_SECONDS = 60;
 
 export function clampRetryAfterSeconds(
   raw: number | undefined
@@ -408,6 +411,63 @@ export class GongClient {
     return this.handleResponse(response, endpoint, codec);
   }
 
+  private async withLocalRateLimitRetries<T>({
+    operation,
+    run,
+  }: {
+    operation: string;
+    run: () => Promise<T>;
+  }): Promise<T> {
+    const maxAttempts = GET_TRANSCRIPTS_RATE_LIMIT_MAX_LOCAL_RETRIES + 1;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await run();
+      } catch (err) {
+        if (
+          !(err instanceof GongAPIError) ||
+          err.status !== 429 ||
+          attempt >= maxAttempts
+        ) {
+          throw err;
+        }
+
+        const retryAfterSeconds = clampRetryAfterSeconds(
+          err.retryAfterSeconds
+        );
+        if (
+          retryAfterSeconds === undefined ||
+          retryAfterSeconds > GET_TRANSCRIPTS_MAX_LOCAL_RETRY_AFTER_SECONDS
+        ) {
+          throw err;
+        }
+
+        logger.info(
+          {
+            attempt,
+            connectorId: this.connectorId,
+            endpoint: err.endpoint,
+            maxAttempts,
+            operation,
+            provider: "gong",
+            requestId: err.requestId,
+            retryAfterSeconds,
+          },
+          "[Gong] Rate limit hit, waiting before retrying locally."
+        );
+
+        statsDClient.increment("gong.api.local_rate_limit_retry", 1, [
+          `endpoint:${err.endpoint}`,
+          "provider:gong",
+        ]);
+
+        await setTimeoutAsync(retryAfterSeconds * 1000);
+      }
+    }
+
+    throw new Error("Unreachable: local Gong rate limit retry loop exhausted.");
+  }
+
   // https://gong.app.gong.io/settings/api/documentation#post-/v2/calls/transcript
   async getTranscripts({
     startTimestamp,
@@ -417,18 +477,22 @@ export class GongClient {
     pageCursor: string | null;
   }) {
     try {
-      const transcripts = await this.postRequest(
-        "/calls/transcript",
-        {
-          cursor: pageCursor,
-          filter: {
-            fromDateTime: startTimestamp
-              ? new Date(startTimestamp).toISOString()
-              : undefined,
-          },
-        },
-        GongPaginatedResults("callTranscripts", GongCallTranscriptCodec)
-      );
+      const transcripts = await this.withLocalRateLimitRetries({
+        operation: "getTranscripts",
+        run: async () =>
+          this.postRequest(
+            "/calls/transcript",
+            {
+              cursor: pageCursor,
+              filter: {
+                fromDateTime: startTimestamp
+                  ? new Date(startTimestamp).toISOString()
+                  : undefined,
+              },
+            },
+            GongPaginatedResults("callTranscripts", GongCallTranscriptCodec)
+          ),
+      });
       return {
         transcripts: transcripts.callTranscripts,
         nextPageCursor: transcripts.records.cursor ?? null,

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -1,10 +1,10 @@
 import { GongAPIError } from "@connectors/connectors/gong/lib/errors";
+import { setTimeoutAsync } from "@connectors/lib/async_utils";
 import {
   ExternalOAuthTokenError,
   HTTPError,
   isNotFoundError,
 } from "@connectors/lib/error";
-import { setTimeoutAsync } from "@connectors/lib/async_utils";
 import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import type { ModelId } from "@connectors/types";
@@ -432,9 +432,7 @@ export class GongClient {
           throw err;
         }
 
-        const retryAfterSeconds = clampRetryAfterSeconds(
-          err.retryAfterSeconds
-        );
+        const retryAfterSeconds = clampRetryAfterSeconds(err.retryAfterSeconds);
         if (
           retryAfterSeconds === undefined ||
           retryAfterSeconds > GET_TRANSCRIPTS_MAX_LOCAL_RETRY_AFTER_SECONDS

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -398,6 +398,14 @@ export async function gongListAndSaveUsersActivity({
   const connector = await fetchGongConnector({ connectorId });
   const configuration = await fetchGongConfiguration(connector);
 
+  const loggerArgs = {
+    connectorId: connector.id,
+    dataSourceId: connector.dataSourceId,
+    provider: "gong",
+    startTimestamp: configuration.lastSyncTimestamp,
+    workspaceId: connector.workspaceId,
+  };
+
   // Skip the full sync of users if we are not on the initial full sync.
   // The call to /users is costly (many users usually) and heavily rate-limited:
   // we have seen retry-after of ~20 minutes.
@@ -409,9 +417,11 @@ export async function gongListAndSaveUsersActivity({
 
   let pageCursor = null;
   do {
+    logger.info({ ...loggerArgs, pageCursor }, "[Gong] Fetching users page.");
     const { users, nextPageCursor } = await gongClient.getUsers({
       pageCursor,
     });
+    logger.info({ ...loggerArgs, pageCursor }, "[Gong] Success users page.");
 
     await GongUserResource.batchCreate(
       connector,


### PR DESCRIPTION
## Description

Local retry in client honouring retryAfter (clamped)

## Tests

N/A

## Risk

Low easy to revert

## Deploy Plan

- deploy `connectors`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25434">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->