### PR TITLE
Rename visible content from reinforcement to self improving skills

### DIFF
--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -114,7 +114,7 @@ export const adminRoutes: RouteObject[] = [
         element: <SandboxPage />,
       },
       {
-        path: "developers/reinforcement",
+        path: "developers/self-improving-skills",
         element: <ReinforcementPage />,
       },
     ],

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -87,7 +87,7 @@ export type SubNavigationAdminId =
   | "analytics"
   | "credits_usage"
   | "usage"
-  | "reinforcement";
+  | "self_improving_skills";
 
 export const ADMIN_ROUTE_PATTERNS: Record<SubNavigationAdminId, string[]> = {
   members: ["/w/[wId]/members"],
@@ -101,7 +101,7 @@ export const ADMIN_ROUTE_PATTERNS: Record<SubNavigationAdminId, string[]> = {
   dev_secrets: ["/w/[wId]/developers/dev-secrets"],
   sandbox: ["/w/[wId]/developers/sandbox"],
   usage: ["/w/[wId]/usage"],
-  reinforcement: ["/w/[wId]/developers/reinforcement"],
+  self_improving_skills: ["/w/[wId]/developers/self-improving-skills"],
 };
 
 export type SubNavigationAppId =
@@ -212,7 +212,7 @@ export const getTopNavigationTabs = (
           "/w/[wId]/developers/dev-secrets",
           "/w/[wId]/developers/sandbox",
           "/w/[wId]/usage",
-          "/w/[wId]/developers/reinforcement",
+          "/w/[wId]/developers/self-improving-skills",
         ]),
       sizing: "hug",
     });
@@ -342,11 +342,11 @@ export const subNavigationAdmin = ({
           featureFlag: "sandbox_workspace_admin",
         },
         {
-          id: "reinforcement",
-          label: "Reinforcement",
+          id: "self_improving_skills",
+          label: "Self-Improving Skills",
           icon: SparklesIcon,
-          href: `/w/${owner.sId}/developers/reinforcement`,
-          current: isCurrent("reinforcement"),
+          href: `/w/${owner.sId}/developers/self-improving-skills`,
+          current: isCurrent("self_improving_skills"),
           featureFlag: "reinforcement_ui",
         },
       ],

--- a/front/components/pages/workspace/developers/ReinforcementPage.tsx
+++ b/front/components/pages/workspace/developers/ReinforcementPage.tsx
@@ -23,14 +23,14 @@ export function ReinforcementPage() {
     if (!isAdmin) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Only workspace admins can manage reinforcement settings.
+          Only workspace admins can manage self-improving skills settings.
         </ContentMessage>
       );
     }
     if (!hasReinforcement) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Reinforcement is not enabled for this workspace.
+          Self-improving skills are not enabled for this workspace.
         </ContentMessage>
       );
     }
