### PR TITLE
Free user allowance

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -9,6 +9,7 @@ import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   hasContractSeatSubscription,
   syncSeatCount,
+  voidFreeUserAwuCredit,
 } from "@app/lib/metronome/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -338,6 +339,29 @@ export async function updateMembershipSeatAndTrack({
     newSeatType,
     author,
   });
+
+  // Transitioning out of "free" — the unused balance of the one-shot free
+  // credit is not transferable, so void it immediately. Failures are logged
+  // but do not block the seat type change.
+  if (
+    updateRes.previousSeatType === "free" &&
+    updateRes.newSeatType !== "free"
+  ) {
+    const voidResult = await voidFreeUserAwuCredit({
+      workspace,
+      userId: user.sId,
+    });
+    if (voidResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          userId: user.sId,
+          error: voidResult.error,
+        },
+        "[Metronome] Failed to void free user credit on seat type change"
+      );
+    }
+  }
 
   const syncResult = await syncSeatCountForWorkspace(workspace);
   if (syncResult.isErr()) {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -930,14 +930,15 @@ export async function updateSubscriptionQuantity({
 // `retrieveSubscriptionQuantityHistory` is the closest and returns quantity
 // totals, not seat IDs. So we route through the SDK client's generic post(),
 // which still gives us auth + retries + error handling.
-interface SubscriptionSeatsHistoryResponse {
-  data: Array<{
-    starting_at: string;
-    ending_before?: string | null;
-    seat_ids: string[];
-    unassigned_seats?: number;
-  }>;
-}
+//
+// The endpoint returns the history segments at the top level (no `data`
+// wrapper), each carrying `assigned_seat_ids` plus the segment totals.
+type SubscriptionSeatsHistoryResponse = Array<{
+  starting_at: string;
+  ending_before?: string | null;
+  total_quantity?: string;
+  assigned_seat_ids: string[];
+}>;
 
 /**
  * Fetch the currently assigned seat IDs on a SEAT_BASED subscription. Returns
@@ -966,7 +967,7 @@ export async function getMetronomeSubscriptionAssignedSeatIds({
           },
         }
       );
-    return new Ok(response.data[0]?.seat_ids ?? []);
+    return new Ok(response[0]?.assigned_seat_ids ?? []);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
@@ -1465,6 +1466,7 @@ export async function createMetronomeCredit({
   idempotencyKey,
   applicableProductTags,
   applicableProductIds,
+  specifiers,
   priority,
 }: {
   metronomeCustomerId: string;
@@ -1475,8 +1477,18 @@ export async function createMetronomeCredit({
   endingBefore: string;
   name: string;
   idempotencyKey: string;
+  // Mutually exclusive with `specifiers` (Metronome rejects requests that
+  // combine the two).
   applicableProductTags?: string[];
   applicableProductIds?: string[];
+  // Per-specifier filters (presentation/pricing group values, product tags).
+  // Mutually exclusive with `applicableProductTags` / `applicableProductIds`.
+  specifiers?: Array<{
+    presentation_group_values?: Record<string, string>;
+    pricing_group_values?: Record<string, string>;
+    product_id?: string;
+    product_tags?: string[];
+  }>;
   priority: number;
 }): Promise<Result<{ id: string } | null, Error>> {
   // Metronome requires dates on hour boundaries — round down start, round up end.
@@ -1495,6 +1507,7 @@ export async function createMetronomeCredit({
       ...(applicableProductIds
         ? { applicable_product_ids: applicableProductIds }
         : {}),
+      ...(specifiers ? { specifiers } : {}),
       access_schedule: {
         credit_type_id: creditTypeId,
         schedule_items: [

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1,10 +1,18 @@
 import {
+  ceilToHourISO,
+  createMetronomeCredit,
+  findMetronomeCreditByUniquenessKey,
   getMetronomeContractById,
   getMetronomeSubscriptionAssignedSeatIds,
+  updateMetronomeCreditEndDate,
   updateSubscriptionQuantity,
   updateSubscriptionSeats,
 } from "@app/lib/metronome/client";
-import { getSeatTypeForProductId } from "@app/lib/metronome/constants";
+import {
+  getCreditTypeAwuId,
+  getProductFreeCreditId,
+  getSeatTypeForProductId,
+} from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
@@ -12,6 +20,13 @@ import type { MembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
+
+// One-shot AWU credit granted to each "free" seat user, drawn against any
+// usage-tagged product for events carrying that user's user_id.
+const FREE_USER_AWU_CREDITS_AMOUNT = 300;
+// Metronome caps credit end dates, so we anchor 5 years out from now rather
+// than a fixed far-future bound.
+const FREE_USER_AWU_CREDITS_DURATION_YEARS = 5;
 
 /**
  * Returns true if the contract has any seat-billed subscription (workspace /
@@ -118,7 +133,14 @@ export async function syncSeatCount({
     workspace,
   });
 
+  // Initialize a bucket for every seat type that has a subscription on the
+  // contract, so seat types with zero current memberships still drive a sync
+  // (e.g. draining a Pro Seat subscription to 0 when the last "pro" member
+  // moves to "max").
   const sIdsBySeatType = new Map<MembershipSeatType, string[]>();
+  for (const { seatType } of seatSubscriptions) {
+    sIdsBySeatType.set(seatType, []);
+  }
   for (const m of memberships) {
     const userId = m.user?.sId;
     if (!userId) {
@@ -155,6 +177,27 @@ export async function syncSeatCount({
     );
   }
 
+  // Grant the one-shot free AWU credit to every "free" seat member that
+  // doesn't already have one. Failures are logged but don't fail the sync —
+  // the call is idempotent and will be retried on the next sync.
+  const freeUserIds = sIdsBySeatType.get("free") ?? [];
+  for (const userId of freeUserIds) {
+    const ensureResult = await ensureFreeUserAwuCredit({
+      workspace,
+      userId,
+    });
+    if (ensureResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          userId,
+          error: ensureResult.error,
+        },
+        "[Metronome] Failed to ensure free user credit"
+      );
+    }
+  }
+
   for (const { sub, seatType } of seatSubscriptions) {
     const subscriptionId = sub.id!;
     const sIds = sIdsBySeatType.get(seatType) ?? [];
@@ -178,7 +221,7 @@ export async function syncSeatCount({
       );
 
       if (addSeatIds.length === 0 && removeSeatIds.length === 0) {
-        return new Ok(undefined);
+        continue;
       }
 
       logger.info(
@@ -230,4 +273,152 @@ export async function syncSeatCount({
   }
 
   return new Ok(undefined);
+}
+
+/**
+ * Ensure a one-shot AWU free credit exists for a "free" seat user on the
+ * given workspace. Idempotent — checks for an existing credit via its
+ * uniqueness key before attempting to create.
+ *
+ * The credit is scoped to events carrying the user's `user_id` (via a
+ * presentation specifier) and to any usage-tagged product. Workspaces without
+ * a Metronome customer id are no-ops.
+ */
+export async function ensureFreeUserAwuCredit({
+  workspace,
+  userId,
+  amountAwu = FREE_USER_AWU_CREDITS_AMOUNT,
+}: {
+  workspace: LightWorkspaceType;
+  userId: string;
+  amountAwu?: number;
+}): Promise<Result<{ creditId: string | null; created: boolean }, Error>> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return new Ok({ creditId: null, created: false });
+  }
+
+  // Stable per (workspace, user) — used both as uniqueness key (server-side
+  // idempotency) and as the lookup key for the pre-create existence check.
+  const uniquenessKey = `free-user-credit-${workspace.sId}-${userId}`;
+  const now = new Date();
+  const startingAt = now.toISOString();
+  const endingBeforeDate = new Date(now);
+  endingBeforeDate.setUTCFullYear(
+    endingBeforeDate.getUTCFullYear() + FREE_USER_AWU_CREDITS_DURATION_YEARS
+  );
+  const endingBefore = endingBeforeDate.toISOString();
+
+  const existing = await findMetronomeCreditByUniquenessKey({
+    metronomeCustomerId,
+    uniquenessKey,
+    coveringDate: startingAt,
+  });
+  if (existing.isErr()) {
+    return new Err(existing.error);
+  }
+  if (existing.value) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        userId,
+        metronomeCreditId: existing.value.id,
+      },
+      "[Metronome] Free user credit already exists, skipping create"
+    );
+    return new Ok({ creditId: existing.value.id, created: false });
+  }
+
+  const createResult = await createMetronomeCredit({
+    metronomeCustomerId,
+    productId: getProductFreeCreditId(),
+    creditTypeId: getCreditTypeAwuId(),
+    amount: amountAwu,
+    startingAt,
+    endingBefore,
+    name: `Free credits for user ${userId}`,
+    idempotencyKey: uniquenessKey,
+    priority: 50,
+    specifiers: [
+      {
+        presentation_group_values: { user_id: userId },
+        product_tags: ["usage"],
+      },
+    ],
+  });
+  if (createResult.isErr()) {
+    return new Err(createResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      userId,
+      metronomeCreditId: createResult.value?.id,
+      amountAwu,
+    },
+    "[Metronome] Free user credit created"
+  );
+  return new Ok({ creditId: createResult.value?.id ?? null, created: true });
+}
+
+/**
+ * Void any one-shot free AWU credit previously granted to this user. Called
+ * when a user transitions out of the "free" seat type — the unused balance is
+ * not transferable, so we cut the access end date to now. No-op if no
+ * matching credit exists or the workspace is not Metronome-billed.
+ */
+export async function voidFreeUserAwuCredit({
+  workspace,
+  userId,
+}: {
+  workspace: LightWorkspaceType;
+  userId: string;
+}): Promise<Result<{ creditId: string | null; voided: boolean }, Error>> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return new Ok({ creditId: null, voided: false });
+  }
+
+  const uniquenessKey = `free-user-credit-${workspace.sId}-${userId}`;
+  const now = new Date();
+  const nowIso = now.toISOString();
+  // Metronome requires end dates on hour boundaries. Ceil to the next hour
+  // rather than floor: flooring would push the end into the past and
+  // retroactively invalidate already-consumed usage from earlier in the
+  // current hour. Ceiling keeps prior consumption intact at the cost of a
+  // sub-hour window where the credit remains usable.
+  const accessEndingBefore = ceilToHourISO(now);
+
+  const existing = await findMetronomeCreditByUniquenessKey({
+    metronomeCustomerId,
+    uniquenessKey,
+    coveringDate: nowIso,
+  });
+  if (existing.isErr()) {
+    return new Err(existing.error);
+  }
+  if (!existing.value) {
+    return new Ok({ creditId: null, voided: false });
+  }
+
+  const updateResult = await updateMetronomeCreditEndDate({
+    metronomeCustomerId,
+    creditId: existing.value.id,
+    accessEndingBefore,
+  });
+  if (updateResult.isErr()) {
+    return new Err(updateResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      userId,
+      metronomeCreditId: existing.value.id,
+      accessEndingBefore,
+    },
+    "[Metronome] Free user credit voided"
+  );
+  return new Ok({ creditId: existing.value.id, voided: true });
 }


