### PR TITLE
Support unfurl_links / unfurl_media on post_message and schedule_message

### DIFF
--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -752,12 +752,16 @@ export async function executePostMessage(
     message,
     threadTs,
     fileId,
+    unfurlLinks,
+    unfurlMedia,
   }: {
     accessToken: string;
     to: string | string[];
     message: string;
     threadTs: string | undefined;
     fileId: string | undefined;
+    unfurlLinks: boolean | undefined;
+    unfurlMedia: boolean | undefined;
   }
 ) {
   const slackClient = await getSlackClient(accessToken);
@@ -859,6 +863,8 @@ export async function executePostMessage(
     text: message,
     mrkdwn: true,
     thread_ts: threadTs,
+    unfurl_links: unfurlLinks,
+    unfurl_media: unfurlMedia,
   });
 
   if (!response.ok) {
@@ -912,12 +918,16 @@ export async function executeScheduleMessage(
     message,
     post_at,
     threadTs,
+    unfurlLinks,
+    unfurlMedia,
   }: {
     accessToken: string;
     to: string;
     message: string;
     post_at: number | string;
     threadTs: string | undefined;
+    unfurlLinks: boolean | undefined;
+    unfurlMedia: boolean | undefined;
   }
 ) {
   const slackClient = await getSlackClient(accessToken);
@@ -976,6 +986,8 @@ export async function executeScheduleMessage(
     text: message,
     post_at: timestampSeconds.toString(),
     thread_ts: threadTs,
+    unfurl_links: unfurlLinks,
+    unfurl_media: unfurlMedia,
   });
 
   if (!response.ok) {

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -31,6 +31,18 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional file to attach to the Slack message. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
         ),
+      unfurlLinks: z
+        .boolean()
+        .optional()
+        .describe(
+          "If false, disable link previews (unfurling) for URLs in the message. Useful when posting newsletters or curated lists where previews add clutter. Defaults to Slack's behavior."
+        ),
+      unfurlMedia: z
+        .boolean()
+        .optional()
+        .describe(
+          "If false, disable media previews (unfurling) for image/video URLs in the message. Defaults to Slack's behavior."
+        ),
     },
     stake: "low",
     displayLabels: {

--- a/front/lib/api/actions/servers/slack_bot/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_bot/tools/index.ts
@@ -23,7 +23,10 @@ export function createSlackBotTools(
   agentLoopContext?: AgentLoopContextType
 ): ToolDefinition[] {
   const handlers: ToolHandlers<typeof SLACK_BOT_TOOLS_METADATA> = {
-    post_message: async ({ to, message, threadTs, fileId }, { authInfo }) => {
+    post_message: async (
+      { to, message, threadTs, fileId, unfurlLinks, unfurlMedia },
+      { authInfo }
+    ) => {
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return new Err(new MCPError("Access token not found"));
@@ -39,6 +42,8 @@ export function createSlackBotTools(
           message,
           threadTs,
           fileId,
+          unfurlLinks,
+          unfurlMedia,
           accessToken,
         });
       } catch (error) {

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -116,6 +116,18 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional file to attach to the message. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
         ),
+      unfurlLinks: z
+        .boolean()
+        .optional()
+        .describe(
+          "If false, disable link previews (unfurling) for URLs in the message. Useful when posting newsletters or curated lists where previews add clutter. Defaults to Slack's behavior."
+        ),
+      unfurlMedia: z
+        .boolean()
+        .optional()
+        .describe(
+          "If false, disable media previews (unfurling) for image/video URLs in the message. Defaults to Slack's behavior."
+        ),
     },
     stake: "medium",
     displayLabels: {
@@ -150,6 +162,18 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
         .optional()
         .describe(
           "The thread ts of the message to reply to. If you need to find the thread ts, you can use the `search_messages` tool, the thread ts is the id of the message you want to reply to. If you don't provide a thread ts, the message will be posted as a top-level message."
+        ),
+      unfurlLinks: z
+        .boolean()
+        .optional()
+        .describe(
+          "If false, disable link previews (unfurling) for URLs in the message. Useful when posting newsletters or curated lists where previews add clutter. Defaults to Slack's behavior."
+        ),
+      unfurlMedia: z
+        .boolean()
+        .optional()
+        .describe(
+          "If false, disable media previews (unfurling) for image/video URLs in the message. Defaults to Slack's behavior."
         ),
     },
     stake: "medium",

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -550,7 +550,10 @@ export function createSlackPersonalTools(
       }
     },
 
-    post_message: async ({ to, message, threadTs, fileId }, { authInfo }) => {
+    post_message: async (
+      { to, message, threadTs, fileId, unfurlLinks, unfurlMedia },
+      { authInfo }
+    ) => {
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return new Err(new MCPError("Access token not found"));
@@ -568,6 +571,8 @@ export function createSlackPersonalTools(
           message,
           threadTs,
           fileId,
+          unfurlLinks,
+          unfurlMedia,
           accessToken,
         });
       } catch (error) {
@@ -582,7 +587,7 @@ export function createSlackPersonalTools(
     },
 
     schedule_message: async (
-      { to, message, post_at, threadTs },
+      { to, message, post_at, threadTs, unfurlLinks, unfurlMedia },
       { authInfo }
     ) => {
       const accessToken = authInfo?.token;
@@ -602,6 +607,8 @@ export function createSlackPersonalTools(
           message,
           post_at,
           threadTs,
+          unfurlLinks,
+          unfurlMedia,
           accessToken,
         });
       } catch (error) {


### PR DESCRIPTION
## Description

- Add optional unfurlLinks / unfurlMedia booleans to the post_message tool of the slack_bot and slack_personal MCP servers, and to schedule_message on slack_personal.
- Both flags are forwarded to Slack as unfurl_links / unfurl_media on chat.postMessage and chat.scheduleMessage. When omitted, behavior is unchanged (Slack uses its defaults).
- Unblocks a customer use case where agents post weekly newsletters and link previews clutter the output, requiring manual cleanup. Pattern follows PR #16054 which already wired unfurl_links: false in connectors/.../bot.ts.

Fixes https://github.com/dust-tt/tasks/issues/8044

## Tests

Manually tested.

## Risk

Low, new optional params

## Deploy Plan

Front