### PR TITLE
Self improving skills: add graph to view the consumption per day over the period

### DIFF
--- a/front/components/pages/workspace/developers/ReinforcementPage.tsx
+++ b/front/components/pages/workspace/developers/ReinforcementPage.tsx
@@ -1,3 +1,4 @@
+import { SelfImprovingSkillsConsumptionSection } from "@app/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection";
 import { ReinforcementSection } from "@app/components/workspace/settings/AgentReinforcementToggle";
 import { ReinforcementSkillsSection } from "@app/components/workspace/settings/ReinforcementSkillsSection";
 import {
@@ -6,56 +7,24 @@ import {
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import { getReinforcementMonthlyCapMicroUsd } from "@app/lib/reinforcement/consumption";
-import { useSkillsReinforcementSpend } from "@app/lib/swr/useReinforcementToggle";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   ContentMessage,
   InformationCircleIcon,
   LinkWrapper,
   Page,
   SparklesIcon,
-  Spinner,
 } from "@dust-tt/sparkle";
-
-interface ReinforcementTotalConsumptionSectionProps {
-  owner: LightWorkspaceType;
-}
-
-function ReinforcementTotalConsumptionSection({
-  owner,
-}: ReinforcementTotalConsumptionSectionProps) {
-  const { spentMicroUsdBySkillId, isSpendLoading } =
-    useSkillsReinforcementSpend({ owner });
-
-  const totalSpentDollars =
-    Object.values(spentMicroUsdBySkillId).reduce((sum, v) => sum + v, 0) /
-    1_000_000;
-  const capDollars = getReinforcementMonthlyCapMicroUsd(owner) / 1_000_000;
-
-  return (
-    <Page.Vertical align="stretch" gap="md">
-      <Page.SectionHeader title="Current period consumption" />
-      {isSpendLoading ? (
-        <div className="flex justify-center py-4">
-          <Spinner />
-        </div>
-      ) : (
-        <div className="text-sm text-foreground dark:text-foreground-night">
-          <span className="font-semibold">${totalSpentDollars.toFixed(2)}</span>{" "}
-          spent out of{" "}
-          <span className="font-semibold">${capDollars.toFixed(2)}</span>{" "}
-          monthly cap
-        </div>
-      )}
-    </Page.Vertical>
-  );
-}
+import { useState } from "react";
 
 export function ReinforcementPage() {
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
   const { featureFlags } = useFeatureFlags();
   const hasReinforcement = featureFlags.includes("reinforced_agents");
+
+  const [capMicroUsd, setCapMicroUsd] = useState(() =>
+    getReinforcementMonthlyCapMicroUsd(owner)
+  );
 
   const renderBody = () => {
     if (!isAdmin) {
@@ -90,8 +59,11 @@ export function ReinforcementPage() {
           </LinkWrapper>{" "}
           to share some feedback about this feature.
         </ContentMessage>
-        <ReinforcementSection owner={owner} />
-        <ReinforcementTotalConsumptionSection owner={owner} />
+        <ReinforcementSection owner={owner} onCapSaved={setCapMicroUsd} />
+        <SelfImprovingSkillsConsumptionSection
+          owner={owner}
+          capMicroUsd={capMicroUsd}
+        />
         <ReinforcementSkillsSection owner={owner} />
       </>
     );

--- a/front/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection.tsx
+++ b/front/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection.tsx
@@ -1,0 +1,398 @@
+import {
+  CHART_HEIGHT,
+  COST_PALETTE,
+} from "@app/components/agent_builder/observability/constants";
+import { ChartContainer } from "@app/components/charts/ChartContainer";
+import type { LegendItem } from "@app/components/charts/ChartLegend";
+import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import {
+  useReinforcementDailySpend,
+  useSkillsReinforcementSpend,
+} from "@app/lib/swr/useReinforcementToggle";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Page,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+type DisplayMode = "cumulative" | "daily";
+
+const DISPLAY_MODE_OPTIONS: { value: DisplayMode; label: string }[] = [
+  { value: "cumulative", label: "Cumulative" },
+  { value: "daily", label: "Daily" },
+];
+
+const ANIMATION_DURATION_MS = 1500;
+
+type ChartDataPoint = {
+  date: string;
+  timestamp: number;
+  spendMicroUsd?: number;
+  predictionMicroUsd?: number;
+  capMicroUsd?: number;
+};
+
+function SpendTooltip(
+  props: TooltipContentProps<number, string>,
+  displayMode: DisplayMode
+): JSX.Element | null {
+  const { active, payload } = props;
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const data = payload[0]?.payload as ChartDataPoint | undefined;
+  if (!data) {
+    return null;
+  }
+
+  const date = new Date(data.timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+
+  const rows: { label: string; value: string; colorClassName: string }[] = [];
+
+  if (data.spendMicroUsd !== undefined) {
+    rows.push({
+      label: displayMode === "cumulative" ? "Total spent" : "Daily spend",
+      value: `$${(data.spendMicroUsd / 1_000_000).toFixed(2)}`,
+      colorClassName: COST_PALETTE.costMicroUsd,
+    });
+  }
+
+  if (data.predictionMicroUsd !== undefined) {
+    rows.push({
+      label: "Projected",
+      value: `$${(data.predictionMicroUsd / 1_000_000).toFixed(2)}`,
+      colorClassName: COST_PALETTE.costMicroUsd,
+    });
+  }
+
+  if (data.capMicroUsd !== undefined) {
+    rows.push({
+      label: "Monthly cap",
+      value: `$${(data.capMicroUsd / 1_000_000).toFixed(2)}`,
+      colorClassName: COST_PALETTE.totalCredits,
+    });
+  }
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return <ChartTooltipCard title={date} rows={rows} />;
+}
+
+interface ReinforcementSpendChartProps {
+  owner: LightWorkspaceType;
+  capMicroUsd: number;
+}
+
+function ReinforcementSpendChart({
+  owner,
+  capMicroUsd,
+}: ReinforcementSpendChartProps) {
+  const [displayMode, setDisplayMode] = useState<DisplayMode>("cumulative");
+
+  const {
+    dailySpendMicroUsd,
+    periodStartDate,
+    periodEndDate,
+    isDailySpendLoading,
+    isDailySpendError,
+  } = useReinforcementDailySpend({ owner });
+
+  const chartData = useMemo(() => {
+    if (!periodStartDate || !periodEndDate) {
+      return [];
+    }
+
+    const start = new Date(periodStartDate);
+    const end = new Date(periodEndDate);
+    const today = new Date();
+    const effectiveEnd = end < today ? end : today;
+
+    // Build actual data points up to today.
+    const points: ChartDataPoint[] = [];
+    let cumulativeSpend = 0;
+    const current = new Date(start);
+
+    while (current < effectiveEnd) {
+      const dateStr = current.toISOString().slice(0, 10);
+      const daySpend = dailySpendMicroUsd[dateStr] ?? 0;
+      cumulativeSpend += daySpend;
+
+      points.push({
+        date: dateStr,
+        timestamp: current.getTime(),
+        spendMicroUsd:
+          displayMode === "cumulative" ? cumulativeSpend : daySpend,
+      });
+
+      current.setUTCDate(current.getUTCDate() + 1);
+    }
+
+    // Add remaining days of the period.
+    if (points.length > 0 && end > today) {
+      const elapsedDays = points.length;
+      const avgDailySpend = cumulativeSpend / elapsedDays;
+
+      if (displayMode === "cumulative") {
+        // Anchor the prediction at the last actual point.
+        points[points.length - 1].predictionMicroUsd = cumulativeSpend;
+      }
+
+      let projectedSpend = cumulativeSpend;
+      const projectionCurrent = new Date(effectiveEnd);
+      while (projectionCurrent < end) {
+        const dateStr = projectionCurrent.toISOString().slice(0, 10);
+        projectedSpend += avgDailySpend;
+
+        const point: ChartDataPoint = {
+          date: dateStr,
+          timestamp: projectionCurrent.getTime(),
+        };
+
+        if (displayMode === "cumulative") {
+          point.predictionMicroUsd = projectedSpend;
+        } else {
+          // Show future days as zero bars.
+          point.spendMicroUsd = 0;
+        }
+
+        points.push(point);
+        projectionCurrent.setUTCDate(projectionCurrent.getUTCDate() + 1);
+      }
+    }
+
+    // In cumulative mode, add the cap as a flat reference line.
+    if (displayMode === "cumulative" && capMicroUsd > 0) {
+      for (const point of points) {
+        point.capMicroUsd = capMicroUsd;
+      }
+    }
+
+    return points;
+  }, [
+    dailySpendMicroUsd,
+    periodStartDate,
+    periodEndDate,
+    displayMode,
+    capMicroUsd,
+  ]);
+
+  const ChartComponent = displayMode === "daily" ? BarChart : LineChart;
+
+  const hasPrediction =
+    displayMode === "cumulative" &&
+    chartData.some((p) => p.predictionMicroUsd !== undefined);
+
+  const legendItems: LegendItem[] = useMemo(() => {
+    const items: LegendItem[] = [
+      {
+        key: "spend",
+        label:
+          displayMode === "cumulative" ? "Cumulative spend" : "Daily spend",
+        colorClassName: COST_PALETTE.costMicroUsd,
+        isActive: true,
+      },
+    ];
+    if (displayMode === "cumulative" && capMicroUsd > 0) {
+      items.push({
+        key: "cap",
+        label: "Monthly cap",
+        colorClassName: COST_PALETTE.totalCredits,
+        isActive: true,
+      });
+    }
+    return items;
+  }, [displayMode, capMicroUsd]);
+
+  return (
+    <ChartContainer
+      title="Spending over billing period"
+      isLoading={isDailySpendLoading}
+      legendItems={legendItems}
+      errorMessage={
+        isDailySpendError ? "Failed to load spend data." : undefined
+      }
+      emptyMessage={
+        chartData.length === 0 ? "No spend data for this period." : undefined
+      }
+      height={CHART_HEIGHT}
+      additionalControls={
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              label={
+                DISPLAY_MODE_OPTIONS.find((o) => o.value === displayMode)
+                  ?.label ?? "Cumulative"
+              }
+              size="xs"
+              variant="outline"
+              isSelect
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {DISPLAY_MODE_OPTIONS.map((o) => (
+              <DropdownMenuItem
+                key={o.value}
+                label={o.label}
+                onClick={() => setDisplayMode(o.value)}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      }
+    >
+      <ChartComponent
+        data={chartData}
+        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+      >
+        <CartesianGrid
+          vertical={false}
+          className="stroke-border dark:stroke-border-night"
+        />
+        <XAxis
+          dataKey="timestamp"
+          type="category"
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={true}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={8}
+          tickFormatter={(value) =>
+            new Date(value).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+            })
+          }
+        />
+        <YAxis
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(value) => `$${(value / 1_000_000).toFixed(0)}`}
+        />
+        <Tooltip
+          content={(props: TooltipContentProps<number, string>) =>
+            SpendTooltip(props, displayMode)
+          }
+          cursor={false}
+          wrapperStyle={{ outline: "none" }}
+          contentStyle={{
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            boxShadow: "none",
+          }}
+        />
+        {displayMode === "daily" ? (
+          <Bar
+            dataKey="spendMicroUsd"
+            fill="currentColor"
+            className={COST_PALETTE.costMicroUsd}
+          />
+        ) : (
+          <>
+            <Line
+              type="monotone"
+              dataKey="spendMicroUsd"
+              stroke="currentColor"
+              strokeWidth={2}
+              className={COST_PALETTE.costMicroUsd}
+              dot={false}
+              activeDot={{ r: 5 }}
+              connectNulls={false}
+              animationDuration={ANIMATION_DURATION_MS / 2}
+            />
+            {hasPrediction && (
+              <Line
+                type="monotone"
+                dataKey="predictionMicroUsd"
+                stroke="currentColor"
+                strokeWidth={2}
+                className={COST_PALETTE.costMicroUsd}
+                strokeDasharray="5 5"
+                dot={false}
+                activeDot={{ r: 5 }}
+                connectNulls={false}
+                animationBegin={ANIMATION_DURATION_MS / 2}
+                animationDuration={ANIMATION_DURATION_MS / 2}
+              />
+            )}
+            {capMicroUsd > 0 && (
+              <Line
+                type="monotone"
+                dataKey="capMicroUsd"
+                stroke="currentColor"
+                strokeWidth={2}
+                className={COST_PALETTE.totalCredits}
+                dot={false}
+                activeDot={false}
+                connectNulls={false}
+                animationDuration={ANIMATION_DURATION_MS}
+              />
+            )}
+          </>
+        )}
+      </ChartComponent>
+    </ChartContainer>
+  );
+}
+
+interface SelfImprovingSkillsConsumptionSectionProps {
+  owner: LightWorkspaceType;
+  capMicroUsd: number;
+}
+
+export function SelfImprovingSkillsConsumptionSection({
+  owner,
+  capMicroUsd,
+}: SelfImprovingSkillsConsumptionSectionProps) {
+  const { spentMicroUsdBySkillId, isSpendLoading } =
+    useSkillsReinforcementSpend({ owner });
+
+  const totalSpentDollars =
+    Object.values(spentMicroUsdBySkillId).reduce((sum, v) => sum + v, 0) /
+    1_000_000;
+  const capDollars = capMicroUsd / 1_000_000;
+
+  return (
+    <Page.Vertical align="stretch" gap="md">
+      <Page.SectionHeader title="Current period consumption" />
+      {isSpendLoading ? (
+        <div className="flex justify-center py-4">
+          <Spinner />
+        </div>
+      ) : (
+        <div className="text-sm text-foreground dark:text-foreground-night">
+          <span className="font-semibold">${totalSpentDollars.toFixed(2)}</span>{" "}
+          spent out of{" "}
+          <span className="font-semibold">${capDollars.toFixed(2)}</span>{" "}
+          monthly cap
+        </div>
+      )}
+      <ReinforcementSpendChart owner={owner} capMicroUsd={capMicroUsd} />
+    </Page.Vertical>
+  );
+}

--- a/front/components/workspace/settings/AgentReinforcementToggle.tsx
+++ b/front/components/workspace/settings/AgentReinforcementToggle.tsx
@@ -23,9 +23,13 @@ import { useState } from "react";
 
 interface ReinforcementSectionProps {
   owner: WorkspaceType;
+  onCapSaved?: (capMicroUsd: number) => void;
 }
 
-export function ReinforcementSection({ owner }: ReinforcementSectionProps) {
+export function ReinforcementSection({
+  owner,
+  onCapSaved,
+}: ReinforcementSectionProps) {
   const { isEnabled, isChanging, doToggleReinforcement } =
     useReinforcementToggle({ owner });
 
@@ -49,7 +53,7 @@ export function ReinforcementSection({ owner }: ReinforcementSectionProps) {
           <ContextItem.Description description="Allow Dust to analyze conversations to improve your workspace's skills. Dust does not use conversations to train models." />
         </ContextItem>
         <ReinforcementBatchModeToggle owner={owner} />
-        <ReinforcementCapItem owner={owner} />
+        <ReinforcementCapItem owner={owner} onCapSaved={onCapSaved} />
         <SelfImprovementCapPerSkillItem owner={owner} />
       </ContextItem.List>
     </Page.Vertical>
@@ -145,7 +149,10 @@ function SelfImprovementCapPerSkillItem({ owner }: ReinforcementSectionProps) {
   );
 }
 
-function ReinforcementCapItem({ owner }: ReinforcementSectionProps) {
+function ReinforcementCapItem({
+  owner,
+  onCapSaved,
+}: ReinforcementSectionProps) {
   const { capDollars, isSaving, saveCapDollars } = useReinforcementCapSetting({
     owner,
   });
@@ -165,7 +172,10 @@ function ReinforcementCapItem({ owner }: ReinforcementSectionProps) {
     if (!isInputValid) {
       return;
     }
-    await saveCapDollars(parsedInput);
+    const ok = await saveCapDollars(parsedInput);
+    if (ok) {
+      onCapSaved?.(Math.round(parsedInput * 1_000_000));
+    }
   };
 
   return (

--- a/front/lib/resources/self_improving_skills_usage_resource.test.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.test.ts
@@ -66,7 +66,7 @@ describe("SelfImprovingSkillsUsageResource", () => {
     expect(sum).toBe(300);
   });
 
-  it("returns daily spend aggregated by calendar day", async () => {
+  it("returns daily spend with markup aggregated by calendar day", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const { authenticator: otherAuthenticator } = await createResourceTest({
       role: "admin",
@@ -117,17 +117,18 @@ describe("SelfImprovingSkillsUsageResource", () => {
       },
     ]);
 
-    const result = await SelfImprovingSkillsUsageResource.getDailySpendMicroUsd(
-      authenticator,
-      {
-        startDate: new Date("2026-03-10T00:00:00.000Z"),
-        endDate: new Date("2026-03-15T00:00:00.000Z"),
-      }
-    );
+    const result =
+      await SelfImprovingSkillsUsageResource.getDailySpendMicroUsdWithMarkup(
+        authenticator,
+        {
+          startDate: new Date("2026-03-10T00:00:00.000Z"),
+          endDate: new Date("2026-03-15T00:00:00.000Z"),
+        }
+      );
 
-    expect(result.get("2026-03-10")).toBe(300);
+    expect(result.get("2026-03-10")).toBe(300 * MARKUP_MULTIPLIER);
     expect(result.has("2026-03-11")).toBe(false);
-    expect(result.get("2026-03-12")).toBe(500);
+    expect(result.get("2026-03-12")).toBe(500 * MARKUP_MULTIPLIER);
     expect(result.has("2026-03-09")).toBe(false);
     expect(result.size).toBe(2);
   });

--- a/front/lib/resources/self_improving_skills_usage_resource.test.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.test.ts
@@ -66,6 +66,72 @@ describe("SelfImprovingSkillsUsageResource", () => {
     expect(sum).toBe(300);
   });
 
+  it("returns daily spend aggregated by calendar day", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const { authenticator: otherAuthenticator } = await createResourceTest({
+      role: "admin",
+    });
+
+    const skill = await SkillFactory.create(authenticator, {
+      name: "Daily Spend Skill",
+    });
+
+    await SelfImprovingSkillsUsageResource.bulkCreate(authenticator, [
+      {
+        createdAt: new Date("2026-03-10T08:00:00.000Z"),
+        skillId: skill.id,
+        conversationId: null,
+        priceMicroUsd: 100,
+      },
+      {
+        createdAt: new Date("2026-03-10T20:00:00.000Z"),
+        skillId: skill.id,
+        conversationId: null,
+        priceMicroUsd: 200,
+      },
+      {
+        createdAt: new Date("2026-03-12T10:00:00.000Z"),
+        skillId: skill.id,
+        conversationId: null,
+        priceMicroUsd: 500,
+      },
+      // Outside the queried range.
+      {
+        createdAt: new Date("2026-03-09T23:59:59.000Z"),
+        skillId: skill.id,
+        conversationId: null,
+        priceMicroUsd: 999,
+      },
+    ]);
+
+    // Other workspace — should be excluded.
+    const otherSkill = await SkillFactory.create(otherAuthenticator, {
+      name: "Other WS Skill",
+    });
+    await SelfImprovingSkillsUsageResource.bulkCreate(otherAuthenticator, [
+      {
+        createdAt: new Date("2026-03-10T12:00:00.000Z"),
+        skillId: otherSkill.id,
+        conversationId: null,
+        priceMicroUsd: 9999,
+      },
+    ]);
+
+    const result = await SelfImprovingSkillsUsageResource.getDailySpendMicroUsd(
+      authenticator,
+      {
+        startDate: new Date("2026-03-10T00:00:00.000Z"),
+        endDate: new Date("2026-03-15T00:00:00.000Z"),
+      }
+    );
+
+    expect(result.get("2026-03-10")).toBe(300);
+    expect(result.has("2026-03-11")).toBe(false);
+    expect(result.get("2026-03-12")).toBe(500);
+    expect(result.has("2026-03-09")).toBe(false);
+    expect(result.size).toBe(2);
+  });
+
   it("sums usage after a date by skill", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const skill = await SkillFactory.create(authenticator, {

--- a/front/lib/resources/self_improving_skills_usage_resource.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.ts
@@ -167,6 +167,51 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
     );
   }
 
+  /**
+   * Return total spend per calendar day (UTC) within a date range.
+   *
+   * Each entry maps an ISO date string ("YYYY-MM-DD") to the summed spend in
+   * micro-USD for that day. Days with no spend are omitted.
+   */
+  static async getDailySpendMicroUsd(
+    auth: Authenticator,
+    {
+      startDate,
+      endDate,
+    }: {
+      startDate: Date;
+      endDate: Date;
+    }
+  ): Promise<Map<string, number>> {
+    const dayExpr = Sequelize.fn(
+      "DATE",
+      Sequelize.cast(Sequelize.col("createdAt"), "TIMESTAMPTZ")
+    );
+
+    const rows = await this.model.findAll({
+      attributes: [
+        [dayExpr, "day"],
+        [Sequelize.fn("SUM", Sequelize.col("priceMicroUsd")), "priceMicroUsd"],
+      ],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        createdAt: {
+          [Op.gte]: startDate,
+          [Op.lt]: endDate,
+        },
+      },
+      group: [dayExpr],
+      order: [[dayExpr, "ASC"]],
+      raw: true,
+    });
+
+    return new Map(
+      (rows as unknown as { day: string; priceMicroUsd: string }[]).map(
+        (row) => [row.day, Number(row.priceMicroUsd)]
+      )
+    );
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}

--- a/front/lib/resources/self_improving_skills_usage_resource.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.ts
@@ -173,7 +173,7 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
    * Each entry maps an ISO date string ("YYYY-MM-DD") to the summed spend in
    * micro-USD for that day. Days with no spend are omitted.
    */
-  static async getDailySpendMicroUsd(
+  private static async getDailySpendMicroUsd(
     auth: Authenticator,
     {
       startDate,
@@ -188,7 +188,7 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       Sequelize.cast(Sequelize.col("createdAt"), "TIMESTAMPTZ")
     );
 
-    const rows = await this.model.findAll({
+    const rows = (await this.model.findAll({
       attributes: [
         [dayExpr, "day"],
         [Sequelize.fn("SUM", Sequelize.col("priceMicroUsd")), "priceMicroUsd"],
@@ -203,12 +203,22 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       group: [dayExpr],
       order: [[dayExpr, "ASC"]],
       raw: true,
-    });
+    })) as unknown as { day: string; priceMicroUsd: string }[];
+
+    return new Map(rows.map((row) => [row.day, Number(row.priceMicroUsd)]));
+  }
+
+  static async getDailySpendMicroUsdWithMarkup(
+    auth: Authenticator,
+    params: {
+      startDate: Date;
+      endDate: Date;
+    }
+  ): Promise<Map<string, number>> {
+    const raw = await this.getDailySpendMicroUsd(auth, params);
 
     return new Map(
-      (rows as unknown as { day: string; priceMicroUsd: string }[]).map(
-        (row) => [row.day, Number(row.priceMicroUsd)]
-      )
+      [...raw.entries()].map(([day, value]) => [day, value * MARKUP_MULTIPLIER])
     );
   }
 

--- a/front/lib/swr/useReinforcementToggle.ts
+++ b/front/lib/swr/useReinforcementToggle.ts
@@ -5,6 +5,7 @@ import {
   getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetReinforcementDailySpendResponseBody } from "@app/pages/api/w/[wId]/skills/reinforcement_daily_spend";
 import type { GetSkillsSpendResponseBody } from "@app/pages/api/w/[wId]/skills/reinforcement_spend";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -178,6 +179,31 @@ export function useSkillsReinforcementSpend({
     isSpendLoading: isLoading,
     isSpendError: !!error,
     mutateSpend: mutate,
+  };
+}
+
+export function useReinforcementDailySpend({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const dailyFetcher: Fetcher<GetReinforcementDailySpendResponseBody> = fetcher;
+
+  const { data, error, isLoading } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/skills/reinforcement_daily_spend`,
+    dailyFetcher,
+    { disabled }
+  );
+
+  return {
+    dailySpendMicroUsd: data?.dailySpendMicroUsd ?? {},
+    periodStartDate: data?.periodStartDate ?? null,
+    periodEndDate: data?.periodEndDate ?? null,
+    isDailySpendLoading: isLoading,
+    isDailySpendError: !!error,
   };
 }
 

--- a/front/pages/api/w/[wId]/skills/reinforcement_daily_spend.test.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_daily_spend.test.ts
@@ -1,0 +1,109 @@
+import { Authenticator } from "@app/lib/auth";
+import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import type { RequestMethod } from "node-mocks-http";
+import { describe, expect, it } from "vitest";
+
+import handler from "./reinforcement_daily_spend";
+
+async function setupTest(
+  method: RequestMethod = "GET",
+  role: MembershipRoleType = "admin"
+) {
+  return createPrivateApiMockRequest({ method, role });
+}
+
+describe("GET /api/w/[wId]/skills/reinforcement_daily_spend", () => {
+  it("returns daily spend keyed by date with period boundaries", async () => {
+    const { req, res, workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const skill = await SkillFactory.create(auth, {
+      name: "Daily Spend Skill",
+    });
+
+    const now = new Date();
+    const currentMonthStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)
+    );
+    const day1 = new Date(currentMonthStart.getTime() + 60_000);
+    const day2 = new Date(
+      currentMonthStart.getTime() + 24 * 60 * 60 * 1000 + 60_000
+    );
+    const beforePeriod = new Date(currentMonthStart.getTime() - 60_000);
+
+    await SelfImprovingSkillsUsageResource.bulkCreate(auth, [
+      {
+        createdAt: day1,
+        skillId: skill.id,
+        conversationId: null,
+        priceMicroUsd: 1_000_000,
+      },
+      {
+        createdAt: day1,
+        skillId: skill.id,
+        conversationId: null,
+        priceMicroUsd: 500_000,
+      },
+      {
+        createdAt: day2,
+        skillId: skill.id,
+        conversationId: null,
+        priceMicroUsd: 3_000_000,
+      },
+      // Excluded: before the current period.
+      {
+        createdAt: beforePeriod,
+        skillId: skill.id,
+        conversationId: null,
+        priceMicroUsd: 999_000_000,
+      },
+    ]);
+
+    req.query = { wId: workspace.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const { dailySpendMicroUsd, periodStartDate, periodEndDate } =
+      res._getJSONData();
+
+    // Period boundaries are returned as ISO strings.
+    expect(periodStartDate).toBeTruthy();
+    expect(periodEndDate).toBeTruthy();
+
+    const day1Str = day1.toISOString().slice(0, 10);
+    const day2Str = day2.toISOString().slice(0, 10);
+
+    expect(dailySpendMicroUsd[day1Str]).toBe(1_500_000);
+    expect(dailySpendMicroUsd[day2Str]).toBe(3_000_000);
+
+    // Before-period row should not appear.
+    const beforeStr = beforePeriod.toISOString().slice(0, 10);
+    expect(dailySpendMicroUsd[beforeStr]).toBeUndefined();
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    for (const role of ["builder", "user"] as const) {
+      const { req, res, workspace } = await setupTest("GET", role);
+      req.query = { wId: workspace.sId };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "workspace_auth_error",
+          message: "Only admins can view self-improving skills daily spend.",
+        },
+      });
+    }
+  });
+});

--- a/front/pages/api/w/[wId]/skills/reinforcement_daily_spend.test.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_daily_spend.test.ts
@@ -1,3 +1,4 @@
+import { MARKUP_MULTIPLIER } from "@app/lib/api/programmatic_usage/common";
 import { Authenticator } from "@app/lib/auth";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -82,8 +83,8 @@ describe("GET /api/w/[wId]/skills/reinforcement_daily_spend", () => {
     const day1Str = day1.toISOString().slice(0, 10);
     const day2Str = day2.toISOString().slice(0, 10);
 
-    expect(dailySpendMicroUsd[day1Str]).toBe(1_500_000);
-    expect(dailySpendMicroUsd[day2Str]).toBe(3_000_000);
+    expect(dailySpendMicroUsd[day1Str]).toBe(1_500_000 * MARKUP_MULTIPLIER);
+    expect(dailySpendMicroUsd[day2Str]).toBe(3_000_000 * MARKUP_MULTIPLIER);
 
     // Before-period row should not appear.
     const beforeStr = beforePeriod.toISOString().slice(0, 10);

--- a/front/pages/api/w/[wId]/skills/reinforcement_daily_spend.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_daily_spend.ts
@@ -36,10 +36,13 @@ async function handler(
       const period = await getCurrentPeriod(auth);
 
       const dailyMap =
-        await SelfImprovingSkillsUsageResource.getDailySpendMicroUsd(auth, {
-          startDate: period.cycleStart,
-          endDate: period.cycleEnd,
-        });
+        await SelfImprovingSkillsUsageResource.getDailySpendMicroUsdWithMarkup(
+          auth,
+          {
+            startDate: period.cycleStart,
+            endDate: period.cycleEnd,
+          }
+        );
 
       const dailySpendMicroUsd: Record<string, number> = {};
       for (const [day, spend] of dailyMap) {

--- a/front/pages/api/w/[wId]/skills/reinforcement_daily_spend.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_daily_spend.ts
@@ -1,0 +1,67 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
+import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetReinforcementDailySpendResponseBody = {
+  // ISO date strings ("YYYY-MM-DD") → spend in microUSD for that day.
+  dailySpendMicroUsd: Record<string, number>;
+  periodStartDate: string;
+  periodEndDate: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetReinforcementDailySpendResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only admins can view self-improving skills daily spend.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const period = await getCurrentPeriod(auth);
+
+      const dailyMap =
+        await SelfImprovingSkillsUsageResource.getDailySpendMicroUsd(auth, {
+          startDate: period.cycleStart,
+          endDate: period.cycleEnd,
+        });
+
+      const dailySpendMicroUsd: Record<string, number> = {};
+      for (const [day, spend] of dailyMap) {
+        dailySpendMicroUsd[day] = spend;
+      }
+
+      return res.status(200).json({
+        dailySpendMicroUsd,
+        periodStartDate: period.cycleStart.toISOString(),
+        periodEndDate: period.cycleEnd.toISOString(),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

 - add resource method to get consumption per day
 - add endpoint
 - add graphs in the admin UI
   - cumulative
     - current consumption
     - prediction by averaging the daily consumption
     - cap
   - daily (only consumption)

<img width="1060" height="589" alt="Screenshot 2026-05-12 at 13 52 51" src="https://github.com/user-attachments/assets/f8603eb5-f3b7-4696-8a01-da6826bf8f6e" />

<img width="1093" height="468" alt="Screenshot 2026-05-12 at 13 53 01" src="https://github.com/user-attachments/assets/e2fe4ef1-108a-4acd-b2be-9ab49d1d9b31" />


## Tests

 - resource test
 - endpoint test

## Risk

low

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->