### PR TITLE
tolerate syntax errors when extracting frame file refs

### DIFF
--- a/.github/workflows/build-viz.yml
+++ b/.github/workflows/build-viz.yml
@@ -1,4 +1,4 @@
-name: Lint & Build (viz)
+name: Lint & Build & Test (viz)
 
 on:
   push:
@@ -22,3 +22,13 @@ jobs:
           node-version: "24.14.0"
       - name: Build
         run: npm -w viz run build
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          node-version: "24.14.0"
+      - name: Test
+        run: npm -w viz run test

--- a/viz/app/lib/parseFileRefs.test.ts
+++ b/viz/app/lib/parseFileRefs.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { extractFileRefs } from "@viz/app/lib/parseFileRefs";
+
+describe("extractFileRefs", () => {
+  it("extracts file IDs from useFile() calls", () => {
+    const code = `
+      function Comp() {
+        const f = useFile("fil_ABCDEFGHIJ");
+        return f;
+      }
+    `;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "fileId", fileId: "fil_ABCDEFGHIJ" },
+    ]);
+  });
+
+  it("extracts file IDs from fileId JSX attributes", () => {
+    const code = `
+      function Comp() {
+        return <Image fileId="fil_XYZ1234567" />;
+      }
+    `;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "fileId", fileId: "fil_XYZ1234567" },
+    ]);
+  });
+
+  it("extracts file IDs from any string literal", () => {
+    const code = `const s = "fil_ABCDEFGHIJ";`;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "fileId", fileId: "fil_ABCDEFGHIJ" },
+    ]);
+  });
+
+  it("extracts scoped paths from string literals", () => {
+    const code = `const path = "conversation/abc/file.csv";`;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "path", scopedPath: "conversation/abc/file.csv" },
+    ]);
+  });
+
+  it("deduplicates refs across visitors", () => {
+    const code = `
+      function Comp() {
+        useFile("fil_ABCDEFGHIJ");
+        return <Image fileId="fil_ABCDEFGHIJ" />;
+      }
+    `;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "fileId", fileId: "fil_ABCDEFGHIJ" },
+    ]);
+  });
+
+  it("extracts file IDs and scoped paths from import specifiers", () => {
+    const code = `
+      import data from "fil_ABCDEFGHIJ";
+      import { thing } from "fil_BBBBBBBBBB";
+      const lazy = import("fil_CCCCCCCCCC");
+      export * from "fil_DDDDDDDDDD";
+      const csv = require("conversation/abc/data.csv");
+    `;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "fileId", fileId: "fil_ABCDEFGHIJ" },
+      { type: "fileId", fileId: "fil_BBBBBBBBBB" },
+      { type: "fileId", fileId: "fil_CCCCCCCCCC" },
+      { type: "fileId", fileId: "fil_DDDDDDDDDD" },
+      { type: "path", scopedPath: "conversation/abc/data.csv" },
+    ]);
+  });
+
+  it("ignores non-matching string literals", () => {
+    const code = `
+      const a = "hello world";
+      const b = "fil_TOO_SHORT";
+      const c = "/conversation/wrong-prefix";
+    `;
+    expect(extractFileRefs(code)).toEqual([]);
+  });
+
+  it("recovers refs from code with spec-level syntax errors", () => {
+    // `a ?? b || c` without parens is a SyntaxError per the JS spec — this is
+    // the pattern AI-generated frame code occasionally emits.
+    const code = `
+      function Comp() {
+        const f = useFile("fil_ABCDEFGHIJ");
+        const broken = a ?? b || c;
+        return <Image fileId="fil_XYZ1234567" path="conversation/x/y.csv" />;
+      }
+    `;
+    const refs = extractFileRefs(code);
+    expect(refs).toEqual(
+      expect.arrayContaining([
+        { type: "fileId", fileId: "fil_ABCDEFGHIJ" },
+        { type: "fileId", fileId: "fil_XYZ1234567" },
+        { type: "path", scopedPath: "conversation/x/y.csv" },
+      ])
+    );
+    expect(refs).toHaveLength(3);
+  });
+
+  it("returns an empty array for completely unparseable input without throwing", () => {
+    const code = "@@@ not even javascript @@@";
+    expect(() => extractFileRefs(code)).not.toThrow();
+    expect(extractFileRefs(code)).toEqual([]);
+  });
+
+  it("returns refs in the order they're first seen", () => {
+    const code = `
+      useFile("fil_AAAAAAAAAA");
+      const p = "conversation/foo/bar.txt";
+      useFile("fil_BBBBBBBBBB");
+    `;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "fileId", fileId: "fil_AAAAAAAAAA" },
+      { type: "path", scopedPath: "conversation/foo/bar.txt" },
+      { type: "fileId", fileId: "fil_BBBBBBBBBB" },
+    ]);
+  });
+});

