### PR TITLE
[LLM] Fix logger.error arg order for Anthropic token-details errors

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -454,10 +454,13 @@ async function estimateReasoningTokens(
     tokenUsageAccumulator.outputTokens =
       tokenUsageAccumulator.outputTokens - reasoningTokens;
   } catch (err) {
-    logger.error("Failed getting token details from Anthropic", {
-      error: normalizeError(err),
-      metadata,
-    });
+    logger.error(
+      {
+        errorDetails: normalizeError(err),
+        metadata,
+      },
+      "Failed getting token details from Anthropic"
+    );
   }
 }
 


### PR DESCRIPTION
## Description

`logger.error` (pino) expects `(payload, message)`; the call was inverted, so `error` and `metadata` were swallowed in the message arg. Swapped to the canonical form so Anthropic token-details failures are inspectable in Datadog.

## Tests

None.

## Risk

None — logging-only change.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
