### PR TITLE
db: add isStarred to user project preference

### DIFF
--- a/front/lib/resources/storage/models/user_project_notification_preferences.ts
+++ b/front/lib/resources/storage/models/user_project_notification_preferences.ts
@@ -15,7 +15,8 @@ export class UserProjectNotificationPreferenceModel extends WorkspaceAwareModel<
 
   declare userId: ForeignKey<UserModel["id"]>;
   declare spaceId: ForeignKey<SpaceModel["id"]>;
-  declare preference: NotificationCondition;
+  declare preference: NotificationCondition | null;
+  declare isStarred: boolean | null;
 }
 
 UserProjectNotificationPreferenceModel.init(
@@ -32,10 +33,15 @@ UserProjectNotificationPreferenceModel.init(
     },
     preference: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
       validate: {
         isIn: [NOTIFICATION_CONDITION_OPTIONS],
       },
+    },
+    isStarred: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/lib/resources/user_project_notification_preferences_resource.ts
+++ b/front/lib/resources/user_project_notification_preferences_resource.ts
@@ -93,12 +93,15 @@ export class UserProjectNotificationPreferenceResource extends BaseResource<User
         workspaceId: auth.getNonNullableWorkspace().id,
         spaceId: spaceModelId,
         userId: { [Op.in]: userModelIds },
+        preference: { [Op.ne]: null },
       },
     });
 
     const preferenceMap = new Map<ModelId, NotificationCondition>();
     for (const result of results) {
-      preferenceMap.set(result.userId, result.preference);
+      if (result.preference !== null) {
+        preferenceMap.set(result.userId, result.preference);
+      }
     }
 
     return preferenceMap;

--- a/front/migrations/db/migration_635.sql
+++ b/front/migrations/db/migration_635.sql
@@ -1,0 +1,3 @@
+-- Migration created on mai 12, 2026
+ALTER TABLE "public"."user_project_notification_preferences" ADD COLUMN "isStarred" BOOLEAN DEFAULT NULL;
+ALTER TABLE "user_project_notification_preferences" ALTER COLUMN "preference" DROP NOT NULL;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
@@ -162,10 +162,17 @@ async function handler(
           auth,
           space.id
         );
+      const serialized = preference?.toJSON();
       return res.status(200).json({
-        userProjectNotificationPreference: preference
-          ? preference.toJSON()
-          : null,
+        userProjectNotificationPreference:
+          serialized && serialized.preference !== null
+            ? {
+                sId: serialized.sId,
+                spaceId: serialized.spaceId,
+                userId: serialized.userId,
+                preference: serialized.preference,
+              }
+            : null,
       });
     }
 
@@ -194,8 +201,17 @@ async function handler(
           preference: body.preference,
         });
 
+      const serialized = preferenceResource.toJSON();
       return res.status(200).json({
-        userProjectNotificationPreference: preferenceResource.toJSON(),
+        userProjectNotificationPreference:
+          serialized.preference !== null
+            ? {
+                sId: serialized.sId,
+                spaceId: serialized.spaceId,
+                userId: serialized.userId,
+                preference: serialized.preference,
+              }
+            : null,
       });
     }
 


### PR DESCRIPTION
## Description

This PR extends the user project notification preferences model to support starred projects functionality.

- Adds `isStarred` boolean field (nullable) to track project starring status
- Changes `preference` field to nullable to accommodate preferences that only have starred status

## Tests

Manually

## Risks
Database migration changes column nullability and adds new column

## Deploy Plan

1. Run migration to add `isStarred` column and make `preference` nullable
2. Deploy backend changes
