### PR TITLE
[front] fix: Do not read sync directories on sbx build

### DIFF
--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -13,7 +13,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.8";
+const DUST_BASE_IMAGE_VERSION = "0.8.9";
 const DSBX_CLI_VERSION = "0.1.7";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
@@ -102,6 +102,23 @@ function getPythonInstallCmd(): string {
 
 function getLocalContent(dir: string, filename: string): () => string {
   return () => fs.readFileSync(path.join(dir, filename), "utf-8");
+}
+
+function getLocalDirContent(
+  dir: string,
+  subdir: string
+): () => Map<string, Buffer> {
+  return () => {
+    const full = path.join(dir, subdir);
+    return new Map(
+      fs
+        .readdirSync(full)
+        .map((filename) => [
+          filename,
+          fs.readFileSync(path.join(full, filename)),
+        ])
+    );
+  };
 }
 
 function getAgentProxiedSetupCommand(): string {
@@ -275,9 +292,11 @@ SHELLEOF`,
     getLocalContent(PROFILE_LOCAL_DIR, "gemini.sh"),
     `${PROFILE_DIR}/gemini.sh`
   )
-  .copyDir(path.join(PROFILE_LOCAL_DIR, "soffice"), `${PROFILE_DIR}/soffice`, {
-    user: "root",
-  })
+  .copy(
+    getLocalDirContent(PROFILE_LOCAL_DIR, "soffice"),
+    `${PROFILE_DIR}/soffice`,
+    { user: "root" }
+  )
   .runCmd(`chmod +x ${PROFILE_DIR}/soffice/*.py`, { user: "root" })
   // Telemetry configs for fluent-bit
   .copy(

--- a/front/lib/api/sandbox/image/sandbox_image.ts
+++ b/front/lib/api/sandbox/image/sandbox_image.ts
@@ -15,8 +15,6 @@ import type {
   SandboxResources,
   ToolEntry,
 } from "@app/lib/api/sandbox/image/types";
-import fs from "fs";
-import path from "path";
 
 const DEFAULT_RESOURCES: SandboxResources = {
   vcpu: 1,
@@ -162,24 +160,6 @@ export class SandboxImage {
     return this.clone({
       operations: [...this.operations, operation],
     });
-  }
-
-  copyDir(
-    srcDir: string,
-    destDir: string,
-    options?: { user?: string }
-  ): SandboxImage {
-    return fs
-      .readdirSync(srcDir)
-      .reduce<SandboxImage>(
-        (img, filename) =>
-          img.copy(
-            () => fs.readFileSync(path.join(srcDir, filename)),
-            `${destDir}/${filename}`,
-            options
-          ),
-        this
-      );
   }
 
   setWorkdir(path: string): SandboxImage {

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -53,7 +53,10 @@ export interface ToolEntry {
 
 export type ManifestFormat = "json" | "yaml";
 
-export type ContentGenerator = () => Buffer | string;
+export type ContentGenerator = () =>
+  | Buffer
+  | string
+  | Map<string, Buffer | string>;
 
 export type CopySource =
   | { readonly type: "path"; readonly path: string }

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -59,23 +59,32 @@ class ContentMaterializer {
   private tempDir: string | null = null;
   private fileCount = 0;
 
-  materializeToPath(
+  // Writes the generator's content into a temp subdir under __dirname (E2B
+  // resolves paths from there). For single-file content, dest is treated as
+  // the file path. For multi-file content (Map), dest is treated as the
+  // destination directory.
+  materialize(
     getContent: ContentGenerator,
-    destFileName: string
-  ): string {
+    dest: string
+  ): { tempDir: string; destDir: string } {
     if (!this.tempDir) {
-      // Create temp dir relative to this module (E2B resolves paths from __dirname).
       const uniqueId = `sandbox-build-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       this.tempDir = path.join(__dirname, uniqueId);
       fs.mkdirSync(this.tempDir, { recursive: true });
     }
-    // Use a subdirectory per file so E2B's directory-based copy works correctly.
     const contentDir = path.join(this.tempDir, `content-${this.fileCount++}`);
     fs.mkdirSync(contentDir, { recursive: true });
-    const fileName = path.basename(destFileName);
-    const tempFile = path.join(contentDir, fileName);
-    fs.writeFileSync(tempFile, getContent());
-    return path.relative(__dirname, contentDir);
+
+    const result = getContent();
+    const tempDir = path.relative(__dirname, contentDir);
+    if (result instanceof Map) {
+      for (const [filename, content] of result) {
+        fs.writeFileSync(path.join(contentDir, filename), content);
+      }
+      return { tempDir, destDir: dest };
+    }
+    fs.writeFileSync(path.join(contentDir, path.basename(dest)), result);
+    return { tempDir, destDir: path.dirname(dest) };
   }
 
   cleanup(): void {
@@ -130,13 +139,10 @@ class E2BTemplateBuilder {
             user: op.user,
           });
         } else {
-          // E2B copy works with directories, so we create a temp dir containing
-          // a file with the destination's filename, then copy to dest's parent.
-          const tempDir = this.materializer.materializeToPath(
+          const { tempDir, destDir } = this.materializer.materialize(
             op.src.getContent,
             op.dest
           );
-          const destDir = path.dirname(op.dest);
           this.builder = this.builder.copy(tempDir, destDir, { user: op.user });
         }
         break;


### PR DESCRIPTION
## Description

https://github.com/dust-tt/dust/pull/25530 introduced a bug when it was copying files at module import, which is not what we want. Instead we want the copy function to return lazily and copy at build time in the e2b provider.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25535">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->