### PR TITLE
[front] checkout: APIs and endpoints for checkout flow

### DIFF
--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -53,6 +53,7 @@ export type RedisUsageTagsType =
   | "mcp_client_side_request"
   | "mcp_client_side_results"
   | "mentions_count"
+  | "stripe_checkout_status"
   | "metronome_checkout_error"
   | "metronome_credit_cache"
   | "metronome_limit"

--- a/front/lib/metronome/credits.ts
+++ b/front/lib/metronome/credits.ts
@@ -1,0 +1,68 @@
+import { metronomeAmount } from "@app/lib/metronome/amounts";
+import {
+  createMetronomeCredit,
+  floorToHourISO,
+} from "@app/lib/metronome/client";
+import {
+  CURRENCY_TO_CREDIT_TYPE_ID,
+  getProductSeatSubscriptionCreditsId,
+} from "@app/lib/metronome/constants";
+import logger from "@app/logger/logger";
+import type { SupportedCurrency } from "@app/types/currency";
+import type { Result } from "@app/types/shared/result";
+import { Err } from "@app/types/shared/result";
+import { addDays } from "date-fns";
+
+/**
+ * Load a first-period credit on a Metronome customer to zero out the first
+ * Metronome-generated invoice. The credit is scoped to the specific contract
+ * and expires after a few days (Metronome generates the first invoice
+ * immediately on contract creation).
+ */
+export async function loadFirstPeriodCredit({
+  metronomeCustomerId,
+  amountCents,
+  currency,
+  uniquenessKey,
+  now,
+}: {
+  metronomeCustomerId: string;
+  amountCents: number;
+  currency: SupportedCurrency;
+  uniquenessKey: string;
+  now: Date;
+}): Promise<Result<{ id: string } | null, Error>> {
+  const creditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[currency];
+  if (!creditTypeId) {
+    return new Err(
+      new Error(`Unsupported currency for first period credit: ${currency}`)
+    );
+  }
+
+  const amount = metronomeAmount(amountCents, currency);
+  const startingAt = floorToHourISO(now);
+  // 7-day window gives Metronome time to generate the first invoice while
+  // ensuring the credit does not bleed into subsequent billing periods.
+  const endingBefore = floorToHourISO(addDays(now, 7));
+
+  const result = await createMetronomeCredit({
+    metronomeCustomerId,
+    productId: getProductSeatSubscriptionCreditsId(),
+    creditTypeId,
+    amount,
+    startingAt,
+    endingBefore,
+    name: "First period subscription credit",
+    idempotencyKey: `first-period-${uniquenessKey}`,
+    priority: 0,
+  });
+
+  if (result.isErr()) {
+    logger.error(
+      { error: result.error, metronomeCustomerId },
+      "[Metronome] Failed to load first period credit"
+    );
+  }
+
+  return result;
+}

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -380,12 +380,13 @@ export async function calculateTax({
   }
 }
 
