### PR TITLE
fix(conversation_search): remove ACL superset check on requested_space_ids for private conversations

### DIFF
--- a/front/lib/conversation_search/search.ts
+++ b/front/lib/conversation_search/search.ts
@@ -12,9 +12,9 @@ import type { Result } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
 
 interface ListPrivateConversationsFromESParams {
-  accessibleSpaceIds: string[];
   lastValue?: string;
   limit: number;
+  nonMemberProjectSpaceIds: string[];
   orderDirection: "asc" | "desc";
   userId: string;
   workspaceId: string;
@@ -54,54 +54,13 @@ function parseSearchAfterCursor(
 export async function listPrivateConversationsFromES({
   workspaceId,
   userId,
-  accessibleSpaceIds,
   limit,
   lastValue,
+  nonMemberProjectSpaceIds,
   orderDirection,
 }: ListPrivateConversationsFromESParams): Promise<
   Result<ListPrivateConversationsFromESResult, ElasticsearchError>
 > {
-  // Filter: all values in requested_space_ids must be in the user's accessible spaces.
-  // terms_set with minimum_should_match_script = doc field length implements the
-  // "superset check": every space the conversation references must be accessible.
-  // When accessibleSpaceIds is empty, conversations with non-empty requested_space_ids
-  // are correctly excluded (0 matches < required length).
-  // When accessibleSpaceIds is non-empty we need two cases:
-  //   1. Conversations with no space requirements (empty array → ES treats field as missing).
-  //   2. Conversations where every required space is in the user's accessible set.
-  // terms_set alone misses case 1 because ES skips documents where the field has no values,
-  // even when the Painless script would return minimum=0.
-  const requestedSpaceIdsFilter: estypes.QueryDslQueryContainer =
-    accessibleSpaceIds.length > 0
-      ? {
-          bool: {
-            should: [
-              // Case 1: no space requirements, always accessible.
-              {
-                bool: {
-                  must_not: [{ exists: { field: "requested_space_ids" } }],
-                },
-              },
-              // Case 2: all required spaces are in the user's accessible set.
-              {
-                terms_set: {
-                  requested_space_ids: {
-                    terms: accessibleSpaceIds,
-                    minimum_should_match_script: {
-                      source: "doc['requested_space_ids'].size()",
-                    },
-                  },
-                },
-              },
-            ],
-            minimum_should_match: 1,
-          },
-        }
-      : {
-          // No accessible spaces: only pass conversations with no space requirements.
-          bool: { must_not: [{ exists: { field: "requested_space_ids" } }] },
-        };
-
   const sortOrder = orderDirection === "desc" ? "desc" : "asc";
   const fetchLimit = limit + 1;
   const searchAfter = parseSearchAfterCursor(lastValue, orderDirection);
@@ -128,7 +87,24 @@ export async function listPrivateConversationsFromES({
                 },
               },
             },
-            requestedSpaceIdsFilter,
+            // Mirror the DB path: hide conversations that reference a project space
+            // the user is not a member of. Only project spaces are filtered; regular,
+            // global, and system spaces do not trigger exclusion.
+            ...(nonMemberProjectSpaceIds.length > 0
+              ? [
+                  {
+                    bool: {
+                      must_not: [
+                        {
+                          terms: {
+                            requested_space_ids: nonMemberProjectSpaceIds,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ]
+              : []),
           ],
         },
       },

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -27,6 +27,7 @@ import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/c
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -7289,5 +7290,191 @@ describe("filterVisibleConversations", () => {
     );
 
     expect(visible).toHaveLength(0);
+  });
+});
+
+describe("listPrivateConversationsForUserPaginated", () => {
+  it("returns only conversations the user participates in", async () => {
+    const { authenticator: adminAuth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const regularUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, regularUser, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      regularUser.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      name: "Agent",
+      description: "Agent",
+      scope: "visible",
+    });
+
+    // Conversation the user is NOT a participant in.
+    await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    // Conversation the user IS a participant in.
+    const ownConversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation: ownConversation,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+    });
+
+    const { conversations } =
+      await ConversationResource.listPrivateConversationsForUserPaginated(
+        userAuth,
+        { limit: 20 }
+      );
+
+    const ids = conversations.map((c) => c.sId);
+    expect(ids).toContain(ownConversation.sId);
+    expect(ids).toHaveLength(1);
+  });
+
+  it("hides conversations that reference an open project space the user is not a member of", async () => {
+    // This tests the explicit project-space filter in fetchPrivateConversationsPaginated.
+    // An "open" project space (has the global group) is visible to all workspace members
+    // via baseFetchWithAuthorization, so that general ACL check alone would not hide the
+    // conversation. The project-space filter (isProject() && !isMember()) is what hides it.
+    const {
+      authenticator: adminAuth,
+      user: adminUser,
+      workspace,
+    } = await createResourceTest({ role: "admin" });
+    const regularUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, regularUser, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      regularUser.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      name: "Agent",
+      description: "Agent",
+      scope: "visible",
+    });
+
+    const projectSpace = await SpaceFactory.project(workspace, adminUser.id);
+    // Add the global group to the project space to make it "open" (visible to all
+    // workspace members), so the conversation passes baseFetchWithAuthorization but
+    // is still caught by the explicit project-space member check.
+    const globalGroupResult =
+      await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
+    assert(globalGroupResult.isOk(), "Global group not found");
+    await GroupSpaceFactory.associate(projectSpace, globalGroupResult.value);
+
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: agent.sId,
+      requestedSpaceIds: [projectSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+    });
+
+    const { conversations } =
+      await ConversationResource.listPrivateConversationsForUserPaginated(
+        userAuth,
+        { limit: 20 }
+      );
+
+    expect(conversations.map((c) => c.sId)).not.toContain(conversation.sId);
+  });
+
+  it("shows conversations that reference an open project space the user IS a member of", async () => {
+    const {
+      authenticator: adminAuth,
+      user: adminUser,
+      workspace,
+    } = await createResourceTest({ role: "admin" });
+    const regularUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, regularUser, { role: "user" });
+    let userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      regularUser.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      name: "Agent",
+      description: "Agent",
+      scope: "visible",
+    });
+
+    const projectSpace = await SpaceFactory.project(workspace, adminUser.id);
+    const globalGroupResult =
+      await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
+    assert(globalGroupResult.isOk(), "Global group not found");
+    await GroupSpaceFactory.associate(projectSpace, globalGroupResult.value);
+
+    const addResult = await projectSpace.addMembers(adminAuth, {
+      userIds: [regularUser.sId],
+    });
+    assert(addResult.isOk(), "Failed to add user to project space");
+    userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      regularUser.sId,
+      workspace.sId
+    );
+
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: agent.sId,
+      requestedSpaceIds: [projectSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+    });
+
+    const { conversations } =
+      await ConversationResource.listPrivateConversationsForUserPaginated(
+        userAuth,
+        { limit: 20 }
+      );
+
+    expect(conversations.map((c) => c.sId)).toContain(conversation.sId);
+  });
+
+  it("shows conversations that reference an open project space when user has no requestedSpaceIds", async () => {
+    // Conversations with empty requestedSpaceIds are always shown regardless of
+    // which spaces exist; this ensures the filter is not over-eager.
+    const { authenticator: adminAuth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const regularUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, regularUser, { role: "user" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      regularUser.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      name: "Agent",
+      description: "Agent",
+      scope: "visible",
+    });
+
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+    });
+
+    const { conversations } =
+      await ConversationResource.listPrivateConversationsForUserPaginated(
+        userAuth,
+        { limit: 20 }
+      );
+
+    expect(conversations.map((c) => c.sId)).toContain(conversation.sId);
   });
 });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1631,6 +1631,30 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       resultConversations = conversations.slice(0, pagination.limit);
     }
 
