### PR TITLE
Refactor the skills handler to remove bus logic for API 

### DIFF
--- a/front/lib/api/skills/create_skill.ts
+++ b/front/lib/api/skills/create_skill.ts
@@ -1,0 +1,225 @@
+import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import logger from "@app/logger/logger";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import uniq from "lodash/uniq";
+
+export interface CreateSkillError {
+  message: string;
+  statusCode: 400 | 403 | 404;
+}
+
+export interface CreateSkillInput {
+  name: string;
+  agentFacingDescription: string;
+  userFacingDescription: string;
+  instructions: string;
+  instructionsHtml: string | null;
+  icon: string | null;
+  tools: { mcpServerViewId: string }[];
+  extendedSkillId: string | null;
+  attachedKnowledge: {
+    dataSourceViewId: string;
+    nodeId: string;
+    spaceId: string;
+    title: string;
+  }[];
+  additionalRequestedSpaceIds?: string[];
+  fileAttachments?: { fileId: string }[];
+  isDefault?: boolean;
+  source?: "github" | "local_file" | "web_app";
+  sourceMetadata?:
+    | { repoUrl: string; filePath: string }
+    | { filePath: string }
+    | null;
+}
+
+export async function createSkill(
+  auth: Authenticator,
+  input: CreateSkillInput
+): Promise<Result<SkillType, CreateSkillError>> {
+  const name = input.name.trim();
+  if (!name) {
+    return new Err({
+      message: "Skill name cannot be empty.",
+      statusCode: 400,
+    });
+  }
+
+  const existingSkill = await SkillResource.fetchActiveByName(auth, name);
+  if (existingSkill) {
+    return new Err({
+      message: `A skill with the name "${name}" already exists.`,
+      statusCode: 400,
+    });
+  }
+
+  const mcpServerViewIds = uniq(input.tools.map((t) => t.mcpServerViewId));
+  const mcpServerViews = await MCPServerViewResource.fetchByIds(
+    auth,
+    mcpServerViewIds
+  );
+  if (mcpServerViewIds.length !== mcpServerViews.length) {
+    return new Err({
+      message: `MCP server views not all found, ${mcpServerViews.length} found, ${mcpServerViewIds.length} requested`,
+      statusCode: 404,
+    });
+  }
+
+  const dataSourceViewIds = uniq(
+    input.attachedKnowledge.map((a) => a.dataSourceViewId)
+  );
+  const dataSourceViews = await DataSourceViewResource.fetchByIds(
+    auth,
+    dataSourceViewIds
+  );
+  if (dataSourceViews.length !== dataSourceViewIds.length) {
+    return new Err({
+      message: `Data source views not all found, ${dataSourceViews.length} found, ${dataSourceViewIds.length} requested`,
+      statusCode: 404,
+    });
+  }
+
+  const dataSourceViewIdMap = new Map(
+    dataSourceViews.map((dsv) => [dsv.sId, dsv])
+  );
+  const attachedKnowledgeWithDataSourceViews = input.attachedKnowledge.map(
+    (attachment) => ({
+      // Non-null assertion is safe: count check above guarantees presence.
+      dataSourceView: dataSourceViewIdMap.get(attachment.dataSourceViewId)!,
+      nodeId: attachment.nodeId,
+    })
+  );
+
+  const computedRequestedSpaceIds =
+    await SkillResource.computeRequestedSpaceIds(auth, {
+      mcpServerViews,
+      attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+    });
+
+  const additionalRequestedSpaceIdsRes =
+    await resolveAdditionalRequestedSpaceModelIds(
+      auth,
+      input.additionalRequestedSpaceIds
+    );
+  if (additionalRequestedSpaceIdsRes.isErr()) {
+    return new Err({
+      message: additionalRequestedSpaceIdsRes.error.message,
+      statusCode: 400,
+    });
+  }
+
+  const requestedSpaceIds = uniq([
+    ...computedRequestedSpaceIds,
+    ...additionalRequestedSpaceIdsRes.value,
+  ]);
+
+  const extendedSkill = input.extendedSkillId
+    ? await SkillResource.fetchById(auth, input.extendedSkillId)
+    : null;
+  if (extendedSkill !== null && !extendedSkill.isExtendable) {
+    return new Err({
+      message: `The extended skill with id "${input.extendedSkillId}" cannot be extended.`,
+      statusCode: 400,
+    });
+  }
+
+  const filesRes = await resolveFileAttachments(auth, input.fileAttachments);
+  if (filesRes.isErr()) {
+    return filesRes;
+  }
+  const files = filesRes.value;
+
+  let icon = input.icon;
+  if (!icon) {
+    const iconResult = await getSkillIconSuggestion(auth, {
+      name,
+      instructions: input.instructions,
+      agentFacingDescription: input.agentFacingDescription,
+    });
+    if (iconResult.isOk()) {
+      icon = iconResult.value;
+    } else {
+      logger.warn(
+        { error: iconResult.error },
+        "Failed to generate icon suggestion for skill"
+      );
+    }
+  }
+
+  const skill = await SkillResource.makeNew(
+    auth,
+    {
+      status: "active",
+      name,
+      agentFacingDescription: input.agentFacingDescription,
+      userFacingDescription: input.userFacingDescription,
+      instructions: input.instructions,
+      instructionsHtml: input.instructionsHtml,
+      editedBy: auth.getNonNullableUser().id,
+      requestedSpaceIds,
+      extendedSkillId: input.extendedSkillId,
+      icon,
+      source: input.source ?? "web_app",
+      sourceMetadata: input.sourceMetadata ?? null,
+      isDefault: input.isDefault ?? false,
+    },
+    {
+      mcpServerViews,
+      attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+      fileAttachments: files,
+    }
+  );
+
+  if (files) {
+    await FileResource.bulkSetUseCaseMetadata(auth, files, {
+      skillId: skill.sId,
+    });
+  }
+
+  return new Ok(skill.toJSON(auth));
+}
+
+async function resolveFileAttachments(
+  auth: Authenticator,
+  fileAttachments: { fileId: string }[] | undefined
+): Promise<Result<FileResource[] | undefined, CreateSkillError>> {
+  if (!fileAttachments) {
+    return new Ok(undefined);
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("sandbox_tools") && fileAttachments.length > 0) {
+    return new Err({
+      message: "File attachments are not supported.",
+      statusCode: 403,
+    });
+  }
+
+  const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
+  const files = await FileResource.fetchByIds(auth, fileAttachmentIds);
+  if (files.length !== fileAttachmentIds.length) {
+    return new Err({
+      message: `File attachments not all found, ${files.length} found, ${fileAttachmentIds.length} requested`,
+      statusCode: 404,
+    });
+  }
+
+  for (const file of files) {
+    if (!file.isReady || file.useCase !== "skill_attachment") {
+      return new Err({
+        message: `File ${file.sId} is not ready or not a skill_attachment.`,
+        statusCode: 400,
+      });
+    }
+  }
+
+  return new Ok(files);
+}

