### PR TITLE
[LLM] Remove claude-opus-4-7 from Vertex model map

### DIFF
--- a/front/lib/api/llm/clients/anthropic/types.ts
+++ b/front/lib/api/llm/clients/anthropic/types.ts
@@ -107,7 +107,6 @@ export const VERTEX_MODEL_ID_MAP: Partial<Record<ModelIdType, string>> = {
   [CLAUDE_OPUS_4_6_MODEL_ID]: "claude-opus-4-6@default",
   [CLAUDE_4_5_OPUS_20251101_MODEL_ID]: "claude-opus-4-5@20251101",
   [CLAUDE_4_5_HAIKU_20251001_MODEL_ID]: "claude-haiku-4-5@20251001",
-  [CLAUDE_OPUS_4_7_MODEL_ID]: "claude-opus-4-7@default",
 };
 
 export function isVertexWhitelistedModelId(


### PR DESCRIPTION
## Description

We don't have quota for Claude Opus 4.7 on Vertex yet, so it shouldn't appear in `VERTEX_MODEL_ID_MAP`. Removing the entry until quota is granted.

## Tests

None.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`