### PR TITLE
Fix import in SPA app

### DIFF
--- a/front/lib/reinforcement/billing.ts
+++ b/front/lib/reinforcement/billing.ts
@@ -1,0 +1,41 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { BillingCycle } from "@app/lib/client/subscription";
+import { getMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import logger from "@app/logger/logger";
+
+function currentCalendarMonth(): BillingCycle {
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  return {
+    cycleStart: new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)),
+    cycleEnd: new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0)),
+  };
+}
+
+/**
+ * Return the start and end of the current reinforcement billing period.
+ *
+ * Uses the Metronome contract's billing period as the source of truth when
+ * available. Falls back to the current calendar month otherwise.
+ */
+export async function getCurrentPeriod(
+  auth: Authenticator
+): Promise<BillingCycle> {
+  const subscription = auth.subscription();
+  const workspace = auth.workspace();
+
+  const result = await getMetronomeCurrentBillingPeriod({
+    metronomeContractId: subscription?.metronomeContractId ?? null,
+    metronomeCustomerId: workspace?.metronomeCustomerId ?? null,
+  });
+
+  if (result.isOk() && result.value !== null) {
+    return result.value;
+  }
+  if (result.isErr()) {
+    logger.warn("Failed to get billing period from metronome");
+  }
+
+  return currentCalendarMonth();
+}

--- a/front/lib/reinforcement/consumption.test.ts
+++ b/front/lib/reinforcement/consumption.test.ts
@@ -1,11 +1,11 @@
 import type { Authenticator } from "@app/lib/auth";
 import * as metronomeContracts from "@app/lib/metronome/contracts";
+import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import {
   DEFAULT_REINFORCEMENT_CAP_MICRO_USD,
   DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD,
 } from "@app/lib/reinforcement/constants";
 import {
-  getCurrentPeriod,
   getReinforcementMonthlyCapMicroUsd,
   getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";

--- a/front/lib/reinforcement/consumption.ts
+++ b/front/lib/reinforcement/consumption.ts
@@ -1,11 +1,7 @@
-import type { Authenticator } from "@app/lib/auth";
-import type { BillingCycle } from "@app/lib/client/subscription";
-import { getMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import {
   DEFAULT_REINFORCEMENT_CAP_MICRO_USD,
   DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD,
 } from "@app/lib/reinforcement/constants";
-import logger from "@app/logger/logger";
 import type { LightWorkspaceType } from "@app/types/user";
 
 /**
@@ -31,41 +27,4 @@ export function getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(
     "number"
     ? workspace.metadata.selfImprovementCapPerSkillMicroUsd
     : DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD;
-}
-
-function currentCalendarMonth(): BillingCycle {
-  const now = new Date();
-  const year = now.getUTCFullYear();
-  const month = now.getUTCMonth();
-  return {
-    cycleStart: new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)),
-    cycleEnd: new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0)),
-  };
-}
-
-/**
- * Return the start and end of the current reinforcement billing period.
- *
- * Uses the Metronome contract's billing period as the source of truth when
- * available. Falls back to the current calendar month otherwise.
- */
-export async function getCurrentPeriod(
-  auth: Authenticator
-): Promise<BillingCycle> {
-  const subscription = auth.subscription();
-  const workspace = auth.workspace();
-
-  const result = await getMetronomeCurrentBillingPeriod({
-    metronomeContractId: subscription?.metronomeContractId ?? null,
-    metronomeCustomerId: workspace?.metronomeCustomerId ?? null,
-  });
-
-  if (result.isOk() && result.value !== null) {
-    return result.value;
-  }
-  if (result.isErr()) {
-    logger.warn("Failed to get billing period from metronome");
-  }
-
-  return currentCalendarMonth();
 }

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -1,5 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
-import { getCurrentPeriod } from "@app/lib/reinforcement/consumption";
+import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";

--- a/front/pages/api/w/[wId]/skills/reinforcement_spend.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_spend.ts
@@ -1,7 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getCurrentPeriod } from "@app/lib/reinforcement/consumption";
+import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -27,14 +27,12 @@ import {
   buildSkillAnalysisSystemPrompt,
   buildSkillConversationAnalysisBatchMap,
 } from "@app/lib/reinforcement/analyze_conversation";
+import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import {
   DEFAULT_MAX_CONVERSATIONS_PER_RUN,
   DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
 } from "@app/lib/reinforcement/constants";
-import {
-  getCurrentPeriod,
-  getReinforcementMonthlyCapMicroUsd,
-} from "@app/lib/reinforcement/consumption";
+import { getReinforcementMonthlyCapMicroUsd } from "@app/lib/reinforcement/consumption";
 import {
   buildReinforcedSkillsSpecifications,
   classifySkillToolCalls,


### PR DESCRIPTION
## Description

Fix bad import in SPA app due to https://github.com/dust-tt/dust/pull/25478
`getCurrentPeriod` should not be imported in SPA
This just move code around to avoid the bad import leaking.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front 


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25489">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->