### PR TITLE
includ markup when computing the cost of self-improvement

### DIFF
--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -106,7 +106,7 @@ async function fetchEligibleSkillIds(
   // Filter out skills that have reached their per-skill consumption cap.
   const { cycleStart } = await getCurrentPeriod(auth);
   const skillConsumptionMap =
-    await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDateForSkills(
+    await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdWithMarkupAfterDateForSkills(
       auth,
       {
         createdAfter: cycleStart,

--- a/front/lib/resources/self_improving_skills_usage_resource.test.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.test.ts
@@ -56,7 +56,8 @@ describe("SelfImprovingSkillsUsageResource", () => {
     const sum =
       await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDate(
         authenticator,
-        cutoff
+        cutoff,
+        { applyMarkup: false }
       );
 
     expect(usages).toHaveLength(3);
@@ -101,7 +102,11 @@ describe("SelfImprovingSkillsUsageResource", () => {
     const sums =
       await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDateForSkills(
         authenticator,
-        { createdAfter: cutoff, skillModelIds: [skill.id, otherSkill.id] }
+        {
+          createdAfter: cutoff,
+          skillModelIds: [skill.id, otherSkill.id],
+          applyMarkup: false,
+        }
       );
 
     expect(sums.get(skill.id)).toBe(100);

--- a/front/lib/resources/self_improving_skills_usage_resource.test.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.test.ts
@@ -56,8 +56,7 @@ describe("SelfImprovingSkillsUsageResource", () => {
     const sum =
       await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDate(
         authenticator,
-        cutoff,
-        { applyMarkup: false }
+        cutoff
       );
 
     expect(usages).toHaveLength(3);
@@ -102,18 +101,14 @@ describe("SelfImprovingSkillsUsageResource", () => {
     const sums =
       await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDateForSkills(
         authenticator,
-        {
-          createdAfter: cutoff,
-          skillModelIds: [skill.id, otherSkill.id],
-          applyMarkup: false,
-        }
+        { createdAfter: cutoff, skillModelIds: [skill.id, otherSkill.id] }
       );
 
     expect(sums.get(skill.id)).toBe(100);
     expect(sums.get(otherSkill.id)).toBe(200);
   });
 
-  it("applies markup multiplier by default and can be disabled", async () => {
+  it("applies markup multiplier in WithMarkup variants", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const skill = await SkillFactory.create(authenticator, {
       name: "Markup Test Skill",
@@ -137,32 +132,27 @@ describe("SelfImprovingSkillsUsageResource", () => {
     ]);
 
     const sumWithMarkup =
-      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDate(
+      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdWithMarkupAfterDate(
         authenticator,
         cutoff
       );
     const sumWithoutMarkup =
       await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDate(
         authenticator,
-        cutoff,
-        { applyMarkup: false }
+        cutoff
       );
 
     expect(sumWithMarkup).toBe(sumWithoutMarkup * MARKUP_MULTIPLIER);
 
     const sumsWithMarkup =
-      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDateForSkills(
+      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdWithMarkupAfterDateForSkills(
         authenticator,
         { createdAfter: cutoff, skillModelIds: [skill.id] }
       );
     const sumsWithoutMarkup =
       await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDateForSkills(
         authenticator,
-        {
-          createdAfter: cutoff,
-          skillModelIds: [skill.id],
-          applyMarkup: false,
-        }
+        { createdAfter: cutoff, skillModelIds: [skill.id] }
       );
 
     expect(sumsWithMarkup.get(skill.id)).toBe(

--- a/front/lib/resources/self_improving_skills_usage_resource.test.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.test.ts
@@ -1,3 +1,4 @@
+import { MARKUP_MULTIPLIER } from "@app/lib/api/programmatic_usage/common";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -105,5 +106,62 @@ describe("SelfImprovingSkillsUsageResource", () => {
 
     expect(sums.get(skill.id)).toBe(100);
     expect(sums.get(otherSkill.id)).toBe(200);
+  });
+
+  it("applies markup multiplier by default and can be disabled", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const skill = await SkillFactory.create(authenticator, {
+      name: "Markup Test Skill",
+    });
+
+    const cutoff = new Date("2026-01-02T00:00:00.000Z");
+
+    await SelfImprovingSkillsUsageResource.bulkCreate(authenticator, [
+      {
+        createdAt: new Date("2026-01-03T00:00:00.000Z"),
+        skillId: skill.id,
+        conversationId: null,
+        priceMicroUsd: 100,
+      },
+      {
+        createdAt: new Date("2026-01-04T00:00:00.000Z"),
+        skillId: null,
+        conversationId: null,
+        priceMicroUsd: 200,
+      },
+    ]);
+
+    const sumWithMarkup =
+      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDate(
+        authenticator,
+        cutoff
+      );
+    const sumWithoutMarkup =
+      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDate(
+        authenticator,
+        cutoff,
+        { applyMarkup: false }
+      );
+
+    expect(sumWithMarkup).toBe(sumWithoutMarkup * MARKUP_MULTIPLIER);
+
+    const sumsWithMarkup =
+      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDateForSkills(
+        authenticator,
+        { createdAfter: cutoff, skillModelIds: [skill.id] }
+      );
+    const sumsWithoutMarkup =
+      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDateForSkills(
+        authenticator,
+        {
+          createdAfter: cutoff,
+          skillModelIds: [skill.id],
+          applyMarkup: false,
+        }
+      );
+
+    expect(sumsWithMarkup.get(skill.id)).toBe(
+      (sumsWithoutMarkup.get(skill.id) ?? 0) * MARKUP_MULTIPLIER
+    );
   });
 });

--- a/front/lib/resources/self_improving_skills_usage_resource.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.ts
@@ -1,3 +1,4 @@
+import { MARKUP_MULTIPLIER } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
 import { SelfImprovingSkillsUsageModel } from "@app/lib/models/skill/self_improving_skills_usage";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -91,7 +92,8 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
 
   static async getSumPriceMicroUsdAfterDate(
     auth: Authenticator,
-    createdAfter: Date
+    createdAfter: Date,
+    { applyMarkup = true }: { applyMarkup?: boolean } = {}
   ): Promise<number> {
     const sum = await this.model.sum("priceMicroUsd", {
       where: {
@@ -100,7 +102,8 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       },
     });
 
-    return sum ?? 0;
+    const raw = sum ?? 0;
+    return applyMarkup ? raw * MARKUP_MULTIPLIER : raw;
   }
 
   static async getSumPriceMicroUsdAfterDateForSkills(
@@ -108,9 +111,11 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
     {
       createdAfter,
       skillModelIds,
+      applyMarkup = true,
     }: {
       createdAfter: Date;
       skillModelIds: ModelId[];
+      applyMarkup?: boolean;
     }
   ): Promise<Map<ModelId, number>> {
     const uniqueSkillIds = [...new Set(skillModelIds)];
@@ -132,7 +137,10 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
     });
 
     return new Map(
-      rows.map((row) => [row.skillId as ModelId, Number(row.priceMicroUsd)])
+      rows.map((row) => [
+        row.skillId as ModelId,
+        Number(row.priceMicroUsd) * (applyMarkup ? MARKUP_MULTIPLIER : 1),
+      ])
     );
   }
 

--- a/front/lib/resources/self_improving_skills_usage_resource.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.ts
@@ -92,8 +92,7 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
 
   static async getSumPriceMicroUsdAfterDate(
     auth: Authenticator,
-    createdAfter: Date,
-    { applyMarkup = true }: { applyMarkup?: boolean } = {}
+    createdAfter: Date
   ): Promise<number> {
     const sum = await this.model.sum("priceMicroUsd", {
       where: {
@@ -102,8 +101,17 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       },
     });
 
-    const raw = sum ?? 0;
-    return applyMarkup ? raw * MARKUP_MULTIPLIER : raw;
+    return sum ?? 0;
+  }
+
+  static async getSumPriceMicroUsdWithMarkupAfterDate(
+    auth: Authenticator,
+    createdAfter: Date
+  ): Promise<number> {
+    return (
+      (await this.getSumPriceMicroUsdAfterDate(auth, createdAfter)) *
+      MARKUP_MULTIPLIER
+    );
   }
 
   static async getSumPriceMicroUsdAfterDateForSkills(
@@ -111,11 +119,9 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
     {
       createdAfter,
       skillModelIds,
-      applyMarkup = true,
     }: {
       createdAfter: Date;
       skillModelIds: ModelId[];
-      applyMarkup?: boolean;
     }
   ): Promise<Map<ModelId, number>> {
     const uniqueSkillIds = [...new Set(skillModelIds)];
@@ -137,10 +143,27 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
     });
 
     return new Map(
-      rows.map((row) => [
-        row.skillId as ModelId,
-        Number(row.priceMicroUsd) * (applyMarkup ? MARKUP_MULTIPLIER : 1),
-      ])
+      rows.map((row) => [row.skillId as ModelId, Number(row.priceMicroUsd)])
+    );
+  }
+
+  static async getSumPriceMicroUsdWithMarkupAfterDateForSkills(
+    auth: Authenticator,
+    {
+      createdAfter,
+      skillModelIds,
+    }: {
+      createdAfter: Date;
+      skillModelIds: ModelId[];
+    }
+  ): Promise<Map<ModelId, number>> {
+    const raw = await this.getSumPriceMicroUsdAfterDateForSkills(auth, {
+      createdAfter,
+      skillModelIds,
+    });
+
+    return new Map(
+      [...raw.entries()].map(([id, value]) => [id, value * MARKUP_MULTIPLIER])
     );
   }
 

--- a/front/pages/api/w/[wId]/skills/reinforcement_spend.test.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_spend.test.ts
@@ -72,8 +72,8 @@ describe("GET /api/w/[wId]/skills/reinforcement_spend", () => {
     expect(res._getStatusCode()).toBe(200);
     const { spentMicroUsdBySkillId } = res._getJSONData();
     expect(spentMicroUsdBySkillId).toEqual({
-      [skill.sId]: 2_000_000,
-      [otherSkill.sId]: 7_000_000,
+      [skill.sId]: 2_600_000,
+      [otherSkill.sId]: 9_100_000,
     });
   });
 

--- a/front/pages/api/w/[wId]/skills/reinforcement_spend.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_spend.ts
@@ -39,7 +39,7 @@ async function handler(
       });
 
       const spentByModelId =
-        await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDateForSkills(
+        await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdWithMarkupAfterDateForSkills(
           auth,
           {
             createdAfter: (await getCurrentPeriod(auth)).cycleStart,


### PR DESCRIPTION
## Description

Applying the markup by default when retrieving the consumption
Can be disabled if needed but not actaully needed
We always want to check the limit with the markup and display cost with markup.

## Tests

unit tests

## Risk

low

## Deploy Plan

deploy front 


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25491">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->