### PR TITLE
[Google Drive] Parallelize sheet parent updates

### DIFF
--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -47,6 +47,8 @@ import { removeNulls } from "@dust-tt/client";
 import type { Logger } from "pino";
 import type { InferAttributes, WhereOptions } from "sequelize";
 
+const SHEET_PARENT_UPDATES_CONCURRENCY = 8;
+
 export async function isDriveObjectExpandable({
   objectId,
   mimeType,
@@ -216,18 +218,22 @@ export async function updateParentsField(
         notUpsertedReason: null,
       },
     });
-    for (const sheet of sheets) {
-      const tableId = getGoogleSheetTableId(
-        sheet.driveFileId,
-        sheet.driveSheetId
-      );
-      await updateDataSourceTableParents({
-        dataSourceConfig,
-        tableId,
-        parents: [tableId, ...parentIds],
-        parentId: file.dustFileId,
-      });
-    }
+    await concurrentExecutor(
+      sheets,
+      async (sheet) => {
+        const tableId = getGoogleSheetTableId(
+          sheet.driveFileId,
+          sheet.driveSheetId
+        );
+        await updateDataSourceTableParents({
+          dataSourceConfig,
+          tableId,
+          parents: [tableId, ...parentIds],
+          parentId: file.dustFileId,
+        });
+      },
+      { concurrency: SHEET_PARENT_UPDATES_CONCURRENCY }
+    );
   } else {
     await updateDataSourceDocumentParents({
       dataSourceConfig,


### PR DESCRIPTION
## Description
Parallelizes Google Sheet table parent updates when refreshing a spreadsheet folder parent, using a bounded concurrency constant.

## Risks
Blast radius: Google Drive spreadsheet parent refreshes in connectors.
Risk: low

## Deploy Plan
- pmrr
- deploy connectors

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->