### PR TITLE
[front] fix: detect root-level `SKILL.md` in GitHub import

### DIFF
--- a/front/lib/api/skills/detection/parsing.test.ts
+++ b/front/lib/api/skills/detection/parsing.test.ts
@@ -85,7 +85,21 @@ describe("findSkillDirectories", () => {
     });
   });
 
-  test("skips SKILL.md at the root", () => {
+  test("uses SKILL.md at the root when no nested skills exist", () => {
+    const entries: FileEntry[] = [
+      { path: "SKILL.md", sizeBytes: 100 },
+      { path: "README.md", sizeBytes: 100 },
+    ];
+
+    const dirs = findSkillDirectories(entries);
+    expect(dirs).toHaveLength(1);
+    expect(dirs[0]).toEqual({
+      dirPath: ".",
+      skillMdPath: "SKILL.md",
+    });
+  });
+
+  test("prefers nested skills over SKILL.md at the root", () => {
     const entries: FileEntry[] = [
       { path: "SKILL.md", sizeBytes: 100 },
       { path: "sub/SKILL.md", sizeBytes: 100 },

--- a/front/lib/api/skills/detection/parsing.ts
+++ b/front/lib/api/skills/detection/parsing.ts
@@ -83,11 +83,14 @@ function extractFrontmatter(
 
 /**
  * Scans file entries for directories containing a SKILL.md (case-insensitive).
- * Skips root-level skill.md files and deduplicates by directory.
+ * Prefers nested skill directories, and falls back to a root-level SKILL.md
+ * only when no nested skills were found. This avoids treating a whole
+ * multi-skill repository as attachments for a root skill.
  */
 export function findSkillDirectories(entries: FileEntry[]): SkillDirectory[] {
   const skillDirs: SkillDirectory[] = [];
   const seenDirs = new Set<string>();
+  let rootSkillDir: SkillDirectory | null = null;
 
   for (const entry of entries) {
     if (path.basename(entry.path).toLowerCase() !== SKILL_MD_FILENAME) {
@@ -95,8 +98,8 @@ export function findSkillDirectories(entries: FileEntry[]): SkillDirectory[] {
     }
 
     const dirPath = path.dirname(entry.path);
-    // A skill must live in a directory, not at the root.
     if (dirPath === ".") {
+      rootSkillDir ??= { dirPath, skillMdPath: entry.path };
       continue;
     }
 
@@ -107,6 +110,10 @@ export function findSkillDirectories(entries: FileEntry[]): SkillDirectory[] {
     seenDirs.add(dirPath);
 
     skillDirs.push({ dirPath, skillMdPath: entry.path });
+  }
+
+  if (skillDirs.length === 0 && rootSkillDir) {
+    return [rootSkillDir];
   }
 
   return skillDirs;


### PR DESCRIPTION
## Description

- Support repositories and archives where the skill lives directly at the root as `SKILL.md`, which can happen in single-skill repos and previously produced a misleading “No skills found” error.
- Only fall back to root-level `SKILL.md` when no nested skills are found, because treating the repository root as the skill directory can include the broader codebase as skill attachments. This makes root detection explicit for single-skill repos without changing multi-skill repository (the most common type) behavior.

## Tests

- Added/updated existing tests
- Tested locally with https://github.com/blader/humanizer
## Risk

- Low: scoped to skill detection for GitHub imports.
- Safe to rollback.

## Deploy Plan

- Deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25507">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->