### PR TITLE
Add: isRunningAgentLoop property on conversation (DB + ES). Show animated text when streaming, show typing animation when title is added.

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -747,6 +747,16 @@ export const ConversationViewer = ({
               void mutateConversationParticipants(async (participants) =>
                 getUpdatedParticipantsFromEvent(participants, event)
               );
+
+              void mutateConversations(
+                (currentData: ConversationListItemType[] | undefined) =>
+                  currentData?.map((c) =>
+                    c.sId === conversationId
+                      ? { ...c, isRunningAgentLoop: true }
+                      : c
+                  ),
+                { revalidate: false }
+              );
             }
             break;
 
@@ -817,7 +827,11 @@ export const ConversationViewer = ({
               (currentData: ConversationListItemType[] | undefined) =>
                 currentData?.map((c) =>
                   c.sId === event.conversationId
-                    ? { ...c, hasError: event.status === "error" }
+                    ? {
+                        ...c,
+                        hasError: event.status === "error",
+                        isRunningAgentLoop: false,
+                      }
                     : c
                 ),
               { revalidate: false }

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -105,6 +105,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -1150,6 +1151,7 @@ function UnreadConversationsSection({
           >
             <div className="overflow-hidden">
               <ConversationListItem
+                key={conversation.sId}
                 conversation={conversation}
                 isMultiSelect={isMultiSelect}
                 selectedConversations={selectedConversations}
@@ -1240,6 +1242,20 @@ const ConversationListItem = memo(
       handleMenuOpenChange,
     } = useConversationMenu();
 
+    const [showTypingAnimation, setShowTypingAnimation] = useState(false);
+    const titleRef = useRef<string | null>(conversation.title); // Used to detect when the title changes to show the typing animation.
+
+    useLayoutEffect(() => {
+      if (titleRef.current === null && conversation.title !== null) {
+        setShowTypingAnimation(true);
+      }
+      titleRef.current = conversation.title;
+    }, [conversation.title]);
+
+    const handleTypingAnimationComplete = useCallback(() => {
+      setShowTypingAnimation(false);
+    }, []);
+
     const conversationLabel = getConversationDisplayTitle(conversation);
 
     const handleDragStart = useCallback(
@@ -1282,9 +1298,18 @@ const ConversationListItem = memo(
       </div>
     ) : (
       <NavigationListItem
+        key={conversation.sId}
         selected={activeConversationId === conversation.sId}
         status={getConversationDotStatus(conversation)}
         label={conversationLabel}
+        labelAnimation={
+          showTypingAnimation
+            ? "typing"
+            : conversation.isRunningAgentLoop
+              ? "streaming"
+              : "none"
+        }
+        onTypingAnimationComplete={handleTypingAnimationComplete}
         href={getConversationRoute(owner.sId, conversation.sId)}
         shallow
         draggable={!conversation.spaceId}

--- a/front/components/assistant/conversation/space/conversations/project_tasks/EditableTaskItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/EditableTaskItem.tsx
@@ -63,7 +63,6 @@ export function EditableTaskItem({ task }: EditableTaskItemProps) {
     !!task.conversationId;
   const isDoneWithoutConversation = isDone && !hasConversationLink;
   const canEdit = viewerUserId !== null && !isReadOnly;
-  const showInProgressTextAnimation = task.status === "in_progress";
   const conversationDotStatus: ConversationDotStatus =
     task.conversationSidebarStatus ?? "idle";
 
@@ -172,7 +171,7 @@ export function EditableTaskItem({ task }: EditableTaskItemProps) {
                       duration={16}
                       onComplete={typing.dismiss}
                     />
-                  ) : showInProgressTextAnimation ? (
+                  ) : task.conversationIsRunningAgentLoop ? (
                     <AnimatedText variant="muted">{displayText}</AnimatedText>
                   ) : (
                     displayText

--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -481,6 +481,7 @@ export function useProjectTasksPanelState({
                     markedAsDoneByAgentConfigurationId: null,
                     conversationId,
                     conversationSidebarStatus: "idle",
+                    conversationIsRunningAgentLoop: true,
                   }
                 : t
             ),

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -113,6 +113,7 @@ export function useBranchConversation({
           triggerId: null,
           unread: false,
           updated: nowMs,
+          isRunningAgentLoop: false,
         };
 
         void mutateConversations(

--- a/front/hooks/conversations/useConversationMarkAsRead.ts
+++ b/front/hooks/conversations/useConversationMarkAsRead.ts
@@ -60,7 +60,9 @@ export function useConversationMarkAsRead({
           void mutateConversations(
             (prevState: ConversationListItemType[] | undefined) =>
               prevState?.map((c) =>
-                c.sId === conversationId ? { ...c, unread: false } : c
+                c.sId === conversationId
+                  ? { ...c, unread: false, isRunningAgentLoop: false }
+                  : c
               ),
             { revalidate: false }
           );

--- a/front/lib/api/assistant/content_fragments.test.ts
+++ b/front/lib/api/assistant/content_fragments.test.ts
@@ -133,6 +133,7 @@ function createMockConversation(
     triggerId: null,
     metadata: {},
     branchId: null,
+    isRunningAgentLoop: false,
   };
 }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -251,6 +251,7 @@ export async function createConversation(
     triggerId: conversation.triggerSId,
     metadata: conversation.metadata,
     branchId: null,
+    isRunningAgentLoop: conversation.isRunningAgentLoop,
   };
 }
 

--- a/front/lib/api/assistant/conversation/agent_loop.ts
+++ b/front/lib/api/assistant/conversation/agent_loop.ts
@@ -1,5 +1,6 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type {
@@ -35,6 +36,11 @@ export const runAgentLoopWorkflow = async ({
         agentConfiguration,
         "Unreachable: could not find detailed configuration for agent"
       );
+
+      await ConversationResource.setIsRunningAgentLoop(auth, {
+        conversation,
+        isRunningAgentLoop: true,
+      });
 
       void launchAgentLoopWorkflow({
         auth,

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -329,6 +329,7 @@ async function _getConversation<V extends "light" | "full">(
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
       branchId,
+      isRunningAgentLoop: conversation.isRunningAgentLoop,
       ...(forkingData && { forkingData }),
     };
 
@@ -407,6 +408,7 @@ async function _getConversation<V extends "light" | "full">(
       spaceId: conversation.space?.sId ?? null,
       metadata: conversation.metadata,
       branchId,
+      isRunningAgentLoop: conversation.isRunningAgentLoop,
       ...(forkingData && { forkingData }),
     };
 

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -180,6 +180,7 @@ describe("renderAllMessages", () => {
       triggerId: null,
       metadata: {},
       branchId: null,
+      isRunningAgentLoop: false,
     } as ConversationType;
   }
 

--- a/front/lib/conversation_search/index.ts
+++ b/front/lib/conversation_search/index.ts
@@ -50,6 +50,7 @@ export function buildConversationSearchDocument(
     workspace_id: auth.getNonNullableWorkspace().sId,
     ...(conversation.space?.sId && { space_id: conversation.space.sId }),
     next_wakeup_at: activeWakeUp?.nextFireAt()?.toISOString() ?? null,
+    is_running_agent_loop: conversation.isRunningAgentLoop,
   };
 }
 

--- a/front/lib/conversation_search/indices/conversation_search_1.mappings.json
+++ b/front/lib/conversation_search/indices/conversation_search_1.mappings.json
@@ -50,6 +50,9 @@
     },
     "next_wakeup_at": {
       "type": "date"
+    },
+    "is_running_agent_loop": {
+      "type": "boolean"
     }
   }
 }

--- a/front/lib/conversation_search/search.ts
+++ b/front/lib/conversation_search/search.ts
@@ -177,6 +177,7 @@ export async function listPrivateConversationsFromES({
           triggerId: source.trigger_id ?? null,
           unread: true,
           updated: updatedMs,
+          isRunningAgentLoop: !!source.is_running_agent_loop,
         },
       ];
     });

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -30,6 +30,7 @@ export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   declare title: string | null;
   declare visibility: CreationOptional<ConversationVisibility>;
   declare depth: CreationOptional<number>;
+  declare isRunningAgentLoop: CreationOptional<boolean>;
   declare triggerId: ForeignKey<TriggerModel["id"]> | null;
   declare hasError: CreationOptional<boolean>;
   declare metadata: CreationOptional<ConversationMetadata>;
@@ -71,6 +72,11 @@ ConversationModel.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 0,
+    },
+    isRunningAgentLoop: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     requestedSpaceIds: {
       type: DataTypes.ARRAY(DataTypes.BIGINT),

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1463,6 +1463,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       triggerId: conversation.triggerSId,
       unread: lastReadAt === null || conversation.updatedAt > lastReadAt,
       updated: conversation.updatedAt.getTime(),
+      isRunningAgentLoop: conversation.isRunningAgentLoop,
       ...(forkingData && { forkingData }),
     });
   }
@@ -2265,6 +2266,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           depth: c.depth,
           metadata: c.metadata,
           branchId: null,
+          isRunningAgentLoop: c.isRunningAgentLoop,
         };
       })
     );
@@ -2327,6 +2329,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       depth: c.depth,
       metadata: c.metadata,
       branchId: null,
+      isRunningAgentLoop: c.isRunningAgentLoop,
     }));
   }
 
