### PR TITLE
[Notion GC] Avoid heartbeat timeouts on transient retries

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -357,6 +357,7 @@ async function retryWithBackoff<T>(
     logger,
     onProgress,
     operationName,
+    retriableErrorCodes = NOTION_RETRIABLE_ERRORS,
   }: {
     maxTries?: number;
     backoffFactor?: number;
@@ -364,6 +365,7 @@ async function retryWithBackoff<T>(
     logger: Logger;
     onProgress?: NotionRetryProgressCallback;
     operationName: string;
+    retriableErrorCodes?: string[];
   }
 ): Promise<T> {
   let tries = 0;
@@ -380,7 +382,7 @@ async function retryWithBackoff<T>(
     } catch (e) {
       if (
         APIResponseError.isAPIResponseError(e) &&
-        NOTION_RETRIABLE_ERRORS.includes(e.code)
+        retriableErrorCodes.includes(e.code)
       ) {
         let waitTime = baseWaitTime * backoffFactor ** tries;
         let usingHeader = false;
@@ -436,6 +438,7 @@ export async function isAccessibleAndUnarchived(
   retryOptions?: {
     maxTries?: number;
     onProgress?: NotionRetryProgressCallback;
+    retriableErrorCodes?: string[];
   }
 ): Promise<boolean> {
   const notionClient = new Client({
@@ -457,6 +460,7 @@ export async function isAccessibleAndUnarchived(
           maxTries: retryOptions?.maxTries,
           onProgress: retryOptions?.onProgress,
           operationName: "retrieve_page",
+          retriableErrorCodes: retryOptions?.retriableErrorCodes,
         }
       );
       if (!isFullPage(page)) {
@@ -478,6 +482,7 @@ export async function isAccessibleAndUnarchived(
           maxTries: retryOptions?.maxTries,
           onProgress: retryOptions?.onProgress,
           operationName: "retrieve_database",
+          retriableErrorCodes: retryOptions?.retriableErrorCodes,
         }
       );
       if (!isFullDatabase(db)) {

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -346,6 +346,8 @@ const NOTION_NOT_FOUND_ERROR_CODES = ["object_not_found"];
 
 const NOTION_RETRIABLE_ERRORS = ["rate_limited", "internal_server_error"];
 
+type NotionRetryProgressCallback = () => Promise<void>;
+
 async function retryWithBackoff<T>(
   operation: () => Promise<T>,
   {
@@ -353,12 +355,14 @@ async function retryWithBackoff<T>(
     backoffFactor = 2,
     baseWaitTime = 10000,
     logger,
+    onProgress,
     operationName,
   }: {
     maxTries?: number;
     backoffFactor?: number;
     baseWaitTime?: number;
     logger: Logger;
+    onProgress?: NotionRetryProgressCallback;
     operationName: string;
   }
 ): Promise<T> {
@@ -397,14 +401,21 @@ async function retryWithBackoff<T>(
           tryLogger.error({ error: e }, "Error parsing Retry-After header.");
         }
 
+        tries += 1;
+        if (tries >= maxTries) {
+          throw e;
+        }
+
         tryLogger.info(
           { waitTime, usingHeader },
           "Got potentially transient error. Trying again."
         );
+        if (onProgress) {
+          await onProgress();
+        }
         await new Promise((resolve) => setTimeout(resolve, waitTime));
-        tries += 1;
-        if (tries >= maxTries) {
-          throw e;
+        if (onProgress) {
+          await onProgress();
         }
         continue;
       }
@@ -421,7 +432,11 @@ export async function isAccessibleAndUnarchived(
   notionAccessToken: string,
   objectId: string,
   objectType: "page" | "database",
-  localLogger?: Logger
+  localLogger?: Logger,
+  retryOptions?: {
+    maxTries?: number;
+    onProgress?: NotionRetryProgressCallback;
+  }
 ): Promise<boolean> {
   const notionClient = new Client({
     auth: notionAccessToken,
@@ -439,6 +454,8 @@ export async function isAccessibleAndUnarchived(
           ),
         {
           logger: loggerToUse,
+          maxTries: retryOptions?.maxTries,
+          onProgress: retryOptions?.onProgress,
           operationName: "retrieve_page",
         }
       );
@@ -458,6 +475,8 @@ export async function isAccessibleAndUnarchived(
           ),
         {
           logger: loggerToUse,
+          maxTries: retryOptions?.maxTries,
+          onProgress: retryOptions?.onProgress,
           operationName: "retrieve_database",
         }
       );

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -107,6 +107,7 @@ const SKIP_DELETION_CONNECTOR_ID_HASHES = new Set<string>([
   "pDddXWMzWYw4oN/acYfLiOwxB3tlp51IH6MuMYD3YXQ=",
 ]);
 const MIN_ATTEMPTS_BEFORE_SKIPPING_UNHEALTHY_NOTION_RESOURCE = 15;
+const RETRIABLE_NOTION_ERROR_CODES_AFTER_SKIP_THRESHOLD = ["rate_limited"];
 
 const wrapWithErrorCheck = async <T>(
   callback: () => Promise<T>,
@@ -926,7 +927,11 @@ export async function garbageCollectBatch({
       Context.current().info.attempt >=
       MIN_ATTEMPTS_BEFORE_SKIPPING_UNHEALTHY_NOTION_RESOURCE;
     const accessibilityCheckRetryOptions = shouldSkipUnhealthyNotionResource
-      ? { maxTries: 1, onProgress: heartbeat }
+      ? {
+          onProgress: heartbeat,
+          retriableErrorCodes:
+            RETRIABLE_NOTION_ERROR_CODES_AFTER_SKIP_THRESHOLD,
+        }
       : { onProgress: heartbeat };
 
     let resourceIsAccessible: boolean;

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -106,6 +106,7 @@ const logger = mainLogger.child({ provider: "notion" });
 const SKIP_DELETION_CONNECTOR_ID_HASHES = new Set<string>([
   "pDddXWMzWYw4oN/acYfLiOwxB3tlp51IH6MuMYD3YXQ=",
 ]);
+const MIN_ATTEMPTS_BEFORE_SKIPPING_UNHEALTHY_NOTION_RESOURCE = 15;
 
 const wrapWithErrorCheck = async <T>(
   callback: () => Promise<T>,
@@ -921,6 +922,12 @@ export async function garbageCollectBatch({
       stillAccessiblePagesCount,
       stillAccessibleDatabasesCount,
     });
+    const shouldSkipUnhealthyNotionResource =
+      Context.current().info.attempt >=
+      MIN_ATTEMPTS_BEFORE_SKIPPING_UNHEALTHY_NOTION_RESOURCE;
+    const accessibilityCheckRetryOptions = shouldSkipUnhealthyNotionResource
+      ? { maxTries: 1, onProgress: heartbeat }
+      : { onProgress: heartbeat };
 
     let resourceIsAccessible: boolean;
     try {
@@ -928,7 +935,8 @@ export async function garbageCollectBatch({
         notionAccessToken,
         x.id,
         x.type,
-        iterationLogger
+        iterationLogger,
+        accessibilityCheckRetryOptions
       );
     } catch (e) {
       // Sometimes a request will consistently fail with a 500 We don't want to delete the page in
@@ -943,7 +951,7 @@ export async function garbageCollectBatch({
           (typeof potentialNotionError.status === "number" &&
             potentialNotionError.status >= 500 &&
             potentialNotionError.status < 600)) &&
-        Context.current().info.attempt >= 15
+        shouldSkipUnhealthyNotionResource
       ) {
         iterationLogger.error(
           {


### PR DESCRIPTION
## Description
Notion GC batches can spend several minutes retrying transient Notion retrieve failures without heartbeating, causing heartbeat timeouts and retries of the whole batch.

This adds an optional progress callback to the Notion retry helper and heartbeats GC accessibility checks around retry backoff. It also reuses the existing skip-unhealthy-resource threshold to avoid full retry backoff after repeated activity attempts.

## Risks
Blast radius: Notion connector garbage collection accessibility checks and opt-in Notion retry progress callbacks.
Risk: low

## Deploy Plan
- pmrr
- deploy connectors-worker

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25571">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->