### PR TITLE
fix(oauth): url-encode client_id and client_secret in Basic auth headers per RFC 6749

### DIFF
--- a/core/src/oauth/providers/freshservice.rs
+++ b/core/src/oauth/providers/freshservice.rs
@@ -12,6 +12,7 @@ use base64::{engine::general_purpose, Engine as _};
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::env;
+use urlencoding;
 
 lazy_static! {
     static ref OAUTH_FRESHWORKS_CLIENT_ID: String = env::var("OAUTH_FRESHWORKS_CLIENT_ID").unwrap();
@@ -58,11 +59,13 @@ impl Provider for FreshserviceConnectionProvider {
             ("redirect_uri", redirect_uri),
         ];
 
+        // RFC 6749 §2.3.1 requires URL-encoding client_id and client_secret before base64-encoding.
         let auth_header = format!(
             "Basic {}",
             general_purpose::STANDARD.encode(format!(
                 "{}:{}",
-                *OAUTH_FRESHWORKS_CLIENT_ID, *OAUTH_FRESHWORKS_CLIENT_SECRET
+                urlencoding::encode(&*OAUTH_FRESHWORKS_CLIENT_ID),
+                urlencoding::encode(&*OAUTH_FRESHWORKS_CLIENT_SECRET)
             ))
         );
 
@@ -124,11 +127,13 @@ impl Provider for FreshserviceConnectionProvider {
             ("refresh_token", &refresh_token),
         ];
 
+        // RFC 6749 §2.3.1 requires URL-encoding client_id and client_secret before base64-encoding.
         let auth_header = format!(
             "Basic {}",
             general_purpose::STANDARD.encode(format!(
                 "{}:{}",
-                *OAUTH_FRESHWORKS_CLIENT_ID, *OAUTH_FRESHWORKS_CLIENT_SECRET
+                urlencoding::encode(&*OAUTH_FRESHWORKS_CLIENT_ID),
+                urlencoding::encode(&*OAUTH_FRESHWORKS_CLIENT_SECRET)
             ))
         );
 

--- a/core/src/oauth/providers/gong.rs
+++ b/core/src/oauth/providers/gong.rs
@@ -14,6 +14,7 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine as _};
 use lazy_static::lazy_static;
 use std::env;
+use urlencoding;
 
 lazy_static! {
     static ref OAUTH_GONG_CLIENT_ID: String = env::var("OAUTH_GONG_CLIENT_ID").unwrap();
@@ -21,7 +22,12 @@ lazy_static! {
 }
 
 pub fn create_gong_basic_auth_token() -> String {
-    let credentials = format!("{}:{}", *OAUTH_GONG_CLIENT_ID, *OAUTH_GONG_CLIENT_SECRET);
+    // RFC 6749 §2.3.1 requires URL-encoding client_id and client_secret before base64-encoding.
+    let credentials = format!(
+        "{}:{}",
+        urlencoding::encode(&*OAUTH_GONG_CLIENT_ID),
+        urlencoding::encode(&*OAUTH_GONG_CLIENT_SECRET)
+    );
     format!("Basic {}", general_purpose::STANDARD.encode(credentials))
 }
 

--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -63,12 +63,17 @@ impl MCPConnectionProvider {
         MCPConnectionProvider {}
     }
 
+    /// RFC 6749 §2.3.1 requires URL-encoding client_id and client_secret before base64-encoding.
     fn build_basic_auth_header(client_id: &str, client_secret: &str) -> String {
         format!(
             "Basic {}",
             base64::Engine::encode(
                 &base64::engine::general_purpose::STANDARD,
-                format!("{}:{}", client_id, client_secret)
+                format!(
+                    "{}:{}",
+                    urlencoding::encode(client_id),
+                    urlencoding::encode(client_secret)
+                )
             )
         )
     }

--- a/core/src/oauth/providers/notion.rs
+++ b/core/src/oauth/providers/notion.rs
@@ -11,6 +11,7 @@ use base64::{engine::general_purpose, Engine as _};
 use lazy_static::lazy_static;
 use serde_json::json;
 use std::env;
+use urlencoding;
 
 lazy_static! {
     static ref OAUTH_NOTION_CLIENT_ID: String = env::var("OAUTH_NOTION_CLIENT_ID").unwrap();
@@ -61,7 +62,12 @@ impl NotionConnectionProvider {
             ),
             NotionUseCase::Connection => (&*OAUTH_NOTION_CLIENT_ID, &*OAUTH_NOTION_CLIENT_SECRET),
         };
-        general_purpose::STANDARD.encode(&format!("{}:{}", client_id, client_secret))
+        // RFC 6749 §2.3.1 requires URL-encoding client_id and client_secret before base64-encoding.
+        general_purpose::STANDARD.encode(&format!(
+            "{}:{}",
+            urlencoding::encode(client_id),
+            urlencoding::encode(client_secret)
+        ))
     }
 }
 

