### PR TITLE
Decouple various uses of Next from lib/api

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { StepContext } from "@app/lib/actions/types";
 import {
@@ -158,8 +157,8 @@ import { md5 } from "@app/types/shared/utils/encryption";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
+import type { IncomingHttpHeaders } from "http";
 import uniq from "lodash/uniq";
-import type { NextApiRequest } from "next";
 import type { Transaction } from "sequelize";
 import { col } from "sequelize";
 
@@ -506,7 +505,7 @@ async function getNextConversationMessageRank(
 
 export function isUserMessageContextValid(
   auth: Authenticator,
-  req: NextApiRequest,
+  headers: IncomingHttpHeaders,
   context: UserMessageContext
 ): boolean {
   const authMethod = auth.authMethod();
@@ -519,7 +518,7 @@ export function isUserMessageContextValid(
     "user-agent": userAgent,
     "x-dust-extension-version": extensionVersion,
     "x-zendesk-user-id": zendeskUserId,
-  } = req.headers;
+  } = headers;
 
   switch (context.origin) {
     case "api":

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -1,7 +1,6 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { NextApiRequest } from "next";
+import type { ParsedUrlQuery } from "querystring";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
@@ -54,16 +53,16 @@ interface PaginationOptions {
 }
 
 export function getPaginationParams(
-  req: NextApiRequest,
+  query: ParsedUrlQuery,
   defaults: PaginationOptions
 ): Result<PaginationParams, InvalidPaginationParamsError> {
   const rawParams = {
     // Don't support a default order column.
-    orderColumn: req.query.orderColumn ?? defaults.defaultOrderColumn,
-    orderDirection: req.query.orderDirection ?? defaults.defaultOrderDirection,
-    lastValue: req.query.lastValue,
-    limit: req.query.limit
-      ? parseInt(req.query.limit as string)
+    orderColumn: query.orderColumn ?? defaults.defaultOrderColumn,
+    orderDirection: query.orderDirection ?? defaults.defaultOrderDirection,
+    lastValue: query.lastValue,
+    limit: query.limit
+      ? parseInt(query.limit as string)
       : defaults.defaultLimit,
   };
 
@@ -107,15 +106,15 @@ export interface CursorPaginationParams {
 }
 
 export function getCursorPaginationParams(
-  req: NextApiRequest
+  query: ParsedUrlQuery
 ): Result<CursorPaginationParams | undefined, InvalidPaginationParamsError> {
-  if (!req.query.limit) {
+  if (!query.limit) {
     return new Ok(undefined);
   }
 
   const rawParams = {
-    cursor: req.query.cursor ?? null,
-    limit: parseInt(req.query.limit as string, 10),
+    cursor: query.cursor ?? null,
+    limit: parseInt(query.limit as string, 10),
   };
 
   const queryValidation = CursorPaginationParamsSchema.safeParse(rawParams);

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import config from "@app/lib/api/config";
 import {
   getContentNodeFromCoreNode,
@@ -21,7 +20,7 @@ import type { APIError } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { NextApiRequest } from "next";
+import type { ParsedUrlQuery } from "querystring";
 import { z } from "zod";
 
 export type DataSourceContentNode = ContentNodeWithParent & {
@@ -147,7 +146,7 @@ function selectHighestPriorityDataSourceView(
 }
 
 export async function handleSearch(
-  req: NextApiRequest,
+  reqQuery: ParsedUrlQuery,
   auth: Authenticator,
   {
     allowAdminSearch,
@@ -251,7 +250,7 @@ export async function handleSearch(
 
   const searchFilter = searchFilterRes.value;
 
-  const paginationRes = getCursorPaginationParams(req);
+  const paginationRes = getCursorPaginationParams(reqQuery);
   if (paginationRes.isErr()) {
     return new Err({
       status: 400,

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -126,7 +126,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getCursorPaginationParams(req);
+  const paginationRes = getCursorPaginationParams(req.query);
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -204,7 +204,7 @@ async function handler(
 
       const validateUserMessageContextRes = isUserMessageContextValid(
         auth,
-        req,
+        req.headers,
         ctx
       );
       if (!validateUserMessageContextRes) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -463,7 +463,7 @@ async function handler(
 
         const validateUserMessageContextRes = isUserMessageContextValid(
           auth,
-          req,
+          req.headers,
           ctx
         );
         if (!validateUserMessageContextRes) {

--- a/front/pages/api/v1/w/[wId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/search.ts
@@ -110,7 +110,7 @@ async function handleStreamingSearch(
     );
 
     // First, stream knowledge results
-    const searchResult = await handleSearch(req, auth, searchParams);
+    const searchResult = await handleSearch(req.query, auth, searchParams);
 
     if (searchResult.isErr()) {
       return apiError(req, res, {
@@ -349,7 +349,7 @@ async function handler(
     });
   }
 
-  const searchResult = await handleSearch(req, auth, r.data);
+  const searchResult = await handleSearch(req.query, auth, r.data);
 
   if (searchResult.isErr()) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -56,7 +56,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       // asc id is equivalent to desc createdAt
-      const paginationRes = getPaginationParams(req, {
+      const paginationRes = getPaginationParams(req.query, {
         defaultLimit: 50,
         defaultOrderColumn: "id",
         defaultOrderDirection: "asc",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -195,7 +195,7 @@ async function handler(
     case "GET":
       const messageStartTime = performance.now();
 
-      const paginationRes = getPaginationParams(req, {
+      const paginationRes = getPaginationParams(req.query, {
         defaultLimit: 10,
         defaultOrderColumn: "rank",
         defaultOrderDirection: "desc",

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -180,7 +180,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const paginationRes = getPaginationParams(req, {
+      const paginationRes = getPaginationParams(req.query, {
         defaultLimit: 100,
         defaultOrderColumn: "updatedAt",
         defaultOrderDirection: "desc",

--- a/front/pages/api/w/[wId]/assistant/conversations/search.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/search.ts
@@ -32,7 +32,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getPaginationParams(req, {
+  const paginationRes = getPaginationParams(req.query, {
     defaultLimit: 20,
     defaultOrderColumn: "updatedAt",
     defaultOrderDirection: "desc",

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -57,7 +57,7 @@ async function handler(
         });
       }
 
-      const paginationRes = getPaginationParams(req, {
+      const paginationRes = getPaginationParams(req.query, {
         defaultLimit: 20,
         defaultOrderColumn: "updatedAt",
         defaultOrderDirection: "desc",

--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -121,7 +121,7 @@ async function handleStreamingSearch(
     );
 
     // First, stream knowledge results
-    const searchResult = await handleSearch(req, auth, searchParams);
+    const searchResult = await handleSearch(req.query, auth, searchParams);
 
     if (searchResult.isErr()) {
       return apiError(req, res, {
@@ -223,7 +223,7 @@ async function handler(
     });
   }
 
-  const searchResult = await handleSearch(req, auth, bodyValidation.data);
+  const searchResult = await handleSearch(req.query, auth, bodyValidation.data);
 
   if (searchResult.isErr()) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -89,7 +89,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getCursorPaginationParams(req);
+  const paginationRes = getCursorPaginationParams(req.query);
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -33,7 +33,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const paginationRes = getCursorPaginationParams(req);
+      const paginationRes = getCursorPaginationParams(req.query);
       if (paginationRes.isErr()) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
@@ -58,7 +58,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getCursorPaginationParams(req);
+  const paginationRes = getCursorPaginationParams(req.query);
   if (paginationRes.isErr()) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/search_projects.ts
+++ b/front/pages/api/w/[wId]/spaces/search_projects.ts
@@ -32,7 +32,7 @@ async function handler(
     });
   }
 
-  const paginationRes = getPaginationParams(req, {
+  const paginationRes = getPaginationParams(req.query, {
     defaultLimit: 20,
     defaultOrderColumn: "name",
     defaultOrderDirection: "asc",


### PR DESCRIPTION
## Description

Stop importing NextApiRequest / NextApiResponse in lib/api business functions where the function only needs a subset of the request (typically req.query or req.headers). Pass the narrowed value in instead. This makes the affected functions runtime-agnostic and easier to migrate when we move away from the Next pages router (e.g. Hono).

## Tests

Existing coverage

## Risk

Low, no-op refactor

## Deploy Plan

Front