### PR TITLE
[sandbox,front] bump dsbx to 0.1.7 and base image to 0.8.6

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [[bin]]

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -13,8 +13,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.5";
-const DSBX_CLI_VERSION = "0.1.6";
+const DUST_BASE_IMAGE_VERSION = "0.8.6";
+const DSBX_CLI_VERSION = "0.1.7";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.


### PR DESCRIPTION
## Description

Follow-up to #25424 (slice 4). That PR added the \`--secrets-file\` flag to dsbx and made front pass it, but did not bump the dsbx version or the image pin. Without this bump the deploy plan can't run: \`release-dsbx-cli\` would try to retag \`dsbx-v0.1.6\` and the image build would keep pulling the slice 3 binary.

Worse, with front already on slice 4 code, prod sandboxes spawned from the existing image (dsbx 0.1.6) reject \`--secrets-file\` and dsbx fails to start.

- \`cli/dust-sandbox/Cargo.toml\` + \`Cargo.lock\`: 0.1.6 -> 0.1.7
- \`front/lib/api/sandbox/image/registry.ts\`:
  - \`DSBX_CLI_VERSION\` 0.1.6 -> 0.1.7
  - \`DUST_BASE_IMAGE_VERSION\` 0.8.5 -> 0.8.6

## Tests

\`cargo build\` on dsbx clean. No behavior change beyond version strings.

## Risk

Low. Pure version bumps. Deploy ordering is the same as slice 3: release dsbx, build image, bump pins in front, deploy front.

## Deploy Plan

- [ ] Merge this PR.
- [ ] Run the \`Release dsbx CLI\` workflow (manual \`workflow_dispatch\`). Produces \`dsbx-v0.1.7\` GitHub Release.
- [ ] Run the \`Sandbox Image Registry\` workflow (manual \`workflow_dispatch\`). Builds base image 0.8.6, which pulls dsbx 0.1.7.
- [ ] Deploy front.
- [ ] On a fresh sandbox: confirm dsbx logs \`loaded egress secrets table\` with \`secret_count\` and \`domain_pattern_count\` when \`/run/dust/egress-secrets.json\` is present.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25451">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->