### PR TITLE
Store and show pending subscriptions

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -132,6 +132,7 @@ export function WorkspacePage() {
     hasMetronomeFeature,
     membersCount,
     metronomeCustomerId,
+    pendingSubscription,
     stripeSubscription,
     stripeCustomerId,
     subscriptions,
@@ -229,6 +230,7 @@ export function WorkspacePage() {
                   owner={owner}
                   metronomeCustomerId={metronomeCustomerId}
                   subscription={activeSubscription}
+                  pendingSubscription={pendingSubscription}
                   subscriptions={subscriptions}
                   programmaticUsageConfig={programmaticUsageConfig}
                   hasMetronomeBillingFeature={hasMetronomeFeature}

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -181,10 +181,103 @@ export function SubscriptionsDataTable({
   );
 }
 
+interface SubscriptionDetailsTableProps {
+  subscription: SubscriptionType;
+  metronomeCustomerId: string | null;
+}
+
+function SubscriptionDetailsTable({
+  subscription,
+  metronomeCustomerId,
+}: SubscriptionDetailsTableProps) {
+  return (
+    <PokeTable>
+      <PokeTableBody>
+        <PokeTableRow>
+          <PokeTableCell>Plan Name</PokeTableCell>
+          <PokeTableCell>{subscription.plan.name}</PokeTableCell>
+        </PokeTableRow>
+        <PokeTableRow>
+          <PokeTableCell>Plan Code</PokeTableCell>
+          <PokeTableCell>{subscription.plan.code}</PokeTableCell>
+        </PokeTableRow>
+        <PokeTableRow>
+          <PokeTableCell>Is in Trial?</PokeTableCell>
+          <PokeTableCell>{subscription.trialing ? "✅" : "❌"}</PokeTableCell>
+        </PokeTableRow>
+        <PokeTableRow>
+          <PokeTableCell>Stripe Subscription Id</PokeTableCell>
+          <PokeTableCell>
+            {subscription.stripeSubscriptionId ? (
+              <LinkWrapper
+                href={
+                  isDevelopment()
+                    ? `https://dashboard.stripe.com/test/subscriptions/${subscription.stripeSubscriptionId}`
+                    : `https://dashboard.stripe.com/subscriptions/${subscription.stripeSubscriptionId}`
+                }
+                target="_blank"
+                className="text-xs text-highlight-400"
+              >
+                {subscription.stripeSubscriptionId}
+              </LinkWrapper>
+            ) : (
+              "No subscription id"
+            )}
+          </PokeTableCell>
+        </PokeTableRow>
+        {subscription.metronomeContractId && metronomeCustomerId && (
+          <PokeTableRow>
+            <PokeTableCell>Metronome Contract</PokeTableCell>
+            <PokeTableCell>
+              <LinkWrapper
+                href={getMetronomeContractUrl(
+                  metronomeCustomerId,
+                  subscription.metronomeContractId
+                )}
+                target="_blank"
+                className="text-xs text-highlight-400"
+              >
+                {subscription.metronomeContractId}
+              </LinkWrapper>
+            </PokeTableCell>
+          </PokeTableRow>
+        )}
+        <PokeTableRow>
+          <PokeTableCell>Start Date</PokeTableCell>
+          <PokeTableCell>
+            {subscription.startDate
+              ? format(subscription.startDate, "yyyy-MM-dd HH:mm")
+              : "/"}
+          </PokeTableCell>
+        </PokeTableRow>
+        <PokeTableRow>
+          <PokeTableCell>End Date</PokeTableCell>
+          <PokeTableCell>
+            {subscription.endDate ? (
+              <span
+                className={cn(
+                  subscription.status === "active" &&
+                    subscription.endDate <= Date.now() &&
+                    "font-semibold text-red-500"
+                )}
+              >
+                {format(subscription.endDate, "yyyy-MM-dd HH:mm")}
+              </span>
+            ) : (
+              "/"
+            )}
+          </PokeTableCell>
+        </PokeTableRow>
+      </PokeTableBody>
+    </PokeTable>
+  );
+}
+
 interface ActiveSubscriptionTableProps {
   owner: WorkspaceType;
   metronomeCustomerId: string | null;
   subscription: SubscriptionType;
+  pendingSubscription: SubscriptionType | null;
   subscriptions: SubscriptionType[];
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
   hasMetronomeBillingFeature: boolean;
@@ -195,6 +288,7 @@ export function ActiveSubscriptionTable({
   owner,
   metronomeCustomerId,
   subscription,
+  pendingSubscription,
   subscriptions,
   programmaticUsageConfig,
   hasMetronomeBillingFeature,
@@ -213,7 +307,7 @@ export function ActiveSubscriptionTable({
     (hasNoBillingYet && hasMetronomeBillingFeature);
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col gap-3">
       <div className="flex justify-between gap-3">
         <div
           className={`flex flex-grow flex-col rounded-lg border p-4 pb-2 ${cardClass}`}
@@ -253,89 +347,30 @@ export function ActiveSubscriptionTable({
               />
             </div>
           )}
-          <PokeTable>
-            <PokeTableBody>
-              <PokeTableRow>
-                <PokeTableCell>Plan Name</PokeTableCell>
-                <PokeTableCell>{subscription.plan.name}</PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>Plan Code</PokeTableCell>
-                <PokeTableCell>{subscription.plan.code}</PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>Is in Trial?</PokeTableCell>
-                <PokeTableCell>
-                  {subscription.trialing ? "✅" : "❌"}
-                </PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>Stripe Subscription Id</PokeTableCell>
-                <PokeTableCell>
-                  {subscription.stripeSubscriptionId ? (
-                    <LinkWrapper
-                      href={
-                        isDevelopment()
-                          ? `https://dashboard.stripe.com/test/subscriptions/${subscription.stripeSubscriptionId}`
-                          : `https://dashboard.stripe.com/subscriptions/${subscription.stripeSubscriptionId}`
-                      }
-                      target="_blank"
-                      className="text-xs text-highlight-400"
-                    >
-                      {subscription.stripeSubscriptionId}
-                    </LinkWrapper>
-                  ) : (
-                    "No subscription id"
-                  )}
-                </PokeTableCell>
-              </PokeTableRow>
-              {subscription.metronomeContractId && metronomeCustomerId && (
-                <PokeTableRow>
-                  <PokeTableCell>Metronome Contract</PokeTableCell>
-                  <PokeTableCell>
-                    <LinkWrapper
-                      href={getMetronomeContractUrl(
-                        metronomeCustomerId,
-                        subscription.metronomeContractId
-                      )}
-                      target="_blank"
-                      className="text-xs text-highlight-400"
-                    >
-                      {subscription.metronomeContractId}
-                    </LinkWrapper>
-                  </PokeTableCell>
-                </PokeTableRow>
-              )}
-              <PokeTableRow>
-                <PokeTableCell>Start Date</PokeTableCell>
-                <PokeTableCell>
-                  {subscription.startDate
-                    ? format(subscription.startDate, "yyyy-MM-dd")
-                    : "/"}
-                </PokeTableCell>
-              </PokeTableRow>
-              <PokeTableRow>
-                <PokeTableCell>End Date</PokeTableCell>
-                <PokeTableCell>
-                  {subscription.endDate ? (
-                    <span
-                      className={cn(
-                        subscription.status === "active" &&
-                          subscription.endDate <= Date.now() &&
-                          "font-semibold text-red-500"
-                      )}
-                    >
-                      {format(subscription.endDate, "yyyy-MM-dd")}
-                    </span>
-                  ) : (
-                    "/"
-                  )}
-                </PokeTableCell>
-              </PokeTableRow>
-            </PokeTableBody>
-          </PokeTable>
+          <SubscriptionDetailsTable
+            subscription={subscription}
+            metronomeCustomerId={metronomeCustomerId}
+          />
         </div>
       </div>
+      {pendingSubscription && (
+        <div className="flex justify-between gap-3">
+          <div className="flex flex-grow flex-col rounded-lg border border-blue-200 bg-blue-50 p-4 pb-2 dark:border-blue-200-night dark:bg-blue-50-night">
+            <div className="flex items-center gap-2 pb-4">
+              <h2 className="text-md font-bold">Pending Subscription</h2>
+              <Chip color="blue" label="Pending activation" size="xs" />
+            </div>
+            <p className="pb-2 text-xs text-muted-foreground">
+              Provisioned in DB. The `contract.start` Metronome webhook will
+              flip it to active and end the current subscription.
+            </p>
+            <SubscriptionDetailsTable
+              subscription={pendingSubscription}
+              metronomeCustomerId={metronomeCustomerId}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -546,6 +546,81 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     );
   }
 
+  static async fetchPendingByWorkspaceModelId(
+    workspaceModelId: ModelId
+  ): Promise<SubscriptionResource | null> {
+    const res = await this.model.findOne({
+      where: {
+        workspaceId: workspaceModelId,
+        status: "created_backend_only",
+      },
+      include: [PlanModel],
+      order: [["createdAt", "DESC"]],
+    });
+    if (!res) {
+      return null;
+    }
+    return new this(
+      SubscriptionModel,
+      res.get(),
+      renderPlanFromModel({ plan: res.plan })
+    );
+  }
+
+  /**
+   * Persist a pending (created_backend_only) subscription for a workspace that
+   * is provisioning a new Metronome contract via a future-effective swap. If a
+   * prior pending sub exists it is ended (status: "ended") within the same
+   * transaction — the prior contract is sunset on Metronome's side by the
+   * overlap-sunset pass in `provisionMetronomeContract`.
+   *
+   * The row flips to "active" when the matching `contract.start` webhook
+   * fires (`activatePending`).
+   */
+  static async createPendingMetronomeContract({
+    workspaceModelId,
+    planCode,
+    metronomeContractId,
+    startDate,
+  }: {
+    workspaceModelId: ModelId;
+    planCode: string;
+    metronomeContractId: string;
+    startDate: Date;
+  }): Promise<SubscriptionResource> {
+    const plan = await this.findPlanOrThrow(planCode);
+    return withTransaction(async (t) => {
+      const existing = await this.model.findOne({
+        where: {
+          workspaceId: workspaceModelId,
+          status: "created_backend_only",
+        },
+        transaction: t,
+      });
+      if (existing) {
+        await existing.update(
+          { status: "ended", endDate: new Date() },
+          { transaction: t }
+        );
+      }
+      return this.makeNew(
+        {
+          sId: generateRandomModelSId(),
+          workspaceId: workspaceModelId,
+          planId: plan.id,
+          status: "created_backend_only",
+          trialing: false,
+          startDate,
+          endDate: null,
+          stripeSubscriptionId: null,
+          metronomeContractId,
+        },
+        renderPlanFromModel({ plan }),
+        t
+      );
+    });
+  }
+
   static async isStripeIdAlreadyUsed(
     stripeSubscriptionId: string
   ): Promise<boolean> {
@@ -1281,6 +1356,37 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         renderPlanFromModel({ plan: newPlan }),
         t
       );
+    });
+  }
+
+  /**
+   * Flip this pending (created_backend_only) subscription to active, while
+   * ending whatever active subscription currently holds the workspace's seat.
+   * Mirrors `swapMetronomeContract` but for the pre-provisioned pending-row
+   * model — used by the `contract.start` webhook when the new contract was
+   * created up-front (e.g. by the poke switch_contract flow).
+   *
+   * `this` must be in `created_backend_only` state.
+   */
+  async activatePending(): Promise<void> {
+    if (this.status !== "created_backend_only") {
+      throw new Error(
+        `Cannot activate subscription ${this.sId}: status is ${this.status}, expected created_backend_only.`
+      );
+    }
+    await withTransaction(async (t) => {
+      const currentActive =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(
+          this.workspaceId,
+          t
+        );
+      if (currentActive && !currentActive.isLegacyFreeNoPlan()) {
+        const endedStatus = currentActive.isBilled
+          ? "ended_backend_only"
+          : "ended";
+        await currentActive.markAsEnded(endedStatus, t);
+      }
+      await this.update({ status: "active" }, t);
     });
   }
 

--- a/front/pages/api/metronome/webhook.test.ts
+++ b/front/pages/api/metronome/webhook.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/lib/metronome/client";
 import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import { PlanModel } from "@app/lib/models/plan";
+import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -327,6 +328,64 @@ describe("Metronome webhook — contract.start", () => {
       refreshed!.id
     );
     expect(sub!.metronomeContractId).toBe(NEW_CONTRACT_ID);
+  });
+
+  it("flips a pending (created_backend_only) subscription to active and ends the prior active", async () => {
+    await ensureEnterprisePlan();
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    // Stage the pending sub that switch_contract would have created.
+    const workspaceModelId = (await WorkspaceResource.fetchById(workspace.sId))!
+      .id;
+    const targetPlan = await PlanModel.findOne({
+      where: { code: ENT_PLAN_CODE },
+    });
+    await SubscriptionResource.makeNew(
+      {
+        sId: generateRandomModelSId(),
+        workspaceId: workspaceModelId,
+        planId: targetPlan!.id,
+        status: "created_backend_only",
+        startDate: new Date(),
+        endDate: null,
+        stripeSubscriptionId: null,
+        metronomeContractId: NEW_CONTRACT_ID,
+      },
+      renderPlanFromModel({ plan: targetPlan! })
+    );
+
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: NEW_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        custom_fields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
+      } as never)
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    // Pending sub is now active.
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const activeSub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(activeSub!.metronomeContractId).toBe(NEW_CONTRACT_ID);
+    expect(activeSub!.status).toBe("active");
+    expect(activeSub!.getPlan().code).toBe(ENT_PLAN_CODE);
+
+    // Prior active is ended_backend_only (was Metronome-billed).
+    const oldSub = await SubscriptionResource.fetchByMetronomeContractId(
+      refreshed!,
+      OLD_CONTRACT_ID
+    );
+    expect(oldSub!.status).toBe("ended_backend_only");
+
+    expect(restoreWorkspaceAfterSubscription).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -473,13 +473,49 @@ async function handler(
             break;
           }
 
-          // Only swap when the workspace is Metronome-only billed, or not
-          // billed at all. Shadow billed subscriptions (Stripe + Metronome)
-          // follow Stripe's signal, and pure Stripe subs have no Metronome
-          // contract at all. Pro and Business swaps are synchronous, so this
-          // branch effectively only fires for Enterprise upgrades scheduled
-          // in the future via Poke - the idempotency check below catches
-          // the sync cases.
+          // Idempotency: re-deliveries land here with the active subscription
+          // already pointing at the new contract.
+          if (activeSubscription.metronomeContractId === contractId) {
+            logger.info(
+              { contractId, workspaceId: workspace.sId },
+              "[Metronome Webhook] contract.start: subscription already swapped, skipping"
+            );
+            break;
+          }
+
+          // Preferred path: a pending (created_backend_only) subscription was
+          // staged when the contract was provisioned. Flip it to active and
+          // end whatever active sub the workspace currently holds.
+          const pendingSubscription =
+            await SubscriptionResource.fetchByMetronomeContractId(
+              workspace,
+              contractId
+            );
+          if (
+            pendingSubscription &&
+            pendingSubscription.status === "created_backend_only"
+          ) {
+            await pendingSubscription.activatePending();
+            await invalidateContractCache(workspace.sId);
+            const auth = await Authenticator.internalAdminForWorkspace(
+              workspace.sId
+            );
+            await restoreWorkspaceAfterSubscription(auth);
+            logger.info(
+              {
+                contractId,
+                planCode: targetPlan.code,
+                workspaceId: workspace.sId,
+              },
+              "[Metronome Webhook] contract.start: pending subscription activated"
+            );
+            break;
+          }
+
+          // Legacy fallback: no pending row was staged. Only swap when the
+          // workspace is Metronome-only billed, or not billed at all. Shadow
+          // billed subscriptions (Stripe + Metronome) follow Stripe's signal,
+          // and pure Stripe subs have no Metronome contract at all.
           if (
             !activeSubscription.isMetronomeOnlyBilled &&
             activeSubscription.isBilled
@@ -491,16 +527,6 @@ async function handler(
                 workspaceId: workspace.sId,
               },
               "[Metronome Webhook] contract.start: subscription is not Metronome-only billed, leaving subscription alone"
-            );
-            break;
-          }
-
-          // Idempotency: re-deliveries land here with the subscription
-          // already pointing at the new contract.
-          if (activeSubscription.metronomeContractId === contractId) {
-            logger.info(
-              { contractId, workspaceId: workspace.sId },
-              "[Metronome Webhook] contract.start: subscription already swapped, skipping"
             );
             break;
           }
@@ -576,6 +602,17 @@ async function handler(
               logger.info(
                 { contractId, workspaceId: workspace.sId },
                 "[Metronome Webhook] contract.end: marking as ended (backend-initiated)"
+              );
+              await subscription.markAsEnded("ended");
+              break;
+
+            case "created_backend_only":
+              // Pending sub whose contract ended before activating (e.g.
+              // sunset by an overlapping new contract). No active billing —
+              // just close out the pending row.
+              logger.info(
+                { contractId, workspaceId: workspace.sId },
+                "[Metronome Webhook] contract.end: pending subscription never activated, marking as ended"
               );
               await subscription.markAsEnded("ended");
               break;

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -16,6 +16,8 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -390,6 +392,81 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
         swapAt: "current-hour",
       })
     );
