### PR TITLE
[CONNECTORS] add Looker LookML extensions to GitHub supported files

### DIFF
--- a/connectors/src/connectors/github/lib/code/supported_files.ts
+++ b/connectors/src/connectors/github/lib/code/supported_files.ts
@@ -66,6 +66,8 @@ const EXTENSION_WHITELIST = [
   ".properties", // Java properties files
   ".avsc", // Apache Avro schema definition
   ".avdl", // Apache Avro IDL definition
+  ".lkml", // Looker LookML model/view files
+  ".lookml", // Looker legacy dashboard files
 
   ".item", // Talend files, a data integration/ETL platform.
 


### PR DESCRIPTION
## Description

Adds `.lkml` (Looker LookML model/view files) and `.lookml` (Looker legacy dashboard files) to the GitHub connector's whitelist of code file extensions, so they get synced and indexed like other supported source files.

## Tests

No

## Risk

Low. Purely additive to an allow-list — only effect is that GitHub repos containing `.lkml` / `.lookml` files will start syncing them.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `connectors`