### PR TITLE
[slackbot] strip away citation marker during streaming 

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -225,6 +225,9 @@ async function streamAgentAnswerToSlack(
   }
 
   let answer = "";
+  // Holds back text that might be the start of a :cite[...] marker
+  // split across streaming tokens (e.g. ":c", ":cite[ab").
+  let pendingCitePrefix = "";
   const actions: AgentActionPublicType[] = [];
   let pendingPersonalAuth: {
     redisKey: string;
@@ -433,9 +436,24 @@ async function streamAgentAnswerToSlack(
           break;
         }
         if (answer.length <= MAX_SLACK_MESSAGE_LENGTH) {
-          // Strip complete :cite[...] markers during streaming — they'll be
-          // resolved to proper footnotes on the final chat.update.
-          const safeText = event.text.replace(/ ?:cite\[[a-zA-Z0-9, ]+\]/g, "");
+          // Combine any buffered partial citation prefix with the new token.
+          const combined = pendingCitePrefix + event.text;
+          pendingCitePrefix = "";
+
+          // Strip complete :cite[...] markers — they'll be resolved to
+          // proper footnotes on the final chat.update.
+          let safeText = combined.replace(/ ?:cite\[[a-zA-Z0-9, ]+\]/g, "");
+
+          // Hold back any trailing partial citation prefix so it isn't
+          // rendered if the next token completes the marker.
+          const partialMatch = safeText.match(
+            / ?:c(?:i(?:t(?:e(?:\[[a-zA-Z0-9, ]*)?)?)?)?$/
+          );
+          if (partialMatch) {
+            pendingCitePrefix = partialMatch[0];
+            safeText = safeText.slice(0, -pendingCitePrefix.length);
+          }
+
           if (safeText) {
             await streamHandler.appendText(safeText);
           }
@@ -471,6 +489,12 @@ async function streamAgentAnswerToSlack(
 
       case "agent_message_gracefully_stopped":
       case "agent_message_success": {
+        // Flush any buffered partial text that turned out not to be a citation.
+        if (pendingCitePrefix) {
+          await streamHandler.appendText(pendingCitePrefix);
+          pendingCitePrefix = "";
+        }
+
         planHandler.abortAllChildStreams();
         await planHandler.deletePlanMessage();
 

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -225,8 +225,7 @@ async function streamAgentAnswerToSlack(
   }
 
   let answer = "";
-  // Holds back text that might be the start of a :cite[...] marker
-  // split across streaming tokens (e.g. ":c", ":cite[ab").
+  // Partial :cite[...] marker that may span across tokens.
   let pendingCitePrefix = "";
   const actions: AgentActionPublicType[] = [];
   let pendingPersonalAuth: {
@@ -436,16 +435,13 @@ async function streamAgentAnswerToSlack(
           break;
         }
         if (answer.length <= MAX_SLACK_MESSAGE_LENGTH) {
-          // Combine any buffered partial citation prefix with the new token.
           const combined = pendingCitePrefix + event.text;
           pendingCitePrefix = "";
 
-          // Strip complete :cite[...] markers — they'll be resolved to
-          // proper footnotes on the final chat.update.
+          // Strip complete :cite[...] markers (resolved to footnotes on final chat.update).
           let safeText = combined.replace(/ ?:cite\[[a-zA-Z0-9, ]+\]/g, "");
 
-          // Hold back any trailing partial citation prefix so it isn't
-          // rendered if the next token completes the marker.
+          // Hold back trailing partial markers until the next token.
           const partialMatch = safeText.match(
             / ?:c(?:i(?:t(?:e(?:\[[a-zA-Z0-9, ]*)?)?)?)?$/
           );
@@ -489,7 +485,7 @@ async function streamAgentAnswerToSlack(
 
       case "agent_message_gracefully_stopped":
       case "agent_message_success": {
-        // Flush any buffered partial text that turned out not to be a citation.
+        // Flush pending text that turned out not to be a citation.
         if (pendingCitePrefix) {
           await streamHandler.appendText(pendingCitePrefix);
           pendingCitePrefix = "";

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -433,7 +433,12 @@ async function streamAgentAnswerToSlack(
           break;
         }
         if (answer.length <= MAX_SLACK_MESSAGE_LENGTH) {
-          await streamHandler.appendText(event.text);
+          // Strip complete :cite[...] markers during streaming — they'll be
+          // resolved to proper footnotes on the final chat.update.
+          const safeText = event.text.replace(/ ?:cite\[[a-zA-Z0-9, ]+\]/g, "");
+          if (safeText) {
+            await streamHandler.appendText(safeText);
+          }
           break;
         }
 


### PR DESCRIPTION
## Description
This PR is to avoid showing citation maker while slackbot is streaming. If streaming token contains a citation marker, we skip it. If it ends with something look like a citation marker (e.g. `:cite[`, we keep it, and when the next token arrives: 
  - If it completes a citation => the full marker gets stripped (not rendered)
  - If it doesn't =>  the held-back text gets prepended and rendered normally

Once streaming is done, we format the markdown and process citation here so we should be able to show the proper citation: https://github.com/dust-tt/dust/blob/a20015445b0c606c64ce499633b953e4361345c9/connectors/src/connectors/slack/chat/stream_conversation_handler.ts#L467-L482

Closing https://github.com/dust-tt/tasks/issues/7756

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally with @matteotrab, it seems to be working but we might miss some edge cases. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->