### PR TITLE
Refactor stripe webhook to correctly suppport metronome-only path

### DIFF
--- a/front/lib/credits/committed.test.ts
+++ b/front/lib/credits/committed.test.ts
@@ -13,7 +13,6 @@ import {
   getCreditAmountFromInvoice,
   getCreditPurchaseCouponId,
   isCreditPurchaseInvoice,
-  isEnterpriseSubscription,
   MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
   makeCreditPurchaseOneOffInvoiceForSubscription,
   payInvoice,
@@ -25,14 +24,10 @@ import { Err, Ok } from "@app/types/shared/result";
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const MONTH_SECONDS = 30 * 24 * 60 * 60;
-const NOW = 1700000000; // Fixed timestamp for tests
-
 vi.mock("@app/lib/plans/stripe", async () => {
   const actual = await vi.importActual("@app/lib/plans/stripe");
   return {
     ...actual,
-    isEnterpriseSubscription: vi.fn(),
     isCreditPurchaseInvoice: vi.fn(),
     getCreditAmountFromInvoice: vi.fn(),
     voidInvoiceWithReason: vi.fn(),
@@ -42,21 +37,6 @@ vi.mock("@app/lib/plans/stripe", async () => {
     payInvoice: vi.fn(),
   };
 });
-
-function makeProSubscription(
-  overrides: Partial<Stripe.Subscription> = {}
-): Stripe.Subscription {
-  return {
-    id: "sub_pro",
-    current_period_start: NOW,
-    current_period_end: NOW + MONTH_SECONDS,
-    start_date: NOW - MONTH_SECONDS * 3,
-    status: "active",
-    customer: "cus_123",
-    items: { data: [], has_more: false, object: "list", url: "" },
-    ...overrides,
-  } as Stripe.Subscription;
-}
 
 function makeCreditPurchaseInvoice(
   overrides: Partial<Stripe.Invoice> = {}
@@ -85,53 +65,23 @@ describe("startCreditFromProOneOffInvoice", () => {
 
   it("should throw when invoice is not a credit purchase invoice", async () => {
     vi.mocked(isCreditPurchaseInvoice).mockReturnValue(false);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
 
     const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
 
     await expect(
-      startCreditFromProOneOffInvoice({
-        auth,
-        invoice,
-        stripeSubscription: subscription,
-      })
+      startCreditFromProOneOffInvoice({ auth, invoice })
     ).rejects.toThrow("Cannot process this invoice for credit purchase");
 
     expect(isCreditPurchaseInvoice).toHaveBeenCalledWith(invoice);
   });
 
-  it("should throw when subscription is enterprise", async () => {
-    vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
-
-    const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
-
-    await expect(
-      startCreditFromProOneOffInvoice({
-        auth,
-        invoice,
-        stripeSubscription: subscription,
-      })
-    ).rejects.toThrow("Cannot process this invoice for credit purchase");
-
-    expect(isEnterpriseSubscription).toHaveBeenCalledWith(subscription);
-  });
-
   it("should return error when credit amount metadata is invalid", async () => {
     vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
     vi.mocked(getCreditAmountFromInvoice).mockReturnValue(null);
 
     const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
 
-    const result = await startCreditFromProOneOffInvoice({
-      auth,
-      invoice,
-      stripeSubscription: subscription,
-    });
+    const result = await startCreditFromProOneOffInvoice({ auth, invoice });
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
@@ -143,17 +93,11 @@ describe("startCreditFromProOneOffInvoice", () => {
 
   it("should return error when credit not found for invoice", async () => {
     vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
     vi.mocked(getCreditAmountFromInvoice).mockReturnValue(10000);
 
     const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
 
-    const result = await startCreditFromProOneOffInvoice({
-      auth,
-      invoice,
-      stripeSubscription: subscription,
-    });
+    const result = await startCreditFromProOneOffInvoice({ auth, invoice });
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
@@ -163,11 +107,9 @@ describe("startCreditFromProOneOffInvoice", () => {
 
   it("should start credit successfully when all conditions met", async () => {
     vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
     vi.mocked(getCreditAmountFromInvoice).mockReturnValue(10000);
 
     const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
 
     await CreditResource.makeNew(auth, {
       type: "committed",
@@ -176,11 +118,7 @@ describe("startCreditFromProOneOffInvoice", () => {
       invoiceOrLineItemId: invoice.id,
     });
 
-    const result = await startCreditFromProOneOffInvoice({
-      auth,
-      invoice,
-      stripeSubscription: subscription,
-    });
+    const result = await startCreditFromProOneOffInvoice({ auth, invoice });
 
     expect(result.isOk()).toBe(true);
     const credits = await CreditResource.listAll(auth);
@@ -200,35 +138,11 @@ describe("startCreditFromEnterpriseOneOffInvoice", () => {
 
   it("should throw when invoice is not a credit purchase invoice", async () => {
     vi.mocked(isCreditPurchaseInvoice).mockReturnValue(false);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
 
     const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
 
     await expect(
-      startCreditFromEnterpriseOneOffInvoice({
-        auth,
-        invoice,
-        stripeSubscription: subscription,
-      })
-    ).rejects.toThrow(
-      "Cannot process this invoice for enterprise credit purchase"
-    );
-  });
-
-  it("should throw when subscription is not enterprise", async () => {
-    vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
-
-    const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
-
-    await expect(
-      startCreditFromEnterpriseOneOffInvoice({
-        auth,
-        invoice,
-        stripeSubscription: subscription,
-      })
+      startCreditFromEnterpriseOneOffInvoice({ auth, invoice })
     ).rejects.toThrow(
       "Cannot process this invoice for enterprise credit purchase"
     );
@@ -236,16 +150,13 @@ describe("startCreditFromEnterpriseOneOffInvoice", () => {
 
   it("should return error when credit amount metadata is invalid", async () => {
     vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
     vi.mocked(getCreditAmountFromInvoice).mockReturnValue(null);
 
     const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
 
     const result = await startCreditFromEnterpriseOneOffInvoice({
       auth,
       invoice,
-      stripeSubscription: subscription,
     });
 
     expect(result.isErr()).toBe(true);
@@ -258,16 +169,13 @@ describe("startCreditFromEnterpriseOneOffInvoice", () => {
 
   it("should return error when credit not found for invoice", async () => {
     vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
     vi.mocked(getCreditAmountFromInvoice).mockReturnValue(10000);
 
     const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
 
     const result = await startCreditFromEnterpriseOneOffInvoice({
       auth,
       invoice,
-      stripeSubscription: subscription,
     });
 
     expect(result.isErr()).toBe(true);
@@ -278,11 +186,9 @@ describe("startCreditFromEnterpriseOneOffInvoice", () => {
 
   it("should be idempotent and return alreadyStarted:true when credit was started optimistically", async () => {
     vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
     vi.mocked(getCreditAmountFromInvoice).mockReturnValue(10000);
 
     const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
 
     const credit = await CreditResource.makeNew(auth, {
       type: "committed",
@@ -299,7 +205,6 @@ describe("startCreditFromEnterpriseOneOffInvoice", () => {
     const result = await startCreditFromEnterpriseOneOffInvoice({
       auth,
       invoice,
-      stripeSubscription: subscription,
     });
 
     expect(result.isOk()).toBe(true);
@@ -312,11 +217,9 @@ describe("startCreditFromEnterpriseOneOffInvoice", () => {
 
   it("should start credit and return alreadyStarted:false when credit was not started optimistically", async () => {
     vi.mocked(isCreditPurchaseInvoice).mockReturnValue(true);
-    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
     vi.mocked(getCreditAmountFromInvoice).mockReturnValue(10000);
 
     const invoice = makeCreditPurchaseInvoice();
-    const subscription = makeProSubscription();
 
     await CreditResource.makeNew(auth, {
       type: "committed",
@@ -328,7 +231,6 @@ describe("startCreditFromEnterpriseOneOffInvoice", () => {
     const result = await startCreditFromEnterpriseOneOffInvoice({
       auth,
       invoice,
-      stripeSubscription: subscription,
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/credits/committed.ts
+++ b/front/lib/credits/committed.ts
@@ -12,7 +12,6 @@ import {
   getCreditAmountFromInvoice,
   getCreditPurchaseCouponId,
   isCreditPurchaseInvoice,
-  isEnterpriseSubscription,
   MAX_PRO_INVOICE_ATTEMPTS_BEFORE_VOIDED,
   makeCreditPurchaseOneOffInvoiceForCustomer,
   makeCreditPurchaseOneOffInvoiceForSubscription,
@@ -31,20 +30,13 @@ import type Stripe from "stripe";
 export async function startCreditFromProOneOffInvoice({
   auth,
   invoice,
-  stripeSubscription,
 }: {
   auth: Authenticator;
   invoice: Stripe.Invoice;
-  stripeSubscription: Stripe.Subscription;
 }): Promise<Result<undefined, Error>> {
-  if (
-    !isCreditPurchaseInvoice(invoice) ||
-    isEnterpriseSubscription(stripeSubscription)
-  ) {
+  if (!isCreditPurchaseInvoice(invoice)) {
     throw new Error(
-      `Cannot process this invoice for credit purchase: ${invoice.id}\n` +
-        `isCreditPurchaseInvoice: ${isCreditPurchaseInvoice(invoice)}\n` +
-        `isEntrepriseSubscription: ${isEnterpriseSubscription(stripeSubscription)}`
+      `Cannot process this invoice for credit purchase: ${invoice.id}`
     );
   }
 
@@ -145,20 +137,13 @@ export async function startCreditFromProOneOffInvoice({
 export async function startCreditFromEnterpriseOneOffInvoice({
   auth,
   invoice,
-  stripeSubscription,
 }: {
   auth: Authenticator;
   invoice: Stripe.Invoice;
-  stripeSubscription: Stripe.Subscription;
 }): Promise<Result<{ alreadyStarted: boolean }, Error>> {
-  if (
-    !isCreditPurchaseInvoice(invoice) ||
-    !isEnterpriseSubscription(stripeSubscription)
-  ) {
+  if (!isCreditPurchaseInvoice(invoice)) {
     throw new Error(
-      `Cannot process this invoice for enterprise credit purchase: ${invoice.id}\n` +
-        `isCreditPurchaseInvoice: ${isCreditPurchaseInvoice(invoice)}\n` +
-        `isEntrepriseSubscription: ${isEnterpriseSubscription(stripeSubscription)}`
+      `Cannot process this invoice for enterprise credit purchase: ${invoice.id}`
     );
   }
 
@@ -480,114 +465,6 @@ export async function createEnterpriseCreditPurchase({
   );
 
   return new Ok({ credit, invoiceOrLineItemId: invoice.id });
-}
-
-/**
- * Webhook-side credit activation for Metronome-only Pro purchases. Mirrors
- * `startCreditFromProOneOffInvoice` but doesn't take a Stripe subscription —
- * the workspace is resolved upstream from the invoice metadata.
- */
-export async function startCreditFromMetronomeOneOffInvoice({
-  auth,
-  invoice,
-}: {
-  auth: Authenticator;
-  invoice: Stripe.Invoice;
-}): Promise<Result<undefined, Error>> {
-  if (!isCreditPurchaseInvoice(invoice)) {
-    throw new Error(
-      `Cannot process this invoice for credit purchase: ${invoice.id}`
-    );
-  }
-
-  const workspace = auth.getNonNullableWorkspace();
-  const creditAmountCents = getCreditAmountFromInvoice(invoice);
-
-  if (creditAmountCents === null) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        invoiceId: invoice.id,
-        creditAmountCents: invoice.metadata?.credit_amount_cents,
-      },
-      "[Credit Purchase] Invalid credit amount in invoice metadata"
-    );
-    getStatsDClient().increment("credits.top_up.error", 1, [
-      `workspace_id:${workspace.sId}`,
-      "type:committed",
-      "customer:metronome",
-    ]);
-    return new Err(new Error("Invalid credit amount in invoice metadata"));
-  }
-
-  const credit = await CreditResource.fetchByInvoiceOrLineItemId(
-    auth,
-    invoice.id
-  );
-
-  if (!credit) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        invoiceId: invoice.id,
-      },
-      "[Credit Purchase] Credit not found for invoice"
-    );
-    getStatsDClient().increment("credits.top_up.error", 1, [
-      `workspace_id:${workspace.sId}`,
-      "type:committed",
-      "customer:metronome",
-    ]);
-    return new Err(new Error("Credit not found for invoice"));
-  }
-
-  const startResult = await credit.start(auth);
-  if (startResult.isErr()) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        creditAmountCents,
-        invoiceId: invoice.id,
-        creditId: credit.id,
-        expirationDate: credit.expirationDate,
-      },
-      "[Credit Purchase] Error starting credit"
-    );
-    getStatsDClient().increment("credits.top_up.error", 1, [
-      `workspace_id:${workspace.sId}`,
-      "type:committed",
-      "customer:metronome",
-    ]);
-    return new Err(startResult.error);
-  }
-
-  getStatsDClient().increment("credits.top_up.success", 1, [
-    `workspace_id:${workspace.sId}`,
-    "type:committed",
-    "customer:metronome",
-  ]);
-
-  const metronomeResult = await addMetronomeCommitsForWorkspace({
-    auth,
-    credit,
-    amountCredits: creditAmountCents / 100,
-    startDate: startResult.value.startDate,
-    expirationDate: startResult.value.expirationDate,
-  });
-  if (metronomeResult.isErr()) {
-    return new Err(metronomeResult.error);
-  }
-
-  logger.info(
-    {
-      workspaceId: workspace.sId,
-      creditAmountCents,
-      invoiceId: invoice.id,
-      creditId: credit.id,
-    },
-    "[Credit Purchase] Successfully activated credit for Metronome-only subscription"
-  );
-  return new Ok(undefined);
 }
 
 // Where the Stripe one-off credit-purchase invoice lives:

--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -117,22 +117,14 @@ export async function handleMetronomeSetupCheckout({
     ? await getSetupIntentDetails({ setupIntentId })
     : { paymentMethodId: null, country: null };
 
-  // Stamp workspace_id on the Stripe customer so Stripe webhooks for
-  // Metronome-pushed invoices (which carry no Stripe subscription id) can
-  // resolve the invoice back to a workspace.
-  const stripe = getStripeClient();
-  await stripe.customers.update(stripeCustomerId, {
-    metadata: { workspace_id: workspaceId },
-    ...(setupIntentDetails.paymentMethodId
-      ? {
-          invoice_settings: {
-            default_payment_method: setupIntentDetails.paymentMethodId,
-          },
-        }
-      : {}),
-  });
-
-  if (!setupIntentDetails.paymentMethodId) {
+  if (setupIntentDetails.paymentMethodId) {
+    const stripe = getStripeClient();
+    await stripe.customers.update(stripeCustomerId, {
+      invoice_settings: {
+        default_payment_method: setupIntentDetails.paymentMethodId,
+      },
+    });
+  } else {
     logger.warn(
       { sessionId, workspaceId, stripeCustomerId, setupIntentId },
       "[Metronome] No payment method on setup intent; default payment method not set. Future invoices may fail to auto-charge."

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -840,15 +840,29 @@ export type CustomerFacingInvoiceInfo = {
   purchaseOrderId?: string;
 };
 
+/**
+ * Target of an invoice: either an existing Stripe subscription (the invoice
+ * gets attached to it and inherits its currency) or a Stripe customer
+ * directly (used for Metronome-only billed workspaces with no Stripe
+ * subscription, where the currency must be passed explicitly).
+ */
+type InvoiceTarget =
+  | { kind: "subscription"; stripeSubscription: Stripe.Subscription }
+  | {
+      kind: "customer";
+      stripeCustomerId: string;
+      currency: SupportedCurrency;
+    };
+
 async function makeInvoice({
-  stripeSubscription,
+  target,
   metadata,
   lineItem,
   idempotencyKey,
   customerFacingInfo,
   ...collectionParams
 }: {
-  stripeSubscription: Stripe.Subscription;
+  target: InvoiceTarget;
   metadata: Record<string, string>;
   lineItem: InvoiceLineItem;
   idempotencyKey?: string;
@@ -860,11 +874,16 @@ async function makeInvoice({
   >
 > {
   const stripe = getStripeClient();
-  const customerId = getCustomerId(stripeSubscription);
+  const customerId =
+    target.kind === "subscription"
+      ? getCustomerId(target.stripeSubscription)
+      : target.stripeCustomerId;
 
   const invoiceParams: Stripe.InvoiceCreateParams = {
     customer: customerId,
-    subscription: stripeSubscription.id,
+    ...(target.kind === "subscription"
+      ? { subscription: target.stripeSubscription.id }
+      : { currency: target.currency }),
     collection_method: collectionParams.collectionMethod,
     metadata,
     auto_advance: true,
@@ -904,6 +923,7 @@ async function makeInvoice({
     await stripe.invoiceItems.create({
       customer: customerId,
       price: lineItem.priceId,
+      ...(target.kind === "customer" ? { currency: target.currency } : {}),
       quantity: lineItem.quantity,
       description: lineItem.description,
       invoice: invoice.id,
@@ -925,8 +945,10 @@ async function makeInvoice({
 
     logger.error(
       {
-        stripeSubscriptionId: stripeSubscription.id,
         stripeError: true,
+        ...(target.kind === "subscription"
+          ? { stripeSubscriptionId: target.stripeSubscription.id }
+          : { stripeCustomerId: target.stripeCustomerId }),
       },
       "[Stripe] Failed to create invoice"
     );
@@ -1061,7 +1083,7 @@ export async function makeCreditPurchaseOneOffInvoiceForSubscription({
   const amountDollars = amountCents / 100;
 
   return makeInvoice({
-    stripeSubscription: subscription,
+    target: { kind: "subscription", stripeSubscription: subscription },
     metadata: {
       credit_purchase: "true",
       credit_amount_cents: amountCents.toString(),
@@ -1075,89 +1097,6 @@ export async function makeCreditPurchaseOneOffInvoiceForSubscription({
     customerFacingInfo,
     ...collectionParams,
   });
-}
-
-// Variant for Metronome-only billed customers: no Stripe subscription, just a
-// Stripe customer (linked via the Metronome billing config). Issues a one-off
-// invoice directly on the customer in the requested currency.
-async function makeInvoiceForCustomer({
-  stripeCustomerId,
-  currency,
-  metadata,
-  lineItem,
-  customerFacingInfo,
-  ...collectionParams
-}: {
-  stripeCustomerId: string;
-  // Required for the customer-only path: prices are multi-currency, but with
-  // no subscription Stripe has no anchor to pick from — pass it explicitly so
-  // the issued invoice matches the contract / customer's billing currency.
-  currency: SupportedCurrency;
-  metadata: Record<string, string>;
-  lineItem: InvoiceLineItem;
-  customerFacingInfo?: CustomerFacingInvoiceInfo;
-} & InvoiceCollectionParams): Promise<
-  Result<Stripe.Invoice, { error_message: string }>
-> {
-  const stripe = getStripeClient();
-
-  const invoiceParams: Stripe.InvoiceCreateParams = {
-    customer: stripeCustomerId,
-    currency,
-    collection_method: collectionParams.collectionMethod,
-    metadata,
-    auto_advance: true,
-    automatic_tax: { enabled: true },
-    custom_fields: customerFacingInfo?.purchaseOrderId
-      ? [{ name: "Purchase Order", value: customerFacingInfo.purchaseOrderId }]
-      : undefined,
-  };
-
-  switch (collectionParams.collectionMethod) {
-    case "charge_automatically":
-      invoiceParams.payment_settings = {
-        payment_method_options: {
-          card: {
-            request_three_d_secure: (collectionParams.requestThreeDSecure ??
-              "automatic") as Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Card.RequestThreeDSecure,
-          },
-        },
-      };
-      break;
-    case "send_invoice":
-      invoiceParams.days_until_due = collectionParams.daysUntilDue;
-      break;
-    default:
-      assertNever(collectionParams);
-  }
-
-  try {
-    const invoice = await stripe.invoices.create(invoiceParams);
-
-    await stripe.invoiceItems.create({
-      customer: stripeCustomerId,
-      price: lineItem.priceId,
-      currency,
-      quantity: lineItem.quantity,
-      description: lineItem.description,
-      invoice: invoice.id,
-      ...(lineItem.couponId && { discounts: [{ coupon: lineItem.couponId }] }),
-    });
-
-    return new Ok(invoice);
-  } catch (error) {
-    logger.error(
-      {
-        stripeCustomerId,
-        stripeError: true,
-        error: normalizeError(error).message,
-      },
-      "[Stripe] Failed to create invoice for customer"
-    );
-    return new Err({
-      error_message: `Failed to create invoice: ${normalizeError(error).message}`,
-    });
-  }
 }
 
 /**
@@ -1190,9 +1129,8 @@ export async function makeCreditPurchaseOneOffInvoiceForCustomer({
   const amountCents = Math.ceil(amountMicroUsd / 10_000);
   const amountDollars = amountCents / 100;
 
-  return makeInvoiceForCustomer({
-    stripeCustomerId,
-    currency,
+  return makeInvoice({
+    target: { kind: "customer", stripeCustomerId, currency },
     metadata: {
       credit_purchase: "true",
       credit_amount_cents: amountCents.toString(),
@@ -1321,7 +1259,7 @@ export async function makeAndFinalizeCreditsPAYGInvoice({
   const amountDollars = amountCents / 100;
 
   const invoiceResult = await makeInvoice({
-    stripeSubscription,
+    target: { kind: "subscription", stripeSubscription },
     metadata: {
       credits_payg: "true",
       arrears_invoice: "true",

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -797,7 +797,7 @@ async function handler(
                 planCode,
                 stripeError: true,
               },
-              `[Stripe Webhook] Received checkout.session.completed with unkown status "${session.status}". Ignoring event.`
+              `[Stripe Webhook] Received checkout.session.completed with unknown status "${session.status}". Ignoring event.`
             );
             break;
           }
@@ -1488,7 +1488,13 @@ async function handler(
                   },
                   "Error launching scrub workspace workflow"
                 );
-                return res.status(200).json({ success: true });
+                return apiError(req, res, {
+                  status_code: 500,
+                  api_error: {
+                    type: "internal_server_error",
+                    message: `Error launching scrub workspace workflow: ${scheduleScrubRes.error.message}`,
+                  },
+                });
               }
               break;
             default:

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -11,7 +11,6 @@ import { Authenticator } from "@app/lib/auth";
 import {
   deleteCreditFromVoidedInvoice,
   startCreditFromEnterpriseOneOffInvoice,
-  startCreditFromMetronomeOneOffInvoice,
   startCreditFromProOneOffInvoice,
   voidFailedProCreditPurchaseInvoice,
 } from "@app/lib/credits/committed";
@@ -42,7 +41,6 @@ import {
   assertStripeSubscriptionIsValid,
   createCustomerPortalSession,
   getStripeClient,
-  getStripeCustomer,
   getStripeSubscription,
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
@@ -162,6 +160,280 @@ async function provisionShadowMetronome({
   }
 }
 
+// ---------------------------------------------------------------------------
+// Invoice classification & context resolution
+//
+// A Stripe invoice received on this webhook falls into one of three buckets:
+//
+//   1. Stripe-subscription invoice         — `invoice.subscription` is set.
+//      Either a regular periodic invoice or a Stripe-subscription credit
+//      purchase (distinguished by `metadata.credit_purchase`).
+//
+//   2. Metronome subscription invoice      — no `invoice.subscription`.
+//      Pushed by Metronome via direct_to_billing_provider. Workspace is
+//      resolved through `invoice.metadata.metronome_customer_id`, which
+//      Metronome stamps on every invoice it pushes.
+//
+//   3. Credit-purchase invoice (no subscription) — no `invoice.subscription`,
+//      `metadata.credit_purchase = "true"`. Workspace is stamped directly on
+//      `invoice.metadata.workspace_id` when the invoice is created.
+//
+// Each `resolve*InvoiceCtx` helper builds the context for its bucket and
+// logs/returns null on missing data so callers can stay terse.
+// ---------------------------------------------------------------------------
+
+interface SubscriptionInvoiceCtx {
+  workspace: WorkspaceResource;
+  subscription: SubscriptionResource;
+  auth: Authenticator;
+  isEnterprise: boolean;
+}
+
+function isAuthOnEnterprisePlan(auth: Authenticator): boolean {
+  const subscription = auth.subscription();
+  return (
+    subscription !== null && isEntreprisePlanPrefix(subscription.plan.code)
+  );
+}
+
+async function resolveStripeSubscriptionInvoiceCtx(
+  invoice: Stripe.Invoice
+): Promise<SubscriptionInvoiceCtx | null> {
+  if (typeof invoice.subscription !== "string") {
+    return null;
+  }
+  const subscription = await SubscriptionResource.fetchByStripeId(
+    invoice.subscription
+  );
+  if (!subscription || !subscription.stripeSubscriptionId) {
+    logger.warn(
+      { invoiceId: invoice.id, stripeSubscriptionId: invoice.subscription },
+      "[Stripe Webhook] Subscription not found."
+    );
+    return null;
+  }
+  // Determine enterprise status from the invoice's Stripe subscription when
+  // we can retrieve it (matches behavior prior to the unified ctx). Fall back
+  // to the workspace's current plan when the Stripe subscription can't be
+  // retrieved — should be very rare.
+  const stripeSubscription = await getStripeSubscription(
+    subscription.stripeSubscriptionId
+  );
+  if (!stripeSubscription) {
+    logger.error(
+      {
+        invoiceId: invoice.id,
+        stripeSubscriptionId: invoice.subscription,
+        stripeError: true,
+      },
+      "[Stripe Webhook] Stripe subscription not found."
+    );
+  }
+  const workspace = await WorkspaceResource.fetchByModelId(
+    subscription.workspaceId
+  );
+  assert(workspace !== null, "Workspace not found for subscription.");
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const isEnterprise = stripeSubscription
+    ? isEnterpriseSubscription(stripeSubscription)
+    : isAuthOnEnterprisePlan(auth);
+  return { workspace, subscription, auth, isEnterprise };
+}
+
+async function resolveMetronomeSubscriptionInvoiceCtx(
+  invoice: Stripe.Invoice
+): Promise<SubscriptionInvoiceCtx | null> {
+  // Metronome stamps `metronome_customer_id` on every invoice it pushes to
+  // Stripe. Map it back to our workspace via the persisted Metronome customer
+  // id on the workspace row.
+  const metronomeCustomerId = invoice.metadata?.metronome_customer_id;
+  if (!metronomeCustomerId) {
+    logger.error(
+      {
+        invoiceId: invoice.id,
+        customer: invoice.customer,
+        stripeError: true,
+      },
+      "[Stripe Webhook] Metronome subscription invoice missing metronome_customer_id metadata"
+    );
+    return null;
+  }
+  const workspace =
+    await WorkspaceResource.fetchByMetronomeCustomerId(metronomeCustomerId);
+  if (!workspace) {
+    logger.warn(
+      { invoiceId: invoice.id, metronomeCustomerId },
+      "[Stripe Webhook] Metronome subscription invoice: workspace not found"
+    );
+    return null;
+  }
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!subscription) {
+    return null;
+  }
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  return {
+    workspace,
+    subscription,
+    auth,
+    isEnterprise: isAuthOnEnterprisePlan(auth),
+  };
+}
+
+async function resolveCreditPurchaseInvoiceCtx(
+  invoice: Stripe.Invoice
+): Promise<SubscriptionInvoiceCtx | null> {
+  const workspaceId = invoice.metadata?.workspace_id;
+  if (!workspaceId) {
+    logger.error(
+      { invoiceId: invoice.id, customer: invoice.customer },
+      "[Stripe Webhook] Credit purchase invoice missing workspace_id metadata"
+    );
+    return null;
+  }
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    return null;
+  }
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!subscription) {
+    return null;
+  }
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  return {
+    workspace,
+    subscription,
+    auth,
+    isEnterprise: isAuthOnEnterprisePlan(auth),
+  };
+}
+
+/**
+ * Single entry point for resolving any invoice (subscription or credit
+ * purchase, Stripe-billed or Metronome-pushed) to a uniform context.
+ * Picks the right underlying resolver based on which identifiers are present
+ * on the invoice.
+ */
+async function resolveInvoiceCtx(
+  invoice: Stripe.Invoice
+): Promise<SubscriptionInvoiceCtx | null> {
+  // Stripe-subscription invoice (regular or credit-purchase).
+  if (typeof invoice.subscription === "string") {
+    return resolveStripeSubscriptionInvoiceCtx(invoice);
+  }
+  // Standalone credit-purchase invoice — workspace_id stamped on the invoice
+  // when it was created.
+  if (invoice.metadata?.workspace_id) {
+    return resolveCreditPurchaseInvoiceCtx(invoice);
+  }
+  // Metronome subscription invoice — metronome_customer_id stamped by
+  // Metronome on every invoice it pushes.
+  return resolveMetronomeSubscriptionInvoiceCtx(invoice);
+}
+
+/**
+ * Dispatch a paid credit-purchase invoice to the Pro or Enterprise activator.
+ * Used for both Stripe-subscription invoices and Metronome-pushed invoices.
+ */
+async function startCreditFromPaidInvoice({
+  invoice,
+  auth,
+  isEnterprise,
+}: {
+  invoice: Stripe.Invoice;
+  auth: Authenticator;
+  isEnterprise: boolean;
+}): Promise<void> {
+  const result = isEnterprise
+    ? await startCreditFromEnterpriseOneOffInvoice({ auth, invoice })
+    : await startCreditFromProOneOffInvoice({ auth, invoice });
+
+  if (result.isErr()) {
+    logger.error(
+      { error: result.error, invoiceId: invoice.id, isEnterprise },
+      "[Stripe Webhook] Error processing credit purchase"
+    );
+  }
+}
+
+async function voidProCreditPurchaseInvoiceOnFailure({
+  auth,
+  invoice,
+  workspaceId,
+}: {
+  auth: Authenticator;
+  invoice: Stripe.Invoice;
+  workspaceId: string;
+}): Promise<void> {
+  const result = await voidFailedProCreditPurchaseInvoice({ auth, invoice });
+  if (result.isErr()) {
+    // For eng-oncall: this is supposed to be extremely rare. Inspect the
+    // invoice in Stripe and invoice manually with the metadata put in
+    // `voidFailedProCreditPurchase`. Contact Stripe owners in case of doubt.
+    logger.error(
+      {
+        error: result.error,
+        panic: true,
+        stripeError: true,
+        invoiceId: invoice.id,
+        workspaceId,
+      },
+      "[Stripe Webhook] Error handling failed credit purchase"
+    );
+    return;
+  }
+  if (result.value.voided) {
+    logger.warn(
+      { invoiceId: invoice.id, workspaceId },
+      "[Stripe Webhook] Voided Pro credit purchase invoice after 3 failures"
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Metronome-pushed invoice force-charge (invoice.finalized)
+//
+// Metronome pushes its subscription invoices to Stripe via
+// `direct_to_billing_provider` with `charge_automatically`, but Stripe
+// occasionally finalizes them with the PaymentIntent in "incomplete" state
+// (no PM on the PI), so the auto-charge never fires. We force a charge here
+// using the customer's default PM. Stripe dunning still handles real
+// declines / SCA fallthrough.
+// ---------------------------------------------------------------------------
+
+async function forceChargeMetronomeFinalizedInvoice(
+  invoice: Stripe.Invoice
+): Promise<void> {
+  if (
+    invoice.status !== "open" ||
+    invoice.amount_due <= 0 ||
+    invoice.collection_method !== "charge_automatically" ||
+    !invoice.id
+  ) {
+    return;
+  }
+  try {
+    await getStripeClient().invoices.pay(invoice.id);
+    logger.info(
+      { invoiceId: invoice.id, customer: invoice.customer },
+      "[Stripe Webhook] Charged Metronome subscription invoice on finalize"
+    );
+  } catch (err) {
+    logger.warn(
+      {
+        error: normalizeError(err),
+        invoiceId: invoice.id,
+        customer: invoice.customer,
+      },
+      "[Stripe Webhook] Failed to charge Metronome subscription invoice on finalize; Stripe dunning will retry"
+    );
+  }
+}
+
 /**
  * Shared payment-failure handling for a workspace subscription. Skips
  * enterprise plans (paid by wire on 30-day terms), flags the subscription as
@@ -220,6 +492,229 @@ async function notifyAdminsOfPaymentFailure({
   }
 }
 
+// ---------------------------------------------------------------------------
+// checkout.session.completed handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles a completed Stripe Checkout session in `setup` mode (Metronome
+ * subscriptions). On error, stores the error alongside the session for the
+ * client-side payment-processing page to surface, then logs at the right
+ * severity based on the error code.
+ *
+ * Does not write a response — the caller acks Stripe via the trailing 200.
+ */
+async function handleMetronomeCheckoutCompleted({
+  session,
+  workspaceId,
+  planCode,
+  now,
+}: {
+  session: Stripe.Checkout.Session;
+  workspaceId: string | null;
+  planCode: string | null;
+  now: Date;
+}): Promise<void> {
+  const result = await handleMetronomeSetupCheckout({ session, now });
+  if (result.isErr()) {
+    await storeMetronomeCheckoutError({
+      sessionId: session.id,
+      message: result.error.message,
+    });
+
+    switch (result.error.code) {
+      case "subscription_already_exists":
+      case "workspace_not_found":
+        logger.warn(
+          { error: result.error, workspaceId, planCode },
+          `[Stripe Webhook] Metronome setup: ${result.error.message}`
+        );
+        break;
+      default:
+        logger.error(
+          { error: result.error, workspaceId, planCode },
+          `[Stripe Webhook] Metronome setup: ${result.error.message}`
+        );
+        break;
+    }
+  }
+}
+
+/**
+ * Handles a completed Stripe Checkout session in `subscription` mode (the
+ * legacy Stripe-billed path). Creates the local Subscription row, ends any
+ * prior active subscription, restores the workspace, and shadow-provisions a
+ * Metronome contract when the session carries a `metronomePackageAlias`.
+ *
+ * Does not write a response — the caller acks Stripe via the trailing 200.
+ */
+async function handleStripeCheckoutCompleted({
+  session,
+  workspaceId,
+  planCode,
+  stripeSubscriptionId,
+  metronomePackageAlias,
+  userId,
+  stripe,
+  now,
+}: {
+  session: Stripe.Checkout.Session;
+  workspaceId: string | null;
+  planCode: string | null;
+  stripeSubscriptionId: string | Stripe.Subscription | null;
+  metronomePackageAlias: string | null;
+  userId: string | null;
+  stripe: Stripe;
+  now: Date;
+}): Promise<void> {
+  try {
+    if (
+      workspaceId === null ||
+      planCode === null ||
+      typeof stripeSubscriptionId !== "string"
+    ) {
+      throw new Error("Missing required data in event.");
+    }
+
+    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    if (!workspace) {
+      // DD watches this warning across regions; alerts if it fires in all of
+      // them (i.e. the workspace really doesn't exist anywhere).
+      logger.warn(
+        { workspaceId, subscriptionId: stripeSubscriptionId },
+        "[Stripe Webhook] Cannot find workspace."
+      );
+      return;
+    }
+    const plan = await PlanModel.findOne({ where: { code: planCode } });
+    if (!plan) {
+      throw new Error(`Cannot subscribe to plan ${planCode}: not found.`);
+    }
+    const checkoutStripeSubscription =
+      await stripe.subscriptions.retrieve(stripeSubscriptionId);
+
+    // Conflict checks return null from the transaction so we skip the rest
+    // of the post-creation work (tracking, restore, shadow Metronome,
+    // WorkOS workflow). The conflict is already logged.
+    const newSubscription = await withTransaction(async (t) => {
+      const activeSubscription =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          workspace.id,
+          t
+        );
+
+      // Block a double subscription on the same plan.
+      if (activeSubscription && activeSubscription.planId === plan.id) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            stripeSubscriptionId,
+            planCode,
+            stripeError: true,
+          },
+          "[Stripe Webhook] Received checkout.session.completed when we already have a subscription for this plan on the workspace. Check on Stripe dashboard."
+        );
+        return null;
+      }
+
+      // Block a new subscription if the active one is already paid.
+      if (
+        activeSubscription &&
+        activeSubscription.stripeSubscriptionId !== null
+      ) {
+        logger.error(
+          {
+            workspaceId,
+            stripeSubscriptionId,
+            planCode,
+            stripeError: true,
+          },
+          "[Stripe Webhook] Received checkout.session.completed when we already have a paid subscription on the workspace. Check on Stripe dashboard."
+        );
+        return null;
+      }
+
+      if (activeSubscription) {
+        await activeSubscription.markAsEnded("ended", t);
+      }
+
+      return SubscriptionResource.makeNew(
+        {
+          sId: generateRandomModelSId(),
+          workspaceId: workspace.id,
+          planId: plan.id,
+          status: "active",
+          trialing: checkoutStripeSubscription.status === "trialing",
+          startDate: now,
+          stripeSubscriptionId,
+        },
+        renderPlanFromModel({ plan }),
+        t
+      );
+    });
+
+    if (!newSubscription) {
+      // Conflict already logged inside the transaction.
+      return;
+    }
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    if (userId) {
+      const workspaceSeats =
+        await MembershipResource.countActiveSeatsInWorkspace(workspace.sId);
+      await ServerSideTracking.trackSubscriptionCreated({
+        userId,
+        workspace: renderLightWorkspaceType({ workspace }),
+        planCode,
+        workspaceSeats,
+        subscriptionStartAt: now,
+      });
+    }
+    await restoreWorkspaceAfterSubscription(auth);
+
+    if (
+      metronomePackageAlias &&
+      isString(checkoutStripeSubscription.customer)
+    ) {
+      const currentPeriodStart = new Date(
+        checkoutStripeSubscription.current_period_start * 1000
+      );
+
+      const billingCurrency = resolveCurrencyFromStripe({
+        stripeSubscription: checkoutStripeSubscription,
+      });
+      const resolvedAlias = resolvePackageAliasForCurrency(
+        metronomePackageAlias,
+        billingCurrency
+      );
+      void provisionShadowMetronome({
+        workspace,
+        stripeCustomerId: checkoutStripeSubscription.customer,
+        metronomePackageAlias: resolvedAlias,
+        sessionId: session.id,
+        subscriptionModelId: newSubscription.id,
+        periodStart: new Date(floorToHourISO(currentPeriodStart)),
+      });
+    }
+
+    await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({ workspaceId });
+  } catch (error) {
+    // Ack to Stripe (no retry) — retrying won't fix data/logic errors. The
+    // failure is logged for follow-up.
+    logger.error(
+      {
+        error,
+        workspaceId,
+        stripeSubscriptionId,
+        planCode,
+        stripeError: true,
+      },
+      "Error creating subscription."
+    );
+  }
+}
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetResponseBody>>
@@ -270,13 +765,11 @@ async function handler(
         "Processing Stripe event."
       );
 
-      let subscription;
       let stripeSubscription;
-      let invoice;
       const now = new Date();
 
       switch (event.type) {
-        case "checkout.session.completed":
+        case "checkout.session.completed": {
           // Payment is successful and the stripe subscription is created.
           // We can create the new subscription and end the active one if any.
           const session = event.data.object as Stripe.Checkout.Session;
@@ -288,17 +781,13 @@ async function handler(
           const userId = session?.metadata?.userId || null;
 
           if (session.status === "open" || session.status === "expired") {
-            // Open: The checkout session is still in progress. Payment processing has not started.
-            // Expired: The checkout session has expired (e.g., because of lack of payment).
+            // Open: still in progress, payment processing has not started.
+            // Expired: e.g. lack of payment.
             logger.info(
-              {
-                workspaceId,
-                stripeSubscriptionId,
-                planCode,
-              },
+              { workspaceId, stripeSubscriptionId, planCode },
               `[Stripe Webhook] Received checkout.session.completed with status "${session.status}". Ignoring event.`
             );
-            return res.status(200).json({ success: true });
+            break;
           }
           if (session.status !== "complete") {
             logger.error(
@@ -310,630 +799,113 @@ async function handler(
               },
               `[Stripe Webhook] Received checkout.session.completed with unkown status "${session.status}". Ignoring event.`
             );
-            return res.status(200).json({ success: true });
+            break;
           }
 
-          // Branch on session mode: "setup" for Metronome, "subscription" for Stripe.
+          // Branch on session mode: "setup" for Metronome, "subscription"
+          // for the legacy Stripe-billed path.
           if (session.mode === "setup") {
-            const result = await handleMetronomeSetupCheckout({
+            await handleMetronomeCheckoutCompleted({
               session,
+              workspaceId,
+              planCode,
               now,
             });
-
-            if (result.isOk()) {
-              return res.status(200).json({ success: true });
-            }
-
-            await storeMetronomeCheckoutError({
-              sessionId: session.id,
-              message: result.error.message,
-            });
-
-            switch (result.error.code) {
-              case "subscription_already_exists":
-              case "workspace_not_found":
-                logger.warn(
-                  { error: result.error, workspaceId, planCode },
-                  `[Stripe Webhook] Metronome setup: ${result.error.message}`
-                );
-                break;
-
-              default:
-                logger.error(
-                  { error: result.error, workspaceId, planCode },
-                  `[Stripe Webhook] Metronome setup: ${result.error.message}`
-                );
-                break;
-            }
-
-            return res
-              .status(200)
-              .json({ success: false, message: result.error.message });
-          }
-
-          try {
-            if (
-              workspaceId === null ||
-              planCode === null ||
-              typeof stripeSubscriptionId !== "string"
-            ) {
-              throw new Error("Missing required data in event.");
-            }
-
-            const workspace = await WorkspaceResource.fetchById(workspaceId);
-            if (!workspace) {
-              logger.warn(
-                {
-                  event,
-                  workspaceId,
-                  subscriptionId: stripeSubscriptionId,
-                },
-                "[Stripe Webhook] Cannot find workspace."
-              );
-              // We return a 200 here to handle multiple regions, DD will watch
-              // the warnings and create an alert if this log appears in all regions
-              return res.status(200).json({ success: true });
-            }
-            const plan = await PlanModel.findOne({
-              where: { code: planCode },
-            });
-            if (!plan) {
-              throw new Error(
-                `Cannot subscribe to plan ${planCode}: not found.`
-              );
-            }
-            const checkoutStripeSubscription =
-              await stripe.subscriptions.retrieve(stripeSubscriptionId);
-
-            const newSubscription = await withTransaction(async (t) => {
-              const activeSubscription =
-                await SubscriptionResource.fetchActiveByWorkspaceModelId(
-                  workspace.id,
-                  t
-                );
-
-              // We block a double subscription for a workspace on the same plan
-              if (activeSubscription && activeSubscription.planId === plan.id) {
-                logger.error(
-                  {
-                    workspaceId: workspace.sId,
-                    stripeSubscriptionId,
-                    planCode,
-                    stripeError: true,
-                  },
-                  "[Stripe Webhook] Received checkout.session.completed when we already have a subscription for this plan on the workspace. Check on Stripe dashboard."
-                );
-
-                return res.status(200).json({
-                  success: false,
-                  message:
-                    "Conflict: Active subscription already exists for this workspace/plan.",
-                });
-              }
-
-              // We block a new subscription if the active one is with payment
-              if (
-                activeSubscription &&
-                activeSubscription.stripeSubscriptionId !== null
-              ) {
-                logger.error(
-                  {
-                    workspaceId,
-                    stripeSubscriptionId,
-                    planCode,
-                    stripeError: true,
-                  },
-                  "[Stripe Webhook] Received checkout.session.completed when we already have a paid subscription on the workspace. Check on Stripe dashboard."
-                );
-
-                return res.status(200).json({
-                  success: false,
-                  message:
-                    "Conflict: Active subscription with payment already exists for this workspace.",
-                });
-              }
-
-              if (activeSubscription) {
-                await activeSubscription.markAsEnded("ended", t);
-              }
-
-              return SubscriptionResource.makeNew(
-                {
-                  sId: generateRandomModelSId(),
-                  workspaceId: workspace.id,
-                  planId: plan.id,
-                  status: "active",
-                  trialing: checkoutStripeSubscription.status === "trialing",
-                  startDate: now,
-                  stripeSubscriptionId: stripeSubscriptionId,
-                },
-                renderPlanFromModel({ plan }),
-                t
-              );
-            });
-            const auth = await Authenticator.internalAdminForWorkspace(
-              workspace.sId
-            );
-
-            if (userId) {
-              const workspaceSeats =
-                await MembershipResource.countActiveSeatsInWorkspace(
-                  workspace.sId
-                );
-              await ServerSideTracking.trackSubscriptionCreated({
-                userId,
-                workspace: renderLightWorkspaceType({ workspace }),
-                planCode,
-                workspaceSeats,
-                subscriptionStartAt: now,
-              });
-            }
-            await restoreWorkspaceAfterSubscription(auth);
-
-            if (
-              metronomePackageAlias &&
-              newSubscription &&
-              isString(checkoutStripeSubscription.customer)
-            ) {
-              const currentPeriodStart = new Date(
-                checkoutStripeSubscription.current_period_start * 1000
-              );
-
-              const billingCurrency = resolveCurrencyFromStripe({
-                stripeSubscription: checkoutStripeSubscription,
-              });
-              const resolvedAlias = resolvePackageAliasForCurrency(
-                metronomePackageAlias,
-                billingCurrency
-              );
-              void provisionShadowMetronome({
-                workspace,
-                stripeCustomerId: checkoutStripeSubscription.customer,
-                metronomePackageAlias: resolvedAlias,
-                sessionId: session.id,
-                subscriptionModelId: newSubscription.id,
-                periodStart: new Date(floorToHourISO(currentPeriodStart)),
-              });
-            }
-
-            await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({
+          } else {
+            await handleStripeCheckoutCompleted({
+              session,
               workspaceId,
-            });
-
-            return res.status(200).json({ success: true });
-          } catch (error) {
-            logger.error(
-              {
-                error,
-                workspaceId,
-                stripeSubscriptionId,
-                planCode,
-                stripeError: true,
-              },
-              "Error creating subscription."
-            );
-
-            return apiError(req, res, {
-              status_code: 500,
-              api_error: {
-                type: "internal_server_error",
-                message:
-                  "Stripe Webhook: error handling checkout.session.completed.",
-              },
+              planCode,
+              stripeSubscriptionId,
+              metronomePackageAlias,
+              userId,
+              stripe,
+              now,
             });
           }
+          break;
+        }
+
         case "invoice.paid": {
-          // This is what confirms the subscription is active and payments are being made.
           logger.info(
             { event },
             "[Stripe Webhook] Received customer.invoice.paid event."
           );
           const invoice = event.data.object as Stripe.Invoice;
-          if (typeof invoice.subscription !== "string") {
-            // Metronome-only billed workspaces issue credit-purchase invoices
-            // directly on the Stripe customer (no subscription). Activate the
-            // credit now that payment has cleared. The originating workspace
-            // is stamped on `invoice.metadata.workspace_id`.
-            if (isCreditPurchaseInvoice(invoice)) {
-              const workspaceId = invoice.metadata?.workspace_id;
-              if (!workspaceId) {
-                logger.error(
-                  { invoiceId: invoice.id, customer: invoice.customer },
-                  "[Stripe Webhook] Metronome-only credit purchase invoice missing workspace_id metadata"
-                );
-                return res.status(200).json({ success: true });
-              }
-              const metronomeAuth =
-                await Authenticator.internalAdminForWorkspace(workspaceId);
-              const startResult = await startCreditFromMetronomeOneOffInvoice({
-                auth: metronomeAuth,
-                invoice,
-              });
-              if (startResult.isErr()) {
-                logger.error(
-                  {
-                    error: startResult.error,
-                    invoiceId: invoice.id,
-                    workspaceId,
-                  },
-                  "[Stripe Webhook] Error processing Metronome-only credit purchase"
-                );
-              }
-              return res.status(200).json({ success: true });
-            }
-            // Metronome subscription invoices are pushed to Stripe via
-            // direct_to_billing_provider delivery and have no Stripe
-            // subscription attached. Subscription/credit state is driven
-            // by Metronome's own credit_segment events, so we just
-            // acknowledge the payment here.
-            logger.info(
-              { invoiceId: invoice.id, customer: invoice.customer },
-              "[Stripe Webhook] Metronome subscription invoice paid"
-            );
-            return res.status(200).json({ success: true });
+          const ctx = await resolveInvoiceCtx(invoice);
+          if (!ctx) {
+            break;
           }
-          // Setting subscription payment status to succeeded.
-          const subscription = await SubscriptionResource.fetchByStripeId(
-            invoice.subscription
-          );
-
-          if (!subscription || !subscription.stripeSubscriptionId) {
-            logger.warn(
-              {
-                event,
-                stripeSubscriptionId: invoice.subscription,
-              },
-              "[Stripe Webhook] Subscription not found."
-            );
-            // We return a 200 here to handle multiple regions, DD will watch
-            // the warnings and create an alert if this log appears in all regions
-            return res.status(200).json({ success: true });
-          }
-
-          const stripeSubscription = await getStripeSubscription(
-            subscription.stripeSubscriptionId
-          );
-
-          if (!stripeSubscription) {
-            logger.warn(
-              {
-                event,
-                stripeSubscriptionId: invoice.subscription,
-              },
-              "[Stripe Webhook] Stripe subscription not found."
-            );
-            // We return a 200 here to handle multiple regions, DD will watch
-            // the warnings and create an alert if this log appears in all regions
-            return res.status(200).json({ success: true });
-          }
-
-          const isProCreditPurchaseInvoice =
-            isCreditPurchaseInvoice(invoice) &&
-            !isEnterpriseSubscription(stripeSubscription);
-
-          const isEnterpriseCreditPurchaseInvoice =
-            isCreditPurchaseInvoice(invoice) &&
-            isEnterpriseSubscription(stripeSubscription);
-
-          const workspace = await WorkspaceResource.fetchByModelId(
-            subscription.workspaceId
-          );
-          assert(workspace !== null, "Workspace not found for subscription.");
-
-          const auth = await Authenticator.internalAdminForWorkspace(
-            workspace.sId
-          );
-
-          if (isProCreditPurchaseInvoice) {
-            const creditPurchaseResult = await startCreditFromProOneOffInvoice({
-              auth,
+          if (isCreditPurchaseInvoice(invoice)) {
+            await startCreditFromPaidInvoice({
               invoice,
-              stripeSubscription,
+              auth: ctx.auth,
+              isEnterprise: ctx.isEnterprise,
             });
-
-            if (creditPurchaseResult.isErr()) {
-              logger.error(
-                {
-                  error: creditPurchaseResult.error,
-                  invoiceId: invoice.id,
-                  stripeSubscriptionId: invoice.subscription,
-                },
-                "[Stripe Webhook] Error processing credit purchase"
-              );
-            }
-          } else if (isEnterpriseCreditPurchaseInvoice) {
-            const creditPurchaseResult =
-              await startCreditFromEnterpriseOneOffInvoice({
-                auth,
-                invoice,
-                stripeSubscription,
-              });
-
-            if (creditPurchaseResult.isErr()) {
-              logger.error(
-                {
-                  error: creditPurchaseResult.error,
-                  invoiceId: invoice.id,
-                  stripeSubscriptionId: invoice.subscription,
-                },
-                "[Stripe Webhook] Error processing enterprise credit purchase"
-              );
-            }
-          } else if (!isCreditPurchaseInvoice(invoice)) {
-            await subscription.clearPaymentFailingStatus();
+          } else {
+            await ctx.subscription.clearPaymentFailingStatus();
           }
           break;
         }
 
         case "invoice.finalized": {
-          // Metronome-billed subscription invoices are pushed to Stripe via
-          // direct_to_billing_provider delivery. They sometimes finalize with
-          // the PaymentIntent in "incomplete" state (no payment method on the
-          // PI), so Stripe never auto-charges. Force a charge here using the
-          // customer's default payment method. Stripe-subscription invoices
-          // and credit-purchase invoices are charged through their own flows.
-          const finalizedInvoice = event.data.object as Stripe.Invoice;
-          if (typeof finalizedInvoice.subscription === "string") {
-            return res.status(200).json({ success: true });
+          logger.info(
+            { event },
+            "[Stripe Webhook] Received invoice.finalized event."
+          );
+
+          const invoice = event.data.object as Stripe.Invoice;
+          const isMetronomeInvoice = typeof invoice.subscription !== "string";
+          const isCreditPurchase = isCreditPurchaseInvoice(invoice);
+
+          // Only Metronome subscription invoices need the force-charge.
+          // Stripe-subscription invoices have their own auto-charge flow;
+          // credit-purchase invoices have their own flow too.
+          if (isMetronomeInvoice && !isCreditPurchase) {
+            await forceChargeMetronomeFinalizedInvoice(invoice);
           }
-          if (isCreditPurchaseInvoice(finalizedInvoice)) {
-            return res.status(200).json({ success: true });
-          }
-          if (
-            finalizedInvoice.status !== "open" ||
-            finalizedInvoice.amount_due <= 0 ||
-            finalizedInvoice.collection_method !== "charge_automatically"
-          ) {
-            return res.status(200).json({ success: true });
-          }
-          if (!finalizedInvoice.id) {
-            return res.status(200).json({ success: true });
-          }
-          try {
-            await stripe.invoices.pay(finalizedInvoice.id);
-            logger.info(
-              {
-                invoiceId: finalizedInvoice.id,
-                customer: finalizedInvoice.customer,
-              },
-              "[Stripe Webhook] Charged Metronome subscription invoice on finalize"
-            );
-          } catch (err) {
-            logger.warn(
-              {
-                error: normalizeError(err),
-                invoiceId: finalizedInvoice.id,
-                customer: finalizedInvoice.customer,
-              },
-              "[Stripe Webhook] Failed to charge Metronome subscription invoice on finalize; Stripe dunning will retry"
-            );
-          }
-          return res.status(200).json({ success: true });
+          break;
         }
 
-        case "invoice.payment_failed":
-          // Occurs when payment failed or the user does not have a valid payment method.
-          // The stripe subscription becomes "past_due".
-          // We log it on the Subscription to display a banner and email the admins.
+        case "invoice.payment_failed": {
           logger.warn(
             { event },
             "[Stripe Webhook] Received invoice.payment_failed event."
           );
-          invoice = event.data.object as Stripe.Invoice;
+          const invoice = event.data.object as Stripe.Invoice;
 
-          // If the invoice is for a subscription creation, we don't need to do anything
+          // First-invoice failures during subscription creation are handled
+          // by Stripe's own dunning retries — nothing to do.
           if (invoice.billing_reason === "subscription_create") {
-            return res.status(200).json({ success: true });
+            break;
           }
 
-          if (typeof invoice.subscription !== "string") {
-            // Metronome-only credit purchase: no subscription on the invoice.
-            // Reuse the Pro void-after-N-attempts flow — it's keyed off the
-            // invoice id, not the subscription.
-            if (isCreditPurchaseInvoice(invoice)) {
-              const workspaceId = invoice.metadata?.workspace_id;
-              if (!workspaceId) {
-                logger.error(
-                  { invoiceId: invoice.id, customer: invoice.customer },
-                  "[Stripe Webhook] Metronome-only failed credit purchase invoice missing workspace_id metadata"
-                );
-                return res.status(200).json({ success: true });
-              }
-              const metronomeAuth =
-                await Authenticator.internalAdminForWorkspace(workspaceId);
-              const result = await voidFailedProCreditPurchaseInvoice({
-                auth: metronomeAuth,
-                invoice,
-              });
-              if (result.isErr()) {
-                logger.error(
-                  {
-                    error: result.error,
-                    panic: true,
-                    stripeError: true,
-                    invoiceId: invoice.id,
-                    workspaceId,
-                  },
-                  "[Stripe Webhook] Error handling failed Metronome-only credit purchase"
-                );
-              } else if (result.value.voided) {
-                logger.warn(
-                  { invoiceId: invoice.id, workspaceId },
-                  "[Stripe Webhook] Voided Metronome-only credit purchase invoice after 3 failures"
-                );
-              }
-              return res.status(200).json({ success: true });
-            }
-            // Metronome subscription invoice failure (no Stripe subscription,
-            // not a credit purchase). Resolve workspace via the Stripe
-            // customer's `workspace_id` metadata, then mirror the Stripe
-            // subscription failure path: set payment failing status and email
-            // admins.
-            const customerId = isString(invoice.customer)
-              ? invoice.customer
-              : invoice.customer?.id;
-            if (!customerId) {
-              logger.error(
-                { invoiceId: invoice.id },
-                "[Stripe Webhook] Metronome subscription invoice missing customer"
-              );
-              return res.status(200).json({ success: true });
-            }
-            const stripeCustomer = await getStripeCustomer(customerId);
-            if (!stripeCustomer) {
-              return apiError(req, res, {
-                status_code: 500,
-                api_error: {
-                  type: "internal_server_error",
-                  message: "Failed to fetch customer from Stripe.",
-                },
-              });
-            }
-            const metronomeWorkspaceId =
-              stripeCustomer?.metadata?.workspace_id ?? null;
-            if (!metronomeWorkspaceId) {
-              logger.error(
-                {
-                  invoiceId: invoice.id,
-                  stripeCustomerId: customerId,
-                  stripeError: true,
-                },
-                "[Stripe Webhook] Metronome subscription invoice: Stripe customer missing workspace_id metadata"
-              );
-              return res.status(200).json({ success: true });
-            }
-            const metronomeWorkspace =
-              await WorkspaceResource.fetchById(metronomeWorkspaceId);
-            if (!metronomeWorkspace) {
-              logger.warn(
-                {
-                  invoiceId: invoice.id,
-                  workspaceId: metronomeWorkspaceId,
-                },
-                "[Stripe Webhook] Metronome subscription invoice: workspace not found"
-              );
-              return res.status(200).json({ success: true });
-            }
-            const metronomeSubscription =
-              await SubscriptionResource.fetchActiveByWorkspaceModelId(
-                metronomeWorkspace.id
-              );
-            if (
-              !metronomeSubscription ||
-              metronomeSubscription.status === "ended"
-            ) {
-              return res.status(200).json({ success: true });
-            }
-            const metronomeAuth = await Authenticator.internalAdminForWorkspace(
-              metronomeWorkspace.sId
-            );
-            await notifyAdminsOfPaymentFailure({
-              auth: metronomeAuth,
-              subscription: metronomeSubscription,
-              invoice,
-              now,
-            });
-            return res.status(200).json({ success: true });
+          const ctx = await resolveInvoiceCtx(invoice);
+          if (!ctx) {
+            break;
           }
-
-          // Logging that we have a failed payment
-          subscription = await SubscriptionResource.fetchByStripeId(
-            invoice.subscription
-          );
-          if (!subscription) {
-            logger.warn(
-              {
-                event,
-                stripeSubscriptionId: invoice.subscription,
-              },
-              "[Stripe Webhook] Subscription not found."
-            );
-            // We return a 200 here to handle multiple regions, DD will watch
-            // the warnings and create an alert if this log appears in all regions
-            return res.status(200).json({ success: true });
-          }
-
-          // TODO(2024-01-16 by flav) This line should be removed after all Stripe webhooks have been retried.
-          // Previously, there was an error in how we handled the cancellation of subscriptions.
-          // This change ensures that we return a success status if the subscription is already marked as "ended".
-          if (subscription.status === "ended") {
-            return res.status(200).json({ success: true });
-          }
-
-          const workspace = await WorkspaceResource.fetchByModelId(
-            subscription.workspaceId
-          );
-          assert(
-            workspace !== null,
-            "Workspace not found for subscription in invoice.payment_failed."
-          );
-
-          // Send email to admins + customer email who subscribed in Stripe
-          const auth = await Authenticator.internalAdminForWorkspace(
-            workspace.sId
-          );
-
-          // Handle Pro credit purchase invoice failures
-          stripeSubscription = await getStripeSubscription(
-            invoice.subscription
-          );
-
-          if (!stripeSubscription) {
-            logger.error(
-              {
-                event,
-                stripeError: true,
-                stripeSubscriptionId: invoice.subscription,
-              },
-              "[Stripe Webhook] Stripe Subscription not found."
-            );
-          }
-          const isProCreditPurchaseInvoice =
-            stripeSubscription &&
-            isCreditPurchaseInvoice(invoice) &&
-            !isEnterpriseSubscription(stripeSubscription);
-          // When we received a failed payment for a credit purchase (pro or enterprise),
-          // we do NOT want to set the payment failing status or send an email to the admin
-          // telling them their subscription is going to be cancelled.
-          // Credits have not been provisioned yet — for pro, we void the invoice after
-          // repeated failures; for enterprise, they are paid in arrears or with a 30-day notice.
           if (isCreditPurchaseInvoice(invoice)) {
-            if (isProCreditPurchaseInvoice) {
-              const result = await voidFailedProCreditPurchaseInvoice({
-                auth,
+            // Credits have not been provisioned yet, so we do NOT mark the
+            // subscription as payment-failing or email admins. Pro: void
+            // after repeated failures. Enterprise: paid in arrears /
+            // 30-day notice — no-op.
+            if (!ctx.isEnterprise) {
+              await voidProCreditPurchaseInvoiceOnFailure({
+                auth: ctx.auth,
                 invoice,
+                workspaceId: ctx.workspace.sId,
               });
-              if (result.isErr()) {
-                // For eng-oncall
-                // This case is supposed to be extremely rare, as there are not a lot of things that can fail
-                // during an invoice void, you will need to inspect the invoice directly in stripe to see what
-                // happened, and invoice it by hand, with the added metadata put in `voidFailedProCreditPurchase`
-                // contact Stripe owners in case of doubt
-                logger.error(
-                  {
-                    error: result.error,
-                    panic: true,
-                    stripeError: true,
-                    invoiceId: invoice.id,
-                  },
-                  "[Stripe Webhook] Error handling failed credit purchase"
-                );
-              } else if (result.value.voided) {
-                logger.warn(
-                  { invoiceId: invoice.id },
-                  "[Stripe Webhook] Voided Pro credit purchase invoice after 3 failures"
-                );
-              }
             }
           } else {
             await notifyAdminsOfPaymentFailure({
-              auth,
-              subscription,
+              auth: ctx.auth,
+              subscription: ctx.subscription,
               invoice,
               now,
             });
           }
           break;
+        }
 
         case "charge.dispute.created": {
           const dispute = event.data.object as Stripe.Dispute;
@@ -961,72 +933,37 @@ async function handler(
             break;
           }
 
-          if (!isString(disputeInvoice.subscription)) {
-            logger.error(
-              {
-                disputeId: dispute.id,
-                invoiceId: disputeInvoice.id,
-                stripeError: true,
-              },
-              "[Stripe Webhook] Credit purchase invoice has no subscription."
-            );
+          // Disputed credit purchase: freeze the credit, regardless of
+          // whether the invoice is Stripe-subscription-attached or pushed by
+          // Metronome.
+          const ctx = await resolveInvoiceCtx(disputeInvoice);
+          if (!ctx) {
             break;
           }
-
-          const disputeSubscription =
-            await SubscriptionResource.fetchByStripeId(
-              disputeInvoice.subscription
-            );
-          if (!disputeSubscription) {
-            logger.warn(
-              {
-                disputeId: dispute.id,
-                invoiceId: disputeInvoice.id,
-                stripeSubscriptionId: disputeInvoice.subscription,
-              },
-              "[Stripe Webhook] Subscription not found for disputed credit purchase."
-            );
-            break;
-          }
-
-          const workspace = await WorkspaceResource.fetchByModelId(
-            disputeSubscription.workspaceId
-          );
-          assert(
-            workspace !== null,
-            "Workspace not found for subscription in charge.dispute.created."
-          );
-
-          const disputeAuth = await Authenticator.internalAdminForWorkspace(
-            workspace.sId
-          );
-
           const credit = await CreditResource.fetchByInvoiceOrLineItemId(
-            disputeAuth,
+            ctx.auth,
             disputeInvoice.id
           );
-
           if (!credit) {
             logger.error(
               {
                 disputeId: dispute.id,
                 invoiceId: disputeInvoice.id,
-                workspaceId: workspace.sId,
+                workspaceId: ctx.workspace.sId,
                 stripeError: true,
               },
               "[Stripe Webhook] Credit not found for disputed credit purchase invoice."
             );
             break;
           }
-
-          const freezeResult = await credit.freeze(disputeAuth);
+          const freezeResult = await credit.freeze(ctx.auth);
           if (freezeResult.isErr()) {
             logger.error(
               {
                 disputeId: dispute.id,
                 invoiceId: disputeInvoice.id,
                 creditId: credit.id,
-                workspaceId: workspace.sId,
+                workspaceId: ctx.workspace.sId,
                 error: freezeResult.error,
                 stripeError: true,
               },
@@ -1038,12 +975,11 @@ async function handler(
                 disputeId: dispute.id,
                 invoiceId: disputeInvoice.id,
                 creditId: credit.id,
-                workspaceId: workspace.sId,
+                workspaceId: ctx.workspace.sId,
               },
               "[Stripe Webhook] Successfully froze credit due to payment dispute."
             );
           }
-
           break;
         }
 
@@ -1054,139 +990,39 @@ async function handler(
             break;
           }
 
-          if (!isString(voidedInvoice.subscription)) {
-            // Metronome-only credit purchase: no subscription. Resolve the
-            // workspace via the metadata stamp and route to the same delete
-            // helper used for Pro voids.
-            const workspaceId = voidedInvoice.metadata?.workspace_id;
-            if (!workspaceId) {
-              logger.warn(
-                { invoiceId: voidedInvoice.id, stripeError: true },
-                "[Stripe Webhook] Voided credit purchase invoice has no subscription and no workspace_id metadata."
-              );
-              break;
-            }
-
-            const metronomeAuth =
-              await Authenticator.internalAdminForWorkspace(workspaceId);
-            const deleteResult = await deleteCreditFromVoidedInvoice({
-              auth: metronomeAuth,
-              invoice: voidedInvoice,
-            });
-            if (deleteResult.isOk()) {
-              logger.info(
-                { invoiceId: voidedInvoice.id, workspaceId },
-                "[Stripe Webhook] Successfully deleted Metronome-only credit for voided invoice."
-              );
-              break;
-            }
-            const error = deleteResult.error;
-            if (error.type === "credit_already_started") {
-              const freezeResult = await error.credit.freeze(metronomeAuth);
-              if (freezeResult.isErr()) {
-                logger.warn(
-                  {
-                    invoiceId: voidedInvoice.id,
-                    creditId: error.credit.id,
-                    workspaceId,
-                    error: freezeResult.error.message,
-                  },
-                  "[Stripe Webhook] Failed to freeze started Metronome-only credit for voided invoice."
-                );
-              } else {
-                logger.warn(
-                  {
-                    invoiceId: voidedInvoice.id,
-                    creditId: error.credit.id,
-                    workspaceId,
-                  },
-                  "[Stripe Webhook] Froze started Metronome-only credit for voided invoice"
-                );
-              }
-            } else {
-              logger.warn(
-                { invoiceId: voidedInvoice.id, workspaceId },
-                "[Stripe Webhook] Metronome-only credit not found for voided invoice (likely already voided)."
-              );
-            }
+          const ctx = await resolveInvoiceCtx(voidedInvoice);
+          if (!ctx) {
             break;
           }
-
-          const voidedSubscription = await SubscriptionResource.fetchByStripeId(
-            voidedInvoice.subscription
-          );
-
-          if (!voidedSubscription) {
-            logger.warn(
-              {
-                invoiceId: voidedInvoice.id,
-                stripeSubscriptionId: voidedInvoice.subscription,
-              },
-              "[Stripe Webhook] Subscription not found for voided credit purchase invoice."
-            );
+          // Enterprise customers handle credit purchases differently (paid
+          // in arrears / 30-day notice) — no auto-delete on void.
+          if (ctx.isEnterprise) {
             break;
           }
-
-          const stripeSubscription = await getStripeSubscription(
-            voidedInvoice.subscription
-          );
-
-          if (!stripeSubscription) {
-            logger.error(
-              {
-                invoiceId: voidedInvoice.id,
-                stripeSubscriptionId: voidedInvoice.subscription,
-                stripeError: true,
-              },
-              "[Stripe Webhook] Stripe subscription not found for voided invoice"
-            );
-            break;
-          }
-
-          // Skip enterprise subscriptions - they handle credit purchases differently
-          if (isEnterpriseSubscription(stripeSubscription)) {
-            break;
-          }
-          const workspace = await WorkspaceResource.fetchByModelId(
-            voidedSubscription.workspaceId
-          );
-          assert(
-            workspace !== null,
-            "Workspace not found for subscription in invoice.voided."
-          );
-
-          const auth = await Authenticator.internalAdminForWorkspace(
-            workspace.sId
-          );
 
           const deleteResult = await deleteCreditFromVoidedInvoice({
-            auth,
+            auth: ctx.auth,
             invoice: voidedInvoice,
           });
-
           if (deleteResult.isOk()) {
             logger.info(
-              {
-                invoiceId: voidedInvoice.id,
-                workspaceId: workspace.sId,
-              },
+              { invoiceId: voidedInvoice.id, workspaceId: ctx.workspace.sId },
               "[Stripe Webhook] Successfully deleted credit for voided credit purchase invoice."
             );
             break;
           }
 
           const error = deleteResult.error;
-
           switch (error.type) {
             case "credit_already_started": {
               // Unexpected: credit was started but invoice was voided. Freeze it.
-              const freezeResult = await error.credit.freeze(auth);
+              const freezeResult = await error.credit.freeze(ctx.auth);
               if (freezeResult.isErr()) {
                 logger.warn(
                   {
                     invoiceId: voidedInvoice.id,
                     creditId: error.credit.id,
-                    workspaceId: workspace.sId,
+                    workspaceId: ctx.workspace.sId,
                     error: freezeResult.error.message,
                   },
                   "[Stripe Webhook] Failed to freeze started credit for voided invoice. Possible race condition."
@@ -1196,7 +1032,7 @@ async function handler(
                   {
                     invoiceId: voidedInvoice.id,
                     creditId: error.credit.id,
-                    workspaceId: workspace.sId,
+                    workspaceId: ctx.workspace.sId,
                   },
                   "[Stripe Webhook] Froze started credit for voided invoice"
                 );
@@ -1204,12 +1040,11 @@ async function handler(
               break;
             }
             case "credit_not_found":
-              // Possible race condition with voidFailedProCreditPurchaseInvoice
-              // no-op
+              // Possible race with voidFailedProCreditPurchaseInvoice — no-op.
               logger.warn(
                 {
                   invoiceId: voidedInvoice.id,
-                  workspaceId: workspace.sId,
+                  workspaceId: ctx.workspace.sId,
                   error: error.type,
                 },
                 "[Stripe Webhook] Failed to delete credit for voided invoice, credit_not_found. Possible race condition."
@@ -1218,7 +1053,6 @@ async function handler(
             default:
               assertNever(error);
           }
-
           break;
         }
 
@@ -1580,13 +1414,16 @@ async function handler(
           stripeSubscription = event.data.object as Stripe.Subscription;
 
           if (stripeSubscription.status !== "canceled") {
-            return apiError(req, res, {
-              status_code: 500,
-              api_error: {
-                type: "internal_server_error",
-                message: `[Stripe Webhook] Received customer.subscription.deleted with unknown status = ${stripeSubscription.status}. Expected status = canceled.`,
+            logger.error(
+              {
+                event,
+                stripeSubscriptionId: stripeSubscription.id,
+                status: stripeSubscription.status,
+                stripeError: true,
               },
-            });
+              `[Stripe Webhook] Received customer.subscription.deleted with unknown status = ${stripeSubscription.status}. Expected status = canceled.`
+            );
+            return res.status(200).json({ success: true });
           }
 
           const matchingSubscription =
@@ -1651,13 +1488,7 @@ async function handler(
                   },
                   "Error launching scrub workspace workflow"
                 );
-                return apiError(req, res, {
-                  status_code: 500,
-                  api_error: {
-                    type: "internal_server_error",
-                    message: `Error launching scrub workspace workflow: ${scheduleScrubRes.error.message}`,
-                  },
-                });
+                return res.status(200).json({ success: true });
               }
               break;
             default:
@@ -1716,21 +1547,6 @@ async function handler(
         },
       });
   }
-}
-
-function _returnStripeApiError(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetResponseBody>>,
-  event: string,
-  message: string
-) {
-  return apiError(req, res, {
-    status_code: 500,
-    api_error: {
-      type: "internal_server_error",
-      message: `[Stripe Webhook][${event}] ${message}`,
-    },
-  });
 }
 
 export default withLogging(handler);


### PR DESCRIPTION
## Description

Stacked on #25429.

Refactors the Stripe webhook so the Metronome-only billing path is treated as a first-class citizen, sharing the same handlers and credit-activation flow as the Stripe-subscription path. No new functionality — pure structure cleanup that follows from #25429.

**Webhook (`front/pages/api/stripe/webhook.ts`):**
- Introduced a single `resolveInvoiceCtx(invoice)` entry point that classifies any incoming invoice into one of three buckets and returns a uniform `SubscriptionInvoiceCtx { workspace, subscription, auth, isEnterprise }`:
  1. Stripe-subscription invoice — resolved via `invoice.subscription`.
  2. Metronome subscription invoice — resolved via `invoice.metadata.metronome_customer_id` (which Metronome stamps on every invoice it pushes; replaces the previous workspace-id stamp on the Stripe customer).
  3. Standalone credit-purchase invoice — resolved via `invoice.metadata.workspace_id`.
- `invoice.paid`, `invoice.payment_failed`, `invoice.voided`, and `charge.dispute.created` are collapsed into terse handlers that share the same context-resolution + dispatch.
- Pro vs Enterprise dispatch is centralised behind a single `isEnterprise` flag on the ctx (computed from the invoice's Stripe subscription when available, else from the workspace's plan code).
- Extracted `notifyAdminsOfPaymentFailure`, `forceChargeMetronomeFinalizedInvoice`, `voidProCreditPurchaseInvoiceOnFailure`, and `startCreditFromPaidInvoice` helpers to keep each case body small.

**Credits (`front/lib/credits/committed.ts`):**
- Removed `startCreditFromMetronomeOneOffInvoice` — its body is now subsumed by `startCreditFromProOneOffInvoice` / `startCreditFromEnterpriseOneOffInvoice` (the `addMetronomeCommitsForWorkspace` call is a no-op when the workspace has no Metronome customer, so the same code path handles both billing sources).
- Dropped the now-unused `stripeSubscription` parameter from both Pro and Enterprise activators (the enterprise check moved to the dispatcher).
- Tests updated accordingly.

**Stripe wrapper (`front/lib/plans/stripe.ts`):**
- Merged `makeInvoiceForCustomer` into `makeInvoice` via a discriminated `target` parameter:
  ```ts
  target:
    | { kind: "subscription"; stripeSubscription: Stripe.Subscription }
    | { kind: "customer"; stripeCustomerId: string; currency: SupportedCurrency }
  ```
  Customer target sets `currency` on both the invoice and the line item (required for multi-currency prices when there's no subscription anchor).

**Checkout (`front/lib/metronome/checkout.ts`):**
- No longer stamps `workspace_id` on the Stripe customer metadata (now relying on Metronome's `metronome_customer_id` on each invoice for resolution).

## Tests

- Existing `committed.test.ts` tests updated to drop the now-removed `stripeSubscription` parameter and the obsolete enterprise-validation tests.
- Manual smoke test of the Stripe webhook on the billing hive against a Metronome-billed workspace (paid, finalized, payment_failed events all hit the unified flow).
- `npx tsgo --noEmit` and Biome lint clean.

## Risk

- Low. Pure refactor — no functional changes other than two intentional consequences:
  1. Paid Metronome subscription invoices now also call `clearPaymentFailingStatus` (symmetric to the failure path that already calls `setPaymentFailingStatus` for Metronome).
  2. Voided enterprise standalone credit purchases are now skipped (matching the pre-existing Stripe-subscription behaviour).
- Easy to roll back independently of #25429.

## Deploy Plan

1. Merge #25429 first.
2. Merge this PR.
3. Smoke-test a Metronome subscription paid + a credit purchase on a test workspace; confirm credits activate and webhook logs show the unified handler.