### PR TITLE
[front] Swap Business contracts at the current hour, not the next

### DIFF
--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -47,6 +47,7 @@ const {
 
 vi.mock("@app/lib/metronome/client", () => ({
   ceilToHourISO: (date: Date) => date.toISOString(),
+  floorToHourISO: (date: Date) => date.toISOString(),
   createMetronomeContract: mockCreateMetronomeContract,
   createMetronomeCustomer: mockCreateMetronomeCustomer,
   epochSecondsToFloorHourISO: vi.fn(),
@@ -745,6 +746,7 @@ describe("switchMetronomeContractPackage", () => {
       packageAlias: "legacy-business",
       enableStripeBilling: false,
       planCode: "PRO_PLAN_SEAT_39",
+      swapAt: "current-hour",
     });
 
     expect(result.isOk()).toBe(true);
@@ -770,6 +772,7 @@ describe("switchMetronomeContractPackage", () => {
       packageAlias: "legacy-enterprise-eur",
       enableStripeBilling: false,
       planCode: "PRO_PLAN_SEAT_39",
+      swapAt: "current-hour",
     });
 
     expect(result.isOk()).toBe(true);
@@ -787,6 +790,7 @@ describe("switchMetronomeContractPackage", () => {
       packageAlias: "legacy-business",
       enableStripeBilling: false,
       planCode: "PRO_PLAN_SEAT_39",
+      swapAt: "current-hour",
     });
 
     expect(result.isOk()).toBe(true);

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -57,6 +57,16 @@ import { metronomeAmount } from "./amounts";
 /**
  * Switch a Metronome contract to a different package (end old + create new).
  * Customer must already exist.
+ *
+ * `swapAt` controls when the swap happens:
+ *  - `"current-hour"`: floor to the current hour boundary (in the past). Use
+ *    for seat-based plans (Pro, Business) where the current partial hour has
+ *    no usage to attribute. The new contract is effectively active "now", so
+ *    callers can flip the DB subscription synchronously.
+ *  - `"next-hour"`: ceil to the next hour boundary (in the future, by up to
+ *    one hour). Preserves the current partial hour's usage on the old
+ *    contract — required for MAU-based Enterprise plans. Callers should
+ *    defer the DB flip until `contract.start` fires.
  */
 export async function switchMetronomeContractPackage({
   metronomeCustomerId,
@@ -65,6 +75,7 @@ export async function switchMetronomeContractPackage({
   packageAlias,
   enableStripeBilling,
   planCode,
+  swapAt,
 }: {
   metronomeCustomerId: string;
   oldContractId: string;
@@ -72,10 +83,13 @@ export async function switchMetronomeContractPackage({
   packageAlias: string;
   enableStripeBilling: boolean;
   planCode: string;
+  swapAt: "current-hour" | "next-hour";
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
-  // Round up to the next hour boundary (Metronome requires hour-aligned dates)
-  // so the new contract starts exactly when the old one ends.
-  const switchAt = new Date(ceilToHourISO(new Date()));
+  const switchAt = new Date(
+    swapAt === "current-hour"
+      ? floorToHourISO(new Date())
+      : ceilToHourISO(new Date())
+  );
 
   const endResult = await scheduleMetronomeContractEnd({
     metronomeCustomerId,

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1022,6 +1022,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         packageAlias,
         enableStripeBilling: isSubscriptionMetronomeBilled(this.toJSON()),
         planCode: PRO_PLAN_SEAT_39_CODE,
+        // Business is seat-based — swap at the current hour boundary so the
+        // new contract is active immediately and the sync DB flip below is
+        // consistent with Metronome.
+        swapAt: "current-hour",
       });
       if (result.isErr() && !this.isMetronomeShadowBilled) {
         return new Err(result.error);

--- a/front/pages/api/metronome/webhook.test.ts
+++ b/front/pages/api/metronome/webhook.test.ts
@@ -56,7 +56,6 @@ const METRONOME_CUSTOMER_ID = "cust_test_xxx";
 const OLD_CONTRACT_ID = "contract_old_xxx";
 const NEW_CONTRACT_ID = "contract_new_yyy";
 const ENT_PLAN_CODE = "ENT_TEST_PLAN";
-const NON_ENTERPRISE_PLAN_CODE = "PRO_PLAN_SEAT_29";
 
 async function ensureEnterprisePlan(): Promise<void> {
   await PlanModel.upsert({
@@ -128,7 +127,8 @@ function makeWebhookRequest(eventBody: Record<string, unknown>) {
 }
 
 async function setupMetronomeWorkspace(
-  contractId: string
+  contractId: string,
+  { stripeSubscriptionId = null }: { stripeSubscriptionId?: string | null } = {}
 ): Promise<WorkspaceType> {
   const workspace = await WorkspaceFactory.basic();
   const workspaceModelId = (await WorkspaceResource.fetchById(workspace.sId))!
@@ -148,7 +148,7 @@ async function setupMetronomeWorkspace(
       status: "active",
       startDate: new Date(),
       endDate: null,
-      stripeSubscriptionId: null,
+      stripeSubscriptionId,
       metronomeContractId: contractId,
     },
     sub!.getPlan()
@@ -201,8 +201,14 @@ describe("Metronome webhook — contract.start", () => {
     expect(restoreWorkspaceAfterSubscription).not.toHaveBeenCalled();
   });
 
-  it("does nothing when PLAN_CODE refers to a non-enterprise plan", async () => {
-    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+  it("does nothing when the active subscription is shadow-billed (Stripe + Metronome)", async () => {
+    // Shadow-billed: Stripe is the source of truth, Metronome runs in
+    // parallel. The webhook must not flip the subscription on contract.start
+    // — Stripe drives that transition on its own webhook.
+    await ensureEnterprisePlan();
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID, {
+      stripeSubscriptionId: "sub_shadow_xxx",
+    });
     const event = contractEvent("contract.start", NEW_CONTRACT_ID);
     mockUnwrap(event);
     vi.mocked(getMetronomeContractById).mockResolvedValue(
@@ -211,7 +217,7 @@ describe("Metronome webhook — contract.start", () => {
         customer_id: METRONOME_CUSTOMER_ID,
         starting_at: new Date().toISOString(),
         custom_fields: {
-          [PLAN_CODE_CUSTOM_FIELD_KEY]: NON_ENTERPRISE_PLAN_CODE,
+          [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE,
         },
       } as never)
     );

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -23,7 +23,6 @@ import {
   MetronomeWebhookEventSchema,
 } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
-import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -412,10 +411,12 @@ async function handler(
         case "contract.start": {
           const { contract_id: contractId, customer_id: customerId } = event;
 
-          // Read the PLAN_CODE custom field to determine whether this is a
-          // Poke-scheduled Enterprise upgrade. Only Enterprise plan codes
-          // should trigger a subscription swap; other plan contract starts
-          // are handled by their own creation/update flows.
+          // Read the PLAN_CODE custom field to know which plan to swap the
+          // workspace subscription onto. The actual swap is gated below on
+          // `isMetronomeOnlyBilled` — other billing paths (shadow, pure
+          // Stripe) handle their own state transitions, and contracts whose
+          // start aligns with a synchronous DB flip get caught by the
+          // idempotency check.
           const contractResult = await getMetronomeContractById({
             metronomeCustomerId: customerId,
             metronomeContractId: contractId,
@@ -460,14 +461,6 @@ async function handler(
             break;
           }
 
-          if (!isEntreprisePlanPrefix(targetPlan.code)) {
-            logger.info(
-              { contractId, targetPlanCode, workspaceId: workspace.sId },
-              `[Metronome Webhook] contract.start: non-enterprise ${PLAN_CODE_CUSTOM_FIELD_KEY}, leaving subscription alone`
-            );
-            break;
-          }
-
           const activeSubscription =
             await SubscriptionResource.fetchActiveByWorkspaceModelId(
               workspace.id
@@ -476,6 +469,24 @@ async function handler(
             logger.warn(
               { contractId, customerId, workspaceId: workspace.sId },
               "[Metronome Webhook] contract.start: no active subscription"
+            );
+            break;
+          }
+
+          // Only swap when the workspace is Metronome-only billed. Shadow
+          // billed subscriptions (Stripe + Metronome) follow Stripe's signal,
+          // and pure Stripe subs have no Metronome contract at all. Pro and
+          // Business swaps are synchronous, so this branch effectively only
+          // fires for Enterprise upgrades scheduled in the future via Poke —
+          // the idempotency check below catches the sync cases.
+          if (!activeSubscription.isMetronomeOnlyBilled) {
+            logger.info(
+              {
+                contractId,
+                targetPlanCode,
+                workspaceId: workspace.sId,
+              },
+              "[Metronome Webhook] contract.start: subscription is not Metronome-only billed, leaving subscription alone"
             );
             break;
           }


### PR DESCRIPTION
## Description

`switchMetronomeContractPackage` previously hardcoded the swap point to the next hour boundary (ceilToHourISO), borrowed from the Enterprise flow where future scheduling is intentional. Used from upgradeToBusinessPlan this produced a window of up to ~1h where the DB pointed at the new Business plan but the Metronome contract hadn't started yet.

Add a `swapAt: "current-hour" | "next-hour"` parameter. Business passes "current-hour": Pro/Business are seat-based, so there's no usage in the current partial hour to attribute to the old contract, and we can swap retroactively at the current hour boundary. The sync DB flip in upgradeToBusinessPlan is now consistent with Metronome's view.

Replace the `isEntreprisePlanPrefix` carve-out in the `contract.start` handler with a check on the workspace's active subscription: **only swap when the sub is Metronome-only billed**.

The old gate was a conservative safety belt from when Enterprise was the only path going through here. With PLAN_CODE now stamped on every contract, the right gate is "is this workspace's billing source of truth Metronome?" which:

- Correctly excludes shadow-billed (Stripe + Metronome): Stripe drives state transitions, not contract.start. The old gate happily swapped shadow-billed Enterprise, which was a bug.
- Excludes pure Stripe naturally (no Metronome contract id, so the subscription has nothing to compare against).

The test that asserted "non-enterprise PLAN_CODE → skip" no longer maps to behavior we want; replace it with one that exercises the new gate directly (shadow-billed → skip).

**Note that we still are still doing a sync subscription flip when switching to pro/business to avoid having to implement the logic in Stripe and Metronome**. Metronome webhook will no-op. When there is no longer any Stripe-billed contract, we can remove the sync flip and let the Metronome webhook handle that logic.

## Tests

Local

## Risk

Low, metronome-only

## Deploy Plan

front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25464">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->