### PR TITLE
Refactor the MCP handler to remove bus logic for API

### DIFF
--- a/front/lib/api/mcp/servers.ts
+++ b/front/lib/api/mcp/servers.ts
@@ -1,0 +1,388 @@
+import { isCustomResourceIconType } from "@app/components/resources/resources_icons";
+import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/constants";
+import { requiresBearerTokenConfiguration } from "@app/lib/actions/mcp_helper";
+import {
+  allowsMultipleInstancesOfInternalMCPServerByName,
+  getInternalMCPServerInfo,
+  isInternalMCPServerName,
+  matchesInternalMCPServerName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import { DEFAULT_REMOTE_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/remote_servers";
+import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
+import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
+import apiConfig from "@app/lib/api/config";
+import type {
+  MCPServerType,
+  MCPServerTypeWithViews,
+  MCPServerViewType,
+} from "@app/lib/api/mcp";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
+import type { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
+import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
+
+const MAX_URL_LENGTH = 2048;
+const MAX_NAME_LENGTH = 2048;
+
+type CustomHeader = { key: string; value: string };
+
+export async function listMCPServersWithViews(
+  auth: Authenticator
+): Promise<MCPServerTypeWithViews[]> {
+  const [remoteMCPs, internalMCPs] = await Promise.all([
+    RemoteMCPServerResource.listByWorkspace(auth),
+    InternalMCPServerInMemoryResource.listByWorkspace(auth),
+  ]);
+
+  const servers = [...remoteMCPs, ...internalMCPs]
+    .map((r) => r.toJSON())
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Batch-fetch all views in a single query instead of N+1.
+  const allViews = await MCPServerViewResource.listByMCPServers(
+    auth,
+    servers.map((s) => s.sId)
+  );
+
+  const viewsByServerId = new Map<string, MCPServerViewType[]>();
+  for (const view of allViews) {
+    const existing = viewsByServerId.get(view.mcpServerId) ?? [];
+    existing.push(view.toJSON());
+    viewsByServerId.set(view.mcpServerId, existing);
+  }
+
+  return servers.map((server) => ({
+    ...server,
+    views: viewsByServerId.get(server.sId) ?? [],
+  }));
+}
+
+export interface CreateRemoteMCPServerInput {
+  url: string;
+  defaultServerId?: number;
+  includeGlobal?: boolean;
+  sharedSecret?: string;
+  useCase?: MCPOAuthUseCase;
+  connectionId?: string;
+  customHeaders?: CustomHeader[];
+}
+
+export async function createRemoteMCPServer(
+  auth: Authenticator,
+  input: CreateRemoteMCPServerInput
+): Promise<Result<MCPServerType, Error>> {
+  const { url, sharedSecret, customHeaders, connectionId, includeGlobal } =
+    input;
+
+  if (!url) {
+    return new Err(new Error("URL is required"));
+  }
+  if (url.length > MAX_URL_LENGTH) {
+    return new Err(
+      new Error(
+        `MCP server URL exceeds maximum length (${MAX_URL_LENGTH} characters).`
+      )
+    );
+  }
+
+  // Default to the shared secret if it exists.
+  let bearerToken = sharedSecret ?? null;
+  let authorization: AuthorizationInfo | null = null;
+
+  // If a connectionId is provided, we use it to fetch the access token that must
+  // have been created by the admin.
+  if (connectionId) {
+    const token = await getOAuthConnectionAccessToken({
+      config: apiConfig.getOAuthAPIConfig(),
+      logger,
+      connectionId,
+    });
+    if (token.isErr()) {
+      return new Err(new Error("Error fetching OAuth connection access token"));
+    }
+    bearerToken = token.value.access_token;
+    authorization = {
+      provider: token.value.connection.provider,
+      supported_use_cases: ["platform_actions", "personal_actions"],
+    };
+  }
+
+  // Merge custom headers (if any) with Authorization when probing the server.
+  // Authorization from OAuth/sharedSecret takes precedence over custom headers.
+  const sanitizedCustomHeaders = headersArrayToRecord(customHeaders);
+  const headers = bearerToken
+    ? {
+        ...(sanitizedCustomHeaders ?? {}),
+        Authorization: `Bearer ${bearerToken}`,
+      }
+    : sanitizedCustomHeaders;
+
+  const metadataRes = await fetchRemoteServerMetaDataByURL(auth, url, headers);
+  if (metadataRes.isErr()) {
+    return metadataRes;
+  }
+  const metadata = metadataRes.value;
+
+  const defaultConfig =
+    DEFAULT_REMOTE_MCP_SERVERS.find((config) => config.url === url) ??
+    (input.defaultServerId !== undefined
+      ? DEFAULT_REMOTE_MCP_SERVERS.find(
+          (config) => config.id === input.defaultServerId
+        )
+      : undefined);
+
+  const name = defaultConfig?.name ?? metadata.name;
+  if (name.length > MAX_NAME_LENGTH) {
+    return new Err(
+      new Error(
+        `MCP server name exceeds maximum length (${MAX_NAME_LENGTH} characters).`
+      )
+    );
+  }
+
+  if (includeGlobal) {
+    const conflict = await checkNameConflictInGlobalSpace(auth, name);
+    if (conflict.isErr()) {
+      return conflict;
+    }
+  }
+
+  const newRemoteMCPServer = await RemoteMCPServerResource.makeNew(auth, {
+    workspaceId: auth.getNonNullableWorkspace().id,
+    url,
+    cachedName: name,
+    cachedDescription: defaultConfig?.description ?? metadata.description,
+    cachedTools: metadata.tools,
+    icon:
+      defaultConfig?.icon ??
+      (isCustomResourceIconType(metadata.icon)
+        ? metadata.icon
+        : DEFAULT_MCP_SERVER_ICON),
+    version: metadata.version,
+    sharedSecret: sharedSecret ?? null,
+    // Persist only user-provided custom headers
+    customHeaders: headersArrayToRecord(customHeaders),
+    authorization,
+    oAuthUseCase: input.useCase ?? null,
+  });
+
+  if (connectionId) {
+    // We create a connection to the remote MCP server to allow the user to use
+    // the MCP server in the future. The connection is of type "workspace"
+    // because it is created by the admin. If the server can use personal
+    // connections, we rely on this "workspace" connection to get the related
+    // credentials.
+    await MCPServerConnectionResource.makeNew(auth, {
+      connectionId,
+      connectionType: "workspace",
+      serverType: "remote",
+      remoteMCPServerId: newRemoteMCPServer.id,
+    });
+  }
+
+  if (defaultConfig?.toolStakes) {
+    for (const [toolName, stakeLevel] of Object.entries(
+      defaultConfig.toolStakes
+    )) {
+      await RemoteMCPServerToolMetadataResource.makeNew(auth, {
+        remoteMCPServerId: newRemoteMCPServer.id,
+        toolName,
+        permission: stakeLevel,
+        enabled: true,
+      });
+    }
+  }
+
+  if (includeGlobal) {
+    const viewRes = await createGlobalSpaceView(
+      auth,
+      newRemoteMCPServer.sId,
+      "remote"
+    );
+    if (viewRes.isErr()) {
+      return viewRes;
+    }
+  }
+
+  return new Ok(newRemoteMCPServer.toJSON());
+}
+
+export interface CreateInternalMCPServerInput {
+  name: string;
+  useCase?: MCPOAuthUseCase;
+  connectionId?: string;
+  includeGlobal?: boolean;
+  sharedSecret?: string;
+  customHeaders?: CustomHeader[];
+  viewName?: string;
+  oauthScope?: string;
+}
+
+export async function createInternalMCPServer(
+  auth: Authenticator,
+  input: CreateInternalMCPServerInput
+): Promise<Result<MCPServerType, Error>> {
+  const { name, viewName, connectionId, includeGlobal } = input;
+
+  if (!isInternalMCPServerName(name)) {
+    return new Err(new Error("Invalid internal MCP server name"));
+  }
+
+  if (viewName !== undefined) {
+    const trimmed = viewName.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_NAME_LENGTH) {
+      return new Err(new Error("viewName must be a non-empty string."));
+    }
+  }
+
+  if (!allowsMultipleInstancesOfInternalMCPServerByName(name)) {
+    const installedMCPServers = await MCPServerViewResource.listForSystemSpace(
+      auth,
+      { where: { serverType: "internal" } }
+    );
+    const alreadyUsed = installedMCPServers.some((mcpServer) =>
+      matchesInternalMCPServerName(mcpServer.internalMCPServerId, name)
+    );
+    if (alreadyUsed) {
+      return new Err(
+        new Error(
+          "This internal tool has already been added and only one instance is allowed."
+        )
+      );
+    }
+  }
+
+  // Use viewName for the conflict check when provided (multi-instance),
+  // otherwise fall back to the internal server name.
+  const nameForConflictCheck = viewName ?? name;
+  if (includeGlobal) {
+    const conflict = await checkNameConflictInGlobalSpace(
+      auth,
+      nameForConflictCheck
+    );
+    if (conflict.isErr()) {
+      return conflict;
+    }
+  }
+
+  const newInternalMCPServer = await InternalMCPServerInMemoryResource.makeNew(
+    auth,
+    {
+      name,
+      useCase: input.useCase ?? null,
+      viewName,
+      oauthScope: input.oauthScope ?? null,
+    }
+  );
+
+  if (connectionId) {
+    // For personal tools, automatically create a personal connection for the
+    // admin so they don't need to re-authenticate when they first use the tool.
+    // Exception: If the provider has overridable credentials at personal auth
+    // time, each user should authenticate separately with their own settings.
+    const serverInfo = getInternalMCPServerInfo(name);
+    const provider = serverInfo.authorization?.provider;
+    const hasOverridableInputs = provider
+      ? !!getOverridablePersonalAuthInputs({ provider })
+      : false;
+    if (input.useCase === "personal_actions" && !hasOverridableInputs) {
+      await MCPServerConnectionResource.makeNew(auth, {
+        connectionId,
+        connectionType: "personal",
+        serverType: "internal",
+        internalMCPServerId: newInternalMCPServer.id,
+      });
+    }
+
+    // Workspace connection used to get the related credentials for personal
+    // connections.
+    await MCPServerConnectionResource.makeNew(auth, {
+      connectionId,
+      connectionType: "workspace",
+      serverType: "internal",
+      internalMCPServerId: newInternalMCPServer.id,
+    });
+  }
+
+  if (
+    requiresBearerTokenConfiguration(newInternalMCPServer.toJSON()) &&
+    (input.sharedSecret !== undefined || input.customHeaders !== undefined)
+  ) {
+    const sanitizedRecord = headersArrayToRecord(input.customHeaders);
+    const customHeaders =
+      Object.keys(sanitizedRecord).length > 0 ? sanitizedRecord : null;
+
+    const upsertResult = await newInternalMCPServer.upsertCredentials(auth, {
+      sharedSecret: input.sharedSecret,
+      customHeaders,
+    });
+    if (upsertResult.isErr()) {
+      throw upsertResult.error;
+    }
+  }
+
+  if (includeGlobal) {
+    const viewRes = await createGlobalSpaceView(
+      auth,
+      newInternalMCPServer.id,
+      "internal"
+    );
+    if (viewRes.isErr()) {
+      return viewRes;
+    }
+  }
+
+  return new Ok(newInternalMCPServer.toJSON());
+}
+
+async function checkNameConflictInGlobalSpace(
+  auth: Authenticator,
+  name: string
+): Promise<Result<void, Error>> {
+  const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+  const { hasConflict } =
+    await MCPServerViewResource.hasNameConflictInSpaceByName(
+      auth,
+      name,
+      globalSpace
+    );
+  if (hasConflict) {
+    return new Err(
+      new Error(`An existing Tool is already using the name "${name}"`)
+    );
+  }
+  return new Ok(undefined);
+}
+
+async function createGlobalSpaceView(
+  auth: Authenticator,
+  serverId: string,
+  serverType: "remote" | "internal"
+): Promise<Result<void, Error>> {
+  const systemView = await MCPServerViewResource.getMCPServerViewForSystemSpace(
+    auth,
+    serverId
+  );
+  if (!systemView) {
+    return new Err(
+      new Error(
+        `Missing system view for ${serverType} MCP server, it should have been created when creating the ${serverType} server.`
+      )
+    );
+  }
+  await MCPServerViewResource.create(auth, {
+    systemView,
+    space: await SpaceResource.fetchWorkspaceGlobalSpace(auth),
+  });
+  return new Ok(undefined);
+}

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -1,10 +1,7 @@
 /** @ignoreswagger */
 import { isRemoteMCPServerError } from "@app/lib/actions/mcp_errors";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type {
-  MCPServerType,
-  MCPServerTypeWithViews,
-} from "@app/lib/api/mcp";
+import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
 import {
   createInternalMCPServer,
   createRemoteMCPServer,

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -1,36 +1,17 @@
 /** @ignoreswagger */
-import { isCustomResourceIconType } from "@app/components/resources/resources_icons";
-import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/constants";
 import { isRemoteMCPServerError } from "@app/lib/actions/mcp_errors";
-import { requiresBearerTokenConfiguration } from "@app/lib/actions/mcp_helper";
-import {
-  allowsMultipleInstancesOfInternalMCPServerByName,
-  getInternalMCPServerInfo,
-  isInternalMCPServerName,
-  matchesInternalMCPServerName,
-} from "@app/lib/actions/mcp_internal_actions/constants";
-import { DEFAULT_REMOTE_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/remote_servers";
-import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
-import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import apiConfig from "@app/lib/api/config";
 import type {
   MCPServerType,
   MCPServerTypeWithViews,
-  MCPServerViewType,
 } from "@app/lib/api/mcp";
-import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
+import {
+  createInternalMCPServer,
+  createRemoteMCPServer,
+  listMCPServersWithViews,
+} from "@app/lib/api/mcp/servers";
 import type { Authenticator } from "@app/lib/auth";
-import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
-import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
-import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -43,10 +24,6 @@ export type CreateMCPServerResponseBody = {
   success: true;
   server: MCPServerType;
 };
-
-const MAX_URL_LENGTH = 2048;
-
-const MAX_NAME_LENGTH = 2048;
 
 const CustomHeadersSchema = z
   .array(z.object({ key: z.string(), value: z.string() }))
@@ -94,43 +71,13 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const { method } = req;
-
-  switch (method) {
+  switch (req.method) {
     case "GET": {
-      const remoteMCPs = await RemoteMCPServerResource.listByWorkspace(auth);
-      const internalMCPs =
-        await InternalMCPServerInMemoryResource.listByWorkspace(auth);
-
-      const servers = [...remoteMCPs, ...internalMCPs]
-        .map((r) => r.toJSON())
-        .sort((a, b) => a.name.localeCompare(b.name));
-
-      // Batch-fetch all views in a single query instead of N+1.
-      const allViews = await MCPServerViewResource.listByMCPServers(
-        auth,
-        servers.map((s) => s.sId)
-      );
-
-      const viewsByServerId = new Map<string, MCPServerViewType[]>();
-      for (const view of allViews) {
-        const serverId = view.mcpServerId;
-        const existing = viewsByServerId.get(serverId) ?? [];
-        existing.push(view.toJSON());
-        viewsByServerId.set(serverId, existing);
-      }
-
-      return res.status(200).json({
-        success: true,
-        servers: servers.map((server) => ({
-          ...server,
-          views: viewsByServerId.get(server.sId) ?? [],
-        })),
-      });
+      const servers = await listMCPServersWithViews(auth);
+      return res.status(200).json({ success: true, servers });
     }
     case "POST": {
       const r = PostBodySchema.safeParse(req.body);
-
       if (!r.success) {
         return apiError(req, res, {
           status_code: 400,
@@ -141,383 +88,27 @@ async function handler(
         });
       }
 
-      const body = r.data;
-      switch (body.serverType) {
-        case "remote": {
-          const { url, sharedSecret } = body;
+      const result =
+        r.data.serverType === "remote"
+          ? await createRemoteMCPServer(auth, r.data)
+          : await createInternalMCPServer(auth, r.data);
 
-          if (!url) {
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
-                message: "URL is required",
-              },
-            });
-          }
-
-          if (url.length > MAX_URL_LENGTH) {
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
-                message: `MCP server URL exceeds maximum length (${MAX_URL_LENGTH} characters).`,
-              },
-            });
-          }
-
-          // Default to the shared secret if it exists.
-          let bearerToken = sharedSecret ?? null;
-          let authorization: AuthorizationInfo | null = null;
-
-          // If a connectionId is provided, we use it to fetch the access token that must have been created by the admin.
-          if (body.connectionId) {
-            const token = await getOAuthConnectionAccessToken({
-              config: apiConfig.getOAuthAPIConfig(),
-              logger,
-              connectionId: body.connectionId,
-            });
-            if (token.isErr()) {
-              // We fail early if the connectionId is provided, but the access token cannot be fetched.
-              return apiError(req, res, {
-                status_code: 400,
-                api_error: {
-                  type: "invalid_request_error",
-                  message: "Error fetching OAuth connection access token",
-                },
-              });
-            }
-            bearerToken = token.value.access_token;
-            authorization = {
-              provider: token.value.connection.provider,
-              supported_use_cases: ["platform_actions", "personal_actions"],
-            };
-          }
-
-          // Merge custom headers (if any) with Authorization when probing the server.
-          // Note: Authorization from OAuth/sharedSecret takes precedence over custom headers.
-          const sanitizedCustomHeaders = headersArrayToRecord(
-            body.customHeaders
-          );
-
-          const headers = bearerToken
-            ? {
-                ...(sanitizedCustomHeaders ?? {}),
-                Authorization: `Bearer ${bearerToken}`,
-              }
-            : sanitizedCustomHeaders;
-
-          const r = await fetchRemoteServerMetaDataByURL(auth, url, headers);
-          if (r.isErr()) {
-            res.status(400).json({
-              error: {
-                type: "invalid_request_error",
-                message: r.error.message,
-              },
-              isRemoteServerError: isRemoteMCPServerError(r.error),
-            });
-            return;
-          }
-
-          const metadata = r.value;
-
-          const defaultConfig =
-            DEFAULT_REMOTE_MCP_SERVERS.find((config) => config.url === url) ??
-            (body.defaultServerId !== undefined
-              ? DEFAULT_REMOTE_MCP_SERVERS.find(
-                  (config) => config.id === body.defaultServerId
-                )
-              : undefined);
-
-          const name = defaultConfig?.name ?? metadata.name;
-          if (name.length > MAX_NAME_LENGTH) {
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
-                message: `MCP server name exceeds maximum length (${MAX_NAME_LENGTH} characters).`,
-              },
-            });
-          }
-
-          // Check for name conflicts before creating the server.
-          if (body.includeGlobal) {
-            const globalSpace =
-              await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-
-            const { hasConflict } =
-              await MCPServerViewResource.hasNameConflictInSpaceByName(
-                auth,
-                name,
-                globalSpace
-              );
-
-            if (hasConflict) {
-              return apiError(req, res, {
-                status_code: 400,
-                api_error: {
-                  type: "invalid_request_error",
-                  message: `An existing Tool is already using the name "${name}"`,
-                },
-              });
-            }
-          }
-
-          const newRemoteMCPServer = await RemoteMCPServerResource.makeNew(
-            auth,
-            {
-              workspaceId: auth.getNonNullableWorkspace().id,
-              url: url,
-              cachedName: name,
-              cachedDescription:
-                defaultConfig?.description ?? metadata.description,
-              cachedTools: metadata.tools,
-              icon:
-                defaultConfig?.icon ??
-                (isCustomResourceIconType(metadata.icon)
-                  ? metadata.icon
-                  : DEFAULT_MCP_SERVER_ICON),
-              version: metadata.version,
-              sharedSecret: sharedSecret ?? null,
-              // Persist only user-provided custom headers
-              customHeaders: headersArrayToRecord(body.customHeaders),
-              authorization,
-              oAuthUseCase: body.useCase ?? null,
-            }
-          );
-
-          if (body.connectionId) {
-            // We create a connection to the remote MCP server to allow the user to use the MCP server in the future.
-            // The connection is of type "workspace" because it is created by the admin.
-            // If the server can use personal connections, we rely on this "workspace" connection to get the related credentials.
-            await MCPServerConnectionResource.makeNew(auth, {
-              connectionId: body.connectionId,
-              connectionType: "workspace",
-              serverType: "remote",
-              remoteMCPServerId: newRemoteMCPServer.id,
-            });
-          }
-
-          // Create default tool stakes if specified
-          if (defaultConfig?.toolStakes) {
-            for (const [toolName, stakeLevel] of Object.entries(
-              defaultConfig.toolStakes
-            )) {
-              await RemoteMCPServerToolMetadataResource.makeNew(auth, {
-                remoteMCPServerId: newRemoteMCPServer.id,
-                toolName,
-                permission: stakeLevel,
-                enabled: true,
-              });
-            }
-          }
-
-          if (body.includeGlobal) {
-            const systemView =
-              await MCPServerViewResource.getMCPServerViewForSystemSpace(
-                auth,
-                newRemoteMCPServer.sId
-              );
-
-            if (!systemView) {
-              return apiError(req, res, {
-                status_code: 400,
-                api_error: {
-                  type: "invalid_request_error",
-                  message:
-                    "Missing system view for remote MCP server, it should have been created when creating the remote server.",
-                },
-              });
-            }
-
-            await MCPServerViewResource.create(auth, {
-              systemView,
-              space: await SpaceResource.fetchWorkspaceGlobalSpace(auth),
-            });
-          }
-
-          return res.status(201).json({
-            success: true,
-            server: newRemoteMCPServer.toJSON(),
+      if (result.isErr()) {
+        const message = result.error.message;
+        if (isRemoteMCPServerError(result.error)) {
+          res.status(400).json({
+            error: { type: "invalid_request_error", message },
+            isRemoteServerError: true,
           });
+          return;
         }
-        case "internal": {
-          const { name, viewName } = body;
-
-          if (!isInternalMCPServerName(name)) {
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
-                message: "Invalid internal MCP server name",
-              },
-            });
-          }
-
-          if (viewName !== undefined) {
-            const trimmed = viewName.trim();
-            if (trimmed.length === 0 || trimmed.length > MAX_NAME_LENGTH) {
-              return apiError(req, res, {
-                status_code: 400,
-                api_error: {
-                  type: "invalid_request_error",
-                  message: "viewName must be a non-empty string.",
-                },
-              });
-            }
-          }
-
-          if (!allowsMultipleInstancesOfInternalMCPServerByName(name)) {
-            const installedMCPServers =
-              await MCPServerViewResource.listForSystemSpace(auth, {
-                where: {
-                  serverType: "internal",
-                },
-              });
-
-            const alreadyUsed = installedMCPServers.some((mcpServer) =>
-              matchesInternalMCPServerName(mcpServer.internalMCPServerId, name)
-            );
-
-            if (alreadyUsed) {
-              return apiError(req, res, {
-                status_code: 400,
-                api_error: {
-                  type: "invalid_request_error",
-                  message:
-                    "This internal tool has already been added and only one instance is allowed.",
-                },
-              });
-            }
-          }
-
-          // Use viewName for the conflict check when provided (multi-instance),
-          // otherwise fall back to the internal server name.
-          const nameForConflictCheck = viewName ?? name;
-
-          // Check for name conflicts before creating the server.
-          if (body.includeGlobal) {
-            const globalSpace =
-              await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-
-            const { hasConflict } =
-              await MCPServerViewResource.hasNameConflictInSpaceByName(
-                auth,
-                nameForConflictCheck,
-                globalSpace
-              );
-
-            if (hasConflict) {
-              return apiError(req, res, {
-                status_code: 400,
-                api_error: {
-                  type: "invalid_request_error",
-                  message: `An existing Tool is already using the name "${nameForConflictCheck}"`,
-                },
-              });
-            }
-          }
-
-          const newInternalMCPServer =
-            await InternalMCPServerInMemoryResource.makeNew(auth, {
-              name,
-              useCase: body.useCase ?? null,
-              viewName,
-              oauthScope: body.oauthScope ?? null,
-            });
-
-          if (body.connectionId) {
-            // For personal tools, automatically create a personal connection for the admin
-            // so they don't need to re-authenticate when they first use the tool.
-            // Exception: If the provider has overridable credentials at personal auth time,
-            // each user should authenticate separately with their own settings.
-            const serverInfo = getInternalMCPServerInfo(name);
-            const provider = serverInfo.authorization?.provider;
-            const hasOverridableInputs = provider
-              ? !!getOverridablePersonalAuthInputs({ provider })
-              : false;
-            if (body.useCase === "personal_actions" && !hasOverridableInputs) {
-              await MCPServerConnectionResource.makeNew(auth, {
-                connectionId: body.connectionId,
-                connectionType: "personal",
-                serverType: "internal",
-                internalMCPServerId: newInternalMCPServer.id,
-              });
-            }
-
-            // We create a workspace connection to the internal MCP server.
-            // This connection is used to get the related credentials for personal connections.
-            await MCPServerConnectionResource.makeNew(auth, {
-              connectionId: body.connectionId,
-              connectionType: "workspace",
-              serverType: "internal",
-              internalMCPServerId: newInternalMCPServer.id,
-            });
-          }
-
-          if (
-            requiresBearerTokenConfiguration(newInternalMCPServer.toJSON()) &&
-            (body.sharedSecret !== undefined ||
-              body.customHeaders !== undefined)
-          ) {
-            const sanitizedRecord = headersArrayToRecord(body.customHeaders);
-            const customHeaders =
-              Object.keys(sanitizedRecord).length > 0 ? sanitizedRecord : null;
-
-            const upsertResult = await newInternalMCPServer.upsertCredentials(
-              auth,
-              {
-                sharedSecret: body.sharedSecret,
-                customHeaders,
-              }
-            );
-            if (upsertResult.isErr()) {
-              throw upsertResult.error;
-            }
-          }
-
-          if (body.includeGlobal) {
-            const globalSpace =
-              await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-
-            const systemView =
-              await MCPServerViewResource.getMCPServerViewForSystemSpace(
-                auth,
-                newInternalMCPServer.id
-              );
-
-            if (!systemView) {
-              return apiError(req, res, {
-                status_code: 400,
-                api_error: {
-                  type: "invalid_request_error",
-                  message:
-                    "Missing system view for internal MCP server, it should have been created when creating the internal server.",
-                },
-              });
-            }
-
-            await MCPServerViewResource.create(auth, {
-              systemView,
-              space: globalSpace,
-            });
-          }
-
-          return res.status(201).json({
-            success: true,
-            server: newInternalMCPServer.toJSON(),
-          });
-        }
-        default: {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Invalid server type",
-            },
-          });
-        }
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: { type: "invalid_request_error", message },
+        });
       }
+
+      return res.status(201).json({ success: true, server: result.value });
     }
 
     default: {


### PR DESCRIPTION
## Description

To prepare for the Next -> Hono migration, it helps to have minimal handlers that delegate business logic to code in lib/api. This is a no-op refactor that does this for this handler.

## Tests

Existing handler tests

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
