### PR TITLE
Add public API endpoint to download conversation-scoped files

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -1,0 +1,165 @@
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import {
+  getConversationFilesBasePath,
+  parseScopedFilePath,
+} from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import path from "path";
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/assistant/conversations/{cId}/files/{rel}:
+ *   get:
+ *     tags:
+ *       - Conversations
+ *     summary: Download a conversation-scoped file by path
+ *     description: |
+ *       Download a file from a conversation's file system by its scoped path. The path must
+ *       be conversation-scoped, i.e. start with `conversation/` (as surfaced by agent file
+ *       system tools). The file content is streamed directly from the conversation mount.
+ *     parameters:
+ *       - name: wId
+ *         in: path
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - name: cId
+ *         in: path
+ *         required: true
+ *         description: ID of the conversation
+ *         schema:
+ *           type: string
+ *       - name: rel
+ *         in: path
+ *         required: true
+ *         description: |
+ *           Conversation-scoped file path, e.g. `conversation/foo.pdf` or
+ *           `conversation/subdir/foo.pdf`. The `conversation/` prefix is required; any other
+ *           scope prefix is rejected. Path traversal segments (`..`) are rejected.
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: File content streamed directly.
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       400:
+ *         description: Missing or invalid path parameters (e.g. missing or wrong scope prefix).
+ *       403:
+ *         description: Resolved path is outside the conversation scope.
+ *       404:
+ *         description: Conversation or file not found.
+ *       405:
+ *         description: Method not supported.
+ */
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<never>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET method is supported.",
+      },
+    });
+  }
+
+  const { cId, rel } = req.query;
+  if (!isString(cId) || !Array.isArray(rel) || rel.length === 0) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing conversation id or file path.",
+      },
+    });
+  }
+
+  const conversation = await ConversationResource.fetchById(auth, cId);
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  // Require a conversation-scoped path (e.g. `conversation/foo.pdf`), matching what the agent
+  // file system tools surface. Bare relative paths and other scope prefixes are rejected.
+  const scoped = parseScopedFilePath(rel.join("/"));
+  if (!scoped || scoped.prefix !== "conversation") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Invalid file path: must be a conversation-scoped path (e.g. `conversation/foo.pdf`).",
+      },
+    });
+  }
+
+  const normalizedRelative = path.posix.normalize(scoped.rel);
+  if (
+    normalizedRelative.startsWith("..") ||
+    normalizedRelative.startsWith("/")
+  ) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Access denied: path is outside conversation scope.",
+      },
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const basePath = getConversationFilesBasePath({
+    workspaceId: owner.sId,
+    conversationId: cId,
+  });
+  const mountFilePath = `${basePath}${normalizedRelative}`;
+
+  const bucket = getPrivateUploadBucket();
+  const contentTypeResult = await bucket.getFileContentType(mountFilePath);
+  if (contentTypeResult.isErr()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  }
+  const contentType = contentTypeResult.value ?? "application/octet-stream";
+  res.setHeader("Content-Type", contentType);
+  const readStream = bucket.file(mountFilePath).createReadStream();
+  readStream.on("error", (err) => {
+    logger.error(
+      { err, mountFilePath },
+      "Error streaming conversation file (GCS)"
+    );
+    readStream.destroy();
+    res.end();
+  });
+  readStream.pipe(res);
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
@@ -154,10 +154,7 @@ describe("GET /api/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel]", () 
   });
 
   it("should reject non-GET methods", async () => {
-    const { req, res } = await setupTest(
-      ["conversation", "chart.png"],
-      "POST"
-    );
+    const { req, res } = await setupTest(["conversation", "chart.png"], "POST");
     await handler(req, res);
     expect(res._getStatusCode()).toBe(405);
   });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
