### PR TITLE
[dust-hive] enh: add shared dust-hive shell shorthands

### DIFF
--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -190,6 +190,22 @@ dust-hive down
 
 **Aliases**: Most commands have short aliases (e.g., `s` for spawn, `o` for open, `w` for warm). Run `dust-hive --help` to see all aliases.
 
+When you source the shell completion script, it also defines shorthand commands:
+
+| Shorthand | Equivalent |
+|-----------|------------|
+| `dh` | `dust-hive` |
+| `dhs` | `dust-hive spawn -C -c "claude --dangerously-skip-permissions"` |
+| `dho` | `dust-hive open -C` |
+| `dhl` | `dust-hive list` |
+| `dhd` | `dust-hive destroy` |
+| `dhw` | `dust-hive warm` |
+| `dhc` | `dust-hive cool` |
+| `dhx` | `dust-hive spawn -C -c "codex"` |
+| `dhb <query>` | Open the matched environment app URL in your browser |
+| `dhdb <query> [database]` | Open `psql` on the matched environment database |
+| `dhcd` | Change directory into the environment worktree |
+
 > **Tip**: When `NAME` is omitted, you'll get an interactive picker to select an environment.
 > It pre-selects the current environment (if you're in a worktree) or the last one you used.
 

--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -16,6 +16,9 @@
 #   dhd   - destroy
 #   dhw   - warm
 #   dhc   - cool
+#   dhx   - spawn -C -c "codex"
+#   dhb   - open app URL in browser
+#   dhdb  - open psql on environment database
 #   dhcd  - cd into environment worktree (changes dir in current shell)
 
 _dust_hive_services=(sdk sparkle front core oauth connectors front-workers front-spa-poke front-spa-app viz)
@@ -290,6 +293,75 @@ dhl() { command dust-hive list "$@"; }
 dhd() { command dust-hive destroy "$@"; }
 dhw() { command dust-hive warm "$@"; }
 dhc() { command dust-hive cool "$@"; }
+dhx() { command dust-hive spawn -C -c "codex" "$@"; }
+
+_dust_hive_matching_row() {
+  local query="${1:?usage: _dust_hive_matching_row <worktree-name-query>}"
+
+  command dust-hive list | awk '
+    /^[[:space:]]*$/ { next }
+    /^NAME[[:space:]]/ { next }
+    /^-+/ { next }
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^[0-9]+-[0-9]+$/) {
+          print $1 "\t" $i "\t" $0
+          next
+        }
+      }
+    }
+  ' | fzf --filter="$query" --delimiter=$'\t' --nth=1,3 | head -n 1
+}
+
+_dust_hive_base_port() {
+  local query="${1:?usage: _dust_hive_base_port <worktree-name-query>}"
+  local row range
+
+  row="$(_dust_hive_matching_row "$query")"
+
+  if [[ -z "$row" ]]; then
+    echo "No matching dust-hive worktree for: $query" >&2
+    return 1
+  fi
+
+  range="$(printf '%s\n' "$row" | cut -f2)"
+  printf '%s\n' "${range%%-*}"
+}
+
+dhb() {
+  local query="${1:?usage: dhb <worktree-name-query>}"
+  local offset="${DHB_PORT_OFFSET:-11}"
+  local base port url
+
+  base="$(_dust_hive_base_port "$query")" || return
+  port=$((base + offset))
+  url="http://localhost:${port}"
+
+  echo "Opening $url"
+  open "$url"
+}
+
+dhdb() {
+  local query="${1:?usage: dhdb <worktree-name-query> [dust_front|dust_connectors|dust_api|dust_oauth]}"
+  local db="${2:-dust_front}"
+  local offset="${DHDB_PORT_OFFSET:-432}"
+  local base port
+
+  case "$db" in
+    dust_front|dust_connectors|dust_api|dust_oauth) ;;
+    *)
+      echo "Invalid database: $db" >&2
+      echo "usage: dhdb <worktree-name-query> [dust_front|dust_connectors|dust_api|dust_oauth]" >&2
+      return 2
+      ;;
+  esac
+
+  base="$(_dust_hive_base_port "$query")" || return
+  port=$((base + offset))
+
+  echo "Connecting to $db on localhost:$port"
+  command psql "postgres://dev:dev@localhost:${port}/${db}"
+}
 
 # dhcd: cd into an environment's worktree in the current shell
 dhcd() {
@@ -314,6 +386,19 @@ _dhl()  { :; }
 _dhd()  { local COMP_WORDS=("dust-hive" "destroy" "${COMP_WORDS[@]:1}"); local COMP_CWORD=$(( COMP_CWORD + 1 )); _dust_hive_complete; }
 _dhw()  { local COMP_WORDS=("dust-hive" "warm" "${COMP_WORDS[@]:1}"); local COMP_CWORD=$(( COMP_CWORD + 1 )); _dust_hive_complete; }
 _dhc()  { local COMP_WORDS=("dust-hive" "cool" "${COMP_WORDS[@]:1}"); local COMP_CWORD=$(( COMP_CWORD + 1 )); _dust_hive_complete; }
+_dhx()  { local COMP_WORDS=("dust-hive" "spawn" "${COMP_WORDS[@]:1}"); local COMP_CWORD=$(( COMP_CWORD + 1 )); _dust_hive_complete; }
+_dhb() {
+  if (( COMP_CWORD == 1 )); then
+    COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "${COMP_WORDS[COMP_CWORD]}"))
+  fi
+}
+_dhdb() {
+  if (( COMP_CWORD == 1 )); then
+    COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "${COMP_WORDS[COMP_CWORD]}"))
+  elif (( COMP_CWORD == 2 )); then
+    COMPREPLY=($(compgen -W "dust_front dust_connectors dust_api dust_oauth" -- "${COMP_WORDS[COMP_CWORD]}"))
+  fi
+}
 _dhcd() { local COMP_WORDS=("dust-hive" "cd" "${COMP_WORDS[@]:1}"); local COMP_CWORD=$(( COMP_CWORD + 1 )); _dust_hive_complete; }
 
 complete -F _dhs  dhs
