### PR TITLE
refactor: rename UserProjectNotificationPreference

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -127,7 +127,7 @@ import {
   UserModel,
   UserToolApprovalModel,
 } from "@app/lib/resources/storage/models/user";
-import { UserProjectNotificationPreferenceModel } from "@app/lib/resources/storage/models/user_project_notification_preferences";
+import { UserProjectPreferencesModel } from "@app/lib/resources/storage/models/user_project_preferences";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
@@ -250,7 +250,7 @@ export function loadAllModels() {
     TakeawaysModel,
     TakeawaySourcesModel,
     TakeawaysVersionModel,
-    UserProjectNotificationPreferenceModel,
+    UserProjectPreferencesModel,
     WorkspaceSensitivityLabelConfigModel,
     WorkspaceSandboxEnvVarModel,
   ];

--- a/front/lib/notifications/triggers/project-new-conversation.test.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.test.ts
@@ -1,7 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { filterMembersByNotifyCondition } from "@app/lib/notifications/triggers/project-new-conversation";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
+import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -171,9 +171,9 @@ describe("filterMembersByNotifyCondition", () => {
         user.sId,
         workspace.sId
       );
-      await UserProjectNotificationPreferenceResource.setPreference(userAuth, {
+      await UserProjectPreferencesResource.setNotificationPreference(userAuth, {
         spaceModelId: space.id,
-        preference,
+        notificationPreference: preference,
       });
     }
 

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -4,7 +4,7 @@ import { getNovuClient } from "@app/lib/notifications";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
-import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
+import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -44,13 +44,10 @@ export const filterMembersByNotifyCondition = async (
   });
 
   const projectPreferenceMap =
-    await UserProjectNotificationPreferenceResource.fetchAllBySpaceAndUsers(
-      auth,
-      {
-        spaceModelId,
-        userModelIds,
-      }
-    );
+    await UserProjectPreferencesResource.fetchNotificationPreferenceMap(auth, {
+      spaceModelId,
+      userModelIds,
+    });
 
   const generalPreferenceMap = new Map<number, NotificationCondition>();
   for (const pref of generalPreferences) {

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -62,7 +62,7 @@ vi.mock("@app/lib/api/assistant/conversation_rendering", () => ({
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
+import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 
 describe("conversation-unread workflow business logic", () => {
@@ -371,9 +371,9 @@ describe("conversation-unread workflow business logic", () => {
           user.sId,
           workspace.sId
         );
-        await UserProjectNotificationPreferenceResource.setPreference(
+        await UserProjectPreferencesResource.setNotificationPreference(
           userAuth,
-          { spaceModelId: space.id, preference }
+          { spaceModelId: space.id, notificationPreference: preference }
         );
       }
 

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -24,7 +24,7 @@ import { renderEmail } from "@app/lib/notifications/email-templates/conversation
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
-import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
+import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
@@ -1116,9 +1116,12 @@ export const filterParticipantsByNotifyCondition = async ({
   }
 
   const projectPreferenceMap = spaceModelId
-    ? await UserProjectNotificationPreferenceResource.fetchAllBySpaceAndUsers(
+    ? await UserProjectPreferencesResource.fetchNotificationPreferenceMap(
         auth,
-        { spaceModelId, userModelIds }
+        {
+          spaceModelId,
+          userModelIds,
+        }
       )
     : new Map<ModelId, NotificationCondition>();
 

--- a/front/lib/resources/storage/models/user_project_preferences.ts
+++ b/front/lib/resources/storage/models/user_project_preferences.ts
@@ -9,17 +9,17 @@ import {
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
-export class UserProjectNotificationPreferenceModel extends WorkspaceAwareModel<UserProjectNotificationPreferenceModel> {
+export class UserProjectPreferencesModel extends WorkspaceAwareModel<UserProjectPreferencesModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare userId: ForeignKey<UserModel["id"]>;
   declare spaceId: ForeignKey<SpaceModel["id"]>;
-  declare preference: NotificationCondition | null;
+  declare notificationPreference: NotificationCondition | null;
   declare isStarred: boolean | null;
 }
 
-UserProjectNotificationPreferenceModel.init(
+UserProjectPreferencesModel.init(
   {
     createdAt: {
       type: DataTypes.DATE,
@@ -31,8 +31,9 @@ UserProjectNotificationPreferenceModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    preference: {
+    notificationPreference: {
       type: DataTypes.STRING,
+      field: "preference",
       allowNull: true,
       validate: {
         isIn: [NOTIFICATION_CONDITION_OPTIONS],
@@ -60,18 +61,18 @@ UserProjectNotificationPreferenceModel.init(
   }
 );
 
-UserModel.hasMany(UserProjectNotificationPreferenceModel, {
+UserModel.hasMany(UserProjectPreferencesModel, {
   foreignKey: { allowNull: false },
   onDelete: "RESTRICT",
 });
-UserProjectNotificationPreferenceModel.belongsTo(UserModel, {
+UserProjectPreferencesModel.belongsTo(UserModel, {
   foreignKey: { allowNull: false },
 });
 
-SpaceModel.hasMany(UserProjectNotificationPreferenceModel, {
+SpaceModel.hasMany(UserProjectPreferencesModel, {
   foreignKey: { allowNull: false, name: "spaceId" },
   onDelete: "RESTRICT",
 });
-UserProjectNotificationPreferenceModel.belongsTo(SpaceModel, {
+UserProjectPreferencesModel.belongsTo(SpaceModel, {
   foreignKey: { allowNull: false, name: "spaceId" },
 });

--- a/front/lib/resources/user_project_preferences_resource.ts
+++ b/front/lib/resources/user_project_preferences_resource.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { NotificationCondition } from "@app/types/notification_preferences";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
@@ -8,33 +9,33 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Attributes } from "sequelize";
 import { Op } from "sequelize";
 import { SpaceResource } from "./space_resource";
-import { UserProjectNotificationPreferenceModel } from "./storage/models/user_project_notification_preferences";
+import { UserProjectPreferencesModel } from "./storage/models/user_project_preferences";
 import { makeSId } from "./string_ids";
 import type { UserResource } from "./user_resource";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface UserProjectNotificationPreferenceResource
-  extends ReadonlyAttributesType<UserProjectNotificationPreferenceModel> {}
+export interface UserProjectPreferencesResource
+  extends ReadonlyAttributesType<UserProjectPreferencesModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class UserProjectNotificationPreferenceResource extends BaseResource<UserProjectNotificationPreferenceModel> {
-  static model: typeof UserProjectNotificationPreferenceModel =
-    UserProjectNotificationPreferenceModel;
+export class UserProjectPreferencesResource extends BaseResource<UserProjectPreferencesModel> {
+  static model: typeof UserProjectPreferencesModel =
+    UserProjectPreferencesModel;
 
   readonly user: UserResource;
 
   constructor(
-    model: typeof UserProjectNotificationPreferenceModel,
-    blob: Attributes<UserProjectNotificationPreferenceModel>,
+    model: typeof UserProjectPreferencesModel,
+    blob: Attributes<UserProjectPreferencesModel>,
     { user }: { user: UserResource }
   ) {
-    super(UserProjectNotificationPreferenceModel, blob);
+    super(UserProjectPreferencesModel, blob);
 
     this.user = user;
   }
 
   get sId(): string {
-    return UserProjectNotificationPreferenceResource.modelIdToSId({
+    return UserProjectPreferencesResource.modelIdToSId({
       id: this.id,
       workspaceId: this.workspaceId,
     });
@@ -53,32 +54,25 @@ export class UserProjectNotificationPreferenceResource extends BaseResource<User
     });
   }
 
-  static async create(
+  private static async baseFetch(
     auth: Authenticator,
-    {
-      spaceModelId,
-      preference,
-    }: {
-      spaceModelId: ModelId;
-      preference: NotificationCondition;
-    }
-  ): Promise<UserProjectNotificationPreferenceResource> {
-    const workspace = auth.getNonNullableWorkspace();
+    options: ResourceFindOptions<UserProjectPreferencesModel> = {}
+  ): Promise<UserProjectPreferencesResource[]> {
+    const { where, ...otherOptions } = options;
     const user = auth.getNonNullableUser();
 
-    const entry = await UserProjectNotificationPreferenceModel.create({
-      workspaceId: workspace.id,
-      spaceId: spaceModelId,
-      userId: user.id,
-      preference,
+    const results = await UserProjectPreferencesModel.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      ...otherOptions,
     });
 
-    return new this(this.model, entry.get(), {
-      user,
-    });
+    return results.map((r) => new this(this.model, r.get(), { user }));
   }
 
-  static async fetchAllBySpaceAndUsers(
+  static async fetchNotificationPreferenceMap(
     auth: Authenticator,
     {
       spaceModelId,
@@ -88,59 +82,96 @@ export class UserProjectNotificationPreferenceResource extends BaseResource<User
       userModelIds: ModelId[];
     }
   ): Promise<Map<ModelId, NotificationCondition>> {
-    const results = await UserProjectNotificationPreferenceModel.findAll({
+    const preferences = await this.baseFetch(auth, {
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
         spaceId: spaceModelId,
         userId: { [Op.in]: userModelIds },
-        preference: { [Op.ne]: null },
+        notificationPreference: { [Op.ne]: null },
       },
     });
 
     const preferenceMap = new Map<ModelId, NotificationCondition>();
-    for (const result of results) {
-      if (result.preference !== null) {
-        preferenceMap.set(result.userId, result.preference);
+    for (const preference of preferences) {
+      if (preference.notificationPreference !== null) {
+        preferenceMap.set(preference.userId, preference.notificationPreference);
       }
     }
 
     return preferenceMap;
   }
 
-  static async fetchByProject(
+  static async fetchBySpace(
     auth: Authenticator,
     spaceModelId: ModelId
-  ): Promise<UserProjectNotificationPreferenceResource | null> {
-    const user = auth.getNonNullableUser();
-    const result = await UserProjectNotificationPreferenceModel.findOne({
+  ): Promise<UserProjectPreferencesResource | null> {
+    const [preference] = await this.baseFetch(auth, {
       where: {
-        userId: user.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: auth.getNonNullableUser().id,
         spaceId: spaceModelId,
       },
     });
 
-    return result ? new this(this.model, result.get(), { user }) : null;
+    return preference ?? null;
   }
 
-  static async setPreference(
+  static async fetchStarred(
+    auth: Authenticator,
+    { spaceIds }: { spaceIds?: ModelId[] } = {}
+  ): Promise<Set<ModelId>> {
+    if (spaceIds && spaceIds.length === 0) {
+      return new Set();
+    }
+    const preferences = await this.baseFetch(auth, {
+      where: {
+        userId: auth.getNonNullableUser().id,
+        isStarred: true,
+        ...(spaceIds ? { spaceId: { [Op.in]: spaceIds } } : {}),
+      },
+    });
+    return new Set(preferences.map((p) => p.spaceId));
+  }
+
+  static async setNotificationPreference(
     auth: Authenticator,
     {
       spaceModelId,
-      preference,
+      notificationPreference,
     }: {
       spaceModelId: ModelId;
-      preference: NotificationCondition;
+      notificationPreference: NotificationCondition;
     }
-  ): Promise<UserProjectNotificationPreferenceResource> {
+  ): Promise<UserProjectPreferencesResource> {
     const workspace = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
 
-    const [entry] = await UserProjectNotificationPreferenceModel.upsert({
-      userId: user.id,
+    const [entry] = await UserProjectPreferencesModel.upsert({
       workspaceId: workspace.id,
+      userId: user.id,
       spaceId: spaceModelId,
-      preference,
+      notificationPreference,
+    });
+
+    return new this(this.model, entry.get(), { user });
+  }
+
+  static async setStarred(
+    auth: Authenticator,
+    {
+      spaceModelId,
+      isStarred,
+    }: {
+      spaceModelId: ModelId;
+      isStarred: boolean;
+    }
+  ): Promise<UserProjectPreferencesResource> {
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.getNonNullableUser();
+
+    const [entry] = await UserProjectPreferencesModel.upsert({
+      workspaceId: workspace.id,
+      userId: user.id,
+      spaceId: spaceModelId,
+      isStarred,
     });
 
     return new this(this.model, entry.get(), { user });
@@ -151,7 +182,7 @@ export class UserProjectNotificationPreferenceResource extends BaseResource<User
     spaceModelId: ModelId
   ): Promise<Result<undefined, Error>> {
     try {
-      await UserProjectNotificationPreferenceModel.destroy({
+      await UserProjectPreferencesModel.destroy({
         where: {
           workspaceId: auth.getNonNullableWorkspace().id,
           spaceId: spaceModelId,
@@ -165,7 +196,7 @@ export class UserProjectNotificationPreferenceResource extends BaseResource<User
 
   async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
     try {
-      await UserProjectNotificationPreferenceModel.destroy({
+      await UserProjectPreferencesModel.destroy({
         where: {
           id: this.id,
           userId: auth.getNonNullableUser().id,
@@ -187,7 +218,8 @@ export class UserProjectNotificationPreferenceResource extends BaseResource<User
         workspaceId: this.workspaceId,
       }),
       userId: this.user.sId,
-      preference: this.preference,
+      notificationPreference: this.notificationPreference,
+      isStarred: this.isStarred === true,
     };
   }
 }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
@@ -110,7 +110,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
+import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import {
@@ -157,20 +157,19 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const preference =
-        await UserProjectNotificationPreferenceResource.fetchByProject(
-          auth,
-          space.id
-        );
+      const preference = await UserProjectPreferencesResource.fetchBySpace(
+        auth,
+        space.id
+      );
       const serialized = preference?.toJSON();
       return res.status(200).json({
         userProjectNotificationPreference:
-          serialized && serialized.preference !== null
+          serialized && serialized.notificationPreference !== null
             ? {
                 sId: serialized.sId,
                 spaceId: serialized.spaceId,
                 userId: serialized.userId,
-                preference: serialized.preference,
+                preference: serialized.notificationPreference,
               }
             : null,
       });
@@ -196,20 +195,20 @@ async function handler(
       const body = bodyValidation.data;
 
       const preferenceResource =
-        await UserProjectNotificationPreferenceResource.setPreference(auth, {
+        await UserProjectPreferencesResource.setNotificationPreference(auth, {
           spaceModelId: space.id,
-          preference: body.preference,
+          notificationPreference: body.preference,
         });
 
       const serialized = preferenceResource.toJSON();
       return res.status(200).json({
         userProjectNotificationPreference:
-          serialized.preference !== null
+          serialized.notificationPreference !== null
             ? {
                 sId: serialized.sId,
                 spaceId: serialized.spaceId,
                 userId: serialized.userId,
-                preference: serialized.preference,
+                preference: serialized.notificationPreference,
               }
             : null,
       });

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -69,7 +69,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TakeawaysResource } from "@app/lib/resources/takeaways_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import { UserProjectNotificationPreferenceResource } from "@app/lib/resources/user_project_notification_preferences_resource";
+import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
@@ -245,10 +245,7 @@ export async function scrubSpaceActivity({
       { concurrency: 8 }
     );
 
-    await UserProjectNotificationPreferenceResource.deleteAllBySpace(
-      auth,
-      space.id
-    );
+    await UserProjectPreferencesResource.deleteAllBySpace(auth, space.id);
   }
 
   hardDeleteLogger.info({ space: space.sId, workspaceId }, "Deleting space");


### PR DESCRIPTION
## Description

This PR renames the `UserProjectNotificationPreference` model and resource to `UserProjectPreferences`.

- Renames `UserProjectNotificationPreferenceModel` → `UserProjectPreferencesModel` and `UserProjectNotificationPreferenceResource` → `UserProjectPreferencesResource`
- Renames the `preference` field to `notificationPreference` (with database field mapping to maintain backward compatibility)
- Adds a `baseFetch` helper method to simplify common query patterns

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.
