### PR TITLE
Add seat plan API

### DIFF
--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -66,7 +66,7 @@ export async function handleSeatPlanRequest(
   const proProductId = getProductProSeatId();
   const maxProductId = getProductMaxSeatId();
 
-  const monthlyPriceMap = new Map<PriceKey, number>();
+  const monthlyPriceCentsMap = new Map<PriceKey, number>();
 
   try {
     const rateSchedule =
@@ -90,7 +90,7 @@ export async function handleSeatPlanRequest(
         continue;
       }
       // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
-      monthlyPriceMap.set(key, entry.rate.price);
+      monthlyPriceCentsMap.set(key, entry.rate.price);
     }
   } catch (err) {
     logger.warn(
@@ -111,13 +111,13 @@ export async function handleSeatPlanRequest(
   }
 
   const buildSeatInfo = (key: PriceKey): SeatTypeInfo | null => {
-    const monthlyPrice = monthlyPriceMap.get(key);
-    if (monthlyPrice === undefined) {
+    const monthlyPriceCents = monthlyPriceCentsMap.get(key);
+    if (monthlyPriceCents === undefined) {
       return null;
     }
     return {
       awuCredits: awuCreditsMap.get(key) ?? 0,
-      priceCents: monthlyPrice,
+      priceCents: monthlyPriceCents,
     };
   };
 

--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -1,0 +1,128 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getMetronomeClient } from "@app/lib/metronome/client";
+import {
+  getProductMaxSeatId,
+  getProductProSeatId,
+  MAX_SEAT_CREDIT_NAME,
+  PRO_SEAT_CREDIT_NAME,
+} from "@app/lib/metronome/constants";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export interface SeatTypeInfo {
+  awuCredits: number;
+  priceCents: number;
+}
+
+export interface SeatPlanResponseBody {
+  pro: SeatTypeInfo | null;
+  max: SeatTypeInfo | null;
+}
+
+type PriceKey = "pro" | "max";
+
+export async function handleSeatPlanRequest(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<SeatPlanResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET is supported.",
+      },
+    });
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const contract = await getActiveContract(workspace.sId);
+
+  if (!contract || !contract.rate_card_id) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "internal_server_error",
+        message: "Workspace is not configured for Metronome billing.",
+      },
+    });
+  }
+
+  // Extract per-seat AWU credit amounts from recurring credits on the contract.
+  const awuCreditsMap = new Map<PriceKey, number>();
+  for (const credit of contract.recurring_credits ?? []) {
+    if (credit.name === PRO_SEAT_CREDIT_NAME) {
+      awuCreditsMap.set("pro", credit.access_amount.unit_price);
+    } else if (credit.name === MAX_SEAT_CREDIT_NAME) {
+      awuCreditsMap.set("max", credit.access_amount.unit_price);
+    }
+  }
+
+  const proProductId = getProductProSeatId();
+  const maxProductId = getProductMaxSeatId();
+
+  const monthlyPriceMap = new Map<PriceKey, number>();
+
+  try {
+    const rateSchedule =
+      await getMetronomeClient().v1.contracts.rateCards.retrieveRateSchedule({
+        rate_card_id: contract.rate_card_id,
+        starting_at: new Date().toISOString(),
+        selectors: [{ product_id: proProductId }, { product_id: maxProductId }],
+      });
+
+    for (const entry of rateSchedule.data ?? []) {
+      if (!entry.entitled || entry.rate.price === undefined) {
+        continue;
+      }
+      const key: PriceKey | undefined =
+        entry.product_id === proProductId
+          ? "pro"
+          : entry.product_id === maxProductId
+            ? "max"
+            : undefined;
+      if (!key) {
+        continue;
+      }
+      // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
+      monthlyPriceMap.set(key, entry.rate.price);
+    }
+  } catch (err) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        rateCardId: contract.rate_card_id,
+        err: normalizeError(err),
+      },
+      "[Metronome] Failed to fetch rate schedule for seat products"
+    );
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to fetch rate schedule for seat products.",
+      },
+    });
+  }
+
+  const buildSeatInfo = (key: PriceKey): SeatTypeInfo | null => {
+    const monthlyPrice = monthlyPriceMap.get(key);
+    if (monthlyPrice === undefined) {
+      return null;
+    }
+    return {
+      awuCredits: awuCreditsMap.get(key) ?? 0,
+      priceCents: monthlyPrice,
+    };
+  };
+
+  return res.status(200).json({
+    pro: buildSeatInfo("pro"),
+    max: buildSeatInfo("max"),
+  });
+}

--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -1,10 +1,10 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import {
-  getProductMaxSeatId,
-  getProductProSeatId,
   MAX_SEAT_CREDIT_NAME,
+  MAX_SEAT_PRODUCT_NAME,
   PRO_SEAT_CREDIT_NAME,
+  PRO_SEAT_PRODUCT_NAME,
 } from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import logger from "@app/logger/logger";
@@ -18,12 +18,10 @@ export interface SeatTypeInfo {
   priceCents: number;
 }
 
