### PR TITLE
Slack Tools: Fix Authentication error provider

### DIFF
--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -349,7 +349,7 @@ function isSlackTokenRevoked(error: unknown): boolean {
 // or null if the error should be handled by the caller.
 function handleSlackAuthError(error: unknown) {
   if (isSlackTokenRevoked(error) || isSlackMissingScope(error)) {
-    return new Ok(makePersonalAuthenticationError("slack").content);
+    return new Ok(makePersonalAuthenticationError("slack_tools").content);
   }
   return null;
 }
@@ -751,7 +751,7 @@ export function createSlackPersonalTools(
       if (!response.ok) {
         // Trigger authentication flow for missing_scope.
         if (response.error === "missing_scope") {
-          return new Ok(makePersonalAuthenticationError("slack").content);
+          return new Ok(makePersonalAuthenticationError("slack_tools").content);
         }
         return new Err(
           new MCPError(response.error ?? "Failed to list threads")


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/8030
See: https://github.com/dust-tt/dust/blob/main/front/lib/api/actions/servers/slack_personal/metadata.ts#L505
Full context: https://app.dust.tt/w/0ec9852c2f/conversation/QKUN4PGXEA

When slack tools auth failed for whatever reason, we reported the error under the wrong provider triggering a potential retry with the wrong provider leading to unhandled extraConfig for the `slack` provider.

[Datadog Logs](https://app.datadoghq.eu/logs?query=service%3Afront%20%28%40workspaceId%3ApYSh5Zk6Qh%20OR%20%40url%3A%2ApYSh5Zk6Qh%2A%20OR%20%40auditEvent.targets.id%3ApYSh5Zk6Qh%29%20%28%40provider%3Aslack_tools%20OR%20slack_tools%20OR%20%40url%3A%2Aoauth%2A%29%20%28%22OAuth%3A%20Invalid%20extraConfig%20before%20getting%20related%20credential%22%20OR%20%22Failed%20to%20get%20access%20token%20for%20admin-setup%20%20%20connection%20when%20updating%20the%20config%20for%20personal%20actions%22%20OR%20%22OAuth%3A%20Failed%20to%20create%20connection%22%20OR%20%22OAuth%3A%20Failed%20to%20finalize%20connection%22%20OR%20%22%5BOAuth%20Finalize%5D%20window.opener.postMessage%20failed%22%20OR%20%22%5BOAuth%20Finalize%5D%20BroadcastChannel%20failed%22%20OR%20%22oauth.authorized%3A%20skipping%20%20%20audit%20log%22%20OR%20%22Failed%20to%20emit%20audit%20log%20event%22%20OR%20%22Failed%20to%20create%20audit%20log%20event%22%20OR%20%22API%20Error%22%20OR%20%22Unhandled%20API%20Error%22%29&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ4TRB4RL2rMQgAAABhBWjRUUkNiM0FBQ25HQTNVRU1Zcm1nRGoAAAAkMDE5ZTEzNWMtOWUwMS00MjRkLTk1OTQtMjBiZjNiNTNhZGFiAAmB0Q&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1778406263369&to_ts=1778453430776&live=false)

## Tests

N/A

## Risk

Low, only kicks in in case of authentication errors.

## Deploy Plan

- deploy `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25517">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->