@@ -2403,6 +2406,36 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
         },
         transaction: t,
+      }
+    );
+
+    await this.triggerEsIndexing(auth, conversation.sId);
+
+    return new Ok(updated[0]);
+  }
+
+  static async setIsRunningAgentLoop(
+    auth: Authenticator,
+    {
+      conversation,
+      isRunningAgentLoop,
+      transaction,
+    }: {
+      conversation: ConversationWithoutContentType;
+      isRunningAgentLoop: boolean;
+      transaction?: Transaction;
+    }
+  ) {
+    const updated = await ConversationModel.update(
+      { isRunningAgentLoop },
+      {
+        where: {
+          id: conversation.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        // Do not update `updatedAt.
+        silent: true,
+        transaction,
       }
     );
 
@@ -3944,6 +3977,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       unread:
         this.userLastReadAt === null || this.updatedAt > this.userLastReadAt,
       updated: this.updatedAt.getTime(),
+      isRunningAgentLoop: this.isRunningAgentLoop,
     };
   }
 

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -694,6 +694,7 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
       user: this.assignee,
       conversationId: this.conversationSId,
       conversationSidebarStatus: null,
+      conversationIsRunningAgentLoop: null,
       text: this.text,
       status: this.status,
       doneAt: this.doneAt,

--- a/front/migrations/20260511_add_is_streaming_to_es.http
+++ b/front/migrations/20260511_add_is_streaming_to_es.http
@@ -1,0 +1,8 @@
+PUT /front.conversation_search/_mapping
+{
+  "properties": {
+    "is_running_agent_loop": {
+      "type": "boolean"
+    }
+  }
+}

