### PR TITLE
fix: sub agent resolve authentication

### DIFF
--- a/front/hooks/useResolveAuthentication.ts
+++ b/front/hooks/useResolveAuthentication.ts
@@ -45,6 +45,8 @@ export function useResolveAuthentication({
       setIsCompleting(true);
 
       try {
+        // The backend resumes both the conversation that contains the action
+        // and any blocked ancestor conversations.
         await fetcher(
           `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/${ROUTE_FOR_KIND[kind]}`,
           {
@@ -52,7 +54,11 @@ export function useResolveAuthentication({
             headers: {
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({ actionId, outcome }),
+            body: JSON.stringify({
+              actionId,
+              outcome,
+              resumeAncestorConversations: true,
+            }),
           }
         );
 

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -3,6 +3,7 @@ import {
   isToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
+import { resumeAncestorConversations as resumeAncestorConversationsHelper } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
@@ -53,11 +54,13 @@ export async function resolveAuthentication(
     messageId,
     outcome,
     kind = "authentication",
+    resumeAncestorConversations = false,
   }: {
     actionId: string;
     messageId: string;
     outcome: ResolveAuthenticationOutcome;
     kind?: ResolveAuthenticationKind;
+    resumeAncestorConversations?: boolean;
   }
 ): Promise<Result<void, DustError>> {
   const { blockedStatus, isMatchingEvent, label } = KIND_CONFIG[kind];
@@ -181,12 +184,19 @@ export async function resolveAuthentication(
     `${label} ${outcome}, agent loop resumed`
   );
 
-  return new Ok(undefined);
+  if (!resumeAncestorConversations) {
+    return new Ok(undefined);
+  }
+
+  return resumeAncestorConversationsHelper(auth, conversation, {
+    agentMessageId,
+  });
 }
 
 const ResolveAuthenticationSchema = z.object({
   actionId: z.string(),
   outcome: z.enum(["completed", "denied"]),
+  resumeAncestorConversations: z.boolean().optional(),
 });
 
 export type ResolveAuthenticationResponse = {
@@ -245,13 +255,14 @@ export function makeResolveAuthenticationHandler(
       });
     }
 
-    const { actionId, outcome } = parseResult.data;
+    const { actionId, outcome, resumeAncestorConversations } = parseResult.data;
 
     const result = await resolveAuthentication(auth, conversation, {
       actionId,
       messageId: mId,
       outcome,
       kind,
+      resumeAncestorConversations,
     });
 
     if (result.isErr()) {


### PR DESCRIPTION
## Description

This PR fixes the sub-agent authentication resolution to properly resume ancestor conversations when authentication is completed or denied.

Followup of https://github.com/dust-tt/dust/pull/24953 to fix https://github.com/dust-tt/tasks/issues/7690

- Added a new optional `resumeAncestorConversations` parameter to the resolve authentication flow
- When enabled, the backend now calls `resumeAncestorConversationsHelper` after successfully resolving authentication to resume any blocked parent conversations in the nested conversation structure
- Updated the frontend hook `useResolveAuthentication` to pass `resumeAncestorConversations: true` when resolving authentication

## Tests

Manually

## Risks

Low.

## Deploy Plan

Standard deployment - no special steps required.
