### PR TITLE
 Tighten conversation_files listing in file-system mode

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -79,6 +79,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "conversation_files": {
     "cat": "never_ask",
     "list": "never_ask",
+    "list_content_nodes_and_tables": "never_ask",
     "semantic_search": "never_ask",
   },
   "data_sources_file_system": {

--- a/front/lib/actions/mcp_internal_actions/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/instructions.ts
@@ -1,11 +1,3 @@
-import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
-import {
-  CONVERSATION_CAT_FILE_ACTION_NAME,
-  CONVERSATION_FILES_SERVER_NAME,
-  CONVERSATION_LIST_FILES_ACTION_NAME,
-  CONVERSATION_SEARCH_FILES_ACTION_NAME,
-} from "@app/lib/api/actions/servers/conversation_files/metadata";
-
 export const SALESFORCE_SERVER_INSTRUCTIONS = `You have access to the following tools: execute_read_query, list_objects, and describe_object.
 
 # General Workflow for Salesforce Data:
@@ -117,6 +109,4 @@ export const DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS =
   "The `cat` tool reads the actual content in a document node, like 'cat' in Unix.\n" +
   "The `locate_in_tree` tool finds the path to a node in the filesystem tree.\n" +
   "The `semantic_search` tool performs a semantic search within the nodes designated by `nodeIds`.\n" +
-  "Note: these tools are specific to data in the space denoted by the server name. For attachments and conversation files " +
-  `prefer using the \`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_LIST_FILES_ACTION_NAME)}\`, \`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_CAT_FILE_ACTION_NAME)}\` and ` +
-  `\`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_SEARCH_FILES_ACTION_NAME)}\` tools instead.`;
+  "Note: these tools are specific to data in the space denoted by the server name. For attachments and files in the current conversation, prefer the conversation's own attachment and file tools when available.";

--- a/front/lib/api/actions/servers/common/viz/instructions.ts
+++ b/front/lib/api/actions/servers/common/viz/instructions.ts
@@ -56,8 +56,8 @@ export const VIZ_STYLING_GUIDELINES = `
 `;
 
 export const VIZ_FILE_HANDLING_GUIDELINES = `
-- Using any file from the \`conversation_files__list_files\` action when available:
-  - Files from the conversation as returned by \`conversation_files__list_files\` can be accessed using the \`useFile()\` React hook (all files can be accessed by the hook irrespective of their status).
+- Using any file from the conversation when available:
+  - Files attached to the conversation can be accessed using the \`useFile()\` React hook (all files can be accessed by the hook irrespective of their status).
   - \`useFile\` has to be imported from \`"@dust/react-hooks"\`.
   - Like any React hook, \`useFile\` must be called inside a React component at the top level (not in event handlers, loops, or conditions).
   - \`useFile()\` accepts either a file ID (e.g. \`"fil_abc123"\`, as found in \`<attachment id="fil_..." ...>\` tags) or a scoped file path (e.g. \`"conversation/report.csv"\`). Pass whichever you already have.

--- a/front/lib/api/actions/servers/conversation_files/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/index.ts
@@ -1,19 +1,13 @@
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { CONVERSATION_FILES_SERVER_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import {
-  CONVERSATION_CAT_FILE_ACTION_NAME,
-  CONVERSATION_FILES_SERVER_NAME,
-  CONVERSATION_SEARCH_FILES_ACTION_NAME,
-} from "@app/lib/api/actions/servers/conversation_files/metadata";
-import { TOOLS } from "@app/lib/api/actions/servers/conversation_files/tools";
+  TOOLS,
+  TOOLS_WITH_FILESYSTEM,
+} from "@app/lib/api/actions/servers/conversation_files/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-
-const NEW_FILE_EXPLORER_HIDDEN_TOOLS = new Set([
-  CONVERSATION_CAT_FILE_ACTION_NAME,
-  CONVERSATION_SEARCH_FILES_ACTION_NAME,
-]);
 
 async function createServer(
   auth: Authenticator,
@@ -26,11 +20,7 @@ async function createServer(
     agentLoopContext?.listToolsContext?.conversation;
   const useFileSystem = conversation?.metadata?.useFileSystem === true;
 
-  for (const tool of TOOLS) {
-    if (useFileSystem && NEW_FILE_EXPLORER_HIDDEN_TOOLS.has(tool.name)) {
-      continue;
-    }
-
+  for (const tool of useFileSystem ? TOOLS_WITH_FILESYSTEM : TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
       monitoringName: CONVERSATION_FILES_SERVER_NAME,
     });

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -1,13 +1,59 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const CONVERSATION_FILES_SERVER_NAME = "conversation_files" as const;
+// Legacy listing action (pre file-system mode). Lists every attachment in the conversation.
 export const CONVERSATION_LIST_FILES_ACTION_NAME = "list";
+// File-system mode listing action. The conversation's regular files have moved to the `files`
+// MCP server, so this listing is narrowed to content nodes and queryable tables.
+export const CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME =
+  "list_content_nodes_and_tables";
 export const CONVERSATION_CAT_FILE_ACTION_NAME = "cat";
 export const CONVERSATION_SEARCH_FILES_ACTION_NAME = "semantic_search";
+
+const CAT_FILE_TOOL = {
+  description:
+    "Read the contents of a large file from conversation attachments with offset/limit and optional grep filtering (named after the 'cat' unix tool). " +
+    "Use this when files are too large to read in full, or when you need to search for specific patterns within a file.",
+  schema: {
+    fileId: z
+      .string()
+      .describe(
+        `The fileId of the attachment to read, as returned by \`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_LIST_FILES_ACTION_NAME)}\``
+      ),
+    offset: z
+      .number()
+      .optional()
+      .describe(
+        "The character position to start reading from (0-based). If not provided, starts from " +
+          "the beginning."
+      ),
+    limit: z
+      .number()
+      .optional()
+      .describe(
+        "The maximum number of characters to read. Capped to ~200K characters per call. " +
+          "If the file is larger, use offset to paginate."
+      ),
+    grep: z
+      .string()
+      .optional()
+      .describe(
+        "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
+          "matching this pattern will be returned."
+      ),
+  },
+  stake: "never_ask" as const,
+  displayLabels: {
+    running: "Reading file from conversation",
+    done: "Read file from conversation",
+  },
+};
 
 export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
   [CONVERSATION_LIST_FILES_ACTION_NAME]: {
@@ -19,44 +65,7 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
       done: "List files in conversation",
     },
   },
