### PR TITLE
Small UI improvements to Self-Improving Skills admin page

### DIFF
--- a/front/components/pages/workspace/developers/ReinforcementPage.tsx
+++ b/front/components/pages/workspace/developers/ReinforcementPage.tsx
@@ -98,26 +98,28 @@ export function ReinforcementPage() {
   };
 
   return (
-    <Page.Vertical gap="xl" align="stretch">
-      <Page.Header
-        title="Self-Improving Skills"
-        icon={SparklesIcon}
-        description={
-          <span>
-            Configure self-improving skills settings for this workspace.{" "}
-            <a
-              href="https://docs.dust.tt/docs/reinforcement"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-highlight dark:text-highlight-night underline"
-            >
-              Learn more
-            </a>
-            .
-          </span>
-        }
-      />
-      {renderBody()}
-    </Page.Vertical>
+    <div className="mb-4">
+      <Page.Vertical gap="xl" align="stretch">
+        <Page.Header
+          title="Self-Improving Skills"
+          icon={SparklesIcon}
+          description={
+            <span>
+              Configure self-improving skills settings for this workspace.{" "}
+              <a
+                href="https://docs.dust.tt/docs/reinforcement"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-highlight dark:text-highlight-night underline"
+              >
+                Learn more
+              </a>
+              .
+            </span>
+          }
+        />
+        {renderBody()}
+      </Page.Vertical>
+    </div>
   );
 }

--- a/front/components/workspace/settings/AgentReinforcementToggle.tsx
+++ b/front/components/workspace/settings/AgentReinforcementToggle.tsx
@@ -11,13 +11,10 @@ import {
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
-  CardIcon,
   ContextItem,
   Input,
   Page,
   SliderToggle,
-  SparklesIcon,
-  Square3Stack3DIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -36,7 +33,7 @@ export function ReinforcementSection({ owner }: ReinforcementSectionProps) {
         <div className="h-full border-b border-border dark:border-border-night" />
         <ContextItem
           title="Allow self-improving skills"
-          visual={<SparklesIcon className="h-6 w-6 shrink-0" />}
+          visual={<></>}
           hasSeparatorIfLast={true}
           action={
             <SliderToggle
@@ -63,7 +60,7 @@ function ReinforcementBatchModeToggle({ owner }: ReinforcementSectionProps) {
   return (
     <ContextItem
       title="Enable batch processing"
-      visual={<Square3Stack3DIcon className="h-6 w-6 shrink-0" />}
+      visual={<></>}
       hasSeparatorIfLast={true}
       action={
         <SliderToggle
@@ -104,7 +101,7 @@ function SelfImprovementCapPerSkillItem({ owner }: ReinforcementSectionProps) {
   return (
     <ContextItem
       title="Default cost cap per skill"
-      visual={<CardIcon className="h-6 w-6 shrink-0" />}
+      visual={<></>}
       hasSeparatorIfLast={true}
       action={
         <form
@@ -171,7 +168,7 @@ function ReinforcementCapItem({ owner }: ReinforcementSectionProps) {
   return (
     <ContextItem
       title="Global spending cap"
-      visual={<CardIcon className="h-6 w-6 shrink-0" />}
+      visual={<></>}
       hasSeparatorIfLast={true}
       action={
         <form

--- a/front/components/workspace/settings/ReinforcementSkillsSection.tsx
+++ b/front/components/workspace/settings/ReinforcementSkillsSection.tsx
@@ -18,7 +18,11 @@ import {
   SliderToggle,
   Spinner,
 } from "@dust-tt/sparkle";
-import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import type {
+  CellContext,
+  ColumnDef,
+  PaginationState,
+} from "@tanstack/react-table";
 import { useCallback, useMemo, useState } from "react";
 
 interface ReinforcementSkillsSectionProps {
@@ -94,36 +98,23 @@ const COLUMNS: ColumnDef<RowData, unknown>[] = [
     header: "Enabled",
     accessorKey: "enabled",
     cell: (info: CellContext<RowData, unknown>) => {
-      const { enabled, pendingEnabled, isEnabledUpdating, onToggleEnabled } =
-        info.row.original;
+      const {
+        enabled,
+        pendingEnabled,
+        isEnabledUpdating,
+        lock,
+        pendingLock,
+        onToggleEnabled,
+      } = info.row.original;
       const selected = pendingEnabled ?? enabled;
+      const isLocked = pendingLock ?? lock;
       return (
         <DataTable.CellContent>
           <SliderToggle
             size="xs"
             selected={selected}
-            disabled={isEnabledUpdating}
+            disabled={isEnabledUpdating || isLocked}
             onClick={onToggleEnabled}
-          />
-        </DataTable.CellContent>
-      );
-    },
-    meta: { className: "w-24" },
-  },
-  {
-    header: "Lock State",
-    accessorKey: "lock",
-    cell: (info: CellContext<RowData, unknown>) => {
-      const { lock, pendingLock, isLockUpdating, onToggleLock } =
-        info.row.original;
-      const selected = pendingLock ?? lock;
-      return (
-        <DataTable.CellContent>
-          <SliderToggle
-            size="xs"
-            selected={selected}
-            disabled={isLockUpdating}
-            onClick={onToggleLock}
           />
         </DataTable.CellContent>
       );
@@ -165,6 +156,26 @@ const COLUMNS: ColumnDef<RowData, unknown>[] = [
       );
     },
     meta: { className: "w-32" },
+  },
+  {
+    header: "Lock State",
+    accessorKey: "lock",
+    cell: (info: CellContext<RowData, unknown>) => {
+      const { lock, pendingLock, isLockUpdating, onToggleLock } =
+        info.row.original;
+      const selected = pendingLock ?? lock;
+      return (
+        <DataTable.CellContent>
+          <SliderToggle
+            size="xs"
+            selected={selected}
+            disabled={isLockUpdating}
+            onClick={onToggleLock}
+          />
+        </DataTable.CellContent>
+      );
+    },
+    meta: { className: "w-24" },
   },
 ];
 
@@ -299,6 +310,10 @@ export function ReinforcementSkillsSection({
   );
 
   const [filter, setFilter] = useState("");
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 25,
+  });
 
   const sortedSkills = useMemo(
     () =>
@@ -393,6 +408,8 @@ export function ReinforcementSkillsSection({
           columns={COLUMNS}
           filter={filter}
           filterColumn="name"
+          pagination={pagination}
+          setPagination={setPagination}
         />
       )}
     </Page.Vertical>


### PR DESCRIPTION
## Description

  1. Removed icons from settings
  2. Moved Lock State column to the right
  3. Disabled Enabled toggle when locked
  4. Added pagination to the skills table
  5. Added bottom padding (so we have some space below the table of skills)


## Tests

tested locally

<img width="3444" height="1758" alt="image" src="https://github.com/user-attachments/assets/98f091dc-1f46-4e23-ae0c-dddc306d5ad2" />

<img width="2768" height="786" alt="image" src="https://github.com/user-attachments/assets/87e30aa4-0b6d-4da7-973a-114f5ad952dd" />

<img width="2458" height="1702" alt="image" src="https://github.com/user-attachments/assets/6c08b09e-330b-4497-9897-a9f2ab326e8c" />


## Risk

no

## Deploy Plan
deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25511">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->