### PR TITLE
Refactor agent_configurations handler to remove bus logic for API 

### DIFF
--- a/front/lib/api/assistant/configuration/list_for_view.ts
+++ b/front/lib/api/assistant/configuration/list_for_view.ts
@@ -1,0 +1,140 @@
+import { getAgentsUsage } from "@app/lib/api/assistant/agent_usage";
+import type { SortStrategyType } from "@app/lib/api/assistant/configuration/types";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { getAgentsEditors } from "@app/lib/api/assistant/editors";
+import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
+import { runOnRedis } from "@app/lib/api/redis";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import type {
+  AgentsGetViewType,
+  LightAgentConfigurationType,
+} from "@app/types/assistant/agent";
+import keyBy from "lodash/keyBy";
+import omit from "lodash/omit";
+
+interface ListAgentConfigurationsForViewOptions {
+  view: AgentsGetViewType;
+  limit?: number;
+  sort?: SortStrategyType;
+  withUsage?: boolean;
+  withAuthors?: boolean;
+  withEditors?: boolean;
+  withFeedbacks?: boolean;
+}
+
+export async function listAgentConfigurationsForView(
+  auth: Authenticator,
+  {
+    view,
+    limit,
+    sort,
+    withUsage,
+    withAuthors,
+    withEditors,
+    withFeedbacks,
+  }: ListAgentConfigurationsForViewOptions
+): Promise<LightAgentConfigurationType[]> {
+  let agents = await getAgentConfigurationsForView({
+    auth,
+    agentsGetView: view,
+    variant: "light",
+    limit,
+    sort,
+  });
+
+  if (withUsage) {
+    agents = await addUsage(auth, agents, limit);
+  }
+
+  if (withAuthors) {
+    agents = await addRecentAuthors(auth, agents);
+  }
+
+  if (withEditors) {
+    agents = await addEditors(auth, agents);
+  }
+
+  if (withFeedbacks) {
+    agents = await addFeedbacks(auth, agents);
+  }
+
+  return agents;
+}
+
+async function addUsage(
+  auth: Authenticator,
+  agents: LightAgentConfigurationType[],
+  limit: number | undefined
+): Promise<LightAgentConfigurationType[]> {
+  const owner = auth.getNonNullableWorkspace();
+  const mentionCounts = await runOnRedis(
+    { origin: "agent_usage" },
+    async (redis) =>
+      getAgentsUsage({
+        providedRedis: redis,
+        workspaceId: owner.sId,
+        limit: limit ?? -1,
+      })
+  );
+  const usageMap = keyBy(mentionCounts, "agentId");
+  return agents.map((agent) =>
+    usageMap[agent.sId]
+      ? { ...agent, usage: omit(usageMap[agent.sId], ["agentId"]) }
+      : agent
+  );
+}
+
+async function addRecentAuthors(
+  auth: Authenticator,
+  agents: LightAgentConfigurationType[]
+): Promise<LightAgentConfigurationType[]> {
+  const recentAuthors = await getAgentsRecentAuthors({ auth, agents });
+  return agents.map((agent, index) => ({
+    ...agent,
+    lastAuthors: recentAuthors[index],
+  }));
+}
+
+async function addEditors(
+  auth: Authenticator,
+  agents: LightAgentConfigurationType[]
+): Promise<LightAgentConfigurationType[]> {
+  const editors = await getAgentsEditors(auth, agents);
+  return agents.map((agent) => ({
+    ...agent,
+    editors: editors[agent.sId],
+  }));
+}
+
+async function addFeedbacks(
+  auth: Authenticator,
+  agents: LightAgentConfigurationType[]
+): Promise<LightAgentConfigurationType[]> {
+  const nonGlobalAgentIds = agents
+    .filter((agent) => agent.scope !== "global")
+    .map((agent) => agent.sId);
+  const feedbacks =
+    await AgentMessageFeedbackResource.getFeedbackCountForAssistants(
+      auth,
+      nonGlobalAgentIds,
+      30
+    );
+  const feedbackByAgentId = new Map<string, { up: number; down: number }>();
+  for (const f of feedbacks) {
+    const current = feedbackByAgentId.get(f.agentConfigurationId) ?? {
+      up: 0,
+      down: 0,
+    };
+    if (f.thumbDirection === "up") {
+      current.up = f.count;
+    } else if (f.thumbDirection === "down") {
+      current.down = f.count;
+    }
+    feedbackByAgentId.set(f.agentConfigurationId, current);
+  }
+  return agents.map((agent) => ({
+    ...agent,
+    feedbacks: feedbackByAgentId.get(agent.sId) ?? { up: 0, down: 0 },
+  }));
+}

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -121,21 +121,16 @@ import type {
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
 import { pruneSuggestionsForAgent } from "@app/lib/api/assistant/agent_suggestion_pruning";
-import { getAgentsUsage } from "@app/lib/api/assistant/agent_usage";
 import { createAgentActionConfiguration } from "@app/lib/api/assistant/configuration/actions";
 import {
   createAgentConfiguration,
   restoreAgentConfiguration,
   unsafeHardDeleteAgentConfiguration,
 } from "@app/lib/api/assistant/configuration/agent";
-import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
-import { getAgentsEditors } from "@app/lib/api/assistant/editors";
+import { listAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/list_for_view";
 import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
-import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { runOnRedis } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -157,8 +152,6 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
-import keyBy from "lodash/keyBy";
-import omit from "lodash/omit";
 import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
@@ -188,11 +181,8 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-
   switch (req.method) {
     case "GET":
-      // extract the view from the query parameters
       const queryValidation = GetAgentConfigurationsQuerySchema.safeParse({
         ...req.query,
         limit:
@@ -232,90 +222,17 @@ async function handler(
           },
         });
       }
-      let agentConfigurations = await getAgentConfigurationsForView({
-        auth,
-        agentsGetView:
-          viewParam === "workspace"
-            ? "published" // workspace is deprecated, return all visible agents
-            : viewParam,
-        variant: "light",
+
+      const agentConfigurations = await listAgentConfigurationsForView(auth, {
+        // workspace is deprecated, return all visible agents
+        view: viewParam === "workspace" ? "published" : viewParam,
         limit,
         sort,
+        withUsage: withUsage === "true",
+        withAuthors: withAuthors === "true",
+        withEditors: withEditors === "true",
+        withFeedbacks: withFeedbacks === "true",
       });
-      if (withUsage === "true") {
-        const mentionCounts = await runOnRedis(
-          { origin: "agent_usage" },
-          async (redis) => {
-            return getAgentsUsage({
-              providedRedis: redis,
-              workspaceId: owner.sId,
-              limit:
-                typeof req.query.limit === "string"
-                  ? parseInt(req.query.limit, 10)
-                  : -1,
-            });
-          }
-        );
-        const usageMap = keyBy(mentionCounts, "agentId");
-        agentConfigurations = agentConfigurations.map((agentConfiguration) =>
-          usageMap[agentConfiguration.sId]
-            ? {
-                ...agentConfiguration,
-                usage: omit(usageMap[agentConfiguration.sId], ["agentId"]),
-              }
-            : agentConfiguration
-        );
-      }
-      if (withAuthors === "true") {
-        const recentAuthors = await getAgentsRecentAuthors({
-          auth,
-          agents: agentConfigurations,
-        });
-        agentConfigurations = agentConfigurations.map(
-          (agentConfiguration, index) => {
-            return {
-              ...agentConfiguration,
-              lastAuthors: recentAuthors[index],
-            };
-          }
-        );
-      }
-
-      if (withEditors === "true") {
-        const editors = await getAgentsEditors(auth, agentConfigurations);
-        agentConfigurations = agentConfigurations.map((agentConfiguration) => ({
-          ...agentConfiguration,
-          editors: editors[agentConfiguration.sId],
-        }));
-      }
-
-      if (withFeedbacks === "true") {
-        const feedbacks =
-          await AgentMessageFeedbackResource.getFeedbackCountForAssistants(
-            auth,
-            agentConfigurations
-              .filter((agent) => agent.scope !== "global")
-              .map((agent) => agent.sId),
-            30
-          );
-        agentConfigurations = agentConfigurations.map((agentConfiguration) => ({
-          ...agentConfiguration,
-          feedbacks: {
-            up:
-              feedbacks.find(
-                (f) =>
-                  f.agentConfigurationId === agentConfiguration.sId &&
-                  f.thumbDirection === "up"
-              )?.count ?? 0,
-            down:
-              feedbacks.find(
-                (f) =>
-                  f.agentConfigurationId === agentConfiguration.sId &&
-                  f.thumbDirection === "down"
-              )?.count ?? 0,
-          },
-        }));
-      }
 
       return res.status(200).json({
         agentConfigurations,


### PR DESCRIPTION
## Description

To prepare for the Next -> Hono migration, it helps to have minimal handlers that delegate business logic to code in lib/api. This is a no-op refactor that does this for this handler.

## Tests

Existing handler tests

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