-  [CONVERSATION_CAT_FILE_ACTION_NAME]: {
-    description:
-      "Read the contents of a large file from conversation attachments with offset/limit and optional grep filtering (named after the 'cat' unix tool). " +
-      "Use this when files are too large to read in full, or when you need to search for specific patterns within a file.",
-    schema: {
-      fileId: z
-        .string()
-        .describe(
-          "The fileId of the attachment to read, as returned by the conversation_list_files action"
-        ),
-      offset: z
-        .number()
-        .optional()
-        .describe(
-          "The character position to start reading from (0-based). If not provided, starts from " +
-            "the beginning."
-        ),
-      limit: z
-        .number()
-        .optional()
-        .describe(
-          "The maximum number of characters to read. Capped to ~200K characters per call. " +
-            "If the file is larger, use offset to paginate."
-        ),
-      grep: z
-        .string()
-        .optional()
-        .describe(
-          "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
-            "matching this pattern will be returned."
-        ),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Reading file from conversation",
-      done: "Read file from conversation",
-    },
-  },
+  [CONVERSATION_CAT_FILE_ACTION_NAME]: CAT_FILE_TOOL,
   [CONVERSATION_SEARCH_FILES_ACTION_NAME]: {
     description:
       "Perform a semantic search within the files and content nodes attached to the conversation.",
@@ -71,6 +80,33 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
   },
 });
 