-export interface SeatPlanResponseBody {
-  pro: SeatTypeInfo | null;
-  max: SeatTypeInfo | null;
-}
-
 type PriceKey = "pro" | "max";
+
+export interface SeatPlanResponseBody
+  extends Record<PriceKey, SeatTypeInfo | null> {}
 
 export async function handleSeatPlanRequest(
   req: NextApiRequest,
@@ -63,35 +61,38 @@ export async function handleSeatPlanRequest(
     }
   }
 
-  const proProductId = getProductProSeatId();
-  const maxProductId = getProductMaxSeatId();
-
   const monthlyPriceCentsMap = new Map<PriceKey, number>();
 
   try {
-    const rateSchedule =
-      await getMetronomeClient().v1.contracts.rateCards.retrieveRateSchedule({
-        rate_card_id: contract.rate_card_id,
-        starting_at: new Date().toISOString(),
-        selectors: [{ product_id: proProductId }, { product_id: maxProductId }],
-      });
+    const startingAt = new Date().toISOString();
+    let nextPage: string | null | undefined = undefined;
+    do {
+      const rateSchedule =
+        await getMetronomeClient().v1.contracts.rateCards.retrieveRateSchedule({
+          rate_card_id: contract.rate_card_id,
+          starting_at: startingAt,
+          ...(nextPage ? { next_page: nextPage } : {}),
+        });
 
-    for (const entry of rateSchedule.data ?? []) {
-      if (!entry.entitled || entry.rate.price === undefined) {
-        continue;
+      for (const entry of rateSchedule.data ?? []) {
+        if (!entry.entitled || entry.rate.price === undefined) {
+          continue;
+        }
+        const key: PriceKey | undefined =
+          entry.product_name === PRO_SEAT_PRODUCT_NAME
+            ? "pro"
+            : entry.product_name === MAX_SEAT_PRODUCT_NAME
+              ? "max"
+              : undefined;
+        if (!key) {
+          continue;
+        }
+        // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
+        monthlyPriceCentsMap.set(key, entry.rate.price);
       }
-      const key: PriceKey | undefined =
-        entry.product_id === proProductId
-          ? "pro"
-          : entry.product_id === maxProductId
-            ? "max"
-            : undefined;
-      if (!key) {
-        continue;
-      }
-      // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
-      monthlyPriceCentsMap.set(key, entry.rate.price);
-    }
+
+      nextPage = rateSchedule.next_page;
+    } while (nextPage && monthlyPriceCentsMap.size < 2);
   } catch (err) {
     logger.warn(
       {

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -88,6 +88,8 @@ export const PLAN_CODE_CUSTOM_FIELD_KEY = "DUST_PLAN_CODE";
 
 export const PRO_SEAT_CREDIT_NAME = "Pro Seat Credits";
 export const MAX_SEAT_CREDIT_NAME = "Max Seat Credits";
+export const PRO_SEAT_PRODUCT_NAME = "Pro Seat";
+export const MAX_SEAT_PRODUCT_NAME = "Max Seat";
 
 // AWU (Agentic Work Units) differs per environment.
 export const DEV_CREDIT_TYPE_AWU_ID = "eb003cc7-4935-467d-a41c-c1738c1c9dc2";

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -86,6 +86,9 @@ export const CREDIT_TYPE_EUR_ID = "58f0be15-cc47-4220-bdaf-072ab0e44f96";
 
 export const PLAN_CODE_CUSTOM_FIELD_KEY = "DUST_PLAN_CODE";
 
+export const PRO_SEAT_CREDIT_NAME = "Pro Seat Credits";
+export const MAX_SEAT_CREDIT_NAME = "Max Seat Credits";
+
 // AWU (Agentic Work Units) differs per environment.
 export const DEV_CREDIT_TYPE_AWU_ID = "eb003cc7-4935-467d-a41c-c1738c1c9dc2";
 export const PROD_CREDIT_TYPE_AWU_ID = "8dfc9846-a38e-44f8-a625-bd9372af681c";

--- a/front/pages/api/w/[wId]/seats/plan.ts
+++ b/front/pages/api/w/[wId]/seats/plan.ts
@@ -1,0 +1,18 @@
+/** @ignoreswagger */
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
+import { handleSeatPlanRequest } from "@app/lib/api/credits/seat_plan";
+import type { Authenticator } from "@app/lib/auth";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<SeatPlanResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  return handleSeatPlanRequest(req, res, auth);
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -19,8 +19,10 @@ import {
   DEV_CREDIT_TYPE_AWU_ID,
   DEV_CREDIT_TYPE_PROG_USD_ID,
   MAX_SEAT_CREDIT_NAME,
+  MAX_SEAT_PRODUCT_NAME,
   PLAN_CODE_CUSTOM_FIELD_KEY,
   PRO_SEAT_CREDIT_NAME,
+  PRO_SEAT_PRODUCT_NAME,
   PROD_CREDIT_TYPE_AWU_ID,
   PROD_CREDIT_TYPE_PROG_USD_ID,
 } from "@app/lib/metronome/constants";
@@ -348,11 +350,11 @@ const PRODUCTS: ProductDef[] = [
   // seat-based plans. Used as SEAT_BASED subscriptions in packages with per-seat
   // INDIVIDUAL recurring credits (Pro: 8000 AWU/mo, Max: 40000 AWU/mo).
   {
-    name: "Pro Seat",
+    name: PRO_SEAT_PRODUCT_NAME,
     type: "SUBSCRIPTION",
   },
   {
-    name: "Max Seat",
+    name: MAX_SEAT_PRODUCT_NAME,
     type: "SUBSCRIPTION",
   },
   // MAU product — single subscription for simple (non-tiered) enterprise contracts.
@@ -834,7 +836,7 @@ function getRateCards(): RateCardDef[] {
       ],
       rates: [
         {
-          product_name: "Pro Seat",
+          product_name: PRO_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -842,7 +844,7 @@ function getRateCards(): RateCardDef[] {
           billing_frequency: "MONTHLY",
         },
         {
-          product_name: "Max Seat",
+          product_name: MAX_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -876,7 +878,7 @@ function getRateCards(): RateCardDef[] {
       ],
       rates: [
         {
-          product_name: "Pro Seat",
+          product_name: PRO_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -885,7 +887,7 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
-          product_name: "Max Seat",
+          product_name: MAX_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -1040,7 +1042,7 @@ const MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID = "max-seat-sub";
 
 const PRO_SEAT_SUBSCRIPTION: PackageSubscription = {
   temporary_id: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-  product_name: "Pro Seat",
+  product_name: PRO_SEAT_PRODUCT_NAME,
   billing_frequency: "MONTHLY",
   collection_schedule: "ADVANCE",
   quantity_management_mode: "SEAT_BASED",
@@ -1053,7 +1055,7 @@ const PRO_SEAT_SUBSCRIPTION: PackageSubscription = {
 
 const MAX_SEAT_SUBSCRIPTION: PackageSubscription = {
   temporary_id: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-  product_name: "Max Seat",
+  product_name: MAX_SEAT_PRODUCT_NAME,
   billing_frequency: "MONTHLY",
   collection_schedule: "ADVANCE",
   quantity_management_mode: "SEAT_BASED",

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -18,9 +18,11 @@ import {
   CREDIT_TYPE_USD_ID,
   DEV_CREDIT_TYPE_AWU_ID,
   DEV_CREDIT_TYPE_PROG_USD_ID,
+  MAX_SEAT_CREDIT_NAME,
   PLAN_CODE_CUSTOM_FIELD_KEY,
   PROD_CREDIT_TYPE_AWU_ID,
   PROD_CREDIT_TYPE_PROG_USD_ID,
+  PRO_SEAT_CREDIT_NAME,
 } from "@app/lib/metronome/constants";
 import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
 import {
@@ -1254,12 +1256,12 @@ function getPackages(): PackageDef[] {
         getPerSeatIndividualAwuCredits({
           subscriptionTemporaryId: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
           quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          name: "Pro Seat Credits",
+          name: PRO_SEAT_CREDIT_NAME,
         }),
         getPerSeatIndividualAwuCredits({
           subscriptionTemporaryId: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
           quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
-          name: "Max Seat Credits",
+          name: MAX_SEAT_CREDIT_NAME,
         }),
       ],
       ...BILLING_CYCLE_CONFIG,
@@ -1275,12 +1277,12 @@ function getPackages(): PackageDef[] {
         getPerSeatIndividualAwuCredits({
           subscriptionTemporaryId: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
           quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          name: "Pro Seat Credits",
+          name: PRO_SEAT_CREDIT_NAME,
         }),
         getPerSeatIndividualAwuCredits({
           subscriptionTemporaryId: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
           quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
-          name: "Max Seat Credits",
+          name: MAX_SEAT_CREDIT_NAME,
         }),
       ],
       ...BILLING_CYCLE_CONFIG,

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -20,9 +20,9 @@ import {
   DEV_CREDIT_TYPE_PROG_USD_ID,
   MAX_SEAT_CREDIT_NAME,
   PLAN_CODE_CUSTOM_FIELD_KEY,
+  PRO_SEAT_CREDIT_NAME,
   PROD_CREDIT_TYPE_AWU_ID,
   PROD_CREDIT_TYPE_PROG_USD_ID,
-  PRO_SEAT_CREDIT_NAME,
 } from "@app/lib/metronome/constants";
 import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
 import {


### PR DESCRIPTION
## Description

* Adding API to surface recurring seat plan credits + price
* Will be used on the usage page seat change modal - 
https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=5458-13794&p=f&t=VSBQEPRiMBXr5gkN-0

## Tests

```
{
    "pro": {
        "awuCredits": 8000,
        "priceCents": 2900
    },
    "max": {
        "awuCredits": 40000,
        "priceCents": 14900
    }
}
```

## Risk

* Low

## Deploy Plan

* Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25539">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->