### PR TITLE
fix(inlineActivity): restore message content in SWR cache on agent_message_done

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -796,31 +796,48 @@ export const ConversationViewer = ({
             void mutateContextUsage();
 
             // Update the messages SWR cache in place so a future remount
-            // of this conversation (e.g. navigating away and back) sees the
-            // message as terminal instead of the stale "created" snapshot
-            // (which would otherwise re-open an SSE replay). We only flip
-            // status here to avoid a network refetch on every termination,
-            // which on prod was slow enough to delay retry feedback. The
-            // richer final state (activitySteps, content, gracefully_stopped
-            // vs cancelled) is restored by the next real fetch when needed.
-            void mutateMessages(
-              (pages) =>
-                pages?.map((page) => ({
-                  ...page,
-                  messages: page.messages.map((m) =>
-                    isLightAgentMessageType(m) && m.sId === event.messageId
-                      ? {
-                          ...m,
-                          status:
-                            event.status === "error"
-                              ? ("failed" as const)
-                              : ("succeeded" as const),
-                        }
-                      : m
-                  ),
-                })),
-              { revalidate: false }
-            );
+            // (e.g. navigating away and back) sees the full terminal state.
+            // The message-level SSE fires agent_message_success before this
+            // conversation-level event, so Virtuoso already holds the final
+            // content, completionDurationMs, and activitySteps. We copy them
+            // into the SWR snapshot to avoid a blank message body on remount.
+            // If Virtuoso hasn't committed the update yet (rare race between
+            // two independent SSE streams), we fall back to a real revalidation.
+            {
+              const vMsg = virtuosoMessageListRef.current?.data.find(
+                (m) => m.sId === event.messageId
+              );
+              const msg =
+                vMsg && isAgentMessageWithStreaming(vMsg) ? vMsg : null;
+
+              void mutateMessages(
+                (pages) =>
+                  pages?.map((page) => ({
+                    ...page,
+                    messages: page.messages.map((m) =>
+                      isLightAgentMessageType(m) && m.sId === event.messageId
+                        ? {
+                            ...m,
+                            status:
+                              event.status === "error"
+                                ? ("failed" as const)
+                                : ("succeeded" as const),
+                            ...(msg !== null
+                              ? {
+                                  content: msg.content,
+                                  completionDurationMs:
+                                    msg.completionDurationMs,
+                                  activitySteps:
+                                    msg.streaming.inlineActivitySteps,
+                                }
+                              : {}),
+                          }
+                        : m
+                    ),
+                  })),
+                { revalidate: msg === null }
+              );
+            }
 
             // Update the conversation hasError state in the local cache without making a network request.
             void mutateConversations(


### PR DESCRIPTION
## Description

### Bug

When an agent message completed, the `agent_message_done` handler in `ConversationViewer` only updated `status` in the SWR messages cache, leaving `content`, `completionDurationMs`, and `activitySteps` at their original null values from the initial `"created"` snapshot. The intent was that the richer state would be restored by  the next real fetch, but that fetch never happened: the mutation used `{ revalidate: false }`, and SWR considered the data fresh enough to skip revalidation when the user navigated back to the conversation within the cache window.

On remount, `makeInitialMessageStreamState` was called with the stale `content: null`. The rendering condition `agentMessage.content !== null` in `AgentMessage.tsx` then evaluated to false, silently hiding the message body while the header ("Completed, without tools.") still rendered. A full page reload fixed it because the SWR cache had expired and returned fresh data from the server.

### Fix

At the time `agent_message_done` fires, `virtuosoMessageListRef.current` already holds the final message state because `agent_message_success` on the message-level SSE fires before this conversation-level event. We now copy `content`, `completionDurationMs`, and `activitySteps` from the Virtuoso snapshot into the SWR cache update alongside the status flip, so a future remount always sees the complete message body.

If the Virtuoso message is not found (a rare race between two independent SSE streams), we fall back to `{ revalidate: true }` so the next mount fetches fresh data from the  server.


## Tests

Locally. 

## Risk

Can be rolled back; 

## Deploy Plan

Deploy front. 


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25573">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->