### PR TITLE
Drop attach_to_conversation and reshape get_information

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -503,7 +503,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "project_manager": {
     "add_content_node": "never_ask",
     "add_message_to_conversation": "medium",
-    "attach_to_conversation": "never_ask",
     "create_conversation": "medium",
     "create_project": "low",
     "edit_description": "low",

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -18,7 +18,7 @@ export const CAT_LINES_MAX = 500;
 export const GREP_MATCHES_MAX = 50;
 export const CREATE_CONTENT_MAX_BYTES = 50 * 1024; // 50 KB (~12K tokens).
 
-// Shared `list` description that opens with the generic capability — the file-system listing —
+// Shared `list` description that opens with the generic file-system listing capability and is
 // followed by a context-specific suffix injected by the conversation-only or project-aware
 // metadata.
 const LIST_DESCRIPTION_PREFIX =
@@ -98,7 +98,7 @@ const COPY_CONVERSATION_ONLY_TOOL = {
 const COPY_PROJECT_AWARE_TOOL = {
   description:
     `${COPY_DESCRIPTION_BASE} ` +
-    "Since this conversation belongs to a project, you can also copy between scopes — " +
+    "Since this conversation belongs to a project, you can also copy between scopes, " +
     "e.g. `conversation/report.pdf` -> `project/report.pdf` to promote a file into the project, " +
     "or `project/spec.md` -> `conversation/spec.md` to pull it into the conversation.",
   schema: {
@@ -131,7 +131,7 @@ const FILES_TOOLS_COMMON_METADATA = {
       "When the output is truncated, a footer indicates the next offset to use. " +
       "For images (JPEG, PNG, GIF), returns a vision block the model can inspect directly. " +
       "For binary sources such as PDFs, scanned documents, or audio files, prefer the " +
-      `\`*.processed.<ext>\` sibling listed in \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` — it carries the extracted text or transcript.`,
+      `\`*.processed.<ext>\` sibling listed in \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\`. It carries the extracted text or transcript.`,
     schema: {
       path: z
         .string()

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -112,7 +112,7 @@ export async function listHandler(
     const mimeType = stripMimeParameters(file.contentType);
     const kb = Math.ceil(file.sizeBytes / 1024);
     const annotation = sourcePath
-      ? ` — processed version of ${sourcePath}`
+      ? ` (processed version of ${sourcePath})`
       : "";
     lines.push(`${file.path} (${mimeType}, ${kb} KB)${annotation}`);
   }

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -1,7 +1,9 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
+  type GCSMountEntry,
   type GCSMountPoint,
   getGCSPathFromScopedPath,
+  listGCSMountFiles,
 } from "@app/lib/api/files/gcs_mount/files";
 import {
   getConversationFilesBasePath,
@@ -139,6 +141,35 @@ export async function resolveMountByUseCase(
     default:
       assertNever(useCase);
   }
+}
+
+/**
+ * List the files mounted under a project's GCS prefix. Verifies `space.canRead(auth)` before
+ * touching the bucket. Use this from callers that already hold a `SpaceResource` so the
+ * file-listing path stays funneled through the same helper as `files__list`.
+ */
+export async function listProjectFiles(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<Result<GCSMountEntry[], MCPError>> {
+  if (!space.isProject) {
+    return new Err(new MCPError("Space is not a project.", { tracked: false }));
+  }
+
+  if (!space.canRead(auth)) {
+    return new Err(
+      new MCPError("You do not have read permissions for this project.", {
+        tracked: false,
+      })
+    );
+  }
+
+  const entries = await listGCSMountFiles(auth, {
+    useCase: "project",
+    projectId: space.sId,
+  });
+
+  return new Ok(entries);
 }
 
 /**

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -1,6 +1,7 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import {
   IncludeInputSchema,
   SearchWithNodesInputSchema,
@@ -64,27 +65,6 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
       done: "Remove content node from project",
     },
   },
-  attach_to_conversation: {
-    description:
-      "Attach an existing project context file to the current conversation without creating or copying a new file.",
-    schema: {
-      fileId: z
-        .string()
-        .describe("ID of an existing file in the project context to attach"),
-      dustProject: ConfigurableToolInputSchemas[
-        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-      ]
-        .optional()
-        .describe(
-          "Optional project to attach the file to, will fallback to the conversation's project."
-        ),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Attaching project file to conversation",
-      done: "Attach project file to conversation",
-    },
-  },
   edit_description: {
     description:
       "Edit the project description. Only plain text is accepted (no markdown, HTML, or formatting). Descriptions should be brief and concise.",
@@ -110,7 +90,9 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   get_information: {
     description:
-      "Get comprehensive information about the project context, including project URL, description, file count, and file list.",
+      "Get information about the project: URL, description, and linked Company Data nodes " +
+      "attached to the project context. Does NOT list project files. Project files live under " +
+      `\`project/<rel>\` scoped paths and are discovered through the \`${FILES_SERVER_NAME}\` MCP server.`,
     schema: {
       dustProject: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
@@ -223,7 +205,7 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   create_conversation: {
     description:
-      "Create a new conversation in the project and post a user message. Default: always pass an agentName to delegate the task to an agent running inside the project. Do NOT do the work yourself — if work needs to be done, delegate it via agentName. Omit agentName only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output.",
+      "Create a new conversation in the project and post a user message. Default: always pass an agentName to delegate the task to an agent running inside the project. Do NOT do the work yourself. If work needs to be done, delegate it via agentName. Omit agentName only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output.",
     schema: {
       message: z
         .string()
@@ -235,7 +217,7 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "The name of the agent to trigger in the new conversation. The tool searches matching agent configurations and uses the best match. Use this whenever the user asks for work to be done in a project (research, analysis, drafting, etc.). When omitted, no agent is triggered and the message is posted as a static result — use this only to deposit a finished artifact you have already fully produced."
+          "The name of the agent to trigger in the new conversation. The tool searches matching agent configurations and uses the best match. Use this whenever the user asks for work to be done in a project (research, analysis, drafting, etc.). When omitted, no agent is triggered and the message is posted as a static result. Use this only to deposit a finished artifact you have already fully produced."
         ),
       dustProject:
         ConfigurableToolInputSchemas[
@@ -305,7 +287,7 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   add_message_to_conversation: {
     description:
-      "Post a user message to an existing conversation in this project. Default: always pass an agentName to delegate the task to an agent running inside the conversation. Do NOT do the work yourself — if work needs to be done, delegate it via agentName. Omit agentName only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output." +
+      "Post a user message to an existing conversation in this project. Default: always pass an agentName to delegate the task to an agent running inside the conversation. Do NOT do the work yourself. If work needs to be done, delegate it via agentName. Omit agentName only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output." +
       "The conversation must belong to the same project. If conversationId is omitted, the current agent conversation is used (when available).",
     schema: {
       conversationId: z
@@ -323,7 +305,7 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "The name of the agent to trigger in the conversation. The tool searches matching agent configurations and uses the best match. Use this whenever the user asks for work to be done in a project (research, analysis, drafting, etc.). When omitted, no agent is triggered and the message is posted as a static result — use this only to deposit a finished artifact you have already fully produced."
+          "The name of the agent to trigger in the conversation. The tool searches matching agent configurations and uses the best match. Use this whenever the user asks for work to be done in a project (research, analysis, drafting, etc.). When omitted, no agent is triggered and the message is posted as a static result. Use this only to deposit a finished artifact you have already fully produced."
         ),
       dustProject:
         ConfigurableToolInputSchemas[
@@ -340,12 +322,10 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
 
 const PROJECT_MANAGER_INSTRUCTIONS =
   "Project files and metadata are shared across all conversations in this project. " +
-  "Project files are managed through the `files` MCP server using `project/<rel>` scoped paths " +
-  "(create, cat, grep, list, delete) — not through this server. " +
+  `Project files are managed through the \`${FILES_SERVER_NAME}\` MCP server using \`project/<rel>\` scoped paths ` +
+  "(create, cat, grep, list, delete), not through this server. " +
   "Use `add_content_node` to reference a Company Data node in the project context, and " +
   "`remove_content_node` to remove such a reference. " +
-  "Use `attach_to_conversation` to surface an existing project context file inside the current " +
-  "conversation without recreating it. " +
   "Use `list_projects` to discover projects you can access and obtain the dustProject uri for other tools. " +
   "Use `retrieve_recent_documents` to load recent content from the project data source and from " +
   "knowledge nodes in the project context. " +
@@ -358,7 +338,7 @@ export const PROJECT_MANAGER_SERVER = {
     version: "1.0.0",
     description:
       "Manage project metadata, members, conversations, and Company Data references. " +
-      "Raw project file operations (create, read, search, write, delete) live in the `files` MCP " +
+      `Raw project file operations (create, read, search, write, delete) live in the \`${FILES_SERVER_NAME}\` MCP ` +
       "server under `project/<rel>` scoped paths.",
     icon: "ActionDocumentTextIcon",
     authorization: null,

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -1,11 +1,11 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import {
   IncludeInputSchema,
   SearchWithNodesInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
+import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -90,7 +90,7 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   get_information: {
     description:
-      "Get information about the project: URL, description, and linked Company Data nodes " +
+      "Get information about the project: URL, description, and linked content nodes " +
       "attached to the project context. Does NOT list project files. Project files live under " +
       `\`project/<rel>\` scoped paths and are discovered through the \`${FILES_SERVER_NAME}\` MCP server.`,
     schema: {

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -274,7 +274,7 @@ export function createProjectManagerTools(
         // surface them here. Project files do (they live under `project/<rel>` scoped paths and
         // are discovered through the `files` MCP server), so we only report a count plus a hint.
         const attachments = await listProjectContextAttachments(auth, space);
-        const linkedContentNodes = attachments
+        const contentNodes = attachments
           .filter(isContentNodeAttachmentType)
           .map((node) => ({
             name: node.title,
@@ -302,7 +302,7 @@ export function createProjectManagerTools(
               name: space.name,
               url: projectUrl,
               description: metadata?.description ?? null,
-              linkedContentNodes,
+              contentNodes,
               files: {
                 count: projectFileCount,
                 hint: `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` with \`scope: "project"\` to enumerate.`,

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -5,7 +5,13 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  FILES_LIST_ACTION_NAME,
+  FILES_SERVER_NAME,
+} from "@app/lib/api/actions/servers/files/metadata";
+import { listProjectFiles } from "@app/lib/api/actions/servers/files/tools/utils";
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import {
   buildProjectRetrieveDataSources,
@@ -14,12 +20,6 @@ import {
   makeSuccessResponse,
   withErrorHandling,
 } from "@app/lib/api/actions/servers/project_manager/helpers";
-import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
-import {
-  FILES_LIST_ACTION_NAME,
-  FILES_SERVER_NAME,
-} from "@app/lib/api/actions/servers/files/metadata";
-import { listProjectFiles } from "@app/lib/api/actions/servers/files/tools/utils";
 import { PROJECT_MANAGER_TOOLS_METADATA } from "@app/lib/api/actions/servers/project_manager/metadata";
 import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
 import {
@@ -34,7 +34,6 @@ import {
 import config from "@app/lib/api/config";
 import {
   addContentNodeToProject,
-  fetchLatestProjectContextFileContentFragment,
   listProjectContextAttachments,
   removeContentNodeFromProject,
 } from "@app/lib/api/projects/context";

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -14,13 +14,19 @@ import {
   makeSuccessResponse,
   withErrorHandling,
 } from "@app/lib/api/actions/servers/project_manager/helpers";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  FILES_LIST_ACTION_NAME,
+  FILES_SERVER_NAME,
+} from "@app/lib/api/actions/servers/files/metadata";
+import { listProjectFiles } from "@app/lib/api/actions/servers/files/tools/utils";
 import { PROJECT_MANAGER_TOOLS_METADATA } from "@app/lib/api/actions/servers/project_manager/metadata";
 import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
 import {
   createConversation,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
-import { renderAttachmentXml } from "@app/lib/api/assistant/conversation/attachments";
+import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   getConversation,
   getLightConversation,
@@ -207,58 +213,6 @@ export function createProjectManagerTools(
       }, "Failed to remove linked content from project");
     },
 
-    attach_to_conversation: async (params) => {
-      return withErrorHandling(async () => {
-        if (!agentLoopContext?.runContext?.conversation) {
-          return new Err(
-            new MCPError("No conversation context available", {
-              tracked: false,
-            })
-          );
-        }
-
-        const contextRes = await getProjectSpace(auth, {
-          agentLoopContext,
-          dustProject: params.dustProject,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const { space } = contextRes.value;
-        const { fileId } = params;
-
-        const projectFile = await fetchLatestProjectContextFileContentFragment(
-          auth,
-          space,
-          fileId
-        );
-        if (!projectFile) {
-          return new Err(
-            new MCPError("File not found in this project context", {
-              tracked: false,
-            })
-          );
-        }
-        const { file } = projectFile;
-
-        return new Ok([
-          {
-            type: "resource" as const,
-            resource: {
-              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-              uri: file.getPublicUrl(auth),
-              fileId: file.sId,
-              title: file.fileName,
-              contentType: file.contentType,
-              snippet: file.snippet,
-              text: `File "${file.fileName}" (${file.sId}) attached to the current conversation.`,
-            },
-          },
-        ]);
-      }, "Failed to attach project file to conversation");
-    },
-
     edit_description: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getWritableProjectContext(auth, {
@@ -317,7 +271,25 @@ export function createProjectManagerTools(
           space
         );
 
+        // Linked content nodes (Company Data references) have no other discovery surface, so we
+        // surface them here. Project files do (they live under `project/<rel>` scoped paths and
+        // are discovered through the `files` MCP server), so we only report a count plus a hint.
         const attachments = await listProjectContextAttachments(auth, space);
+        const linkedContentNodes = attachments
+          .filter(isContentNodeAttachmentType)
+          .map((node) => ({
+            name: node.title,
+            nodeId: node.nodeId,
+            dataSourceViewId: node.nodeDataSourceViewId,
+          }));
+
+        const projectFilesRes = await listProjectFiles(auth, space);
+        if (projectFilesRes.isErr()) {
+          return projectFilesRes;
+        }
+        const projectFileCount = projectFilesRes.value.filter(
+          (e) => !e.isDirectory
+        ).length;
 
         // Construct project URL
         const projectPath = getProjectRoute(owner.sId, space.sId);
@@ -331,20 +303,10 @@ export function createProjectManagerTools(
               name: space.name,
               url: projectUrl,
               description: metadata?.description ?? null,
-              context: {
-                count: attachments.length,
-                attachments: attachments
-                  .map((a) =>
-                    renderAttachmentXml({
-                      attachment: a,
-                      content: "",
-                      // When in the project context, the flags might be misleading, version is useless (it's always the latest)
-                      // eg: a csv might have been uploaded in a convo (becoming queryable) but then moved to the project context.
-                      // This will be obsolete once we run query directly in the sandbox.
-                      hideFlagsAndVersion: true,
-                    })
-                  )
-                  .join("\n"),
+              linkedContentNodes,
+              files: {
+                count: projectFileCount,
+                hint: `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` with \`scope: "project"\` to enumerate.`,
               },
             },
             message: "Successfully retrieved project information",

--- a/front/lib/resources/skill/code_defined/projects.ts
+++ b/front/lib/resources/skill/code_defined/projects.ts
@@ -1,8 +1,5 @@
 import { SEARCH_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
-import {
-  CONVERSATION_FILES_SERVER_NAME,
-  CONVERSATION_SEARCH_FILES_ACTION_NAME,
-} from "@app/lib/api/actions/servers/conversation_files/metadata";
+import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { PROJECT_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/project_manager/metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -22,23 +19,23 @@ export const projectsSkill = {
     "Use project context instructions and tools for project knowledge retrieval and search. Allow agents to create conversations and messages in projects.",
   instructions: `
 The project provides:
-- Persistent knowledge storage shared accross this project
+- Persistent knowledge storage shared across this project
 - Project metadata (description, URLs, members, etc.) for organizational context
-- Semantic search over project knowledge and project conversation transcripts
 - Collaborative context that persists beyond individual conversations
 
 ## Persistent Knowledge
 
-Can be also referred to as the "Project Context".
-It contains attachments (files, linked connected data nodes) as well as conversations transcripts.
-It is stored in the project data source and can be searched using the \`semantic_search\` tool.
+Can be also referred to as the "Project Context". Project files live under \`project/<rel>\`
+scoped paths and persist across every conversation in the project. Conversation-only files live
+under \`conversation/<rel>\` and are visible to this conversation only. Both surfaces are reached
+through the same file system; prefer the sandbox when it's available (see the sandbox skill for
+the mount layout), and fall back to the \`${FILES_SERVER_NAME}\` MCP tools when it isn't. The project also accepts
+references to connected data nodes (Company Data); those are managed through the
+\`${PROJECT_MANAGER_SERVER_NAME}\` server.
 
-### Project attachments vs conversation attachments
-- **Project attachments**: Persist for every conversation in the project; managed with \`${PROJECT_MANAGER_SERVER_NAME}\` (e.g. \`add_file\`).
-- **Conversation attachments**: Only for this conversation; use \`${CONVERSATION_FILES_SERVER_NAME}\` tools when present.
-
-To keep something for later project-wide use, add it with \`add_file\`.
-To reuse an existing project file in this conversation, use \`attach_to_conversation\`.
+To keep something for later project-wide use, write it under a \`project/<rel>\` path. To duplicate
+binary content (PDFs, images, audio) between scopes, use the dedicated copy tool rather than
+reading and rewriting, because the round-trip through the agent loses the bytes.
 
 ## Referencing project tasks in messages
 
@@ -50,11 +47,10 @@ Use the \`sId\` from \`project_tasks\` tools (e.g. \`list_tasks\`, \`create_task
 
 ## Tool Usage Priority
 
-When you need to find information, uses this order (skip steps if the relevant tools are not in your tool list):
-1. **Project overview**: \`${PROJECT_MANAGER_SERVER_NAME}\` \`get_information\` — project URL, description, and what is attached to the project.
-2. **This conversation's attachments** (only when \`${CONVERSATION_FILES_SERVER_NAME}\` is available): \`${CONVERSATION_SEARCH_FILES_ACTION_NAME}\` on \`${CONVERSATION_FILES_SERVER_NAME}\` — search files attached to the current conversation.
-3. **Project-wide search**: \`${PROJECT_MANAGER_SERVER_NAME}\` \`semantic_search\` — search project knowledge and/or conversations in the project; usually the best source for project-specific questions.
-4. **Company-wide**: If still insufficient, use \`company_data_*\` tools and \`${SEARCH_SERVER_NAME}\` for broader company data sources.
+When you need to find information, use this order (skip steps if the relevant tools are not in your tool list):
+1. **Project overview**: \`${PROJECT_MANAGER_SERVER_NAME}\` \`get_information\` returns the project URL, description, and what is attached to the project.
+2. **Project files**: read and search \`project/<rel>\` files through the sandbox or the \`${FILES_SERVER_NAME}\` MCP tools.
+3. **Company-wide**: If still insufficient, use \`company_data_*\` tools and \`${SEARCH_SERVER_NAME}\` for broader company data sources.
 `,
 
   mcpServers: [{ name: "project_manager" }, { name: "project_tasks" }],

--- a/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/shrink-wrap.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/shrink-wrap.ts
@@ -58,7 +58,7 @@ Example:
 
 <identifying_knowledge_sources>
 Step 1 — Scan \`inspect_conversation\` for knowledge-access actions. Look for tool names:
-- \`semantic_search\` (server: \`search\` or \`project_manager\`), \`retrieve_recent_documents\` (server: \`project_manager\`) → semantic / recent retrieval
+- \`semantic_search\` (server: \`search\`), \`retrieve_recent_documents\` (server: \`project_manager\`) → semantic / recent retrieval
 - \`cat\`, \`find\`, \`list\`, \`locate_in_tree\` → filesystem browsing (server: \`data_sources_file_system\`)
 - \`query_tables\`, \`get_database_schema\` → table/SQL access
 - \`run_agent\` → sub-agent (inspect child conversation separately)


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Now that project files have their own discovery surface (`files__list` with `scope: "project"`, or the sandbox mount), two pieces of `project_manager` no longer fit:
- `attach_to_conversation` was the bridge for surfacing a project file inside a conversation when
files lived behind `FileResources`. With the mount in place, every conversation in a project already sees those files via
`/files/project/`, so the bridge is redundant.
- `get_information` had a related problem: it returned an attachments list rendered as XML from `listProjectContextAttachments`, which only sees files with a backing `FileResource`. Agent-created files via `files__create` are pure GCS objects on the mount, so they were silently missing from that list, while the file count and overall framing implied the response was authoritative. The handler now returns three things: project metadata (URL, name, description, spaceId), a slim `linkedContentNodes` array (name, nodeId, dataSourceViewId, only what `remove_content_node` needs to round-trip. no XML rendering), and a `files: { count, hint }` block where the count comes from the same `listGCSMountFiles` source as files__list({ scope: "project" }).

The tool description and `PROJECT_MANAGER_INSTRUCTIONS` were updated to reflect the new contract, and the projects skill prompt was rewritten to describe project files in terms of paths and mounts rather than tool names, deferring file-access guidance to the sandbox skill prompt.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->