### PR TITLE
Use FF+kill switch for initial subscriptions

### DIFF
--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -23,7 +23,10 @@ import {
 import { useAppRouter } from "@app/lib/platform";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
-import { isSubscriptionMetronomeBilled } from "@app/types/plan";
+import {
+  isSubscriptionMetronomeBilled,
+  isSubscriptionStripeBilled,
+} from "@app/types/plan";
 import type { ProgrammaticUsageConfigurationType } from "@app/types/programmatic_usage";
 import { isDevelopment } from "@app/types/shared/env";
 import type { WorkspaceType } from "@app/types/user";
@@ -200,6 +203,15 @@ export function ActiveSubscriptionTable({
   const status = getSubscriptionDisplayStatus(subscription);
   const { chipColor, chipLabel, cardClass } = STATUS_CONFIG[status];
 
+  // For workspaces with no paid subscription yet, the flow is selected by the
+  // Metronome billing feature; otherwise it follows the active billing rail.
+  const hasNoBillingYet =
+    !isSubscriptionStripeBilled(subscription) &&
+    !isSubscriptionMetronomeBilled(subscription);
+  const useMetronomeFlow =
+    isSubscriptionMetronomeBilled(subscription) ||
+    (hasNoBillingYet && hasMetronomeBillingFeature);
+
   return (
     <div className="flex flex-col">
       <div className="flex justify-between gap-3">
@@ -216,7 +228,7 @@ export function ActiveSubscriptionTable({
                 subscriptions={subscriptions}
               />
             </div>
-            {!isSubscriptionMetronomeBilled(subscription) && (
+            {!useMetronomeFlow && (
               <UpgradeDowngradeModal
                 owner={owner}
                 subscription={subscription}
@@ -226,7 +238,7 @@ export function ActiveSubscriptionTable({
               />
             )}
           </div>
-          {isSubscriptionMetronomeBilled(subscription) && (
+          {useMetronomeFlow && (
             <div className="flex flex-wrap items-center gap-2 pb-4">
               <SwitchContractDialog
                 owner={owner}

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -1,11 +1,26 @@
 import apiConfig from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import logger from "@app/logger/logger";
 import { terminateScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { removeNulls } from "@app/types/shared/utils/general";
+
+// Metronome billing is enabled by default for all workspaces. The
+// `global_disable_metronome_billing` kill switch turns it off globally; the
+// `metronome_billing` feature flag re-enables it for individual workspaces.
+export async function isMetronomeBillingEnabled(
+  auth: Authenticator
+): Promise<boolean> {
+  const [hasFlag, killed] = await Promise.all([
+    hasFeatureFlag(auth, "metronome_billing"),
+    KillSwitchResource.isKillSwitchEnabled("global_disable_metronome_billing"),
+  ]);
+  return hasFlag || !killed;
+}
 
 /**
  * Restores a workspace to full functionality after subscription activation/reactivation.

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -56,7 +56,8 @@ import type Stripe from "stripe";
 import { metronomeAmount } from "./amounts";
 
 /**
- * Switch a Metronome contract to a different package (end old + create new).
+ * Switch a Metronome contract to a different package (end old + create new),
+ * or create the first contract on the customer when `oldContractId` is null.
  * Customer must already exist.
  *
  * `swapAt` controls when the swap happens:
@@ -79,7 +80,7 @@ export async function switchMetronomeContractPackage({
   swapAt,
 }: {
   metronomeCustomerId: string;
-  oldContractId: string;
+  oldContractId: string | null;
   workspace: LightWorkspaceType;
   packageAlias: string;
   enableStripeBilling: boolean;
@@ -92,20 +93,25 @@ export async function switchMetronomeContractPackage({
       : ceilToHourISO(new Date())
   );
 
-  const endResult = await scheduleMetronomeContractEnd({
-    metronomeCustomerId,
-    contractId: oldContractId,
-    endingBefore: switchAt,
-  });
-  if (endResult.isErr()) {
-    return new Err(endResult.error);
+  if (oldContractId) {
+    const endResult = await scheduleMetronomeContractEnd({
+      metronomeCustomerId,
+      contractId: oldContractId,
+      endingBefore: switchAt,
+    });
+    if (endResult.isErr()) {
+      return new Err(endResult.error);
+    }
   }
 
   const contractResult = await createMetronomeContract({
     metronomeCustomerId,
     packageAlias,
-    // One switch per old contract — retries dedup against the same successor.
-    uniquenessKey: `switch:${oldContractId}`,
+    // Retries dedup against the same successor. When switching, the old
+    // contract is unique enough; for first contracts use customer+package+plan.
+    uniquenessKey: oldContractId
+      ? `switch:${oldContractId}`
+      : `switch:${metronomeCustomerId}:${packageAlias}:${planCode}`,
     startingAt: switchAt,
     enableStripeBilling,
     planCode,

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1241,13 +1241,13 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
   }
 
   /**
-   * End the current subscription as `ended_backend_only` and create a new
-   * active subscription on a different Metronome contract and plan code.
-   * Used by the contract.start webhook when an admin-scheduled Enterprise
-   * upgrade activates — preserves the plan-change history rather than
-   * mutating the existing subscription in place. The `ended_backend_only`
-   * status ensures the contract.end webhook for the old contract finds the
-   * old subscription in that state and does not scrub the workspace.
+   * End the current subscription and create a new active subscription on a
+   * different Metronome contract and plan code. Used by the contract.start
+   * webhook when an admin-scheduled upgrade activates — preserves the
+   * plan-change history rather than mutating the existing subscription in
+   * place. A billed current sub is ended as `ended_backend_only` so the
+   * contract.end webhook does not scrub the workspace; a non-billed (free)
+   * current sub is ended as `ended` since no external webhook will close it.
    */
   async swapMetronomeContract({
     metronomeContractId,
@@ -1257,9 +1257,10 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     planCode: string;
   }): Promise<void> {
     const newPlan = await SubscriptionResource.findPlanOrThrow(planCode);
+    const endedStatus = this.isBilled ? "ended_backend_only" : "ended";
 
     await withTransaction(async (t) => {
-      await this.markAsEnded("ended_backend_only", t);
+      await this.markAsEnded(endedStatus, t);
 
       await SubscriptionResource.makeNew(
         {

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -50,9 +50,15 @@ vi.mock("@app/lib/metronome/contracts", async () => {
   };
 });
 
-vi.mock("@app/lib/api/subscription", () => ({
-  restoreWorkspaceAfterSubscription: vi.fn(),
-}));
+vi.mock("@app/lib/api/subscription", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/api/subscription")
+  >("@app/lib/api/subscription");
+  return {
+    ...actual,
+    restoreWorkspaceAfterSubscription: vi.fn(),
+  };
+});
 
 vi.mock("@app/lib/metronome/plan_type", async () => {
   const actual = await vi.importActual<

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -17,7 +17,6 @@ import { getStripeCustomer } from "@app/lib/plans/stripe";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
@@ -359,27 +358,35 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
     expect(res._getJSONData().error.message).toContain("not supported");
   });
 
-  it("rejects when workspace has no current Metronome contract (fresh-Metronome path)", async () => {
+  it("creates the first Pro contract and sync-flips the DB when the workspace has no current Metronome contract", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });
-    // metronome_billing flag + no Stripe sub bypasses the Metronome-only-billed
-    // eligibility check; ends up in the handler with no contract to switch.
-    const adminAuth = await Authenticator.internalAdminForWorkspace(
-      workspace.sId
-    );
-    await FeatureFlagFactory.basic(adminAuth, "metronome_billing");
+    // No Stripe sub + no Metronome contract: with Metronome billing enabled
+    // by default, the workspace is eligible for a fresh Metronome contract.
 
     req.body = proBody();
     req.query.wId = workspace.sId;
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(400);
-    expect(res._getJSONData().error.message).toContain(
-      "no current Metronome contract"
+    expect(res._getStatusCode()).toBe(200);
+    expect(switchMetronomeContractPackage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oldContractId: null,
+        packageAlias: "legacy-pro-monthly",
+        planCode: PRO_PLAN_SEAT_29_CODE,
+        swapAt: "current-hour",
+      })
     );
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const sub = adminAuth.subscriptionResource();
+    expect(sub!.metronomeContractId).toBe(NEW_CONTRACT_ID);
+    expect(sub!.getPlan().code).toBe(PRO_PLAN_SEAT_29_CODE);
   });
 });
 

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -454,18 +454,11 @@ async function handleProOrBusinessSwitch({
     });
   }
 
-  const currentMetronomeContractId = currentSubscription.metronomeContractId;
-  if (!currentMetronomeContractId) {
-    const errorMessage =
-      "Workspace has no current Metronome contract. Fresh Pro/Business " +
-      "provisioning via Poke is not yet supported — the user must complete " +
-      "the regular checkout flow first.";
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
-    });
-  }
+  // When the workspace has no Metronome contract yet, fall through to the
+  // same call with `oldContractId: null` — `switchMetronomeContractPackage`
+  // skips the end-of-old step and just creates the first contract.
+  const currentMetronomeContractId =
+    currentSubscription.metronomeContractId ?? null;
 
   const switchResult = await switchMetronomeContractPackage({
     metronomeCustomerId,

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -1,8 +1,11 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
-import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import {
+  isMetronomeBillingEnabled,
+  restoreWorkspaceAfterSubscription,
+} from "@app/lib/api/subscription";
+import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import {
   ceilToHourISO,
@@ -151,13 +154,13 @@ async function handler(
   const body = validation.data;
 
   // Workspace must be Metronome-billed (current sub Metronome-only) or
-  // freshly Metronome-eligible (metronome_billing flag + no Stripe sub).
+  // freshly Metronome-eligible (Metronome billing enabled + no Stripe sub).
   const currentSubscription = auth.subscriptionResource();
   const isCurrentlyMetronomeOnlyBilled =
     currentSubscription?.isMetronomeOnlyBilled ?? false;
-  const hasMetronomeFlag = await hasFeatureFlag(auth, "metronome_billing");
+  const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
   const canStartFreshMetronomeContract =
-    hasMetronomeFlag && !currentSubscription?.stripeSubscriptionId;
+    metronomeBillingEnabled && !currentSubscription?.stripeSubscriptionId;
   if (!isCurrentlyMetronomeOnlyBilled && !canStartFreshMetronomeContract) {
     const errorMessage =
       "switch_contract is only available for Metronome-billed workspaces. " +

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
 import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -105,10 +106,7 @@ async function handler(
         "dummy_feature_for_flag_testing"
       );
 
-      const hasMetronomeFeature = await hasFeatureFlag(
-        auth,
-        "metronome_billing"
-      );
+      const hasMetronomeFeature = await isMetronomeBillingEnabled(auth);
 
       const membersCount = await MembershipResource.getMembersCountForWorkspace(
         {

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -1,13 +1,12 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
   cancelSubscriptionAtPeriodEnd,
   skipSubscriptionFreeTrial,
 } from "@app/lib/plans/stripe";
-import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -259,19 +258,6 @@ async function handler(
         },
       });
   }
-}
-
-// Metronome billing is enabled by default for all workspaces. The
-// `global_disable_metronome_billing` kill switch turns it off globally; the
-// `metronome_billing` feature flag re-enables it for individual workspaces.
-async function isMetronomeBillingEnabled(
-  auth: Authenticator
-): Promise<boolean> {
-  const [hasFlag, killed] = await Promise.all([
-    hasFeatureFlag(auth, "metronome_billing"),
-    KillSwitchResource.isKillSwitchEnabled("global_disable_metronome_billing"),
-  ]);
-  return hasFlag || !killed;
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {


### PR DESCRIPTION
## Description

Centralizes the "is Metronome billing enabled?" decision so Poke and the user-facing subscription endpoint agree on it, and uses that signal to drive Poke's initial-subscription flow.

- Move `isMetronomeBillingEnabled(auth)` from `pages/api/w/[wId]/subscriptions/index.ts` into `lib/api/subscription.ts` and export it (kill switch + `metronome_billing` FF override, unchanged semantics).
- Poke `workspace-info`: `hasMetronomeFeature` now goes through `isMetronomeBillingEnabled` so it accounts for the `global_disable_metronome_billing` kill switch instead of the raw FF.
- Poke `switch_contract`: replace the direct `hasFeatureFlag(auth, "metronome_billing")` check with `isMetronomeBillingEnabled` (same eligibility rule for the fresh-Metronome path, plus kill-switch awareness).
- `ActiveSubscriptionTable`: when a workspace has no paid subscription yet (no Stripe sub, no Metronome contract), pick the action group from `hasMetronomeBillingFeature` — Metronome flow (`SwitchContractDialog` + `FreePlanUpgradeDialog` + `DowngradeToNoPlanButton`) when enabled, otherwise the existing Stripe `UpgradeDowngradeModal`. Behavior for subs already on a billing rail is unchanged.

## Tests

- `npx tsgo --noEmit` clean.
- `npm run test -- subscriptions/index.test` — 6/6 pass.
- `npm run test -- switch_contract.test` — 10/10 pass (mock for `@app/lib/api/subscription` switched to `importActual` so the newly exported helper isn't stripped).

## Risk

Low. The `isMetronomeBillingEnabled` move is a pure relocation with identical semantics, so existing Stripe/Metronome eligibility behavior is preserved. The Poke `hasMetronomeFeature` change means workspaces without the FF are now treated as Metronome-enabled by default (kill switch off), which matches what the customer-facing endpoint already does — so Poke is catching up to the real billing rail rather than diverging from it. The `ActiveSubscriptionTable` fork only changes the no-paid-subscription branch in Poke; admins can still pick the other flow by toggling the kill switch / FF if needed.

## Deploy Plan

Standard deploy. No migration, no config change.