+// In file-system mode, regular files are accessed via the `files` MCP server. This server is
+// narrowed to listing the attachments that don't live on the file mount: content nodes
+// (Notion pages, Slack threads, etc.) and queryable tables.
+export const CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM =
+  createToolsRecord({
+    [CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME]: {
+      description:
+        "List content nodes (e.g. Notion pages, Slack threads) and queryable tables attached " +
+        "to the conversation. Regular files attached to the conversation are not listed here; " +
+        `they are accessible via the \`${FILES_SERVER_NAME}\` MCP server.`,
+      schema: {},
+      stake: "never_ask",
+      displayLabels: {
+        running: "Listing conversation attachments",
+        done: "List conversation attachments",
+      },
+    },
+  });
+
+// Union of the legacy and file-system-mode metadata. The runtime picks one or the other based on
+// the conversation's `useFileSystem` flag, but the static server descriptor surfaces every tool
+// name this server can register so UI discovery and monitoring labels cover both modes.
+const ALL_CONVERSATION_FILES_TOOLS = [
+  ...Object.values(CONVERSATION_FILES_TOOLS_METADATA),
+  ...Object.values(CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM),
+];
+
 export const CONVERSATION_FILES_SERVER = {
   serverInfo: {
     name: CONVERSATION_FILES_SERVER_NAME,
@@ -81,16 +117,13 @@ export const CONVERSATION_FILES_SERVER = {
     documentationUrl: null,
     instructions: null,
   },
-  tools: Object.values(CONVERSATION_FILES_TOOLS_METADATA).map((t) => ({
+  tools: ALL_CONVERSATION_FILES_TOOLS.map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
-    Object.values(CONVERSATION_FILES_TOOLS_METADATA).map((t) => [
-      t.name,
-      t.stake,
-    ])
+    ALL_CONVERSATION_FILES_TOOLS.map((t) => [t.name, t.stake])
   ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -9,6 +9,8 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import {
   CONVERSATION_CAT_FILE_ACTION_NAME,
   CONVERSATION_FILES_TOOLS_METADATA,
+  CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM,
+  CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME,
   CONVERSATION_LIST_FILES_ACTION_NAME,
   CONVERSATION_SEARCH_FILES_ACTION_NAME,
 } from "@app/lib/api/actions/servers/conversation_files/metadata";
@@ -78,52 +80,56 @@ export const contentFromAttachments = (
   return content;
 };
 
-const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
-  [CONVERSATION_LIST_FILES_ACTION_NAME]: async (
-    _,
-    { auth, agentLoopContext }
-  ) => {
-    if (!agentLoopContext?.runContext) {
-      return new Err(new MCPError("No conversation context available"));
-    }
+// Shared list handler used under two action names: the legacy `list` (all attachments) and the
+// file-system-mode `list_content_nodes_and_tables` (narrowed). Filtering is driven by the
+// conversation's `useFileSystem` flag so the same handler is correct under either name.
+const listAttachmentsHandler: ToolHandlers<
+  typeof CONVERSATION_FILES_TOOLS_METADATA
+>[typeof CONVERSATION_LIST_FILES_ACTION_NAME] = async (
+  _,
+  { auth, agentLoopContext }
+) => {
+  if (!agentLoopContext?.runContext) {
+    return new Err(new MCPError("No conversation context available"));
+  }
 
-    const conversation = agentLoopContext.runContext.conversation;
-    const allAttachments = await listAttachments(auth, { conversation });
+  const conversation = agentLoopContext.runContext.conversation;
+  const allAttachments = await listAttachments(auth, { conversation });
 
-    // When the conversation uses the new file system, files are surfaced via the
-    // `files` server. Only list content nodes and queryable attachments (tables) here.
-    const useFileSystem = conversation.metadata?.useFileSystem === true;
-    const attachments = useFileSystem
-      ? allAttachments.filter(
-          (a) => isContentNodeAttachmentType(a) || a.isQueryable
-        )
-      : allAttachments;
+  // When the conversation uses the new file system, regular files are surfaced via the
+  // `files` server. Only list content nodes and queryable attachments (tables) here.
+  const useFileSystem = conversation.metadata?.useFileSystem === true;
+  const attachments = useFileSystem
+    ? allAttachments.filter(
+        (a) => isContentNodeAttachmentType(a) || a.isQueryable
+      )
+    : allAttachments;
 
-    if (attachments.length === 0) {
-      return new Ok([
-        {
-          type: "text",
-          text: "No files are currently attached to the conversation.",
-        },
-      ]);
-    }
-
-    let content = contentFromAttachments(attachments);
-
-    if (content.length > MAX_CONTENT_SIZE_FOR_LIST_FILES) {
-      content = contentFromAttachments(
-        attachments,
-        "Snippet content too large."
-      );
-    }
-
+  if (attachments.length === 0) {
     return new Ok([
       {
         type: "text",
-        text: content,
+        text: "No files are currently attached to the conversation.",
       },
     ]);
-  },
+  }
+
+  let content = contentFromAttachments(attachments);
+
+  if (content.length > MAX_CONTENT_SIZE_FOR_LIST_FILES) {
+    content = contentFromAttachments(attachments, "Snippet content too large.");
+  }
+
+  return new Ok([
+    {
+      type: "text",
+      text: content,
+    },
+  ]);
+};
+
+const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
+  [CONVERSATION_LIST_FILES_ACTION_NAME]: listAttachmentsHandler,
 
   [CONVERSATION_CAT_FILE_ACTION_NAME]: async (
     { fileId, offset, limit, grep },
@@ -401,3 +407,15 @@ async function getFileFromConversation(
 }
 
 export const TOOLS = buildTools(CONVERSATION_FILES_TOOLS_METADATA, handlers);
+
+const handlersWithFilesystem: ToolHandlers<
+  typeof CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM
+> = {
+  [CONVERSATION_LIST_CONTENT_NODES_AND_TABLES_ACTION_NAME]:
+    listAttachmentsHandler,
+};
+
+export const TOOLS_WITH_FILESYSTEM = buildTools(
+  CONVERSATION_FILES_TOOLS_METADATA_WITH_FILESYSTEM,
+  handlersWithFilesystem
+);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In file-system-mode conversations, the `conversation_files` server's listing tool was named list and described as "List all files attached to the conversation" while at runtime it filtered down to content nodes and queryable tables. All regular files had moved to the files MCP server. The name and the description both lied, which is exactly the kind of mismatch that confuses tool
selection.

This renames the action to `list_content_nodes_and_tables` in file-system mode and gives it a description that says what it
actually returns, with a pointer to the files server for regular files. The legacy list action stays unchanged for conversations
not on the file system. **This ensures that throughout one conversation lifetime, tool name never changes!**

Took the opportunity to clean up a handful of stale cross-references in this PR. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25584">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->