### PR TITLE
[front] Filter Metronome packages by currency and sort by tier

### DIFF
--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -10,9 +10,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   Input,
 } from "@dust-tt/sparkle";
+import { Fragment } from "react";
 import type { Control, FieldValues, Path } from "react-hook-form";
 
 interface SelectFieldOption {
@@ -20,25 +23,38 @@ interface SelectFieldOption {
   display?: string;
 }
 
+export interface SelectFieldOptionGroup {
+  label: string;
+  options: SelectFieldOption[];
+}
+
+type SelectFieldProps<T extends FieldValues> = {
+  control: Control<T>;
+  name: Path<T>;
+  title?: string;
+  mountPortalContainer?: HTMLElement;
+} & (
+  | { options: SelectFieldOption[]; groups?: never }
+  | { groups: SelectFieldOptionGroup[]; options?: never }
+);
+
 export function SelectField<T extends FieldValues>({
   control,
   name,
   title,
   options,
+  groups,
   mountPortalContainer,
-}: {
-  control: Control<T>;
-  name: Path<T>;
-  title?: string;
-  options: SelectFieldOption[];
-  mountPortalContainer?: HTMLElement;
-}) {
+}: SelectFieldProps<T>) {
+  const flatOptions: SelectFieldOption[] =
+    options ?? groups!.flatMap((g) => g.options);
+
   return (
     <PokeFormField
       control={control}
       name={name}
       render={({ field }) => {
-        const selectedOption = options.find((o) => o.value === field.value);
+        const selectedOption = flatOptions.find((o) => o.value === field.value);
         const displayLabel =
           selectedOption?.display ?? selectedOption?.value ?? title ?? name;
 
@@ -55,13 +71,30 @@ export function SelectField<T extends FieldValues>({
                 <DropdownMenuContent
                   mountPortalContainer={mountPortalContainer}
                 >
-                  {options.map((option) => (
-                    <DropdownMenuItem
-                      key={option.value}
-                      label={option.display ?? option.value}
-                      onClick={() => field.onChange(option.value)}
-                    />
-                  ))}
+                  {options &&
+                    options.map((option) => (
+                      <DropdownMenuItem
+                        key={option.value}
+                        label={option.display ?? option.value}
+                        onClick={() => field.onChange(option.value)}
+                      />
+                    ))}
+                  {groups &&
+                    groups
+                      .filter((g) => g.options.length > 0)
+                      .map((group, groupIdx) => (
+                        <Fragment key={group.label}>
+                          {groupIdx > 0 && <DropdownMenuSeparator />}
+                          <DropdownMenuLabel label={group.label} />
+                          {group.options.map((option) => (
+                            <DropdownMenuItem
+                              key={option.value}
+                              label={option.display ?? option.value}
+                              onClick={() => field.onChange(option.value)}
+                            />
+                          ))}
+                        </Fragment>
+                      ))}
                 </DropdownMenuContent>
               </DropdownMenu>
             </PokeFormControl>

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -120,16 +120,28 @@ export default function SwitchContractDialog({
     disabled: !open,
   });
 
-  const packageOptions = useMemo(
-    () =>
-      metronomePackages
-        .filter((p) => p.currency === resolvedCurrency)
-        .map((p) => ({
-          value: p.id,
-          display: `${p.name} (${p.tier}, ${p.currency.toUpperCase()})`,
-        })),
-    [metronomePackages, resolvedCurrency]
-  );
+  // Split packages into Current vs Legacy sections (name contains "legacy",
+  // case-insensitive). Each section preserves the lib-side sort order.
+  const packageGroups = useMemo(() => {
+    const inCurrency = metronomePackages.filter(
+      (p) => p.currency === resolvedCurrency
+    );
+    const isLegacy = (name: string) => /\blegacy\b/i.test(name);
+    const toOption = (p: (typeof inCurrency)[number]) => ({
+      value: p.id,
+      display: `${p.name} (${p.tier}, ${p.currency.toUpperCase()})`,
+    });
+    return [
+      {
+        label: "Current",
+        options: inCurrency.filter((p) => !isLegacy(p.name)).map(toOption),
+      },
+      {
+        label: "Legacy",
+        options: inCurrency.filter((p) => isLegacy(p.name)).map(toOption),
+      },
+    ];
+  }, [metronomePackages, resolvedCurrency]);
 
   const selectedPackageId = form.watch("metronomePackageId");
   const selectedPackage = useMemo(
@@ -301,7 +313,7 @@ export default function SwitchContractDialog({
                       name="metronomePackageId"
                       title={`Metronome Package (${resolvedCurrency.toUpperCase()})`}
                       mountPortalContainer={portalContainer}
-                      options={packageOptions}
+                      groups={packageGroups}
                     />
                   )}
                 {selectedTier === "enterprise" && (

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -10,7 +10,11 @@ import {
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
-import { usePokeMetronomePackages, usePokePlans } from "@app/lib/swr/poke";
+import {
+  usePokeMetronomePackages,
+  usePokePlans,
+  usePokeStripeCustomerCurrency,
+} from "@app/lib/swr/poke";
 import type { ProgrammaticUsageConfigurationType } from "@app/types/programmatic_usage";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -95,15 +99,6 @@ export default function SwitchContractDialog({
     );
   }, []);
 
-  const packageOptions = useMemo(
-    () =>
-      metronomePackages.map((p) => ({
-        value: p.id,
-        display: `${p.name} (${p.tier})`,
-      })),
-    [metronomePackages]
-  );
-
   const form = useForm<SwitchContractFormValues>({
     resolver: zodResolver(SwitchContractFormSchema),
     defaultValues: {
@@ -114,12 +109,46 @@ export default function SwitchContractDialog({
     },
   });
 
+  const watchedStripeCustomerId = form.watch("stripeCustomerId");
+  const trimmedStripeCustomerId = watchedStripeCustomerId.trim() || null;
+  const {
+    currency: resolvedCurrency,
+    isCurrencyLoading,
+    currencyError,
+  } = usePokeStripeCustomerCurrency({
+    stripeCustomerId: trimmedStripeCustomerId,
+    disabled: !open,
+  });
+
+  const packageOptions = useMemo(
+    () =>
+      metronomePackages
+        .filter((p) => p.currency === resolvedCurrency)
+        .map((p) => ({
+          value: p.id,
+          display: `${p.name} (${p.tier}, ${p.currency.toUpperCase()})`,
+        })),
+    [metronomePackages, resolvedCurrency]
+  );
+
   const selectedPackageId = form.watch("metronomePackageId");
   const selectedPackage = useMemo(
     () => metronomePackages.find((p) => p.id === selectedPackageId),
     [metronomePackages, selectedPackageId]
   );
   const selectedTier = selectedPackage?.tier ?? null;
+
+  // Clear a stale package selection when the resolved currency changes so a
+  // previously-picked package can't survive a currency switch silently.
+  useEffect(() => {
+    if (
+      resolvedCurrency &&
+      selectedPackage &&
+      selectedPackage.currency !== resolvedCurrency
+    ) {
+      form.setValue("metronomePackageId", "");
+    }
+  }, [resolvedCurrency, selectedPackage, form]);
 
   // When the operator picks a package, derive (Pro/Business) or reset
   // (Enterprise) the plan code. The full list of ENT_* plans is offered for
@@ -233,6 +262,25 @@ export default function SwitchContractDialog({
                 onSubmit={form.handleSubmit(onSubmit)}
                 className="space-y-4"
               >
+                <InputField
+                  control={form.control}
+                  name="stripeCustomerId"
+                  title="Stripe Customer Id"
+                  placeholder="cus_1234567890"
+                  readOnly={stripeCustomerId !== null}
+                />
+                {isCurrencyLoading && (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Spinner size="sm" />
+                    <span>Resolving customer currency...</span>
+                  </div>
+                )}
+                {currencyError && (
+                  <div className="text-warning text-sm">
+                    Failed to resolve currency from Stripe customer:{" "}
+                    {currencyError.message}
+                  </div>
+                )}
                 {isPackagesLoading && (
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">
                     <Spinner size="sm" />
@@ -244,15 +292,18 @@ export default function SwitchContractDialog({
                     Failed to load Metronome packages: {packagesError.message}
                   </div>
                 )}
-                {!isPackagesLoading && !packagesError && (
-                  <SelectField
-                    control={form.control}
-                    name="metronomePackageId"
-                    title="Metronome Package"
-                    mountPortalContainer={portalContainer}
-                    options={packageOptions}
-                  />
-                )}
+                {!isPackagesLoading &&
+                  !packagesError &&
+                  resolvedCurrency &&
+                  !isCurrencyLoading && (
+                    <SelectField
+                      control={form.control}
+                      name="metronomePackageId"
+                      title={`Metronome Package (${resolvedCurrency.toUpperCase()})`}
+                      mountPortalContainer={portalContainer}
+                      options={packageOptions}
+                    />
+                  )}
                 {selectedTier === "enterprise" && (
                   <>
                     <SelectField
@@ -281,19 +332,12 @@ export default function SwitchContractDialog({
                     synchronously.
                   </div>
                 )}
-                <InputField
-                  control={form.control}
-                  name="stripeCustomerId"
-                  title="Stripe Customer Id"
-                  placeholder="cus_1234567890"
-                  readOnly={stripeCustomerId !== null}
-                />
                 <DialogFooter>
                   <Button
                     type="submit"
                     variant="warning"
                     label="Switch"
-                    disabled={!selectedTier}
+                    disabled={!selectedTier || !resolvedCurrency}
                   />
                 </DialogFooter>
               </form>

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -420,9 +420,9 @@ let packageListCache: {
 } | null = null;
 
 const TIER_SORT_ORDER: Record<MetronomePackageTier, number> = {
-  pro: 0,
+  enterprise: 0,
   business: 1,
-  enterprise: 2,
+  pro: 2,
 };
 const CURRENCY_SORT_ORDER: Record<SupportedCurrency, number> = {
   usd: 0,

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
+import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -16,7 +17,10 @@ import type {
   MetronomeUsageListResponse,
   MetronomeUsageWithGroupsResponse,
 } from "./types";
-import { classifyMetronomePackageByName } from "./types";
+import {
+  classifyMetronomePackageByName,
+  classifyMetronomePackageCurrencyByName,
+} from "./types";
 
 let cachedClient: Metronome | null = null;
 
@@ -404,6 +408,7 @@ export interface MetronomePackageSummary {
   aliases: string[];
   rateCardId?: string;
   tier: MetronomePackageTier;
+  currency: SupportedCurrency;
 }
 
 // Cache the package list for a few minutes as the catalog rarely changes and
@@ -413,6 +418,32 @@ let packageListCache: {
   expiresAtMs: number;
   packages: MetronomePackageSummary[];
 } | null = null;
+
+const TIER_SORT_ORDER: Record<MetronomePackageTier, number> = {
+  pro: 0,
+  business: 1,
+  enterprise: 2,
+};
+const CURRENCY_SORT_ORDER: Record<SupportedCurrency, number> = {
+  usd: 0,
+  eur: 1,
+};
+
+function comparePackagesForDisplay(
+  a: MetronomePackageSummary,
+  b: MetronomePackageSummary
+): number {
+  const tierDelta = TIER_SORT_ORDER[a.tier] - TIER_SORT_ORDER[b.tier];
+  if (tierDelta !== 0) {
+    return tierDelta;
+  }
+  const currencyDelta =
+    CURRENCY_SORT_ORDER[a.currency] - CURRENCY_SORT_ORDER[b.currency];
+  if (currencyDelta !== 0) {
+    return currencyDelta;
+  }
+  return a.name.localeCompare(b.name);
+}
 
 /**
  * List all Metronome packages on the account. Cached for 5 minutes.
@@ -443,8 +474,10 @@ export async function listMetronomePackages(): Promise<
         aliases,
         rateCardId: pkg.rate_card_id ?? undefined,
         tier,
+        currency: classifyMetronomePackageCurrencyByName(name),
       });
     }
+    packages.sort(comparePackagesForDisplay);
     packageListCache = {
       expiresAtMs: Date.now() + PACKAGE_LIST_CACHE_TTL_MS,
       packages,

--- a/front/lib/metronome/types.test.ts
+++ b/front/lib/metronome/types.test.ts
@@ -1,4 +1,7 @@
-import { classifyMetronomePackageByName } from "@app/lib/metronome/types";
+import {
+  classifyMetronomePackageByName,
+  classifyMetronomePackageCurrencyByName,
+} from "@app/lib/metronome/types";
 import { describe, expect, it } from "vitest";
 
 describe("classifyMetronomePackageByName", () => {
@@ -32,5 +35,37 @@ describe("classifyMetronomePackageByName", () => {
     expect(classifyMetronomePackageByName("Starter")).toBeNull();
     expect(classifyMetronomePackageByName("Premium")).toBeNull();
     expect(classifyMetronomePackageByName("")).toBeNull();
+  });
+});
+
+describe("classifyMetronomePackageCurrencyByName", () => {
+  it("returns eur when the name contains a euro marker", () => {
+    expect(
+      classifyMetronomePackageCurrencyByName("Legacy Pro Monthly EUR")
+    ).toBe("eur");
+    expect(classifyMetronomePackageCurrencyByName("Enterprise euro")).toBe(
+      "eur"
+    );
+  });
+
+  it("is case-insensitive", () => {
+    expect(classifyMetronomePackageCurrencyByName("BUSINESS eur")).toBe("eur");
+  });
+
+  it("defaults to usd when no euro marker is present", () => {
+    expect(classifyMetronomePackageCurrencyByName("Legacy Pro Monthly")).toBe(
+      "usd"
+    );
+    expect(classifyMetronomePackageCurrencyByName("Enterprise USD")).toBe(
+      "usd"
+    );
+    expect(classifyMetronomePackageCurrencyByName("")).toBe("usd");
+  });
+
+  it("respects word boundaries so substrings don't false-match", () => {
+    expect(classifyMetronomePackageCurrencyByName("Neurology Plan")).toBe(
+      "usd"
+    );
+    expect(classifyMetronomePackageCurrencyByName("Heuristic Pro")).toBe("usd");
   });
 });

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -11,6 +11,7 @@ import {
   getProductExcessCreditsId,
   getProductFreeCreditId,
 } from "@app/lib/metronome/constants";
+import type { SupportedCurrency } from "@app/types/currency";
 import type { Commit, Credit } from "@metronome/sdk/resources/shared";
 
 // Metronome package aliases for contract provisioning.
@@ -53,6 +54,16 @@ export function classifyMetronomePackageByName(
     return "pro";
   }
   return null;
+}
+
+export function classifyMetronomePackageCurrencyByName(
+  name: string
+): SupportedCurrency {
+  const normalized = name.toLowerCase();
+  if (/\b(?:eur|euro)\b/.test(normalized)) {
+    return "eur";
+  }
+  return "usd";
 }
 
 export interface MetronomeEvent {

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -9,6 +9,7 @@ import type { GetPokeCouponsResponseBody } from "@app/pages/api/poke/coupons/ind
 import type { GetPokeMetronomePackagesResponseBody } from "@app/pages/api/poke/metronome/packages";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetRegionResponseType } from "@app/pages/api/poke/region";
+import type { PostPokeStripeCustomerCurrencyResponseBody } from "@app/pages/api/poke/stripe/customers/currency";
 import type { GetPokeWorkspaceAuthContextResponseType } from "@app/pages/api/poke/workspaces/[wId]/auth-context";
 import type { GetPokeFeaturesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/features";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
@@ -169,6 +170,47 @@ export function usePokeMetronomePackages({
     isPackagesLoading: !error && !data && !disabled,
     isPackagesError: error,
     packagesError: isAPIErrorResponse(error) ? error.error : null,
+  };
+}
+
+export function usePokeStripeCustomerCurrency({
+  stripeCustomerId,
+  disabled,
+}: {
+  stripeCustomerId: string | null;
+  disabled?: boolean;
+}) {
+  const { fetcherWithBody } = useFetcher();
+
+  const enabled = !disabled && !!stripeCustomerId;
+  const { data, error } = useSWRWithDefaults<
+    string | null,
+    PostPokeStripeCustomerCurrencyResponseBody
+  >(
+    enabled
+      ? JSON.stringify({
+          url: "/api/poke/stripe/customers/currency",
+          stripeCustomerId,
+        })
+      : null,
+    async () => {
+      if (!stripeCustomerId) {
+        throw new Error("stripeCustomerId is required.");
+      }
+
+      return fetcherWithBody([
+        "/api/poke/stripe/customers/currency",
+        { stripeCustomerId },
+        "POST",
+      ]);
+    },
+    { disabled: !enabled }
+  );
+
+  return {
+    currency: data?.currency ?? null,
+    isCurrencyLoading: enabled && !error && !data,
+    currencyError: isAPIErrorResponse(error) ? error.error : null,
   };
 }
 

--- a/front/pages/api/poke/metronome/packages.test.ts
+++ b/front/pages/api/poke/metronome/packages.test.ts
@@ -28,6 +28,7 @@ describe("GET /api/poke/metronome/packages", () => {
           name: "Enterprise USD",
           aliases: ["enterprise-usd"],
           tier: "enterprise",
+          currency: "usd",
         },
       ])
     );
@@ -47,6 +48,7 @@ describe("GET /api/poke/metronome/packages", () => {
           name: "Enterprise USD",
           aliases: ["enterprise-usd"],
           tier: "enterprise",
+          currency: "usd",
         },
       ],
     });

--- a/front/pages/api/poke/stripe/customers/currency.test.ts
+++ b/front/pages/api/poke/stripe/customers/currency.test.ts
@@ -1,0 +1,111 @@
+import { getStripeCustomer } from "@app/lib/plans/stripe";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type Stripe from "stripe";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./currency";
+
+vi.mock("@app/lib/plans/stripe", async () => {
+  const actual = await vi.importActual<typeof import("@app/lib/plans/stripe")>(
+    "@app/lib/plans/stripe"
+  );
+  return {
+    ...actual,
+    getStripeCustomer: vi.fn(),
+  };
+});
+
+describe("POST /api/poke/stripe/customers/currency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the resolved currency for a super user", async () => {
+    vi.mocked(getStripeCustomer).mockResolvedValue({
+      id: "cus_test_eur",
+      address: { country: "FR" },
+    } as unknown as Stripe.Customer);
+
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    req.body = { stripeCustomerId: "cus_test_eur" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ currency: "eur" });
+  });
+
+  it("returns 401 when the user is not a super user", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: false,
+    });
+    req.body = { stripeCustomerId: "cus_test_usd" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "not_authenticated",
+        message: "The user does not have permission",
+      },
+    });
+  });
+
+  it("only supports POST", async () => {
+    for (const method of ["DELETE", "GET", "PUT", "PATCH"] as const) {
+      const { req, res } = await createPrivateApiMockRequest({
+        method,
+        isSuperUser: true,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+    }
+  });
+
+  it("returns 400 when stripeCustomerId is missing", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    req.body = { stripeCustomerId: "" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    expect(res._getJSONData().error.message).toContain("Required");
+  });
+
+  it("returns 404 when the Stripe customer does not exist", async () => {
+    vi.mocked(getStripeCustomer).mockResolvedValue(null);
+
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    req.body = { stripeCustomerId: "cus_missing" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Stripe customer not found: cus_missing.",
+      },
+    });
+  });
+});

--- a/front/pages/api/poke/stripe/customers/currency.ts
+++ b/front/pages/api/poke/stripe/customers/currency.ts
@@ -1,0 +1,80 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
+import { getStripeCustomer } from "@app/lib/plans/stripe";
+import { apiError } from "@app/logger/withlogging";
+import type { SupportedCurrency } from "@app/types/currency";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const PostPokeStripeCustomerCurrencyBodySchema = z.object({
+  stripeCustomerId: z.string().min(1, "Required"),
+});
+
+export type PostPokeStripeCustomerCurrencyResponseBody = {
+  currency: SupportedCurrency;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PostPokeStripeCustomerCurrencyResponseBody>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const validation = PostPokeStripeCustomerCurrencyBodySchema.safeParse(
+    req.body
+  );
+  if (!validation.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `The request body is invalid: ${fromError(validation.error).toString()}`,
+      },
+    });
+  }
+
+  const { stripeCustomerId } = validation.data;
+  const stripeCustomer = await getStripeCustomer(stripeCustomerId);
+  if (!stripeCustomer) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Stripe customer not found: ${stripeCustomerId}.`,
+      },
+    });
+  }
+
+  const currency = resolveCurrencyFromStripe({ stripeCustomer });
+  return res.status(200).json({ currency });
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -192,18 +192,21 @@ beforeEach(() => {
         name: "Enterprise USD",
         aliases: ["legacy-enterprise"],
         tier: "enterprise",
+        currency: "usd",
       },
       {
         id: PRO_PACKAGE_ID,
         name: "Pro USD",
         aliases: ["legacy-pro-monthly"],
         tier: "pro",
+        currency: "usd",
       },
       {
         id: BUSINESS_PACKAGE_ID,
         name: "Business USD",
         aliases: ["legacy-business"],
         tier: "business",
+        currency: "usd",
       },
     ])
   );
@@ -281,6 +284,30 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () =>
 
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.message).toContain("at least one hour");
+  });
+
+  it("rejects when the package currency does not match the Stripe customer currency", async () => {
+    await ensureEnterprisePlan();
+    vi.mocked(getStripeCustomer).mockResolvedValue({
+      id: STRIPE_CUSTOMER_ID,
+      address: { country: "FR" },
+    } as unknown as Stripe.Customer);
+
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = enterpriseBody();
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain("resolves to EUR");
+    expect(res._getJSONData().error.message).toContain("Pick a EUR package");
+    expect(createMetronomeContract).not.toHaveBeenCalled();
   });
 });
 

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -17,6 +17,7 @@ import {
 } from "@app/lib/metronome/contracts";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import type { MetronomePackageTier } from "@app/lib/metronome/types";
+import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
 import {
   isEntreprisePlanPrefix,
   isProPlanPrefix,
@@ -194,6 +195,7 @@ async function handler(
       api_error: { type: "invalid_request_error", message: errorMessage },
     });
   }
+  const resolvedCurrency = resolveCurrencyFromStripe({ stripeCustomer });
 
   // Resolve the Metronome customer.
   const customerResult = await ensureMetronomeCustomerForWorkspace({
@@ -229,6 +231,20 @@ async function handler(
     return apiError(req, res, {
       status_code: 400,
       api_error: { type: "invalid_request_error", message: errorMessage },
+    });
+  }
+  if (pkg.currency !== resolvedCurrency) {
+    const errorMessage =
+      `Metronome package ${body.metronomePackageId} is ${pkg.currency.toUpperCase()}, ` +
+      `but Stripe customer ${body.stripeCustomerId} resolves to ` +
+      `${resolvedCurrency.toUpperCase()}. Pick a ${resolvedCurrency.toUpperCase()} package.`;
+    await pluginRun.recordError(errorMessage);
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: errorMessage,
+      },
     });
   }
   // Plan ↔ package tier compatibility.


### PR DESCRIPTION
## Description

In Poke, only show Metronome packages that corresponds to the user currency in Stripe. Also sort resulting list by tier (pro/business/ enterprise)

## Tests

Unit

## Risk

Low

## Deploy Plan

front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25503">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->