@@ -1,0 +1,170 @@
+import handler from "@app/pages/api/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel]";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { Err, Ok } from "@app/types/shared/result";
+import type { RequestMethod } from "node-mocks-http";
+import { PassThrough } from "stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetFileContentType, mockCreateReadStream } = vi.hoisted(() => ({
+  mockGetFileContentType: vi.fn(),
+  mockCreateReadStream: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/auth_wrappers", async () => {
+  const actual = await vi.importActual("@app/lib/api/auth_wrappers");
+  return {
+    ...actual,
+    withPublicAPIAuthentication: (handler: any) => {
+      return async (req: any, res: any) => {
+        return handler(req, res, req.auth);
+      };
+    },
+  };
+});
+
+vi.mock("@app/lib/resources/conversation_resource", () => ({
+  ConversationResource: {
+    fetchById: vi.fn().mockResolvedValue({ sId: "conv_abc" }),
+  },
+}));
+
+vi.mock("@app/lib/file_storage", () => ({
+  getPrivateUploadBucket: () => ({
+    getFileContentType: mockGetFileContentType,
+    file: () => ({ createReadStream: mockCreateReadStream }),
+  }),
+}));
+
+const WORKSPACE_SID = "ws_test123";
+const CONVERSATION_SID = "conv_abc";
+
+async function setupTest(rel: string[], method: RequestMethod = "GET") {
+  const { req, res } = await createPublicApiMockRequest({ method });
+
+  req.query = { wId: WORKSPACE_SID, cId: CONVERSATION_SID, rel };
+  req.auth = {
+    getNonNullableWorkspace: () => ({ sId: WORKSPACE_SID }),
+  };
+
+  return { req, res };
+}
+
+describe("GET /api/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel]", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetFileContentType.mockResolvedValue(new Ok("image/png"));
+    mockCreateReadStream.mockReturnValue(
+      Object.assign(new PassThrough(), {
+        pipe: vi.fn(),
+      })
+    );
+    const { ConversationResource } = await import(
+      "@app/lib/resources/conversation_resource"
+    );
+    vi.mocked(ConversationResource.fetchById).mockResolvedValue({
+      sId: CONVERSATION_SID,
+    } as never);
+  });
+
+  it("should stream a file for a valid conversation-scoped path", async () => {
+    const { req, res } = await setupTest(["conversation", "chart.png"]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader("Content-Type")).toBe("image/png");
+  });
+
+  it("should stream a nested scoped file path", async () => {
+    const { req, res } = await setupTest([
+      "conversation",
+      "results",
+      "report.csv",
+    ]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockGetFileContentType).toHaveBeenCalledWith(
+      expect.stringContaining("results/report.csv")
+    );
+  });
+
+  it("should resolve to the conversation-scoped GCS path (without the scope prefix)", async () => {
+    const { req, res } = await setupTest(["conversation", "chart.png"]);
+    await handler(req, res);
+    expect(mockGetFileContentType).toHaveBeenCalledWith(
+      `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files/chart.png`
+    );
+  });
+
+  it("should return 404 when GCS file does not exist", async () => {
+    mockGetFileContentType.mockResolvedValue(new Err(new Error("not found")));
+    const { req, res } = await setupTest(["conversation", "missing.png"]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: { type: "file_not_found", message: "File not found." },
+    });
+  });
+
+  it("should reject path traversal attempts", async () => {
+    const { req, res } = await setupTest([
+      "conversation",
+      "..",
+      "..",
+      "etc",
+      "passwd",
+    ]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message: "Access denied: path is outside conversation scope.",
+      },
+    });
+  });
+
+  it("should return 404 when conversation is not found", async () => {
+    const { ConversationResource } = await import(
+      "@app/lib/resources/conversation_resource"
+    );
+    vi.mocked(ConversationResource.fetchById).mockResolvedValue(null);
+
+    const { req, res } = await setupTest(["conversation", "chart.png"]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  });
+
+  it("should reject a bare relative path with no scope prefix", async () => {
+    const { req, res } = await setupTest(["chart.png"]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should reject a non-conversation scope prefix", async () => {
+    const { req, res } = await setupTest(["project", "chart.png"]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("should reject non-GET methods", async () => {
+    const { req, res } = await setupTest(
+      ["conversation", "chart.png"],
+      "POST"
+    );
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it("should reject missing rel segments", async () => {
+    const { req, res } = await setupTest([]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+});

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -1459,6 +1459,74 @@
         }
       }
     },
+    "/api/v1/w/{wId}/assistant/conversations/{cId}/files/{rel}": {
+      "get": {
+        "tags": [
+          "Conversations"
+        ],
+        "summary": "Download a conversation-scoped file by path",
+        "description": "Download a file from a conversation's file system by its scoped path. The path must\nbe conversation-scoped, i.e. start with `conversation/` (as surfaced by agent file\nsystem tools). The file content is streamed directly from the conversation mount.\n",
+        "parameters": [
+          {
+            "name": "wId",
+            "in": "path",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cId",
+            "in": "path",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rel",
+            "in": "path",
+            "required": true,
+            "description": "Conversation-scoped file path, e.g. `conversation/foo.pdf` or\n`conversation/subdir/foo.pdf`. The `conversation/` prefix is required; any other\nscope prefix is rejected. Path traversal segments (`..`) are rejected.\n",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File content streamed directly.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid path parameters (e.g. missing or wrong scope prefix)."
+          },
+          "403": {
+            "description": "Resolved path is outside the conversation scope."
+          },
+          "404": {
+            "description": "Conversation or file not found."
+          },
+          "405": {
+            "description": "Method not supported."
+          }
+        }
+      }
+    },
     "/api/v1/w/{wId}/assistant/conversations/{cId}": {
       "get": {
         "summary": "Get a conversation",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Adds `GET /api/v1/w/{wId}/assistant/conversations/{cId}/files/{...rel}` so external callers (notably MCP tools lik) can download
files surfaced by the agent file system tools using a conversation-scoped path such as `conversation/foo.pptx`. Previously these callers were constructing URLs against `/api/v1/w/{wId}/files/{fileId}` with the scoped path as the `fileId`, which 404'd because the route expects a `fil_` sId and is not catch-all.

The new endpoint mirrors the existing private `/api/w/{wId}/assistant/conversations/{cId}/files/[...rel]` handler. It validates conversation access via `ConversationResource.fetchById`, requires the path to parse as a conversation/-scoped path (rejecting bare paths and other prefixes like `project/).

The endpoint is documented with a @swagger block (parameters, accepted path shape, responses).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25487">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->