### PR TITLE
Agent new convo button not closing slideout

### DIFF
--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -68,6 +68,13 @@ export function AgentDetailsButtonBar({
   const isFavoriteDisabled =
     isAgentConfigurationValidating || isUpdatingFavorite;
 
+  const handleNewConversation = async () => {
+    onClose();
+    await router.push(
+      getConversationRoute(owner.sId, "new", `agent=${agentConfiguration.sId}`)
+    );
+  };
+
   return (
     <div className="flex flex-row items-center gap-2 px-1.5">
       <div className="group">
@@ -110,16 +117,7 @@ export function AgentDetailsButtonBar({
           size="sm"
           variant="outline"
           tooltip="New conversation"
-          onClick={async () => {
-            onClose();
-            await router.push(
-              getConversationRoute(
-                owner.sId,
-                "new",
-                `agent=${agentConfiguration.sId}`
-              )
-            );
-          }}
+          onClick={handleNewConversation}
         />
       )}
 

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -38,14 +38,17 @@ interface AgentDetailsButtonBarProps {
   agentConfiguration: LightAgentConfigurationType;
   owner: WorkspaceType;
   isAgentConfigurationValidating: boolean;
+  onClose: () => void;
 }
 
 export function AgentDetailsButtonBar({
   agentConfiguration,
   isAgentConfigurationValidating,
   owner,
+  onClose,
 }: AgentDetailsButtonBarProps) {
   const { user, providersHealth } = useAuth();
+  const router = useAppRouter();
 
   const { updateUserFavorite, isUpdatingFavorite } = useUpdateUserFavorite({
     owner,
@@ -107,11 +110,16 @@ export function AgentDetailsButtonBar({
           size="sm"
           variant="outline"
           tooltip="New conversation"
-          href={getConversationRoute(
-            owner.sId,
-            "new",
-            `agent=${agentConfiguration.sId}`
-          )}
+          onClick={async () => {
+            onClose();
+            await router.push(
+              getConversationRoute(
+                owner.sId,
+                "new",
+                `agent=${agentConfiguration.sId}`
+              )
+            );
+          }}
         />
       )}
 

--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -260,6 +260,7 @@ export function AgentDetailsSheet({
             owner={owner}
             agentConfiguration={agentConfiguration}
             isAgentConfigurationValidating={isAgentConfigurationValidating}
+            onClose={onClose}
           />
         )}
 


### PR DESCRIPTION
fix https://github.com/dust-tt/tasks/issues/8054
## Description
The "+" new conversation button in the agent details sheet used href for navigation, which navigated the URL but didn't close the Radix sheet — leaving the overlay visually on top of the new conversation page which gives the impression the click didn't do anything.

This switches the button to an onClick handler that calls onClose() (clearing the agentDetails URL param via useURLSheet) and then router.pushs to the new conversation. Same pattern already used by the Duplicate dropdown item in the same component.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25540">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->