### PR TITLE
db: remove user project notification preferences

### DIFF
--- a/front/migrations/db/migration_637.sql
+++ b/front/migrations/db/migration_637.sql
@@ -1,0 +1,2 @@
+-- Migration created on mai 13, 2026
+DROP TABLE "public"."user_project_notification_preferences";


### PR DESCRIPTION
## Description

This PR removes the `user_project_notification_preferences` table from the database.

- Adds migration 637 to drop the `user_project_notification_preferences` table

## Tests

Manually

## Risks

Low.

## Deploy Plan

Deploy front and run the migration.
