### PR TITLE
Unified contract creation flows

### DIFF
--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -4,7 +4,6 @@ import {
   extractEnterprisePricing,
   provisionMetronomeContract,
   resolveCurrencyForExistingMetronomeCustomer,
-  switchMetronomeContractPackage,
 } from "@app/lib/metronome/contracts";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -21,6 +20,7 @@ const {
   mockGetStripeCustomer,
   mockGetStripeSubscription,
   mockHasMauSubscriptionInContract,
+  mockListMetronomeContracts,
   mockPrices,
   mockScheduleMetronomeContractEnd,
   mockSyncMauCount,
@@ -38,6 +38,7 @@ const {
     mockGetStripeCustomer: vi.fn(),
     mockGetStripeSubscription: vi.fn(),
     mockHasMauSubscriptionInContract: vi.fn(),
+    mockListMetronomeContracts: vi.fn(),
     mockPrices,
     mockScheduleMetronomeContractEnd: vi.fn(),
     mockSyncMauCount: vi.fn(),
@@ -56,6 +57,7 @@ vi.mock("@app/lib/metronome/client", () => ({
   getMetronomeContractById: mockGetMetronomeContractById,
   getMetronomeCustomerStripeCustomerId:
     mockGetMetronomeCustomerStripeCustomerId,
+  listMetronomeContracts: mockListMetronomeContracts,
   scheduleMetronomeContractEnd: mockScheduleMetronomeContractEnd,
 }));
 
@@ -138,6 +140,9 @@ beforeEach(() => {
 
   mockScheduleMetronomeContractEnd.mockReset();
   mockScheduleMetronomeContractEnd.mockResolvedValue(new Ok(undefined));
+
+  mockListMetronomeContracts.mockReset();
+  mockListMetronomeContracts.mockResolvedValue(new Ok([]));
 
   mockGetMetronomeContractById.mockReset();
   mockGetMetronomeContractById.mockResolvedValue(new Ok(CONTRACT));
@@ -737,65 +742,86 @@ describe("provisionMetronomeContract", () => {
   });
 });
 
-describe("switchMetronomeContractPackage", () => {
-  it("syncs seats and MAU when the contract has both subscriptions", async () => {
-    const result = await switchMetronomeContractPackage({
+describe("provisionMetronomeContract — overlap sunset", () => {
+  it("ends non-archived contracts that overlap with the new start", async () => {
+    mockListMetronomeContracts.mockResolvedValue(
+      new Ok([
+        // overlaps — starts before, no end
+        {
+          id: "overlap-1",
+          starting_at: "2026-03-01T00:00:00.000Z",
+          ending_before: null,
+          archived_at: null,
+        },
+        // starts AFTER the new start — skipped
+        {
+          id: "future",
+          starting_at: "2026-05-01T00:00:00.000Z",
+          ending_before: null,
+          archived_at: null,
+        },
+        // ended BEFORE the new start — skipped
+        {
+          id: "ended",
+          starting_at: "2026-03-01T00:00:00.000Z",
+          ending_before: "2026-03-15T00:00:00.000Z",
+          archived_at: null,
+        },
+        // archived — skipped
+        {
+          id: "archived",
+          starting_at: "2026-03-01T00:00:00.000Z",
+          ending_before: null,
+          archived_at: "2026-03-10T00:00:00.000Z",
+        },
+        // the newly-created contract — skipped by id
+        {
+          id: "m-contract",
+          starting_at: START_DATE,
+          ending_before: null,
+          archived_at: null,
+        },
+      ])
+    );
+
+    const result = await provisionMetronomeContract({
       metronomeCustomerId: "m-customer",
-      oldContractId: "old-contract",
       workspace: WORKSPACE,
-      packageAlias: "legacy-business",
-      enableStripeBilling: false,
-      planCode: "PRO_PLAN_SEAT_39",
-      swapAt: "current-hour",
+      packageAlias: "legacy-pro-monthly",
+      uniquenessKey: "uniq_123",
+      startingAt: new Date(START_DATE),
+      planCode: "PRO_PLAN_SEAT_29",
     });
 
     expect(result.isOk()).toBe(true);
     expect(mockScheduleMetronomeContractEnd).toHaveBeenCalledTimes(1);
-    expect(mockSyncSeatCount).toHaveBeenCalledTimes(1);
-    expect(mockSyncSeatCount).toHaveBeenCalledWith({
-      metronomeCustomerId: "m-customer",
-      contractId: "m-contract",
-      workspace: WORKSPACE,
-      startingAt: START_DATE,
-      contract: CONTRACT,
-    });
-    expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
+    expect(mockScheduleMetronomeContractEnd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: "m-customer",
+        contractId: "overlap-1",
+      })
+    );
   });
 
-  it("skips seat sync when the switched contract has no seat subscription", async () => {
-    mockGetSeatSubscriptionIdFromContract.mockReturnValue(undefined);
+  it("returns an error when listing contracts fails", async () => {
+    mockListMetronomeContracts.mockResolvedValue(
+      new Err(new Error("list failed"))
+    );
 
-    const result = await switchMetronomeContractPackage({
+    const result = await provisionMetronomeContract({
       metronomeCustomerId: "m-customer",
-      oldContractId: "old-contract",
       workspace: WORKSPACE,
-      packageAlias: "legacy-enterprise-eur",
-      enableStripeBilling: false,
-      planCode: "PRO_PLAN_SEAT_39",
-      swapAt: "current-hour",
+      packageAlias: "legacy-pro-monthly",
+      uniquenessKey: "uniq_123",
+      startingAt: new Date(START_DATE),
+      planCode: "PRO_PLAN_SEAT_29",
     });
 
-    expect(result.isOk()).toBe(true);
-    expect(mockSyncSeatCount).not.toHaveBeenCalled();
-    expect(mockSyncMauCount).toHaveBeenCalledTimes(1);
-  });
-
-  it("skips MAU sync when the switched contract has no MAU subscription", async () => {
-    mockHasMauSubscriptionInContract.mockReturnValue(false);
-
-    const result = await switchMetronomeContractPackage({
-      metronomeCustomerId: "m-customer",
-      oldContractId: "old-contract",
-      workspace: WORKSPACE,
-      packageAlias: "legacy-business",
-      enableStripeBilling: false,
-      planCode: "PRO_PLAN_SEAT_39",
-      swapAt: "current-hour",
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(mockSyncSeatCount).toHaveBeenCalledTimes(1);
-    expect(mockSyncMauCount).not.toHaveBeenCalled();
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("expected error");
+    }
+    expect(result.error.message).toContain("failed to list");
   });
 });
 

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -9,6 +9,7 @@ import {
   getMetronomeClient,
   getMetronomeContractById,
   getMetronomeCustomerStripeCustomerId,
+  listMetronomeContracts,
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
 import {
@@ -54,85 +55,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import type Stripe from "stripe";
 import { metronomeAmount } from "./amounts";
-
-/**
- * Switch a Metronome contract to a different package (end old + create new),
- * or create the first contract on the customer when `oldContractId` is null.
- * Customer must already exist.
- *
- * `swapAt` controls when the swap happens:
- *  - `"current-hour"`: floor to the current hour boundary (in the past). Use
- *    for seat-based plans (Pro, Business) where the current partial hour has
- *    no usage to attribute. The new contract is effectively active "now", so
- *    callers can flip the DB subscription synchronously.
- *  - `"next-hour"`: ceil to the next hour boundary (in the future, by up to
- *    one hour). Preserves the current partial hour's usage on the old
- *    contract — required for MAU-based Enterprise plans. Callers should
- *    defer the DB flip until `contract.start` fires.
- */
-export async function switchMetronomeContractPackage({
-  metronomeCustomerId,
-  oldContractId,
-  workspace,
-  packageAlias,
-  enableStripeBilling,
-  planCode,
-  swapAt,
-}: {
-  metronomeCustomerId: string;
-  oldContractId: string | null;
-  workspace: LightWorkspaceType;
-  packageAlias: string;
-  enableStripeBilling: boolean;
-  planCode: string;
-  swapAt: "current-hour" | "next-hour";
-}): Promise<Result<{ metronomeContractId: string }, Error>> {
-  const switchAt = new Date(
-    swapAt === "current-hour"
-      ? floorToHourISO(new Date())
-      : ceilToHourISO(new Date())
-  );
-
-  if (oldContractId) {
-    const endResult = await scheduleMetronomeContractEnd({
-      metronomeCustomerId,
-      contractId: oldContractId,
-      endingBefore: switchAt,
-    });
-    if (endResult.isErr()) {
-      return new Err(endResult.error);
-    }
-  }
-
-  const contractResult = await createMetronomeContract({
-    metronomeCustomerId,
-    packageAlias,
-    // Retries dedup against the same successor. When switching, the old
-    // contract is unique enough; for first contracts use customer+package+plan.
-    uniquenessKey: oldContractId
-      ? `switch:${oldContractId}`
-      : `switch:${metronomeCustomerId}:${packageAlias}:${planCode}`,
-    startingAt: switchAt,
-    enableStripeBilling,
-    planCode,
-  });
-  if (contractResult.isErr()) {
-    return new Err(contractResult.error);
-  }
-
-  const { contractId: metronomeContractId } = contractResult.value;
-  const syncResult = await syncContractQuantities(
-    metronomeCustomerId,
-    metronomeContractId,
-    workspace,
-    switchAt.toISOString()
-  );
-  if (syncResult.isErr()) {
-    return new Err(syncResult.error);
-  }
-
-  return new Ok({ metronomeContractId });
-}
 
 /**
  * Idempotently ensure a Metronome customer exists for a workspace and that
@@ -268,8 +190,17 @@ export async function resolveCurrencyForExistingMetronomeCustomer({
 
 /**
  * Provision a Metronome contract on an already-existing Metronome customer.
- * Creates the contract from the given package alias, then syncs seat / MAU
- * subscription quantities seeded by the package.
+ * Snaps `startingAt` to an hour boundary, ends any non-archived existing
+ * contracts that would overlap the new start (a customer must never have two
+ * overlapping active contracts), creates the contract from the given package
+ * alias, then syncs seat / MAU subscription quantities seeded by the package.
+ *
+ * `swapAt` controls how `startingAt` is snapped:
+ *  - `"current-hour"` (default): floor — for seat-based plans where the
+ *    current partial hour has no usage to attribute. New contract is active
+ *    immediately.
+ *  - `"next-hour"`: ceil — preserves the current partial hour on whatever
+ *    contract was running; required when usage attribution matters.
  *
  * The Metronome customer must already exist (call
  * `ensureMetronomeCustomerForWorkspace` first).
@@ -280,45 +211,99 @@ export async function provisionMetronomeContract({
   packageAlias,
   uniquenessKey,
   startingAt,
+  swapAt = "current-hour",
   enableStripeBilling = true,
   planCode,
 }: {
   metronomeCustomerId: string;
   workspace: LightWorkspaceType;
   packageAlias: string;
-  uniquenessKey: string;
-  // Must already be on an hour boundary (Metronome requirement).
+  uniquenessKey?: string;
   startingAt: Date;
+  swapAt?: "current-hour" | "next-hour";
   enableStripeBilling?: boolean;
   planCode: string;
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
+  const alignedStart = new Date(
+    swapAt === "current-hour"
+      ? floorToHourISO(startingAt)
+      : ceilToHourISO(startingAt)
+  );
+
   logger.info(
     {
       metronomeCustomerId,
       workspaceId: workspace.sId,
       packageAlias,
       enableStripeBilling,
+      startingAt: alignedStart.toISOString(),
+      swapAt,
     },
     "[Metronome] Provisioning contract"
   );
+
   const contractResult = await createMetronomeContract({
     metronomeCustomerId,
     packageAlias,
     uniquenessKey,
-    startingAt,
+    startingAt: alignedStart,
     enableStripeBilling,
     planCode,
   });
   if (contractResult.isErr()) {
     return new Err(contractResult.error);
   }
-
   const { contractId: metronomeContractId } = contractResult.value;
+
+  const contractsResult = await listMetronomeContracts(metronomeCustomerId);
+  if (contractsResult.isErr()) {
+    return new Err(
+      new Error(
+        `Created new contract ${metronomeContractId} but failed to list ` +
+          `existing contracts to sunset: ${contractsResult.error.message}. ` +
+          "Manual cleanup may be required."
+      )
+    );
+  }
+  const newStartMs = alignedStart.getTime();
+  for (const existing of contractsResult.value) {
+    if (existing.id === metronomeContractId) {
+      continue;
+    }
+    if (existing.archived_at) {
+      continue;
+    }
+    const existingStartMs = new Date(existing.starting_at).getTime();
+    if (existingStartMs > newStartMs) {
+      continue;
+    }
+    const existingEndsBeforeMs = existing.ending_before
+      ? new Date(existing.ending_before).getTime()
+      : null;
+    if (existingEndsBeforeMs !== null && existingEndsBeforeMs <= newStartMs) {
+      continue;
+    }
+    const sunsetResult = await scheduleMetronomeContractEnd({
+      metronomeCustomerId,
+      contractId: existing.id,
+      endingBefore: alignedStart,
+    });
+    if (sunsetResult.isErr()) {
+      return new Err(
+        new Error(
+          `Created new contract ${metronomeContractId} but failed to ` +
+            `sunset existing contract ${existing.id}: ` +
+            `${sunsetResult.error.message}. Manual cleanup may be required.`
+        )
+      );
+    }
+  }
+
   const syncResult = await syncContractQuantities(
     metronomeCustomerId,
     metronomeContractId,
     workspace,
-    startingAt.toISOString()
+    alignedStart.toISOString()
   );
   if (syncResult.isErr()) {
     return new Err(syncResult.error);
@@ -1069,10 +1054,14 @@ export async function provisionShadowEnterpriseMetronomeContract({
   }
   const { metronomeCustomerId } = customerResult.value;
 
-  // Create the (empty) contract directly — overrides below will add the MAU
-  // subscriptions with the right initial quantities.
-  const contractResult = await createMetronomeContract({
+  // Create the (initially empty) contract — overrides below will add the
+  // MAU subscriptions with the right initial quantities. The shared provision
+  // helper also sunsets any overlapping contracts on the customer; the inner
+  // quantity sync is a no-op here because no seat/MAU subscriptions exist
+  // until `applyEnterpriseOverrides` runs.
+  const contractResult = await provisionMetronomeContract({
     metronomeCustomerId,
+    workspace,
     packageAlias,
     uniquenessKey: stripeSubscription.id,
     startingAt: new Date(startDate),
@@ -1082,7 +1071,7 @@ export async function provisionShadowEnterpriseMetronomeContract({
   if (contractResult.isErr()) {
     return new Err(contractResult.error);
   }
-  const { contractId: metronomeContractId } = contractResult.value;
+  const { metronomeContractId } = contractResult.value;
 
   // Count MAUs for initial subscription quantities on the first invoice.
   const initialMauCount = await countMauForWorkspace(

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -7,9 +7,9 @@ import { DustError } from "@app/lib/error";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
+  provisionMetronomeContract,
   provisionShadowEnterpriseMetronomeContract,
   resolveCurrencyForExistingMetronomeCustomer,
-  switchMetronomeContractPackage,
   syncContractQuantities,
 } from "@app/lib/metronome/contracts";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
@@ -1015,17 +1015,18 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         LEGACY_BUSINESS_PACKAGE_ALIAS,
         billingCurrencyResult.value
       );
-      const result = await switchMetronomeContractPackage({
+      const result = await provisionMetronomeContract({
         metronomeCustomerId: owner.metronomeCustomerId,
-        oldContractId: this.metronomeContractId,
         workspace: owner,
         packageAlias,
-        enableStripeBilling: isSubscriptionMetronomeBilled(this.toJSON()),
-        planCode: PRO_PLAN_SEAT_39_CODE,
+        uniquenessKey: `switch:${this.metronomeContractId}`,
+        startingAt: new Date(),
         // Business is seat-based — swap at the current hour boundary so the
         // new contract is active immediately and the sync DB flip below is
         // consistent with Metronome.
         swapAt: "current-hour",
+        enableStripeBilling: isSubscriptionMetronomeBilled(this.toJSON()),
+        planCode: PRO_PLAN_SEAT_39_CODE,
       });
       if (result.isErr() && !this.isMetronomeShadowBilled) {
         return new Err(result.error);

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -1,12 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
-import {
-  createMetronomeContract,
-  listMetronomeContracts,
-  listMetronomePackages,
-} from "@app/lib/metronome/client";
+import { listMetronomePackages } from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
-  switchMetronomeContractPackage,
+  provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
 import { PlanModel } from "@app/lib/models/plan";
 import {
@@ -32,9 +28,6 @@ vi.mock("@app/lib/metronome/client", async () => {
   return {
     ...actual,
     listMetronomePackages: vi.fn(),
-    createMetronomeContract: vi.fn(),
-    listMetronomeContracts: vi.fn(),
-    scheduleMetronomeContractEnd: vi.fn(),
   };
 });
 
@@ -45,17 +38,7 @@ vi.mock("@app/lib/metronome/contracts", async () => {
   return {
     ...actual,
     ensureMetronomeCustomerForWorkspace: vi.fn(),
-    switchMetronomeContractPackage: vi.fn(),
-  };
-});
-
-vi.mock("@app/lib/api/subscription", async () => {
-  const actual = await vi.importActual<
-    typeof import("@app/lib/api/subscription")
-  >("@app/lib/api/subscription");
-  return {
-    ...actual,
-    restoreWorkspaceAfterSubscription: vi.fn(),
+    provisionMetronomeContract: vi.fn(),
   };
 });
 
@@ -215,17 +198,13 @@ beforeEach(() => {
       },
     ])
   );
-  vi.mocked(createMetronomeContract).mockResolvedValue(
-    new Ok({ contractId: NEW_CONTRACT_ID })
-  );
-  vi.mocked(listMetronomeContracts).mockResolvedValue(new Ok([]));
-  vi.mocked(switchMetronomeContractPackage).mockResolvedValue(
+  vi.mocked(provisionMetronomeContract).mockResolvedValue(
     new Ok({ metronomeContractId: NEW_CONTRACT_ID })
   );
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () => {
-  it("creates a future-scheduled contract and leaves the subscription untouched", async () => {
+  it("provisions a future-scheduled contract and leaves the DB subscription for contract.start", async () => {
     await ensureEnterprisePlan();
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
@@ -239,15 +218,16 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () =>
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(createMetronomeContract).toHaveBeenCalledWith(
+    expect(provisionMetronomeContract).toHaveBeenCalledWith(
       expect.objectContaining({
         metronomeCustomerId: METRONOME_CUSTOMER_ID,
-        packageId: ENT_PACKAGE_ID,
+        packageAlias: "legacy-enterprise",
         planCode: ENT_PLAN_CODE,
+        swapAt: "next-hour",
       })
     );
 
-    // Subscription DB record is unchanged: still points at the old contract.
+    // DB subscription unchanged — the contract.start webhook will flip it.
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
@@ -312,12 +292,12 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () =>
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.message).toContain("resolves to EUR");
     expect(res._getJSONData().error.message).toContain("Pick a EUR package");
-    expect(createMetronomeContract).not.toHaveBeenCalled();
+    expect(provisionMetronomeContract).not.toHaveBeenCalled();
   });
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", () => {
-  it("switches Pro contract at current hour and sync-flips the DB", async () => {
+  it("provisions a Pro contract at the current hour and leaves the DB subscription for contract.start", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
@@ -330,24 +310,23 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(switchMetronomeContractPackage).toHaveBeenCalledWith(
+    expect(provisionMetronomeContract).toHaveBeenCalledWith(
       expect.objectContaining({
-        oldContractId: EXISTING_CONTRACT_ID,
         packageAlias: "legacy-pro-monthly",
         planCode: PRO_PLAN_SEAT_29_CODE,
         swapAt: "current-hour",
       })
     );
 
+    // DB subscription unchanged — the contract.start webhook will flip it.
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
     const sub = adminAuth.subscriptionResource();
-    expect(sub!.metronomeContractId).toBe(NEW_CONTRACT_ID);
-    expect(sub!.getPlan().code).toBe(PRO_PLAN_SEAT_29_CODE);
+    expect(sub!.metronomeContractId).toBe(EXISTING_CONTRACT_ID);
   });
 
-  it("switches Business contract at current hour and sync-flips the DB", async () => {
+  it("provisions a Business contract at the current hour", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
@@ -360,7 +339,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(switchMetronomeContractPackage).toHaveBeenCalledWith(
+    expect(provisionMetronomeContract).toHaveBeenCalledWith(
       expect.objectContaining({
         packageAlias: "legacy-business",
         planCode: PRO_PLAN_SEAT_39_CODE,
@@ -369,7 +348,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
     );
   });
 
-  it("rejects when startingAt is provided", async () => {
+  it("accepts startingAt and schedules at the next hour boundary", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
@@ -381,11 +360,16 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(400);
-    expect(res._getJSONData().error.message).toContain("not supported");
+    expect(res._getStatusCode()).toBe(200);
+    expect(provisionMetronomeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packageAlias: "legacy-pro-monthly",
+        swapAt: "next-hour",
+      })
+    );
   });
 
-  it("creates the first Pro contract and sync-flips the DB when the workspace has no current Metronome contract", async () => {
+  it("provisions the first Pro contract when the workspace has no current Metronome contract", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
@@ -399,21 +383,13 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(switchMetronomeContractPackage).toHaveBeenCalledWith(
+    expect(provisionMetronomeContract).toHaveBeenCalledWith(
       expect.objectContaining({
-        oldContractId: null,
         packageAlias: "legacy-pro-monthly",
         planCode: PRO_PLAN_SEAT_29_CODE,
         swapAt: "current-hour",
       })
     );
-
-    const adminAuth = await Authenticator.internalAdminForWorkspace(
-      workspace.sId
-    );
-    const sub = adminAuth.subscriptionResource();
-    expect(sub!.metronomeContractId).toBe(NEW_CONTRACT_ID);
-    expect(sub!.getPlan().code).toBe(PRO_PLAN_SEAT_29_CODE);
   });
 });
 

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -1,24 +1,14 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
-import {
-  isMetronomeBillingEnabled,
-  restoreWorkspaceAfterSubscription,
-} from "@app/lib/api/subscription";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import {
-  ceilToHourISO,
-  createMetronomeContract,
-  listMetronomeContracts,
-  listMetronomePackages,
-  scheduleMetronomeContractEnd,
-} from "@app/lib/metronome/client";
+import { listMetronomePackages } from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
-  switchMetronomeContractPackage,
+  provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
-import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import type { MetronomePackageTier } from "@app/lib/metronome/types";
 import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
 import {
@@ -29,9 +19,7 @@ import {
 import { getStripeCustomer } from "@app/lib/plans/stripe";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
-import type { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
@@ -263,203 +251,50 @@ async function handler(
     });
   }
 
-  // Branch on tier — enterprise schedules in the future, pro/business swap now.
-  if (pkg.tier === "enterprise") {
-    return handleEnterpriseSwitch({
-      req,
-      res,
-      pluginRun,
-      owner,
-      body,
-      pkg,
-      metronomeCustomerId,
-    });
-  }
-
-  if (!currentSubscription) {
-    const errorMessage = "Workspace has no active subscription to switch from.";
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
-    });
-  }
-
-  return handleProOrBusinessSwitch({
-    req,
-    res,
-    pluginRun,
-    auth,
-    owner,
-    body,
-    pkg,
-    metronomeCustomerId,
-    currentSubscription,
-  });
-}
-
-async function handleEnterpriseSwitch({
-  req,
-  res,
-  pluginRun,
-  owner,
-  body,
-  pkg,
-  metronomeCustomerId,
-}: {
-  req: NextApiRequest;
-  res: NextApiResponse<WithAPIErrorResponse<SwitchContractSuccessResponseBody>>;
-  pluginRun: PluginRunResource;
-  owner: ReturnType<Authenticator["workspace"]>;
-  body: z.infer<typeof SwitchContractBodySchema>;
-  pkg: { id: string; name: string };
-  metronomeCustomerId: string;
-}): Promise<void> {
-  if (!body.startingAt) {
-    const errorMessage =
-      "startingAt is required for enterprise packages and must be at least " +
-      "one hour in the future.";
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
-    });
-  }
-  const ONE_HOUR_MS = 60 * 60 * 1000;
-  const requestedStartMs = Date.parse(body.startingAt);
-  if (Number.isNaN(requestedStartMs)) {
-    const errorMessage = "startingAt is not a valid ISO timestamp.";
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
-    });
-  }
-  if (requestedStartMs < Date.now() + ONE_HOUR_MS) {
-    const errorMessage = "startingAt must be at least one hour in the future.";
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
-    });
-  }
-
-  const startingAtDate = new Date(ceilToHourISO(new Date(requestedStartMs)));
-
-  const createResult = await createMetronomeContract({
-    metronomeCustomerId,
-    packageId: pkg.id,
-    uniquenessKey: `switch-contract:${metronomeCustomerId}:${pkg.id}:${body.planCode}:${startingAtDate.toISOString()}`,
-    startingAt: startingAtDate,
-    enableStripeBilling: true,
-    planCode: body.planCode,
-  });
-  if (createResult.isErr()) {
-    const errorMessage = `Failed to create Metronome contract: ${createResult.error.message}`;
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 502,
-      api_error: { type: "internal_server_error", message: errorMessage },
-    });
-  }
-  const newMetronomeContractId = createResult.value.contractId;
-
-  // Sunset any non-archived contract that overlaps with our new contract's
-  // window. Same logic as upgrade_enterprise.ts.
-  const contractsResult = await listMetronomeContracts(metronomeCustomerId);
-  if (contractsResult.isErr()) {
-    const errorMessage =
-      `Created new contract ${newMetronomeContractId} but failed to list ` +
-      `existing contracts to sunset: ${contractsResult.error.message}. ` +
-      "Manual cleanup may be required.";
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 502,
-      api_error: { type: "internal_server_error", message: errorMessage },
-    });
-  }
-
-  const newStartMs = startingAtDate.getTime();
-  for (const existing of contractsResult.value) {
-    if (existing.id === newMetronomeContractId) {
-      continue;
-    }
-    if (existing.archived_at) {
-      continue;
-    }
-    const existingStartMs = new Date(existing.starting_at).getTime();
-    if (existingStartMs > newStartMs) {
-      continue;
-    }
-    const existingEndsBeforeMs = existing.ending_before
-      ? new Date(existing.ending_before).getTime()
-      : null;
-    if (existingEndsBeforeMs !== null && existingEndsBeforeMs <= newStartMs) {
-      continue;
-    }
-    const sunsetResult = await scheduleMetronomeContractEnd({
-      metronomeCustomerId,
-      contractId: existing.id,
-      endingBefore: startingAtDate,
-    });
-    if (sunsetResult.isErr()) {
-      const errorMessage =
-        `Created new contract ${newMetronomeContractId} but failed to sunset ` +
-        `existing contract ${existing.id}: ${sunsetResult.error.message}. ` +
-        "Manual cleanup may be required.";
+  // Resolve when the swap happens.
+  //  - startingAt provided: schedule at the requested moment, ceiled to the
+  //    next hour boundary. Must be ≥1h in the future.
+  //  - startingAt omitted: swap immediately at the current hour boundary.
+  //    Required when the package is enterprise-tier (no immediate swap).
+  let startingAtDate: Date;
+  let swapAt: "current-hour" | "next-hour";
+  if (body.startingAt) {
+    const requestedStartMs = Date.parse(body.startingAt);
+    if (Number.isNaN(requestedStartMs)) {
+      const errorMessage = "startingAt is not a valid ISO timestamp.";
       await pluginRun.recordError(errorMessage);
       return apiError(req, res, {
-        status_code: 502,
-        api_error: { type: "internal_server_error", message: errorMessage },
+        status_code: 400,
+        api_error: { type: "invalid_request_error", message: errorMessage },
       });
     }
+    const ONE_HOUR_MS = 60 * 60 * 1000;
+    if (requestedStartMs < Date.now() + ONE_HOUR_MS) {
+      const errorMessage =
+        "startingAt must be at least one hour in the future.";
+      await pluginRun.recordError(errorMessage);
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: { type: "invalid_request_error", message: errorMessage },
+      });
+    }
+    startingAtDate = new Date(requestedStartMs);
+    swapAt = "next-hour";
+  } else {
+    if (pkg.tier === "enterprise") {
+      const errorMessage =
+        "startingAt is required for enterprise packages and must be at " +
+        "least one hour in the future.";
+      await pluginRun.recordError(errorMessage);
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: { type: "invalid_request_error", message: errorMessage },
+      });
+    }
+    startingAtDate = new Date();
+    swapAt = "current-hour";
   }
 
-  await pluginRun.recordResult({
-    display: "text",
-    value:
-      `Workspace ${owner!.name} scheduled to switch to plan ${body.planCode} ` +
-      `at ${startingAtDate.toISOString()} (Metronome contract ${newMetronomeContractId}). ` +
-      "Subscription will flip when the contract.start webhook fires.",
-  });
-  res.status(200).json({ success: true });
-}
-
-async function handleProOrBusinessSwitch({
-  req,
-  res,
-  pluginRun,
-  auth,
-  owner,
-  body,
-  pkg,
-  metronomeCustomerId,
-  currentSubscription,
-}: {
-  req: NextApiRequest;
-  res: NextApiResponse<WithAPIErrorResponse<SwitchContractSuccessResponseBody>>;
-  pluginRun: PluginRunResource;
-  auth: Authenticator;
-  owner: ReturnType<Authenticator["workspace"]>;
-  body: z.infer<typeof SwitchContractBodySchema>;
-  pkg: { id: string; name: string; aliases: string[] };
-  metronomeCustomerId: string;
-  currentSubscription: SubscriptionResource;
-}): Promise<void> {
-  if (body.startingAt) {
-    const errorMessage =
-      "startingAt is not supported for Pro/Business packages — they swap at " +
-      "the current hour boundary. Omit the field.";
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
-    });
-  }
-
-  // Pro/Business packages are picked by alias for switchMetronomeContractPackage.
-  // Pick the first known alias on the package (the legacy aliases are 1:1
-  // with packages in metronome_setup.ts).
   const packageAlias = pkg.aliases[0];
   if (!packageAlias) {
     const errorMessage = `Package ${pkg.id} has no alias to switch to.`;
@@ -470,66 +305,31 @@ async function handleProOrBusinessSwitch({
     });
   }
 
-  // When the workspace has no Metronome contract yet, fall through to the
-  // same call with `oldContractId: null` — `switchMetronomeContractPackage`
-  // skips the end-of-old step and just creates the first contract.
-  const currentMetronomeContractId =
-    currentSubscription.metronomeContractId ?? null;
-
-  const switchResult = await switchMetronomeContractPackage({
+  const provisionResult = await provisionMetronomeContract({
     metronomeCustomerId,
-    oldContractId: currentMetronomeContractId,
-    workspace: renderLightWorkspaceType({ workspace: owner! }),
+    workspace: renderLightWorkspaceType({ workspace: owner }),
     packageAlias,
+    startingAt: startingAtDate,
+    swapAt,
     enableStripeBilling: true,
     planCode: body.planCode,
-    swapAt: "current-hour",
   });
-  if (switchResult.isErr()) {
-    const errorMessage = `Failed to switch Metronome contract: ${switchResult.error.message}`;
+  if (provisionResult.isErr()) {
+    const errorMessage = `Failed to provision Metronome contract: ${provisionResult.error.message}`;
     await pluginRun.recordError(errorMessage);
     return apiError(req, res, {
       status_code: 502,
       api_error: { type: "internal_server_error", message: errorMessage },
     });
   }
-  const { metronomeContractId: newMetronomeContractId } = switchResult.value;
-
-  // Sync DB flip: end old subscription, create new on the target plan
-  // pointing at the new contract. Mirrors the contract.start webhook handler.
-  try {
-    await currentSubscription.swapMetronomeContract({
-      metronomeContractId: newMetronomeContractId,
-      planCode: body.planCode,
-    });
-  } catch (err) {
-    const errorMessage =
-      `Switched Metronome contract to ${newMetronomeContractId} but failed ` +
-      `to update the DB subscription: ${err instanceof Error ? err.message : String(err)}. ` +
-      "Manual cleanup may be required.";
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 502,
-      api_error: { type: "internal_server_error", message: errorMessage },
-    });
-  }
-  await invalidateContractCache(owner!.sId);
-  await restoreWorkspaceAfterSubscription(auth);
-
-  logger.info(
-    {
-      workspaceId: owner!.sId,
-      planCode: body.planCode,
-      metronomeContractId: newMetronomeContractId,
-    },
-    "[Poke] Workspace switched to Pro/Business plan via switch_contract"
-  );
+  const { metronomeContractId } = provisionResult.value;
 
   await pluginRun.recordResult({
     display: "text",
     value:
-      `Workspace ${owner!.name} switched to plan ${body.planCode} ` +
-      `(Metronome contract ${newMetronomeContractId}).`,
+      `Workspace ${owner.name} scheduled to switch to plan ${body.planCode} ` +
+      `(Metronome contract ${metronomeContractId}). Subscription will flip ` +
+      "when the contract.start webhook fires.",
   });
   res.status(200).json({ success: true });
 }


### PR DESCRIPTION
## Description

Consolidates Metronome contract creation. Every contract now goes through a single helper that handles boundary alignment, overlap sunset, and quantity sync — and the poke `switch_contract` handler has one path instead of one per tier.

- `lib/metronome/contracts.ts`
  - Deleted `switchMetronomeContractPackage`.
  - Extended `provisionMetronomeContract`:
    - New `swapAt: "current-hour" | "next-hour"` (default `"current-hour"`) snaps `startingAt` to an hour boundary via floor/ceil.
    - Always lists customer contracts and `scheduleMetronomeContractEnd`s any non-archived overlap. Overlapping active contracts are an invariant violation, so this isn't opt-in.
    - `uniquenessKey` is now optional.
  - `provisionShadowEnterpriseMetronomeContract` routes the create through `provisionMetronomeContract` for free overlap sunset; still calls `countMauForWorkspace` + `applyEnterpriseOverrides` so the first shadow invoice has the correct MAU.

- `pages/api/poke/workspaces/[wId]/switch_contract.ts`
  - Collapsed `handleEnterpriseSwitch` + `handleProOrBusinessSwitch` into one path.
  - `startingAt` policy:
    - Provided → must be ≥1h in the future → schedule with `swapAt: "next-hour"`.
    - Omitted → required for `enterprise` tier (reject), otherwise default to now with `swapAt: "current-hour"`.
  - Dropped the sync DB flip and the `switchMetronomeContractPackage` import: the DB transition is now driven by the `contract.start` webhook for every tier (the eventual end state, per discussion).
  - Dropped the `uniquenessKey` from this call site — the sunset loop reconciles any duplicates from in-call SDK retries.

- `lib/resources/subscription_resource.ts`
  - `upgradeToBusinessPlan` migrated from `switchMetronomeContractPackage` to `provisionMetronomeContract({ swapAt: "current-hour" })`; keeps `uniquenessKey: 'switch:\${this.metronomeContractId}'` for retry safety.

## Tests

- `npx tsgo --noEmit` clean.
- `npm run test -- contracts.test` — 29/29 pass (new coverage for the unconditional overlap sunset: filter logic and list-error propagation).
- `npm run test -- switch_contract.test` — 10/10 pass (mocks `provisionMetronomeContract` instead of `switchMetronomeContractPackage`; tests now assert that the DB sub is left for the webhook to flip, and that Pro/Business accepts an optional future `startingAt`).
- `npm run test -- subscriptions/index.test` — 6/6 pass.
- `npm run test -- metronome/webhook.test` — 8/8 pass.

## Risk

Medium-low.

- **Behaviour change for poke switch_contract — DB transition is no longer synchronous for Pro/Business.** Previously the handler did the swap inline via `swapMetronomeContract` + `restoreWorkspaceAfterSubscription`; it now waits for the `contract.start` Metronome webhook. Because the new contract starts at the floored current hour (a moment in the past), the webhook fires immediately/very soon and the existing idempotency branch handles redelivery. UI may briefly show the old sub until the webhook lands.
- **Sunset is now unconditional on every `provisionMetronomeContract` call** (including Stripe checkout and shadow enterprise paths, which didn't sunset before). These flows happen on fresh Stripe subscriptions where the customer should have no overlapping active contracts; if one exists it's by definition stale and should be sunset. The filter (non-archived, starts ≤ new start, doesn't end before new start) matches the previous Enterprise-only logic.
- No public API changes. Rollback is a single revert.

## Deploy Plan

Standard deploy. No migration, no config change.