### PR TITLE
Teach the files MCP about project paths

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -112,6 +112,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "files": {
     "cat": "never_ask",
     "create": "never_ask",
+    "delete": "medium",
     "grep": "never_ask",
     "list": "never_ask",
   },

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -15,8 +15,8 @@ import {
   resolveConversationFileRef,
 } from "./file_utils";
 
-const { mockResolveConversationFile } = vi.hoisted(() => ({
-  mockResolveConversationFile: vi.fn(),
+const { mockResolveFile } = vi.hoisted(() => ({
+  mockResolveFile: vi.fn(),
 }));
 
 vi.mock(
@@ -28,7 +28,7 @@ vi.mock(
       >();
     return {
       ...actual,
-      resolveConversationFile: mockResolveConversationFile,
+      resolveFile: mockResolveFile,
     };
   }
 );
@@ -145,7 +145,7 @@ describe("getFileFromConversationAttachment", () => {
   });
 
   describe("scoped path (conversation/...)", () => {
-    it("reads the file content from GCS via resolveConversationFile", async () => {
+    it("reads the file content from GCS via resolveFile", async () => {
       const { authenticator: auth } = await createResourceTest({
         role: "admin",
       });
@@ -157,7 +157,7 @@ describe("getFileFromConversationAttachment", () => {
       });
 
       const expectedContent = "gcs bytes";
-      mockResolveConversationFile.mockResolvedValue(
+      mockResolveFile.mockResolvedValue(
         new Ok({
           file: { createReadStream: () => makeReadableStream(expectedContent) },
           mimeType: "text/plain",
@@ -180,7 +180,7 @@ describe("getFileFromConversationAttachment", () => {
       expect(result.value.filename).toBe("notes.txt");
     });
 
-    it("returns Err when resolveConversationFile fails", async () => {
+    it("returns Err when resolveFile fails", async () => {
       const { authenticator: auth } = await createResourceTest({
         role: "admin",
       });
@@ -191,7 +191,7 @@ describe("getFileFromConversationAttachment", () => {
         spaceId: null,
       });
 
-      mockResolveConversationFile.mockResolvedValue(
+      mockResolveFile.mockResolvedValue(
         new Err({ message: "GCS object not found" })
       );
 

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,5 +1,5 @@
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { resolveConversationFile } from "@app/lib/api/actions/servers/files/tools/utils";
+import { resolveFileForRead } from "@app/lib/api/actions/servers/files/tools/utils";
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   conversationAttachmentId,
@@ -53,11 +53,7 @@ export async function resolveConversationFileRef(
   const parsed = parseScopedFilePath(fileId);
   if (parsed) {
     const conversation = agentLoopContext.runContext.conversation;
-    const resolvedRes = await resolveConversationFile(
-      auth,
-      conversation,
-      fileId
-    );
+    const resolvedRes = await resolveFileForRead(auth, conversation, fileId);
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
     }
@@ -125,11 +121,7 @@ export async function getFileFromConversationAttachment(
   const parsed = parseScopedFilePath(fileId);
   if (parsed) {
     const conversation = agentLoopContext.runContext.conversation;
-    const resolvedRes = await resolveConversationFile(
-      auth,
-      conversation,
-      fileId
-    );
+    const resolvedRes = await resolveFileForRead(auth, conversation, fileId);
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
     }

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,5 +1,5 @@
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { resolveFileForRead } from "@app/lib/api/actions/servers/files/tools/utils";
+import { resolveFile } from "@app/lib/api/actions/servers/files/tools/utils";
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   conversationAttachmentId,
@@ -53,7 +53,7 @@ export async function resolveConversationFileRef(
   const parsed = parseScopedFilePath(fileId);
   if (parsed) {
     const conversation = agentLoopContext.runContext.conversation;
-    const resolvedRes = await resolveFileForRead(auth, conversation, fileId);
+    const resolvedRes = await resolveFile(auth, conversation, fileId);
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
     }
@@ -121,7 +121,7 @@ export async function getFileFromConversationAttachment(
   const parsed = parseScopedFilePath(fileId);
   if (parsed) {
     const conversation = agentLoopContext.runContext.conversation;
-    const resolvedRes = await resolveFileForRead(auth, conversation, fileId);
+    const resolvedRes = await resolveFile(auth, conversation, fileId);
     if (resolvedRes.isErr()) {
       return new Err(resolvedRes.error.message);
     }

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -10,6 +10,7 @@ export const FILES_LIST_ACTION_NAME = "list" as const;
 export const FILES_CAT_ACTION_NAME = "cat" as const;
 export const FILES_GREP_ACTION_NAME = "grep" as const;
 export const FILES_CREATE_ACTION_NAME = "create" as const;
+export const FILES_DELETE_ACTION_NAME = "delete" as const;
 
 export const CAT_LINES_DEFAULT = 200;
 export const CAT_LINES_MAX = 500;
@@ -120,6 +121,23 @@ export const FILES_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Writing file",
       done: "Write file",
+    },
+  },
+  [FILES_DELETE_ACTION_NAME]: {
+    description:
+      "Delete a file from the conversation file system. " +
+      "Returns an error if the file does not exist. Deletion is permanent.",
+    schema: {
+      path: z
+        .string()
+        .describe(
+          `Scoped file path as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` (e.g. \`conversation/output.json\`)`
+        ),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Deleting file",
+      done: "Deleted file",
     },
   },
 });

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -7,7 +7,7 @@ import type {
 import { CAT_LINES_DEFAULT } from "@app/lib/api/actions/servers/files/metadata";
 import {
   isReadableAsText,
-  resolveFileForRead,
+  resolveFile,
 } from "@app/lib/api/actions/servers/files/tools/utils";
 import { isLLMVisionSupportedImageContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
@@ -139,7 +139,7 @@ export async function catHandler(
     );
   }
 
-  const resolvedRes = await resolveFileForRead(auth, conversation, path);
+  const resolvedRes = await resolveFile(auth, conversation, path);
   if (resolvedRes.isErr()) {
     return resolvedRes;
   }

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -7,7 +7,7 @@ import type {
 import { CAT_LINES_DEFAULT } from "@app/lib/api/actions/servers/files/metadata";
 import {
   isReadableAsText,
-  resolveConversationFile,
+  resolveFileForRead,
 } from "@app/lib/api/actions/servers/files/tools/utils";
 import { isLLMVisionSupportedImageContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
@@ -132,11 +132,14 @@ export async function catHandler(
   { path, offset, limit }: { path: string; offset?: number; limit?: number },
   { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const resolvedRes = await resolveConversationFile(
-    auth,
-    agentLoopContext?.runContext?.conversation,
-    path
-  );
+  const conversation = agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(
+      new MCPError("No conversation context available.", { tracked: false })
+    );
+  }
+
+  const resolvedRes = await resolveFileForRead(auth, conversation, path);
   if (resolvedRes.isErr()) {
     return resolvedRes;
   }

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -30,8 +30,9 @@ export async function createHandler(
     );
   }
 
-  const mountRes = await resolveMountPointForPath(auth, conversation, path, {
+  const mountRes = await resolveMountPointForPath(auth, conversation, {
     access: "write",
+    scopedPath: path,
   });
   if (mountRes.isErr()) {
     return mountRes;

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -5,7 +5,7 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
-import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
+import { resolveMountPointForPath } from "@app/lib/api/actions/servers/files/tools/utils";
 import {
   createGCSMountFile,
   getGCSPathFromScopedPath,
@@ -23,10 +23,16 @@ export async function createHandler(
   }: { path: string; content: string; content_type: string },
   { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const mountRes = resolveMountPoint(
-    auth,
-    agentLoopContext?.runContext?.conversation
-  );
+  const conversation = agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(
+      new MCPError("No conversation context available.", { tracked: false })
+    );
+  }
+
+  const mountRes = await resolveMountPointForPath(auth, conversation, path, {
+    access: "write",
+  });
   if (mountRes.isErr()) {
     return mountRes;
   }
@@ -40,7 +46,7 @@ export async function createHandler(
   if (!gcsPath) {
     return new Err(
       new MCPError(
-        `Invalid path: \`${path}\` does not belong to the conversation file system.`,
+        `Invalid path: \`${path}\` does not match the resolved mount point.`,
         { tracked: false }
       )
     );

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -5,7 +5,7 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
-import { resolveMountPointForPath } from "@app/lib/api/actions/servers/files/tools/utils";
+import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
 import {
   createGCSMountFile,
   getGCSPathFromScopedPath,
@@ -30,7 +30,7 @@ export async function createHandler(
     );
   }
 
-  const mountRes = await resolveMountPointForPath(auth, conversation, {
+  const mountRes = await resolveMountPoint(auth, conversation, {
     access: "write",
     scopedPath: path,
   });

--- a/front/lib/api/actions/servers/files/tools/delete.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.ts
@@ -20,8 +20,9 @@ export async function deleteHandler(
     );
   }
 
-  const mountRes = await resolveMountPointForPath(auth, conversation, path, {
+  const mountRes = await resolveMountPointForPath(auth, conversation, {
     access: "write",
+    scopedPath: path,
   });
   if (mountRes.isErr()) {
     return mountRes;

--- a/front/lib/api/actions/servers/files/tools/delete.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.ts
@@ -1,0 +1,67 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { resolveMountPointForPath } from "@app/lib/api/actions/servers/files/tools/utils";
+import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export async function deleteHandler(
+  { path }: { path: string },
+  { auth, agentLoopContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const conversation = agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(
+      new MCPError("No conversation context available.", { tracked: false })
+    );
+  }
+
+  const mountRes = await resolveMountPointForPath(auth, conversation, path, {
+    access: "write",
+  });
+  if (mountRes.isErr()) {
+    return mountRes;
+  }
+
+  const { scope, prefix } = mountRes.value;
+
+  const gcsPath = getGCSPathFromScopedPath({
+    prefix,
+    scopedPath: path,
+    useCase: scope.useCase,
+  });
+  if (!gcsPath) {
+    return new Err(
+      new MCPError(
+        `Invalid path: \`${path}\` does not match the resolved mount point.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const bucket = getPrivateUploadBucket();
+  const file = bucket.file(gcsPath);
+
+  const [exists] = await file.exists();
+  if (!exists) {
+    return new Err(
+      new MCPError(`File not found: \`${path}\`.`, { tracked: false })
+    );
+  }
+
+  try {
+    await file.delete();
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `Failed to delete file \`${path}\`: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  return new Ok([{ type: "text", text: `Deleted \`${path}\`.` }]);
+}

--- a/front/lib/api/actions/servers/files/tools/delete.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.ts
@@ -3,7 +3,7 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { resolveMountPointForPath } from "@app/lib/api/actions/servers/files/tools/utils";
+import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
 import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { Err, Ok } from "@app/types/shared/result";
@@ -20,7 +20,7 @@ export async function deleteHandler(
     );
   }
 
-  const mountRes = await resolveMountPointForPath(auth, conversation, {
+  const mountRes = await resolveMountPoint(auth, conversation, {
     access: "write",
     scopedPath: path,
   });

--- a/front/lib/api/actions/servers/files/tools/grep.ts
+++ b/front/lib/api/actions/servers/files/tools/grep.ts
@@ -11,7 +11,7 @@ import {
 } from "@app/lib/api/actions/servers/files/metadata";
 import {
   isReadableAsText,
-  resolveFileForRead,
+  resolveFile,
 } from "@app/lib/api/actions/servers/files/tools/utils";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -28,7 +28,7 @@ export async function grepHandler(
     );
   }
 
-  const resolvedRes = await resolveFileForRead(auth, conversation, path);
+  const resolvedRes = await resolveFile(auth, conversation, path);
   if (resolvedRes.isErr()) {
     return resolvedRes;
   }

--- a/front/lib/api/actions/servers/files/tools/grep.ts
+++ b/front/lib/api/actions/servers/files/tools/grep.ts
@@ -11,7 +11,7 @@ import {
 } from "@app/lib/api/actions/servers/files/metadata";
 import {
   isReadableAsText,
-  resolveConversationFile,
+  resolveFileForRead,
 } from "@app/lib/api/actions/servers/files/tools/utils";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -21,11 +21,14 @@ export async function grepHandler(
   { path, pattern }: { path: string; pattern: string },
   { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const resolvedRes = await resolveConversationFile(
-    auth,
-    agentLoopContext?.runContext?.conversation,
-    path
-  );
+  const conversation = agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(
+      new MCPError("No conversation context available.", { tracked: false })
+    );
+  }
+
+  const resolvedRes = await resolveFileForRead(auth, conversation, path);
   if (resolvedRes.isErr()) {
     return resolvedRes;
   }

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -2,12 +2,14 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import {
   FILES_CAT_ACTION_NAME,
   FILES_CREATE_ACTION_NAME,
+  FILES_DELETE_ACTION_NAME,
   FILES_GREP_ACTION_NAME,
   FILES_LIST_ACTION_NAME,
   FILES_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/files/metadata";
 import { catHandler } from "@app/lib/api/actions/servers/files/tools/cat";
 import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
+import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
 import { grepHandler } from "@app/lib/api/actions/servers/files/tools/grep";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 
@@ -16,4 +18,5 @@ export const TOOLS = buildTools(FILES_TOOLS_METADATA, {
   [FILES_CAT_ACTION_NAME]: catHandler,
   [FILES_GREP_ACTION_NAME]: grepHandler,
   [FILES_CREATE_ACTION_NAME]: createHandler,
+  [FILES_DELETE_ACTION_NAME]: deleteHandler,
 });

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -3,8 +3,7 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { resolveAvailableMountPoints } from "@app/lib/api/actions/servers/files/tools/utils";
-import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
+import type { GCSMountPoint } from "@app/lib/api/files/gcs_mount/files";
 import { listGCSMountFiles } from "@app/lib/api/files/gcs_mount/files";
 import { parseProcessedFilename } from "@app/lib/api/files/mount_path";
 import { stripMimeParameters } from "@app/types/files";
@@ -34,15 +33,13 @@ export async function listHandler(
     );
   }
 
-  const mounts = await resolveAvailableMountPoints(extra.auth, conversation);
-
-  const entries: GCSMountEntry[] = [];
-  for (const mount of mounts) {
-    const mountEntries = await listGCSMountFiles(extra.auth, mount.scope, {
-      includeProcessed: true,
-    });
-    entries.push(...mountEntries);
-  }
+  const scope: GCSMountPoint = {
+    useCase: "conversation",
+    conversationId: conversation.sId,
+  };
+  const entries = await listGCSMountFiles(extra.auth, scope, {
+    includeProcessed: true,
+  });
 
   const [dirs, files] = partition(entries, (e) => e.isDirectory);
 

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -1,12 +1,14 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
+import { resolveAvailableMountPoints } from "@app/lib/api/actions/servers/files/tools/utils";
+import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
 import { listGCSMountFiles } from "@app/lib/api/files/gcs_mount/files";
 import { parseProcessedFilename } from "@app/lib/api/files/mount_path";
 import { stripMimeParameters } from "@app/types/files";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import partition from "lodash/partition";
 
 function getDirAndFileName(path: string): { dir: string; fileName: string } {
@@ -25,17 +27,22 @@ export async function listHandler(
   _params: Record<string, never>,
   extra: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const mountRes = resolveMountPoint(
-    extra.auth,
-    extra.agentLoopContext?.runContext?.conversation
-  );
-  if (mountRes.isErr()) {
-    return mountRes;
+  const conversation = extra.agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(
+      new MCPError("No conversation context available.", { tracked: false })
+    );
   }
 
-  const entries = await listGCSMountFiles(extra.auth, mountRes.value.scope, {
-    includeProcessed: true,
-  });
+  const mounts = await resolveAvailableMountPoints(extra.auth, conversation);
+
+  const entries: GCSMountEntry[] = [];
+  for (const mount of mounts) {
+    const mountEntries = await listGCSMountFiles(extra.auth, mount.scope, {
+      includeProcessed: true,
+    });
+    entries.push(...mountEntries);
+  }
 
   const [dirs, files] = partition(entries, (e) => e.isDirectory);
 

--- a/front/lib/api/actions/servers/files/tools/utils.test.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.test.ts
@@ -1,8 +1,8 @@
 import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import assert from "assert";
 import { describe, expect, it } from "vitest";
 

--- a/front/lib/api/actions/servers/files/tools/utils.test.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.test.ts
@@ -1,0 +1,170 @@
+import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { Authenticator } from "@app/lib/auth";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+describe("resolveMountPoint", () => {
+  describe("conversation paths", () => {
+    it("returns the conversation mount with the correct prefix", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const result = await resolveMountPoint(auth, conversation, {
+        access: "read",
+        scopedPath: "conversation/notes.md",
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.scope).toEqual({
+        useCase: "conversation",
+        conversationId: conversation.sId,
+      });
+      expect(result.value.prefix).toBe(
+        `w/${workspace.sId}/conversations/${conversation.sId}/files/`
+      );
+    });
+
+    it("returns the conversation mount on a write access request too", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const result = await resolveMountPoint(auth, conversation, {
+        access: "write",
+        scopedPath: "conversation/folder/sub/output.csv",
+      });
+
+      expect(result.isOk()).toBe(true);
+    });
+  });
+
+  describe("project paths", () => {
+    it("returns the project mount for a project conversation", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const userId = auth.getNonNullableUser().id;
+      const userSId = auth.getNonNullableUser().sId;
+
+      const space = await SpaceFactory.project(workspace, userId);
+      const addRes = await space.addMembers(auth, { userIds: [userSId] });
+      assert(addRes.isOk(), "Failed to add user to project space");
+
+      // Refresh the auth so the new space membership is picked up.
+      const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        userSId,
+        workspace.sId
+      );
+
+      const conversation = await createConversation(projectAuth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: space.id,
+      });
+
+      const result = await resolveMountPoint(projectAuth, conversation, {
+        access: "read",
+        scopedPath: "project/spec.md",
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.scope).toEqual({
+        useCase: "project",
+        projectId: space.sId,
+      });
+      expect(result.value.prefix).toBe(
+        `w/${workspace.sId}/projects/${space.sId}/files/`
+      );
+    });
+
+    it("returns Err for a project path in a non-project conversation", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const result = await resolveMountPoint(auth, conversation, {
+        access: "read",
+        scopedPath: "project/spec.md",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error.message).toContain("project conversations");
+    });
+  });
+
+  describe("invalid paths", () => {
+    it("returns Err for a path without a known scope prefix", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const result = await resolveMountPoint(auth, conversation, {
+        access: "read",
+        scopedPath: "other/foo.txt",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error.message).toContain("must start with");
+    });
+
+    it("returns Err for a path without a slash", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const result = await resolveMountPoint(auth, conversation, {
+        access: "read",
+        scopedPath: "conversation",
+      });
+
+      expect(result.isErr()).toBe(true);
+    });
+  });
+});

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -103,8 +103,7 @@ async function buildProjectMountPoint(
 export async function resolveMountPointForPath(
   auth: Authenticator,
   conversation: ConversationType,
-  scopedPath: string,
-  { access }: { access: Access }
+  { access, scopedPath }: { access: Access; scopedPath: string }
 ): Promise<Result<MountPoint, MCPError>> {
   const parsed = parseScopedFilePath(scopedPath);
   if (!parsed) {
@@ -163,8 +162,9 @@ export async function resolveFileForRead(
   conversation: ConversationType,
   path: string
 ): Promise<Result<ResolvedFile, MCPError>> {
-  const mountRes = await resolveMountPointForPath(auth, conversation, path, {
+  const mountRes = await resolveMountPointForPath(auth, conversation, {
     access: "read",
+    scopedPath: path,
   });
   if (mountRes.isErr()) {
     return mountRes;

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -1,15 +1,23 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   type GCSMountPoint,
   getGCSPathFromScopedPath,
 } from "@app/lib/api/files/gcs_mount/files";
-import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import {
+  getConversationFilesBasePath,
+  getProjectFilesBasePath,
+  parseScopedFilePath,
+} from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ConversationType } from "@app/types/assistant/conversation";
+import { isProjectConversation } from "@app/types/assistant/conversation";
 import { stripMimeParameters } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import type { File as GCSFile } from "@google-cloud/storage";
@@ -20,45 +28,149 @@ interface ResolvedFile {
   sizeBytes: number;
 }
 
-interface MountPoint {
+export interface MountPoint {
   prefix: string;
   scope: GCSMountPoint;
 }
 
-export function resolveMountPoint(
+type Access = "read" | "write";
+
+function buildConversationMountPoint(
   auth: Authenticator,
-  conversation: ConversationType | null | undefined
-): Result<MountPoint, MCPError> {
-  if (!conversation) {
-    return new Err(new MCPError("No conversation context available."));
+  conversation: ConversationType
+): MountPoint {
+  const owner = auth.getNonNullableWorkspace();
+  return {
+    scope: { useCase: "conversation", conversationId: conversation.sId },
+    prefix: getConversationFilesBasePath({
+      workspaceId: owner.sId,
+      conversationId: conversation.sId,
+    }),
+  };
+}
+
+async function buildProjectMountPoint(
+  auth: Authenticator,
+  conversation: ConversationType,
+  { access }: { access: Access }
+): Promise<Result<MountPoint, MCPError>> {
+  if (!isProjectConversation(conversation)) {
+    return new Err(
+      new MCPError(
+        "Project file paths are only available in project conversations.",
+        { tracked: false }
+      )
+    );
+  }
+
+  const space = await SpaceResource.fetchById(auth, conversation.spaceId);
+  if (!space) {
+    return new Err(
+      new MCPError("Project not found for this conversation.", {
+        tracked: false,
+      })
+    );
+  }
+
+  const allowed =
+    access === "write" ? space.canWrite(auth) : space.canRead(auth);
+  if (!allowed) {
+    return new Err(
+      new MCPError(
+        access === "write"
+          ? "You do not have write permissions for this project."
+          : "You do not have read permissions for this project.",
+        { tracked: false }
+      )
+    );
   }
 
   const owner = auth.getNonNullableWorkspace();
-  const scope: GCSMountPoint = {
-    useCase: "conversation",
-    conversationId: conversation.sId,
-  };
-
-  const prefix = getConversationFilesBasePath({
-    workspaceId: owner.sId,
-    conversationId: conversation.sId,
+  return new Ok({
+    scope: { useCase: "project", projectId: space.sId },
+    prefix: getProjectFilesBasePath({
+      workspaceId: owner.sId,
+      projectId: space.sId,
+    }),
   });
-
-  return new Ok({ scope, prefix });
 }
 
-export async function resolveConversationFile(
+/**
+ * Resolve the mount point a scoped path belongs to. Dispatches by the path's `conversation/` or
+ * `project/` prefix, looks up the parent project space when needed, and verifies the requested
+ * access level.
+ */
+export async function resolveMountPointForPath(
   auth: Authenticator,
-  conversation: ConversationType | undefined,
+  conversation: ConversationType,
+  scopedPath: string,
+  { access }: { access: Access }
+): Promise<Result<MountPoint, MCPError>> {
+  const parsed = parseScopedFilePath(scopedPath);
+  if (!parsed) {
+    return new Err(
+      new MCPError(
+        `Invalid path: \`${scopedPath}\` must start with \`conversation/\` or \`project/\`.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  switch (parsed.prefix) {
+    case "conversation":
+      return new Ok(buildConversationMountPoint(auth, conversation));
+
+    case "project":
+      return buildProjectMountPoint(auth, conversation, { access });
+
+    default:
+      assertNever(parsed.prefix);
+  }
+}
+
+/**
+ * Resolve all mount points visible from the given conversation: the conversation's own mount, plus
+ * the parent project mount when the conversation is in a project (and the actor can read it).
+ * Used by the `list` tool to enumerate everything available.
+ */
+export async function resolveAvailableMountPoints(
+  auth: Authenticator,
+  conversation: ConversationType
+): Promise<MountPoint[]> {
+  const mounts: MountPoint[] = [
+    buildConversationMountPoint(auth, conversation),
+  ];
+
+  if (isProjectConversation(conversation)) {
+    const projectRes = await buildProjectMountPoint(auth, conversation, {
+      access: "read",
+    });
+    // Silently skip the project mount if the actor lacks read permissions — listing should still
+    // surface conversation files. Other errors (e.g. space not found) also drop the mount.
+    if (projectRes.isOk()) {
+      mounts.push(projectRes.value);
+    }
+  }
+
+  return mounts;
+}
+
+/**
+ * Resolve a GCS file from a scoped path for read access. Used by `cat` and `grep`.
+ */
+export async function resolveFileForRead(
+  auth: Authenticator,
+  conversation: ConversationType,
   path: string
 ): Promise<Result<ResolvedFile, MCPError>> {
-  const mountRes = resolveMountPoint(auth, conversation);
+  const mountRes = await resolveMountPointForPath(auth, conversation, path, {
+    access: "read",
+  });
   if (mountRes.isErr()) {
     return mountRes;
   }
 
   const { scope, prefix } = mountRes.value;
-
   const gcsPath = getGCSPathFromScopedPath({
     prefix,
     scopedPath: path,
@@ -67,7 +179,7 @@ export async function resolveConversationFile(
   if (!gcsPath) {
     return new Err(
       new MCPError(
-        `Invalid path: \`${path}\` does not belong to the conversation file system.`,
+        `Invalid path: \`${path}\` does not match the resolved mount point.`,
         { tracked: false }
       )
     );

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -99,7 +99,7 @@ async function buildProjectMountPoint(
  * `project/` prefix, looks up the parent project space when needed, and verifies the requested
  * access level.
  */
-export async function resolveMountPointForPath(
+export async function resolveMountPoint(
   auth: Authenticator,
   conversation: ConversationType,
   { access, scopedPath }: { access: Access; scopedPath: string }
@@ -127,41 +127,15 @@ export async function resolveMountPointForPath(
 }
 
 /**
- * Resolve all mount points visible from the given conversation: the conversation's own mount, plus
- * the parent project mount when the conversation is in a project (and the actor can read it).
- * Used by the `list` tool to enumerate everything available.
+ * Resolve a GCS file from a scoped path. Looks up the file metadata via `resolveMountPoint`.
+ * Used by `cat` and `grep`.
  */
-export async function resolveAvailableMountPoints(
-  auth: Authenticator,
-  conversation: ConversationType
-): Promise<MountPoint[]> {
-  const mounts: MountPoint[] = [
-    buildConversationMountPoint(auth, conversation),
-  ];
-
-  if (isProjectConversation(conversation)) {
-    const projectRes = await buildProjectMountPoint(auth, conversation, {
-      access: "read",
-    });
-    // Silently skip the project mount if the actor lacks read permissions — listing should still
-    // surface conversation files. Other errors (e.g. space not found) also drop the mount.
-    if (projectRes.isOk()) {
-      mounts.push(projectRes.value);
-    }
-  }
-
-  return mounts;
-}
-
-/**
- * Resolve a GCS file from a scoped path for read access. Used by `cat` and `grep`.
- */
-export async function resolveFileForRead(
+export async function resolveFile(
   auth: Authenticator,
   conversation: ConversationType,
   path: string
 ): Promise<Result<ResolvedFile, MCPError>> {
-  const mountRes = await resolveMountPointForPath(auth, conversation, {
+  const mountRes = await resolveMountPoint(auth, conversation, {
     access: "read",
     scopedPath: path,
   });

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -1,5 +1,4 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   type GCSMountPoint,
   getGCSPathFromScopedPath,

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import {
   getConversationFilesBasePath,
+  getProjectFilesBasePath,
   TOOL_OUTPUTS_FOLDER_NAME,
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
@@ -33,10 +34,9 @@ export type GCSMountFileEntry = GCSMountEntryBase & {
 
 export type GCSMountEntry = GCSMountDirectoryEntry | GCSMountFileEntry;
 
-export type GCSMountPoint = {
-  useCase: "conversation";
-  conversationId: string;
-};
+export type GCSMountPoint =
+  | { useCase: "conversation"; conversationId: string }
+  | { useCase: "project"; projectId: string };
 
 function resolvePrefix(
   owner: LightWorkspaceType,
@@ -49,8 +49,14 @@ function resolvePrefix(
         conversationId: scope.conversationId,
       });
 
+    case "project":
+      return getProjectFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: scope.projectId,
+      });
+
     default:
-      assertNever(scope.useCase);
+      assertNever(scope);
   }
 }
 
@@ -125,10 +131,40 @@ function makeFileEntry(
     contentType,
     lastModifiedMs,
     fileId,
-    thumbnailUrl: isSupportedImageContentType(contentType)
-      ? `${config.getClientFacingUrl()}/api/w/${workspaceId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(`${scope.useCase}/${relativeFilePath}`)}`
-      : null,
+    thumbnailUrl: makeThumbnailUrl({
+      scope,
+      relativeFilePath,
+      contentType,
+      workspaceId,
+    }),
   };
+}
+
+function makeThumbnailUrl({
+  scope,
+  relativeFilePath,
+  contentType,
+  workspaceId,
+}: {
+  scope: GCSMountPoint;
+  relativeFilePath: string;
+  contentType: string;
+  workspaceId: string;
+}): string | null {
+  if (!isSupportedImageContentType(contentType)) {
+    return null;
+  }
+  switch (scope.useCase) {
+    case "conversation":
+      return `${config.getClientFacingUrl()}/api/w/${workspaceId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(`${scope.useCase}/${relativeFilePath}`)}`;
+
+    case "project":
+      // TODO(FILE SYSTEM PROJECT) Expose a project files thumbnail endpoint.
+      return null;
+
+    default:
+      assertNever(scope);
+  }
 }
 
 /**
@@ -246,7 +282,7 @@ export async function getConversationFileMountSignedUrl(
   if (!gcsPath.startsWith(prefix)) {
     return new Err(
       new Error(
-        `GCS path does not belong to the expected conversation file system.`
+        `GCS path does not belong to the expected mount point.`
       )
     );
   }

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -132,34 +132,35 @@ function makeFileEntry(
     lastModifiedMs,
     fileId,
     thumbnailUrl: makeThumbnailUrl({
-      scope,
-      relativeFilePath,
       contentType,
+      relativeFilePath,
+      scope,
       workspaceId,
     }),
   };
 }
 
 function makeThumbnailUrl({
-  scope,
-  relativeFilePath,
   contentType,
+  relativeFilePath,
+  scope,
   workspaceId,
 }: {
-  scope: GCSMountPoint;
-  relativeFilePath: string;
   contentType: string;
+  relativeFilePath: string;
+  scope: GCSMountPoint;
   workspaceId: string;
 }): string | null {
   if (!isSupportedImageContentType(contentType)) {
     return null;
   }
+
   switch (scope.useCase) {
     case "conversation":
       return `${config.getClientFacingUrl()}/api/w/${workspaceId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(`${scope.useCase}/${relativeFilePath}`)}`;
 
     case "project":
-      // TODO(FILE SYSTEM PROJECT) Expose a project files thumbnail endpoint.
+      // TODO(2026-05-10: FILE SYSTEM) Expose a project files thumbnail endpoint.
       return null;
 
     default:
@@ -281,9 +282,7 @@ export async function getConversationFileMountSignedUrl(
   const prefix = resolvePrefix(owner, scope);
   if (!gcsPath.startsWith(prefix)) {
     return new Err(
-      new Error(
-        `GCS path does not belong to the expected mount point.`
-      )
+      new Error(`GCS path does not belong to the expected mount point.`)
     );
   }
   try {

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -3,8 +3,10 @@ import {
   getBaseMountPathForWorkspace,
   getConversationFilePath,
   getConversationFilesBasePath,
+  getProjectFilesBasePath,
   makeProcessedMountFileName,
   parseProcessedFilename,
+  parseScopedFilePath,
 } from "@app/lib/api/files/mount_path";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -27,6 +29,38 @@ describe("mount_path helpers", () => {
           conversationId: "conv1",
         })
       ).toBe("w/ws1/conversations/conv1/files/");
+    });
+  });
+
+  describe("getProjectFilesBasePath", () => {
+    it("should return full project files path", () => {
+      expect(
+        getProjectFilesBasePath({ workspaceId: "ws1", projectId: "spc1" })
+      ).toBe("w/ws1/projects/spc1/files/");
+    });
+  });
+
+  describe("parseScopedFilePath", () => {
+    it("parses a conversation path", () => {
+      expect(parseScopedFilePath("conversation/report.pdf")).toEqual({
+        prefix: "conversation",
+        rel: "report.pdf",
+      });
+    });
+
+    it("parses a project path", () => {
+      expect(parseScopedFilePath("project/notes/2026/draft.md")).toEqual({
+        prefix: "project",
+        rel: "notes/2026/draft.md",
+      });
+    });
+
+    it("returns null for unknown prefixes", () => {
+      expect(parseScopedFilePath("other/foo.txt")).toBeNull();
+    });
+
+    it("returns null when there is no slash", () => {
+      expect(parseScopedFilePath("conversation")).toBeNull();
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -1,4 +1,10 @@
-// Pure path helpers for conversation file mount paths (gcsfuse sandbox mounting).
+// Pure path helpers for sandbox mount paths (gcsfuse mounting).
+//
+// Two scoped mounts are supported:
+//   - "conversation": files scoped to a single conversation, mounted at /files/conversation
+//   - "project":      files scoped to a project (space), mounted at /files/project when the
+//                     conversation belongs to a project. Persistent across conversations within
+//                     the same project.
 
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { AllSupportedFileContentType } from "@app/types/files";
@@ -45,6 +51,16 @@ export function getConversationFilePath({
   fileName: string;
 }): string {
   return `${getConversationFilesBasePath({ workspaceId, conversationId })}${fileName}`;
+}
+
+export function getProjectFilesBasePath({
+  workspaceId,
+  projectId,
+}: {
+  workspaceId: string;
+  projectId: string;
+}): string {
+  return `${getBaseMountPathForWorkspace({ workspaceId })}projects/${projectId}/files/`;
 }
 
 /**
@@ -127,11 +143,7 @@ export function parseProcessedFilename(
   return { isProcessed: true, sourceBaseName: fileName.slice(0, idx) };
 }
 
-export const scopedFilePathPrefixSchema = z.enum([
-  "conversation",
-  // TODO(20260428 FILE SYSTEM) Add support for project.
-  // "project"
-]);
+export const scopedFilePathPrefixSchema = z.enum(["conversation", "project"]);
 export type ScopedFilePathPrefix = z.infer<typeof scopedFilePathPrefixSchema>;
 
 export type ScopedFilePath = {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This is the first wave of bringing project files onto the same mount-based file system that already serves conversation
files. The `GCSMountPoint` discriminated union now carries a project arm, the scoped path schema accepts `project/...` paths, and the new `getProjectFilesBasePath` helper produces the GCS
prefix `w/{wId}/projects/{spaceId}/files/`. None of this is mounted in the sandbox yet. That comes in the next wave but the
type system can now represent a project mount end-to-end, and any GCS path is one helper call away.

The files MCP server has been updated to also support operations on project files (following the `canRead` and `canWrite` permissioning). For now the agent can only list conversations files, we will add support to list project files in a follow up PR.

The wave also fills in a missing piece by adding a `files__delete` tool. It uses the same path-aware resolver and works for
both mounts, so the agent can finally clean up files it created.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25456">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->