### PR TITLE
db: rename project preference table

### DIFF
--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1600,7 +1600,7 @@ const KNOWN_SPACE_RELATED_MODELS = [
   "takeaways",
   "takeaways_version",
   "webhook_sources_view",
-  "user_project_notification_preferences",
+  "user_project_preferences",
 ];
 
 describe("SpaceResource cleanup on delete", () => {

--- a/front/lib/resources/storage/models/user_project_preferences.ts
+++ b/front/lib/resources/storage/models/user_project_preferences.ts
@@ -33,7 +33,6 @@ UserProjectPreferencesModel.init(
     },
     notificationPreference: {
       type: DataTypes.STRING,
-      field: "preference",
       allowNull: true,
       validate: {
         isIn: [NOTIFICATION_CONDITION_OPTIONS],
@@ -42,15 +41,14 @@ UserProjectPreferencesModel.init(
     isStarred: {
       type: DataTypes.BOOLEAN,
       allowNull: true,
-      defaultValue: null,
     },
   },
   {
-    modelName: "user_project_notification_preferences",
+    modelName: "user_project_preferences",
     sequelize: frontSequelize,
     indexes: [
       {
-        name: "user_project_notif_pref_workspace_user_space_unique",
+        name: "user_project_preferences_workspace_user_space_unique",
         fields: ["workspaceId", "userId", "spaceId"],
         unique: true,
         concurrently: true,

--- a/front/lib/resources/storage/models/user_project_preferences.ts
+++ b/front/lib/resources/storage/models/user_project_preferences.ts
@@ -53,8 +53,7 @@ UserProjectPreferencesModel.init(
         unique: true,
         concurrently: true,
       },
-      { fields: ["userId"], concurrently: true },
-      { fields: ["spaceId"], concurrently: true },
+      { fields: ["workspaceId", "spaceId"], concurrently: true },
     ],
   }
 );

--- a/front/migrations/20260513_copy_user_project_notification_preferences.ts
+++ b/front/migrations/20260513_copy_user_project_notification_preferences.ts
@@ -1,0 +1,44 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+// Copy from user_project_notification_preferences into
+// user_project_preferences.
+makeScript({}, async ({ execute }, logger) => {
+  const [{ count: pendingCountStr }] = await frontSequelize.query<{
+    count: string;
+  }>(
+    `SELECT COUNT(*) AS count
+       FROM "user_project_notification_preferences" old
+       WHERE NOT EXISTS (
+         SELECT 1 FROM "user_project_preferences" new
+         WHERE new."workspaceId" = old."workspaceId"
+           AND new."userId" = old."userId"
+           AND new."spaceId" = old."spaceId"
+       )`,
+    { type: QueryTypes.SELECT }
+  );
+  const pendingCount = parseInt(pendingCountStr);
+
+  logger.info(
+    { pendingCount, execute },
+    execute
+      ? `Copying ${pendingCount} rows`
+      : `Would copy ${pendingCount} rows (dry run)`
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  await frontSequelize.query(
+    `INSERT INTO "user_project_preferences"
+       ("createdAt", "updatedAt", "notificationPreference", "isStarred", "workspaceId", "userId", "spaceId")
+     SELECT "createdAt", "updatedAt", "preference", "isStarred", "workspaceId", "userId", "spaceId"
+       FROM "user_project_notification_preferences"
+     ON CONFLICT ON CONSTRAINT "user_project_preferences_workspace_user_space_unique" DO NOTHING`
+  );
+
+  logger.info({}, "Copy done");
+});

--- a/front/migrations/20260513_copy_user_project_notification_preferences.ts
+++ b/front/migrations/20260513_copy_user_project_notification_preferences.ts
@@ -37,7 +37,7 @@ makeScript({}, async ({ execute }, logger) => {
        ("createdAt", "updatedAt", "notificationPreference", "isStarred", "workspaceId", "userId", "spaceId")
      SELECT "createdAt", "updatedAt", "preference", "isStarred", "workspaceId", "userId", "spaceId"
        FROM "user_project_notification_preferences"
-     ON CONFLICT ON CONSTRAINT "user_project_preferences_workspace_user_space_unique" DO NOTHING`
+     ON CONFLICT ("workspaceId", "userId", "spaceId") DO NOTHING`
   );
 
   logger.info({}, "Copy done");

--- a/front/migrations/db/migration_636.sql
+++ b/front/migrations/db/migration_636.sql
@@ -1,0 +1,5 @@
+-- Migration created on mai 13, 2026
+CREATE TABLE IF NOT EXISTS "user_project_preferences" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "notificationPreference" VARCHAR(255), "isStarred" BOOLEAN, "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , "userId" BIGINT NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "spaceId" BIGINT NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, PRIMARY KEY ("id"));
+CREATE UNIQUE INDEX CONCURRENTLY "user_project_preferences_workspace_user_space_unique" ON "user_project_preferences" ("workspaceId", "userId", "spaceId");
+CREATE INDEX CONCURRENTLY "user_project_preferences_user_id" ON "user_project_preferences" ("userId");
+CREATE INDEX CONCURRENTLY "user_project_preferences_space_id" ON "user_project_preferences" ("spaceId");

--- a/front/migrations/db/migration_636.sql
+++ b/front/migrations/db/migration_636.sql
@@ -1,5 +1,4 @@
 -- Migration created on mai 13, 2026
 CREATE TABLE IF NOT EXISTS "user_project_preferences" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "notificationPreference" VARCHAR(255), "isStarred" BOOLEAN, "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , "userId" BIGINT NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "spaceId" BIGINT NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, PRIMARY KEY ("id"));
 CREATE UNIQUE INDEX CONCURRENTLY "user_project_preferences_workspace_user_space_unique" ON "user_project_preferences" ("workspaceId", "userId", "spaceId");
-CREATE INDEX CONCURRENTLY "user_project_preferences_user_id" ON "user_project_preferences" ("userId");
-CREATE INDEX CONCURRENTLY "user_project_preferences_space_id" ON "user_project_preferences" ("spaceId");
+CREATE INDEX CONCURRENTLY "user_project_preferences_workspace_id_space_id" ON "user_project_preferences" ("workspaceId", "spaceId");


### PR DESCRIPTION
## Description

This PR renames the `user_project_notification_preferences` database table to `user_project_preferences`.

- Creates a new `user_project_preferences` table with the same structure as the old table
- Adds a re-runnable migration script to copy data from the old table to the new one 
- Updates the Sequelize model to use the new table name and removes the field mapping for `notificationPreference` (column now matches property name)

## Tests

Manually

## Risks

Low.

## Deploy Plan

1. Run the migration to create the new `user_project_preferences` table
2. Run the copy script to migrate existing data
3. Deploy the code that switches the model to use the new table
4. Re-run the copy script after deploy to capture any rows written to the old table during cutover
