### PR TITLE
[front] enh: Track idle-in-tx

### DIFF
--- a/front/lib/api/database.ts
+++ b/front/lib/api/database.ts
@@ -1,4 +1,6 @@
 import { queryTracker } from "@app/lib/api/query_tracker";
+import logger from "@app/logger/logger";
+import { isString } from "@app/types/shared/utils/general";
 import { context as otelContext, trace } from "@opentelemetry/api";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import type {
@@ -9,8 +11,91 @@ import type {
   QueryOptionsWithModel,
   QueryOptionsWithType,
   QueryTypes,
+  Transaction,
 } from "sequelize";
 import { Sequelize } from "sequelize";
+
+const IDLE_IN_TX_THRESHOLD_MS = 250;
+
+interface TxState {
+  beginAtMs: number;
+  busyMs: number;
+  route: string | undefined;
+  lastQuerySql: string;
+}
+
+const txStates = new WeakMap<Transaction, TxState>();
+
+function trackTx(
+  transaction: Transaction | null | undefined,
+  sql: string | { query: string; values: unknown[] }
+): (() => void) | undefined {
+  if (!transaction) {
+    return undefined;
+  }
+  const sqlString = isString(sql) ? sql : sql.query;
+  const upper = sqlString.trimStart().toUpperCase();
+  const isBegin =
+    upper.startsWith("BEGIN") || upper.startsWith("START TRANSACTION");
+  const isCommit = upper.startsWith("COMMIT");
+  const isRollback =
+    upper.startsWith("ROLLBACK") && !upper.startsWith("ROLLBACK TO");
+
+  if (isBegin) {
+    const span = trace.getSpan(otelContext.active());
+    let route: string | undefined;
+    if (span && span.isRecording()) {
+      const attrs = (span as unknown as ReadableSpan).attributes;
+      if (attrs?.["next.route"]) {
+        route = String(attrs["next.route"]);
+      } else if (attrs?.["next.span_name"]) {
+        const m = String(attrs["next.span_name"]).match(
+          /executing api route \(pages\) (.+)$/
+        );
+        if (m) {
+          route = m[1];
+        }
+      }
+    }
+    txStates.set(transaction, {
+      beginAtMs: performance.now(),
+      busyMs: 0,
+      route,
+      lastQuerySql: "",
+    });
+    return undefined;
+  }
+
+  const state = txStates.get(transaction);
+  if (!state) {
+    return undefined;
+  }
+  const startMs = performance.now();
+
+  return () => {
+    if (isCommit || isRollback) {
+      txStates.delete(transaction);
+      const totalMs = performance.now() - state.beginAtMs;
+      const idleMs = Math.max(0, totalMs - state.busyMs);
+      if (idleMs >= IDLE_IN_TX_THRESHOLD_MS) {
+        logger.warn(
+          {
+            totalMs,
+            idleMs,
+            busyMs: state.busyMs,
+            outcome: isCommit ? "commit" : "rollback",
+            route: state.route,
+            lastQuerySql: state.lastQuerySql,
+          },
+          "Idle-in-transaction detected"
+        );
+      }
+      return;
+    }
+    state.busyMs += performance.now() - startMs;
+    state.lastQuerySql = sqlString;
+  };
+}
 
 // Why are we doing this?
 // Sequelize is loosely typed and connection parameters are passed as is
@@ -116,6 +201,8 @@ export class SequelizeWithComments<
       ctx.peak = Math.max(ctx.peak, ctx.concurrent);
     }
 
+    const onQueryEnd = trackTx(options?.transaction, sql);
+
     try {
       // Only process string queries.
       if (typeof sql !== "string") {
@@ -171,6 +258,7 @@ export class SequelizeWithComments<
       if (ctx) {
         ctx.concurrent--;
       }
+      onQueryEnd?.();
     }
   }
 }


### PR DESCRIPTION
## Description

Given our workloads (high qps OLTP), idle in transaction can be catastrophic, every idle-in-tx is a connection being held, and an api request in the event loop not moving forward, for all intent and purposes, we can process 40 requests at the same time (assuming we always hit the database at some point, which is 99% true).

We have a few codepath using transactions with 10s of sql statement and some calls to providers (e.g Workos).
While these are easy to spot, with the pace at which the codebase grows, it's easy to miss network i/o (or even cpu-bound code) in a transaction block.

This PR introduces a warning when we detect idle in transaction for more than 250ms.
In the future we will want to lower that threshold, but we need to start from somewhere.


## Tests

Tested locally.

## Risk

Low
Blast radius: The whole application.

## Deploy Plan

- Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25481">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->