### PR TITLE
Remove all direct use of getClientFacingUrl()

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1377,7 +1377,7 @@ function AgentMessageContent({
                 const href = file.fileId
                   ? `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${file.fileId}`
                   : file.filePath
-                    ? `${config.getClientFacingUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${file.filePath.replace("conversation/", "")}`
+                    ? `${config.getApiBaseUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${file.filePath.replace("conversation/", "")}`
                     : undefined;
                 return {
                   index: -1,

--- a/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
@@ -51,7 +51,7 @@ function getConversationFileUrl(
   const scoped = parseScopedFilePath(filePath);
   const rel = scoped ? scoped.rel : filePath;
 
-  return `${config.getClientFacingUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${rel}`;
+  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${rel}`;
 }
 
 const EXTENSION_TO_LANGUAGE: Record<string, string> = {

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -39,7 +39,7 @@ const {
 
 vi.mock("@app/lib/api/config", () => ({
   default: {
-    getClientFacingUrl: () => "https://dust.tt",
+    getApiBaseUrl: () => "https://dust.tt",
     getSandboxDevFrontHostName: () => undefined,
   },
 }));

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -261,7 +261,7 @@ export async function runSandboxBashTool(
   const sandboxAPIBase =
     isDevelopment() && config.getSandboxDevFrontHostName()
       ? `https://${config.getSandboxDevFrontHostName()}`
-      : config.getClientFacingUrl();
+      : config.getApiBaseUrl();
 
   const execResult = await sandbox.exec(auth, wrappedCommand, {
     workingDirectory: workingDirectory ?? DEFAULT_WORKING_DIRECTORY,

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -878,7 +878,7 @@ export async function sendToolValidationEmail({
     ? email.subject
     : `Re: ${email.subject}`;
 
-  const baseUrl = config.getClientFacingUrl();
+  const baseUrl = config.getAppUrl();
   const conversationUrl = getConversationRoute(
     workspace.sId,
     conversation.sId,

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -30,33 +30,34 @@ export function getDefaultInit(): Promise<RequestInit> | null {
   return defaultInitResolver?.() ?? null;
 }
 
+// Deprecated: use getStaticWebsiteUrl, getApiBaseUrl or getAppUrl instead, depending on the context.
+function getClientFacingUrl(): string {
+  // We override the NEXT_PUBLIC_DUST_CLIENT_FACING_URL in `front-internal` to ensure that the
+  // uploadUrl returned by the file API points to the `http://front-internal-service` and not our
+  // public API URL.
+  const override = EnvironmentConfig.getOptionalEnvVariable(
+    "DUST_INTERNAL_CLIENT_FACING_URL"
+  );
+  if (override) {
+    return override;
+  }
+
+  // Using process.env here to make sure the function is usable on the client side.
+  if (!process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL) {
+    throw new Error("NEXT_PUBLIC_DUST_CLIENT_FACING_URL is not set");
+  }
+  return process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL;
+}
+
 const config = {
   // Dynamic API base URL: uses a custom resolver when set (SPA region switching),
   // otherwise falls back to getClientFacingUrl().
   getApiBaseUrl: (): string => {
-    return baseUrlResolver?.() || config.getClientFacingUrl();
+    return baseUrlResolver?.() || getClientFacingUrl();
   },
 
-  // Deprecated: use getStaticWebsiteUrl, getApiBaseUrl or getAppUrl instead, depending on the context.
-  getClientFacingUrl: (): string => {
-    // We override the NEXT_PUBLIC_DUST_CLIENT_FACING_URL in `front-internal` to ensure that the
-    // uploadUrl returned by the file API points to the `http://front-internal-service` and not our
-    // public API URL.
-    const override = EnvironmentConfig.getOptionalEnvVariable(
-      "DUST_INTERNAL_CLIENT_FACING_URL"
-    );
-    if (override) {
-      return override;
-    }
-
-    // Using process.env here to make sure the function is usable on the client side.
-    if (!process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL) {
-      throw new Error("NEXT_PUBLIC_DUST_CLIENT_FACING_URL is not set");
-    }
-    return process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL;
-  },
   getStaticWebsiteUrl: (): string => {
-    return config.getClientFacingUrl();
+    return getClientFacingUrl();
   },
   // URL for the main app pages (/w/..., /share/..., etc.).
   // Use this for page URLs, not API endpoints.

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -16,7 +16,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/config", () => ({
   default: {
-    getClientFacingUrl: vi.fn(() => "https://dust.tt"),
+    getApiBaseUrl: vi.fn(() => "https://dust.tt"),
   },
 }));
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -163,7 +163,7 @@ function makeThumbnailUrl({
 
   switch (scope.useCase) {
     case "conversation":
-      return `${config.getClientFacingUrl()}/api/w/${workspaceId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(`${scope.useCase}/${relativeFilePath}`)}`;
+      return `${config.getApiBaseUrl()}/api/w/${workspaceId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(`${scope.useCase}/${relativeFilePath}`)}`;
 
     case "project":
       // TODO(2026-05-10: FILE SYSTEM) Expose a project files thumbnail endpoint.

--- a/front/lib/connectors.test.ts
+++ b/front/lib/connectors.test.ts
@@ -9,9 +9,7 @@ import {
 // Mock the config module before importing
 vi.mock("@app/lib/api/config", () => ({
   default: {
-    getClientFacingUrl: vi.fn(() => "dust.tt"),
     getAppUrl: vi.fn(() => "dust.tt"),
-    getApiBaseUrl: vi.fn(() => "https://dust.tt"),
   },
 }));
 

--- a/front/lib/plans/stripe.test.ts
+++ b/front/lib/plans/stripe.test.ts
@@ -63,7 +63,6 @@ const { MockStripeError, MockStripeInvalidRequestError } = vi.hoisted(() => {
 vi.mock("@app/lib/api/config", () => ({
   default: {
     getStripeSecretKey: vi.fn(() => "sk_test_mock_key"),
-    getClientFacingUrl: vi.fn(() => "https://test.example.com"),
     getAppUrl: vi.fn(() => "https://test.example.com"),
   },
 }));

--- a/front/pages/api/v1/w/[wId]/files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.test.ts
@@ -15,8 +15,6 @@ describe(
 
 vi.mock(import("@app/lib/api/config"), (() => ({
   default: {
-    getClientFacingUrl: vi.fn().mockReturnValue("http://localhost:9999"),
-    getAppUrl: vi.fn().mockReturnValue("http://localhost:9999"),
     getApiBaseUrl: vi.fn().mockReturnValue("http://localhost:9999"),
   },
 })) as any);

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -64,8 +64,6 @@ vi.mock(import("@app/lib/api/config"), (() => ({
       url: "http://localhost:9999",
       apiKey: "foo",
     }),
-    getClientFacingUrl: vi.fn().mockReturnValue("http://localhost:3000"),
-    getAppUrl: vi.fn().mockReturnValue("http://localhost:3011"),
     getApiBaseUrl: vi.fn().mockReturnValue("http://localhost:3000"),
   },
 })) as any);

--- a/front/pages/api/w/[wId]/files/[fileId]/export/pdf.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/export/pdf.test.ts
@@ -28,7 +28,6 @@ vi.mock("@app/lib/api/config", () => ({
     getDocumentRendererUrl: vi.fn().mockReturnValue("http://localhost:3100"),
     getVizPublicUrl: vi.fn().mockReturnValue("https://viz.dust.tt"),
     getAppUrl: vi.fn().mockReturnValue("http://localhost:3000"),
-    getClientFacingUrl: vi.fn().mockReturnValue("http://localhost:3000"),
     getVizJwtSecret: vi.fn().mockReturnValue("test-secret"),
   },
 }));


### PR DESCRIPTION
## Description

Even though it was deprecated, it sneaked back up in various places. Replaced them all. And to make sure it can't happen again, pulled it out of the `config` object, into an internal helper.

Fixes https://github.com/dust-tt/tasks/issues/8085

## Tests

Adapted a few

## Risk

Low

## Deploy Plan

Front