### PR TITLE
[connectors] enh(Gong): batch API calls to fetch users

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -467,6 +467,42 @@ export class GongClient {
     }
   }
 
+  // https://gong.app.gong.io/settings/api/documentation#post-/v2/users/extensive
+  async getUsersByIds({
+    userIds,
+    pageCursor = null,
+  }: {
+    userIds: string[];
+    pageCursor?: string | null;
+  }) {
+    try {
+      const users = await this.postRequest(
+        "/users/extensive",
+        {
+          cursor: pageCursor,
+          filter: {
+            userIds,
+          },
+        },
+        GongPaginatedResults("users", GongUserCodec)
+      );
+
+      return {
+        users: users.users,
+        nextPageCursor: users.records.cursor ?? null,
+      };
+    } catch (err) {
+      if (isNotFoundError(err)) {
+        return {
+          users: [],
+          nextPageCursor: null,
+        };
+      }
+
+      throw err;
+    }
+  }
+
   async getUser({ userId }: { userId: string }) {
     try {
       return await this.getRequest(`/users/${userId}`, {}, GongUserCodec);

--- a/connectors/src/connectors/gong/lib/users.ts
+++ b/connectors/src/connectors/gong/lib/users.ts
@@ -3,9 +3,7 @@ import { getGongClient } from "@connectors/connectors/gong/lib/utils";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { GongUserBlob } from "@connectors/resources/gong_resources";
 import { GongUserResource } from "@connectors/resources/gong_resources";
-import { concurrentExecutor } from "@connectors/types";
-// biome-ignore lint/plugin/noBulkLodash: existing usage
-import { difference } from "lodash";
+import { removeNulls } from "@connectors/types/shared/utils/general";
 
 export function getUserBlobFromGongAPI(user: GongAPIUser): GongUserBlob | null {
   if (!user.emailAddress || !user.id) {
@@ -30,34 +28,37 @@ export async function getGongUsers(
   });
 
   // Find requested users that are missing from our local database.
-  const missingUsers = difference(
-    gongUserIds,
-    users.map((user) => user.gongId)
+  const existingUserIds = new Set(users.map((user) => user.gongId));
+  const missingUserIds = gongUserIds.filter(
+    (gongUserId) => !existingUserIds.has(gongUserId)
   );
 
-  if (missingUsers.length === 0) {
+  if (missingUserIds.length === 0) {
     return users;
   }
 
   const gongClient = await getGongClient(connector);
 
-  await concurrentExecutor(
-    missingUsers,
-    async (gongUserId) => {
-      // If the user does not exist yet, fetch it from the API and save it.
-      const user = await gongClient.getUser({ userId: gongUserId });
-      if (!user) {
-        return null;
-      }
+  const gongApiUsers: GongAPIUser[] = [];
+  let pageCursor: string | null = null;
 
-      const userBlob = getUserBlobFromGongAPI(user);
-      if (userBlob) {
-        const newUser = await GongUserResource.makeNew(connector, userBlob);
-        users.push(newUser);
-      }
-    },
-    { concurrency: 10 }
-  );
+  do {
+    const { users: fetchedUsers, nextPageCursor } =
+      await gongClient.getUsersByIds({
+        userIds: missingUserIds,
+        pageCursor,
+      });
 
-  return users;
+    gongApiUsers.push(...fetchedUsers);
+    pageCursor = nextPageCursor;
+  } while (pageCursor);
+
+  const userBlobs = removeNulls(gongApiUsers.map(getUserBlobFromGongAPI));
+  if (userBlobs.length === 0) {
+    return users;
+  }
+
+  const newUsers = await GongUserResource.batchCreate(connector, userBlobs);
+
+  return [...users, ...newUsers];
 }

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -307,40 +307,14 @@ export async function gongSyncTranscriptsActivity({
   );
 
   const callsMetadataToSync = removeNulls(
-    transcriptsToSync.map((transcript) =>
-      callsMetadataMap.get(transcript.callId)
-    )
-  ).filter(
-    (metadata) =>
-      shouldSyncTranscript(metadata, permissionFilter, configuration).shouldSync
-  );
-
-  const participants = await getGongUsers(connector, {
-    gongUserIds: [
-      ...new Set(
-        callsMetadataToSync.flatMap(({ parties = [] }) =>
-          removeNulls(parties.map((p) => p.userId))
-        )
-      ),
-    ],
-  });
-  const participantsByGongId = new Map(
-    participants.map((participant) => [participant.gongId, participant])
-  );
-
-  await heartbeat();
-
-  await concurrentExecutor(
-    transcriptsToSync,
-    async (transcript) => {
-      await heartbeat();
+    transcriptsToSync.map((transcript) => {
       const transcriptMetadata = callsMetadataMap.get(transcript.callId);
       if (!transcriptMetadata) {
         logger.warn(
           { ...loggerArgs, callId: transcript.callId },
           "[Gong] Transcript metadata not found."
         );
-        return;
+        return null;
       }
 
       const { shouldSync, reason } = shouldSyncTranscript(
@@ -353,8 +327,32 @@ export async function gongSyncTranscriptsActivity({
           { ...loggerArgs, callId: transcript.callId, reason },
           `[Gong] Skipping transcript.`
         );
-        return;
+        return null;
       }
+
+      return { transcript, transcriptMetadata };
+    })
+  );
+
+  const participants = await getGongUsers(connector, {
+    gongUserIds: [
+      ...new Set(
+        callsMetadataToSync.flatMap(({ transcriptMetadata }) =>
+          removeNulls(transcriptMetadata.parties?.map((p) => p.userId) ?? [])
+        )
+      ),
+    ],
+  });
+  const participantsByGongId = new Map(
+    participants.map((participant) => [participant.gongId, participant])
+  );
+
+  await heartbeat();
+
+  await concurrentExecutor(
+    callsMetadataToSync,
+    async ({ transcript, transcriptMetadata }) => {
+      await heartbeat();
 
       const { parties = [] } = transcriptMetadata;
 

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -306,6 +306,24 @@ export async function gongSyncTranscriptsActivity({
     configuration
   );
 
+  const callsMetadataToSync = removeNulls(
+    transcriptsToSync.map((transcript) =>
+      callsMetadataMap.get(transcript.callId)
+    )
+  ).filter(
+    (metadata) =>
+      shouldSyncTranscript(metadata, permissionFilter, configuration).shouldSync
+  );
+
+  const participants = await getGongUsers(connector, {
+    gongUserIds: callsMetadataToSync.flatMap(({ parties = [] }) =>
+      removeNulls(parties.map((p) => p.userId))
+    ),
+  });
+  const participantsByGongId = new Map(
+    participants.map((participant) => [participant.gongId, participant])
+  );
+
   await heartbeat();
 
   await concurrentExecutor(
@@ -336,17 +354,12 @@ export async function gongSyncTranscriptsActivity({
 
       const { parties = [] } = transcriptMetadata;
 
-      const participants = await getGongUsers(connector, {
-        gongUserIds: parties
-          .map((p) => p.userId)
-          .filter((id): id is string => Boolean(id)),
-      });
-
       const participantEmails = parties
         .map(
           (party) =>
-            participants.find((p) => party.userId === p.gongId)?.email ||
-            party.emailAddress
+            (party.userId
+              ? participantsByGongId.get(party.userId)?.email
+              : null) ?? party.emailAddress
         )
         .filter((email): email is string => Boolean(email));
 
@@ -354,9 +367,9 @@ export async function gongSyncTranscriptsActivity({
         parties.map((party) => [
           party.speakerId,
           // Prefer gong_users table, fallback to metadata email
-          participants.find(
-            (participant) => participant.gongId === party.userId
-          )?.email || party.emailAddress,
+          (party.userId
+            ? participantsByGongId.get(party.userId)?.email
+            : null) ?? party.emailAddress,
         ])
       );
 

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -316,9 +316,13 @@ export async function gongSyncTranscriptsActivity({
   );
 
   const participants = await getGongUsers(connector, {
-    gongUserIds: [...new Set(callsMetadataToSync.flatMap(({ parties = [] }) =>
-      removeNulls(parties.map((p) => p.userId))
-    ))],
+    gongUserIds: [
+      ...new Set(
+        callsMetadataToSync.flatMap(({ parties = [] }) =>
+          removeNulls(parties.map((p) => p.userId))
+        )
+      ),
+    ],
   });
   const participantsByGongId = new Map(
     participants.map((participant) => [participant.gongId, participant])

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -316,9 +316,9 @@ export async function gongSyncTranscriptsActivity({
   );
 
   const participants = await getGongUsers(connector, {
-    gongUserIds: callsMetadataToSync.flatMap(({ parties = [] }) =>
+    gongUserIds: [...new Set(callsMetadataToSync.flatMap(({ parties = [] }) =>
       removeNulls(parties.map((p) => p.userId))
-    ),
+    ))],
   });
   const participantsByGongId = new Map(
     participants.map((participant) => [participant.gongId, participant])


### PR DESCRIPTION
## Description

- We are seeing an increasing number of rate limit hits across several Gong connectors, specifically on the `/users/:uId` endpoint
- We fetch the users in two places: on the initial full sync (all users) and when syncing transcripts (only the call's participants)
- This PR changes the 2nd location to fetch all the users in batch instead of 1 by 1, using the new `/users/extensive` endpoint: https://gong.app.gong.io/settings/api/documentation#post-/v2/users/extensive
- Potential next steps if the issue persists: 1. lower concurrency across the board 2. add a separate schedule to sync users based on this endpoint (it does support a timestamp cursor)

## Tests

- Tested locally.

## Risk

- Low. Can be safely rolled back.

## Deploy Plan

- Deploy connectors.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25436">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->