### PR TITLE
[Google Drive] Batch moved folder parent updates

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.test.ts
@@ -297,6 +297,180 @@ describe("google drive incremental sync folder metadata", () => {
     );
   });
 
+  it("updates moved folder descendants before the moved folder retry marker", async () => {
+    const suffix = randomUUID();
+    const folderId = `folder-${suffix}`;
+    const oldParentId = `old-parent-${suffix}`;
+    const newParentId = `new-parent-${suffix}`;
+    const rootId = `root-${suffix}`;
+    const childFolderId = `child-folder-${suffix}`;
+    const childFileId = `child-file-${suffix}`;
+    const connector = await makeConnector(suffix);
+
+    await GoogleDriveFilesModel.bulkCreate([
+      {
+        connectorId: connector.id,
+        driveFileId: folderId,
+        dustFileId: `gdrive-${folderId}`,
+        mimeType: "application/vnd.google-apps.folder",
+        name: "Team",
+        parentId: oldParentId,
+      },
+      {
+        connectorId: connector.id,
+        driveFileId: childFolderId,
+        dustFileId: `gdrive-${childFolderId}`,
+        mimeType: "application/vnd.google-apps.folder",
+        name: "Planning",
+        parentId: folderId,
+      },
+      {
+        connectorId: connector.id,
+        driveFileId: childFileId,
+        dustFileId: `gdrive-${childFileId}`,
+        mimeType: "application/pdf",
+        name: "Brief",
+        parentId: childFolderId,
+      },
+    ]);
+
+    const driveFile = makeGoogleDriveFolder({
+      id: folderId,
+      name: "Team",
+      parent: newParentId,
+    });
+
+    mocks.changeList.mockResolvedValue({
+      data: {
+        changes: [makeFolderChange(driveFile)],
+        newStartPageToken: "sync-token",
+        nextPageToken: undefined,
+      },
+      status: 200,
+    });
+    mocks.driveObjectToDustType.mockResolvedValue(driveFile);
+    mocks.getFileParentsMemoized.mockResolvedValue([
+      folderId,
+      newParentId,
+      rootId,
+    ]);
+
+    const result = await incrementalSync(
+      connector.id,
+      "drive-1",
+      false,
+      Date.now(),
+      "page-token"
+    );
+
+    const folder = await GoogleDriveFilesModel.findOne({
+      where: {
+        connectorId: connector.id,
+        driveFileId: folderId,
+      },
+    });
+    const childFolder = await GoogleDriveFilesModel.findOne({
+      where: {
+        connectorId: connector.id,
+        driveFileId: childFolderId,
+      },
+    });
+    const childFile = await GoogleDriveFilesModel.findOne({
+      where: {
+        connectorId: connector.id,
+        driveFileId: childFileId,
+      },
+    });
+
+    expect(result).toEqual({ newFolders: [], nextPageToken: undefined });
+    expect(folder?.parentId).toBe(newParentId);
+    expect(childFolder?.parentId).toBe(folderId);
+    expect(childFile?.parentId).toBe(childFolderId);
+    expect(mocks.updateDataSourceDocumentParents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: `gdrive-${childFileId}`,
+        parentId: `gdrive-${childFolderId}`,
+        parents: [
+          `gdrive-${childFileId}`,
+          `gdrive-${childFolderId}`,
+          `gdrive-${folderId}`,
+          `gdrive-${newParentId}`,
+          `gdrive-${rootId}`,
+        ],
+      })
+    );
+    expect(
+      mocks.upsertDataSourceFolder.mock.calls.map(([args]) => args.folderId)
+    ).toEqual([`gdrive-${childFolderId}`, `gdrive-${folderId}`]);
+  });
+
+  it("does not move the folder retry marker when a descendant parent update fails", async () => {
+    const suffix = randomUUID();
+    const folderId = `folder-${suffix}`;
+    const oldParentId = `old-parent-${suffix}`;
+    const newParentId = `new-parent-${suffix}`;
+    const rootId = `root-${suffix}`;
+    const childFileId = `child-file-${suffix}`;
+    const connector = await makeConnector(suffix);
+
+    await GoogleDriveFilesModel.bulkCreate([
+      {
+        connectorId: connector.id,
+        driveFileId: folderId,
+        dustFileId: `gdrive-${folderId}`,
+        mimeType: "application/vnd.google-apps.folder",
+        name: "Team",
+        parentId: oldParentId,
+      },
+      {
+        connectorId: connector.id,
+        driveFileId: childFileId,
+        dustFileId: `gdrive-${childFileId}`,
+        mimeType: "application/pdf",
+        name: "Brief",
+        parentId: folderId,
+      },
+    ]);
+
+    const driveFile = makeGoogleDriveFolder({
+      id: folderId,
+      name: "Team",
+      parent: newParentId,
+    });
+
+    mocks.changeList.mockResolvedValue({
+      data: {
+        changes: [makeFolderChange(driveFile)],
+        newStartPageToken: "sync-token",
+        nextPageToken: undefined,
+      },
+      status: 200,
+    });
+    mocks.driveObjectToDustType.mockResolvedValue(driveFile);
+    mocks.getFileParentsMemoized.mockResolvedValue([
+      folderId,
+      newParentId,
+      rootId,
+    ]);
+    mocks.updateDataSourceDocumentParents.mockRejectedValueOnce(
+      new Error("parent update failed")
+    );
+
+    await expect(
+      incrementalSync(connector.id, "drive-1", false, Date.now(), "page-token")
+    ).rejects.toThrow("parent update failed");
+
+    const folder = await GoogleDriveFilesModel.findOne({
+      where: {
+        connectorId: connector.id,
+        driveFileId: folderId,
+      },
+    });
+
+    expect(folder?.parentId).toBe(oldParentId);
+    expect(mocks.upsertDataSourceFolder).not.toHaveBeenCalled();
+  });
+
   it("keeps skipped folders out of the datasource when renamed in place", async () => {
     const suffix = randomUUID();
     const folderId = `folder-${suffix}`;

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -416,22 +416,26 @@ async function recurseUpdateParents(
         updateBatch.push(update);
       };
 
-      const shouldUpdateInitialFolder = await recurseUpdateParentsInner(
+      await recurseUpdateParentsInner(
         connector,
         file,
         parentIds,
         logger,
-        enqueueUpdate,
-        true
+        enqueueUpdate
       );
+      const initialFolderUpdate = updateBatch.pop();
       await flushUpdateBatch();
 
-      if (!shouldUpdateInitialFolder) {
+      if (!initialFolderUpdate) {
         return;
       }
 
-      await heartbeat();
-      await updateParentsField(connector, file, parentIds, logger);
+      await updateParentsField(
+        connector,
+        initialFolderUpdate.file,
+        initialFolderUpdate.parentIds,
+        logger
+      );
     }
   );
 }
@@ -441,9 +445,8 @@ async function recurseUpdateParentsInner(
   file: GoogleDriveFilesModel,
   parentIds: string[],
   logger: Logger,
-  enqueueUpdate: EnqueueParentsUpdate,
-  isInitialFolder = false
-): Promise<boolean> {
+  enqueueUpdate: EnqueueParentsUpdate
+) {
   await heartbeat();
   const children = await GoogleDriveFilesModel.findAll({
     where: {
@@ -475,7 +478,7 @@ async function recurseUpdateParentsInner(
       },
       "Infinite parent loop."
     );
-    return false;
+    return;
   }
 
   for (const child of children) {
@@ -488,11 +491,7 @@ async function recurseUpdateParentsInner(
     );
   }
 
-  if (!isInitialFolder) {
-    await enqueueUpdate({ file, parentIds });
-  }
-
-  return true;
+  await enqueueUpdate({ file, parentIds });
 }
 
 async function updateParentsFieldForBatch(
@@ -500,14 +499,9 @@ async function updateParentsFieldForBatch(
   updateBatch: ParentsUpdate[],
   logger: Logger
 ) {
-  if (updateBatch.length === 0) {
-    return;
-  }
-
   await concurrentExecutor(
     updateBatch,
     async ({ file, parentIds }) => {
-      await heartbeat();
       await updateParentsField(connector, file, parentIds, logger);
     },
     { concurrency: UPDATE_PARENTS_CONCURRENCY, onBatchComplete: heartbeat }

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -35,12 +35,22 @@ import type { GoogleDriveObjectType, ModelId } from "@connectors/types";
 import { FILE_ATTRIBUTES_TO_FETCH, WithRetriesError } from "@connectors/types";
 import { redisClient } from "@connectors/types/shared/redis_client";
 import { uuid4 } from "@temporalio/workflow";
+import tracer from "dd-trace";
 import type { drive_v3 } from "googleapis";
 import type { GaxiosResponse } from "googleapis-common";
 import { GaxiosError } from "googleapis-common";
 import type { RedisClientType } from "redis";
 
 const PAGE_SIZE = 500;
+const UPDATE_PARENTS_BATCH_SIZE = 1_000;
+const UPDATE_PARENTS_CONCURRENCY = 8;
+
+type ParentsUpdate = {
+  file: GoogleDriveFilesModel;
+  parentIds: string[];
+};
+
+type EnqueueParentsUpdate = (update: ParentsUpdate) => Promise<void>;
 
 export async function incrementalSync(
   connectorId: ModelId,
@@ -384,24 +394,46 @@ async function recurseUpdateParents(
   parentIds: string[],
   logger: Logger
 ) {
-  const updateBatch: { file: GoogleDriveFilesModel; parentIds: string[] }[] =
-    [];
-  const shouldUpdateInitialFolder = await recurseUpdateParentsInner(
-    connector,
-    file,
-    parentIds,
-    logger,
-    updateBatch,
-    true
+  return tracer.trace(
+    "gdrive",
+    {
+      resource: "recurseUpdateParents",
+    },
+    async (span) => {
+      span?.setTag("connectorId", connector.id);
+      span?.setTag("workspaceId", connector.workspaceId);
+      span?.setTag("fileId", file.driveFileId);
+
+      let updateBatch: ParentsUpdate[] = [];
+      const flushUpdateBatch = async () => {
+        await updateParentsFieldForBatch(connector, updateBatch, logger);
+        updateBatch = [];
+      };
+      const enqueueUpdate = async (update: ParentsUpdate) => {
+        if (updateBatch.length >= UPDATE_PARENTS_BATCH_SIZE) {
+          await flushUpdateBatch();
+        }
+        updateBatch.push(update);
+      };
+
+      const shouldUpdateInitialFolder = await recurseUpdateParentsInner(
+        connector,
+        file,
+        parentIds,
+        logger,
+        enqueueUpdate,
+        true
+      );
+      await flushUpdateBatch();
+
+      if (!shouldUpdateInitialFolder) {
+        return;
+      }
+
+      await heartbeat();
+      await updateParentsField(connector, file, parentIds, logger);
+    }
   );
-  await updateParentsFieldForBatch(connector, updateBatch, logger);
-
-  if (!shouldUpdateInitialFolder) {
-    return;
-  }
-
-  await heartbeat();
-  await updateParentsField(connector, file, parentIds, logger);
 }
 
 async function recurseUpdateParentsInner(
@@ -409,7 +441,7 @@ async function recurseUpdateParentsInner(
   file: GoogleDriveFilesModel,
   parentIds: string[],
   logger: Logger,
-  updateBatch: { file: GoogleDriveFilesModel; parentIds: string[] }[],
+  enqueueUpdate: EnqueueParentsUpdate,
   isInitialFolder = false
 ): Promise<boolean> {
   await heartbeat();
@@ -452,17 +484,12 @@ async function recurseUpdateParentsInner(
       child,
       [child.dustFileId, ...parentIds],
       logger,
-      updateBatch
+      enqueueUpdate
     );
   }
 
-  if (updateBatch.length >= 1000) {
-    await updateParentsFieldForBatch(connector, updateBatch, logger);
-    updateBatch.length = 0;
-  }
-
   if (!isInitialFolder) {
-    updateBatch.push({ file, parentIds });
+    await enqueueUpdate({ file, parentIds });
   }
 
   return true;
@@ -470,21 +497,20 @@ async function recurseUpdateParentsInner(
 
 async function updateParentsFieldForBatch(
   connector: ConnectorResource,
-  updateBatch: { file: GoogleDriveFilesModel; parentIds: string[] }[],
+  updateBatch: ParentsUpdate[],
   logger: Logger
 ) {
+  if (updateBatch.length === 0) {
+    return;
+  }
+
   await concurrentExecutor(
     updateBatch,
-    async (update) => {
+    async ({ file, parentIds }) => {
       await heartbeat();
-      return await updateParentsField(
-        connector,
-        update.file,
-        update.parentIds,
-        logger
-      );
+      await updateParentsField(connector, file, parentIds, logger);
     },
-    { concurrency: 8, onBatchComplete: heartbeat }
+    { concurrency: UPDATE_PARENTS_CONCURRENCY, onBatchComplete: heartbeat }
   );
 }
 

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -21,6 +21,7 @@ import {
   isSharedDriveNotFoundError,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
 import {
   GoogleDriveConfigModel,
   GoogleDriveFilesModel,
@@ -34,7 +35,6 @@ import type { GoogleDriveObjectType, ModelId } from "@connectors/types";
 import { FILE_ATTRIBUTES_TO_FETCH, WithRetriesError } from "@connectors/types";
 import { redisClient } from "@connectors/types/shared/redis_client";
 import { uuid4 } from "@temporalio/workflow";
-import tracer from "dd-trace";
 import type { drive_v3 } from "googleapis";
 import type { GaxiosResponse } from "googleapis-common";
 import { GaxiosError } from "googleapis-common";
@@ -384,26 +384,34 @@ async function recurseUpdateParents(
   parentIds: string[],
   logger: Logger
 ) {
-  return tracer.trace(
-    "gdrive",
-    {
-      resource: "recurseUpdateParents",
-    },
-    async (span) => {
-      span?.setTag("connectorId", connector.id);
-      span?.setTag("workspaceId", connector.workspaceId);
-      span?.setTag("fileId", file.driveFileId);
-      return recurseUpdateParentsInner(connector, file, parentIds, logger);
-    }
+  const updateBatch: { file: GoogleDriveFilesModel; parentIds: string[] }[] =
+    [];
+  const shouldUpdateInitialFolder = await recurseUpdateParentsInner(
+    connector,
+    file,
+    parentIds,
+    logger,
+    updateBatch,
+    true
   );
+  await updateParentsFieldForBatch(connector, updateBatch, logger);
+
+  if (!shouldUpdateInitialFolder) {
+    return;
+  }
+
+  await heartbeat();
+  await updateParentsField(connector, file, parentIds, logger);
 }
 
 async function recurseUpdateParentsInner(
   connector: ConnectorResource,
   file: GoogleDriveFilesModel,
   parentIds: string[],
-  logger: Logger
-) {
+  logger: Logger,
+  updateBatch: { file: GoogleDriveFilesModel; parentIds: string[] }[],
+  isInitialFolder = false
+): Promise<boolean> {
   await heartbeat();
   const children = await GoogleDriveFilesModel.findAll({
     where: {
@@ -435,7 +443,7 @@ async function recurseUpdateParentsInner(
       },
       "Infinite parent loop."
     );
-    return;
+    return false;
   }
 
   for (const child of children) {
@@ -443,11 +451,41 @@ async function recurseUpdateParentsInner(
       connector,
       child,
       [child.dustFileId, ...parentIds],
-      logger
+      logger,
+      updateBatch
     );
   }
 
-  await updateParentsField(connector, file, parentIds, logger);
+  if (updateBatch.length >= 1000) {
+    await updateParentsFieldForBatch(connector, updateBatch, logger);
+    updateBatch.length = 0;
+  }
+
+  if (!isInitialFolder) {
+    updateBatch.push({ file, parentIds });
+  }
+
+  return true;
+}
+
+async function updateParentsFieldForBatch(
+  connector: ConnectorResource,
+  updateBatch: { file: GoogleDriveFilesModel; parentIds: string[] }[],
+  logger: Logger
+) {
+  await concurrentExecutor(
+    updateBatch,
+    async (update) => {
+      await heartbeat();
+      return await updateParentsField(
+        connector,
+        update.file,
+        update.parentIds,
+        logger
+      );
+    },
+    { concurrency: 8, onBatchComplete: heartbeat }
+  );
 }
 
 async function alreadySeenAndIgnored({


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7810

Batches descendant parent updates through concurrentExecutor, while keeping the moved folder update separate and last so failures leave the local parentId retry marker for the next incremental sync retry. Preserves the recurseUpdateParents Datadog span and heartbeats during traversal and batch updates.

## Risks
Blast radius: Google Drive incremental sync handling of moved folders.
Risk: standard

## Deploy Plan
- deploy connectors

## Tests
- [x] `NODE_ENV=test CONNECTORS_DATABASE_URI=postgres://dev:dev@localhost:5432/dust_connectors_test npm test -- src/connectors/google_drive/temporal/activities/incremental_sync.test.ts`
- [ x] live local test 

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->