### PR TITLE
Close inline activity on reload for all agent messages

### DIFF
--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -105,7 +105,7 @@ export function InlineActivitySteps({
     agentMessage.status === "failed" ||
     agentMessage.status === "cancelled";
 
-  const [isCollapsed, setIsCollapsed] = useState(isDone && !isLastMessage);
+  const [isCollapsed, setIsCollapsed] = useState(isDone);
 
   const openBreakdownPanel = (actionId?: string) => {
     if (onOpenDetails) {


### PR DESCRIPTION
## Description

On reload, all completed agent message activity panels now start collapsed, including the last message. The previous  behavior (keeping the last message open) makes sense during an active session but less when returning to a conversation.

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25447">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->