### PR TITLE
Allow self-improving cost cap per skill to be null to use default value

### DIFF
--- a/front/components/pages/workspace/developers/ReinforcementPage.tsx
+++ b/front/components/pages/workspace/developers/ReinforcementPage.tsx
@@ -6,7 +6,10 @@ import {
   useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
-import { getReinforcementMonthlyCapMicroUsd } from "@app/lib/reinforcement/consumption";
+import {
+  getReinforcementMonthlyCapMicroUsd,
+  getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
+} from "@app/lib/reinforcement/consumption";
 import {
   ContentMessage,
   InformationCircleIcon,
@@ -24,6 +27,10 @@ export function ReinforcementPage() {
 
   const [capMicroUsd, setCapMicroUsd] = useState(() =>
     getReinforcementMonthlyCapMicroUsd(owner)
+  );
+
+  const [defaultCapPerSkillMicroUsd, setDefaultCapPerSkillMicroUsd] = useState(
+    () => getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(owner)
   );
 
   const renderBody = () => {
@@ -59,12 +66,19 @@ export function ReinforcementPage() {
           </LinkWrapper>{" "}
           to share some feedback about this feature.
         </ContentMessage>
-        <ReinforcementSection owner={owner} onCapSaved={setCapMicroUsd} />
+        <ReinforcementSection
+          owner={owner}
+          onCapSaved={setCapMicroUsd}
+          onDefaultCapPerSkillSaved={setDefaultCapPerSkillMicroUsd}
+        />
         <SelfImprovingSkillsConsumptionSection
           owner={owner}
           capMicroUsd={capMicroUsd}
         />
-        <ReinforcementSkillsSection owner={owner} />
+        <ReinforcementSkillsSection
+          owner={owner}
+          defaultCapPerSkillMicroUsd={defaultCapPerSkillMicroUsd}
+        />
       </>
     );
   };

--- a/front/components/workspace/settings/AgentReinforcementToggle.tsx
+++ b/front/components/workspace/settings/AgentReinforcementToggle.tsx
@@ -21,11 +21,13 @@ import { useState } from "react";
 interface ReinforcementSectionProps {
   owner: WorkspaceType;
   onCapSaved?: (capMicroUsd: number) => void;
+  onDefaultCapPerSkillSaved?: (microUsd: number) => void;
 }
 
 export function ReinforcementSection({
   owner,
   onCapSaved,
+  onDefaultCapPerSkillSaved,
 }: ReinforcementSectionProps) {
   const { isEnabled, isChanging, doToggleReinforcement } =
     useReinforcementToggle({ owner });
@@ -51,7 +53,10 @@ export function ReinforcementSection({
         </ContextItem>
         <ReinforcementBatchModeToggle owner={owner} />
         <ReinforcementCapItem owner={owner} onCapSaved={onCapSaved} />
-        <SelfImprovementCapPerSkillItem owner={owner} />
+        <SelfImprovementCapPerSkillItem
+          owner={owner}
+          onSaved={onDefaultCapPerSkillSaved}
+        />
       </ContextItem.List>
     </Page.Vertical>
   );
@@ -79,7 +84,15 @@ function ReinforcementBatchModeToggle({ owner }: ReinforcementSectionProps) {
   );
 }
 
-function SelfImprovementCapPerSkillItem({ owner }: ReinforcementSectionProps) {
+interface SelfImprovementCapPerSkillItemProps {
+  owner: WorkspaceType;
+  onSaved?: (microUsd: number) => void;
+}
+
+function SelfImprovementCapPerSkillItem({
+  owner,
+  onSaved,
+}: SelfImprovementCapPerSkillItemProps) {
   const { capDollars, isSaving, saveCapDollars } =
     useSelfImprovementCapPerSkillSetting({ owner });
   const [inputValue, setInputValue] = useState<string>(() =>
@@ -99,7 +112,10 @@ function SelfImprovementCapPerSkillItem({ owner }: ReinforcementSectionProps) {
     if (!isInputDollarsValid) {
       return;
     }
-    await saveCapDollars(parsedInputDollars);
+    const ok = await saveCapDollars(parsedInputDollars);
+    if (ok) {
+      onSaved?.(Math.round(parsedInputDollars * 1_000_000));
+    }
   };
 
   return (

--- a/front/components/workspace/settings/ReinforcementSkillsSection.tsx
+++ b/front/components/workspace/settings/ReinforcementSkillsSection.tsx
@@ -27,6 +27,7 @@ import { useCallback, useMemo, useState } from "react";
 
 interface ReinforcementSkillsSectionProps {
   owner: LightWorkspaceType;
+  defaultCapPerSkillMicroUsd: number;
 }
 
 type RowData = {
@@ -42,6 +43,7 @@ type RowData = {
   isLockUpdating: boolean;
   currentSpentDollars: number;
   capInputValue: string;
+  capPlaceholder: string;
   isCapUpdating: boolean;
   onToggleEnabled: () => void;
   onToggleLock: () => void;
@@ -135,13 +137,20 @@ const COLUMNS: ColumnDef<RowData, unknown>[] = [
     header: "Cap ($)",
     accessorKey: "capInputValue",
     cell: (info: CellContext<RowData, unknown>) => {
-      const { sId, capInputValue, isCapUpdating, onCapChange, onCapCommit } =
-        info.row.original;
+      const {
+        sId,
+        capInputValue,
+        capPlaceholder,
+        isCapUpdating,
+        onCapChange,
+        onCapCommit,
+      } = info.row.original;
       return (
         <DataTable.CellContent>
           <Input
             name={`cap-${sId}`}
             value={capInputValue}
+            placeholder={capPlaceholder}
             disabled={isCapUpdating}
             onChange={(e) => onCapChange(e.target.value)}
             onBlur={onCapCommit}
@@ -206,6 +215,7 @@ function withoutSkill<T>(
 
 export function ReinforcementSkillsSection({
   owner,
+  defaultCapPerSkillMicroUsd,
 }: ReinforcementSkillsSectionProps) {
   const { skillsWithRelations, isSkillsWithRelationsLoading } =
     useSkillsWithRelations({ owner, status: "active", onlyCustom: true });
@@ -279,16 +289,37 @@ export function ReinforcementSkillsSection({
   );
 
   const handleCapCommit = useCallback(
-    async (skillId: string, savedDollars: number) => {
+    async (skillId: string, savedCapMicroUsd: number | null) => {
       const inputValue = capInputBySkillId[skillId];
       if (inputValue === undefined) {
         return;
       }
 
-      const parsed = Number(inputValue);
-      const isInvalid =
-        inputValue.trim() === "" || !Number.isFinite(parsed) || parsed < 0;
-      const isUnchanged = parsed === savedDollars;
+      const trimmed = inputValue.trim();
+
+      // Empty input resets to default (null).
+      if (trimmed === "") {
+        if (savedCapMicroUsd === null) {
+          // Already using default — just drop the local override.
+          setCapInputBySkillId((prev) => withoutSkill(prev, skillId));
+          return;
+        }
+        setCapUpdatingBySkillId((prev) => ({ ...prev, [skillId]: true }));
+        const ok = await updateSkillReinforcement(skillId, {
+          selfImprovementCostsCapMicroUsd: null,
+        });
+        setCapUpdatingBySkillId((prev) => withoutSkill(prev, skillId));
+        if (ok) {
+          setCapInputBySkillId((prev) => withoutSkill(prev, skillId));
+        }
+        return;
+      }
+
+      const parsed = Number(trimmed);
+      const isInvalid = !Number.isFinite(parsed) || parsed < 0;
+      const isUnchanged =
+        savedCapMicroUsd !== null &&
+        parsed === microUsdToDollars(savedCapMicroUsd);
       if (isInvalid || isUnchanged) {
         // Drop the local input override so the field falls back to the server value.
         setCapInputBySkillId((prev) => withoutSkill(prev, skillId));
@@ -329,16 +360,19 @@ export function ReinforcementSkillsSection({
     [skillsWithRelations, spentMicroUsdBySkillId]
   );
 
+  const defaultCapPlaceholder = `${formatDollars(microUsdToDollars(defaultCapPerSkillMicroUsd))} (default)`;
+
   const rows: RowData[] = useMemo(
     () =>
       sortedSkills.map((skill: SkillWithRelationsType) => {
         const enabled = isReinforcementEnabled(skill.reinforcement);
         const lock = skill.selfImprovementLock;
-        const savedCapDollars = microUsdToDollars(
-          skill.selfImprovementCostsCapMicroUsd
-        );
+        const savedCapMicroUsd = skill.selfImprovementCostsCapMicroUsd;
         const capInput =
-          capInputBySkillId[skill.sId] ?? formatDollars(savedCapDollars);
+          capInputBySkillId[skill.sId] ??
+          (savedCapMicroUsd !== null
+            ? formatDollars(microUsdToDollars(savedCapMicroUsd))
+            : "");
 
         return {
           sId: skill.sId,
@@ -355,6 +389,7 @@ export function ReinforcementSkillsSection({
             spentMicroUsdBySkillId[skill.sId] ?? 0
           ),
           capInputValue: capInput,
+          capPlaceholder: defaultCapPlaceholder,
           isCapUpdating: capUpdatingBySkillId[skill.sId] ?? false,
           onToggleEnabled: () => {
             void handleToggleEnabled(skill.sId, enabled);
@@ -366,12 +401,13 @@ export function ReinforcementSkillsSection({
             setCapInputBySkillId((prev) => ({ ...prev, [skill.sId]: value }));
           },
           onCapCommit: () => {
-            void handleCapCommit(skill.sId, savedCapDollars);
+            void handleCapCommit(skill.sId, savedCapMicroUsd);
           },
         };
       }),
     [
       sortedSkills,
+      defaultCapPlaceholder,
       pendingEnabledBySkillId,
       enabledUpdatingBySkillId,
       pendingLockBySkillId,

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -118,7 +118,7 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
 
   declare reinforcement: CreationOptional<SkillReinforcementMode>;
   declare lastReinforcementAnalysisAt: CreationOptional<Date | null>;
-  declare selfImprovementCostsCapMicroUsd: CreationOptional<number>;
+  declare selfImprovementCostsCapMicroUsd: CreationOptional<number | null>;
   // Lock toggling of self-improvement to admin only.
   declare selfImprovementLock: CreationOptional<boolean>;
 
@@ -140,8 +140,8 @@ SkillConfigurationModel.init(
     },
     selfImprovementCostsCapMicroUsd: {
       type: DataTypes.BIGINT,
-      allowNull: false,
-      defaultValue: 0,
+      allowNull: true,
+      defaultValue: null,
     },
     selfImprovementLock: {
       type: DataTypes.BOOLEAN,

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -21,7 +21,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     sourceMetadata: null,
     reinforcement: "auto",
     selfImprovementLock: false,
-    selfImprovementCostsCapMicroUsd: 0,
+    selfImprovementCostsCapMicroUsd: null,
     requestedSpaceIds: [],
     tools: [],
     fileAttachments: [],

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -20,7 +20,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     sourceMetadata: null,
     reinforcement: "auto",
     selfImprovementLock: false,
-    selfImprovementCostsCapMicroUsd: 0,
+    selfImprovementCostsCapMicroUsd: null,
     requestedSpaceIds: [],
     tools: [],
     fileAttachments: [],

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
+import { getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd } from "@app/lib/reinforcement/consumption";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
@@ -114,9 +115,13 @@ async function fetchEligibleSkillIds(
       }
     );
 
+  const defaultCapMicroUsd =
+    getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(workspace);
   const capEligibleSkills = eligibleSkills.filter((skill) => {
     const consumedMicroUsd = skillConsumptionMap.get(skill.id) ?? 0;
-    return consumedMicroUsd < skill.selfImprovementCostsCapMicroUsd;
+    const capMicroUsd =
+      skill.selfImprovementCostsCapMicroUsd ?? defaultCapMicroUsd;
+    return consumedMicroUsd < capMicroUsd;
   });
 
   logger.info(

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1,14 +1,11 @@
-import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { SkillDataSourceConfigurationModel } from "@app/lib/models/skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
-import { DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD } from "@app/lib/reinforcement/constants";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
@@ -1158,42 +1155,6 @@ describe("SkillResource", () => {
       expect(results[0].skill.id).toEqual(skillA.id);
       expect(results[0].conversationModelId).toEqual(conv1.id);
       expect(results[0].agentConfigurationId).toEqual(agent.sId);
-    });
-  });
-
-  describe("makeNew - selfImprovementCostsCapMicroUsd", () => {
-    it("defaults to the workspace self-improvement cap (20 USD) when no metadata is set", async () => {
-      const skill = await SkillFactory.create(testContext.authenticator);
-
-      expect(skill.selfImprovementCostsCapMicroUsd).toBe(
-        DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD
-      );
-      expect(skill.selfImprovementLock).toBe(false);
-    });
-
-    it("uses the workspace-level cap override when set", async () => {
-      const customCapMicroUsd = 7_000_000; // $7
-
-      const workspaceResource = await WorkspaceResource.fetchByModelId(
-        testContext.workspace.id
-      );
-      if (!workspaceResource) {
-        throw new Error("Workspace not found");
-      }
-      await workspaceResource.updateWorkspaceSettings({
-        metadata: {
-          ...(testContext.workspace.metadata ?? {}),
-          selfImprovementCapPerSkillMicroUsd: customCapMicroUsd,
-        },
-      });
-
-      const freshAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        testContext.user.sId,
-        testContext.workspace.sId
-      );
-      const skill = await SkillFactory.create(freshAuth);
-
-      expect(skill.selfImprovementCostsCapMicroUsd).toBe(customCapMicroUsd);
     });
   });
 });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -21,7 +21,6 @@ import {
 } from "@app/lib/models/skill/conversation_skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
-import { getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd } from "@app/lib/reinforcement/consumption";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -371,8 +370,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const skill = await this.model.create(
         {
           ...blob,
-          selfImprovementCostsCapMicroUsd:
-            getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(owner),
           workspaceId: owner.id,
         },
         {
@@ -1554,7 +1551,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         isDefault: !SystemSkillsRegistry.isSystemSkill(def.sId),
         reinforcement: "auto",
         lastReinforcementAnalysisAt: null,
-        selfImprovementCostsCapMicroUsd: 0,
+        selfImprovementCostsCapMicroUsd: null,
         selfImprovementLock: false,
       },
       {
@@ -2034,7 +2031,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   async updateSelfImprovementCostsCap(
-    selfImprovementCostsCapMicroUsd: number
+    selfImprovementCostsCapMicroUsd: number | null
   ): Promise<void> {
     await this.update({ selfImprovementCostsCapMicroUsd });
   }

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -288,7 +288,7 @@ export function useArchiveSkill({
 type SkillReinforcementUpdate = {
   reinforcement?: SkillReinforcementMode;
   selfImprovementLock?: boolean;
-  selfImprovementCostsCapMicroUsd?: number;
+  selfImprovementCostsCapMicroUsd?: number | null;
 };
 
 export function useUpdateSkillReinforcement({

--- a/front/migrations/20260511_backfill_skill_self_improvement_cap.sql
+++ b/front/migrations/20260511_backfill_skill_self_improvement_cap.sql
@@ -1,3 +1,0 @@
-UPDATE "skill_configurations"
-SET "selfImprovementCostsCapMicroUsd" = 20000000
-WHERE "selfImprovementCostsCapMicroUsd" = 0;

--- a/front/migrations/20260511_nullify_skill_self_improvement_cap.sql
+++ b/front/migrations/20260511_nullify_skill_self_improvement_cap.sql
@@ -1,0 +1,2 @@
+UPDATE "skill_configurations"
+SET "selfImprovementCostsCapMicroUsd" = null;

--- a/front/migrations/db/migration_633.sql
+++ b/front/migrations/db/migration_633.sql
@@ -1,0 +1,4 @@
+-- Migration created on mai 12, 2026
+ALTER TABLE "skill_configurations"
+ALTER COLUMN "selfImprovementCostsCapMicroUsd" DROP NOT NULL,
+ALTER COLUMN "selfImprovementCostsCapMicroUsd" DROP DEFAULT;

--- a/front/pages/api/w/[wId]/skills/[sId]/reinforcement.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/reinforcement.test.ts
@@ -218,6 +218,22 @@ describe("PATCH /api/w/[wId]/skills/[sId]/reinforcement", () => {
     expect(updated?.selfImprovementCostsCapMicroUsd).toBe(25_000_000);
   });
 
+  it("sets selfImprovementCostsCapMicroUsd to null (use default)", async () => {
+    const { req, res, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    // First set a custom cap.
+    await skill.updateSelfImprovementCostsCap(10_000_000);
+
+    req.body = { selfImprovementCostsCapMicroUsd: null };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const updated = await SkillResource.fetchById(requestUserAuth, skill.sId);
+    expect(updated?.selfImprovementCostsCapMicroUsd).toBeNull();
+  });
+
   it("updates multiple fields in a single request", async () => {
     const { req, res, skill, requestUserAuth } = await setupTest({
       requestUserRole: "admin",
@@ -226,7 +242,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]/reinforcement", () => {
     req.body = {
       reinforcement: "off",
       selfImprovementLock: true,
-      selfImprovementCostsCapMicroUsd: 0,
+      selfImprovementCostsCapMicroUsd: 5_000_000,
     };
     await handler(req, res);
 
@@ -234,7 +250,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]/reinforcement", () => {
     const updated = await SkillResource.fetchById(requestUserAuth, skill.sId);
     expect(updated?.reinforcement).toBe("off");
     expect(updated?.selfImprovementLock).toBe(true);
-    expect(updated?.selfImprovementCostsCapMicroUsd).toBe(0);
+    expect(updated?.selfImprovementCostsCapMicroUsd).toBe(5_000_000);
   });
 
   it("returns 403 when a non-admin tries to set selfImprovementLock", async () => {

--- a/front/pages/api/w/[wId]/skills/[sId]/reinforcement.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/reinforcement.ts
@@ -15,7 +15,12 @@ const PatchSkillReinforcementBodySchema = z
   .object({
     reinforcement: z.enum(SKILL_REINFORCEMENT_MODES).optional(),
     selfImprovementLock: z.boolean().optional(),
-    selfImprovementCostsCapMicroUsd: z.number().int().nonnegative().optional(),
+    selfImprovementCostsCapMicroUsd: z
+      .number()
+      .int()
+      .nonnegative()
+      .nullable() // use default
+      .optional(), // not updated
   })
   .refine(
     (b) =>

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -60,7 +60,7 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     sourceMetadata: null,
     reinforcement: "auto",
     selfImprovementLock: false,
-    selfImprovementCostsCapMicroUsd: 0,
+    selfImprovementCostsCapMicroUsd: null,
     requestedSpaceIds: [],
     tools: (config.tools ?? []).map((t) => ({
       id: 0,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -44,7 +44,7 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
   reinforcement: z.enum(SKILL_REINFORCEMENT_MODES),
   lastReinforcementAnalysisAt: z.string().nullable().optional(),
   selfImprovementLock: z.boolean(),
-  selfImprovementCostsCapMicroUsd: z.number(),
+  selfImprovementCostsCapMicroUsd: z.number().nullable(),
   requestedSpaceIds: z.array(z.string()),
   fileAttachments: z.array(
     z.object({


### PR DESCRIPTION
## Description

 - Allow null value for selfImprovementCostsCapMicroUsd, so we use the dynamic default value instead of hardcoding at creation
 - reset all the skills to null. This impact beta testers but it's better than leaving some skill to random values for non beta testers.
 - in the ui, display the skills without values with "20 (default)" placeholder. Default can be changed, a value already set can be set back to null to use default.

https://github.com/user-attachments/assets/8856727c-0cb8-4987-8ece-3a91e38f6bb4

## Tests

 - Manualy tested the UI
 - unit test updated

## Risk

can change a cap set by a beta tester

## Deploy Plan

lock front
merge
run migration 1
deploy front
wait deployement
run migration 2 to set all skill to null value


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25529">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->