### PR TITLE
[OAUTH] log IdP error/error_description on code_extraction failure

### DIFF
--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -49,6 +49,7 @@ import type { OAuthAPIError } from "@app/types/oauth/oauth_api";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
 import type { ParsedUrlQuery } from "querystring";
 
 export type OAuthError = {
@@ -257,8 +258,14 @@ export async function finalizeConnection(
   const code = providerStrategy.codeFromQuery(query);
 
   if (!code) {
+    const { error, error_description: errorDescription } = query;
+    const oauthError = isString(error) ? error : undefined;
+    const oauthErrorDescription = isString(errorDescription)
+      ? errorDescription
+      : undefined;
+
     logger.error(
-      { provider, step: "code_extraction" },
+      { provider, step: "code_extraction", oauthError, oauthErrorDescription },
       "OAuth: Failed to finalize connection"
     );
     return new Err({


### PR DESCRIPTION
## Description

When an IdP denies an OAuth grant, it redirects back without a `code` and instead with `?error=...&error_description=...`. We currently log a bare `step: "code_extraction"` and return a generic message. This reads both params, logs them, and embeds them in the returned `OAuthError.message` — applies to every provider routed through `finalizeConnection`.

## Tests

Untested.

## Risk

Low — error path only, no behavior change when `code` is present.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->