### PR TITLE
Mirror project files to the GCS mount path

### DIFF
--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -739,6 +739,84 @@ describe("FileResource", () => {
         `w/${workspace.sId}/conversations/conv-retro/files/attachment.pdf`
       );
     });
+
+    it("should resolve mount path via markAsReady for project_context file", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "text/markdown",
+        fileName: "spec.md",
+        fileSize: 200,
+        status: "created",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: "spc-1" },
+      });
+
+      await file.markAsReady(auth);
+
+      const row = await FileModel.findOne({
+        where: { id: file.id, workspaceId: workspace.id },
+      });
+      expect(row?.mountFilePath).toBe(
+        `w/${workspace.sId}/projects/spc-1/files/spec.md`
+      );
+    });
+
+    it("should no-op for project_context when spaceId is missing", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "text/markdown",
+        fileName: "spec.md",
+        fileSize: 200,
+        status: "created",
+        useCase: "project_context",
+      });
+
+      await file.markAsReady(auth);
+
+      const row = await FileModel.findOne({
+        where: { id: file.id, workspaceId: workspace.id },
+      });
+      expect(row?.mountFilePath).toBeNull();
+    });
+
+    it("should disambiguate project_context files with the same name in a space", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file1 = await FileFactory.create(auth, null, {
+        contentType: "text/markdown",
+        fileName: "notes.md",
+        fileSize: 100,
+        status: "created",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: "spc-1" },
+      });
+      await file1.markAsReady(auth);
+
+      const file2 = await FileFactory.create(auth, null, {
+        contentType: "text/markdown",
+        fileName: "notes.md",
+        fileSize: 200,
+        status: "created",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: "spc-1" },
+      });
+      await file2.markAsReady(auth);
+
+      const row2 = await FileModel.findOne({
+        where: { id: file2.id, workspaceId: workspace.id },
+      });
+      expect(row2?.mountFilePath).toBe(
+        `w/${workspace.sId}/projects/spc-1/files/notes_${file2.sId}.md`
+      );
+    });
   });
 
   describe("getContentBucketAndPath", () => {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -5,6 +5,7 @@ import config from "@app/lib/api/config";
 import {
   disambiguateFileName,
   getConversationFilePath,
+  getProjectFilesBasePath,
   makeProcessedMountFileName,
 } from "@app/lib/api/files/mount_path";
 import {
@@ -942,11 +943,20 @@ export class FileResource extends BaseResource<FileModel> {
     return result;
   }
 
+  /**
+   * Public entry point to trigger mount path resolution. Idempotent — no-ops when a path is
+   * already set or when the file's use case isn't mount-eligible. Used by backfill scripts.
+   */
+  async ensureMountFilePath(auth: Authenticator): Promise<void> {
+    await this.resolveAndSetMountFilePath(auth);
+  }
+
   // Mount file path logic.
   //
-  // Files used in conversations are copied to a gcsfuse-mountable GCS path so sandboxes can access
-  // them as a flat, human-readable filesystem:
+  // Files used in conversations or projects are copied to a gcsfuse-mountable GCS path so
+  // sandboxes can access them as a flat, human-readable filesystem:
   //   w/{wId}/conversations/{cId}/files/{fileName}
+  //   w/{wId}/projects/{spaceId}/files/{fileName}
   //
   // The canonical path (files/w/{wId}/{fileId}/{version}) remains the immutable original. The mount
   // path is the mutable "live" version. Initial copy from canonical, then frame edits write
@@ -961,7 +971,7 @@ export class FileResource extends BaseResource<FileModel> {
    * Examines the file's use case and metadata to determine whether a mount path should be created.
    * Branches internally by use case:
    * - conversation / tool_output: mounts under w/{wId}/conversations/{cId}/files/
-   * - (future use cases can be added here)
+   * - project_context:            mounts under w/{wId}/projects/{spaceId}/files/
    *
    * No-ops if the file already has a mountFilePath or conditions aren't met.
    */
@@ -978,9 +988,11 @@ export class FileResource extends BaseResource<FileModel> {
       resolvedPath = await this.resolveConversationMountPath(auth, {
         conversationId: useCaseMetadata.conversationId,
       });
+    } else if (useCase === "project_context" && useCaseMetadata?.spaceId) {
+      resolvedPath = await this.resolveProjectMountPath(auth, {
+        projectId: useCaseMetadata.spaceId,
+      });
     }
-
-    // TODO(2026-03-09 SANDBOX): Add support for project context.
 
     if (resolvedPath) {
       await this.setMountFilePath(auth, resolvedPath);
@@ -1015,8 +1027,29 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   /**
+   * Resolve the mount path for a project_context file. Checks for collisions via the unique index
+   * on mountFilePath and disambiguates with the file's sId if needed.
+   */
+  private async resolveProjectMountPath(
+    auth: Authenticator,
+    { projectId }: { projectId: string }
+  ): Promise<string> {
+    const owner = auth.getNonNullableWorkspace();
+    const basePath = getProjectFilesBasePath({
+      workspaceId: owner.sId,
+      projectId,
+    });
+
+    const desiredPath = `${basePath}${this.fileName}`;
+    const isTaken = await this.isMountFilePathTaken(desiredPath);
+
+    return isTaken ? `${basePath}${disambiguateFileName(this)}` : desiredPath;
+  }
+
+  /**
    * Set the mount file path and copy the file's original (and processed if exists) versions to the
-   * conversation-level GCS path for gcsfuse mounting.
+   * given GCS path for gcsfuse mounting. The path is conversation- or project-scoped depending on
+   * the caller.
    *
    * This is a one-time operation: copies from the canonical path to the mount path. Subsequent
    * edits (frames) write directly to the mount path.

--- a/front/scripts/backfill_project_context_mount_paths.ts
+++ b/front/scripts/backfill_project_context_mount_paths.ts
@@ -1,0 +1,128 @@
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { Op } from "sequelize";
+
+const BATCH_SIZE_DEFAULT = 200;
+const CONCURRENCY_DEFAULT = 4;
+
+makeScript(
+  {
+    wId: {
+      type: "string",
+      describe: "Workspace sId to backfill (omit to run on all workspaces).",
+    },
+    fromWorkspaceModelId: {
+      type: "number",
+      describe:
+        "Skip workspaces with model id below this value (for resuming).",
+    },
+    batchSize: {
+      type: "number",
+      default: BATCH_SIZE_DEFAULT,
+      describe: "Number of files to fetch per DB query.",
+    },
+    concurrency: {
+      type: "number",
+      default: CONCURRENCY_DEFAULT,
+      describe: "Concurrent file mount-path resolutions per batch.",
+    },
+  },
+  async (
+    { execute, wId, fromWorkspaceModelId, batchSize, concurrency },
+    logger
+  ) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const workspaceId = workspace.sId;
+
+        const auth =
+          await Authenticator.internalBuilderForWorkspace(workspaceId);
+
+        const hasProjectEnabled = await hasFeatureFlag(auth, "projects");
+        if (!hasProjectEnabled) {
+          throw new Error("Workspace does not have `projects` FF enabled.");
+        }
+
+        logger.info(
+          { workspaceId, execute },
+          "[backfill_project_mount_paths] Starting workspace"
+        );
+
+        let lastId = 0;
+        let totalProcessed = 0;
+        let totalUpdated = 0;
+
+        while (true) {
+          const rows = await FileModel.findAll({
+            attributes: ["id"],
+            where: {
+              workspaceId: workspace.id,
+              useCase: "project_context",
+              mountFilePath: null,
+              id: { [Op.gt]: lastId },
+            },
+            order: [["id", "ASC"]],
+            limit: batchSize,
+          });
+
+          if (rows.length === 0) {
+            break;
+          }
+
+          lastId = rows[rows.length - 1].id;
+
+          const files = await FileResource.fetchByModelIdsWithAuth(
+            auth,
+            rows.map((r) => r.id)
+          );
+
+          await concurrentExecutor(
+            files,
+            async (file) => {
+              totalProcessed++;
+
+              // Skip files that don't have a spaceId in their metadata. IT can't be mounted.
+              if (!file.useCaseMetadata?.spaceId) {
+                return;
+              }
+
+              if (!execute) {
+                logger.info(
+                  {
+                    fileId: file.sId,
+                    fileName: file.fileName,
+                    spaceId: file.useCaseMetadata.spaceId,
+                  },
+                  "[backfill_project_mount_paths] Would set mount path (dry-run)"
+                );
+                totalUpdated++;
+                return;
+              }
+
+              try {
+                await file.ensureMountFilePath(auth);
+                totalUpdated++;
+              } catch (err) {
+                logger.error(
+                  { err, fileId: file.sId },
+                  "[backfill_project_mount_paths] Failed to set mount path"
+                );
+              }
+            },
+            { concurrency }
+          );
+        }
+
+        logger.info(
+          { workspaceId, totalProcessed, totalUpdated, execute },
+          "[backfill_project_mount_paths] Workspace done"
+        );
+      },
+      { wId, fromWorkspaceId: fromWorkspaceModelId }
+    );
+  }
+);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Currently files uploaded in a project are only wrote to the canonical `FileResource` path. This PR extends `FileResource.resolveAndSetMountFilePath` with a `project_context` branch, so an uploaded project file is now also copied to `w/{wId}/projects/{spaceId}/files/{fileName}`. 

The mechanism mirrors the existing conversation branch: a new `resolveProjectMountPath` helper, shared collision handling via `disambiguateFileName`, and the same `markAsReady` trigger. 

Added a backfill script to mount all project files.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25476">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->