### PR TITLE
[Google Drive] Parallelize moved folder parent updates

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.test.ts
@@ -408,4 +408,114 @@ describe("google drive incremental sync folder metadata", () => {
     expect(folder).toBeNull();
     expect(mocks.upsertDataSourceFolder).not.toHaveBeenCalled();
   });
+
+  it("updates descendant parents when an existing folder is moved", async () => {
+    const suffix = randomUUID();
+    const folderId = `folder-${suffix}`;
+    const oldParentId = `old-parent-${suffix}`;
+    const newParentId = `new-parent-${suffix}`;
+    const rootId = `root-${suffix}`;
+    const childFolderId = `child-folder-${suffix}`;
+    const childDocumentId = `child-document-${suffix}`;
+    const connector = await makeConnector(suffix);
+
+    await GoogleDriveFilesModel.create({
+      connectorId: connector.id,
+      driveFileId: folderId,
+      dustFileId: `gdrive-${folderId}`,
+      mimeType: "application/vnd.google-apps.folder",
+      name: "Board Presentations",
+      parentId: oldParentId,
+    });
+    await GoogleDriveFilesModel.create({
+      connectorId: connector.id,
+      driveFileId: childFolderId,
+      dustFileId: `gdrive-${childFolderId}`,
+      mimeType: "application/vnd.google-apps.folder",
+      name: "Q1",
+      parentId: folderId,
+    });
+    await GoogleDriveFilesModel.create({
+      connectorId: connector.id,
+      driveFileId: childDocumentId,
+      dustFileId: `gdrive-${childDocumentId}`,
+      mimeType: "application/pdf",
+      name: "Roadmap.pdf",
+      parentId: childFolderId,
+    });
+
+    const driveFile = makeGoogleDriveFolder({
+      id: folderId,
+      name: "Board Presentations",
+      parent: newParentId,
+    });
+
+    mocks.changeList.mockResolvedValue({
+      data: {
+        changes: [makeFolderChange(driveFile)],
+        newStartPageToken: "sync-token",
+        nextPageToken: undefined,
+      },
+      status: 200,
+    });
+    mocks.driveObjectToDustType.mockResolvedValue(driveFile);
+    mocks.getFileParentsMemoized.mockResolvedValue([
+      folderId,
+      newParentId,
+      rootId,
+    ]);
+
+    await incrementalSync(
+      connector.id,
+      "drive-1",
+      false,
+      Date.now(),
+      "page-token"
+    );
+
+    const movedFolder = await GoogleDriveFilesModel.findOne({
+      where: {
+        connectorId: connector.id,
+        driveFileId: folderId,
+      },
+    });
+
+    expect(movedFolder?.parentId).toBe(newParentId);
+    expect(mocks.upsertDataSourceFolder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        folderId: `gdrive-${folderId}`,
+        parentId: `gdrive-${newParentId}`,
+        parents: [
+          `gdrive-${folderId}`,
+          `gdrive-${newParentId}`,
+          `gdrive-${rootId}`,
+        ],
+      })
+    );
+    expect(mocks.upsertDataSourceFolder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        folderId: `gdrive-${childFolderId}`,
+        parentId: `gdrive-${folderId}`,
+        parents: [
+          `gdrive-${childFolderId}`,
+          `gdrive-${folderId}`,
+          `gdrive-${newParentId}`,
+          `gdrive-${rootId}`,
+        ],
+      })
+    );
+    expect(mocks.updateDataSourceDocumentParents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: `gdrive-${childDocumentId}`,
+        parentId: `gdrive-${childFolderId}`,
+        parents: [
+          `gdrive-${childDocumentId}`,
+          `gdrive-${childFolderId}`,
+          `gdrive-${folderId}`,
+          `gdrive-${newParentId}`,
+          `gdrive-${rootId}`,
+        ],
+      })
+    );
+  });
 });

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.test.ts
@@ -519,6 +519,75 @@ describe("google drive incremental sync folder metadata", () => {
     );
   });
 