@@ -53,14 +53,14 @@ export function ReinforcementPage() {
       <Page.Header
         title={
           <span className="flex items-center gap-2">
-            Reinforcement
+            Self-Improving Skills
             <Chip size="xs" color="golden" label="Beta" />
           </span>
         }
         icon={SparklesIcon}
         description={
           <span>
-            Configure skill reinforcement settings for this workspace.{" "}
+            Configure self-improving skills settings for this workspace.{" "}
             <a
               href="https://docs.dust.tt/docs/reinforcement"
               target="_blank"

--- a/front/components/poke/conversation/reinforcement_skills_table.tsx
+++ b/front/components/poke/conversation/reinforcement_skills_table.tsx
@@ -128,7 +128,7 @@ export function ReinforcementSkillsConversationDataTable({
 
   return (
     <PokeDataTableConditionalFetch
-      header="Reinforcement conversations"
+      header="Self-improving skills conversations"
       owner={owner}
       showSensitiveDataWarning={true}
       useSWRHook={useReinforcementSkillsConversations}

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -580,7 +580,7 @@ export function ConversationPage() {
               disabled={isRendering}
             />
             <Button
-              label="Reinforcement test"
+              label="Self-improving skills test"
               variant="primary"
               size="xs"
               onClick={() => void copyTestCase()}

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -251,7 +251,7 @@ export function WorkspaceInfoTable({
               </>
             )}
             <PokeTableRow>
-              <PokeTableCell>Reinforcement</PokeTableCell>
+              <PokeTableCell>Self-Improving Skills</PokeTableCell>
               <PokeTableCell>
                 <LinkWrapper
                   href={`https://cloud.temporal.io/namespaces/${temporalFrontNamespace}/schedules?query=%60ScheduleId%60%3D%22reinforcement-workspace-${owner.sId}%22`}

--- a/front/components/workspace/settings/AgentReinforcementToggle.tsx
+++ b/front/components/workspace/settings/AgentReinforcementToggle.tsx
@@ -34,7 +34,7 @@ export function ReinforcementSection({ owner }: ReinforcementSectionProps) {
       <ContextItem.List>
         <div className="h-full border-b border-border dark:border-border-night" />
         <ContextItem
-          title="Allow reinforcement"
+          title="Allow self-improving skills"
           visual={<SparklesIcon className="h-6 w-6 shrink-0" />}
           hasSeparatorIfLast={true}
           action={
@@ -206,7 +206,7 @@ function ReinforcementCapItem({ owner }: ReinforcementSectionProps) {
         </form>
       }
     >
-      <ContextItem.Description description="Reinforcement is priced as programmatic usage. This is the maximum cost per month (in USD) for the feature across all skills. Once reached, no new reinforcement runs are started until the next billing month." />
+      <ContextItem.Description description="Self-improving skills is priced as programmatic usage. This is the maximum cost per month (in USD) for the feature across all skills. Once reached, no new self-improving runs are started until the next billing month." />
     </ContextItem>
   );
 }

--- a/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.test.ts
@@ -436,7 +436,7 @@ describe("PATCH /api/w/[wId]/assistant/skills/[sId]/suggestions", () => {
 
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.message).toContain(
-      "Reinforcement is not enabled"
+      "Self-improving skills are not enabled"
     );
   });
 });

--- a/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.ts
@@ -147,7 +147,8 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Reinforcement is not enabled for this workspace.",
+            message:
+              "Self-improving skills are not enabled for this workspace.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/skills/[sId]/reinforcement.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/reinforcement.test.ts
@@ -284,7 +284,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]/reinforcement", () => {
       error: {
         type: "workspace_auth_error",
         message:
-          "This skill's reinforcement is locked; only admins can change it.",
+          "This skill's self-improvement is locked; only admins can change it.",
       },
     });
   });

--- a/front/pages/api/w/[wId]/skills/[sId]/reinforcement.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/reinforcement.ts
@@ -110,7 +110,7 @@ async function handler(
             api_error: {
               type: "workspace_auth_error",
               message:
-                "This skill's reinforcement is locked; only admins can change it.",
+                "This skill's self-improvement is locked; only admins can change it.",
             },
           });
         }

--- a/front/pages/api/w/[wId]/skills/reinforcement_spend.test.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_spend.test.ts
@@ -106,7 +106,7 @@ describe("GET /api/w/[wId]/skills/reinforcement_spend", () => {
       expect(res._getJSONData()).toEqual({
         error: {
           type: "workspace_auth_error",
-          message: "Only admins can view reinforcement spend.",
+          message: "Only admins can view self-improving skills spend.",
         },
       });
     }

--- a/front/pages/api/w/[wId]/skills/reinforcement_spend.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_spend.ts
@@ -24,7 +24,7 @@ async function handler(
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
-        message: "Only admins can view reinforcement spend.",
+        message: "Only admins can view self-improving skills spend.",
       },
     });
   }


### PR DESCRIPTION
## Description

Only rename visible things for now:
 - admin page
 - error messages
 - poke plugin text
I will rename more non-breaking things progressively
I think breaking things such as DB value won't be updated

Closes https://github.com/dust-tt/tasks/issues/8037

## Tests

<img width="3440" height="1750" alt="image" src="https://github.com/user-attachments/assets/5940d24f-3524-42c2-a0ff-7396726229e9" />

## Risk

low

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25454">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->