+  });
+
+  it("stages a created_backend_only subscription for contract.start to activate", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = proBody();
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const workspaceModelId = (await WorkspaceResource.fetchById(workspace.sId))!
+      .id;
+    const pending =
+      await SubscriptionResource.fetchPendingByWorkspaceModelId(
+        workspaceModelId
+      );
+    expect(pending).not.toBeNull();
+    expect(pending!.status).toBe("created_backend_only");
+    expect(pending!.metronomeContractId).toBe(NEW_CONTRACT_ID);
+    expect(pending!.getPlan().code).toBe(PRO_PLAN_SEAT_29_CODE);
+  });
+
+  it("supersedes a prior pending subscription on a second schedule", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    // First schedule → pending P1.
+    req.body = proBody();
+    req.query.wId = workspace.sId;
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+
+    const workspaceModelId = (await WorkspaceResource.fetchById(workspace.sId))!
+      .id;
+    const firstPending =
+      await SubscriptionResource.fetchPendingByWorkspaceModelId(
+        workspaceModelId
+      );
+    expect(firstPending).not.toBeNull();
+    const firstPendingSId = firstPending!.sId;
+
+    // Second schedule with a different (business) target → ends P1, creates P2.
+    const SECOND_CONTRACT_ID = "contract_new_zzz";
+    vi.mocked(provisionMetronomeContract).mockResolvedValueOnce(
+      new Ok({ metronomeContractId: SECOND_CONTRACT_ID })
+    );
+    const { req: req2, res: res2 } = createMocks<
+      NextApiRequest,
+      NextApiResponse
+    >({
+      method: "POST",
+      query: { wId: workspace.sId },
+      headers: {},
+    });
+    req2.body = businessBody();
+    await handler(req2, res2);
+    expect(res2._getStatusCode()).toBe(200);
+
+    const secondPending =
+      await SubscriptionResource.fetchPendingByWorkspaceModelId(
+        workspaceModelId
+      );
+    expect(secondPending).not.toBeNull();
+    expect(secondPending!.sId).not.toBe(firstPendingSId);
+    expect(secondPending!.metronomeContractId).toBe(SECOND_CONTRACT_ID);
+    expect(secondPending!.getPlan().code).toBe(PRO_PLAN_SEAT_39_CODE);
   });
 });
 

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -4,7 +4,11 @@ import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { listMetronomePackages } from "@app/lib/metronome/client";
+import {
+  ceilToHourISO,
+  floorToHourISO,
+  listMetronomePackages,
+} from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
@@ -19,6 +23,7 @@ import {
 import { getStripeCustomer } from "@app/lib/plans/stripe";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -323,6 +328,36 @@ async function handler(
     });
   }
   const { metronomeContractId } = provisionResult.value;
