### PR TITLE
Tolerate syntax errors when extracting frame file refs

### DIFF
--- a/viz/app/lib/parseFileRefs.ts
+++ b/viz/app/lib/parseFileRefs.ts
@@ -32,6 +32,10 @@ export function extractFileRefs(code: string): FileRef[] {
       sourceType: "module",
       plugins: ["jsx", "typescript"],
       strictMode: false,
+      // AI-generated viz code occasionally contains spec-level syntax errors
+      // (e.g. `a ?? b || c` without parens). Recover and still walk the valid
+      // portions so we can prefetch refs.
+      errorRecovery: true,
     });
 
     traverse(ast, {
@@ -67,7 +71,7 @@ export function extractFileRefs(code: string): FileRef[] {
       },
     });
   } catch (err) {
-    logger.error({ err }, "Failed to parse frame code:");
+    logger.warn({ err }, "Failed to parse frame code:");
   }
 
   return refs;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The server-side prefetch path parses AI-generated visualization code with Babel to find `fil_xxx` IDs and scoped paths before rendering. AI output= occasionally contains spec-level syntax errors (most commonly `a ?? b || c`
without parens, which is a `SyntaxError` in every JS engine), which caused Babel to throw and the entire ref extraction to be skipped. 

This switches the parser to `errorRecovery: true` so Babel returns a partial AST and traversal still walks the valid portions of the file, recovering refs from code that would otherwise fail outright. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25519">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->