+    // Exclude conversations that reference a project space where the user is not an
+    // explicit member. Project-space conversations belong in the project context, not
+    // in the private sidebar. This mirrors the ES path's must_not + isMember check.
+    const uniqueSpaceModelIds = uniq(
+      resultConversations.flatMap((c) => c.requestedSpaceIds)
+    );
+    if (uniqueSpaceModelIds.length > 0) {
+      const referencedSpaces = await SpaceResource.fetchByModelIds(
+        auth,
+        uniqueSpaceModelIds
+      );
+      const nonMemberProjectSpaceIds = new Set(
+        referencedSpaces
+          .filter((s) => s.isProject() && !s.isMember(auth))
+          .map((s) => s.id)
+      );
+      if (nonMemberProjectSpaceIds.size > 0) {
+        resultConversations = resultConversations.filter(
+          (c) =>
+            !c.requestedSpaceIds.some((id) => nonMemberProjectSpaceIds.has(id))
+        );
+      }
+    }
+
     resultConversations.forEach((c) => {
       const participation = participationMap.get(c.id);
       if (participation) {
@@ -1696,14 +1720,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const workspace = auth.getNonNullableWorkspace();
     const orderDirection = pagination.orderDirection ?? "desc";
 
-    const accessibleSpaces =
-      await SpaceResource.listWorkspaceSpacesAsMember(auth);
-    const accessibleSpaceIds = accessibleSpaces.map((s) => s.sId);
+    const projectSpaces = await SpaceResource.listProjectSpaces(auth);
+    const nonMemberProjectSpaceIds = projectSpaces
+      .filter((s) => !s.isMember(auth))
+      .map((s) => s.sId);
 
     const esResult = await listPrivateConversationsFromES({
-      accessibleSpaceIds,
       lastValue: pagination.lastValue,
       limit: pagination.limit,
+      nonMemberProjectSpaceIds,
       orderDirection,
       userId: user.sId,
       workspaceId: workspace.sId,


### PR DESCRIPTION
## Description

Fixes the ES path of `listPrivateConversationsFromES` to correctly mirror the DB path's project-space ACL logic.

**Background:** When `conversation_search_read` is enabled, the sidebar listing goes through Elasticsearch. The original ES path used a broad `terms_set` superset check — all of a conversation's `requested_space_ids` had to be in the user's `accessibleSpaceIds` (every space the user is a member of). The DB path (`fetchPrivateConversationsPaginated`) applies a narrower check: only exclude conversations where a `requestedSpaceId` is a **project** space the user is not a member of (`isProject() && !isMember(auth)`).

**The discrepancy:** The old ES check was too broad — it would exclude conversations that referenced a `regular` or `global` space the user wasn't an explicit member of, even though the DB path wouldn't. This caused conversations to appear in the DB fallback path (search) but not in the ES sidebar.

**Fix:** Replace the `terms_set` superset filter with a targeted `must_not: terms` filter using only the project space sIds the user is not a member of — matching the DB path's intent exactly.

## Tests

The shadow validation task (which compares ES sidebar results against the DB path for a sample of users) should now show no divergence for the affected cases.

Manual repro: an agent configured with a project space the user is not a member of should behave consistently between the ES sidebar path and the DB search path.

see => https://github.com/orgs/dust-tt/projects/2/views/1?pane=issue&itemId=186836144&issue=dust-tt%7Ctasks%7C8071

## Risk