--- a/viz/app/lib/parseFileRefs.test.ts
+++ b/viz/app/lib/parseFileRefs.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from "vitest";
-
 import { extractFileRefs } from "@viz/app/lib/parseFileRefs";
+import { describe, expect, it } from "vitest";
 
 describe("extractFileRefs", () => {
   it("extracts file IDs from useFile() calls", () => {

--- a/viz/app/lib/parseFileRefs.ts
+++ b/viz/app/lib/parseFileRefs.ts
@@ -1,6 +1,5 @@
-import ts from "typescript";
-
 import logger from "@viz/app/lib/logger";
+import ts from "typescript";
 
 export type FileRef =
   | { type: "fileId"; fileId: string }

--- a/viz/app/lib/parseFileRefs.ts
+++ b/viz/app/lib/parseFileRefs.ts
@@ -1,5 +1,5 @@
-import { parse } from "@babel/parser";
-import traverse from "@babel/traverse";
+import ts from "typescript";
+
 import logger from "@viz/app/lib/logger";
 
 export type FileRef =
@@ -28,48 +28,52 @@ export function extractFileRefs(code: string): FileRef[] {
   }
 
   try {
-    const ast = parse(code, {
-      sourceType: "module",
-      plugins: ["jsx", "typescript"],
-      strictMode: false,
-      // AI-generated viz code occasionally contains spec-level syntax errors
-      // (e.g. `a ?? b || c` without parens). Recover and still walk the valid
-      // portions so we can prefetch refs.
-      errorRecovery: true,
-    });
+    // TypeScript's parser is tolerant by design It produces a (partial) AST even for code with
+    // syntax errors (errors are reported via parseDiagnostics rather than thrown), which is what
+    // we want for AI-generated frame code.
+    const sourceFile = ts.createSourceFile(
+      "frame.tsx",
+      code,
+      ts.ScriptTarget.Latest,
+      false,
+      ts.ScriptKind.TSX
+    );
 
-    traverse(ast, {
-      // Extract useFile() calls.
-      CallExpression(path) {
-        if (
-          path.node.callee.type === "Identifier" &&
-          path.node.callee.name === "useFile" &&
-          path.node.arguments.length > 0
-        ) {
-          const arg = path.node.arguments[0];
-          if (arg.type === "StringLiteral") {
-            add(arg.value);
-          }
-        }
-      },
-      // Extract file refs from JSX props like fileId="fil_xxx".
-      JSXAttribute(path) {
-        if (
-          path.node.name.type === "JSXIdentifier" &&
-          path.node.name.name === "fileId" &&
-          path.node.value?.type === "StringLiteral"
-        ) {
-          add(path.node.value.value);
-        }
-      },
-      // Extract fil_xxx patterns and scoped paths from all string literals.
-      StringLiteral(path) {
-        const value = path.node.value;
-        if (typeof value === "string") {
-          add(value);
-        }
-      },
-    });
+    const visit = (node: ts.Node): void => {
+      // Extract useFile("X") calls.
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "useFile" &&
+        node.arguments.length > 0 &&
+        ts.isStringLiteral(node.arguments[0])
+      ) {
+        add(node.arguments[0].text);
+      }
+
+      // Extract fileId="X" JSX attributes.
+      if (
+        ts.isJsxAttribute(node) &&
+        ts.isIdentifier(node.name) &&
+        node.name.text === "fileId" &&
+        node.initializer &&
+        ts.isStringLiteral(node.initializer)
+      ) {
+        add(node.initializer.text);
+      }
+
+      // Extract fil_xxx / scoped paths from any string literal.
+      if (
+        ts.isStringLiteral(node) ||
+        ts.isNoSubstitutionTemplateLiteral(node)
+      ) {
+        add(node.text);
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
   } catch (err) {
     logger.warn({ err }, "Failed to parse frame code:");
   }

--- a/viz/app/lib/parseFileRefs.ts
+++ b/viz/app/lib/parseFileRefs.ts
@@ -11,20 +11,19 @@ function isScopedPath(value: string): boolean {
 }
 
 export function extractFileRefs(code: string): FileRef[] {
-  const seen = new Set<string>();
-  const refs: FileRef[] = [];
+  const refs = new Map<string, FileRef>();
 
-  function add(value: string) {
-    if (seen.has(value)) {
+  const add = (value: string) => {
+    if (refs.has(value)) {
       return;
     }
-    seen.add(value);
+
     if (/^fil_[a-zA-Z0-9]{10,}$/.test(value)) {
-      refs.push({ type: "fileId", fileId: value });
+      refs.set(value, { type: "fileId", fileId: value });
     } else if (isScopedPath(value)) {
-      refs.push({ type: "path", scopedPath: value });
+      refs.set(value, { type: "path", scopedPath: value });
     }
-  }
+  };
 
   try {
     // TypeScript's parser is tolerant by design It produces a (partial) AST even for code with
@@ -77,5 +76,5 @@ export function extractFileRefs(code: string): FileRef[] {
     logger.warn({ err }, "Failed to parse frame code:");
   }
 
-  return refs;
+  return Array.from(refs.values());
 }

--- a/viz/package.json
+++ b/viz/package.json
@@ -9,12 +9,11 @@
     "dev": "next dev -p 3007",
     "build": "next build",
     "start": "next start",
+    "test": "vitest --run",
     "format": "biome format --write .",
     "format:check": "biome format ."
   },
   "dependencies": {
-    "@babel/parser": "^7.28.5",
-    "@babel/traverse": "^7.28.5",
     "@hookform/resolvers": "^5.2.1",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -68,17 +67,17 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.3.6",
+    "typescript": "^5.7.2",
     "vaul": "^1.1.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@types/babel__traverse": "^7.28.0",
     "@types/node": "^24.12.2",
     "@types/papaparse": "^5.3.14",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.7.2"
+    "vitest": "^4.0.16"
   }
 }

--- a/viz/vitest.config.ts
+++ b/viz/vitest.config.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@viz": path.resolve(__dirname, "."),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["**/*.test.ts", "**/*.test.tsx"],
+  },
+});


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The server-side prefetch path parses visualization code to find `fil_xxx` IDs and scoped paths before rendering. Previously this used `@babel/parser`, which hard-throws on certain spec-level syntax errors (e.g:
`a ?? b || c` without parens, a SyntaxError per the JS spec). The throw blanked out all prefetching for
the entire frame and produced noisy `error`-level logs, even though the client-side renderer was perfectly happy to display the code.

We initially tried https://github.com/dust-tt/dust/pull/25519 setting `errorRecovery: true`, but Babel's parser explicitly
throws this particular error regardless of that flag. This PR swaps the parser for the TypeScript compiler API, which is designed to be tolerant: `ts.createSourceFile` produces a partial AST even from broken code and reports diagnostics separately instead of throwing.

Took the opportunity to add some tests.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25536">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->