### PR TITLE
Forward scoped file paths to sub-agents in run_agent

### DIFF
--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -1,5 +1,11 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { ResolvedScopedFilePath } from "@app/lib/api/actions/servers/run_agent/file_paths";
+import {
+  appendFilePathsHintToQuery,
+  copyConversationFilesIntoSub,
+  resolveFilePathsInParentScope,
+} from "@app/lib/api/actions/servers/run_agent/file_paths";
 import { isTransientNetworkError } from "@app/lib/api/actions/servers/run_agent/network_errors";
 import type { ChildAgentBlob } from "@app/lib/api/actions/servers/run_agent/types";
 import { isRunAgentResumeState } from "@app/lib/api/actions/servers/run_agent/types";
@@ -54,6 +60,7 @@ export async function getOrCreateConversation(
     query,
     toolsetsToAdd,
     fileOrContentFragmentIds,
+    filePaths,
     conversationId,
   }: {
     childAgentBlob: ChildAgentBlob;
@@ -64,6 +71,7 @@ export async function getOrCreateConversation(
     query: string;
     toolsetsToAdd: string[] | null;
     fileOrContentFragmentIds: string[] | null;
+    filePaths: string[] | null;
     conversationId: string | null;
   }
 ): Promise<
@@ -104,6 +112,30 @@ export async function getOrCreateConversation(
       userMessageId: resumeState.userMessageId,
     });
   }
+
+  // Resolve scoped file paths in the parent's auth/conversation scope. Any failure here surfaces
+  // cleanly before the sub-conversation is created. `project/<rel>` paths are validated but not
+  // copied (the project mount is shared across the project's conversations).
+  // `conversation/<rel>` paths are copied to the sub-conversation's mount once the sub exists.
+  // A short hint is appended to the sub's first message so it knows which paths were forwarded;
+  // the sub reads them through the files MCP server.
+  let resolvedFilePaths: ResolvedScopedFilePath[] = [];
+  if (filePaths && filePaths.length > 0) {
+    const resolvedFilePathsRes = await resolveFilePathsInParentScope(
+      auth,
+      mainConversation,
+      filePaths
+    );
+    if (resolvedFilePathsRes.isErr()) {
+      return resolvedFilePathsRes;
+    }
+    resolvedFilePaths = resolvedFilePathsRes.value;
+  }
+
+  const queryWithFilePaths = appendFilePathsHintToQuery(
+    query,
+    resolvedFilePaths
+  );
 
   const contentFragments: PublicPostContentFragmentRequestBody[] = [];
 