### PR DESCRIPTION
## Description

Introduces a per-user "free AWU allowance" for users on the `free` seat type, plus the surrounding plumbing changes needed to make it work in Metronome.

### Free user credit mechanism
- New helper `ensureFreeUserAwuCredit` (`lib/metronome/seats.ts`) creates a Metronome customer-level credit:
  - 300 AWU, 5-year access window (Metronome caps end dates, so we don't go further).
  - Stable uniqueness key `free-user-credit-<workspaceId>-<userId>` — pre-create existence check + server-side idempotency.
  - Drawn down only by the matching user's usage via specifier `{ presentation_group_values: { user_id }, product_tags: ["usage"] }`.
- Granted automatically inside `syncSeatCount` for every active member whose seat type is `free`. Failures are logged but don't fail the sync (idempotent on retry).
- New helper `voidFreeUserAwuCredit` clamps the credit's access end date to the next hour boundary. Called from `updateMembershipSeatAndTrack` when a user transitions out of `free` — the unused balance isn't transferable. Ceiling (not flooring) the hour preserves any usage consumed in the current hour.

### Supporting changes
- `createMetronomeCredit` now accepts `specifiers` (mutually exclusive with `applicableProductTags` / `applicableProductIds` per Metronome SDK constraint).
- `getMetronomeSubscriptionAssignedSeatIds`: the endpoint actually returns a top-level array of segments and the field is `assigned_seat_ids` (not `seat_ids` under `data`). Fixing this also unblocks Pro→Max seat draining that was previously silently no-op.
- `syncSeatCount` pre-seeds `sIdsBySeatType` for every seat type with a contract subscription, so seat types with zero current memberships still drive the reconciliation loop (e.g. last `pro` user moves to `max` → Pro subscription is now correctly drained to 0).
- `syncSeatCount` SEAT_BASED no-op branch uses `continue` instead of `return new Ok(undefined)`, so subsequent subscriptions on the same contract are still processed.

## Tests

- Type-check clean (`npx tsgo --noEmit`).
- Manual: flip a user to/from `free` and observe the per-user credit being created / voided in the Metronome customer ledger (with the access end on an hour boundary).
- Manual: flip a user across seat types (`pro` ↔ `max`) and confirm both the source and destination seat-based subscriptions are reconciled.

## Risk

- The `cost_awu` scaling change is significant — verify the corresponding Metronome rate cards and per-seat credit allocations match the new unit. If rates remain sized for the prior unit, the per-user 300 AWU allowance and the per-seat credit math will both be off.
- Voiding the free credit on transition out of `free` is irreversible from this code path.
- Sub-hour leak: up to ~59 minutes of credit availability after a seat-type change, by design (preserves prior consumption).

## Deploy Plan

1. Confirm the Metronome rate card / package configuration is aligned with the new `cost_awu` scaling.
2. Deploy.
3. Watch for `[Metronome] Free user credit created` / `[Metronome] Free user credit voided` log lines on free-seat churn.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25569">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->