### PR TITLE
feat: starred projecs in sidebar

### DIFF
--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -7,7 +7,7 @@ import { useURLSheet } from "@app/hooks/useURLSheet";
 import config from "@app/lib/api/config";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
-import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { useSpaceInfo, useStarProject } from "@app/lib/swr/spaces";
 import {
   getConversationRoute,
   getProjectRoute,
@@ -31,6 +31,7 @@ import {
   EyeSlashIcon,
   LinkIcon,
   PencilSquareIcon,
+  StarIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type React from "react";
@@ -110,6 +111,7 @@ export function ProjectMenu({
   activeSpaceId,
   space,
   owner,
+  isStarred,
   trigger,
   isProjectDisplayed,
   isOpen,
@@ -119,6 +121,7 @@ export function ProjectMenu({
   activeSpaceId: string | null;
   space?: SpaceType;
   owner: WorkspaceType;
+  isStarred: boolean;
   trigger: ReactElement;
   isProjectDisplayed: boolean;
   isOpen: boolean;
@@ -146,6 +149,11 @@ export function ProjectMenu({
     includeAllMembers: true,
   });
   const [showRenameDialog, setShowRenameDialog] = useState<boolean>(false);
+
+  const starProject = useStarProject({
+    workspaceId: owner.sId,
+    spaceId: activeSpaceId,
+  });
 
   const shareLink = activeSpaceId
     ? `${config.getApiBaseUrl()}${getProjectRoute(owner.sId, activeSpaceId)}`
@@ -242,6 +250,11 @@ export function ProjectMenu({
         )}
         <DropdownMenuContent onFocusOutside={(e) => e.preventDefault()}>
           <DropdownMenuLabel label="My settings" />
+          <DropdownMenuItem
+            label={isStarred ? "Remove from starred" : "Add to starred"}
+            icon={StarIcon}
+            onClick={() => void starProject(!isStarred)}
+          />
           {canLeave && (
             <DropdownMenuItem
               label="Leave"

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -32,6 +32,7 @@ import { useMoveConversationToProject } from "@app/hooks/useMoveConversationToPr
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useProjectsSectionCollapsed } from "@app/hooks/useProjectsSectionCollapsed";
 import { useSearchProjects } from "@app/hooks/useSearchProjects";
+import { useStarredProjectsSectionCollapsed } from "@app/hooks/useStarredProjectsSectionCollapsed";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { CONVERSATIONS_UPDATED_EVENT } from "@app/lib/notifications/events";
@@ -96,6 +97,7 @@ import {
   RobotIcon,
   SearchInput,
   Spinner,
+  StarIcon,
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
@@ -493,6 +495,11 @@ export function AgentSidebarMenu({
   const { isProjectsSectionCollapsed, setProjectsSectionCollapsed } =
     useProjectsSectionCollapsed();
 
+  const {
+    isStarredProjectsSectionCollapsed,
+    setStarredProjectsSectionCollapsed,
+  } = useStarredProjectsSectionCollapsed();
+
   const isRestrictedFromAgentCreation =
     hasFeature("disallow_agent_creation_to_users") && !isBuilder(owner);
 
@@ -668,16 +675,76 @@ export function AgentSidebarMenu({
 
   const sidebarTitleFilter = hasSpaceConversations ? "" : titleFilter;
 
+  const starredSection = useMemo(() => {
+    if (!hasSpaceConversations) {
+      return null;
+    }
+    const starredSummary = summary.filter(({ space }) => space.isStarred);
+    const starredCountInSummary = starredSummary.length;
+
+    if (starredCountInSummary === 0) {
+      return null;
+    }
+
+    const showCount =
+      isStarredProjectsSectionCollapsed && starredCountInSummary > 0;
+
+    const VISIBLE_STARRED = 5;
+    const hiddenStarredSummary = starredSummary.slice(VISIBLE_STARRED);
+    const hiddenOverflowCount = hiddenStarredSummary.reduce(
+      (sum, s) => sum + s.unreadConversations.length,
+      0
+    );
+    const hiddenOverflowHasActivity = hiddenStarredSummary.some(
+      (s) =>
+        s.unreadConversations.length > 0 ||
+        s.nonParticipantUnreadConversations.length > 0
+    );
+
+    return (
+      <NavigationList className="px-2">
+        <NavigationListCollapsibleSection
+          label={showCount ? `Starred (${starredCountInSummary})` : "Starred"}
+          icon={StarIcon}
+          type="collapse"
+          visibleItems={VISIBLE_STARRED}
+          overflowCount={hiddenOverflowCount}
+          overflowHasActivity={hiddenOverflowHasActivity}
+          open={!isStarredProjectsSectionCollapsed}
+          onOpenChange={(open) => setStarredProjectsSectionCollapsed(!open)}
+        >
+          {renderProjectsList({
+            owner,
+            summary: starredSummary,
+            titleFilter: sidebarTitleFilter,
+            moveConversationToProject,
+          })}
+        </NavigationListCollapsibleSection>
+      </NavigationList>
+    );
+  }, [
+    hasSpaceConversations,
+    summary,
+    owner,
+    sidebarTitleFilter,
+    moveConversationToProject,
+    isStarredProjectsSectionCollapsed,
+    setStarredProjectsSectionCollapsed,
+  ]);
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const projectsSection = useMemo(() => {
     if (!hasSpaceConversations) {
       return null;
     }
-    const projectCountInSummary = summary.length;
+    const nonStarredSummary = summary.filter(
+      (project) => !project.space.isStarred
+    );
+    const projectCountInSummary = nonStarredSummary.length;
     const showCount = isProjectsSectionCollapsed && projectCountInSummary > 0;
 
     const VISIBLE_PROJECTS = 4;
-    const hiddenSummary = summary.slice(VISIBLE_PROJECTS);
+    const hiddenSummary = nonStarredSummary.slice(VISIBLE_PROJECTS);
     const hiddenOverflowCount = hiddenSummary.reduce(
       (sum, s) => sum + s.unreadConversations.length,
       0
@@ -700,7 +767,7 @@ export function AgentSidebarMenu({
           onOpenChange={(open) => setProjectsSectionCollapsed(!open)}
           action={
             <>
-              {summary.length > 0 && (
+              {nonStarredSummary.length > 0 && (
                 <Button
                   size="xs"
                   icon={PlusIcon}
@@ -721,10 +788,10 @@ export function AgentSidebarMenu({
             <div className="flex items-center justify-center">
               <Spinner size="xs" />
             </div>
-          ) : summary.length > 0 ? (
+          ) : nonStarredSummary.length > 0 ? (
             renderProjectsList({
               owner,
-              summary,
+              summary: nonStarredSummary,
               titleFilter: sidebarTitleFilter,
               moveConversationToProject,
             })
@@ -760,6 +827,7 @@ export function AgentSidebarMenu({
         toggleConversationSelection={toggleConversationSelection}
         activeConversationId={activeConversationId}
         owner={owner}
+        starredSection={starredSection}
         projectsSection={projectsSection}
         hasTriggeredConversations={hasTriggeredConversations}
         hideTriggeredConversations={hideTriggeredConversations}
@@ -780,6 +848,7 @@ export function AgentSidebarMenu({
     toggleConversationSelection,
     activeConversationId,
     owner,
+    starredSection,
     projectsSection,
     hasTriggeredConversations,
     hideTriggeredConversations,
@@ -1358,6 +1427,7 @@ interface NavigationListWithInboxProps {
   toggleConversationSelection: (conversation: ConversationListItemType) => void;
   activeConversationId: string | null;
   owner: WorkspaceType;
+  starredSection?: React.ReactNode;
   projectsSection?: React.ReactNode;
   hasTriggeredConversations: boolean;
   hideTriggeredConversations: boolean;
@@ -1378,6 +1448,7 @@ function NavigationListWithInbox({
   toggleConversationSelection,
   activeConversationId,
   owner,
+  starredSection,
   projectsSection,
   hasTriggeredConversations,
   hideTriggeredConversations,
@@ -1495,6 +1566,7 @@ function NavigationListWithInbox({
           </motion.div>
         )}
       </AnimatePresence>
+      {starredSection}
       {projectsSection}
       <NavigationList className="px-2">
         <NavigationListCollapsibleSection

--- a/front/components/assistant/conversation/sidebar/ProjectsList.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsList.tsx
@@ -19,12 +19,14 @@ import { memo, useCallback, useContext, useRef, useState } from "react";
 const ProjectListItem = memo(
   ({
     space,
+    isStarred,
     unreadCount,
     hasUnread,
     owner,
     moveConversationToProject,
   }: {
     space: SpaceType;
+    isStarred: boolean;
     unreadCount: number;
     hasUnread: boolean;
     owner: WorkspaceType;
@@ -124,6 +126,7 @@ const ProjectListItem = memo(
             activeSpaceId={space.sId}
             space={space}
             owner={owner}
+            isStarred={isStarred}
             trigger={<NavigationListItemAction />}
             isProjectDisplayed={activeConversationId === space.sId}
             isOpen={isMenuOpen}
@@ -173,6 +176,7 @@ export function renderProjectsList({
       <ProjectListItem
         key={space.sId}
         space={space}
+        isStarred={space.isStarred}
         unreadCount={unreadConversations.length}
         hasUnread={
           unreadConversations.length > 0 ||

--- a/front/hooks/useStarredProjectsSectionCollapsed.ts
+++ b/front/hooks/useStarredProjectsSectionCollapsed.ts
@@ -1,0 +1,34 @@
+import { useCallback, useState } from "react";
+
+const LOCAL_STORAGE_KEY = "starredProjectsSectionCollapsed";
+
+export const useStarredProjectsSectionCollapsed = () => {
+  const [isStarredProjectsSectionCollapsed, setCollapsedState] =
+    useState<boolean>(() => {
+      if (typeof window === "undefined") {
+        return false;
+      }
+      try {
+        return localStorage.getItem(LOCAL_STORAGE_KEY) === "true";
+      } catch {
+        return false;
+      }
+    });
+
+  const setStarredProjectsSectionCollapsed = useCallback(
+    (collapsed: boolean) => {
+      setCollapsedState(collapsed);
+      try {
+        localStorage.setItem(LOCAL_STORAGE_KEY, collapsed ? "true" : "false");
+      } catch {
+        // localStorage may be full or unavailable — silently ignore.
+      }
+    },
+    []
+  );
+
+  return {
+    isStarredProjectsSectionCollapsed,
+    setStarredProjectsSectionCollapsed,
+  };
+};

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -39,6 +39,7 @@ import type {
   GetUserProjectNotificationPreferenceResponseBody,
   PatchUserProjectNotificationPreferenceResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences";
+import type { PostUserProjectStarResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/star";
 import type { SpacesLookupResponseBody } from "@app/pages/api/w/[wId]/spaces/projects-lookup";
 import type { PatchProjectMetadataBodyType } from "@app/types/api/internal/spaces";
 import type { DataSourceViewCategoryWithoutApps } from "@app/types/api/public/spaces";
@@ -1231,4 +1232,71 @@ export function useJoinProject({
   };
 
   return doJoin;
+}
+
+export function useStarProject({
+  workspaceId,
+  spaceId,
+}: {
+  workspaceId: string;
+  spaceId: string | null;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+    workspaceId,
+    options: { disabled: true },
+  });
+
+  return useCallback(
+    async (
+      isStarred: boolean
+    ): Promise<PostUserProjectStarResponseBody | null> => {
+      if (!spaceId) {
+        return null;
+      }
+
+      const res = await clientFetch(
+        `/api/w/${workspaceId}/spaces/${spaceId}/star`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ starred: isStarred }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: isStarred
+            ? "Error starring project"
+            : "Error unstarring project",
+          description: `Error: ${errorData.message}`,
+        });
+        return null;
+      }
+
+      const response: PostUserProjectStarResponseBody = await res.json();
+
+      void mutateSpaceSummary((data) => {
+        if (!data) {
+          return data;
+        }
+        return {
+          ...data,
+          summary: data.summary.map((entry) =>
+            entry.space.sId === spaceId
+              ? {
+                  ...entry,
+                  space: { ...entry.space, isStarred: response.isStarred },
+                }
+              : entry
+          ),
+        };
+      }, false);
+
+      return response;
+    },
+    [workspaceId, spaceId, mutateSpaceSummary, sendNotification]
+  );
 }

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
@@ -3,15 +3,16 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { ProjectType } from "@app/types/space";
+import type { ProjectListItemType } from "@app/types/space";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetBySpacesSummaryResponseBody = {
   summary: Array<{
-    space: ProjectType;
+    space: ProjectListItemType;
     unreadConversations: ConversationWithoutContentType[];
     nonParticipantUnreadConversations: ConversationWithoutContentType[];
   }>;
@@ -56,6 +57,11 @@ async function handler(
           auth,
           nonArchivedSpaces.map((s) => s.id)
         );
+
+      const starredSpaceModelIds =
+        await UserProjectPreferencesResource.fetchStarred(auth, {
+          spaceIds: nonArchivedSpaces.map((s) => s.id),
+        });
 
       // Group conversations by space
       const spaceIdToSpaceMap = new Map(
@@ -120,6 +126,7 @@ async function handler(
             // We excluded archived projects and we only list projects where the user is a member.
             archivedAt: null,
             isMember: true,
+            isStarred: starredSpaceModelIds.has(space.id),
           },
           unreadConversations:
             conversationsBySpace.get(space.id)?.unreadConversations ?? [],

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
@@ -1,0 +1,81 @@
+/**
+ * @ignoreswagger
+ */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+export type PostUserProjectStarResponseBody = {
+  sId: string;
+  spaceId: string;
+  userId: string;
+  isStarred: boolean;
+};
+
+const PostUserProjectStarBodySchema = z.object({
+  starred: z.boolean(),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostUserProjectStarResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Project star is only available for project spaces.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = PostUserProjectStarBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
+          },
+        });
+      }
+
+      const body = bodyValidation.data;
+
+      const preferenceResource =
+        await UserProjectPreferencesResource.setStarred(auth, {
+          spaceModelId: space.id,
+          isStarred: body.starred,
+        });
+
+      return res.status(200).json(preferenceResource.toJSON());
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
+);

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -36,6 +36,10 @@ export type ProjectType = SpaceType & {
   archivedAt: number | null;
 };
 
+export type ProjectListItemType = ProjectType & {
+  isStarred: boolean;
+};
+
 export function isProjectType(
   space: SpaceType | ProjectType
 ): space is ProjectType {

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -353,6 +353,7 @@ NavigationListCompactLabel.displayName = "NavigationListCompactLabel";
 interface NavigationListCollapsibleSectionProps
   extends React.HTMLAttributes<HTMLDivElement> {
   label: string;
+  icon?: React.ComponentType;
   action?: React.ReactNode;
   actionOnHover?: boolean;
   defaultOpen?: boolean;
@@ -407,6 +408,7 @@ const NavigationListCollapsibleSection = React.forwardRef<
   (
     {
       label,
+      icon,
       action,
       actionOnHover = true,
       children,
@@ -429,18 +431,25 @@ const NavigationListCollapsibleSection = React.forwardRef<
     const hasPartialCollapse =
       visibleItems !== undefined && visibleItems < childArray.length;
 
-    const visibleChildrenSlice =
-      hasPartialCollapse && !isShowingAll
-        ? childArray.slice(0, visibleItems)
-        : childArray;
+    const visibleChildrenSlice = hasPartialCollapse
+      ? childArray.slice(0, visibleItems)
+      : childArray;
 
-    const overflowChildren =
-      hasPartialCollapse && !isShowingAll ? childArray.slice(visibleItems) : [];
+    const overflowChildren = hasPartialCollapse
+      ? childArray.slice(visibleItems)
+      : [];
 
     const isCollapsible = type !== "static";
     const labelElement = (
       <div className={collapseableStyles({ variant, isCollapsible })}>
-        {label}
+        {icon ? (
+          <span className="s-flex s-items-center s-gap-1.5">
+            <Icon visual={icon} size="xs" />
+            <span className="s-overflow-hidden s-text-ellipsis">{label}</span>
+          </span>
+        ) : (
+          label
+        )}
       </div>
     );
 


### PR DESCRIPTION
## Description

This PR adds the ability to star projects and displays them in a dedicated "Starred" section in the conversation sidebar.

- Added a new collapsible "Starred" section in the sidebar that appears above the "Projects" section
- Added a star/unstar menu item to the project dropdown menu
- Created a new API endpoint (`POST /api/w/[wId]/spaces/[spaceId]/star`) to handle starring/unstarring projects
- Implemented `useStarProject` hook to manage star state and optimistically update the UI
- Added `useStarredProjectsSectionCollapsed` hook to persist the collapsed state of the starred section in localStorage
- Updated the projects section to filter out starred projects (they only appear in the starred section)
- Enhanced `NavigationListCollapsibleSection` to support an optional icon
- Updated backend to fetch and include `isStarred` status for projects

## Tests

Manually

## Risks

Low risk.

## Deploy Plan

Standard deployment. No migrations or special deployment steps required.
