### PR TITLE
Projects knowledge -> files, fix icons and borders for conversations list.

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -19,10 +19,10 @@ import type { BreadcrumbItem } from "@dust-tt/sparkle";
 import {
   ActionGitBranchIcon,
   ArrowLeftIcon,
-  AttachmentIcon,
   Breadcrumbs,
   Button,
   Chip,
+  FolderIcon,
   MoreIcon,
   Tooltip,
 } from "@dust-tt/sparkle";
@@ -172,7 +172,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
           <Button
             size="sm"
             label={isMobile ? undefined : "Files"}
-            icon={AttachmentIcon}
+            icon={FolderIcon}
             variant="ghost"
             onClick={() => openPanel({ type: "files" })}
           />

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -58,7 +58,7 @@ interface SpaceKnowledgeTabProps {
 }
 
 const PROJECT_KNOWLEDGE_MANAGEMENT_DISABLED_TOOLTIP =
-  "Adding knowledge to projects is disabled by your workspace admin.";
+  "Adding files to projects is disabled by your workspace admin.";
 
 type MenuItem = {
   kind: "item";
@@ -147,10 +147,10 @@ const KnowledgeSearchAndTable = memo(function KnowledgeSearchAndTable({
   return (
     <>
       <SearchInput
-        name="knowledge-search"
+        name="files-search"
         value={inputValue}
         onChange={setValue}
-        placeholder="Filter knowledge..."
+        placeholder="Filter..."
         className="w-full"
       />
       <KnowledgeFilteredDataTable
@@ -172,8 +172,8 @@ export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
   return (
     <FileDropProvider>
       <DropzoneContainer
-        description="Drop files here to upload knowledge."
-        title="Upload Knowledge"
+        description="Drop files here to upload them."
+        title="Upload files"
       >
         <SpaceKnowledgeTabContent owner={owner} space={space} />
       </DropzoneContainer>
@@ -517,7 +517,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
 
   const hasFiles = attachments.length > 0;
   const isUploading = projectFileUpload.isProcessingFiles;
-  const uploadButtonLabel = isUploading ? "Uploading..." : "Add knowledge";
+  const uploadButtonLabel = isUploading ? "Uploading..." : "Add";
   const isAddKnowledgeDisabled =
     !canManuallyManageProjectKnowledge || isUploading;
 
@@ -611,7 +611,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
       <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
         <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 py-8">
           <div className="flex gap-2">
-            <h3 className="heading-2xl flex-1 items-center">Knowledge</h3>
+            <h3 className="heading-2xl flex-1 items-center">Files</h3>
             {hasFiles && !isArchived && attachButtonWithPolicyTooltip}
           </div>
 
@@ -619,8 +619,8 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
             <EmptyCTA
               message={
                 isArchived
-                  ? "This project is archived. No knowledge has been added."
-                  : "No knowledge added to this project yet."
+                  ? "This project is archived. No files have been added."
+                  : "No files have been added to this project yet."
               }
               action={isArchived ? null : attachButtonWithPolicyTooltip}
             />

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -111,6 +111,7 @@ export function SpaceConversationListItem({
   return (
     <>
       <ConversationListItem
+        className="border-t-0 border-b-0"
         key={conversation.sId}
         conversation={{
           id: conversation.sId,

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -334,7 +334,7 @@ export function SpaceConversationsTab({
                       return (
                         <div key={dateLabel}>
                           <ListItemSection>{dateLabel}</ListItemSection>
-                          <ListGroup>
+                          <ListGroup className="border-b-0">
                             {dateConversations
                               .toSorted((a, b) => b.updated - a.updated)
                               .map((conversation) => (

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -38,10 +38,10 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import {
-  BookOpenIcon,
   ChatBubbleLeftRightIcon,
   CheckIcon,
   Cog6ToothIcon,
+  FolderIcon,
   Spinner,
   Tabs,
   TabsContent,
@@ -314,10 +314,10 @@ export function SpaceConversationsPage() {
               icon={CheckIcon}
             />
             <TabsTrigger
-              value="knowledge"
-              label={compactProjectTabs ? undefined : "Knowledge"}
-              tooltip={compactProjectTabs ? "Knowledge" : undefined}
-              icon={BookOpenIcon}
+              value="files"
+              label={compactProjectTabs ? undefined : "Files"}
+              tooltip={compactProjectTabs ? "Files" : undefined}
+              icon={FolderIcon}
             />
             <TabsTrigger
               value="settings"
@@ -365,7 +365,7 @@ export function SpaceConversationsPage() {
           />
         </TabsContent>
 
-        <TabsContent value="knowledge">
+        <TabsContent value="files">
           <SpaceKnowledgeTab owner={owner} space={spaceInfo} />
         </TabsContent>
 

--- a/front/hooks/useScopedUIPreferences.ts
+++ b/front/hooks/useScopedUIPreferences.ts
@@ -6,7 +6,7 @@ const SCOPED_UI_PREFERENCES_KEY_PREFIX = "scopedUIPreferences";
 
 const scopedUIPreferencesSchemaByScope = {
   projectUI: z.object({
-    tab: z.enum(["conversations", "tasks", "knowledge", "settings", "alpha"]),
+    tab: z.enum(["conversations", "tasks", "files", "settings", "alpha"]),
     conversationsFilter: z.enum(["all", "group", "with_me"]),
     tasksOwnerFilter: z
       .unknown()

--- a/front/hooks/useSpaceProjectTabs.ts
+++ b/front/hooks/useSpaceProjectTabs.ts
@@ -19,11 +19,11 @@ export function parseSpaceTabFromLocationHash(
     return fallbackTab;
   }
   const hash = window.location.hash.slice(1);
-  if (hash === "context") {
-    return "knowledge";
+  if (hash === "context" || hash === "knowledge") {
+    return "files";
   }
   if (
-    hash === "knowledge" ||
+    hash === "files" ||
     hash === "settings" ||
     hash === "conversations" ||
     hash === "tasks" ||

--- a/sparkle/src/components/ConversationListItem.tsx
+++ b/sparkle/src/components/ConversationListItem.tsx
@@ -1,5 +1,6 @@
 import { Avatar } from "@sparkle/components/Avatar";
 import { ListItem } from "@sparkle/components/ListItem";
+import { cn } from "@sparkle/lib/utils";
 import React, { type ReactNode } from "react";
 
 export interface ReplySectionProps {
@@ -105,6 +106,7 @@ export interface ConversationListItemProps {
   replySection?: ReactNode;
   onClick?: () => void;
   showFocus?: boolean;
+  className?: string;
 }
 
 export function ConversationListItem({
@@ -115,6 +117,7 @@ export function ConversationListItem({
   replySection,
   onClick,
   showFocus = false,
+  className,
 }: ConversationListItemProps) {
   const [isFocusVisible, setIsFocusVisible] = React.useState(false);
   const hasPlayedFocusForCurrentTriggerRef = React.useRef(false);
@@ -145,9 +148,14 @@ export function ConversationListItem({
     <ListItem
       onClick={onClick}
       groupName="conversation-item"
-      className={`s-transition-colors s-duration-500 ${
-        isFocusVisible ? "s-bg-highlight-50 dark:s-bg-highlight-100-night" : ""
-      }`}
+      className={cn(
+        `s-transition-colors s-duration-500 ${
+          isFocusVisible
+            ? "s-bg-highlight-50 dark:s-bg-highlight-100-night"
+            : ""
+        }`,
+        className
+      )}
     >
       {creator ? (
         <Avatar


### PR DESCRIPTION
## Description

Three small polish items.

**"Knowledge" → "Files"**

Renames the project "Knowledge" tab to "Files" throughout: tab value (`"knowledge"` → `"files"`), label, icon (`BookOpenIcon` → `FolderIcon`), `useScopedUIPreferences` schema, `useSpaceProjectTabs` hash parsing (with backward-compat for `#context` and `#knowledge` → `"files"`), and all copy in `SpaceKnowledgeTab` (heading, dropzone, button labels, empty states, tooltips). The "Files" button in `ConversationTitle` also switches from `AttachmentIcon` to `FolderIcon`.

**Conversation list border fix**

Align with design.

**`ConversationListItem` `className` prop**

Expose a `className` prop on `ConversationListItem` (merged via `cn`) to allow call-site border overrides without forking the component.

## Tests

Local

## Risk

Low — hash backward-compat ensures existing bookmarks still route correctly; all other changes are copy and CSS

## Deploy Plan

Deploy `front`