+
+  // Match `provisionMetronomeContract`'s internal alignment so the pending
+  // subscription's startDate matches the Metronome contract's starting_at.
+  const alignedStart = new Date(
+    swapAt === "current-hour"
+      ? floorToHourISO(startingAtDate)
+      : ceilToHourISO(startingAtDate)
+  );
+
+  // Persist the future-state subscription in `created_backend_only`; the
+  // `contract.start` webhook flips it to `active` (and ends the current one).
+  // Any prior pending sub for this workspace is ended in the same txn.
+  try {
+    await SubscriptionResource.createPendingMetronomeContract({
+      workspaceModelId: owner.id,
+      planCode: body.planCode,
+      metronomeContractId,
+      startDate: alignedStart,
+    });
+  } catch (err) {
+    const errorMessage =
+      `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
+      `create pending subscription: ${err instanceof Error ? err.message : String(err)}. ` +
+      "Manual cleanup may be required.";
+    await pluginRun.recordError(errorMessage);
+    return apiError(req, res, {
+      status_code: 502,
+      api_error: { type: "internal_server_error", message: errorMessage },
+    });
+  }
 
   await pluginRun.recordResult({
     display: "text",

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -33,6 +33,7 @@ export type PokeGetWorkspaceInfo = {
   hasMetronomeFeature: boolean;
   membersCount: number;
   metronomeCustomerId: string | null;
+  pendingSubscription: SubscriptionType | null;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
   stripeCustomerId: string | null;
   stripeSubscription: Stripe.Subscription | null;
@@ -108,6 +109,12 @@ async function handler(
 
       const hasMetronomeFeature = await isMetronomeBillingEnabled(auth);
 
+      const pendingSubscriptionResource =
+        await SubscriptionResource.fetchPendingByWorkspaceModelId(
+          workspaceResource.id
+        );
+      const pendingSubscription = pendingSubscriptionResource?.toJSON() ?? null;
+
       const membersCount = await MembershipResource.getMembersCountForWorkspace(
         {
           workspace: owner,
@@ -149,6 +156,7 @@ async function handler(
         hasMetronomeFeature,
         membersCount,
         metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,
+        pendingSubscription,
         stripeCustomerId,
         stripeSubscription,
         subscriptions,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -1452,6 +1452,14 @@ async function handler(
                 "[Stripe Webhook] Received customer.subscription.deleted event but the subscription was already with status = ended. Doing nothing."
               );
               break;
+            case "created_backend_only":
+              // Should never happen — pending subs have no stripeSubscriptionId.
+              logger.warn(
+                { event },
+                "[Stripe Webhook] Unexpected: customer.subscription.deleted matched a created_backend_only subscription. Marking it as ended."
+              );
+              await matchingSubscription.markAsEnded("ended");
+              break;
             case "ended_backend_only":
               // This status is set by the backend after a Poké workspace migration from one plan to another.
               // We don't want to delete any data in this case as the workspace is still active.

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -58,6 +58,7 @@ export type LimitsType = {
 
 export const SUBSCRIPTION_STATUSES = [
   "active",
+  "created_backend_only", // Provisioned in DB, waiting on contract.start to flip to "active"
   "ended",
   "ended_backend_only", // Ended on the backend but not yet propagated to Stripe
 ] as const;


### PR DESCRIPTION
## Description

Adds a new subscription state `created_backend_only` so a contract scheduled via poke `switch_contract` materializes in the DB immediately as a *pending* subscription, instead of being invisible between API success and the `contract.start` webhook landing. Visible in poke, end-of-line owner is the webhook.
<img width="685" height="818" alt="Screenshot 2026-05-12 at 16 00 40" src="https://github.com/user-attachments/assets/b55d5981-151c-4db6-99c2-9351af84416a" />


- `types/plan.ts`
  - Added `"created_backend_only"` to `SUBSCRIPTION_STATUSES`. Column is a STRING with `isIn` validation pointing at the union — no DB migration needed.

- `lib/resources/subscription_resource.ts`
  - `fetchPendingByWorkspaceModelId(workspaceModelId)`: fetch the workspace's pending sub if any.
  - `createPendingMetronomeContract({ workspaceModelId, planCode, metronomeContractId, startDate })`: in a single transaction, end any existing pending sub (`status: \"ended\"`) and create the new one with `created_backend_only`. Lets a second admin schedule supersede the first without leaving an orphan row.
  - `activatePending()` (instance): flip a `created_backend_only` sub to `active` and end whatever active sub the workspace currently holds (`ended_backend_only` if billed, `ended` otherwise). Atomic via `withTransaction`. Throws if the receiver isn't pending.
  - Existing `fetchActiveByWorkspaceModelId` / `isBilled` filters already require `status === \"active\"`, so pending rows are correctly ignored by all active-sub readers.

- `pages/api/poke/workspaces/[wId]/switch_contract.ts`
  - After `provisionMetronomeContract` succeeds, compute the aligned start (mirror of the helper's internal floor/ceil) and call `createPendingMetronomeContract`. The Metronome-side overlap sunset already disposed of the prior pending's contract; this txn ends the prior pending row in the DB.

- `pages/api/metronome/webhook.ts`
  - `contract.start`: prefer the pending-flip path — if a `created_backend_only` sub matches the incoming `contract_id`, call `activatePending()` + cache invalidation + `restoreWorkspaceAfterSubscription`. Falls back to the legacy `swapMetronomeContract` path for any non-staged flows. Idempotency check moved up so a re-delivery is a no-op even after activation.
  - `contract.end`: new case for `"created_backend_only"` — pending that never activated, mark `\"ended\"`, no scrub.

- `pages/api/stripe/webhook.ts`
  - Defensive `\"created_backend_only\"` case in `customer.subscription.deleted` to satisfy exhaustiveness; pending subs have no `stripeSubscriptionId` so it shouldn't fire in practice — logs unexpected occurrence.

- Poke UI
  - `workspace-info` endpoint now returns `pendingSubscription: SubscriptionType | null`.
  - `ActiveSubscriptionTable` extracted a shared `SubscriptionDetailsTable` and renders a second blue \"Pending Subscription\" card below the active one when present.
  - Start Date / End Date in those cards now render with the hour (`yyyy-MM-dd HH:mm`) so admins can see the exact swap moment.

## Tests

- `npx tsgo --noEmit` clean.
- `npm run test -- switch_contract.test` — 13/13 pass. New cases:
  - Pending sub is staged with the right plan/contract.
  - A second schedule supersedes the prior pending row (different `sId`).
- `npm run test -- metronome/webhook.test` — 9/9 pass. New case:
  - Pending sub flipped to active; prior active becomes `ended_backend_only`; `restoreWorkspaceAfterSubscription` invoked once.
- `npm run test -- contracts.test subscriptions/index.test` — all green, no regressions.

## Risk

Medium-low.

- **New status value** is opt-in: nothing writes it except the new switch_contract path; all active-sub readers already filter on `status === \"active\"`. Existing webhook flows that don't stage a pending row fall through to the legacy `swapMetronomeContract` branch unchanged.
- **No DB migration**: `status` is a STRING; the `isIn` validation reads from the union and accepts the new value automatically.
- **Stuck pending rows** if `contract.start` never fires: deferred to a follow-up production-monitoring check (per discussion). Today's behaviour is at worst \"row stays as pending\" — no billing impact, no active-sub impact.
- Rollback is a single revert; no client contract changes (private poke endpoint only).

## Deploy Plan

Standard deploy. No migration, no config change.