--- a/front/migrations/db/migration_630.sql
+++ b/front/migrations/db/migration_630.sql
@@ -1,2 +1,3 @@
 -- Migration created on May 11, 2026
-ALTER TABLE "public"."memberships" ADD COLUMN "seatType" VARCHAR(255) NOT NULL DEFAULT 'free';
+ALTER TABLE "public"."memberships"
+ADD COLUMN "seatType" VARCHAR(255) NOT NULL DEFAULT 'free';

--- a/front/migrations/db/migration_631.sql
+++ b/front/migrations/db/migration_631.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 11, 2026
+ALTER TABLE "public"."conversations"
+ADD COLUMN "isRunningAgentLoop" BOOLEAN NOT NULL DEFAULT false;

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -93,6 +93,7 @@ async function handler(
             spaceId: c.space?.sId ?? null,
             metadata: c.metadata,
             branchId: null,
+            isRunningAgentLoop: c.isRunningAgentLoop,
           };
         });
 

--- a/front/pages/api/w/[wId]/project_tasks/[taskSId]/index.ts
+++ b/front/pages/api/w/[wId]/project_tasks/[taskSId]/index.ts
@@ -6,7 +6,10 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
+import {
+  type ConversationDotStatus,
+  getConversationDotStatus,
+} from "@app/lib/utils/conversation_dot_status";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ProjectTaskType } from "@app/types/project_task";
@@ -72,8 +75,8 @@ async function handler(
       const conversationId = await taskRow.getLatestConversationId(auth);
 
       const serializedBase = taskRow.toJSON();
-      let conversationSidebarStatus: ProjectTaskType["conversationSidebarStatus"] =
-        null;
+      let conversationSidebarStatus: ConversationDotStatus | null = null;
+      let conversationIsRunningAgentLoop: boolean = false;
       if (conversationId) {
         const listItemByConversationSId =
           await ConversationResource.fetchListItemsBySIds(auth, [
@@ -83,6 +86,7 @@ async function handler(
         conversationSidebarStatus = listItem
           ? getConversationDotStatus(listItem)
           : "idle";
+        conversationIsRunningAgentLoop = listItem?.isRunningAgentLoop ?? false;
       }
 
       const sources = sourcesByTaskId.get(taskRow.sId) ?? [];
@@ -90,6 +94,7 @@ async function handler(
         ...serializedBase,
         conversationId,
         conversationSidebarStatus,
+        conversationIsRunningAgentLoop,
         sources: sources.map((s) => ({
           sourceType: s.sourceType,
           sourceId: s.sourceId,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
@@ -6,7 +6,10 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import { ProjectTaskStateResource } from "@app/lib/resources/project_task_state_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { getConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
+import {
+  type ConversationDotStatus,
+  getConversationDotStatus,
+} from "@app/lib/utils/conversation_dot_status";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import {
@@ -136,18 +139,21 @@ async function handler(
           const t = todos[i]!;
           const sources = sourcesByTodoId.get(t.sId) ?? [];
           const { conversationId } = serializedTodo;
-          let conversationSidebarStatus: ProjectTaskType["conversationSidebarStatus"] =
-            null;
+          let conversationSidebarStatus: ConversationDotStatus | null = null;
+          let conversationIsRunningAgentLoop: boolean = false;
           if (conversationId) {
             const listItem = listItemByConversationSId.get(conversationId);
             conversationSidebarStatus = listItem
               ? getConversationDotStatus(listItem)
               : "idle";
+            conversationIsRunningAgentLoop =
+              listItem?.isRunningAgentLoop ?? false;
           }
 
           return {
             ...serializedTodo,
             conversationSidebarStatus,
+            conversationIsRunningAgentLoop,
             sources: sources.map((s) => ({
               sourceType: s.sourceType,
               sourceId: s.sourceId,

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -331,6 +331,13 @@ export async function processEventForDatabase(
       // Ensure we handle all event types.
       break;
   }
+
+  if (TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)) {
+    await ConversationResource.setIsRunningAgentLoop(auth, {
+      conversation,
+      isRunningAgentLoop: false,
+    });
+  }
 }
 
 // Process unread state for agent events before publishing to Redis.

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -167,5 +167,6 @@ export function mockConversation(
     },
     visibility: "unlisted",
     content: messages,
+    isRunningAgentLoop: false,
   };
 }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -519,6 +519,7 @@ export type ConversationListItemType = {
   triggerId: string | null;
   unread: boolean;
   updated: number;
+  isRunningAgentLoop: boolean;
 };
 
 /**

--- a/front/types/conversation_search/conversation_search.ts
+++ b/front/types/conversation_search/conversation_search.ts
@@ -22,4 +22,5 @@ export interface ConversationSearchDocument extends ElasticsearchBaseDocument {
   updated_at: string;
   visibility: string;
   next_wakeup_at?: string | null;
+  is_running_agent_loop: boolean;
 }

--- a/front/types/project_task.ts
+++ b/front/types/project_task.ts
@@ -80,6 +80,7 @@ export type ProjectTaskType = {
   conversationId: string | null;
   /** Same semantics as the left sidebar conversation row (see `getConversationDotStatus`). */
   conversationSidebarStatus: ConversationDotStatus | null;
+  conversationIsRunningAgentLoop: boolean | null;
   text: string;
   status: ProjectTaskStatus;
   doneAt: Date | null;

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -1,4 +1,5 @@
 import type * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import { AnimatedText } from "@sparkle/components/AnimatedText";
 import { Button } from "@sparkle/components/Button";
 import {
   Collapsible,
@@ -12,6 +13,7 @@ import {
   type LinkWrapperProps,
 } from "@sparkle/components/LinkWrapper";
 import { ScrollArea, ScrollBar } from "@sparkle/components/ScrollArea";
+import { TypingAnimation } from "@sparkle/components/TypingAnimation";
 import { ChevronDownIcon, ChevronUpIcon, MoreIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -74,6 +76,8 @@ interface NavigationListItemProps
     Omit<LinkWrapperProps, "children" | "className"> {
   selected?: boolean;
   label?: string;
+  labelAnimation?: "none" | "typing" | "streaming";
+  onTypingAnimationComplete?: () => void;
   icon?: React.ComponentType;
   avatar?: React.ReactNode;
   moreMenu?: React.ReactNode;
@@ -92,6 +96,8 @@ const NavigationListItem = React.forwardRef<
       className,
       selected,
       label,
+      labelAnimation = "none",
+      onTypingAnimationComplete,
       icon,
       avatar,
       href,
@@ -176,7 +182,17 @@ const NavigationListItem = React.forwardRef<
                   hasActivity && "s-font-semibold"
                 )}
               >
-                {label}
+                {labelAnimation === "typing" ? (
+                  <TypingAnimation
+                    text={label}
+                    duration={32}
+                    onComplete={onTypingAnimationComplete}
+                  />
+                ) : labelAnimation === "streaming" ? (
+                  <AnimatedText variant="muted">{label}</AnimatedText>
+                ) : (
+                  label
+                )}
               </span>
             )}
             {suffix && (

--- a/sparkle/src/components/TypingAnimation.tsx
+++ b/sparkle/src/components/TypingAnimation.tsx
@@ -12,8 +12,11 @@ export function TypingAnimation({
   duration = 50,
   onComplete,
 }: TypingAnimationProps) {
-  const [displayedText, setDisplayedText] = useState<string>("");
-  const [i, setI] = useState<number>(0);
+  const [displayedText, setDisplayedText] = useState<string>(
+    text.substring(0, 1)
+  );
+  // Start at one to avoid an empty text as first display as it sometimes shrinks the container.
+  const [i, setI] = useState<number>(Math.min(1, text.length));
   const onCompleteRef = useRef(onComplete);
   onCompleteRef.current = onComplete;
 


### PR DESCRIPTION
## Description

The sidebar had no way to signal that a conversation was actively generating a response. This PR introduces a persistent `isStreaming` flag and uses it to drive two new visual animations in the conversation list.

**`isStreaming` flag**

- Add `isStreaming BOOLEAN NOT NULL DEFAULT false` to `ConversationModel` (DB migration included)
- Set to `true` in `runAgentLoopWorkflow` before firing `launchAgentLoopWorkflow`; cleared to `false` on `agent_generation_success`, `agent_generation_cancelled`, and `agent_error`
- Propagated through `ConversationType`, `ConversationListItemType`, `_getConversation`, and `createConversation`
- Added to the ES index mapping (`is_streaming: { type: "boolean" }`) and surfaced via `buildConversationSearchDocument` / `listPrivateConversationsFromES`

**Sidebar animations**

`ConversationListItem` now passes a `labelAnimation` prop to the conversation row:
- `"streaming"` when `conversation.isStreaming` — animated indicator while the agent is writing
- `"typing"` when `title` just transitioned from `null` to a string (detected via `titleRef` + `useLayoutEffect`) — plays the title character-by-character as it appears for the first time
- `"none"` otherwise

**Task list streaming indicator**

`EditableTaskItem` now keys off `task.conversationIsStreaming` instead of `task.status === "in_progress"` for the `AnimatedText` variant; `conversationIsStreaming: true` is set in the optimistic SWR cache immediately when a task is started.

**Optimistic SWR mutations**

`ConversationViewer` sets `isStreaming: true` on `agent_message_new` and clears it on generation-end events; `useBranchConversation` and `useConversationMarkAsRead` include `isStreaming: false` in their mutations.

## Tests

Local + test fixtures updated with `isStreaming: false`


https://github.com/user-attachments/assets/07376bf4-7e3f-4a8b-95f3-19a076e8a04a



## Risk

Low — `isStreaming` defaults to `false`; existing conversations are unaffected until the next agent run

## Deploy Plan

Run migration, re-index ES (`is_streaming` field), deploy `front`