--- a/front/lib/api/skills/create_skill.ts
+++ b/front/lib/api/skills/create_skill.ts
@@ -10,36 +10,59 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import uniq from "lodash/uniq";
+import { z } from "zod";
 
 export interface CreateSkillError {
   message: string;
   statusCode: 400 | 403 | 404;
 }
 
-export interface CreateSkillInput {
-  name: string;
-  agentFacingDescription: string;
-  userFacingDescription: string;
-  instructions: string;
-  instructionsHtml: string | null;
-  icon: string | null;
-  tools: { mcpServerViewId: string }[];
-  extendedSkillId: string | null;
-  attachedKnowledge: {
-    dataSourceViewId: string;
-    nodeId: string;
-    spaceId: string;
-    title: string;
-  }[];
-  additionalRequestedSpaceIds?: string[];
-  fileAttachments?: { fileId: string }[];
-  isDefault?: boolean;
-  source?: "github" | "local_file" | "web_app";
-  sourceMetadata?:
-    | { repoUrl: string; filePath: string }
-    | { filePath: string }
-    | null;
-}
+export const AttachedKnowledgeSchema = z.object({
+  dataSourceViewId: z.string(),
+  nodeId: z.string(),
+  spaceId: z.string(),
+  title: z.string(),
+});
+
+export const CreateSkillInputSchema = z.intersection(
+  z.object({
+    name: z.string(),
+    agentFacingDescription: z.string(),
+    userFacingDescription: z.string(),
+    instructions: z.string(),
+    icon: z.string().nullable(),
+    tools: z.array(
+      z.object({
+        mcpServerViewId: z.string(),
+      })
+    ),
+    extendedSkillId: z.string().nullable(),
+    attachedKnowledge: z.array(AttachedKnowledgeSchema),
+    instructionsHtml: z.string().nullable(),
+    additionalRequestedSpaceIds: z.array(z.string()).optional(),
+    fileAttachments: z.array(z.object({ fileId: z.string() })).optional(),
+    isDefault: z.boolean().optional(),
+  }),
+  z.union([
+    z.object({
+      source: z.literal("github"),
+      sourceMetadata: z.object({
+        repoUrl: z.string(),
+        filePath: z.string(),
+      }),
+    }),
+    z.object({
+      source: z.literal("local_file"),
+      sourceMetadata: z.object({ filePath: z.string() }).nullable(),
+    }),
+    z.object({
+      source: z.literal("web_app").optional(),
+      sourceMetadata: z.null().optional(),
+    }),
+  ])
+);
+
+export type CreateSkillInput = z.infer<typeof CreateSkillInputSchema>;
 
 export async function createSkill(
   auth: Authenticator,

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -1,5 +1,6 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { AttachedKnowledgeSchema } from "@app/lib/api/skills/create_skill";
 import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
@@ -10,7 +11,6 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import { AttachedKnowledgeSchema } from "@app/pages/api/w/[wId]/skills";
 import type {
   SkillType,
   SkillWithRelationsType,

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -1,14 +1,9 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
-import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { FileResource } from "@app/lib/resources/file_resource";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { createSkill } from "@app/lib/api/skills/create_skill";
+import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import {
   SKILL_VIEWS,
@@ -95,8 +90,6 @@ const PostSkillRequestBodySchema = z.intersection(
     }),
   ])
 );
