### PR TITLE
Self-improving skills: total consumption in admin page

### DIFF
--- a/front/components/pages/workspace/developers/ReinforcementPage.tsx
+++ b/front/components/pages/workspace/developers/ReinforcementPage.tsx
@@ -5,13 +5,51 @@ import {
   useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
+import { getReinforcementMonthlyCapMicroUsd } from "@app/lib/reinforcement/consumption";
+import { useSkillsReinforcementSpend } from "@app/lib/swr/useReinforcementToggle";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Chip,
   ContentMessage,
   InformationCircleIcon,
   Page,
   SparklesIcon,
+  Spinner,
 } from "@dust-tt/sparkle";
+
+interface ReinforcementTotalConsumptionSectionProps {
+  owner: LightWorkspaceType;
+}
+
+function ReinforcementTotalConsumptionSection({
+  owner,
+}: ReinforcementTotalConsumptionSectionProps) {
+  const { spentMicroUsdBySkillId, isSpendLoading } =
+    useSkillsReinforcementSpend({ owner });
+
+  const totalSpentDollars =
+    Object.values(spentMicroUsdBySkillId).reduce((sum, v) => sum + v, 0) /
+    1_000_000;
+  const capDollars = getReinforcementMonthlyCapMicroUsd(owner) / 1_000_000;
+
+  return (
+    <Page.Vertical align="stretch" gap="md">
+      <Page.SectionHeader title="Current period consumption" />
+      {isSpendLoading ? (
+        <div className="flex justify-center py-4">
+          <Spinner />
+        </div>
+      ) : (
+        <div className="text-sm text-foreground dark:text-foreground-night">
+          <span className="font-semibold">${totalSpentDollars.toFixed(2)}</span>{" "}
+          spent out of{" "}
+          <span className="font-semibold">${capDollars.toFixed(2)}</span>{" "}
+          monthly cap
+        </div>
+      )}
+    </Page.Vertical>
+  );
+}
 
 export function ReinforcementPage() {
   const owner = useWorkspace();
@@ -43,6 +81,7 @@ export function ReinforcementPage() {
           testing but will generate additional costs upon release.
         </ContentMessage>
         <ReinforcementSection owner={owner} />
+        <ReinforcementTotalConsumptionSection owner={owner} />
         <ReinforcementSkillsSection owner={owner} />
       </>
     );


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8033

Display the total consumption
This is based on the sum of all the skills consumption so we don't have to add a new endpoint, and we already retrieve the info to displmay per skill.

<img width="2364" height="1202" alt="image" src="https://github.com/user-attachments/assets/f289c621-b40f-47ea-a8bb-4a667ac1c341" />

## Tests

tested locally

## Risk

low

## Deploy Plan

deploy front 


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25457">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->