### PR TITLE
Fix user message action buttons not clickable on mobile

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -523,33 +523,30 @@ function TriggerChip({ message }: { message?: UserMessageType }) {
 
 // When the conversation container is narrow, the action menu sits below the message bubble.
 // When the conversation container is wider, it floats to the left (current user) or right (other user).
-const actionMenuContainerVariants = cva(
-  "flex items-center gap-1 absolute left-0 bottom-0",
-  {
-    variants: {
-      mode: {
-        side: "",
-        bottom: "translate-y-[calc(100%+4px)]",
-      },
-      isCurrentUser: {
-        true: "",
-        false: "",
-      },
+const actionMenuContainerVariants = cva("flex items-center gap-1", {
+  variants: {
+    mode: {
+      side: "absolute left-0 bottom-0",
+      bottom: "",
     },
-    compoundVariants: [
-      {
-        mode: "side",
-        isCurrentUser: true,
-        className: "-translate-x-full pr-2",
-      },
-      {
-        mode: "side",
-        isCurrentUser: false,
-        className: "left-auto right-0 translate-x-full pl-2",
-      },
-    ],
-  }
-);
+    isCurrentUser: {
+      true: "",
+      false: "",
+    },
+  },
+  compoundVariants: [
+    {
+      mode: "side",
+      isCurrentUser: true,
+      className: "-translate-x-full pr-2",
+    },
+    {
+      mode: "side",
+      isCurrentUser: false,
+      className: "left-auto right-0 translate-x-full pl-2",
+    },
+  ],
+});
 
 interface ActionMenuProps {
   mode: "side" | "bottom";


### PR DESCRIPTION
## Description

_Bug TLDR: We could not click on mobile on user message actions unless it's the last message 🙏🏻_ 

On mobile, user messages use "bottom mode" for the action bar (emoji picker and 3-dots menu), which renders it below the message bubble. The action bar was absolutely positioned with translate-y-[calc(100%+4px)] to place it just below the container, but since absolute elements are removed from document flow, the next message in the conversation would render on top of the buttons and intercept all touch events. Only the last message was unaffected since nothing sits below it.

The fix moves absolute left-0 bottom-0 from the shared base class to the side variant only. In bottom mode, the action bar is now a normal in-flow flex child, so the container grows to include it and subsequent messages are pushed down accordingly. Visual position is unchanged since the previous 4px offset from translate-y matches the existing gap-1 in the flex column.

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25452">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->