### PR TITLE
[Sessions Branching] Hide per-message branch action

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -121,6 +121,9 @@ import {
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 
+// TODO(sessions-branching): Re-enable once branching from a source message is fixed.
+const SHOW_BRANCH_FROM_HERE_ACTION = false;
+
 function PrunedContextChip() {
   return (
     <Tooltip
@@ -678,7 +681,9 @@ export function AgentMessage({
     !isProjectArchived;
 
   const canBranchConversation =
-    hasFeature("sessions_branching") && shouldShowCopy;
+    SHOW_BRANCH_FROM_HERE_ACTION &&
+    hasFeature("sessions_branching") &&
+    shouldShowCopy;
 
   const shouldShowFeedback =
     !isDeleted &&


### PR DESCRIPTION
## Description
Temporarily hides the "Branch from here" action from agent message menus while keeping the source-message branching code path in place for re-enable.

Conversation-level "Branch conversation" remains available behind the existing sessions branching feature flag.

## Risks
Blast radius: Agent message action menu in conversations.
Risk: low

## Deploy Plan
- pmrr
- deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->