### PR TITLE
[front] Stamp PLAN_CODE on every Metronome contract at creation

### DIFF
--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -180,6 +180,7 @@ export async function handleMetronomeSetupCheckout({
     packageAlias: resolvedPackageAlias,
     uniquenessKey: sessionId,
     startingAt: new Date(floorToHourISO(now)),
+    planCode,
   });
   if (contractResult.isErr()) {
     return new Err(

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -477,6 +478,7 @@ export async function createMetronomeContract({
   uniquenessKey,
   startingAt,
   enableStripeBilling,
+  planCode,
 }: {
   metronomeCustomerId: string;
   /** Mutually exclusive with `packageId`. */
@@ -487,6 +489,11 @@ export async function createMetronomeContract({
   // Must already be on an hour boundary (Metronome requirement).
   startingAt: Date;
   enableStripeBilling: boolean;
+  // When provided, stamps PLAN_CODE_CUSTOM_FIELD_KEY on the contract so the
+  // contract.start webhook can swap the workspace's subscription onto this
+  // plan when the contract becomes active. Optional during the rollout —
+  // will become required once all callers pass it.
+  planCode?: string;
 }): Promise<Result<{ contractId: string }, Error>> {
   if (!packageAlias === !packageId) {
     return new Err(
@@ -514,11 +521,22 @@ export async function createMetronomeContract({
       });
     }
 
+    if (planCode) {
+      const customFieldsResult = await setMetronomeContractCustomFields({
+        contractId: response.data.id,
+        customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: planCode },
+      });
+      if (customFieldsResult.isErr()) {
+        return new Err(customFieldsResult.error);
+      }
+    }
+
     logger.info(
       {
         metronomeCustomerId,
         package: packageLabel,
         metronomeContractId: response.data.id,
+        planCode,
       },
       "[Metronome] Contract created"
     );

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -489,11 +489,10 @@ export async function createMetronomeContract({
   // Must already be on an hour boundary (Metronome requirement).
   startingAt: Date;
   enableStripeBilling: boolean;
-  // When provided, stamps PLAN_CODE_CUSTOM_FIELD_KEY on the contract so the
-  // contract.start webhook can swap the workspace's subscription onto this
-  // plan when the contract becomes active. Optional during the rollout —
-  // will become required once all callers pass it.
-  planCode?: string;
+  // Stamps PLAN_CODE_CUSTOM_FIELD_KEY on the contract so the contract.start
+  // webhook can swap the workspace's subscription onto this plan when the
+  // contract becomes active.
+  planCode: string;
 }): Promise<Result<{ contractId: string }, Error>> {
   if (!packageAlias === !packageId) {
     return new Err(
@@ -505,6 +504,12 @@ export async function createMetronomeContract({
   const startingAtISO = startingAt.toISOString();
   const packageLabel = packageAlias ?? packageId!;
 
+  // Resolve the contract id from either a fresh create or a 409 recovery.
+  // We split this from the post-create steps (Stripe billing config, PLAN_CODE
+  // stamp) so those steps run on retry too — they're idempotent on Metronome's
+  // side, and re-running them is what makes the overall function recoverable.
+  let contractId: string;
+  let recovered = false;
   try {
     const response = await getMetronomeClient().v1.contracts.create({
       customer_id: metronomeCustomerId,
@@ -513,52 +518,73 @@ export async function createMetronomeContract({
       starting_at: startingAtISO,
       ...(uniquenessKey ? { uniqueness_key: uniquenessKey } : {}),
     });
-
-    if (enableStripeBilling) {
-      addStripeMetronomeBillingConfig({
-        metronomeCustomerId,
-        metronomeContractId: response.data.id,
-      });
-    }
-
-    if (planCode) {
-      const customFieldsResult = await setMetronomeContractCustomFields({
-        contractId: response.data.id,
-        customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: planCode },
-      });
-      if (customFieldsResult.isErr()) {
-        return new Err(customFieldsResult.error);
-      }
-    }
-
-    logger.info(
-      {
-        metronomeCustomerId,
-        package: packageLabel,
-        metronomeContractId: response.data.id,
-        planCode,
-      },
-      "[Metronome] Contract created"
-    );
-    return new Ok({ contractId: response.data.id });
+    contractId = response.data.id;
   } catch (err) {
-    // Conflict-by-uniqueness-key recovery only applies when creating by alias.
-    // When creating by package_id we surface the error.
-    if (err instanceof ConflictError && packageAlias) {
-      const existingContract =
-        await getMetronomeActiveContract(metronomeCustomerId);
-      if (existingContract.isOk() && existingContract.value) {
-        return new Ok({ contractId: existingContract.value.contractId });
+    if (err instanceof ConflictError) {
+      // Prefer uniqueness_key lookup when the caller provided one — this is
+      // the only safe recovery path when creating by package_id (multiple
+      // contracts may coexist on the customer). Falls back to "most recent
+      // active" for legacy alias-only callers without a uniqueness_key.
+      if (uniquenessKey) {
+        const existing = await findMetronomeContractByUniquenessKey({
+          metronomeCustomerId,
+          uniquenessKey,
+        });
+        if (existing.isOk() && existing.value) {
+          contractId = existing.value.contractId;
+          recovered = true;
+        } else {
+          return new Err(normalizeError(err));
+        }
+      } else if (packageAlias) {
+        const existing = await getMetronomeActiveContract(metronomeCustomerId);
+        if (existing.isOk() && existing.value) {
+          contractId = existing.value.contractId;
+          recovered = true;
+        } else {
+          return new Err(normalizeError(err));
+        }
+      } else {
+        return new Err(normalizeError(err));
       }
+    } else {
+      const error = normalizeError(err);
+      logger.error(
+        { error, metronomeCustomerId, package: packageLabel },
+        "[Metronome] Failed to create contract"
+      );
+      return new Err(error);
     }
-
-    const error = normalizeError(err);
-    logger.error(
-      { error, metronomeCustomerId, package: packageLabel },
-      "[Metronome] Failed to create contract"
-    );
-    return new Err(error);
   }
+
+  if (enableStripeBilling) {
+    addStripeMetronomeBillingConfig({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+    });
+  }
+
+  const customFieldsResult = await setMetronomeContractCustomFields({
+    contractId,
+    customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: planCode },
+  });
+  if (customFieldsResult.isErr()) {
+    return new Err(customFieldsResult.error);
+  }
+
+  logger.info(
+    {
+      metronomeCustomerId,
+      package: packageLabel,
+      metronomeContractId: contractId,
+      planCode,
+      recovered,
+    },
+    recovered
+      ? "[Metronome] Contract recovered"
+      : "[Metronome] Contract created"
+  );
+  return new Ok({ contractId });
 }
 
 /**
@@ -641,6 +667,26 @@ export async function listMetronomeContracts(
     );
     return new Err(error);
   }
+}
+
+/**
+ * Find a contract on a Metronome customer by its uniqueness_key. Used to
+ * recover the id after a 409 conflict on creation, regardless of whether
+ * the create call used package_alias or package_id.
+ */
+export async function findMetronomeContractByUniquenessKey({
+  metronomeCustomerId,
+  uniquenessKey,
+}: {
+  metronomeCustomerId: string;
+  uniquenessKey: string;
+}): Promise<Result<{ contractId: string } | null, Error>> {
+  const result = await listMetronomeContracts(metronomeCustomerId);
+  if (result.isErr()) {
+    return result;
+  }
+  const match = result.value.find((c) => c.uniqueness_key === uniquenessKey);
+  return new Ok(match ? { contractId: match.id } : null);
 }
 
 /**

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -671,6 +671,7 @@ describe("provisionMetronomeContract", () => {
       packageAlias: "legacy-pro-monthly",
       uniquenessKey: "uniq_123",
       startingAt: new Date(START_DATE),
+      planCode: "PRO_PLAN_SEAT_29",
     });
 
     expect(result.isOk()).toBe(true);
@@ -709,6 +710,7 @@ describe("provisionMetronomeContract", () => {
       packageAlias: "legacy-enterprise",
       uniquenessKey: "uniq_123",
       startingAt: new Date(START_DATE),
+      planCode: "PRO_PLAN_SEAT_29",
     });
 
     expect(result.isOk()).toBe(true);
@@ -725,6 +727,7 @@ describe("provisionMetronomeContract", () => {
       packageAlias: "legacy-pro-monthly",
       uniquenessKey: "uniq_123",
       startingAt: new Date(START_DATE),
+      planCode: "PRO_PLAN_SEAT_29",
     });
 
     expect(result.isOk()).toBe(true);
@@ -741,6 +744,7 @@ describe("switchMetronomeContractPackage", () => {
       workspace: WORKSPACE,
       packageAlias: "legacy-business",
       enableStripeBilling: false,
+      planCode: "PRO_PLAN_SEAT_39",
     });
 
     expect(result.isOk()).toBe(true);
@@ -765,6 +769,7 @@ describe("switchMetronomeContractPackage", () => {
       workspace: WORKSPACE,
       packageAlias: "legacy-enterprise-eur",
       enableStripeBilling: false,
+      planCode: "PRO_PLAN_SEAT_39",
     });
 
     expect(result.isOk()).toBe(true);
@@ -781,6 +786,7 @@ describe("switchMetronomeContractPackage", () => {
       workspace: WORKSPACE,
       packageAlias: "legacy-business",
       enableStripeBilling: false,
+      planCode: "PRO_PLAN_SEAT_39",
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -71,7 +71,7 @@ export async function switchMetronomeContractPackage({
   workspace: LightWorkspaceType;
   packageAlias: string;
   enableStripeBilling: boolean;
-  planCode?: string;
+  planCode: string;
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
   // Round up to the next hour boundary (Metronome requires hour-aligned dates)
   // so the new contract starts exactly when the old one ends.
@@ -89,6 +89,8 @@ export async function switchMetronomeContractPackage({
   const contractResult = await createMetronomeContract({
     metronomeCustomerId,
     packageAlias,
+    // One switch per old contract — retries dedup against the same successor.
+    uniquenessKey: `switch:${oldContractId}`,
     startingAt: switchAt,
     enableStripeBilling,
     planCode,
@@ -267,7 +269,7 @@ export async function provisionMetronomeContract({
   // Must already be on an hour boundary (Metronome requirement).
   startingAt: Date;
   enableStripeBilling?: boolean;
-  planCode?: string;
+  planCode: string;
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
   logger.info(
     {
@@ -996,7 +998,7 @@ export async function provisionShadowEnterpriseMetronomeContract({
 }: {
   workspace: LightWorkspaceType;
   stripeSubscription: Stripe.Subscription;
-  planCode?: string;
+  planCode: string;
 }): Promise<
   Result<{ metronomeCustomerId: string; metronomeContractId: string }, Error>
 > {

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -64,12 +64,14 @@ export async function switchMetronomeContractPackage({
   workspace,
   packageAlias,
   enableStripeBilling,
+  planCode,
 }: {
   metronomeCustomerId: string;
   oldContractId: string;
   workspace: LightWorkspaceType;
   packageAlias: string;
   enableStripeBilling: boolean;
+  planCode?: string;
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
   // Round up to the next hour boundary (Metronome requires hour-aligned dates)
   // so the new contract starts exactly when the old one ends.
@@ -89,6 +91,7 @@ export async function switchMetronomeContractPackage({
     packageAlias,
     startingAt: switchAt,
     enableStripeBilling,
+    planCode,
   });
   if (contractResult.isErr()) {
     return new Err(contractResult.error);
@@ -255,6 +258,7 @@ export async function provisionMetronomeContract({
   uniquenessKey,
   startingAt,
   enableStripeBilling = true,
+  planCode,
 }: {
   metronomeCustomerId: string;
   workspace: LightWorkspaceType;
@@ -263,6 +267,7 @@ export async function provisionMetronomeContract({
   // Must already be on an hour boundary (Metronome requirement).
   startingAt: Date;
   enableStripeBilling?: boolean;
+  planCode?: string;
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
   logger.info(
     {
@@ -279,6 +284,7 @@ export async function provisionMetronomeContract({
     uniquenessKey,
     startingAt,
     enableStripeBilling,
+    planCode,
   });
   if (contractResult.isErr()) {
     return new Err(contractResult.error);
@@ -986,9 +992,11 @@ export async function applyEnterpriseOverrides({
 export async function provisionShadowEnterpriseMetronomeContract({
   workspace,
   stripeSubscription,
+  planCode,
 }: {
   workspace: LightWorkspaceType;
   stripeSubscription: Stripe.Subscription;
+  planCode?: string;
 }): Promise<
   Result<{ metronomeCustomerId: string; metronomeContractId: string }, Error>
 > {
@@ -1046,6 +1054,7 @@ export async function provisionShadowEnterpriseMetronomeContract({
     uniquenessKey: stripeSubscription.id,
     startingAt: new Date(startDate),
     enableStripeBilling: false,
+    planCode,
   });
   if (contractResult.isErr()) {
     return new Err(contractResult.error);

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -842,6 +842,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       const metronomeResult = await provisionShadowEnterpriseMetronomeContract({
         workspace: renderLightWorkspaceType({ workspace: workspaceResource }),
         stripeSubscription,
+        planCode: plan.code,
       });
 
       if (metronomeResult.isErr()) {
@@ -1020,6 +1021,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         workspace: owner,
         packageAlias,
         enableStripeBilling: isSubscriptionMetronomeBilled(this.toJSON()),
+        planCode: PRO_PLAN_SEAT_39_CODE,
       });
       if (result.isErr() && !this.isMetronomeShadowBilled) {
         return new Err(result.error);

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.test.ts
@@ -4,9 +4,7 @@ import {
   listMetronomeContracts,
   listMetronomePackages,
   scheduleMetronomeContractEnd,
-  setMetronomeContractCustomFields,
 } from "@app/lib/metronome/client";
-import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import { ensureMetronomeCustomerForWorkspace } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import { getStripeCustomer } from "@app/lib/plans/stripe";
@@ -30,7 +28,6 @@ vi.mock("@app/lib/metronome/client", async () => {
     ...actual,
     listMetronomePackages: vi.fn(),
     createMetronomeContract: vi.fn(),
-    setMetronomeContractCustomFields: vi.fn(),
     listMetronomeContracts: vi.fn(),
     scheduleMetronomeContractEnd: vi.fn(),
   };
@@ -160,9 +157,6 @@ beforeEach(() => {
   );
   vi.mocked(createMetronomeContract).mockResolvedValue(
     new Ok({ contractId: NEW_CONTRACT_ID })
-  );
-  vi.mocked(setMetronomeContractCustomFields).mockResolvedValue(
-    new Ok(undefined)
   );
   // After creation, both contracts coexist on the customer.
   vi.mocked(listMetronomeContracts).mockResolvedValue(
@@ -325,13 +319,9 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
       expect.objectContaining({
         metronomeCustomerId: METRONOME_CUSTOMER_ID,
         packageId: PACKAGE_ID,
+        planCode: ENT_PLAN_CODE,
       })
     );
-
-    expect(setMetronomeContractCustomFields).toHaveBeenCalledWith({
-      contractId: NEW_CONTRACT_ID,
-      customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
-    });
 
     // Old contract is sunset, new one is skipped by id.
     expect(scheduleMetronomeContractEnd).toHaveBeenCalledTimes(1);
@@ -419,11 +409,8 @@ describe("POST /api/poke/workspaces/[wId]/upgrade_enterprise — Metronome path"
         metronomeCustomerId: METRONOME_CUSTOMER_ID,
         packageId: PACKAGE_ID,
         enableStripeBilling: true,
+        planCode: ENT_PLAN_CODE,
       })
     );
-    expect(setMetronomeContractCustomFields).toHaveBeenCalledWith({
-      contractId: NEW_CONTRACT_ID,
-      customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
-    });
   });
 });

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -321,6 +321,12 @@ async function handler(
         const createResult = await createMetronomeContract({
           metronomeCustomerId,
           packageId: pkg.id,
+          // Composite of the inputs that define this specific upgrade intent
+          // — retries of the same Poke call dedup against the existing contract,
+          // so a partial failure (e.g. PLAN_CODE stamp) can be recovered by
+          // simply retrying. A different upgrade (different package, plan, or
+          // start date) hashes to a different key and gets its own contract.
+          uniquenessKey: `upgrade-enterprise:${metronomeCustomerId}:${pkg.id}:${body.planCode}:${startingAtDate.toISOString()}`,
           startingAt: startingAtDate,
           enableStripeBilling: true,
           planCode: body.planCode,

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -15,9 +15,7 @@ import {
   listMetronomeContracts,
   listMetronomePackages,
   scheduleMetronomeContractEnd,
-  setMetronomeContractCustomFields,
 } from "@app/lib/metronome/client";
-import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import { ensureMetronomeCustomerForWorkspace } from "@app/lib/metronome/contracts";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import {
@@ -325,6 +323,7 @@ async function handler(
           packageId: pkg.id,
           startingAt: startingAtDate,
           enableStripeBilling: true,
+          planCode: body.planCode,
         });
         if (createResult.isErr()) {
           const errorMessage = `Failed to create Metronome contract: ${createResult.error.message}`;
@@ -339,26 +338,6 @@ async function handler(
         }
 
         const newMetronomeContractId = createResult.value.contractId;
-
-        // Stamp the target plan code on the new contract so the contract.start
-        // webhook can determine which plan to put the subscription on.
-        const customFieldsResult = await setMetronomeContractCustomFields({
-          contractId: newMetronomeContractId,
-          customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: body.planCode },
-        });
-        if (customFieldsResult.isErr()) {
-          const errorMessage =
-            `Created contract ${newMetronomeContractId} but failed to set ` +
-            `${PLAN_CODE_CUSTOM_FIELD_KEY}: ${customFieldsResult.error.message}. Manual cleanup required in Metronome.`;
-          await pluginRun.recordError(errorMessage);
-          return apiError(req, res, {
-            status_code: 502,
-            api_error: {
-              type: "internal_server_error",
-              message: errorMessage,
-            },
-          });
-        }
 
         // Sunset any other non-archived contract on this customer that
         // overlaps with our new contract's window. We list all contracts

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -98,6 +98,7 @@ async function provisionShadowMetronome({
   sessionId,
   subscriptionModelId,
   periodStart,
+  planCode,
 }: {
   workspace: WorkspaceResource;
   stripeCustomerId: string;
@@ -105,6 +106,7 @@ async function provisionShadowMetronome({
   sessionId: string;
   subscriptionModelId: ModelId;
   periodStart: Date;
+  planCode: string;
 }): Promise<void> {
   try {
     const lightWorkspace = renderLightWorkspaceType({ workspace });
@@ -129,6 +131,7 @@ async function provisionShadowMetronome({
       uniquenessKey: sessionId,
       startingAt: periodStart,
       enableStripeBilling: false,
+      planCode,
     });
     if (contractResult.isErr()) {
       logger.error(
@@ -695,6 +698,7 @@ async function handleStripeCheckoutCompleted({
         sessionId: session.id,
         subscriptionModelId: newSubscription.id,
         periodStart: new Date(floorToHourISO(currentPeriodStart)),
+        planCode,
       });
     }
 


### PR DESCRIPTION
## Description

Threads an optional planCode through createMetronomeContract and its three wrappers (provisionMetronomeContract, switchMetronomeContractPackage, provisionShadowEnterpriseMetronomeContract), and through their call sites (Pro checkout, Stripe webhook shadow path, Business switch, shadow Enterprise upgrade, Poke Enterprise upgrade). When provided, createMetronomeContract now sets PLAN_CODE_CUSTOM_FIELD_KEY on the contract internally, so every new contract carries the target plan code without a separate call.

Previously, if Metronome contract creation succeeded but the subsequent PLAN_CODE stamp failed, the contract was left orphaned without its plan code and the 409 conflict-recovery branch on retry returned the existing id without re-stamping. The contract.start webhook would then have nothing to dispatch on.

Restructures createMetronomeContract so once we hold a contract id (from fresh create or 409 recovery), the post-create steps (Stripe billing, PLAN_CODE stamp) always run. setMetronomeContractCustomFields and addStripeMetronomeBillingConfig are both idempotent on Metronome's side, so re-running them on retry is safe.

Extends recovery to packageId callers via a new findMetronomeContractByUniquenessKey helper (mirrors the existing findMetronomeCommitByUniquenessKey pattern).

Adds uniqueness keys to the two callers that lacked them:
- switchMetronomeContractPackage: switch:<oldContractId> — one switch per old contract.
- upgrade_enterprise.ts: composite of customer + package + plan code + start date — retries of the same Poke call dedup, different upgrades get fresh contracts

## Tests

Local

## Risk

Low, only on Metronome contracts

## Deploy Plan

front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25459">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->