@@ -160,7 +192,7 @@ export async function getOrCreateConversation(
     const messageRes = await api.postUserMessage({
       conversationId,
       message: {
-        content: `${serializeMention({ name: childAgentBlob.name, sId: childAgentId })} ${query}`,
+        content: `${serializeMention({ name: childAgentBlob.name, sId: childAgentId })} ${queryWithFilePaths}`,
         mentions: [{ configurationId: childAgentId }],
         context: {
           timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -223,7 +255,7 @@ export async function getOrCreateConversation(
     visibility: "unlisted",
     depth: mainConversation.depth + 1,
     message: {
-      content: `${serializeMention({ name: childAgentBlob.name, sId: childAgentId })} ${query}`,
+      content: `${serializeMention({ name: childAgentBlob.name, sId: childAgentId })} ${queryWithFilePaths}`,
       mentions: [{ configurationId: childAgentId }],
       context: {
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -273,6 +305,15 @@ export async function getOrCreateConversation(
 
   if (!createdUserMessage) {
     return new Err(new MCPError("Failed to retrieve the created message."));
+  }
+
+  const copyRes = await copyConversationFilesIntoSub(auth, {
+    parentConversationId: mainConversation.sId,
+    subConversationId: conversation.sId,
+    resolvedFilePaths,
+  });
+  if (copyRes.isErr()) {
+    return copyRes;
   }
 
   return new Ok({

--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -308,7 +308,7 @@ export async function getOrCreateConversation(
   }
 
   const copyRes = await copyConversationFilesIntoSub(auth, {
-    parentConversationId: mainConversation.sId,
+    parentConversation: mainConversation,
     subConversationId: conversation.sId,
     resolvedFilePaths,
   });

--- a/front/lib/api/actions/servers/run_agent/file_paths.test.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.test.ts
@@ -1,0 +1,195 @@
+import {
+  appendFilePathsHintToQuery,
+  copyConversationFilesIntoSub,
+  resolveFilePathsInParentScope,
+} from "@app/lib/api/actions/servers/run_agent/file_paths";
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import assert from "assert";
+import { describe, expect, it, vi } from "vitest";
+
+async function setupProjectConversation(): Promise<{
+  auth: Authenticator;
+  conversation: ConversationType;
+  projectId: string;
+}> {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const user = auth.getNonNullableUser();
+
+  const space = await SpaceFactory.project(workspace, user.id);
+  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
+  assert(addRes.isOk(), "Failed to add user to project space");
+
+  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const conversation = await createConversation(projectAuth, {
+    title: "Test",
+    visibility: "unlisted",
+    spaceId: space.id,
+  });
+
+  return { auth: projectAuth, conversation, projectId: space.sId };
+}
+
+async function setupPlainConversation(): Promise<{
+  auth: Authenticator;
+  conversation: ConversationType;
+}> {
+  const { authenticator: auth } = await createResourceTest({ role: "admin" });
+  const conversation = await createConversation(auth, {
+    title: "Test",
+    visibility: "unlisted",
+    spaceId: null,
+  });
+  return { auth, conversation };
+}
+
+describe("resolveFilePathsInParentScope", () => {
+  it("resolves a conversation-scoped path in a plain conversation", async () => {
+    const { auth, conversation } = await setupPlainConversation();
+
+    const res = await resolveFilePathsInParentScope(auth, conversation, [
+      "conversation/foo.md",
+    ]);
+
+    assert(res.isOk());
+    expect(res.value).toHaveLength(1);
+    expect(res.value[0].useCase).toBe("conversation");
+    expect(res.value[0].rel).toBe("foo.md");
+    expect(res.value[0].scopedPath).toBe("conversation/foo.md");
+  });
+
+  it("resolves both conversation and project paths in a project conversation", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+
+    const res = await resolveFilePathsInParentScope(auth, conversation, [
+      "conversation/a.txt",
+      "project/b.txt",
+    ]);
+
+    assert(res.isOk());
+    expect(res.value).toHaveLength(2);
+    expect(res.value[0].useCase).toBe("conversation");
+    expect(res.value[1].useCase).toBe("project");
+    expect(res.value[1].rel).toBe("b.txt");
+  });
+
+  it("returns Err for a path with no scope prefix", async () => {
+    const { auth, conversation } = await setupPlainConversation();
+
+    const res = await resolveFilePathsInParentScope(auth, conversation, [
+      "other/foo.md",
+    ]);
+
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error.message).toContain("must start with");
+    }
+  });
+
+  it("returns Err for a project path in a non-project conversation", async () => {
+    const { auth, conversation } = await setupPlainConversation();
+
+    const res = await resolveFilePathsInParentScope(auth, conversation, [
+      "project/spec.md",
+    ]);
+
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error.message).toContain("project conversations");
+    }
+  });
+
+  it("returns Err when the source file is missing", async () => {
+    const { auth, conversation } = await setupPlainConversation();
+
+    // The global mock's `getMetadata` resolves successfully; override here so the file lookup
+    // fails and surfaces the missing-file error path.
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
+      file: vi.fn(() => ({
+        getMetadata: vi.fn().mockRejectedValue(new Error("404")),
+      })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const res = await resolveFilePathsInParentScope(auth, conversation, [
+      "conversation/missing.md",
+    ]);
+
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error.message).toContain("File not found");
+    }
+  });
+});
+
+describe("appendFilePathsHintToQuery", () => {
+  it("returns the query unchanged when no paths are resolved", () => {
+    expect(appendFilePathsHintToQuery("hello", [])).toBe("hello");
+  });
+
+  it("appends a one-line nudge when at least one path is resolved", () => {
+    const result = appendFilePathsHintToQuery("hello", [
+      {
+        scopedPath: "conversation/a.md",
+        useCase: "conversation",
+        rel: "a.md",
+      },
+    ]);
+
+    expect(result).toBe(
+      "hello\n\nSome files have been made available to you through the `files` MCP server."
+    );
+  });
+});
+
+describe("copyConversationFilesIntoSub", () => {
+  it("is a no-op when no paths are conversation-scoped", async () => {
+    const { auth } = await setupPlainConversation();
+
+    const res = await copyConversationFilesIntoSub(auth, {
+      parentConversationId: "parent_sid",
+      subConversationId: "sub_sid",
+      resolvedFilePaths: [
+        {
+          scopedPath: "project/spec.md",
+          useCase: "project",
+          rel: "spec.md",
+        },
+      ],
+    });
+
+    assert(res.isOk());
+  });
+
+  it("dispatches conversation-scoped paths through the GCS mount copy primitive", async () => {
+    const { auth } = await setupPlainConversation();
+
+    const res = await copyConversationFilesIntoSub(auth, {
+      parentConversationId: "parent_sid",
+      subConversationId: "sub_sid",
+      resolvedFilePaths: [
+        {
+          scopedPath: "conversation/a.md",
+          useCase: "conversation",
+          rel: "a.md",
+        },
+        {
+          scopedPath: "project/skipped.md",
+          useCase: "project",
+          rel: "skipped.md",
+        },
+      ],
+    });
+
+    assert(res.isOk());
+  });
+});

--- a/front/lib/api/actions/servers/run_agent/file_paths.test.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.test.ts
@@ -153,10 +153,10 @@ describe("appendFilePathsHintToQuery", () => {
 
 describe("copyConversationFilesIntoSub", () => {
   it("is a no-op when no paths are conversation-scoped", async () => {
-    const { auth } = await setupPlainConversation();
+    const { auth, conversation } = await setupPlainConversation();
 
     const res = await copyConversationFilesIntoSub(auth, {
-      parentConversationId: "parent_sid",
+      parentConversation: conversation,
       subConversationId: "sub_sid",
       resolvedFilePaths: [
         {
@@ -171,10 +171,10 @@ describe("copyConversationFilesIntoSub", () => {
   });
 
   it("dispatches conversation-scoped paths through the GCS mount copy primitive", async () => {
-    const { auth } = await setupPlainConversation();
+    const { auth, conversation } = await setupPlainConversation();
 
     const res = await copyConversationFilesIntoSub(auth, {
-      parentConversationId: "parent_sid",
+      parentConversation: conversation,
       subConversationId: "sub_sid",
       resolvedFilePaths: [
         {
@@ -191,5 +191,30 @@ describe("copyConversationFilesIntoSub", () => {
     });
 
     assert(res.isOk());
+  });
+
+  it("returns Err when the parent auth check fails on a path", async () => {
+    const { auth, conversation } = await setupPlainConversation();
+
+    // Force `resolveFile` to fail by making the source object look missing.
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
+      file: vi.fn(() => ({
+        getMetadata: vi.fn().mockRejectedValue(new Error("404")),
+      })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const res = await copyConversationFilesIntoSub(auth, {
+      parentConversation: conversation,
+      subConversationId: "sub_sid",
+      resolvedFilePaths: [
+        {
+          scopedPath: "conversation/missing.md",
+          useCase: "conversation",
+          rel: "missing.md",
+        },
+      ],
+    });
+
+    expect(res.isErr()).toBe(true);
   });
 });

--- a/front/lib/api/actions/servers/run_agent/file_paths.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.ts
@@ -1,0 +1,109 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
+import { resolveFile } from "@app/lib/api/actions/servers/files/tools/utils";
+import { copyMountFile } from "@app/lib/api/files/gcs_mount/files";
+import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type ResolvedScopedFilePath = {
+  scopedPath: string;
+  useCase: "conversation" | "project";
+  rel: string;
+};
+
+export async function resolveFilePathsInParentScope(
+  auth: Authenticator,
+  mainConversation: ConversationType,
+  filePaths: string[]
+): Promise<Result<ResolvedScopedFilePath[], MCPError>> {
+  const resolved: ResolvedScopedFilePath[] = [];
+
+  for (const scopedPath of filePaths) {
+    const parsed = parseScopedFilePath(scopedPath);
+    if (!parsed) {
+      return new Err(
+        new MCPError(
+          `Invalid path: \`${scopedPath}\` must start with \`conversation/\` or \`project/\`.`,
+          { tracked: false }
+        )
+      );
+    }
+
+    // `resolveFile` resolves the mount point internally (with auth check) and confirms the
+    // object exists in GCS.
+    const fileRes = await resolveFile(auth, mainConversation, scopedPath);
+    if (fileRes.isErr()) {
+      return fileRes;
+    }
+
+    resolved.push({
+      scopedPath,
+      useCase: parsed.prefix,
+      rel: parsed.rel,
+    });
+  }
+
+  return new Ok(resolved);
+}
+
+/**
+ * Append a one-line nudge so the sub-agent knows files were forwarded by the parent. The actual
+ * names, sizes, and content types live in the files MCP server's `files__list` output.
+ */
+export function appendFilePathsHintToQuery(
+  query: string,
+  resolved: ResolvedScopedFilePath[]
+): string {
+  if (resolved.length === 0) {
+    return query;
+  }
+  return `${query}\n\nSome files have been made available to you through the \`${FILES_SERVER_NAME}\` MCP server.`;
+}
+
+export async function copyConversationFilesIntoSub(
+  auth: Authenticator,
+  {
+    parentConversationId,
+    subConversationId,
+    resolvedFilePaths,
+  }: {
+    parentConversationId: string;
+    subConversationId: string;
+    resolvedFilePaths: ResolvedScopedFilePath[];
+  }
+): Promise<Result<void, MCPError>> {
+  const conversationScoped = resolvedFilePaths.filter(
+    (p) => p.useCase === "conversation"
+  );
+  if (conversationScoped.length === 0) {
+    return new Ok(undefined);
+  }
+
+  for (const p of conversationScoped) {
+    const copyRes = await copyMountFile(auth, {
+      source: {
+        scope: {
+          useCase: "conversation",
+          conversationId: parentConversationId,
+        },
+        relativeFilePath: p.rel,
+      },
+      dest: {
+        scope: { useCase: "conversation", conversationId: subConversationId },
+        relativeFilePath: p.rel,
+      },
+    });
+    if (copyRes.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to copy \`${p.scopedPath}\` into the sub-conversation: ${copyRes.error.message}`
+        )
+      );
+    }
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/actions/servers/run_agent/file_paths.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.ts
@@ -66,11 +66,11 @@ export function appendFilePathsHintToQuery(
 export async function copyConversationFilesIntoSub(
   auth: Authenticator,
   {
-    parentConversationId,
+    parentConversation,
     subConversationId,
     resolvedFilePaths,
   }: {
-    parentConversationId: string;
+    parentConversation: ConversationType;
     subConversationId: string;
     resolvedFilePaths: ResolvedScopedFilePath[];
   }
@@ -83,11 +83,17 @@ export async function copyConversationFilesIntoSub(
   }
 
   for (const p of conversationScoped) {
+    // Re-validate auth and existence on every source.
+    const fileRes = await resolveFile(auth, parentConversation, p.scopedPath);
+    if (fileRes.isErr()) {
+      return fileRes;
+    }
+
     const copyRes = await copyMountFile(auth, {
       source: {
         scope: {
           useCase: "conversation",
-          conversationId: parentConversationId,
+          conversationId: parentConversation.sId,
         },
         relativeFilePath: p.rel,
       },

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -84,12 +84,14 @@ const runAgent = async (
     executionMode,
     toolsetsToAdd,
     fileOrContentFragmentIds,
+    filePaths,
   }: {
     query: string;
     childAgent: { uri: string };
     executionMode: { value: "run-agent" | "handoff" };
     toolsetsToAdd?: string[] | null;
     fileOrContentFragmentIds?: string[] | null;
+    filePaths?: string[] | null;
   },
   {
     auth,
@@ -129,6 +131,18 @@ const runAgent = async (
     return result;
   };
   const isHandoff = executionMode.value === "handoff";
+
+  if (isHandoff && filePaths && filePaths.length > 0) {
+    return finalizeAndReturn(
+      new Err(
+        new MCPError(
+          "`filePaths` is not supported in handoff mode: the sub-agent continues in the same " +
+            "conversation, so files are already visible to it.",
+          { tracked: false }
+        )
+      )
+    );
+  }
 
   const { agentConfiguration: mainAgent, conversation: mainConversation } =
     agentLoopContext.runContext;
@@ -210,6 +224,7 @@ const runAgent = async (
         : query,
       toolsetsToAdd: toolsetsToAdd ?? null,
       fileOrContentFragmentIds: fileOrContentFragmentIds ?? null,
+      filePaths: filePaths ?? null,
       conversationId: isHandoff ? mainConversation.sId : null,
       originMessage: agentLoopContext.runContext.agentMessage,
     }

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -76,7 +76,23 @@ export const RUN_AGENT_TOOL_SCHEMA = {
   fileOrContentFragmentIds: z
     .array(z.string().regex(new RegExp(`^[_\\w]+$`)))
     .describe(
-      "The filesId of the files to pass to the agent conversation. If the file is a content node, use the contentFragmentId instead."
+      "File or content-fragment IDs (e.g. `file_xyz`, `cf_abc`) to forward as content " +
+        "fragments to the sub-conversation. Use when you already have an ID returned by a " +
+        "previous tool (uploaded file, content node). Prefer `filePaths` when you have a " +
+        "scoped path."
+    )
+    .optional()
+    .nullable(),
+  filePaths: z
+    .array(z.string())
+    .describe(
+      "Scoped file paths (e.g. `conversation/foo.md`, `project/spec.md`) to forward to the " +
+        "sub-agent. Use when you have a scoped path from a file-listing tool or that you " +
+        "produced yourself in this conversation. `conversation/...` paths are copied into " +
+        "the sub-conversation; `project/...` paths are passed through (the project file " +
+        "system is shared across the project's conversations). " +
+        "For binary sources (PDFs, images, audio), also include their `*.processed.<ext>` " +
+        "sibling so the sub-agent can read the model-friendly representation."
     )
     .optional()
     .nullable(),

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -1,5 +1,6 @@
 import {
   copyConversationGCSMount,
+  copyMountFile,
   createGCSMountFile,
   type GCSMountFileEntry,
   getConversationFileMountSignedUrl,
@@ -427,6 +428,63 @@ describe("copyConversationGCSMount", () => {
     copyFileMock.mockRejectedValue(new Error("GCS copy unavailable"));
 
     const result = await copyConversationGCSMount(auth, { source, dest });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("GCS copy unavailable");
+    }
+  });
+});
+
+describe("copyMountFile", () => {
+  let auth: Authenticator;
+  let workspaceId: string;
+  let copyFileMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    copyFileMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      copyFile: copyFileMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator } = await createResourceTest({});
+    auth = authenticator;
+    workspaceId = auth.getNonNullableWorkspace().sId;
+  });
+
+  it("copies between mounts preserving the relative path", async () => {
+    const result = await copyMountFile(auth, {
+      source: {
+        scope: { useCase: "conversation", conversationId: "parent" },
+        relativeFilePath: "report.pdf",
+      },
+      dest: {
+        scope: { useCase: "conversation", conversationId: "child" },
+        relativeFilePath: "report.pdf",
+      },
+    });
+
+    assert(result.isOk());
+    expect(copyFileMock).toHaveBeenCalledTimes(1);
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `w/${workspaceId}/conversations/parent/files/report.pdf`,
+      `w/${workspaceId}/conversations/child/files/report.pdf`
+    );
+  });
+
+  it("returns Err when the copy fails", async () => {
+    copyFileMock.mockRejectedValue(new Error("GCS copy unavailable"));
+
+    const result = await copyMountFile(auth, {
+      source: {
+        scope: { useCase: "conversation", conversationId: "parent" },
+        relativeFilePath: "notes.md",
+      },
+      dest: {
+        scope: { useCase: "conversation", conversationId: "child" },
+        relativeFilePath: "notes.md",
+      },
+    });
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -344,6 +344,33 @@ export async function createGCSMountFile(
   );
 }
 
+/**
+ * Copy a single file from one mount to another, preserving the relative file path on both sides.
+ */
+export async function copyMountFile(
+  auth: Authenticator,
+  {
+    source,
+    dest,
+  }: {
+    source: { scope: GCSMountPoint; relativeFilePath: string };
+    dest: { scope: GCSMountPoint; relativeFilePath: string };
+  }
+): Promise<Result<void, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const sourceGcsPath = `${resolvePrefix(owner, source.scope)}${source.relativeFilePath}`;
+  const destGcsPath = `${resolvePrefix(owner, dest.scope)}${dest.relativeFilePath}`;
+
+  const bucket = getPrivateUploadBucket();
+
+  try {
+    await bucket.copyFile(sourceGcsPath, destGcsPath);
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
 export async function copyConversationGCSMount(
   auth: Authenticator,
   {

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -61,6 +61,9 @@ class FileStorageMock {
       delete: vi.fn().mockResolvedValue(undefined),
       download: vi.fn().mockResolvedValue([Buffer.from("", "utf-8")]),
       exists: vi.fn().mockResolvedValue([true]),
+      getMetadata: vi
+        .fn()
+        .mockResolvedValue([{ contentType: "text/plain", size: "0" }]),
       getSignedUrl: vi.fn().mockResolvedValue(["https://signed-url.test"]),
       publicUrl: vi.fn().mockReturnValue("https://public-url.test"),
       save: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The `run_agent` tool only accepted `fileOrContentFragmentIds`, which resolves through `listAttachments` and therefore only ever sees `FileResource`-backed attachments (user uploads, agent action `generatedFiles`). Files written directly to the conversation or project mount by `files__create` carry no `FileResource` and were invisible to sub-agents, so a parent agent could not forward anything it had produced through the agent-driven write path.

This adds a `filePaths` parameter on `run_agent` that accepts scoped paths (`conversation/<rel>`, `project/<rel>`). Paths are validated in the parent's auth scope before the sub-conversation is created, so a bad path or a missing object fails cleanly in the parent's stream rather than silently inside the sub. Once the sub exists:
-`conversation/<rel>` paths are GCS-to-GCS copied into the sub's mount at the same relative path through.
- the project mount is shared across the project's conversations

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25581">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->