+  it("skips moved folder parent update when its new parent chain is cyclic", async () => {
+    const suffix = randomUUID();
+    const folderId = `folder-${suffix}`;
+    const oldParentId = `old-parent-${suffix}`;
+    const childFolderId = `child-folder-${suffix}`;
+    const connector = await makeConnector(suffix);
+
+    await GoogleDriveFilesModel.create({
+      connectorId: connector.id,
+      driveFileId: folderId,
+      dustFileId: `gdrive-${folderId}`,
+      mimeType: "application/vnd.google-apps.folder",
+      name: "Board Presentations",
+      parentId: oldParentId,
+    });
+    await GoogleDriveFilesModel.create({
+      connectorId: connector.id,
+      driveFileId: childFolderId,
+      dustFileId: `gdrive-${childFolderId}`,
+      mimeType: "application/vnd.google-apps.folder",
+      name: "Q1",
+      parentId: folderId,
+    });
+
+    const driveFile = makeGoogleDriveFolder({
+      id: folderId,
+      name: "Board Presentations",
+      parent: childFolderId,
+    });
+
+    mocks.changeList.mockResolvedValue({
+      data: {
+        changes: [makeFolderChange(driveFile)],
+        newStartPageToken: "sync-token",
+        nextPageToken: undefined,
+      },
+      status: 200,
+    });
+    mocks.driveObjectToDustType.mockResolvedValue(driveFile);
+    mocks.getFileParentsMemoized.mockResolvedValue([
+      folderId,
+      childFolderId,
+      folderId,
+    ]);
+
+    const result = await incrementalSync(
+      connector.id,
+      "drive-1",
+      false,
+      Date.now(),
+      "page-token"
+    );
+
+    const movedFolder = await GoogleDriveFilesModel.findOne({
+      where: {
+        connectorId: connector.id,
+        driveFileId: folderId,
+      },
+    });
+
+    expect(result).toEqual({
+      newFolders: [],
+      nextPageToken: undefined,
+    });
+    expect(movedFolder?.parentId).toBe(oldParentId);
+    expect(mocks.upsertDataSourceFolder).not.toHaveBeenCalled();
+    expect(mocks.updateDataSourceDocumentParents).not.toHaveBeenCalled();
+  });
+
   it("does not update the moved folder parent marker before descendants", async () => {
     const suffix = randomUUID();
     const folderId = `folder-${suffix}`;

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.test.ts
@@ -518,4 +518,69 @@ describe("google drive incremental sync folder metadata", () => {
       })
     );
   });
+
+  it("does not update the moved folder parent marker before descendants", async () => {
+    const suffix = randomUUID();
+    const folderId = `folder-${suffix}`;
+    const oldParentId = `old-parent-${suffix}`;
+    const newParentId = `new-parent-${suffix}`;
+    const rootId = `root-${suffix}`;
+    const childDocumentId = `child-document-${suffix}`;
+    const connector = await makeConnector(suffix);
+
+    await GoogleDriveFilesModel.create({
+      connectorId: connector.id,
+      driveFileId: folderId,
+      dustFileId: `gdrive-${folderId}`,
+      mimeType: "application/vnd.google-apps.folder",
+      name: "Board Presentations",
+      parentId: oldParentId,
+    });
+    await GoogleDriveFilesModel.create({
+      connectorId: connector.id,
+      driveFileId: childDocumentId,
+      dustFileId: `gdrive-${childDocumentId}`,
+      mimeType: "application/pdf",
+      name: "Roadmap.pdf",
+      parentId: folderId,
+    });
+
+    const driveFile = makeGoogleDriveFolder({
+      id: folderId,
+      name: "Board Presentations",
+      parent: newParentId,
+    });
+
+    mocks.changeList.mockResolvedValue({
+      data: {
+        changes: [makeFolderChange(driveFile)],
+        newStartPageToken: "sync-token",
+        nextPageToken: undefined,
+      },
+      status: 200,
+    });
+    mocks.driveObjectToDustType.mockResolvedValue(driveFile);
+    mocks.getFileParentsMemoized.mockResolvedValue([
+      folderId,
+      newParentId,
+      rootId,
+    ]);
+    mocks.updateDataSourceDocumentParents.mockRejectedValueOnce(
+      new Error("transient descendant update failure")
+    );
+
+    await expect(
+      incrementalSync(connector.id, "drive-1", false, Date.now(), "page-token")
+    ).rejects.toThrow("transient descendant update failure");
+
+    const movedFolder = await GoogleDriveFilesModel.findOne({
+      where: {
+        connectorId: connector.id,
+        driveFileId: folderId,
+      },
+    });
+
+    expect(movedFolder?.parentId).toBe(oldParentId);
+    expect(mocks.upsertDataSourceFolder).not.toHaveBeenCalled();
+  });
 });

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -21,6 +21,7 @@ import {
   isSharedDriveNotFoundError,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
   GoogleDriveConfigModel,
   GoogleDriveFilesModel,
@@ -41,6 +42,17 @@ import { GaxiosError } from "googleapis-common";
 import type { RedisClientType } from "redis";
 
 const PAGE_SIZE = 500;
+// Best effort queued traversal cap: a single folder's direct children are still
+// loaded together. Google Drive folders are assumed to stay below this order of
+// magnitude.
+const UPDATE_PARENTS_QUEUE_MAX_SIZE = 10_000;
+const UPDATE_PARENTS_CONCURRENCY = 8;
+
+type ParentsUpdateQueueItem = {
+  file: GoogleDriveFilesModel;
+  parentIds: string[];
+  skipUpdate: boolean;
+};
 
 export async function incrementalSync(
   connectorId: ModelId,
@@ -393,61 +405,98 @@ async function recurseUpdateParents(
       span?.setTag("connectorId", connector.id);
       span?.setTag("workspaceId", connector.workspaceId);
       span?.setTag("fileId", file.driveFileId);
-      return recurseUpdateParentsInner(connector, file, parentIds, logger);
+      return updateParentsForAllChildren(connector, file, parentIds, logger);
     }
   );
 }
 
