### PR TITLE
fix: accept task button hover

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_tasks/SuggestedTaskItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/SuggestedTaskItem.tsx
@@ -99,7 +99,7 @@ export const SuggestedTaskItem = memo(function SuggestedTaskItem({
         <div
           className={cn(
             "shrink-0 transition-opacity",
-            "opacity-0 group-hover/suggestion-item:opacity-100 group-focus-within/suggestion-item:opacity-100"
+            "[@media(hover:hover)]:opacity-0 group-hover/suggestion-item:opacity-100 group-focus-within/suggestion-item:opacity-100"
           )}
         >
           <Button


### PR DESCRIPTION
## Description

This PR fixes the accept task button to always appear on devices that do not support hover.

## Tests

Manually

## Risks

Low

## Deploy Plan

Standard deployment
