### PR TITLE
Fix: toFileContentFragment() now trigger the GCS mount.

### DIFF
--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -21,6 +21,7 @@ import {
   isContentFragmentInputWithFileId,
   isSupportedContentNodeFragmentContentType,
 } from "@app/types/api/internal/assistant";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type {
   ContentNodeType,
   CoreAPIContentNode,
@@ -59,10 +60,12 @@ interface ContentFragmentBlob {
 export async function toFileContentFragment(
   auth: Authenticator,
   {
+    conversation,
     contentFragment,
     fileName,
     skipDataSourceIndexing,
   }: {
+    conversation: ConversationWithoutContentType;
     contentFragment: ContentFragmentInputWithInlinedContent;
     fileName?: string;
     skipDataSourceIndexing?: boolean;
@@ -80,8 +83,8 @@ export async function toFileContentFragment(
     workspaceId: auth.getNonNullableWorkspace().id,
     useCase: "conversation",
     useCaseMetadata: skipDataSourceIndexing
-      ? { skipDataSourceIndexing: true }
-      : undefined,
+      ? { skipDataSourceIndexing: true, conversationId: conversation.sId }
+      : { conversationId: conversation.sId },
   });
 
   const processRes = await processAndStoreFile(auth, {

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -625,6 +625,7 @@ export async function triggerFromEmail(
 
   if (restOfThread.length > 0) {
     const cfRes = await toFileContentFragment(auth, {
+      conversation,
       contentFragment: {
         title: `Email thread: ${email.subject}`,
         content: restOfThread,

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -331,6 +331,7 @@ export async function createSkillSuggestionsConversation(
   );
 
   const contentFragmentRes = await toFileContentFragment(auth, {
+    conversation,
     contentFragment: {
       title: `${pendingSuggestions.length} pending suggestions for ${skillType.name} skill`,
       content: formattedSuggestions,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -131,6 +131,7 @@ async function handler(
       // one.
       if (isContentFragmentInputWithInlinedContent(contentFragment)) {
         const contentFragmentRes = await toFileContentFragment(auth, {
+          conversation,
           contentFragment,
         });
         if (contentFragmentRes.isErr()) {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -344,6 +344,7 @@ async function handler(
 
         if (isContentFragmentInputWithInlinedContent(contentFragment)) {
           const contentFragmentRes = await toFileContentFragment(auth, {
+            conversation,
             contentFragment,
           });
           if (contentFragmentRes.isErr()) {

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -612,6 +612,7 @@ export async function processTranscriptActivity(
     };
 
     const cfRes = await toFileContentFragment(auth, {
+      conversation: initialConversation,
       contentFragment: {
         title: transcriptTitle,
         content: transcriptContent,

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -4,6 +4,7 @@ import {
   postNewContentFragment,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
+import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   buildAuditLogTarget,
@@ -16,16 +17,16 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
+import { getWebhookRequestPayloadFromGCS } from "@app/lib/triggers/webhook";
 import logger from "@app/logger/logger";
 import { makeTriggerScheduleId } from "@app/temporal/triggers/schedule_client";
-import type { ContentFragmentInputWithFileIdType } from "@app/types/api/internal/assistant";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -37,13 +38,13 @@ async function createConversationForAgentConfiguration({
   agentConfiguration,
   trigger,
   lastRunAt,
-  contentFragment,
+  webhookRequest,
 }: {
   auth: Authenticator;
   agentConfiguration: AgentConfigurationType;
   trigger: TriggerType;
   lastRunAt: Date | null;
-  contentFragment?: ContentFragmentInputWithFileIdType;
+  webhookRequest: WebhookRequestResource | null;
 }): Promise<Result<ConversationType, APIErrorWithStatusCode>> {
   const newConversation = await createConversation(auth, {
     title: null,
@@ -65,8 +66,69 @@ async function createConversationForAgentConfiguration({
     lastTriggerRunAt: lastRunAt?.getTime() ?? null,
   };
 
-  if (contentFragment) {
-    await postNewContentFragment(auth, newConversation, contentFragment, null);
+  if (
+    webhookRequest &&
+    trigger.kind === "webhook" &&
+    trigger.configuration.includePayload
+  ) {
+    // If we need the payload, create a content fragment for it.
+    const payloadRes = await getWebhookRequestPayloadFromGCS(auth, {
+      webhookRequest,
+    });
+    if (payloadRes.isErr()) {
+      logger.error(
+        {
+          triggerId: trigger.sId,
+          error: payloadRes.error,
+        },
+        "Error getting webhook request payload from GCS."
+      );
+      return new Err({
+        api_error: {
+          type: "webhook_storage_error",
+          message: "Webhook request payload not found.",
+        },
+        status_code: 500,
+      });
+    }
+
+    const contentFragmentRes = await toFileContentFragment(auth, {
+      conversation: newConversation,
+      contentFragment: {
+        contentType: "application/json",
+        content: JSON.stringify(payloadRes.value.body),
+        title: `Webhook body (source id: ${webhookRequest.webhookSourceId}, date: ${new Date().toISOString()})`,
+      },
+      fileName: `webhook_body_${webhookRequest.webhookSourceId}_${Date.now()}.json`,
+      skipDataSourceIndexing: true,
+    });
+
+    if (contentFragmentRes.isErr()) {
+      const errorMessage =
+        "Error creating file content fragment from webhook request.";
+      await webhookRequest.markAsFailed(errorMessage);
+      logger.error(
+        {
+          workspaceId: auth.workspace()?.sId,
+          webhookRequestId: webhookRequest.id,
+        },
+        errorMessage
+      );
+      return new Err({
+        api_error: {
+          type: "webhook_storage_error",
+          message: "Error creating file content fragment from webhook request.",
+        },
+        status_code: 500,
+      });
+    }
+
+    await postNewContentFragment(
+      auth,
+      newConversation,
+      contentFragmentRes.value,
+      null
+    );
   }
 
   const messageRes = await postUserMessage(auth, {
@@ -100,13 +162,11 @@ export async function runTriggeredAgentsActivity({
   userId,
   workspaceId,
   triggerId,
-  contentFragment,
   webhookRequestId,
 }: {
   userId: string;
   workspaceId: string;
   triggerId: string;
-  contentFragment?: ContentFragmentInputWithFileIdType;
   webhookRequestId?: number;
 }) {
   const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -179,6 +239,7 @@ export async function runTriggeredAgentsActivity({
   }
 
   let lastRunAt: Date | null = null;
+  let webhookRequest: WebhookRequestResource | null = null;
   switch (trigger.kind) {
     case "schedule": {
       const client = await getTemporalClientForAgentNamespace();
@@ -205,6 +266,12 @@ export async function runTriggeredAgentsActivity({
     }
 
     case "webhook": {
+      if (webhookRequestId) {
+        webhookRequest = await WebhookRequestResource.fetchByModelIdWithAuth(
+          auth,
+          webhookRequestId
+        );
+      }
       break;
     }
 
@@ -219,7 +286,7 @@ export async function runTriggeredAgentsActivity({
     agentConfiguration,
     trigger,
     lastRunAt,
-    contentFragment,
+    webhookRequest,
   });
   if (conversationResult.isErr()) {
     const { type: errorType, message: errorMessage } =
@@ -229,7 +296,8 @@ export async function runTriggeredAgentsActivity({
       errorType === "credits_exhausted" ||
       errorType === "model_disabled" ||
       errorType === "invalid_request_error" ||
-      errorType === "agent_inaccessible";
+      errorType === "agent_inaccessible" ||
+      errorType === "webhook_storage_error";
 
     if (isNonRetryable) {
       // If the agent is inaccessible, disable the trigger.
@@ -245,19 +313,12 @@ export async function runTriggeredAgentsActivity({
         await triggerResource.disable(auth);
       }
 
-      if (webhookRequestId && trigger.kind === "webhook") {
-        const webhookRequest =
-          await WebhookRequestResource.fetchByModelIdWithAuth(
-            auth,
-            webhookRequestId
-          );
-        if (webhookRequest) {
-          await webhookRequest.markRelatedTrigger({
-            trigger,
-            status: "workflow_start_failed",
-            errorMessage,
-          });
-        }
+      if (webhookRequest) {
+        await webhookRequest.markRelatedTrigger({
+          trigger,
+          status: "workflow_start_failed",
+          errorMessage,
+        });
       }
       // Return without throwing, this is normal behaviour so we don't want an error
       return;

--- a/front/temporal/triggers/webhook_client.ts
+++ b/front/temporal/triggers/webhook_client.ts
@@ -1,4 +1,3 @@
-import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
 import { Authenticator } from "@app/lib/auth";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
@@ -8,7 +7,6 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/triggers/config";
 import { agentTriggerWorkflow } from "@app/temporal/triggers/workflows";
-import type { ContentFragmentInputWithFileIdType } from "@app/types/api/internal/assistant";
 import type {
   TriggerType,
   WebhookTriggerType,
@@ -20,12 +18,10 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 async function launchAgentTriggerWorkflow({
   auth,
   trigger,
-  contentFragment,
   webhookRequestId,
 }: {
   auth: Authenticator;
   trigger: TriggerType;
-  contentFragment?: ContentFragmentInputWithFileIdType;
   webhookRequestId?: number;
 }): Promise<Result<undefined, Error>> {
   const client = await getTemporalClientForAgentNamespace();
@@ -43,7 +39,6 @@ async function launchAgentTriggerWorkflow({
           userId: auth.getNonNullableUser().sId,
           workspaceId: auth.getNonNullableWorkspace().sId,
           triggerId: trigger.sId,
-          contentFragment,
           webhookRequestId,
         },
       ],
@@ -83,34 +78,6 @@ export async function launchTriggersWorkflows(
 ): Promise<Result<void, Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const webhookRequestId = webhookRequest.id;
-  // Check if any of the triggers requires the payload.
-  const requiresPayload = filteredTriggers.some(
-    (t) => t.configuration.includePayload
-  );
-
-  // If we need the payload, create a content fragment for it.
-  let contentFragment: ContentFragmentInputWithFileIdType | undefined;
-  if (requiresPayload) {
-    const contentFragmentRes = await toFileContentFragment(auth, {
-      contentFragment: {
-        contentType: "application/json",
-        content: JSON.stringify(body),
-        title: `Webhook body (source id: ${webhookSource.id}, date: ${new Date().toISOString()})`,
-      },
-      fileName: `webhook_body_${webhookSource.id}_${Date.now()}.json`,
-      skipDataSourceIndexing: true,
-    });
-
-    if (contentFragmentRes.isErr()) {
-      const errorMessage =
-        "Error creating file content fragment from webhook request.";
-      await webhookRequest.markAsFailed(errorMessage);
-      logger.error({ workspaceId, webhookRequestId }, errorMessage);
-      return new Err(new Error(errorMessage));
-    }
-
-    contentFragment = contentFragmentRes.value;
-  }
 
   // Launch all the triggers' workflows concurrently.
   await concurrentExecutor(
@@ -135,27 +102,11 @@ export async function launchTriggersWorkflows(
           user.sId,
           workspaceId
         );
-        if (trigger.configuration.includePayload && !contentFragment) {
-          const errorMessage =
-            "One of the triggers requires the payload, but the contentFragment is missing. It should never happen as the content fragment is created if any of the triggers requires the payload.";
-          logger.error(
-            {
-              triggerId: trigger.sId,
-            },
-            errorMessage
-          );
-          await webhookRequest.markRelatedTrigger({
-            trigger,
-            status: "workflow_start_failed",
-          });
-          return;
-        }
 
         // Fire and forget
         const result = await launchAgentTriggerWorkflow({
           auth,
           trigger,
-          contentFragment,
           webhookRequestId,
         });
 

--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -1,4 +1,3 @@
-import type { ContentFragmentInputWithFileIdType } from "@app/types/api/internal/assistant";
 import { ActivityFailure, RetryState } from "@temporalio/common";
 import { proxyActivities } from "@temporalio/workflow";
 
@@ -28,20 +27,17 @@ export async function agentTriggerWorkflow({
   userId,
   workspaceId,
   triggerId,
-  contentFragment,
   webhookRequestId,
 }: {
   userId: string;
   workspaceId: string;
   triggerId: string;
-  contentFragment?: ContentFragmentInputWithFileIdType;
   webhookRequestId?: number;
 }) {
   await runTriggeredAgentsActivity({
     userId,
     workspaceId,
     triggerId,
-    contentFragment,
     webhookRequestId,
   });
 }


### PR DESCRIPTION
## Description

**Root cause**

`toFileContentFragment` was not passing `conversationId` in `useCaseMetadata` when calling `createFileResource`, so the GCS mount needed for the agent loop to read the file was never triggered. The field was absent in both the `skipDataSourceIndexing: true` and normal paths.

**Fix**

Always include `conversationId: conversation.sId` in `useCaseMetadata`. `conversation: ConversationWithoutContentType` is promoted to a required parameter of `toFileContentFragment`; all six call sites are updated accordingly:
- `email_trigger.ts`
- `aggregate_suggestions.ts`
- `conversations/content_fragments.ts` API route
- `conversations/index.ts` API route
- `transcripts/activities.ts`
- `triggers/activities.ts`

**Webhook trigger payload handling**

As a side-effect of threading `conversation` into `toFileContentFragment`, the webhook payload flow is refactored. Previously, `webhook_client.ts` fetched the GCS payload and built a `ContentFragmentInputWithFileId` before scheduling the Temporal workflow. Now:

- `createConversationForAgentConfiguration` receives `webhookRequest: WebhookRequestResource | null` instead of a pre-built content fragment
- The activity fetches `WebhookRequestResource`, calls `getWebhookRequestPayloadFromGCS`, and creates the file content fragment (with `conversation`) in one place
- `webhook_storage_error` is added as a non-retryable error type so storage failures disable the trigger rather than retrying indefinitely
- `webhook_client.ts` is simplified: payload fetching and fragment construction are removed

## Tests

Local

## Risk

Medium — touches every `toFileContentFragment` call site and the webhook trigger activity. All changes are additive (the `conversationId` field was simply missing before) and the webhook refactor consolidates logic that was already present.

## Deploy Plan

Deploy `front`
