### PR TITLE
Refactor programmatic cost export: split handler from business logic

### DIFF
--- a/front/lib/api/analytics/programmatic_cost_export.ts
+++ b/front/lib/api/analytics/programmatic_cost_export.ts
@@ -10,10 +10,10 @@ import { getShouldTrackTokenUsageCostsESFilter } from "@app/lib/api/programmatic
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types/error";
+import type { APIError } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
-import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
 const COMPOSITE_AGG_SIZE = 10000;
@@ -22,6 +22,8 @@ export const ExportQuerySchema = z.object({
   selectedPeriod: z.string().optional(),
   billingCycleStartDay: z.coerce.number().min(1).max(31),
 });
+
+export type ExportQuery = z.infer<typeof ExportQuerySchema>;
 
 type CompositeKey = {
   date: number;
@@ -50,6 +52,16 @@ export interface ExportRow {
   total_spend_usd: string;
   [key: string]: string;
 }
+
+export type ProgrammaticCostExport = {
+  csv: string;
+  filename: string;
+};
+
+type ProgrammaticCostExportError = {
+  status: number;
+  error: APIError;
+};
 
 async function fetchAllCompositeBuckets(
   baseQuery: estypes.QueryDslQueryContainer,
@@ -119,138 +131,105 @@ async function fetchAllCompositeBuckets(
   return allBuckets;
 }
 
-export async function handleProgrammaticCostExportRequest(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<string>>,
-  auth: Authenticator
-): Promise<void> {
-  switch (req.method) {
-    case "GET": {
-      const q = ExportQuerySchema.safeParse(req.query);
-      if (!q.success) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid query parameters: ${q.error.message}`,
-          },
-        });
-      }
-
-      const { selectedPeriod, billingCycleStartDay } = q.data;
-
-      const referenceDate = selectedPeriod
-        ? new Date(selectedPeriod)
-        : new Date();
-      if (selectedPeriod) {
-        referenceDate.setUTCDate(billingCycleStartDay);
-      }
-      const { cycleStart: periodStart, cycleEnd: periodEnd } =
-        getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
-
-      const baseQuery: estypes.QueryDslQueryContainer = {
-        bool: {
-          filter: [
-            getShouldTrackTokenUsageCostsESFilter(auth),
-            {
-              range: {
-                timestamp: {
-                  gte: periodStart.toISOString(),
-                  lt: periodEnd.toISOString(),
-                },
-              },
-            },
-          ],
-        },
-      };
-
-      let allBuckets: CompositeBucket[];
-      try {
-        allBuckets = await fetchAllCompositeBuckets(baseQuery);
-      } catch (err) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message:
-              err instanceof Error
-                ? err.message
-                : "Failed to fetch export data",
-          },
-        });
-      }
-
-      const agentIds = new Set<string>();
-      for (const bucket of allBuckets) {
-        if (bucket.key.agent) {
-          agentIds.add(bucket.key.agent);
-        }
-      }
-
-      const agentNames: Record<string, string> = {};
-      if (agentIds.size > 0) {
-        const agents = await AgentConfigurationModel.findAll({
-          where: { sId: Array.from(agentIds) },
-          attributes: ["sId", "name"],
-        });
-        for (const agent of agents) {
-          agentNames[agent.sId] = agent.name;
-        }
-      }
-
-      const markupMultiplier = 1 + DUST_MARKUP_PERCENT / 100;
-
-      const rows: ExportRow[] = allBuckets.map((bucket) => {
-        const costMicroUsd = (bucket.total_cost.value ?? 0) * markupMultiplier;
-        const costUsd = costMicroUsd / 1_000_000;
-
-        const agentId = bucket.key.agent;
-        let agentName = "N/A";
-        if (agentId) {
-          agentName = agentNames[agentId] ?? agentId;
-        }
-
-        return {
-          date: formatUTCDateFromMillis(bucket.key.date),
-          agent_name: agentName,
-          api_key: bucket.key.api_key ?? "N/A",
-          source: bucket.key.origin ?? "N/A",
-          total_spend_usd: costUsd.toFixed(2),
-        };
-      });
-
-      rows.sort((a, b) => {
-        const dateCompare = a.date.localeCompare(b.date);
-        if (dateCompare !== 0) {
-          return dateCompare;
-        }
-        const agentCompare = a.agent_name.localeCompare(b.agent_name);
-        if (agentCompare !== 0) {
-          return agentCompare;
-        }
-        return a.source.localeCompare(b.source);
-      });
-
-      const sanitizedRows = rows.map((row) =>
-        Object.fromEntries(
-          Object.entries(row).map(([k, v]) => [k, sanitizeCsvCell(v)])
-        )
-      );
-      const csv = await toCsv(sanitizedRows);
-      const filename = `programmatic-cost-${selectedPeriod ?? formatUTCDateFromMillis(Date.now()).slice(0, 7)}.csv`;
-
-      res.setHeader("Content-Type", "text/csv");
-      res.setHeader("Content-Disposition", `attachment; filename=${filename}`);
-      res.status(200).send(csv);
-      return;
-    }
-    default:
-      return apiError(req, res, {
-        status_code: 405,
-        api_error: {
-          type: "method_not_supported_error",
-          message: "The method passed is not supported, GET is expected.",
-        },
-      });
+export async function getProgrammaticCostExport(
+  auth: Authenticator,
+  { selectedPeriod, billingCycleStartDay }: ExportQuery
+): Promise<Result<ProgrammaticCostExport, ProgrammaticCostExportError>> {
+  const referenceDate = selectedPeriod ? new Date(selectedPeriod) : new Date();
+  if (selectedPeriod) {
+    referenceDate.setUTCDate(billingCycleStartDay);
   }
+  const { cycleStart: periodStart, cycleEnd: periodEnd } =
+    getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
+
+  const baseQuery: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [
+        getShouldTrackTokenUsageCostsESFilter(auth),
+        {
+          range: {
+            timestamp: {
+              gte: periodStart.toISOString(),
+              lt: periodEnd.toISOString(),
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  let allBuckets: CompositeBucket[];
+  try {
+    allBuckets = await fetchAllCompositeBuckets(baseQuery);
+  } catch (err) {
+    return new Err({
+      status: 500,
+      error: {
+        type: "internal_server_error",
+        message:
+          err instanceof Error ? err.message : "Failed to fetch export data",
+      },
+    });
+  }
+
+  const agentIds = new Set<string>();
+  for (const bucket of allBuckets) {
+    if (bucket.key.agent) {
+      agentIds.add(bucket.key.agent);
+    }
+  }
+
+  const agentNames: Record<string, string> = {};
+  if (agentIds.size > 0) {
+    const agents = await AgentConfigurationModel.findAll({
+      where: { sId: Array.from(agentIds) },
+      attributes: ["sId", "name"],
+    });
+    for (const agent of agents) {
+      agentNames[agent.sId] = agent.name;
+    }
+  }
+
+  const markupMultiplier = 1 + DUST_MARKUP_PERCENT / 100;
+
+  const rows: ExportRow[] = allBuckets.map((bucket) => {
+    const costMicroUsd = (bucket.total_cost.value ?? 0) * markupMultiplier;
+    const costUsd = costMicroUsd / 1_000_000;
+
+    const agentId = bucket.key.agent;
+    let agentName = "N/A";
+    if (agentId) {
+      agentName = agentNames[agentId] ?? agentId;
+    }
+
+    return {
+      date: formatUTCDateFromMillis(bucket.key.date),
+      agent_name: agentName,
+      api_key: bucket.key.api_key ?? "N/A",
+      source: bucket.key.origin ?? "N/A",
+      total_spend_usd: costUsd.toFixed(2),
+    };
+  });
+
+  rows.sort((a, b) => {
+    const dateCompare = a.date.localeCompare(b.date);
+    if (dateCompare !== 0) {
+      return dateCompare;
+    }
+    const agentCompare = a.agent_name.localeCompare(b.agent_name);
+    if (agentCompare !== 0) {
+      return agentCompare;
+    }
+    return a.source.localeCompare(b.source);
+  });
+
+  const sanitizedRows = rows.map((row) =>
+    Object.fromEntries(
+      Object.entries(row).map(([k, v]) => [k, sanitizeCsvCell(v)])
+    )
+  );
+  const csv = await toCsv(sanitizedRows);
+  const filename = `programmatic-cost-${selectedPeriod ?? formatUTCDateFromMillis(Date.now()).slice(0, 7)}.csv`;
+
+  return new Ok({ csv, filename });
 }

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost-export.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost-export.ts
@@ -1,7 +1,11 @@
 /** @ignoreswagger */
-import { handleProgrammaticCostExportRequest } from "@app/lib/api/analytics/programmatic_cost_export";
+import {
+  ExportQuerySchema,
+  getProgrammaticCostExport,
+} from "@app/lib/api/analytics/programmatic_cost_export";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -10,7 +14,40 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<string>>,
   auth: Authenticator
 ): Promise<void> {
-  return handleProgrammaticCostExportRequest(req, res, auth);
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const q = ExportQuerySchema.safeParse(req.query);
+  if (!q.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid query parameters: ${q.error.message}`,
+      },
+    });
+  }
+
+  const result = await getProgrammaticCostExport(auth, q.data);
+
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: result.error.status,
+      api_error: result.error.error,
+    });
+  }
+
+  const { csv, filename } = result.value;
+  res.setHeader("Content-Type", "text/csv");
+  res.setHeader("Content-Disposition", `attachment; filename=${filename}`);
+  res.status(200).send(csv);
 }
 
 export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

- lib/api/analytics/programmatic_cost_export.ts is now pure business logic: getProgrammaticCostExport(auth, params) returns Result<{ csv, filename }, { status, error }>. No more NextApiRequest/NextApiResponse, apiError, or WithAPIErrorResponse imports.
- pages/api/w/[wId]/analytics/programmatic-cost-export.ts now owns the HTTP layer: method check, ExportQuerySchema validation on req.query, calling the business function, and mapping the Result to either apiError or CSV headers + body.

Aligns with [BACK16] (thin handlers, business logic in lib/api/*) and removes Next coupling from another lib/api module.

## Tests

Did a `GET /api/w/NsqlORPfEf/analytics/programmatic-cost-export?billingCycleStartDay=1` locally and got an empty csv (probably expected I'm not really set up for this). But change should be no-op.

## Risk

Should be no-op refactoring

## Deploy Plan

Front