### PR TITLE
Slack: interrupt streaming after timeout on user action

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -215,10 +215,10 @@ function getUserActionFallbackMessage(
       actionLabel = "file access authorization";
       break;
     case "tool_personal_auth_required":
-      actionLabel = "authentication";
+      actionLabel = "tool authentication";
       break;
     case "tool_ask_user_question":
-      actionLabel = "your response to a question";
+      actionLabel = "a response to a question";
       break;
     default:
       assertNever(actionType);

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -200,7 +200,7 @@ type SlackUserActionType = Extract<
   | "tool_ask_user_question"
 >;
 
-const SLACK_USER_ACTION_IDLE_TIMEOUT_MS = 3 * 60 * 1000;
+const SLACK_USER_ACTION_IDLE_TIMEOUT_MS = 4 * 60 * 1000 + 30 * 1000; // 4.5 minutes
 
 function getUserActionFallbackMessage(
   actionType: SlackUserActionType,
@@ -225,10 +225,10 @@ function getUserActionFallbackMessage(
   }
 
   const urlPart = conversationUrl
-    ? ` <${conversationUrl}|Continue the conversation>.`
+    ? ` <${conversationUrl}|Continue the conversation on Dust>.`
     : "";
 
-  return `:hourglass_flowing_sand: _This conversation is waiting for ${actionLabel}.${urlPart}_`;
+  return `:hourglass_flowing_sand: _Streaming has timed out after 5 mins waiting on ${actionLabel}.${urlPart}_`;
 }
 
 async function streamAgentAnswerToSlack(

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -218,17 +218,17 @@ function getUserActionFallbackMessage(
       actionLabel = "tool authentication";
       break;
     case "tool_ask_user_question":
-      actionLabel = "a response to a question";
+      actionLabel = "response to a question";
       break;
     default:
       assertNever(actionType);
   }
 
   const urlPart = conversationUrl
-    ? ` <${conversationUrl}|Continue the conversation on Dust>.`
+    ? ` <${conversationUrl}|Continue on Dust>.`
     : "";
 
-  return `:hourglass_flowing_sand: _Streaming has timed out after 5 mins waiting on ${actionLabel}.${urlPart}_`;
+  return `:hourglass_flowing_sand: _Streaming was interrupted after 5 mins waiting on a ${actionLabel}.${urlPart}_`;
 }
 
 async function streamAgentAnswerToSlack(

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -36,6 +36,7 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 import { redisClient } from "@connectors/types/shared/redis_client";
 import type {
   AgentActionPublicType,
+  AgentEvent,
   ConversationPublicType,
   LightAgentConfigurationType,
   Result,
@@ -191,6 +192,45 @@ class SlackAnswerRetryableError extends Error {
   }
 }
 
+type SlackUserActionType = Extract<
+  AgentEvent["type"],
+  | "tool_approve_execution"
+  | "tool_file_auth_required"
+  | "tool_personal_auth_required"
+  | "tool_ask_user_question"
+>;
+
+const SLACK_USER_ACTION_IDLE_TIMEOUT_MS = 3 * 60 * 1000;
+
+function getUserActionFallbackMessage(
+  actionType: SlackUserActionType,
+  conversationUrl: string | null
+): string {
+  let actionLabel: string;
+  switch (actionType) {
+    case "tool_approve_execution":
+      actionLabel = "tool execution approval";
+      break;
+    case "tool_file_auth_required":
+      actionLabel = "file access authorization";
+      break;
+    case "tool_personal_auth_required":
+      actionLabel = "authentication";
+      break;
+    case "tool_ask_user_question":
+      actionLabel = "your response to a question";
+      break;
+    default:
+      assertNever(actionType);
+  }
+
+  const urlPart = conversationUrl
+    ? ` You can continue the conversation here: ${conversationUrl}`
+    : "";
+
+  return `:hourglass_flowing_sand: _This conversation is waiting for ${actionLabel}.${urlPart}_`;
+}
+
 async function streamAgentAnswerToSlack(
   dustAPI: DustAPI,
   conversationData: StreamConversationToSlackParams,
@@ -215,14 +255,19 @@ async function streamAgentAnswerToSlack(
     slackUserId,
   } = slack;
 
+  const abortController = new AbortController();
+
   const streamRes = await dustAPI.streamAgentAnswerEvents({
     conversation,
     userMessageId: userMessage.sId,
+    signal: abortController.signal,
   });
 
   if (streamRes.isErr()) {
     return new Err(new Error(streamRes.error.message));
   }
+
+  const { eventStream } = streamRes.value;
 
   let answer = "";
   // Partial :cite[...] marker that may span across tokens.
@@ -232,6 +277,9 @@ async function streamAgentAnswerToSlack(
     redisKey: string;
     serverName: string;
   } | null = null;
+  let pendingUserActionType: SlackUserActionType | null = null;
+  let timedOutUserActionType: SlackUserActionType | null = null;
+  let userActionTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
   const { streamHandler } = conversationData;
 
@@ -242,10 +290,73 @@ async function streamAgentAnswerToSlack(
     },
   };
 
-  for await (const event of streamRes.value.eventStream) {
+  function clearUserActionTimeout() {
+    if (userActionTimeoutHandle) {
+      clearTimeout(userActionTimeoutHandle);
+      userActionTimeoutHandle = null;
+    }
+
+    if (!pendingUserActionType) {
+      return;
+    }
+
+    logger.info(
+      {
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        pendingActionType: pendingUserActionType,
+      },
+      "Clearing user-action idle timeout for Slack stream."
+    );
+
+    pendingUserActionType = null;
+  }
+
+  function startUserActionTimeout(actionType: SlackUserActionType) {
+    clearUserActionTimeout();
+
+    pendingUserActionType = actionType;
+    timedOutUserActionType = null;
+    userActionTimeoutHandle = setTimeout(() => {
+      timedOutUserActionType = pendingUserActionType;
+
+      logger.info(
+        {
+          connectorId: connector.id,
+          conversationId: conversation.sId,
+          pendingActionType: pendingUserActionType,
+        },
+        "Slack stream idle timeout: user action not taken, aborting SSE stream."
+      );
+
+      abortController.abort();
+    }, SLACK_USER_ACTION_IDLE_TIMEOUT_MS);
+    userActionTimeoutHandle.unref?.();
+
+    logger.info(
+      {
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        pendingActionType: actionType,
+      },
+      "Starting user-action idle timeout for Slack stream."
+    );
+  }
+
+  async function* eventStreamWithTimeoutCleanup() {
+    try {
+      yield* eventStream;
+    } finally {
+      clearUserActionTimeout();
+    }
+  }
+
+  for await (const event of eventStreamWithTimeoutCleanup()) {
     switch (event.type) {
       case "tool_params":
       case "tool_notification": {
+        clearUserActionTimeout();
+
         const isRunAgent = event.action.internalMCPServerName === "run_agent";
 
         // For run_agent, skip tool_params and early notifications:
@@ -267,6 +378,8 @@ async function streamAgentAnswerToSlack(
       }
 
       case "tool_approve_execution": {
+        startUserActionTimeout(event.type);
+
         logger.info(
           {
             connectorId: connector.id,
@@ -312,6 +425,8 @@ async function streamAgentAnswerToSlack(
       }
 
       case "tool_personal_auth_required": {
+        startUserActionTimeout(event.type);
+
         const conversationUrl = makeConversationUrl(
           connector.workspaceId,
           conversation.sId
@@ -349,6 +464,8 @@ async function streamAgentAnswerToSlack(
       }
 
       case "tool_file_auth_required": {
+        startUserActionTimeout(event.type);
+
         const conversationUrl = makeConversationUrl(
           connector.workspaceId,
           conversation.sId
@@ -377,6 +494,8 @@ async function streamAgentAnswerToSlack(
       }
 
       case "user_message_error": {
+        clearUserActionTimeout();
+
         return new Err(
           new Error(
             `User message error: code: ${event.error.code} message: ${event.error.message}`
@@ -385,6 +504,8 @@ async function streamAgentAnswerToSlack(
       }
 
       case "tool_error": {
+        clearUserActionTimeout();
+
         return new Err(
           new Error(
             `Tool message error: code: ${event.error.code} message: ${event.error.message}`
@@ -392,6 +513,8 @@ async function streamAgentAnswerToSlack(
         );
       }
       case "agent_error": {
+        clearUserActionTimeout();
+
         planHandler.abortAllChildStreams();
         await planHandler.deletePlanMessage();
         return new Err(
@@ -402,6 +525,8 @@ async function streamAgentAnswerToSlack(
       }
 
       case "agent_action_success": {
+        clearUserActionTimeout();
+
         if (pendingPersonalAuth && slackUserId && !slackUserInfo.is_bot) {
           await cleanupAuthEphemeral(
             pendingPersonalAuth,
@@ -425,6 +550,8 @@ async function streamAgentAnswerToSlack(
       }
 
       case "generation_tokens": {
+        clearUserActionTimeout();
+
         if (event.classification !== "tokens") {
           continue;
         }
@@ -485,6 +612,8 @@ async function streamAgentAnswerToSlack(
 
       case "agent_message_gracefully_stopped":
       case "agent_message_success": {
+        clearUserActionTimeout();
+
         // Flush pending text that turned out not to be a citation.
         if (pendingCitePrefix) {
           await streamHandler.appendText(pendingCitePrefix);
@@ -633,6 +762,8 @@ async function streamAgentAnswerToSlack(
       }
 
       case "agent_generation_cancelled": {
+        clearUserActionTimeout();
+
         planHandler.abortAllChildStreams();
         await planHandler.deletePlanMessage();
         await streamHandler.stop();
@@ -669,6 +800,8 @@ async function streamAgentAnswerToSlack(
       }
 
       case "tool_ask_user_question": {
+        startUserActionTimeout(event.type);
+
         const questionValue = JSON.stringify({
           workspaceId: connector.workspaceId,
           conversationId: event.conversationId,
@@ -695,12 +828,48 @@ async function streamAgentAnswerToSlack(
       case "agent_context_pruned":
       case "agent_message_done":
       case "tool_call_started":
+        clearUserActionTimeout();
+
         // No-op.
         break;
 
       default:
         assertNever(event);
     }
+  }
+
+  if (abortController.signal.aborted && timedOutUserActionType) {
+    planHandler.abortAllChildStreams();
+    await planHandler.deletePlanMessage();
+    await streamHandler.stop();
+
+    const conversationUrl = makeConversationUrl(
+      connector.workspaceId,
+      conversation.sId
+    );
+    const fallbackText = getUserActionFallbackMessage(
+      timedOutUserActionType,
+      conversationUrl
+    );
+
+    await slackClient.chat.postMessage({
+      channel: slackChannelId,
+      text: fallbackText,
+      blocks: makeMarkdownBlock(fallbackText),
+      thread_ts: slackMessageTs,
+      unfurl_links: false,
+    });
+
+    logger.info(
+      {
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        pendingActionType: timedOutUserActionType,
+      },
+      "Posted user-action timeout fallback message to Slack."
+    );
+
+    return new Ok(undefined);
   }
 
   // Clean up if the event stream ended without a terminal event.

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -225,7 +225,7 @@ function getUserActionFallbackMessage(
   }
 
   const urlPart = conversationUrl
-    ? ` You can continue the conversation here: ${conversationUrl}`
+    ? ` <${conversationUrl}|Continue the conversation>.`
     : "";
 
   return `:hourglass_flowing_sand: _This conversation is waiting for ${actionLabel}.${urlPart}_`;

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -290,7 +290,7 @@ async function streamAgentAnswerToSlack(
     },
   };
 
-  function clearUserActionTimeout() {
+  const clearUserActionTimeout = () => {
     if (userActionTimeoutHandle) {
       clearTimeout(userActionTimeoutHandle);
       userActionTimeoutHandle = null;
@@ -310,9 +310,9 @@ async function streamAgentAnswerToSlack(
     );
 
     pendingUserActionType = null;
-  }
+  };
 
-  function startUserActionTimeout(actionType: SlackUserActionType) {
+  const startUserActionTimeout = (actionType: SlackUserActionType) => {
     clearUserActionTimeout();
 
     pendingUserActionType = actionType;
@@ -341,7 +341,7 @@ async function streamAgentAnswerToSlack(
       },
       "Starting user-action idle timeout for Slack stream."
     );
-  }
+  };
 
   async function* eventStreamWithTimeoutCleanup() {
     try {


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/7990
Fixes: https://github.com/dust-tt/tasks/issues/7848
Context: https://app.dust.tt/w/0ec9852c2f/conversation/1F42d4Jbo3

Before this change when a conversation was blocked on a user action that was not taken, the streaming would timeout at 5mn and retry 10 times, and finally error after 50mn with message:

`An unexpected error occurred while answering your message, please retry.`

First:

<img width="537" height="427" alt="Screenshot 2026-05-12 at 14 14 24" src="https://github.com/user-attachments/assets/ad203c34-6e1b-426d-814c-427c231ea35e" />

And then:

<img width="542" height="395" alt="Screenshot 2026-05-12 at 14 13 32" src="https://github.com/user-attachments/assets/54eda8d3-eaf6-463e-8804-a645a2e4c01a" />

We introduce a timeout handler plugged into the pre-existing cancellation mechanism of the streaming SDK to have a smooth cancellation.

New behaviour while not perfect (action cannot be taken from Slack after timeout) we have an informative error message and an invitation to continue the conversation on Dust.

First:

<img width="531" height="494" alt="Screenshot 2026-05-12 at 14 42 10" src="https://github.com/user-attachments/assets/a4897420-09b1-4bb5-b324-74837e1b4275" />

And then:

<img width="549" height="462" alt="Screenshot 2026-05-12 at 14 45 05" src="https://github.com/user-attachments/assets/fcd40374-3782-4f9f-a060-67efa9ba1257" />

And if the user clicks on one of the buttons:

<img width="539" height="461" alt="Screenshot 2026-05-12 at 14 45 32" src="https://github.com/user-attachments/assets/cd44dfce-7e11-4917-b2f4-5ef177ce83c6" />

Limitation: we cannot remove the approval call to action post timeout as ephemeral elements cannot be removed without knowing their `response_url`, which is only received once a user take action. If the user on which the approval is pending clicks on it (others don't see it) the small ⚠️ icon is shown to report an error taking action.



This should remove all these errors [Errors triggering retries](https://app.datadoghq.eu/logs?query=%22Failed%20processing%20event%20stream%22%20service%3Aconnectors&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ4XgJt5rFX8GQAAABhBWjRYZ0txbEFBRGdLUjFVay1PTWh3QWMAAAAkMDE5ZTE3OGItOThiZC00ODFkLTk0OTktMWQ2OTk3MzA4ZjU2AAAY7A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1775920467523&to_ts=1778512467523&live=true) and [Errors post retries exhausted](https://app.datadoghq.eu/logs?query=%22Unexpected%20exception%20answering%20to%20Slack%20Chat%20Bot%20message%22%20%22Error%3A%20Exceeded%20maximum%20reconnection%20attempts%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40connectorId&link_event_id=8618925699268577964&link_event_ts=1777990810&link_monitor_id=22042330&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1775919532277&to_ts=1778511532277&live=true). Example [Trace](https://app.datadoghq.eu/apm/trace/69fc6fec0000000029bc73cf0ea79419?spanID=2217120249777622841&timeHint=1778151404692).

## Tests

Tested locally

## Risk

Low corner case handling.

## Deploy Plan

- deploy `connectors`