-async function recurseUpdateParentsInner(
+async function updateParentsForAllChildren(
   connector: ConnectorResource,
-  file: GoogleDriveFilesModel,
+  baseFile: GoogleDriveFilesModel,
   parentIds: string[],
   logger: Logger
 ) {
-  await heartbeat();
-  const children = await GoogleDriveFilesModel.findAll({
-    where: {
-      connectorId: connector.id,
-      parentId: file.driveFileId,
-      skipReason: null,
-    },
-  });
+  let queue: ParentsUpdateQueueItem[] = [
+    { file: baseFile, parentIds, skipUpdate: false },
+  ];
+  let traversalCursor = 0;
+  let updateCursor = 0;
 
-  logger.info(
-    {
-      fileId: file.driveFileId,
-      parentIds,
-      name: file.name,
-      count: children.length,
-    },
-    "Updating parents recursively"
-  );
+  while (traversalCursor < queue.length) {
+    while (
+      (traversalCursor === updateCursor ||
+        queue.length - updateCursor < UPDATE_PARENTS_QUEUE_MAX_SIZE) &&
+      traversalCursor < queue.length
+    ) {
+      const item = queue[traversalCursor];
+      if (!item) {
+        throw new Error("Unexpected missing Google Drive parent update item.");
+      }
+      traversalCursor += 1;
 
-  // Move updates recurse from the moved folder itself, so `parentIds[0]` is
-  // the current node and only deeper repeats indicate a real parent cycle.
-  if (parentIds.slice(1).includes(file.dustFileId)) {
-    logger.warn(
-      {
-        fileId: file.driveFileId,
-        parentIds,
-        name: file.name,
-        count: children.length,
+      await heartbeat();
+
+      const { file, parentIds } = item;
+      if (parentIds.slice(1).includes(file.dustFileId)) {
+        item.skipUpdate = true;
+        logger.warn(
+          {
+            fileId: file.driveFileId,
+            parentIds,
+            name: file.name,
+          },
+          "Infinite parent loop."
+        );
+        continue;
+      }
+
+      const children = await GoogleDriveFilesModel.findAll({
+        where: {
+          connectorId: connector.id,
+          parentId: file.driveFileId,
+          skipReason: null,
+        },
+      });
+
+      logger.info(
+        {
+          fileId: file.driveFileId,
+          parentIds,
+          name: file.name,
+          count: children.length,
+        },
+        "Updating parents recursively"
+      );
+
+      queue.push(
+        ...children.map((child) => ({
+          file: child,
+          parentIds: [child.dustFileId, ...parentIds],
+          skipUpdate: false,
+        }))
+      );
+    }
+
+    const updateBatch = queue
+      .slice(updateCursor, traversalCursor)
+      .filter((item) => !item.skipUpdate);
+    updateCursor = traversalCursor;
+
+    await concurrentExecutor(
+      updateBatch,
+      async ({ file, parentIds }) => {
+        await heartbeat();
+        await updateParentsField(connector, file, parentIds, logger);
       },
-      "Infinite parent loop."
+      {
+        concurrency: UPDATE_PARENTS_CONCURRENCY,
+        onBatchComplete: heartbeat,
+      }
     );
-    return;
+    queue = queue.slice(updateCursor);
+    traversalCursor -= updateCursor;
+    updateCursor = 0;
   }
-
-  for (const child of children) {
-    await recurseUpdateParentsInner(
-      connector,
-      child,
-      [child.dustFileId, ...parentIds],
-      logger
-    );
-  }
-
-  await updateParentsField(connector, file, parentIds, logger);
 }
 
 async function alreadySeenAndIgnored({

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -50,6 +50,7 @@ const UPDATE_PARENTS_CONCURRENCY = 8;
 
 type ParentsUpdateQueueItem = {
   file: GoogleDriveFilesModel;
+  isBaseFile: boolean;
   parentIds: string[];
   skipBatchUpdate: boolean;
 };
@@ -419,10 +420,11 @@ async function updateParentsForAllChildren(
   // Keep the moved folder parent update last: its local parentId is the retry
   // marker that tells subsequent activity attempts to refresh descendants.
   let queue: ParentsUpdateQueueItem[] = [
-    { file: baseFile, parentIds, skipBatchUpdate: true },
+    { file: baseFile, isBaseFile: true, parentIds, skipBatchUpdate: true },
   ];
   let traversalCursor = 0;
   let updateCursor = 0;
+  let shouldUpdateBaseFile = true;
 
   while (traversalCursor < queue.length) {
     while (
@@ -441,6 +443,9 @@ async function updateParentsForAllChildren(
       const { file, parentIds } = item;
       if (parentIds.slice(1).includes(file.dustFileId)) {
         item.skipBatchUpdate = true;
+        if (item.isBaseFile) {
+          shouldUpdateBaseFile = false;
+        }
         logger.warn(
           {
             fileId: file.driveFileId,
@@ -473,6 +478,7 @@ async function updateParentsForAllChildren(
       queue.push(
         ...children.map((child) => ({
           file: child,
+          isBaseFile: false,
           parentIds: [child.dustFileId, ...parentIds],
           skipBatchUpdate: false,
         }))
@@ -498,6 +504,10 @@ async function updateParentsForAllChildren(
     queue = queue.slice(updateCursor);
     traversalCursor -= updateCursor;
     updateCursor = 0;
+  }
+
+  if (!shouldUpdateBaseFile) {
+    return;
   }
 
   await heartbeat();

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -51,7 +51,7 @@ const UPDATE_PARENTS_CONCURRENCY = 8;
 type ParentsUpdateQueueItem = {
   file: GoogleDriveFilesModel;
   parentIds: string[];
-  skipUpdate: boolean;
+  skipBatchUpdate: boolean;
 };
 
 export async function incrementalSync(
@@ -416,8 +416,10 @@ async function updateParentsForAllChildren(
   parentIds: string[],
   logger: Logger
 ) {
+  // Keep the moved folder parent update last: its local parentId is the retry
+  // marker that tells subsequent activity attempts to refresh descendants.
   let queue: ParentsUpdateQueueItem[] = [
-    { file: baseFile, parentIds, skipUpdate: false },
+    { file: baseFile, parentIds, skipBatchUpdate: true },
   ];
   let traversalCursor = 0;
   let updateCursor = 0;
@@ -438,7 +440,7 @@ async function updateParentsForAllChildren(
 
       const { file, parentIds } = item;
       if (parentIds.slice(1).includes(file.dustFileId)) {
-        item.skipUpdate = true;
+        item.skipBatchUpdate = true;
         logger.warn(
           {
             fileId: file.driveFileId,
@@ -472,14 +474,14 @@ async function updateParentsForAllChildren(
         ...children.map((child) => ({
           file: child,
           parentIds: [child.dustFileId, ...parentIds],
-          skipUpdate: false,
+          skipBatchUpdate: false,
         }))
       );
     }
 
     const updateBatch = queue
       .slice(updateCursor, traversalCursor)
-      .filter((item) => !item.skipUpdate);
+      .filter((item) => !item.skipBatchUpdate);
     updateCursor = traversalCursor;
 
     await concurrentExecutor(
@@ -497,6 +499,9 @@ async function updateParentsForAllChildren(
     traversalCursor -= updateCursor;
     updateCursor = 0;
   }
+
+  await heartbeat();
+  await updateParentsField(connector, baseFile, parentIds, logger);
 }
 
 async function alreadySeenAndIgnored({


### PR DESCRIPTION
## Description
Replaces the recursive moved-folder parent refresh with a cursor-based traversal queue and bounded concurrent parent updates. The queue cap is best effort: each folder's direct children are still loaded together, under the assumption that individual folders stay below this order of magnitude.

Compared with the alternatives we discussed: direct recursive `concurrentExecutor` would create nested queues without a global cap; full level collection risks materializing large subtrees; this keeps traversal incremental, restores cycle protection, and heartbeats during traversal and update batches.

Follows https://github.com/dust-tt/dust/pull/25495.

## Risks
Blast radius: Google Drive incremental sync when an existing folder is moved.
Risk: standard

## Deploy Plan
- deploy connectors

## Tests
- [x] `NODE_ENV=test CONNECTORS_DATABASE_URI=postgres://dev:dev@localhost:5432/dust_connectors_test npm test -- src/connectors/google_drive/temporal/activities/incremental_sync.test.ts`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25498">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->