### PR TITLE
Add audit logs for self improving skill enablement

### DIFF
--- a/front/admin/audit_log_schemas/self_improvement.batch_mode_updated.json
+++ b/front/admin/audit_log_schemas/self_improvement.batch_mode_updated.json
@@ -1,0 +1,9 @@
+{
+  "action": "self_improvement.batch_mode_updated",
+  "targets": [
+    { "type": "workspace" }
+  ],
+  "metadata": {
+    "enabled": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/self_improvement.enabled.json
+++ b/front/admin/audit_log_schemas/self_improvement.enabled.json
@@ -1,0 +1,9 @@
+{
+  "action": "self_improvement.enabled",
+  "targets": [
+    { "type": "workspace" }
+  ],
+  "metadata": {
+    "enabled": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/skill.self_improvement_updated.json
+++ b/front/admin/audit_log_schemas/skill.self_improvement_updated.json
@@ -1,0 +1,10 @@
+{
+  "action": "skill.self_improvement_updated",
+  "targets": [
+    { "type": "workspace" },
+    { "type": "skill" }
+  ],
+  "metadata": {
+    "reinforcement": "string"
+  }
+}

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -56,6 +56,10 @@ type AuditAction =
   // Projects.
   | "project.joined"
   | "project.left"
+  // Self-improvement.
+  | "self_improvement.enabled"
+  | "self_improvement.batch_mode_updated"
+  | "skill.self_improvement_updated"
   // Sandbox.
   | "sandbox_egress_policy.agent_requests_setting_updated"
   | "sandbox_egress_policy.sandbox_updated"

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -280,6 +280,16 @@ async function handler(
         };
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;
+
+        void emitAuditLogEvent({
+          auth,
+          action: "self_improvement.enabled",
+          targets: [buildAuditLogTarget("workspace", owner)],
+          context: getAuditLogContext(auth, req),
+          metadata: {
+            enabled: String(body.allowReinforcement),
+          },
+        });
       } else if ("allowReinforcementBatchMode" in body) {
         const previousMetadata = owner.metadata ?? {};
         const newMetadata = {
@@ -288,6 +298,16 @@ async function handler(
         };
         await workspace.updateWorkspaceSettings({ metadata: newMetadata });
         owner.metadata = newMetadata;
+
+        void emitAuditLogEvent({
+          auth,
+          action: "self_improvement.batch_mode_updated",
+          targets: [buildAuditLogTarget("workspace", owner)],
+          context: getAuditLogContext(auth, req),
+          metadata: {
+            enabled: String(body.allowReinforcementBatchMode),
+          },
+        });
       } else if ("disableExtensionMcpTools" in body) {
         const previousMetadata = owner.metadata ?? {};
         const newMetadata = {

--- a/front/pages/api/w/[wId]/skills/[sId]/reinforcement.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/reinforcement.ts
@@ -133,15 +133,12 @@ async function handler(
           auth,
           action: "skill.self_improvement_updated",
           targets: [
-            buildAuditLogTarget(
-              "workspace",
-              auth.getNonNullableWorkspace()
-            ),
+            buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
             { type: "skill", id: skill.sId, name: skill.name },
           ],
           context: getAuditLogContext(auth, req),
           metadata: {
-            reinforcement,
+            reinforcement: String(reinforcement),
           },
         });
       }

--- a/front/pages/api/w/[wId]/skills/[sId]/reinforcement.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/reinforcement.ts
@@ -1,4 +1,9 @@
 /** @ignoreswagger */
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -123,6 +128,22 @@ async function handler(
 
       if (reinforcement !== undefined) {
         await skill.updateReinforcement(reinforcement);
+
+        void emitAuditLogEvent({
+          auth,
+          action: "skill.self_improvement_updated",
+          targets: [
+            buildAuditLogTarget(
+              "workspace",
+              auth.getNonNullableWorkspace()
+            ),
+            { type: "skill", id: skill.sId, name: skill.name },
+          ],
+          context: getAuditLogContext(auth, req),
+          metadata: {
+            reinforcement,
+          },
+        });
       }
       if (selfImprovementLock !== undefined) {
         await skill.updateSelfImprovementLock(selfImprovementLock);


### PR DESCRIPTION
## Description

Add some audit events so we can track who has enabled/disabled these feature

## Tests

no

## Risk

low

## Deploy Plan

merge and deploy
run
```
  npx tsx front/admin/register_audit_log_schemas.ts --execute --changed
```

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25559">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->