@@ -322,4 +407,7 @@ complete -F _dhl  dhl
 complete -F _dhd  dhd
 complete -F _dhw  dhw
 complete -F _dhc  dhc
+complete -F _dhx  dhx
+complete -F _dhb  dhb
+complete -F _dhdb dhdb
 complete -F _dhcd dhcd

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -18,6 +18,9 @@
 #   dhd   - destroy
 #   dhw   - warm
 #   dhc   - cool
+#   dhx   - spawn -C -c "codex"
+#   dhb   - open app URL in browser
+#   dhdb  - open psql on environment database
 #   dhcd  - cd into environment worktree (changes dir in current shell)
 
 _dust_hive_services=(
@@ -269,13 +272,82 @@ _dust-hive() {
 alias dh=dust-hive
 
 # Shorthand aliases (use `function` keyword to avoid zsh alias expansion on the name)
-unalias dhs dho dhl dhd dhw dhc dhcd 2>/dev/null
+unalias dhs dho dhl dhd dhw dhc dhx dhb dhdb dhcd 2>/dev/null
 function dhs  { command dust-hive spawn -C -c "claude --dangerously-skip-permissions" "$@"; }
 function dho  { command dust-hive open -C "$@"; }
 function dhl  { command dust-hive list "$@"; }
 function dhd  { command dust-hive destroy "$@"; }
 function dhw  { command dust-hive warm "$@"; }
 function dhc  { command dust-hive cool "$@"; }
+function dhx  { command dust-hive spawn -C -c "codex" "$@"; }
+
+function _dust_hive_matching_row {
+  local query="${1:?usage: _dust_hive_matching_row <worktree-name-query>}"
+
+  command dust-hive list | awk '
+    /^[[:space:]]*$/ { next }
+    /^NAME[[:space:]]/ { next }
+    /^-+/ { next }
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^[0-9]+-[0-9]+$/) {
+          print $1 "\t" $i "\t" $0
+          next
+        }
+      }
+    }
+  ' | fzf --filter="$query" --delimiter=$'\t' --nth=1,3 | head -n 1
+}
+
+function _dust_hive_base_port {
+  local query="${1:?usage: _dust_hive_base_port <worktree-name-query>}"
+  local row range
+
+  row="$(_dust_hive_matching_row "$query")"
+
+  if [[ -z "$row" ]]; then
+    echo "No matching dust-hive worktree for: $query" >&2
+    return 1
+  fi
+
+  range="$(printf '%s\n' "$row" | cut -f2)"
+  printf '%s\n' "${range%%-*}"
+}
+
+function dhb {
+  local query="${1:?usage: dhb <worktree-name-query>}"
+  local offset="${DHB_PORT_OFFSET:-11}"
+  local base port url
+
+  base="$(_dust_hive_base_port "$query")" || return
+  port=$((base + offset))
+  url="http://localhost:${port}"
+
+  echo "Opening $url"
+  open "$url"
+}
+
+function dhdb {
+  local query="${1:?usage: dhdb <worktree-name-query> [dust_front|dust_connectors|dust_api|dust_oauth]}"
+  local db="${2:-dust_front}"
+  local offset="${DHDB_PORT_OFFSET:-432}"
+  local base port
+
+  case "$db" in
+    dust_front|dust_connectors|dust_api|dust_oauth) ;;
+    *)
+      echo "Invalid database: $db" >&2
+      echo "usage: dhdb <worktree-name-query> [dust_front|dust_connectors|dust_api|dust_oauth]" >&2
+      return 2
+      ;;
+  esac
+
+  base="$(_dust_hive_base_port "$query")" || return
+  port=$((base + offset))
+
+  echo "Connecting to $db on localhost:$port"
+  command psql "postgres://dev:dev@localhost:${port}/${db}"
+}
 
 # dhcd: cd into an environment's worktree in the current shell
 function dhcd {
@@ -300,6 +372,23 @@ function _dhl  { :; }
 function _dhd  { local words=("dust-hive" "destroy" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
 function _dhw  { local words=("dust-hive" "warm" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
 function _dhc  { local words=("dust-hive" "cool" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
+function _dhx  { local words=("dust-hive" "spawn" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
+function _dhb  { _arguments '1::worktree:_dust_hive_envs'; }
+function _dhdb_database {
+  local -a dbs=(
+    'dust_front:Front database'
+    'dust_connectors:Connectors database'
+    'dust_api:API database'
+    'dust_oauth:OAuth database'
+  )
+
+  _describe 'database' dbs
+}
+function _dhdb {
+  _arguments \
+    '1::worktree:_dust_hive_envs' \
+    '2::database:_dhdb_database'
+}
 function _dhcd { local words=("dust-hive" "cd" "${(@)words[2,-1]}"); local CURRENT=$((CURRENT+1)); _dust-hive; }
 
 # When loaded via fpath, zsh calls the file as a function — invoke the completer.
@@ -314,5 +403,8 @@ else
   compdef _dhd dhd
   compdef _dhw dhw
   compdef _dhc dhc
+  compdef _dhx dhx
+  compdef _dhb dhb
+  compdef _dhdb dhdb
   compdef _dhcd dhcd
 fi


### PR DESCRIPTION
## Description

- Adds shared shell shorthands for common dust-hive workflows when sourcing the bash or zsh completion scripts.
- Adds `dhx` for spawning a compact Codex hive, plus `dhb` and `dhdb` helpers that resolve an environment from dust-hive list and derive the relevant app or Postgres port.
- Documents the available dh* shorthands in the dust-hive README.
- This only changes shell completion/helper scripts and documentation; it does not add new dust-hive CLI commands.

## Tests

- Tested manually in bash and zsh with stubbed dust-hive, open, and psql.

## Risk

- N/A

## Deploy Plan

- No deploy.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25437">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->