### PR TITLE
[sandbox,front] phase 1 slice 4.5: operator MITM kill switch

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -38,6 +38,7 @@ const MITM_CA_CERT_PATH: &str = "/run/dust/egress-ca.pem";
 const MITM_CA_KEY_PATH: &str = "/run/dust/egress-ca.key";
 // Must match `front/lib/api/sandbox/egress_secrets.ts:EGRESS_SECRETS_PATH`.
 const EGRESS_SECRETS_PATH: &str = "/run/dust/egress-secrets.json";
+const DISABLE_MITM_ENV: &str = "DSBX_DISABLE_MITM";
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct ForwardArgs {
@@ -71,6 +72,9 @@ struct ForwardRuntime {
     // request rewriter in Slice 6.
     #[allow(dead_code)]
     secret_table: Arc<SecretTable>,
+    // Plumbed in Slice 4.5; consumed by SNI-scoped MITM in Slice 5.
+    #[allow(dead_code)]
+    disable_mitm: bool,
     tls_connector: TlsConnector,
 }
 
@@ -90,6 +94,7 @@ struct DomainExtraction {
 pub async fn cmd_forward(args: ForwardArgs) -> Result<()> {
     let token = load_token(&args.token_file).await?;
     let tls_connector = build_tls_connector()?;
+    let disable_mitm = read_disable_mitm_from_env();
 
     // The CA must be loaded/generated BEFORE we bind the listener. Front uses
     // "port 9990 is LISTEN" as the readiness signal and, the moment that's
@@ -109,6 +114,10 @@ pub async fn cmd_forward(args: ForwardArgs) -> Result<()> {
     // on sandbox wake; live reload/inotify is deferred to a later phase.
     let secret_table =
         SecretTable::load(&args.secrets_file).context("failed to load egress secrets table")?;
+
+    if disable_mitm {
+        info!(env_var = DISABLE_MITM_ENV, "mitm.disabled_by_kill_switch");
+    }
 
     let listener = TcpListener::bind(args.listen)
         .await
@@ -131,6 +140,7 @@ pub async fn cmd_forward(args: ForwardArgs) -> Result<()> {
         proxy_tls_name: Arc::<str>::from(args.proxy_tls_name),
         deny_log: Arc::new(args.deny_log),
         secret_table: Arc::new(secret_table),
+        disable_mitm,
         tls_connector,
     };
 
@@ -194,6 +204,36 @@ fn build_tls_connector() -> Result<TlsConnector> {
         .with_no_client_auth();
 
     Ok(TlsConnector::from(Arc::new(config)))
+}
+
+fn read_disable_mitm_from_env() -> bool {
+    parse_disable_mitm_env(std::env::var(DISABLE_MITM_ENV).ok().as_deref())
+}
+
+fn parse_disable_mitm_env(value: Option<&str>) -> bool {
+    match value.map(str::trim) {
+        Some("1") => true,
+        Some(value) if value.eq_ignore_ascii_case("true") => true,
+        _ => false,
+    }
+}
+
+// Slice 4.5 pins the rollback contract before the MITM branch lands: even if a
+// domain is in the secret allowlist union, the kill switch forces the 443 path
+// to remain TCP-splice. Slice 5 wires this predicate into handle_connection
+// (either as a free helper sourced off ForwardRuntime fields, or as a thin
+// `&self` method that delegates here).
+#[allow(dead_code)]
+fn should_mitm_https_connection(
+    secret_table: &SecretTable,
+    disable_mitm: bool,
+    original_port: u16,
+    domain: &str,
+) -> bool {
+    original_port == 443
+        && !disable_mitm
+        && !secret_table.is_empty()
+        && secret_table.sni_match_set.matches(domain)
 }
 
 async fn handle_connection(
@@ -376,5 +416,72 @@ where
             _ => ProxyDecision::ProtocolError,
         },
         Ok(Err(_)) | Err(_) => ProxyDecision::ProtocolError,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use anyhow::{Context, Result};
+
+    use super::{parse_disable_mitm_env, should_mitm_https_connection, SecretTable};
+
+    #[test]
+    fn parses_disable_mitm_env_values() {
+        assert!(parse_disable_mitm_env(Some("1")));
+        assert!(parse_disable_mitm_env(Some("true")));
+        assert!(parse_disable_mitm_env(Some(" TRUE ")));
+
+        assert!(!parse_disable_mitm_env(None));
+        assert!(!parse_disable_mitm_env(Some("0")));
+        assert!(!parse_disable_mitm_env(Some("false")));
+        assert!(!parse_disable_mitm_env(Some("yes")));
+    }
+
+    #[test]
+    fn kill_switch_forces_https_connections_off_mitm_scope() -> Result<()> {
+        let dir = tempfile::tempdir().context("failed to create tempdir")?;
+        let path = dir.path().join("egress-secrets.json");
+        fs::write(
+            &path,
+            r#"[
+              {
+                "name": "OPENAI_API_KEY",
+                "placeholder": "__DSEC_0123456789abcdef0123456789abcdef__",
+                "value": "sk-test",
+                "allowedDomains": ["api.openai.com"]
+              }
+            ]"#,
+        )
+        .context("failed to write test secrets file")?;
+        let table = SecretTable::load(&path)?;
+
+        assert!(should_mitm_https_connection(
+            &table,
+            false,
+            443,
+            "api.openai.com"
+        ));
+        assert!(!should_mitm_https_connection(
+            &table,
+            true,
+            443,
+            "api.openai.com"
+        ));
+        assert!(!should_mitm_https_connection(
+            &table,
+            false,
+            80,
+            "api.openai.com"
+        ));
+        assert!(!should_mitm_https_connection(
+            &table,
+            false,
+            443,
+            "example.com"
+        ));
+
+        Ok(())
     }
 }

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -68,11 +68,11 @@ struct ForwardRuntime {
     proxy_addr: std::net::SocketAddr,
     proxy_tls_name: Arc<str>,
     deny_log: Arc<PathBuf>,
-    // Plumbed in Slice 4; consumed by SNI-scoped MITM in Slice 5 and the
-    // request rewriter in Slice 6.
+    // Loaded at startup; consumed by the SNI-scoped MITM predicate and the
+    // request rewriter once those land.
     #[allow(dead_code)]
     secret_table: Arc<SecretTable>,
-    // Plumbed in Slice 4.5; consumed by SNI-scoped MITM in Slice 5.
+    // Operator kill switch read at startup; consumed by the MITM predicate.
     #[allow(dead_code)]
     disable_mitm: bool,
     tls_connector: TlsConnector,
@@ -218,9 +218,9 @@ fn parse_disable_mitm_env(value: Option<&str>) -> bool {
     }
 }
 
-// Slice 4.5 pins the rollback contract before the MITM branch lands: even if a
-// domain is in the secret allowlist union, the kill switch forces the 443 path
-// to remain TCP-splice. Slice 5 wires this predicate into handle_connection
+// Pins the rollback contract before the MITM branch lands: even if a domain
+// is in the secret allowlist union, the kill switch forces the 443 path to
+// remain TCP-splice. Wired into handle_connection once MITM is enabled
 // (either as a free helper sourced off ForwardRuntime fields, or as a thin
 // `&self` method that delegates here).
 #[allow(dead_code)]

--- a/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
+++ b/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
@@ -12,9 +12,9 @@ use rcgen::{
 
 const CA_COMMON_NAME: &str = "Dust Sandbox Egress MITM CA";
 
-// Slice 3 only persists the CA on disk so front can install it in the sandbox
-// trust bundle. Per-host leaf signing + an LRU-bounded cache land in the slice
-// that wires up TLS termination, alongside the per-request placeholder swap.
+// Today we only persist the CA on disk so front can install it in the sandbox
+// trust bundle. Per-host leaf signing + an LRU-bounded cache will land once
+// TLS termination is wired up, alongside the per-request placeholder swap.
 pub struct MitmCa {
     #[allow(dead_code)]
     ca_cert: Certificate,

--- a/cli/dust-sandbox/src/egress_secrets/mod.rs
+++ b/cli/dust-sandbox/src/egress_secrets/mod.rs
@@ -11,8 +11,8 @@ const PLACEHOLDER_PREFIX: &str = "__DSEC_";
 const PLACEHOLDER_SUFFIX: &str = "__";
 const PLACEHOLDER_HEX_LEN: usize = 32;
 
-// Slice 6 will consume `name` and `value` from the request rewriter. Slice 4
-// only loads and plumbs the table so MITM scoping can key off the allowlist
+// `name` and `value` will be consumed by the request-rewriter MITM path;
+// today the table is loaded only to drive SNI scoping off the allowlist
 // union.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -24,7 +24,7 @@ pub struct Secret {
 }
 
 // `by_placeholder` and `sni_match_set` intentionally double-store the
-// allowlist domains: per-secret membership drives Slice 6 substitution
+// allowlist domains: per-secret membership drives substitution
 // (placeholder -> value only fires for connections to that secret's
 // allowed domains), while the union drives whether MITM kicks in at all
 // for a given SNI. Same data, two access shapes; do not dedupe.
@@ -70,7 +70,7 @@ impl SecretTable {
         self.by_placeholder.len()
     }
 
-    // Consumed by Slice 5 to short-circuit MITM when no secrets are loaded.
+    // Used by the MITM predicate to short-circuit when no secrets are loaded.
     #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.by_placeholder.is_empty()
@@ -114,7 +114,8 @@ impl DomainSet {
         Ok(set)
     }
 
-    // Consumed by Slice 5 to gate MITM on SNI; tested directly in this slice.
+    // Used by the MITM predicate to gate scoping on SNI; covered by unit
+    // tests below until the predicate is wired into handle_connection.
     #[allow(dead_code)]
     pub fn matches(&self, domain: &str) -> bool {
         let domain = match normalize_dns_name(domain) {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -30,6 +30,11 @@ export function getDefaultInit(): Promise<RequestInit> | null {
   return defaultInitResolver?.() ?? null;
 }
 
+function isEnabledEnvVar(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
 const config = {
   // Dynamic API base URL: uses a custom resolver when set (SPA region switching),
   // otherwise falls back to getClientFacingUrl().
@@ -217,6 +222,11 @@ const config = {
   },
   getEgressProxyTlsName: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("EGRESS_PROXY_TLS_NAME");
+  },
+  getEgressDisableMitm: (): boolean => {
+    return isEnabledEnvVar(
+      EnvironmentConfig.getOptionalEnvVariable("DSBX_DISABLE_MITM")
+    );
   },
   getEgressPolicyBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("EGRESS_PROXY_POLICY_BUCKET");

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -30,11 +30,6 @@ export function getDefaultInit(): Promise<RequestInit> | null {
   return defaultInitResolver?.() ?? null;
 }
 
-function isEnabledEnvVar(value: string | undefined): boolean {
-  const normalized = value?.trim().toLowerCase();
-  return normalized === "1" || normalized === "true";
-}
-
 const config = {
   // Dynamic API base URL: uses a custom resolver when set (SPA region switching),
   // otherwise falls back to getClientFacingUrl().
@@ -224,8 +219,10 @@ const config = {
     return EnvironmentConfig.getOptionalEnvVariable("EGRESS_PROXY_TLS_NAME");
   },
   getEgressDisableMitm: (): boolean => {
-    return isEnabledEnvVar(
-      EnvironmentConfig.getOptionalEnvVariable("DSBX_DISABLE_MITM")
+    return (
+      EnvironmentConfig.getOptionalEnvVariable(
+        "DSBX_DISABLE_MITM"
+      )?.toLowerCase() === "true"
     );
   },
   getEgressPolicyBucket: (): string => {

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockGetEgressProxyHost,
+  mockGetEgressDisableMitm,
   mockGetEgressProxyJwtSecret,
   mockGetEgressProxyPort,
   mockGetEgressProxyTlsName,
@@ -15,6 +16,7 @@ const {
   mockWriteEgressSecretsFile,
 } = vi.hoisted(() => ({
   mockGetEgressProxyHost: vi.fn(),
+  mockGetEgressDisableMitm: vi.fn(),
   mockGetEgressProxyJwtSecret: vi.fn(),
   mockGetEgressProxyPort: vi.fn(),
   mockGetEgressProxyTlsName: vi.fn(),
@@ -29,6 +31,7 @@ const {
 vi.mock("@app/lib/api/config", () => ({
   default: {
     getEgressProxyHost: mockGetEgressProxyHost,
+    getEgressDisableMitm: mockGetEgressDisableMitm,
     getEgressProxyJwtSecret: mockGetEgressProxyJwtSecret,
     getEgressProxyPort: mockGetEgressProxyPort,
     getEgressProxyTlsName: mockGetEgressProxyTlsName,
@@ -78,6 +81,7 @@ describe("sandbox egress helpers", () => {
     vi.clearAllMocks();
 
     mockGetEgressProxyHost.mockReturnValue(undefined);
+    mockGetEgressDisableMitm.mockReturnValue(false);
     mockGetEgressProxyJwtSecret.mockReturnValue("egress-secret");
     mockGetEgressProxyPort.mockReturnValue(4443);
     mockGetEgressProxyTlsName.mockReturnValue(undefined);
@@ -154,6 +158,8 @@ describe("sandbox egress helpers", () => {
       expect.stringContaining("--secrets-file '/run/dust/egress-secrets.json'"),
       { user: "root" }
     );
+    const startCall = sandbox.exec.mock.calls[1][1] as string;
+    expect(startCall).not.toContain("DSBX_DISABLE_MITM=1");
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       5,
       auth,
@@ -169,6 +175,45 @@ describe("sandbox egress helpers", () => {
         sandboxId: "sandbox-id",
       }),
       "Sandbox egress forwarder is healthy"
+    );
+  });
+
+  it("exports the dsbx MITM kill switch and emits an observability event when enabled", async () => {
+    mockGetEgressDisableMitm.mockReturnValue(true);
+
+    // setupEgressForwarder calls exec four times here:
+    //   [0] chmod the token file
+    //   [1] start dsbx (the call whose command we assert on)
+    //   [2] health probe
+    //   [3] installMitmTrustBundle
+    // Keep the mock count in sync if the function gains/loses exec calls.
+    const sandbox = {
+      providerId: "provider-sandbox-id",
+      sId: "sandbox-id",
+      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
+      exec: vi
+        .fn()
+        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
+        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
+        .mockResolvedValueOnce(
+          new Ok({ exitCode: 0, stdout: "1 0", stderr: "" })
+        )
+        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
+    };
+
+    const result = await setupEgressForwarder(auth, sandbox as never);
+
+    expect(result).toEqual(new Ok(undefined));
+    const startCall = sandbox.exec.mock.calls[1][1] as string;
+    expect(startCall).toContain("DSBX_DISABLE_MITM=1 /opt/bin/dsbx forward");
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "egress.mitm_kill_switch_engaged",
+        providerId: "provider-sandbox-id",
+        sandboxId: "sandbox-id",
+        workspaceId: "workspace-id",
+      }),
+      "Sandbox egress MITM kill switch engaged"
     );
   });
 

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -159,7 +159,7 @@ describe("sandbox egress helpers", () => {
       { user: "root" }
     );
     const startCall = sandbox.exec.mock.calls[1][1] as string;
-    expect(startCall).not.toContain("DSBX_DISABLE_MITM=1");
+    expect(startCall).not.toContain("DSBX_DISABLE_MITM=");
     expect(sandbox.exec).toHaveBeenNthCalledWith(
       5,
       auth,
@@ -205,7 +205,7 @@ describe("sandbox egress helpers", () => {
 
     expect(result).toEqual(new Ok(undefined));
     const startCall = sandbox.exec.mock.calls[1][1] as string;
-    expect(startCall).toContain("DSBX_DISABLE_MITM=1 /opt/bin/dsbx forward");
+    expect(startCall).toContain("DSBX_DISABLE_MITM=true /opt/bin/dsbx forward");
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "egress.mitm_kill_switch_engaged",

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -206,7 +206,7 @@ describe("sandbox egress helpers", () => {
     expect(result).toEqual(new Ok(undefined));
     const startCall = sandbox.exec.mock.calls[1][1] as string;
     expect(startCall).toContain("DSBX_DISABLE_MITM=true /opt/bin/dsbx forward");
-    expect(mockLoggerWarn).toHaveBeenCalledWith(
+    expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "egress.mitm_kill_switch_engaged",
         providerId: "provider-sandbox-id",

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -36,6 +36,15 @@ const MITM_CA_BUNDLE_MARKER_PATH = "/etc/dust/.ca-bundle.merged";
 const MITM_SYSTEM_CA_DEST = "/usr/local/share/ca-certificates/dust-egress.crt";
 const MITM_SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt";
 
+// Read by dsbx at startup. Must match
+// `cli/dust-sandbox/src/commands/forward/mod.rs:DISABLE_MITM_ENV`.
+export const DSBX_DISABLE_MITM_ENV = "DSBX_DISABLE_MITM";
+
+// Used by both setupEgressForwarder (restart path) and the operator
+// engage_egress_kill_switch script (force-respawn path). Kept in one place so
+// the SIGKILL contract stays consistent across callers.
+export const KILL_DSBX_COMMAND = "pkill -KILL dsbx >/dev/null 2>&1 || true";
+
 const REGION_PROXY_PREFIX = {
   "europe-west1": "eu",
   "us-central1": "us",
@@ -273,10 +282,15 @@ export async function setupEgressForwarder(
   sandbox: SandboxResource,
   { restartExisting = false }: { restartExisting?: boolean } = {}
 ): Promise<Result<void, Error>> {
-  const logContext = {
-    event: "egress.setup",
+  const workspace = auth.getNonNullableWorkspace();
+  const baseLogContext = {
     providerId: sandbox.providerId,
     sandboxId: sandbox.sId,
+    workspaceId: workspace.sId,
+  };
+  const logContext = {
+    ...baseLogContext,
+    event: "egress.setup",
   };
 
   let proxyAddr: string;
@@ -286,10 +300,7 @@ export async function setupEgressForwarder(
     return new Err(normalizeError(error));
   }
 
-  const token = mintEgressJwt(
-    sandbox.providerId,
-    auth.getNonNullableWorkspace().sId
-  );
+  const token = mintEgressJwt(sandbox.providerId, workspace.sId);
   const tokenWriteResult = await sandbox.writeFile(
     auth,
     EGRESS_TOKEN_PATH,
@@ -331,11 +342,14 @@ export async function setupEgressForwarder(
   // forge-and-tunnel loop). The list intentionally overshoots
   // buildSandboxEnvVars (-u on an unset var is a harmless no-op) so this
   // stays correct if a future env var gets added there.
+  const disableMitm = config.getEgressDisableMitm();
+
   const startForwarderCommand =
     "nohup env " +
     "-u SSL_CERT_FILE -u SSL_CERT_DIR -u CURL_CA_BUNDLE " +
     "-u REQUESTS_CA_BUNDLE -u AWS_CA_BUNDLE -u GIT_SSL_CAINFO " +
     "-u NODE_EXTRA_CA_CERTS -u DENO_CERT -u DENO_TLS_CA_STORE " +
+    (disableMitm ? `${DSBX_DISABLE_MITM_ENV}=1 ` : "") +
     "/opt/bin/dsbx forward " +
     `--token-file ${shellEscape(EGRESS_TOKEN_PATH)} ` +
     `--proxy-addr ${shellEscape(`${proxyAddr}:${config.getEgressProxyPort()}`)} ` +
@@ -353,6 +367,13 @@ export async function setupEgressForwarder(
   );
   if (startResult.isErr()) {
     return startResult;
+  }
+
+  if (disableMitm) {
+    logger.warn(
+      { ...baseLogContext, event: "egress.mitm_kill_switch_engaged" },
+      "Sandbox egress MITM kill switch engaged"
+    );
   }
 
   for (let i = 0; i < EGRESS_SETUP_WAIT_RETRIES; i++) {
@@ -382,12 +403,7 @@ async function killEgressForwarder(
   // Restarts only happen when no client is using dsbx (after wake, before the
   // agent loop runs; or after a failed health check, when the listener isn't
   // serving anyway). SIGKILL is fine, no graceful shutdown needed.
-  return runSuccessfulSandboxCommand(
-    auth,
-    sandbox,
-    "pkill -KILL dsbx >/dev/null 2>&1 || true",
-    "root"
-  );
+  return runSuccessfulSandboxCommand(auth, sandbox, KILL_DSBX_COMMAND, "root");
 }
 
 // Produces a merged bundle (system roots + dsbx persistent CA) so replace-style

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -349,7 +349,7 @@ export async function setupEgressForwarder(
     "-u SSL_CERT_FILE -u SSL_CERT_DIR -u CURL_CA_BUNDLE " +
     "-u REQUESTS_CA_BUNDLE -u AWS_CA_BUNDLE -u GIT_SSL_CAINFO " +
     "-u NODE_EXTRA_CA_CERTS -u DENO_CERT -u DENO_TLS_CA_STORE " +
-    (disableMitm ? `${DSBX_DISABLE_MITM_ENV}=1 ` : "") +
+    (disableMitm ? `${DSBX_DISABLE_MITM_ENV}=true ` : "") +
     "/opt/bin/dsbx forward " +
     `--token-file ${shellEscape(EGRESS_TOKEN_PATH)} ` +
     `--proxy-addr ${shellEscape(`${proxyAddr}:${config.getEgressProxyPort()}`)} ` +

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -370,7 +370,7 @@ export async function setupEgressForwarder(
   }
 
   if (disableMitm) {
-    logger.warn(
+    logger.info(
       { ...baseLogContext, event: "egress.mitm_kill_switch_engaged" },
       "Sandbox egress MITM kill switch engaged"
     );

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -13,8 +13,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.7";
-const DSBX_CLI_VERSION = "0.1.7";
+const DUST_BASE_IMAGE_VERSION = "0.8.8";
+const DSBX_CLI_VERSION = "0.1.8";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -25,6 +25,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
@@ -42,6 +43,11 @@ interface EnsureSandboxResult {
   freshlyCreated: boolean;
   sandbox: SandboxResource;
   wokeFromSleep: boolean;
+}
+
+export interface RunningSandboxWithWorkspace {
+  sandbox: SandboxResource;
+  workspace: WorkspaceResource;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -212,6 +218,102 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     });
 
     return row ? new this(this.model, row.get()) : null;
+  }
+
+  /**
+   * List currently running sandboxes across workspaces, paired with their
+   * workspace resource. Used by operator runbooks (initially the MITM
+   * kill-switch script) that need to act on active sandboxes without an
+   * authenticator.
+   *
+   * / WORKSPACE_ISOLATION_BYPASS: Operator runbooks intentionally operate
+   * across active sandboxes (e.g. oncall restarting dsbx after flipping
+   * DSBX_DISABLE_MITM).
+   */
+  static async dangerouslyListRunningAcrossWorkspaces({
+    workspaceIds,
+    limit = 500,
+  }: {
+    workspaceIds?: string[];
+    limit?: number;
+  } = {}): Promise<RunningSandboxWithWorkspace[]> {
+    // Caller is operator scripts driven by makeScript; throw is fine, yargs
+    // surfaces it cleanly. Not part of any request path so no Result needed.
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new Error("limit must be a positive integer");
+    }
+
+    const uniqueWorkspaceIds = workspaceIds
+      ? [...new Set(workspaceIds)]
+      : undefined;
+    const scopedWorkspaces =
+      uniqueWorkspaceIds && uniqueWorkspaceIds.length > 0
+        ? await WorkspaceResource.fetchByIds(uniqueWorkspaceIds)
+        : undefined;
+
+    if (
+      scopedWorkspaces &&
+      uniqueWorkspaceIds &&
+      scopedWorkspaces.length !== uniqueWorkspaceIds.length
+    ) {
+      const foundWorkspaceIds = new Set(scopedWorkspaces.map((w) => w.sId));
+      const missingWorkspaceIds = uniqueWorkspaceIds.filter(
+        (workspaceId) => !foundWorkspaceIds.has(workspaceId)
+      );
+      throw new Error(
+        `Could not find workspace(s): ${missingWorkspaceIds.join(", ")}`
+      );
+    }
+
+    const scopedWorkspaceModelIds = scopedWorkspaces?.map(
+      (workspace) => workspace.id
+    );
+    const rows = await this.model.findAll({
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+      where: {
+        status: "running",
+        ...(scopedWorkspaceModelIds
+          ? { workspaceId: { [Op.in]: scopedWorkspaceModelIds } }
+          : {}),
+      },
+      order: [["lastActivityAt", "DESC"]],
+      limit,
+    });
+
+    const sandboxes = rows.map((row) => new this(this.model, row.get()));
+    if (sandboxes.length === 0) {
+      return [];
+    }
+
+    const workspaceModelIds = [
+      ...new Set(sandboxes.map((sandbox) => sandbox.workspaceId)),
+    ];
+    const workspaces =
+      scopedWorkspaces ??
+      (await WorkspaceResource.fetchByModelIds(workspaceModelIds));
+    const workspacesByModelId = new Map(
+      workspaces.map((workspace) => [workspace.id, workspace])
+    );
+
+    const result: RunningSandboxWithWorkspace[] = [];
+    for (const sandbox of sandboxes) {
+      const workspace = workspacesByModelId.get(sandbox.workspaceId);
+      if (!workspace) {
+        logger.warn(
+          {
+            sandboxId: sandbox.sId,
+            workspaceModelId: sandbox.workspaceId,
+          },
+          "Skipping sandbox with missing workspace during cross-workspace listing"
+        );
+        continue;
+      }
+
+      result.push({ sandbox, workspace });
+    }
+
+    return result;
   }
 
   async updateStatus(

--- a/front/scripts/engage_egress_kill_switch.ts
+++ b/front/scripts/engage_egress_kill_switch.ts
@@ -1,0 +1,118 @@
+import config from "@app/lib/api/config";
+import { KILL_DSBX_COMMAND } from "@app/lib/api/sandbox/egress";
+import { Authenticator } from "@app/lib/auth";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+
+const KILL_TIMEOUT_MS = 10_000;
+const KILL_CONCURRENCY = 8;
+
+makeScript(
+  {
+    workspaceIds: {
+      type: "string",
+      description:
+        "Comma-separated workspace sIds to scope the run to (defaults to all running sandboxes).",
+    },
+    limit: {
+      type: "number",
+      description: "Maximum number of running sandboxes to process.",
+      default: 500,
+    },
+    force: {
+      type: "boolean",
+      description:
+        "Bypass the in-process DSBX_DISABLE_MITM check. Only use after confirming a rolled front pod has DSBX_DISABLE_MITM=1; otherwise dsbx will respawn without the kill switch.",
+      default: false,
+    },
+  },
+  async ({ workspaceIds, limit, force, execute }, scriptLogger) => {
+    const killSwitchEnabled = config.getEgressDisableMitm();
+
+    if (execute && !killSwitchEnabled && !force) {
+      throw new Error(
+        "DSBX_DISABLE_MITM is unset in this process. The expected path is: flip the GCP secret, roll the front pods, then rerun this script (the env will be set, no --force needed). Use --force only as an escape hatch when you've confirmed another rolled front pod has DSBX_DISABLE_MITM=1 and will handle the next exec for the sandboxes you SIGKILL here."
+      );
+    }
+
+    if (execute && force && !killSwitchEnabled) {
+      scriptLogger.warn(
+        { killSwitchEnabled, force: true },
+        "Running with --force while DSBX_DISABLE_MITM is unset in this process. Respawned dsbx instances will not have the kill switch unless another rolled front pod handles the next exec."
+      );
+    }
+
+    const parsedWorkspaceIds = workspaceIds
+      ? workspaceIds
+          .split(",")
+          .map((workspaceId) => workspaceId.trim())
+          .filter((workspaceId) => workspaceId.length > 0)
+      : undefined;
+
+    const entries =
+      await SandboxResource.dangerouslyListRunningAcrossWorkspaces({
+        workspaceIds: parsedWorkspaceIds,
+        limit,
+      });
+
+    scriptLogger.info(
+      {
+        execute,
+        killSwitchEnabled,
+        limit,
+        sandboxCount: entries.length,
+        workspaceIds: parsedWorkspaceIds,
+      },
+      execute
+        ? "Killing dsbx in running sandboxes for egress MITM kill switch"
+        : "Dry run: listed running sandboxes for egress MITM kill switch"
+    );
+
+    const authByWorkspaceId = new Map<string, Authenticator>();
+    let failureCount = 0;
+
+    await concurrentExecutor(
+      entries,
+      async ({ sandbox, workspace }) => {
+        const logContext = {
+          providerId: sandbox.providerId,
+          sandboxId: sandbox.sId,
+          workspaceId: workspace.sId,
+        };
+
+        if (!execute) {
+          scriptLogger.info(logContext, "Dry run: would kill dsbx in sandbox");
+          return;
+        }
+
+        let auth = authByWorkspaceId.get(workspace.sId);
+        if (!auth) {
+          auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+          authByWorkspaceId.set(workspace.sId, auth);
+        }
+
+        const result = await sandbox.exec(auth, KILL_DSBX_COMMAND, {
+          user: "root",
+          timeoutMs: KILL_TIMEOUT_MS,
+        });
+
+        if (result.isErr()) {
+          failureCount += 1;
+          scriptLogger.error(
+            { ...logContext, err: result.error },
+            "Failed to kill dsbx in sandbox"
+          );
+          return;
+        }
+
+        scriptLogger.info(logContext, "Killed dsbx in sandbox");
+      },
+      { concurrency: KILL_CONCURRENCY }
+    );
+
+    if (failureCount > 0) {
+      throw new Error(`Failed to kill dsbx in ${failureCount} sandbox(es)`);
+    }
+  }
+);


### PR DESCRIPTION
## Description

Slice 4.5 of the Phase 1 MITM-egress rollout. Ships the operator kill switch before any real MITM traffic is exercised in slice 5.

- dsbx reads `DSBX_DISABLE_MITM` at startup. Loads the secret table for diagnostics regardless, but the slice 5 MITM predicate short-circuits and every 443 stays on TCP-splice.
- Front threads `getEgressDisableMitm()` through `setupEgressForwarder`, exports the env into the dsbx spawn, and emits `egress.mitm_kill_switch_engaged` after the spawn succeeds.
- Adds `front/scripts/engage_egress_kill_switch.ts` (makeScript) to SIGKILL dsbx across active sandboxes so the next exec respawns with the new env. Reuses `KILL_DSBX_COMMAND` from `egress.ts`.
- New `SandboxResource.dangerouslyListRunningAcrossWorkspaces` for the cross-workspace listing the script needs.
- Bumps dsbx 0.1.7 to 0.1.8 and base image 0.8.7 to 0.8.8.

Predicate (`should_mitm_https_connection`) is `#[allow(dead_code)]`. Slice 5 wires it in.

## Tests

Ran the dsbx Cargo tests for the new env parser and predicate truth table, and the vitest suite for the kill-switch spawn path. Did not exercise the runbook end-to-end against a real sandbox; will do that as part of the deploy verification.

## Risk

Low. Pure additive plumbing, kill switch defaults to false, predicate is dead-coded until slice 5. Worst case: kill switch fails to engage when needed, which leaves us at the pre-slice-5 status quo (no MITM yet). Safe to rollback by reverting.

## Deploy Plan

Standard deploy (front + dsbx CLI + base image). The GCP secret + ESO wiring for `DSBX_DISABLE_MITM` lands separately when it is actually flipped.

- [ ] Cut dsbx 0.1.8 release (Release dsbx CLI workflow)
- [ ] Rebuild sandbox base image 0.8.8 (Sandbox Image Registry workflow)
- [ ] Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25494">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->