-export async function makeFirstPeriodInvoiceForCustomer({
+async function makeFirstPeriodInvoiceForCustomer({
   stripeCustomerId,
   paymentMethodId,
   subtotalCents,
   seatCount,
   setupSessionId,
+  workspaceId,
   currency,
 }: {
   stripeCustomerId: string;
@@ -393,6 +394,7 @@ export async function makeFirstPeriodInvoiceForCustomer({
   subtotalCents: number;
   seatCount: number;
   setupSessionId: string;
+  workspaceId: string;
   currency: SupportedCurrency;
 }): Promise<Result<Stripe.Invoice, { error_message: string }>> {
   const stripe = getStripeClient();
@@ -408,6 +410,7 @@ export async function makeFirstPeriodInvoiceForCustomer({
         metadata: {
           metronome_first_period: "true",
           setup_session_id: setupSessionId,
+          workspace_id: workspaceId,
         },
       },
       { idempotencyKey: `first-period-invoice-${setupSessionId}` }
@@ -435,6 +438,93 @@ export async function makeFirstPeriodInvoiceForCustomer({
       error_message: `Failed to create invoice: ${normalizeError(error).message}`,
     });
   }
+}
+
+export async function chargeFirstPeriodInvoice({
+  stripeCustomerId,
+  paymentMethodId,
+  subtotalCents,
+  seatCount,
+  setupSessionId,
+  workspaceId,
+  currency,
+}: {
+  stripeCustomerId: string;
+  paymentMethodId: string;
+  subtotalCents: number;
+  seatCount: number;
+  setupSessionId: string;
+  workspaceId: string;
+  currency: SupportedCurrency;
+}): Promise<Result<void, { error_message: string }>> {
+  const invoiceResult = await makeFirstPeriodInvoiceForCustomer({
+    stripeCustomerId,
+    paymentMethodId,
+    subtotalCents,
+    seatCount,
+    setupSessionId,
+    workspaceId,
+    currency,
+  });
+  if (invoiceResult.isErr()) {
+    logger.error(
+      {
+        workspaceId,
+        error: normalizeError(invoiceResult.error).message,
+      },
+      "[Checkout] Failed to create first-period invoice"
+    );
+    return invoiceResult;
+  }
+
+  const finalizeResult = await finalizeInvoice(invoiceResult.value);
+  if (finalizeResult.isErr()) {
+    logger.error(
+      {
+        workspaceId,
+        error: normalizeError(finalizeResult.error).message,
+        invoiceId: invoiceResult.value.id,
+      },
+      "[Checkout] Failed to finalize first-period invoice"
+    );
+    return finalizeResult;
+  }
+
+  const stripe = getStripeClient();
+  try {
+    const payResult = await stripe.invoices.pay(finalizeResult.value.id, {
+      expand: ["payment_intent"],
+    });
+
+    const paymentIntent = payResult.payment_intent;
+    if (payResult.status !== "paid") {
+      logger.error(
+        {
+          workspaceId,
+          invoiceId: finalizeResult.value.id,
+          invoiceStatus: payResult.status,
+          paymentIntentStatus:
+            paymentIntent && !isString(paymentIntent)
+              ? paymentIntent.status
+              : paymentIntent,
+        },
+        "[Checkout] First-period invoice payment failed"
+      );
+      return new Err({ error_message: "Invoice payment failed" });
+    }
+  } catch (payError) {
+    logger.error(
+      {
+        workspaceId,
+        error: normalizeError(payError).message,
+        invoiceId: finalizeResult.value.id,
+      },
+      "[Checkout] First-period invoice payment failed"
+    );
+    return new Err({ error_message: normalizeError(payError).message });
+  }
+
+  return new Ok(undefined);
 }
 
 /**

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -282,6 +282,8 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
   metronomePackageAlias,
   owner,
   planCode,
+  seatCount,
+  pricePerSeatCents,
   user,
 }: {
   allowedPaymentMethods?: SupportedPaymentMethod[];
@@ -289,6 +291,8 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
   metronomePackageAlias: string;
   owner: WorkspaceType;
   planCode: string;
+  seatCount?: number;
+  pricePerSeatCents?: number;
   user: UserType;
 }): Promise<{ clientSecret: string; sessionId: string }> => {
   const stripe = getStripeClient();
@@ -300,6 +304,12 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
   };
   if (couponCode) {
     metadata.couponCode = couponCode;
+  }
+  if (seatCount !== undefined) {
+    metadata.seatCount = String(seatCount);
+  }
+  if (pricePerSeatCents !== undefined) {
+    metadata.pricePerSeatCents = String(pricePerSeatCents);
   }
 
   const session = await stripe.checkout.sessions.create({
@@ -332,6 +342,100 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
 
   return { clientSecret: session.client_secret, sessionId: session.id };
 };
+
+export async function calculateTax({
+  stripeCustomerId,
+  amountCents,
+  currency,
+}: {
+  stripeCustomerId: string;
+  amountCents: number;
+  currency: SupportedCurrency;
+}): Promise<
+  Result<{ taxCents: number; totalCents: number }, { error_message: string }>
+> {
+  const stripe = getStripeClient();
+  try {
+    const calculation = await stripe.tax.calculations.create({
+      currency,
+      customer: stripeCustomerId,
+      line_items: [{ amount: amountCents, reference: "subscription" }],
+    });
+    return new Ok({
+      taxCents: calculation.tax_amount_exclusive,
+      totalCents: calculation.amount_total,
+    });
+  } catch (error) {
+    logger.error(
+      {
+        stripeCustomerId,
+        stripeError: true,
+        error: normalizeError(error).message,
+      },
+      "[Stripe] Failed to calculate tax"
+    );
+    return new Err({
+      error_message: `Failed to calculate tax: ${normalizeError(error).message}`,
+    });
+  }
+}
+
+export async function makeFirstPeriodInvoiceForCustomer({
+  stripeCustomerId,
+  paymentMethodId,
+  subtotalCents,
+  seatCount,
+  setupSessionId,
+  currency,
+}: {
+  stripeCustomerId: string;
+  paymentMethodId: string;
+  subtotalCents: number;
+  seatCount: number;
+  setupSessionId: string;
+  currency: SupportedCurrency;
+}): Promise<Result<Stripe.Invoice, { error_message: string }>> {
+  const stripe = getStripeClient();
+  try {
+    const invoice = await stripe.invoices.create(
+      {
+        customer: stripeCustomerId,
+        collection_method: "charge_automatically",
+        default_payment_method: paymentMethodId,
+        currency,
+        automatic_tax: { enabled: true },
+        auto_advance: false,
+        metadata: {
+          metronome_first_period: "true",
+          setup_session_id: setupSessionId,
+        },
+      },
+      { idempotencyKey: `first-period-invoice-${setupSessionId}` }
+    );
+
+    await stripe.invoiceItems.create({
+      customer: stripeCustomerId,
+      amount: subtotalCents,
+      currency,
+      description: `Subscription first period — ${seatCount} seat${seatCount > 1 ? "s" : ""}`,
+      invoice: invoice.id,
+    });
+
+    return new Ok(invoice);
+  } catch (error) {
+    logger.error(
+      {
+        stripeCustomerId,
+        stripeError: true,
+        error: normalizeError(error).message,
+      },
+      "[Stripe] Failed to create first-period invoice"
+    );
+    return new Err({
+      error_message: `Failed to create invoice: ${normalizeError(error).message}`,
+    });
+  }
+}
 
 /**
  * Calls the Stripe API to create a customer portal session for a given workspace/plan.
@@ -739,6 +843,13 @@ export function getDefaultPaymentMethodId(
  */
 export function isCreditPurchaseInvoice(invoice: Stripe.Invoice): boolean {
   return invoice.metadata?.credit_purchase === "true";
+}
+
+/**
+ * Checks if a Stripe invoice is for a credit purchase.
+ */
+export function isFirstPeriodInvoice(invoice: Stripe.Invoice): boolean {
+  return invoice.metadata?.metronome_first_period === "true";
 }
 
 /**

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -3,6 +3,11 @@ import { sendProactiveTrialCancelledEmail } from "@app/lib/api/email";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import {
+  BUSINESS_PLAN_COST_MONTHLY,
+  PRO_PLAN_COST_MONTHLY,
+  PRO_PLAN_COST_YEARLY,
+} from "@app/lib/client/subscription";
 import { DustError } from "@app/lib/error";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
@@ -1245,6 +1250,20 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     );
 
     if (useMetronomeBilling) {
+      const seatCount = await MembershipResource.countActiveSeatsInWorkspace(
+        owner.sId
+      );
+
+      // Per-period per-seat price in cents. Business has no yearly variant.
+      const pricePerMonth = isBusiness
+        ? BUSINESS_PLAN_COST_MONTHLY
+        : billingPeriod === "yearly"
+          ? PRO_PLAN_COST_YEARLY
+          : PRO_PLAN_COST_MONTHLY;
+      const pricePerMonthCents = pricePerMonth * 100;
+      const monthsInPeriod = !isBusiness && billingPeriod === "yearly" ? 12 : 1;
+      const pricePerSeatCents = pricePerMonthCents * monthsInPeriod;
+
       const { clientSecret, sessionId } =
         await createEmbeddedMetronomeSetupCheckoutSession({
           owner,
@@ -1253,6 +1272,8 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
           metronomePackageAlias,
           allowedPaymentMethods,
           couponCode,
+          seatCount,
+          pricePerSeatCents,
         });
       return {
         mode: "embedded",

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -835,20 +835,22 @@ export function useCheckoutStatus({
 }: {
   workspaceId: string;
   sessionId: string;
-  planCode: string;
+  planCode?: string;
   disabled?: boolean;
   pollIntervalMs?: number;
 }) {
   const { fetcher } = useFetcher();
   const checkoutFetcher: Fetcher<GetCheckoutStatusResponseBody> = fetcher;
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    disabled
-      ? null
-      : `/api/w/${workspaceId}/subscriptions/checkout-status?session_id=${sessionId}&plan_code=${planCode}`,
-    checkoutFetcher,
-    { refreshInterval: pollIntervalMs }
-  );
+  const url = disabled
+    ? null
+    : planCode
+      ? `/api/w/${workspaceId}/subscriptions/checkout-status?session_id=${sessionId}&plan_code=${planCode}`
+      : `/api/w/${workspaceId}/subscriptions/checkout-status?session_id=${sessionId}`;
+
+  const { data, error, mutate } = useSWRWithDefaults(url, checkoutFetcher, {
+    refreshInterval: pollIntervalMs,
+  });
 
   return {
     checkoutStatus: data ?? null,
@@ -1076,12 +1078,35 @@ export function usePreparePayment({
       ? null
       : `/api/w/${workspaceId}/subscriptions/checkout/prepare-payment?setup_session_id=${setupSessionId}`;
 
-  const { data, error } = useSWRWithDefaults(url, preparePaymentFetcher);
+  const [pollTimedOut, setPollTimedOut] = useState(false);
+
+  const { data, error } = useSWRWithDefaults(url, preparePaymentFetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    dedupingInterval: 500,
+    refreshInterval: (d) =>
+      d?.status === "pending" && !pollTimedOut ? 500 : 0,
+  });
+
+  const isPending = data?.status === "pending";
+
+  useEffect(() => {
+    if (!isPending) {
+      setPollTimedOut(false);
+      return;
+    }
+    const timer = setTimeout(() => setPollTimedOut(true), 5_000);
+    return () => clearTimeout(timer);
+  }, [isPending]);
+
+  const completeData = data?.status === "success" ? data : null;
 
   return {
-    preparePayment: data ?? null,
-    isPreparePaymentLoading: !error && !data && !disabled && !!setupSessionId,
-    isPreparePaymentError: !!error,
+    preparePayment: completeData,
+    isPreparePaymentLoading:
+      (!error && !data && !disabled && !!setupSessionId) ||
+      (isPending && !pollTimedOut),
+    isPreparePaymentError: !!error || pollTimedOut,
   };
 }
 

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -35,6 +35,8 @@ import type {
   GetSubscriptionsResponseBody,
   PostSubscriptionResponseBody,
 } from "@app/pages/api/w/[wId]/subscriptions";
+import type { PostCheckoutPaymentResponseBody } from "@app/pages/api/w/[wId]/subscriptions/checkout/payment";
+import type { GetPreparePaymentResponseBody } from "@app/pages/api/w/[wId]/subscriptions/checkout/prepare-payment";
 import type { GetCheckoutStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/checkout-status";
 import type { GetSubscriptionPricingResponseBody } from "@app/pages/api/w/[wId]/subscriptions/pricing";
 import type { GetSubscriptionStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/status";
@@ -1055,6 +1057,65 @@ export function useCreateCheckoutSession({
   );
 
   return { createSession, isCreating };
+}
+
+export function usePreparePayment({
+  workspaceId,
+  setupSessionId,
+  disabled,
+}: {
+  workspaceId: string;
+  setupSessionId: string | null;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const preparePaymentFetcher: Fetcher<GetPreparePaymentResponseBody> = fetcher;
+
+  const url =
+    disabled || !setupSessionId
+      ? null
+      : `/api/w/${workspaceId}/subscriptions/checkout/prepare-payment?setup_session_id=${setupSessionId}`;
+
+  const { data, error } = useSWRWithDefaults(url, preparePaymentFetcher);
+
+  return {
+    preparePayment: data ?? null,
+    isPreparePaymentLoading: !error && !data && !disabled && !!setupSessionId,
+    isPreparePaymentError: !!error,
+  };
+}
+
+export function useConfirmPayment({ workspaceId }: { workspaceId: string }) {
+  const [isConfirming, setIsConfirming] = useState(false);
+
+  const confirmPayment = useCallback(
+    async ({
+      setupSessionId,
+    }: {
+      setupSessionId: string;
+    }): Promise<PostCheckoutPaymentResponseBody | null> => {
+      setIsConfirming(true);
+      try {
+        const res = await clientFetch(
+          `/api/w/${workspaceId}/subscriptions/checkout/payment`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ setupSessionId }),
+          }
+        );
+        if (!res.ok) {
+          return null;
+        }
+        return res.json() as Promise<PostCheckoutPaymentResponseBody>;
+      } finally {
+        setIsConfirming(false);
+      }
+    },
+    [workspaceId]
+  );
+
+  return { confirmPayment, isConfirming };
 }
 
 export function useValidateCoupon({ workspaceId }: { workspaceId: string }) {

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -5,6 +5,7 @@ import {
   sendCancelSubscriptionEmail,
   sendReactivateSubscriptionEmail,
 } from "@app/lib/api/email";
+import { getRedisCacheClient } from "@app/lib/api/redis";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
@@ -44,6 +45,7 @@ import {
   getStripeSubscription,
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
+  isFirstPeriodInvoice,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -860,11 +862,12 @@ async function handler(
           const invoice = event.data.object as Stripe.Invoice;
           const isMetronomeInvoice = typeof invoice.subscription !== "string";
           const isCreditPurchase = isCreditPurchaseInvoice(invoice);
+          const isFirstPeriod = isFirstPeriodInvoice(invoice);
 
           // Only Metronome subscription invoices need the force-charge.
           // Stripe-subscription invoices have their own auto-charge flow;
           // credit-purchase invoices have their own flow too.
-          if (isMetronomeInvoice && !isCreditPurchase) {
+          if (isMetronomeInvoice && !isCreditPurchase && !isFirstPeriod) {
             await forceChargeMetronomeFinalizedInvoice(invoice);
           }
           break;
@@ -1564,6 +1567,43 @@ async function handler(
         },
       });
   }
+}
+
+const CHECKOUT_TTL_SECONDS = 200;
+const CHECKOUT_KEY_PREFIX = "stripe:checkout:";
+const CheckoutErrorSchema = z.object({ status: z.string() });
+
+export async function storeStripeCheckoutSessionStatus({
+  sessionId,
+  status,
+}: {
+  sessionId: string;
+  status: string;
+}): Promise<void> {
+  const redis = await getRedisCacheClient({
+    origin: "stripe_checkout_status",
+  });
+  await redis.set(
+    `${CHECKOUT_KEY_PREFIX}${sessionId}`,
+    JSON.stringify({ status }),
+    { EX: CHECKOUT_TTL_SECONDS }
+  );
+}
+
+export async function getStripeCheckoutSessionStatus(
+  sessionId: string
+): Promise<{ status: string } | null> {
+  const redis = await getRedisCacheClient({
+    origin: "stripe_checkout_status",
+  });
+  const key = `${CHECKOUT_KEY_PREFIX}${sessionId}`;
+  const raw = await redis.get(key);
+  if (!raw) {
+    return null;
+  }
+  await redis.del(key);
+  const parsed = CheckoutErrorSchema.safeParse(JSON.parse(raw));
+  return parsed.success ? parsed.data : null;
 }
 
 export default withLogging(handler);

--- a/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
@@ -4,16 +4,13 @@ import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
 import {
-  finalizeInvoice,
+  chargeFirstPeriodInvoice,
   getStripeClient,
-  makeFirstPeriodInvoiceForCustomer,
 } from "@app/lib/plans/stripe";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
@@ -96,7 +93,7 @@ async function handler(
 
   const stripe = getStripeClient();
   const setupSession = await stripe.checkout.sessions.retrieve(setupSessionId, {
-    expand: ["setup_intent"],
+    expand: ["setup_intent", "setup_intent.payment_method"],
   });
 
   const setupIntent = setupSession.setup_intent;
@@ -106,6 +103,15 @@ async function handler(
     setupIntent.status !== "succeeded"
   ) {
     return res.status(200).json({ error: "setup_failed" });
+  }
+  if (setupSession.client_reference_id !== owner.sId) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Setup intent does not correspond to the current workspace.",
+      },
+    });
   }
 
   const { seatCount: seatCountStr, pricePerSeatCents: pricePerSeatCentsStr } =
@@ -155,6 +161,11 @@ async function handler(
     });
   }
 
+  const shouldEnforceFirstPeriodPayment =
+    rawPaymentMethod !== null &&
+    !isString(rawPaymentMethod) &&
+    rawPaymentMethod.type === "card";
+
   const customer = await stripe.customers.retrieve(stripeCustomerId);
   if (customer.deleted) {
     return apiError(req, res, {
@@ -168,66 +179,19 @@ async function handler(
   const country = customer.address?.country ?? "US";
   const currency = getBillingCurrencyForCountry(country, true);
 
-  const invoiceResult = await makeFirstPeriodInvoiceForCustomer({
-    stripeCustomerId,
-    paymentMethodId,
-    subtotalCents,
-    seatCount,
-    setupSessionId,
-    currency,
-  });
-  if (invoiceResult.isErr()) {
-    logger.error(
-      {
-        panic: true,
-        workspaceId: owner.sId,
-        error: invoiceResult.error.error_message,
-      },
-      "[Checkout] Failed to create first-period invoice"
-    );
-    return res.status(500).json({ error: "payment_failed" });
-  }
-
-  const finalizeResult = await finalizeInvoice(invoiceResult.value);
-  if (finalizeResult.isErr()) {
-    logger.error(
-      {
-        panic: true,
-        workspaceId: owner.sId,
-        error: finalizeResult.error.error_message,
-        invoiceId: invoiceResult.value.id,
-      },
-      "[Checkout] Failed to finalize first-period invoice"
-    );
-    return res.status(500).json({ error: "payment_failed" });
-  }
-
-  let payResult;
-  try {
-    payResult = await stripe.invoices.pay(finalizeResult.value.id);
-
-    if (payResult.status !== "paid") {
-      logger.error(
-        {
-          panic: true,
-          workspaceId: owner.sId,
-          invoiceId: finalizeResult.value.id,
-        },
-        "[Checkout] First-period invoice payment failed"
-      );
+  if (shouldEnforceFirstPeriodPayment) {
+    const chargeResult = await chargeFirstPeriodInvoice({
+      stripeCustomerId,
+      paymentMethodId,
+      subtotalCents,
+      seatCount,
+      setupSessionId,
+      workspaceId: owner.sId,
+      currency,
+    });
+    if (chargeResult.isErr()) {
       return res.status(500).json({ error: "payment_failed" });
     }
-  } catch (payError) {
-    logger.error(
-      {
-        panic: true,
-        workspaceId: owner.sId,
-        error: normalizeError(payError).message,
-        invoiceId: finalizeResult.value.id,
-      },
-      "[Checkout] First-period invoice payment failed"
-    );
-    return res.status(500).json({ error: "payment_failed" });
   }
 
   return res.status(200).json({ success: true });

--- a/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
@@ -1,0 +1,238 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import type { Authenticator } from "@app/lib/auth";
+import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
+import {
+  finalizeInvoice,
+  getStripeClient,
+  makeFirstPeriodInvoiceForCustomer,
+} from "@app/lib/plans/stripe";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const BodySchema = z.object({
+  setupSessionId: z.string(),
+});
+
+export type PostCheckoutPaymentResponseBody =
+  | { success: true }
+  | {
+      error:
+        | "setup_failed"
+        | "payment_failed"
+        | "metronome_error"
+        | "internal_error";
+    };
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostCheckoutPaymentResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
+      },
+    });
+  }
+
+  const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
+  if (!useMetronomeBilling) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Metronome billing is not enabled for this workspace.",
+      },
+    });
+  }
+
+  const bodyValidation = BodySchema.safeParse(req.body);
+  if (!bodyValidation.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: fromError(bodyValidation.error).toString(),
+      },
+    });
+  }
+
+  const { setupSessionId } = bodyValidation.data;
+  const owner = auth.getNonNullableWorkspace();
+
+  // Idempotency guard: provisioning already completed.
+  const workspace = await WorkspaceResource.fetchById(owner.sId);
+  if (workspace) {
+    const activeSubscription =
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+    if (activeSubscription?.metronomeContractId) {
+      return res.status(200).json({ success: true });
+    }
+  }
+
+  const stripe = getStripeClient();
+  const setupSession = await stripe.checkout.sessions.retrieve(setupSessionId, {
+    expand: ["setup_intent"],
+  });
+
+  const setupIntent = setupSession.setup_intent;
+  if (
+    !setupIntent ||
+    isString(setupIntent) ||
+    setupIntent.status !== "succeeded"
+  ) {
+    return res.status(200).json({ error: "setup_failed" });
+  }
+
+  const { seatCount: seatCountStr, pricePerSeatCents: pricePerSeatCentsStr } =
+    setupSession.metadata ?? {};
+
+  if (!isString(seatCountStr) || !isString(pricePerSeatCentsStr)) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message:
+          "Setup session metadata is missing seatCount or pricePerSeatCents.",
+      },
+    });
+  }
+
+  const seatCount = Number(seatCountStr);
+  const pricePerSeatCents = Number(pricePerSeatCentsStr);
+  const subtotalCents = seatCount * pricePerSeatCents;
+  const stripeCustomerId = setupSession.customer;
+
+  if (!isString(stripeCustomerId)) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Setup session is missing a customer ID.",
+      },
+    });
+  }
+
+  const rawPaymentMethod = setupIntent.payment_method;
+  const paymentMethodId =
+    rawPaymentMethod === null
+      ? null
+      : isString(rawPaymentMethod)
+        ? rawPaymentMethod
+        : rawPaymentMethod.id;
+
+  if (!paymentMethodId) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Setup intent is missing a payment method.",
+      },
+    });
+  }
+
+  const customer = await stripe.customers.retrieve(stripeCustomerId);
+  if (customer.deleted) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Stripe customer has been deleted.",
+      },
+    });
+  }
+  const country = customer.address?.country ?? "US";
+  const currency = getBillingCurrencyForCountry(country, true);
+
+  const invoiceResult = await makeFirstPeriodInvoiceForCustomer({
+    stripeCustomerId,
+    paymentMethodId,
+    subtotalCents,
+    seatCount,
+    setupSessionId,
+    currency,
+  });
+  if (invoiceResult.isErr()) {
+    logger.error(
+      {
+        panic: true,
+        workspaceId: owner.sId,
+        error: invoiceResult.error.error_message,
+      },
+      "[Checkout] Failed to create first-period invoice"
+    );
+    return res.status(500).json({ error: "payment_failed" });
+  }
+
+  const finalizeResult = await finalizeInvoice(invoiceResult.value);
+  if (finalizeResult.isErr()) {
+    logger.error(
+      {
+        panic: true,
+        workspaceId: owner.sId,
+        error: finalizeResult.error.error_message,
+        invoiceId: invoiceResult.value.id,
+      },
+      "[Checkout] Failed to finalize first-period invoice"
+    );
+    return res.status(500).json({ error: "payment_failed" });
+  }
+
+  let payResult;
+  try {
+    payResult = await stripe.invoices.pay(finalizeResult.value.id);
+
+    if (payResult.status !== "paid") {
+      logger.error(
+        {
+          panic: true,
+          workspaceId: owner.sId,
+          invoiceId: finalizeResult.value.id,
+        },
+        "[Checkout] First-period invoice payment failed"
+      );
+      return res.status(500).json({ error: "payment_failed" });
+    }
+  } catch (payError) {
+    logger.error(
+      {
+        panic: true,
+        workspaceId: owner.sId,
+        error: normalizeError(payError).message,
+        invoiceId: finalizeResult.value.id,
+      },
+      "[Checkout] First-period invoice payment failed"
+    );
+    return res.status(500).json({ error: "payment_failed" });
+  }
+
+  return res.status(200).json({ success: true });
+}
+
+export default withSessionAuthenticationForWorkspace(handler, {
+  doesNotRequireCanUseProduct: true,
+});

--- a/front/pages/api/w/[wId]/subscriptions/checkout/prepare-payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/prepare-payment.ts
@@ -4,7 +4,6 @@ import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
 import { calculateTax, getStripeClient } from "@app/lib/plans/stripe";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { getStripeCheckoutSessionStatus } from "@app/pages/api/stripe/webhook";
 import type { SupportedCurrency } from "@app/types/currency";
@@ -12,39 +11,22 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-const SETUP_SESSION_POLL_INTERVAL_MS = 500;
-const SETUP_SESSION_POLL_TIMEOUT_MS = 5_000;
-
-async function pollUntilSetupSessionComplete(
-  sessionId: string
-): Promise<boolean> {
-  const deadlineMs = Date.now() + SETUP_SESSION_POLL_TIMEOUT_MS;
-
-  while (Date.now() < deadlineMs) {
-    const result = await getStripeCheckoutSessionStatus(sessionId);
-    if (result?.status === "complete") {
-      return true;
-    }
-    await new Promise((resolve) =>
-      setTimeout(resolve, SETUP_SESSION_POLL_INTERVAL_MS)
-    );
-  }
-
-  return false;
-}
-
-export type GetPreparePaymentResponseBody = {
-  subtotalCents: number;
-  taxCents: number;
-  totalCents: number;
-  seatCount: number;
-  pricePerSeatCents: number;
-  planCode: string;
-  metronomePackageAlias: string;
-  currency: SupportedCurrency;
-  cardBrand?: string;
-  cardLast4?: string;
-};
+export type GetPreparePaymentResponseBody =
+  | { status: "pending" }
+  | {
+      status: "success";
+      subtotalCents: number;
+      taxCents: number;
+      totalCents: number;
+      seatCount: number;
+      pricePerSeatCents: number;
+      planCode: string;
+      metronomePackageAlias: string;
+      currency: SupportedCurrency;
+      cardBrand?: string;
+      cardLast4?: string;
+      sepaLast4?: string;
+    };
 
 async function handler(
   req: NextApiRequest,
@@ -71,6 +53,7 @@ async function handler(
       },
     });
   }
+  const owner = auth.getNonNullableWorkspace();
 
   const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
   if (!useMetronomeBilling) {
@@ -83,6 +66,9 @@ async function handler(
     });
   }
 
+  // Prevent HTTP caching as session status can change on every call.
+  res.setHeader("Cache-Control", "no-store");
+
   const { setup_session_id } = req.query;
   if (!isString(setup_session_id)) {
     return apiError(req, res, {
@@ -94,35 +80,17 @@ async function handler(
     });
   }
 
-  // We are using the onComplete for checkout session completion.
-  // This is a server-side event that can be triggered
-  // before the session actually has completed.
-  // This is why we need to check for session completion with polling.
-  const isComplete = await pollUntilSetupSessionComplete(setup_session_id);
-  if (!isComplete) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Setup session did not complete in time.",
-      },
-    });
+  // onComplete fires on the client before Stripe marks the session complete server-side.
+  // We return "pending" so the client can retry instead of blocking here.
+  const sessionStatus = await getStripeCheckoutSessionStatus(setup_session_id);
+  if (sessionStatus?.status !== "complete") {
+    return res.status(200).json({ status: "pending" });
   }
 
   const stripe = getStripeClient();
   const setupSession = await stripe.checkout.sessions.retrieve(
     setup_session_id,
     { expand: ["setup_intent", "setup_intent.payment_method"] }
-  );
-  logger.info(
-    {
-      sessionId: setup_session_id,
-      sessionStatus: setupSession.status,
-      setupIntentStatus: isString(setupSession.setup_intent)
-        ? setupSession.setup_intent
-        : setupSession.setup_intent?.status,
-    },
-    "Stripe setup session retrieved"
   );
 
   const setupIntent = setupSession.setup_intent;
@@ -136,6 +104,15 @@ async function handler(
       api_error: {
         type: "invalid_request_error",
         message: "Setup session has not completed successfully.",
+      },
+    });
+  }
+  if (setupSession.client_reference_id !== owner.sId) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Setup intent does not correspond to the current workspace.",
       },
     });
   }
@@ -176,13 +153,14 @@ async function handler(
   const rawPaymentMethod = setupIntent.payment_method;
   let cardBrand: string | undefined;
   let cardLast4: string | undefined;
-  if (
-    rawPaymentMethod &&
-    !isString(rawPaymentMethod) &&
-    rawPaymentMethod.card
-  ) {
-    cardBrand = rawPaymentMethod.card.brand;
-    cardLast4 = rawPaymentMethod.card.last4;
+  let sepaLast4: string | undefined;
+  if (rawPaymentMethod && !isString(rawPaymentMethod)) {
+    if (rawPaymentMethod.card) {
+      cardBrand = rawPaymentMethod.card.brand;
+      cardLast4 = rawPaymentMethod.card.last4;
+    } else if (rawPaymentMethod.sepa_debit) {
+      sepaLast4 = rawPaymentMethod.sepa_debit.last4 ?? undefined;
+    }
   }
 
   const customer = await stripe.customers.retrieve(stripeCustomerId);
@@ -214,6 +192,7 @@ async function handler(
   }
 
   return res.status(200).json({
+    status: "success",
     subtotalCents,
     taxCents: taxResult.value.taxCents,
     totalCents: taxResult.value.totalCents,
@@ -224,6 +203,7 @@ async function handler(
     currency,
     cardBrand,
     cardLast4,
+    sepaLast4,
   });
 }
 

--- a/front/pages/api/w/[wId]/subscriptions/checkout/prepare-payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/prepare-payment.ts
@@ -1,0 +1,232 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import type { Authenticator } from "@app/lib/auth";
+import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
+import { calculateTax, getStripeClient } from "@app/lib/plans/stripe";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import { getStripeCheckoutSessionStatus } from "@app/pages/api/stripe/webhook";
+import type { SupportedCurrency } from "@app/types/currency";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const SETUP_SESSION_POLL_INTERVAL_MS = 500;
+const SETUP_SESSION_POLL_TIMEOUT_MS = 5_000;
+
+async function pollUntilSetupSessionComplete(
+  sessionId: string
+): Promise<boolean> {
+  const deadlineMs = Date.now() + SETUP_SESSION_POLL_TIMEOUT_MS;
+
+  while (Date.now() < deadlineMs) {
+    const result = await getStripeCheckoutSessionStatus(sessionId);
+    if (result?.status === "complete") {
+      return true;
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, SETUP_SESSION_POLL_INTERVAL_MS)
+    );
+  }
+
+  return false;
+}
+
+export type GetPreparePaymentResponseBody = {
+  subtotalCents: number;
+  taxCents: number;
+  totalCents: number;
+  seatCount: number;
+  pricePerSeatCents: number;
+  planCode: string;
+  metronomePackageAlias: string;
+  currency: SupportedCurrency;
+  cardBrand?: string;
+  cardLast4?: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetPreparePaymentResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
+      },
+    });
+  }
+
+  const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
+  if (!useMetronomeBilling) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Metronome billing is not enabled for this workspace.",
+      },
+    });
+  }
+
+  const { setup_session_id } = req.query;
+  if (!isString(setup_session_id)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid setup_session_id query parameter.",
+      },
+    });
+  }
+
+  // We are using the onComplete for checkout session completion.
+  // This is a server-side event that can be triggered
+  // before the session actually has completed.
+  // This is why we need to check for session completion with polling.
+  const isComplete = await pollUntilSetupSessionComplete(setup_session_id);
+  if (!isComplete) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Setup session did not complete in time.",
+      },
+    });
+  }
+
+  const stripe = getStripeClient();
+  const setupSession = await stripe.checkout.sessions.retrieve(
+    setup_session_id,
+    { expand: ["setup_intent", "setup_intent.payment_method"] }
+  );
+  logger.info(
+    {
+      sessionId: setup_session_id,
+      sessionStatus: setupSession.status,
+      setupIntentStatus: isString(setupSession.setup_intent)
+        ? setupSession.setup_intent
+        : setupSession.setup_intent?.status,
+    },
+    "Stripe setup session retrieved"
+  );
+
+  const setupIntent = setupSession.setup_intent;
+  if (
+    !setupIntent ||
+    isString(setupIntent) ||
+    setupIntent.status !== "succeeded"
+  ) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Setup session has not completed successfully.",
+      },
+    });
+  }
+
+  const { seatCount: seatCountStr, pricePerSeatCents: pricePerSeatCentsStr } =
+    setupSession.metadata ?? {};
+
+  if (!isString(seatCountStr) || !isString(pricePerSeatCentsStr)) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message:
+          "Setup session metadata is missing seatCount or pricePerSeatCents.",
+      },
+    });
+  }
+
+  const seatCount = Number(seatCountStr);
+  const pricePerSeatCents = Number(pricePerSeatCentsStr);
+  const subtotalCents = seatCount * pricePerSeatCents;
+  const stripeCustomerId = setupSession.customer;
+
+  if (!isString(stripeCustomerId)) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Setup session is missing a customer ID.",
+      },
+    });
+  }
+
+  const planCode = setupSession.metadata?.planCode ?? "";
+  const metronomePackageAlias =
+    setupSession.metadata?.metronomePackageAlias ?? "";
+
+  const rawPaymentMethod = setupIntent.payment_method;
+  let cardBrand: string | undefined;
+  let cardLast4: string | undefined;
+  if (
+    rawPaymentMethod &&
+    !isString(rawPaymentMethod) &&
+    rawPaymentMethod.card
+  ) {
+    cardBrand = rawPaymentMethod.card.brand;
+    cardLast4 = rawPaymentMethod.card.last4;
+  }
+
+  const customer = await stripe.customers.retrieve(stripeCustomerId);
+  if (customer.deleted) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Stripe customer has been deleted.",
+      },
+    });
+  }
+  const country = customer.address?.country ?? "US";
+  const currency = getBillingCurrencyForCountry(country, true);
+
+  const taxResult = await calculateTax({
+    stripeCustomerId,
+    amountCents: subtotalCents,
+    currency,
+  });
+  if (taxResult.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: taxResult.error.error_message,
+      },
+    });
+  }
+
+  return res.status(200).json({
+    subtotalCents,
+    taxCents: taxResult.value.taxCents,
+    totalCents: taxResult.value.totalCents,
+    seatCount,
+    pricePerSeatCents,
+    planCode,
+    metronomePackageAlias,
+    currency,
+    cardBrand,
+    cardLast4,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler, {
+  doesNotRequireCanUseProduct: true,
+});


### PR DESCRIPTION
## Description

PR1 of https://github.com/dust-tt/tasks/issues/8100
Check it for global specs for checkout flow

Lays the groundwork for the new direct-invoice checkout flow. No behavior change to the existing checkout — all new code is additive and gated behind isMetronomeBillingEnabled.

New helpers:
* loadFirstPeriodCredit() (metronome/credits.ts): creates a Metronome credit scoped to a 7-day window to zero out the first Metronome-generated invoice. The customer pays via Stripe invoice on day 1; this credit ensures Metronome doesn't bill them again for the same period.
* calculateTax() (stripe.ts): calls stripe.tax.calculations.create for a given customer + amount + currency.
* makeFirstPeriodInvoiceForCustomer() (stripe.ts): creates a draft Stripe invoice + item for the first period. Uses first-period-invoice-${setupSessionId} as idempotency key.
* isFirstPeriodInvoice() (stripe.ts): identifies first-period invoices by metadata. Used to skip forceChargeMetronomeFinalizedInvoice in the webhook — these invoices are paid inline, not via the Metronome auto-charge path.
* storeStripeCheckoutSessionStatus / getStripeCheckoutSessionStatus (webhook.ts): Redis helpers (TTL ~200 s) that let GET /prepare-payment poll for session completion. Needed because EmbeddedCheckoutProvider's onComplete callback fires before Stripe has marked the session as complete server-side.

New endpoints:
* GET /api/w/[wId]/subscriptions/checkout/prepare-payment: polls Redis until the setup session is complete, then retrieves the session, computes the tax breakdown via Stripe Tax, and returns { subtotalCents, taxCents, totalCents, currency, cardBrand?, cardLast4?, … }.
* POST /api/w/[wId]/subscriptions/checkout/payment (v1): creates + finalizes + pays the Stripe invoice. Metronome provisioning is not yet wired in this PR — added in PR2.

Setup session changes:
* seatCount + pricePerSeatCents added to metadata (computed in SubscriptionResource).

SWR hooks: usePreparePayment + useConfirmPayment added to lib/swr/workspaces.ts.

## Tests

Tested locally with old checkout with Stripe only + checkout for new pricing

## Risk

Low, additive changes only + behind Metronome kill switch

## Deploy Plan

Deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25579">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->