### PR TITLE
Track the same message status for metronome and current programmatic …

### DIFF
--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -242,6 +242,12 @@ export async function emitMetronomeUsageEventsActivity(
     return;
   }
 
+  // Only send usage events for statuses we track for billing. This ensures
+  // Metronome stays consistent with ES analytics and credit consumption.
+  if (!AGENT_MESSAGE_STATUSES_TO_TRACK.includes(agentMessage.status)) {
+    return;
+  }
+
   // Use dustRunIds from this specific agent loop execution if available,
   // fall back to all accumulated runIds on the message (legacy behavior).
   const effectiveRunIds = agentLoopArgs.dustRunIds ?? agentMessage.runIds;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -243,6 +243,8 @@ export type AgentMessageStatus =
   | "gracefully_stopped";
 
 export const AGENT_MESSAGE_STATUSES_TO_TRACK: AgentMessageStatus[] = [
+  // Message can be in "created" status when we stop the loop to ask for user permission for instance.
+  "created",
   "succeeded",
   "cancelled",
   "interrupted",


### PR DESCRIPTION
…usage, track the created messages

## Description

Fix discrepancies between the Metronome usage graph and the ES-based usage cost graph in Poke by aligning which message statuses are tracked across all billing systems.

Root cause: When an agent message pauses mid-execution (e.g. waiting for tool approval), the agent loop finalizes and reports usage while the message is still in created status. Metronome received these events (billing the customer), but ES analytics and credit consumption skipped them because created was not in `AGENT_MESSAGE_STATUSES_TO_TRACK`. Additionally, Metronome was sending events for failed messages, which shouldn't be billed.

## Changes:

  - Add `created` to AGENT_MESSAGE_STATUSES_TO_TRACK: Messages can be in created status when the loop pauses for user permission. The LLM costs are real and already incurred. This is safe because:
    - ES overwrites the same document when the message eventually finishes, so intermediate created documents are replaced
    - Credit consumption uses per-execution dustRunIds, so there's no double-consumption across executions
  - Filter Metronome events by AGENT_MESSAGE_STATUSES_TO_TRACK — Previously Metronome had no status filter, so failed messages were billed. Now all three systems (ES analytics, credit consumption, Metronome) use the same status list as a single source of truth.

## Tests

Test plan after merge:

  - Verify that paused messages (tool approval flow) correctly report usage to Metronome, ES, and credit
  consumption
  - Verify that failed messages no longer generate Metronome events
  - Compare Metronome and ES usage graphs in Poke for a workspace: the totals should now be closer

## Risk

May change what we actually bill 
I think we do want to bill created message and we won't double bill them

## Deploy Plan

deploy front
then rerun the sync script to sync metronome


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25585">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->