### PR TITLE
Self-improving skills Admin UI: display the consumption as a progress bar

### DIFF
--- a/front/components/pages/workspace/developers/ConsumptionProgressBar.tsx
+++ b/front/components/pages/workspace/developers/ConsumptionProgressBar.tsx
@@ -1,0 +1,54 @@
+import { cn, Page } from "@dust-tt/sparkle";
+
+interface ConsumptionProgressBarProps {
+  consumed: number;
+  total: number;
+}
+
+export function ConsumptionProgressBar({
+  consumed,
+  total,
+}: ConsumptionProgressBarProps) {
+  const percentage = total > 0 ? Math.min((consumed / total) * 100, 100) : 0;
+
+  return (
+    <div className="h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10">
+      <div
+        className={cn(
+          "h-full rounded-full transition-all",
+          percentage > 80
+            ? "bg-warning-700"
+            : "bg-primary dark:bg-primary-night"
+        )}
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
+  );
+}
+
+interface ConsumptionProgressBarWithNumbersProps {
+  consumed: number;
+  total: number;
+  consumedFormatted: string;
+  totalFormatted: string;
+}
+
+export function ConsumptionProgressBarWithNumbers({
+  consumed,
+  total,
+  consumedFormatted,
+  totalFormatted,
+}: ConsumptionProgressBarWithNumbersProps) {
+  return (
+    <Page.Vertical>
+      <Page.P variant="secondary">Total consumed</Page.P>
+      <div className="flex items-baseline gap-2">
+        <span className="text-5xl font-bold">{consumedFormatted}</span>
+        <span className="text-2xl text-muted-foreground dark:text-muted-foreground-night">
+          /{totalFormatted}
+        </span>
+      </div>
+      <ConsumptionProgressBar consumed={consumed} total={total} />
+    </Page.Vertical>
+  );
+}

--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -1,3 +1,7 @@
+import {
+  ConsumptionProgressBar,
+  ConsumptionProgressBarWithNumbers,
+} from "@app/components/pages/workspace/developers/ConsumptionProgressBar";
 import { BuyCreditDialog } from "@app/components/workspace/BuyCreditDialog";
 import { CreditHistorySheet } from "@app/components/workspace/CreditHistorySheet";
 import { CreditsList, isExpired } from "@app/components/workspace/CreditsList";
@@ -15,7 +19,6 @@ import {
   Button,
   CardIcon,
   ContentMessage,
-  cn,
   ExclamationCircleIcon,
   Hoverable,
   Page,
@@ -30,29 +33,6 @@ function isActive(credit: CreditDisplayData): boolean {
   const isExpired =
     credit.expirationDate !== null && credit.expirationDate <= now;
   return isStarted && !isExpired;
-}
-
-interface ProgressBarProps {
-  consumed: number;
-  total: number;
-}
-
-function ProgressBar({ consumed, total }: ProgressBarProps) {
-  const percentage = total > 0 ? Math.min((consumed / total) * 100, 100) : 0;
-
-  return (
-    <div className="h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10">
-      <div
-        className={cn(
-          "h-full rounded-full transition-all",
-          percentage > 80
-            ? "bg-warning-700"
-            : "bg-primary dark:bg-primary-night"
-        )}
-        style={{ width: `${percentage}%` }}
-      />
-    </div>
-  );
 }
 
 interface CreditCategoryBarProps {
@@ -96,7 +76,7 @@ function CreditCategoryBar({
           {isCap ? " cap" : ""}
         </span>
       </div>
-      <ProgressBar consumed={consumed} total={total} />
+      <ConsumptionProgressBar consumed={consumed} total={total} />
       {renewalDate && <Page.P variant="secondary">{renewalDate}</Page.P>}
     </Page.Vertical>
   );
@@ -190,16 +170,12 @@ function UsageSection({
       </div>
 
       {/* Total Consumed */}
-      <Page.Vertical>
-        <Page.P variant="secondary">Total consumed</Page.P>
-        <div className="flex items-baseline gap-2">
-          <span className="text-5xl font-bold">{totalConsumedFormatted}</span>
-          <span className="text-2xl text-muted-foreground dark:text-muted-foreground-night">
-            /{totalCreditsFormatted}
-          </span>
-        </div>
-        <ProgressBar consumed={totalConsumed} total={totalCredits} />
-      </Page.Vertical>
+      <ConsumptionProgressBarWithNumbers
+        consumed={totalConsumed}
+        total={totalCredits}
+        consumedFormatted={totalConsumedFormatted}
+        totalFormatted={totalCreditsFormatted}
+      />
 
       {/* Credit Categories */}
       <div className="grid grid-cols-3 gap-8 border-t border-border pt-6 dark:border-border-night">

--- a/front/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection.tsx
+++ b/front/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection.tsx
@@ -5,6 +5,7 @@ import {
 import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { ConsumptionProgressBarWithNumbers } from "@app/components/pages/workspace/developers/ConsumptionProgressBar";
 import {
   useReinforcementDailySpend,
   useSkillsReinforcementSpend,
@@ -385,12 +386,12 @@ export function SelfImprovingSkillsConsumptionSection({
           <Spinner />
         </div>
       ) : (
-        <div className="text-sm text-foreground dark:text-foreground-night">
-          <span className="font-semibold">${totalSpentDollars.toFixed(2)}</span>{" "}
-          spent out of{" "}
-          <span className="font-semibold">${capDollars.toFixed(2)}</span>{" "}
-          monthly cap
-        </div>
+        <ConsumptionProgressBarWithNumbers
+          consumed={totalSpentDollars}
+          total={capDollars}
+          consumedFormatted={`$${totalSpentDollars.toFixed(2)}`}
+          totalFormatted={`$${capDollars.toFixed(2)}`}
+        />
       )}
       <ReinforcementSpendChart owner={owner} capMicroUsd={capMicroUsd} />
     </Page.Vertical>


### PR DESCRIPTION
## Description

To be consistent with the consumption progresse bar in the programmatic usage page.
The component has been extracted to be re-used.

## Tests

Tested locally

<img width="2116" height="1044" alt="image" src="https://github.com/user-attachments/assets/192248c6-992c-4fe3-84ed-e14d54612790" />

<img width="2142" height="1016" alt="image" src="https://github.com/user-attachments/assets/4bf6cc4b-09b4-405c-942d-63d759486012" />


## Risk

no

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25527">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->