### PR TITLE
Fix files MCP failing to read attachments with accented filenames

### DIFF
--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -82,9 +82,12 @@ export async function resolveConversationFile(
   // been re-keyed or aged out. Uploads are now normalized to NFC at FileResource.makeNew.
   const nfc = gcsPath.normalize("NFC");
   const nfd = gcsPath.normalize("NFD");
+  const candidates = [gcsPath];
+
   if (nfc !== gcsPath) {
     candidates.push(nfc);
   }
+
   if (nfd !== gcsPath && nfd !== nfc) {
     candidates.push(nfd);
   }
@@ -110,6 +113,11 @@ export async function resolveConversationFile(
   }
 
   return new Err(
+    new MCPError(
+      `File not found: \`${path}\`. Error: ${normalizeError(lastError).message}`,
+      { tracked: false }
+    )
+  );
 }
 
 // TODO(20260429 FILE SYSTEM): Find a more exhaustive approach to cover more files.

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -74,26 +74,42 @@ export async function resolveConversationFile(
   }
 
   const bucket = getPrivateUploadBucket();
-  const file = bucket.file(gcsPath);
 
-  try {
-    const [metadata] = await file.getMetadata();
-    const rawContentType = isString(metadata.contentType)
-      ? metadata.contentType
-      : "application/octet-stream";
-    return new Ok({
-      file,
-      mimeType: stripMimeParameters(rawContentType),
-      sizeBytes: Number(metadata.size ?? 0),
-    });
-  } catch (err) {
-    return new Err(
-      new MCPError(
-        `File not found: \`${path}\`. Error: ${normalizeError(err).message}`,
-        { tracked: false }
-      )
-    );
+  // GCS object names are byte-exact. Pre-NFC-normalization rollout, some objects were stored in
+  // NFD (e.g. macOS uploads) while LLMs typically echo paths back as NFC, causing 404s on visually
+  // identical paths. Try the path as-is first, then NFC, then NFD.
+  // TODO(2026-05-11 FILE SYSTEM): Remove the NFC/NFD fallbacks once legacy non-NFC objects have
+  // been re-keyed or aged out. Uploads are now normalized to NFC at FileResource.makeNew.
+  const nfc = gcsPath.normalize("NFC");
+  const nfd = gcsPath.normalize("NFD");
+  if (nfc !== gcsPath) {
+    candidates.push(nfc);
   }
+  if (nfd !== gcsPath && nfd !== nfc) {
+    candidates.push(nfd);
+  }
+
+  let lastError: unknown = null;
+  for (const candidate of candidates) {
+    const file = bucket.file(candidate);
+
+    try {
+      const [metadata] = await file.getMetadata();
+      const rawContentType = isString(metadata.contentType)
+        ? metadata.contentType
+        : "application/octet-stream";
+
+      return new Ok({
+        file,
+        mimeType: stripMimeParameters(rawContentType),
+        sizeBytes: Number(metadata.size ?? 0),
+      });
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  return new Err(
 }
 
 // TODO(20260429 FILE SYSTEM): Find a more exhaustive approach to cover more files.

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -98,8 +98,12 @@ export class FileResource extends BaseResource<FileModel> {
   static async makeNew(
     blob: Omit<CreationAttributes<FileModel>, "status" | "sId" | "version">
   ) {
+    // Normalize the user-visible file name to NFC. GCS object names are byte-exact and macOS
+    // uploads commonly arrive in NFD, which breaks lookups when consumers (e.g. LLMs) echo paths
+    // back in NFC. Normalizing on the way in keeps mount paths stable.
     const key = await FileResource.model.create({
       ...blob,
+      fileName: blob.fileName.normalize("NFC"),
       status: "created",
       version: 0,
     });
@@ -1127,7 +1131,7 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   rename(newFileName: string) {
-    return this.update({ fileName: newFileName });
+    return this.update({ fileName: newFileName.normalize("NFC") });
   }
 
   // Sharing logic.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We had reports that PDFs with French filenames (e.g. Absentéisme) showed up in `files__list` but threw "No such object" on `files__cat`. Confirmed in GCS that the
object name is stored in NFD form (e + U+0301), while the LLM echoes the path back to `files__cat` in NFC (single U+00E9). GCS object names are byte-exact, so the lookup misses even though the strings render identically.

This fixes both sides of the problem. On the read side, resolveFileForRead now retries the GCS lookup with NFC and NFD
normalizations before giving up, which unblocks the conversations that already have NFD objects in the bucket. On the write
side, `FileResource.makeNew` and rename normalize the filename to NFC so new uploads can't drift again. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25450">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->