### PR TITLE
fix(skills): delete conversation/agent-message skill rows before skill configs in workspace scrub

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2645,6 +2645,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where: { workspaceId },
     });
 
+    await AgentMessageSkillModel.destroy({
+      where: { workspaceId },
+    });
+
+    await ConversationSkillModel.destroy({
+      where: { workspaceId },
+    });
+
     await SkillConfigurationModel.destroy({
       where: { workspaceId },
     });


### PR DESCRIPTION
## Description

Fixes a `ForeignKeyConstraintError` that occurs during `scrubWorkspaceData` when deleting `skill_configurations` rows while `agent_message_skills` (or `conversation_skills`) rows still reference them via `customSkillId` (FK constraint with `onDelete: "RESTRICT"`).

`SkillResource.deleteAllForWorkspace` was deleting `skill_configurations` without first clearing the `agent_message_skills` and `conversation_skills` tables that have a RESTRICT foreign key on `customSkillId`. While `destroyConversation` normally removes these rows as part of conversation cleanup, any edge case (e.g., orphaned rows) would break the scrub workflow.

Fix: add explicit `AgentMessageSkillModel` and `ConversationSkillModel` destruction by `workspaceId` in `deleteAllForWorkspace`, immediately before `SkillConfigurationModel` destruction.

To fix [this](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E15&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ4V8YOZv1avMgAAABhBWjRWOFlmcEFBQ05rekVUVkdzSDNnQ20AAAAkMDE5ZTE1ZjEtZWZmOS00YTYxLWE1M2EtYjkxYjlkYjRjYTQ4AAN92g&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1778481050626&to_ts=1778484650626&live=true)
