### PR TITLE
feat: switch agentMCPAction read to new table

### DIFF
--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -77,8 +77,6 @@ export async function validateAction(
     );
   }
 
-  const agentStepContent = action.stepContent;
-
   if (action.status !== "blocked_validation_required") {
     return new Err(
       new DustError(
@@ -188,7 +186,7 @@ export async function validateAction(
       userMessageOrigin,
     },
     // Resume from the step where the action was created.
-    startStep: agentStepContent.step,
+    startStep: action.stepContent.step,
     // Wait for completion of the agent loop workflow that triggered the
     // validation. This avoids race conditions where validation re-triggers the
     // agent loop before it completes, and thus throws a workflow already

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -14,7 +14,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
@@ -78,19 +77,7 @@ export async function validateAction(
     );
   }
 
-  const agentStepContent =
-    await AgentStepContentResource.fetchByModelIdWithAuth(
-      auth,
-      action.stepContentId
-    );
-  if (!agentStepContent) {
-    return new Err(
-      new DustError(
-        "internal_error",
-        `Agent step content not found: ${action.stepContentId}`
-      )
-    );
-  }
+  const agentStepContent = action.stepContent;
 
   if (action.status !== "blocked_validation_required") {
     return new Err(

--- a/front/lib/api/assistant/email/validate_tool_from_email.ts
+++ b/front/lib/api/assistant/email/validate_tool_from_email.ts
@@ -14,7 +14,6 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getIdsFromSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -220,19 +219,7 @@ export async function validateActionFromEmail(
     "[email] Tool validation request from email"
   );
 
-  const agentStepContent =
-    await AgentStepContentResource.fetchByModelIdWithAuth(
-      auth,
-      action.stepContentId
-    );
-  if (!agentStepContent) {
-    return new Err(
-      new DustError(
-        "internal_error",
-        `Agent step content not found: ${action.stepContentId}`
-      )
-    );
-  }
+  const agentStepContent = action.stepContent;
 
   if (action.status !== "blocked_validation_required") {
     return new Err(

--- a/front/lib/api/assistant/email/validate_tool_from_email.ts
+++ b/front/lib/api/assistant/email/validate_tool_from_email.ts
@@ -219,8 +219,6 @@ export async function validateActionFromEmail(
     "[email] Tool validation request from email"
   );
 
-  const agentStepContent = action.stepContent;
-
   if (action.status !== "blocked_validation_required") {
     return new Err(
       new DustError(
@@ -331,7 +329,7 @@ export async function validateActionFromEmail(
       userMessageOrigin: parentMessage.userMessage.userContextOrigin,
       conversationBranchId: message.getBranchId(),
     },
-    startStep: agentStepContent.step,
+    startStep: action.stepContent.step,
     waitForCompletion: true,
   });
 

--- a/front/lib/api/mcp/create_mcp.ts
+++ b/front/lib/api/mcp/create_mcp.ts
@@ -7,11 +7,11 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import type {
   AgentMessageType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
-import type { ModelId } from "@app/types/shared/model_id";
 import omit from "lodash/omit";
 
 /**
@@ -25,7 +25,7 @@ export async function createMCPAction(
     augmentedInputs,
     conversation,
     status,
-    stepContentId,
+    stepContent,
     stepContext,
   }: {
     actionConfiguration: MCPToolConfigurationType;
@@ -33,7 +33,7 @@ export async function createMCPAction(
     augmentedInputs: Record<string, unknown>;
     conversation: ConversationWithoutContentType;
     status: ToolExecutionStatus;
-    stepContentId: ModelId;
+    stepContent: AgentStepContentResource;
     stepContext: StepContext;
   }
 ): Promise<AgentMCPActionResource> {
@@ -42,15 +42,19 @@ export async function createMCPAction(
     MCP_TOOL_CONFIGURATION_FIELDS_TO_OMIT
   ) as LightMCPToolConfigurationType;
 
-  return AgentMCPActionResource.makeNew(auth, conversation, {
-    agentMessageId: agentMessage.agentMessageId,
-    augmentedInputs,
-    citationsAllocated: stepContext.citationsCount,
-    mcpServerConfigurationId: actionConfiguration.id.toString(),
-    status,
-    stepContentId,
-    stepContext,
-    toolConfiguration,
-    version: 0,
-  });
+  return AgentMCPActionResource.makeNew(
+    auth,
+    { conversation, stepContent },
+    {
+      agentMessageId: agentMessage.agentMessageId,
+      augmentedInputs,
+      citationsAllocated: stepContext.citationsCount,
+      mcpServerConfigurationId: actionConfiguration.id.toString(),
+      status,
+      stepContentId: stepContent.id,
+      stepContext,
+      toolConfiguration,
+      version: 0,
+    }
+  );
 }

--- a/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
+++ b/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
@@ -6,7 +6,7 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { CreationOptional, ForeignKey } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
 export class AgentStepContentToolExecutionModel extends WorkspaceAwareModel<AgentStepContentToolExecutionModel> {
@@ -19,6 +19,9 @@ export class AgentStepContentToolExecutionModel extends WorkspaceAwareModel<Agen
 
   declare agentMCPActionId: ForeignKey<AgentMCPActionModel["id"]>;
   declare stepContentId: ForeignKey<AgentStepContentModel["id"]>;
+
+  declare agentMCPAction: NonAttribute<AgentMCPActionModel>;
+  declare stepContent: NonAttribute<AgentStepContentModel>;
 }
 
 AgentStepContentToolExecutionModel.init(

--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -1,4 +1,3 @@
-import type { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -18,7 +17,6 @@ export class AgentStepContentModel extends WorkspaceAwareModel<AgentStepContentM
   declare value: AgentContentItemType;
 
   declare agentMessage?: NonAttribute<AgentMessageModel>;
-  declare agentMCPActions?: NonAttribute<AgentMCPActionModel[]>;
 }
 
 AgentStepContentModel.init(

--- a/front/lib/reinforcement/tool_execution.ts
+++ b/front/lib/reinforcement/tool_execution.ts
@@ -80,55 +80,59 @@ async function createReinforcedAction(
     agentMessageModelId,
     conversation,
     mcpServerViewId,
-    stepContentId,
+    stepContent,
     toolCall,
   }: {
     agentMessageModelId: ModelId;
     conversation: ConversationWithoutContentType;
     mcpServerViewId: string;
-    stepContentId: ModelId;
+    stepContent: AgentStepContentResource;
     toolCall: ReinforcedSkillsToolCallInfo;
   }
 ): Promise<AgentMCPActionResource> {
-  return AgentMCPActionResource.makeNew(auth, conversation, {
-    agentMessageId: agentMessageModelId,
-    augmentedInputs: toolCall.arguments,
-    citationsAllocated: 0,
-    mcpServerConfigurationId: "agent_sidekick_context",
-    status: "ready_allowed_explicitly",
-    stepContentId,
-    stepContext: {
-      citationsCount: 0,
-      citationsOffset: 0,
-      resumeState: null,
-      retrievalTopK: 0,
-      websearchResultCount: 0,
-    },
-    toolConfiguration: {
-      id: -1,
-      sId: generateRandomModelSId(),
-      type: "mcp_configuration",
-      name: toolCall.name,
-      originalName: toolCall.name,
-      mcpServerName: "agent_sidekick_context",
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      timeFrame: null,
-      jsonSchema: null,
-      additionalConfiguration: {},
-      mcpServerViewId,
-      dustAppConfiguration: null,
-      internalMCPServerId: "agent_sidekick_context",
-      secretName: null,
-      dustProject: null,
-      availability: "auto",
-      permission: "never_ask",
-      toolServerId: "agent_sidekick_context",
-      retryPolicy: "no_retry",
-    },
-    version: 0,
-  });
+  return AgentMCPActionResource.makeNew(
+    auth,
+    { conversation, stepContent },
+    {
+      agentMessageId: agentMessageModelId,
+      augmentedInputs: toolCall.arguments,
+      citationsAllocated: 0,
+      mcpServerConfigurationId: "agent_sidekick_context",
+      status: "ready_allowed_explicitly",
+      stepContentId: stepContent.id,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        resumeState: null,
+        retrievalTopK: 0,
+        websearchResultCount: 0,
+      },
+      toolConfiguration: {
+        id: -1,
+        sId: generateRandomModelSId(),
+        type: "mcp_configuration",
+        name: toolCall.name,
+        originalName: toolCall.name,
+        mcpServerName: "agent_sidekick_context",
+        dataSources: null,
+        tables: null,
+        childAgentId: null,
+        timeFrame: null,
+        jsonSchema: null,
+        additionalConfiguration: {},
+        mcpServerViewId,
+        dustAppConfiguration: null,
+        internalMCPServerId: "agent_sidekick_context",
+        secretName: null,
+        dustProject: null,
+        availability: "auto",
+        permission: "never_ask",
+        toolServerId: "agent_sidekick_context",
+        retryPolicy: "no_retry",
+      },
+      version: 0,
+    }
+  );
 }
 
 /**
@@ -169,7 +173,7 @@ export async function prepareReinforcedToolActions(
       toolCall: tc,
       conversation,
       agentMessageModelId,
-      stepContentId: stepContent.id,
+      stepContent,
       mcpServerViewId,
     });
 
@@ -228,7 +232,7 @@ export async function storeTerminalToolCallResults(
       conversation,
       toolCall,
       agentMessageModelId,
-      stepContentId: stepContent.id,
+      stepContent,
       mcpServerViewId,
     });
 
@@ -248,7 +252,7 @@ export async function storeTerminalToolCallResults(
       conversation,
       toolCall,
       agentMessageModelId,
-      stepContentId: stepContent.id,
+      stepContent,
       mcpServerViewId,
     });
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -79,6 +79,7 @@ import type {
   Transaction,
 } from "sequelize";
 import { Op } from "sequelize";
+import { AgentStepContentModel } from "../models/agent/agent_step_content";
 
 // Batch size for fetching output items to avoid loading too many large rows at once.
 const OUTPUT_ITEMS_BATCH_SIZE = 32;
@@ -130,15 +131,42 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       transaction,
     });
 
-    const stepContents = await AgentStepContentResource.fetchByModelIds(
-      auth,
-      actions.map((a) => a.stepContentId)
-    );
+    if (actions.length === 0) {
+      return [];
+    }
 
-    const stepContentsMap = new Map(stepContents.map((s) => [s.id, s]));
+    const agentStepContentToolExecutions =
+      await AgentStepContentToolExecutionModel.findAll({
+        where: {
+          workspaceId,
+          agentMCPActionId: { [Op.in]: actions.map((a) => a.id) },
+        },
+        include: [
+          {
+            model: AgentStepContentModel,
+            as: "stepContent",
+            required: true,
+          },
+        ],
+        transaction,
+      });
+
+    const stepContentByActionId = new Map<ModelId, AgentStepContentResource>();
+    for (const toolExecution of agentStepContentToolExecutions) {
+      const stepContentModel = toolExecution.stepContent;
+      assert(stepContentModel, "Step content join row missing.");
+
+      stepContentByActionId.set(
+        toolExecution.agentMCPActionId,
+        new AgentStepContentResource(
+          AgentStepContentResource.model,
+          stepContentModel.get()
+        )
+      );
+    }
 
     return actions.map((a) => {
-      const stepContent = stepContentsMap.get(a.stepContentId);
+      const stepContent = stepContentByActionId.get(a.id);
 
       // Each action must have a function call step content.
       assert(stepContent, "Step content not found.");
@@ -160,7 +188,13 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
   static async makeNew(
     auth: Authenticator,
-    conversation: ConversationWithoutContentType,
+    {
+      conversation,
+      stepContent,
+    }: {
+      conversation: ConversationWithoutContentType;
+      stepContent: AgentStepContentResource;
+    },
     blob: Omit<CreationAttributes<AgentMCPActionModel>, "workspaceId">,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<AgentMCPActionResource> {
@@ -177,11 +211,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       { transaction }
     );
 
-    const stepContent = await AgentStepContentResource.fetchByModelIdWithAuth(
-      auth,
-      action.stepContentId
-    );
-    assert(stepContent, "Step content not found.");
     assert(
       stepContent.isFunctionCallContent(),
       "Step content is not a function call."
@@ -594,31 +623,39 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    // Not using the baseFetch because we already have the step contents.
-    let actions = await AgentMCPActionModel.findAll({
-      where: {
-        workspaceId,
-        stepContentId: {
-          [Op.in]: stepContents.map((content) => content.id),
+    let agentStepContentToolExecutions =
+      await AgentStepContentToolExecutionModel.findAll({
+        where: {
+          workspaceId,
+          stepContentId: { [Op.in]: stepContents.map((content) => content.id) },
         },
-      },
-    });
+        include: [
+          {
+            model: AgentMCPActionModel,
+            as: "agentMCPAction",
+            required: true,
+          },
+        ],
+      });
 
     if (latestVersionsOnly) {
-      const actionsByStepContentId = _.groupBy(actions, (action) =>
-        action.stepContentId.toString()
+      const rowsByStepContentId = _.groupBy(
+        agentStepContentToolExecutions,
+        (row) => row.stepContentId.toString()
       );
-      actions = removeNulls(
-        Object.values(actionsByStepContentId).map(
-          (actionsForContent) => _.maxBy(actionsForContent, "version") ?? null
+      agentStepContentToolExecutions = removeNulls(
+        Object.values(rowsByStepContentId).map(
+          (rowsForContent) =>
+            _.maxBy(rowsForContent, (row) => row.agentMCPAction.version) ?? null
         )
       );
     }
 
     const stepContentsMap = new Map(stepContents.map((s) => [s.id, s]));
 
-    return actions.map((a) => {
-      const stepContent = stepContentsMap.get(a.stepContentId);
+    return agentStepContentToolExecutions.map((row) => {
+      const a = row.agentMCPAction;
+      const stepContent = stepContentsMap.get(row.stepContentId);
 
       // Each action must have a function call step content.
       assert(stepContent, "Step content not found.");

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -154,7 +154,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     const stepContentByActionId = new Map<ModelId, AgentStepContentResource>();
     for (const toolExecution of agentStepContentToolExecutions) {
       const stepContentModel = toolExecution.stepContent;
-      assert(stepContentModel, "Step content join row missing.");
 
       stepContentByActionId.set(
         toolExecution.agentMCPActionId,

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -124,7 +124,7 @@ async function handler(
       });
 
       const resultActions = actions.map((a) => {
-        const stepContent = contentById.get(a.stepContentId);
+        const stepContent = contentById.get(a.stepContent.id);
         assert(stepContent, "Step content not found.");
 
         return {

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -3,6 +3,7 @@ import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { DurationRecorder } from "@app/lib/duration_recorder";
+import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -351,49 +352,58 @@ async function getExistingActionsAndBlobs(
   // TODO(DURABLE_AGENTS 2025-08-12): Create a proper resource for the agent step content.
   const { agentMessage } = runAgentArgs;
 
-  // Find function_call step contents for this step.
-  const stepContents = await AgentStepContentModel.findAll({
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      agentMessageId: agentMessage.agentMessageId,
-      step,
-      type: "function_call",
-    },
-    include: [
-      {
-        model: AgentMCPActionModel,
-        as: "agentMCPActions",
-        required: true,
+  const agentStepContentToolExecutions =
+    await AgentStepContentToolExecutionModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        agentMessageId: agentMessage.agentMessageId,
       },
-    ],
-  });
+      include: [
+        {
+          model: AgentStepContentModel,
+          as: "stepContent",
+          required: true,
+          where: {
+            workspaceId: auth.getNonNullableWorkspace().id,
+            step,
+            type: "function_call",
+          },
+        },
+        {
+          model: AgentMCPActionModel,
+          as: "agentMCPAction",
+          required: true,
+        },
+      ],
+    });
 
-  if (stepContents.length === 0) {
+  if (agentStepContentToolExecutions.length === 0) {
     return null; // No existing actions.
   }
 
   const actionBlobs: ActionBlob[] = [];
 
-  for (const stepContent of stepContents) {
-    if (stepContent.agentMCPActions && stepContent.agentMCPActions.length > 0) {
-      const [mcpAction] = stepContent.agentMCPActions;
+  for (const toolExecution of agentStepContentToolExecutions) {
+    const stepContent = toolExecution.stepContent;
+    const mcpAction = toolExecution.agentMCPAction;
+    assert(stepContent, "Unexpected: step content join row missing.");
+    assert(mcpAction, "Unexpected: MCP action join row missing.");
 
-      assert(
-        isAgentFunctionCallContent(stepContent.value),
-        "Unexpected: step content is not a function call"
-      );
+    assert(
+      isAgentFunctionCallContent(stepContent.value),
+      "Unexpected: step content is not a function call"
+    );
 
-      // If the tool is not already in a final state we must add it to the list of actions to run.
-      if (!isToolExecutionStatusFinal(mcpAction.status)) {
-        actionBlobs.push({
-          actionId: mcpAction.id,
-          actionStatus: mcpAction.status,
-          needsApproval: mcpAction.status === "blocked_validation_required",
-          retryPolicy: getRetryPolicyFromToolConfiguration(
-            mcpAction.toolConfiguration
-          ),
-        });
-      }
+    // If the tool is not already in a final state we must add it to the list of actions to run.
+    if (!isToolExecutionStatusFinal(mcpAction.status)) {
+      actionBlobs.push({
+        actionId: mcpAction.id,
+        actionStatus: mcpAction.status,
+        needsApproval: mcpAction.status === "blocked_validation_required",
+        retryPolicy: getRetryPolicyFromToolConfiguration(
+          mcpAction.toolConfiguration
+        ),
+      });
     }
   }
 

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -5,7 +5,6 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { DurationRecorder } from "@app/lib/duration_recorder";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
@@ -21,7 +20,6 @@ import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_t
 import { handlePromptCommand } from "@app/temporal/agent_loop/lib/prompt_commands";
 import { runModel } from "@app/temporal/agent_loop/lib/run_model";
 import { getMaxActionsPerStep } from "@app/types/assistant/agent";
-import { isAgentFunctionCallContent } from "@app/types/assistant/agent_message_content";
 import type {
   AgentLoopArgsWithTiming,
   AgentLoopExecutionData,
@@ -33,7 +31,6 @@ import {
 import type { ModelId } from "@app/types/shared/model_id";
 import { startActiveObservation } from "@langfuse/tracing";
 import { Context } from "@temporalio/activity";
-import assert from "assert";
 
 export type RunModelAndCreateActionsResult = {
   actionBlobs: ActionBlob[];
@@ -360,16 +357,6 @@ async function getExistingActionsAndBlobs(
       },
       include: [
         {
-          model: AgentStepContentModel,
-          as: "stepContent",
-          required: true,
-          where: {
-            workspaceId: auth.getNonNullableWorkspace().id,
-            step,
-            type: "function_call",
-          },
-        },
-        {
           model: AgentMCPActionModel,
           as: "agentMCPAction",
           required: true,
@@ -384,15 +371,7 @@ async function getExistingActionsAndBlobs(
   const actionBlobs: ActionBlob[] = [];
 
   for (const toolExecution of agentStepContentToolExecutions) {
-    const stepContent = toolExecution.stepContent;
-    const mcpAction = toolExecution.agentMCPAction;
-    assert(stepContent, "Unexpected: step content join row missing.");
-    assert(mcpAction, "Unexpected: MCP action join row missing.");
-
-    assert(
-      isAgentFunctionCallContent(stepContent.value),
-      "Unexpected: step content is not a function call"
-    );
+    const { agentMCPAction: mcpAction } = toolExecution;
 
     // If the tool is not already in a final state we must add it to the list of actions to run.
     if (!isToolExecutionStatusFinal(mcpAction.status)) {

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -217,7 +217,7 @@ async function createActionForTool(
     augmentedInputs,
     conversation,
     status,
-    stepContentId,
+    stepContent,
     stepContext,
   });
 

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -409,23 +409,27 @@ export class ConversationFactory {
       },
     });
 
-    const action = await AgentMCPActionResource.makeNew(auth, conversation, {
-      agentMessageId: agentMessage.agentMessageId,
-      augmentedInputs: {},
-      citationsAllocated: 0,
-      mcpServerConfigurationId: toolConfiguration.sId,
-      status: "running",
-      stepContentId: stepContent.id,
-      stepContext: {
-        citationsCount: 0,
-        citationsOffset: 0,
-        resumeState: null,
-        retrievalTopK: 0,
-        websearchResultCount: 0,
-      },
-      toolConfiguration,
-      version: 0,
-    });
+    const action = await AgentMCPActionResource.makeNew(
+      auth,
+      { conversation, stepContent },
+      {
+        agentMessageId: agentMessage.agentMessageId,
+        augmentedInputs: {},
+        citationsAllocated: 0,
+        mcpServerConfigurationId: toolConfiguration.sId,
+        status: "running",
+        stepContentId: stepContent.id,
+        stepContext: {
+          citationsCount: 0,
+          citationsOffset: 0,
+          resumeState: null,
+          retrievalTopK: 0,
+          websearchResultCount: 0,
+        },
+        toolConfiguration,
+        version: 0,
+      }
+    );
 
     return { messageRow, agentMessage, action };
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

### Context

Third PR out of 4 to move the data model of `AgentMCPActions` from a direct link to `AgentStepContent` to a join table.

| # | goal                                                                      |
|---|---------------------------------------------------------------------------|
| 1 #25463 | create join table AgentStepContentToolExecution, and introduce dual write |
| 2 #25514 | backfill the new table                                                    |
| 3 this PR | switch read to the new table                                              |
| 4 | drop the StepContentId column from the original table                     |

### This PR

This PR switches the read of the `stepContentId` of the `AgentMCPActions` table to go through the `AgentStepContentToolExecution` table. It also switches the read of the `agentMCPActions` non attribute of `AgentStepContentModel` to the join table.

Everyplace that was fetching stepContent from action.stepContentId now directly goes through the action.stepContent. basefetch now fetches the AgentStepContentToolExecutionModel table.
AgentMCPActionResource.makeNew now takes a stepContent to create it.
Also, instead of reading stepContent.agentMCPActions, it aggregates them from agentStepContentToolExecution.agentMCPAction

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Unit tests updated. front-edge smoke test.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low-ish. Revertable. We still have all the data. 

## Deploy Plan

Deploy front. No need of any migration.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25562">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->