-
-type PostSkillRequestBody = z.infer<typeof PostSkillRequestBodySchema>;
 
 async function handler(
   req: NextApiRequest,
@@ -236,10 +229,7 @@ async function handler(
         });
       }
 
-      const user = auth.getNonNullableUser();
-
       const bodyValidation = PostSkillRequestBodySchema.safeParse(req.body);
-
       if (!bodyValidation.success) {
         const pathError = fromError(bodyValidation.error).toString();
         return apiError(req, res, {
@@ -251,216 +241,18 @@ async function handler(
         });
       }
 
-      const body: PostSkillRequestBody = bodyValidation.data;
-      const name = body.name.trim();
-
-      if (!name) {
+      const result = await createSkill(auth, bodyValidation.data);
+      if (result.isErr()) {
         return apiError(req, res, {
-          status_code: 400,
+          status_code: result.error.statusCode,
           api_error: {
             type: "invalid_request_error",
-            message: "Skill name cannot be empty.",
+            message: result.error.message,
           },
         });
       }
 
-      const existingSkill = await SkillResource.fetchActiveByName(auth, name);
-
-      if (existingSkill) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `A skill with the name "${name}" already exists.`,
-          },
-        });
-      }
-
-      // Validate all MCP server views exist before creating anything
-      const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
-      const mcpServerViews = await MCPServerViewResource.fetchByIds(
-        auth,
-        mcpServerViewIds
-      );
-
-      if (mcpServerViewIds.length !== mcpServerViews.length) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "invalid_request_error",
-            message: `MCP server views not all found, ${mcpServerViews.length} found, ${mcpServerViewIds.length} requested`,
-          },
-        });
-      }
-
-      const { attachedKnowledge, fileAttachments } = body;
-
-      // Validate all data source views from attached knowledge exist and user has access.
-      const dataSourceViewIds = uniq(
-        attachedKnowledge.map((attachment) => attachment.dataSourceViewId)
-      );
-
-      const dataSourceViews = await DataSourceViewResource.fetchByIds(
-        auth,
-        dataSourceViewIds
-      );
-      if (dataSourceViews.length !== dataSourceViewIds.length) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Data source views not all found, ${dataSourceViews.length} found, ${dataSourceViewIds.length} requested`,
-          },
-        });
-      }
-
-      const dataSourceViewIdMap = new Map(
-        dataSourceViews.map((dsv) => [dsv.sId, dsv])
-      );
-
-      const attachedKnowledgeWithDataSourceViews = attachedKnowledge.map(
-        (attachment) => ({
-          dataSourceView: dataSourceViewIdMap.get(attachment.dataSourceViewId)!,
-          nodeId: attachment.nodeId,
-        })
-      );
-
-      const computedRequestedSpaceIds =
-        await SkillResource.computeRequestedSpaceIds(auth, {
-          mcpServerViews,
-          attachedKnowledge: attachedKnowledgeWithDataSourceViews,
-        });
-
-      const additionalRequestedSpaceIdsRes =
-        await resolveAdditionalRequestedSpaceModelIds(
-          auth,
-          body.additionalRequestedSpaceIds
-        );
-
-      if (additionalRequestedSpaceIdsRes.isErr()) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: additionalRequestedSpaceIdsRes.error.message,
-          },
-        });
-      }
-
-      const requestedSpaceIds = uniq([
-        ...computedRequestedSpaceIds,
-        ...additionalRequestedSpaceIdsRes.value,
-      ]);
-
-      const extendedSkill = body.extendedSkillId
-        ? await SkillResource.fetchById(auth, body.extendedSkillId)
-        : null;
-
-      // Only global skills can be extended.
-      if (extendedSkill !== null && !extendedSkill.isExtendable) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `The extended skill with id "${body.extendedSkillId}" cannot be extended.`,
-          },
-        });
-      }
-
-      // Validate file attachments if provided (gated behind sandbox_tools).
-      let files: FileResource[] | undefined;
-      if (fileAttachments) {
-        const featureFlags = await getFeatureFlags(auth);
-        if (
-          !featureFlags.includes("sandbox_tools") &&
-          fileAttachments.length > 0
-        ) {
-          return apiError(req, res, {
-            status_code: 403,
-            api_error: {
-              type: "invalid_request_error",
-              message: "File attachments are not supported.",
-            },
-          });
-        }
-
-        const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
-        files = await FileResource.fetchByIds(auth, fileAttachmentIds);
-        if (files.length !== fileAttachmentIds.length) {
-          return apiError(req, res, {
-            status_code: 404,
-            api_error: {
-              type: "invalid_request_error",
-              message: `File attachments not all found, ${files.length} found, ${fileAttachmentIds.length} requested`,
-            },
-          });
-        }
-
-        for (const file of files) {
-          if (!file.isReady || file.useCase !== "skill_attachment") {
-            return apiError(req, res, {
-              status_code: 400,
-              api_error: {
-                type: "invalid_request_error",
-                message: `File ${file.sId} is not ready or not a skill_attachment.`,
-              },
-            });
-          }
-        }
-      }
-
-      // Generate icon suggestion if not provided.
-      let icon = body.icon;
-      if (!icon) {
-        const iconResult = await getSkillIconSuggestion(auth, {
-          name,
-          instructions: body.instructions,
-          agentFacingDescription: body.agentFacingDescription,
-        });
-        if (iconResult.isOk()) {
-          icon = iconResult.value;
-        } else {
-          logger.warn(
-            { error: iconResult.error },
-            "Failed to generate icon suggestion for skill"
-          );
-        }
-      }
-
-      const skill = await SkillResource.makeNew(
-        auth,
-        {
-          status: "active",
-          name,
-          agentFacingDescription: body.agentFacingDescription,
-          userFacingDescription: body.userFacingDescription,
-          instructions: body.instructions,
-          instructionsHtml: body.instructionsHtml,
-          editedBy: user.id,
-          requestedSpaceIds,
-          extendedSkillId: body.extendedSkillId,
-          icon,
-          source: body.source ?? "web_app",
-          sourceMetadata: body.sourceMetadata ?? null,
-          isDefault: body.isDefault ?? false,
-        },
-        {
-          mcpServerViews,
-          attachedKnowledge: attachedKnowledgeWithDataSourceViews,
-          fileAttachments: files,
-        }
-      );
-
-      // Update file useCaseMetadata with the newly created skill's sId.
-      if (files) {
-        await FileResource.bulkSetUseCaseMetadata(auth, files, {
-          skillId: skill.sId,
-        });
-      }
-
-      return res.status(200).json({
-        skill: skill.toJSON(auth),
-      });
+      return res.status(200).json({ skill: result.value });
     }
 
     default:

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -1,6 +1,9 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { createSkill } from "@app/lib/api/skills/create_skill";
+import {
+  CreateSkillInputSchema,
+  createSkill,
+} from "@app/lib/api/skills/create_skill";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -43,53 +46,6 @@ const SkillStatusSchema = z
 function isSkillViewType(value: string): value is SkillViewType {
   return SKILL_VIEWS.some((skillViewType) => skillViewType === value);
 }
-
-// Schema for attached knowledge.
-export const AttachedKnowledgeSchema = z.object({
-  dataSourceViewId: z.string(),
-  nodeId: z.string(),
-  spaceId: z.string(),
-  title: z.string(),
-});
-
-// Request body schema for POST.
-const PostSkillRequestBodySchema = z.intersection(
-  z.object({
-    name: z.string(),
-    agentFacingDescription: z.string(),
-    userFacingDescription: z.string(),
-    instructions: z.string(),
-    icon: z.string().nullable(),
-    tools: z.array(
-      z.object({
-        mcpServerViewId: z.string(),
-      })
-    ),
-    extendedSkillId: z.string().nullable(),
-    attachedKnowledge: z.array(AttachedKnowledgeSchema),
-    instructionsHtml: z.string().nullable(),
-    additionalRequestedSpaceIds: z.array(z.string()).optional(),
-    fileAttachments: z.array(z.object({ fileId: z.string() })).optional(),
-    isDefault: z.boolean().optional(),
-  }),
-  z.union([
-    z.object({
-      source: z.literal("github"),
-      sourceMetadata: z.object({
-        repoUrl: z.string(),
-        filePath: z.string(),
-      }),
-    }),
-    z.object({
-      source: z.literal("local_file"),
-      sourceMetadata: z.object({ filePath: z.string() }).nullable(),
-    }),
-    z.object({
-      source: z.literal("web_app").optional(),
-      sourceMetadata: z.null().optional(),
-    }),
-  ])
-);
 
 async function handler(
   req: NextApiRequest,
@@ -229,7 +185,7 @@ async function handler(
         });
       }
 
-      const bodyValidation = PostSkillRequestBodySchema.safeParse(req.body);
+      const bodyValidation = CreateSkillInputSchema.safeParse(req.body);
       if (!bodyValidation.success) {
         const pathError = fromError(bodyValidation.error).toString();
         return apiError(req, res, {


### PR DESCRIPTION
## Description

To prepare for the Next -> Hono migration, it helps to have minimal handlers that delegate business logic to code in lib/api. This is a no-op refactor that does this for this handler.

## Tests

- Existing handler tests
- Tried manually listing skills and creating one

## Risk

Low

## Deploy Plan

Front