--- a/core/src/oauth/providers/slack.rs
+++ b/core/src/oauth/providers/slack.rs
@@ -16,6 +16,7 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine as _};
 use lazy_static::lazy_static;
 use std::env;
+use urlencoding;
 
 lazy_static! {
     static ref OAUTH_SLACK_CLIENT_ID: String = env::var("OAUTH_SLACK_CLIENT_ID").unwrap();
@@ -63,7 +64,12 @@ impl SlackConnectionProvider {
             ),
         };
 
-        Ok(general_purpose::STANDARD.encode(&format!("{}:{}", client_id, client_secret)))
+        // RFC 6749 §2.3.1 requires URL-encoding client_id and client_secret before base64-encoding.
+        Ok(general_purpose::STANDARD.encode(&format!(
+            "{}:{}",
+            urlencoding::encode(&client_id),
+            urlencoding::encode(&client_secret)
+        )))
     }
 
     pub fn get_credentials(credentials: Credential) -> Result<(String, String)> {

--- a/core/src/oauth/providers/slack_tools.rs
+++ b/core/src/oauth/providers/slack_tools.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine as _};
 use lazy_static::lazy_static;
 use std::env;
+use urlencoding;
 
 lazy_static! {
     static ref OAUTH_SLACK_TOOLS_CLIENT_ID: String =
@@ -35,10 +36,11 @@ impl SlackToolsConnectionProvider {
     }
 
     fn basic_auth(&self) -> String {
+        // RFC 6749 §2.3.1 requires URL-encoding client_id and client_secret before base64-encoding.
         general_purpose::STANDARD.encode(&format!(
             "{}:{}",
-            OAUTH_SLACK_TOOLS_CLIENT_ID.clone(),
-            OAUTH_SLACK_TOOLS_CLIENT_SECRET.clone()
+            urlencoding::encode(&*OAUTH_SLACK_TOOLS_CLIENT_ID),
+            urlencoding::encode(&*OAUTH_SLACK_TOOLS_CLIENT_SECRET)
         ))
     }
 }


### PR DESCRIPTION
## Description

RFC 6749 §2.3.1 requires that `client_id` and `client_secret` be percent-encoded before concatenation and base64-encoding when building HTTP Basic auth headers for OAuth token endpoints. [This was already fixed for the Snowflake provider](https://github.com/dust-tt/dust/pull/25548#event-25472697891), and has been proven successful; this PR applies the same fix to all remaining providers that use Basic auth.

**Affected providers:** MCP (most critical — uses user-provided credentials), Slack (user-provided credentials via `related_credentials`), Freshservice, Gong, Notion, SlackTools.

Providers that pass credentials in form body or JSON body are not affected since reqwest handles encoding automatically.

## Tests


## Risk

Low. Credentials for platform-managed providers (Freshservice, Gong, Notion, SlackTools) are controlled env vars that don't currently contain special characters, so the change is a no-op for them in practice. For MCP and Slack with user-provided credentials, the fix only matters when `client_id` or `client_secret` contains characters like `+`, `/`, or `=` (common in base64-derived secrets) — which is exactly the scenario that was breaking Snowflake.
