### PR TITLE
[front] enh: sandbox record baseImage + version on creation

### DIFF
--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -43,6 +43,8 @@ async function setupTest() {
     conversationId: conversation.id,
     providerId: "test-provider-id",
     status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
   });
 
   const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -238,7 +238,7 @@ describe("SandboxResource.ensureActive", () => {
     mockGetSandboxImage.mockReturnValue(
       new Ok({
         toCreateConfig: () => ({
-          imageId: { name: "test-image", tag: "latest" },
+          imageId: { imageName: "test-image", tag: "0.0.1" },
           envVars: {
             DST_API_TOKEN: "image-token",
             DD_API_KEY: "image-dd-token",
@@ -343,5 +343,44 @@ describe("SandboxResource.ensureActive", () => {
     expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
       "DST_SECRET_TOKEN"
     );
+  });
+
+  it("records baseImage and version from the registered image on fresh create", async () => {
+    const result = await SandboxResource.ensureActive(
+      authenticator,
+      conversation
+    );
+
+    expect(result.isOk()).toBe(true);
+
+    const persisted = await SandboxResource.fetchByConversationId(
+      authenticator,
+      conversation.sId
+    );
+    expect(persisted?.baseImage).toBe("test-image");
+    expect(persisted?.version).toBe("0.0.1");
+  });
+
+  it("refreshes baseImage and version when recreating from a deleted row", async () => {
+    await SandboxFactory.create(authenticator, conversation, {
+      status: "deleted",
+      baseImage: "stale-image",
+      version: "0.0.0-old",
+    });
+
+    const result = await SandboxResource.ensureActive(
+      authenticator,
+      conversation
+    );
+
+    expect(result.isOk()).toBe(true);
+
+    const persisted = await SandboxResource.fetchByConversationId(
+      authenticator,
+      conversation.sId
+    );
+    expect(persisted?.baseImage).toBe("test-image");
+    expect(persisted?.version).toBe("0.0.1");
+    expect(persisted?.providerId).toBe("provider-id");
   });
 });

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -95,6 +95,8 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       conversationId: number;
       providerId: string;
       status: SandboxStatus;
+      baseImage: string;
+      version: string;
     },
     { transaction }: { transaction?: Transaction } = {}
   ) {
@@ -423,6 +425,8 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           conversationId: conversation.id,
           providerId: createResult.value.providerId,
           status: "running",
+          baseImage: createConfig.imageId.imageName,
+          version: createConfig.imageId.tag,
         });
 
         const startTelemetry = await provider.exec(
@@ -523,7 +527,11 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           if (createResult.isErr()) {
             return createResult;
           }
-          await existing.update({ providerId: createResult.value.providerId });
+          await existing.update({
+            providerId: createResult.value.providerId,
+            baseImage: createConfig.imageId.imageName,
+            version: createConfig.imageId.tag,
+          });
           freshlyCreated = true;
 
           const startTelemetry = await provider.exec(

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -2,7 +2,7 @@ import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, Op } from "sequelize";
 
 export type SandboxStatus =
   | "running"
@@ -19,6 +19,9 @@ export class SandboxModel extends WorkspaceAwareModel<SandboxModel> {
   declare status: SandboxStatus;
   declare statusChangedAt: CreationOptional<Date>;
   declare lastActivityAt: Date;
+  declare baseImage: CreationOptional<string | null>;
+  declare version: CreationOptional<string | null>;
+  declare killRequestedAt: CreationOptional<Date | null>;
 
   // Associations.
   declare conversation: NonAttribute<ConversationModel>;
@@ -62,6 +65,18 @@ SandboxModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
+    baseImage: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    version: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    killRequestedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
   },
   {
     modelName: "sandbox",
@@ -80,6 +95,15 @@ SandboxModel.init(
       {
         fields: ["status", "lastActivityAt"],
         name: "sandboxes_status_last_activity_idx",
+      },
+      {
+        fields: ["killRequestedAt"],
+        name: "sandboxes_kill_requested_at_idx",
+        where: { killRequestedAt: { [Op.ne]: null } },
+      },
+      {
+        fields: ["baseImage", "version"],
+        name: "sandboxes_base_image_version_idx",
       },
     ],
   }

--- a/front/migrations/db/migration_639.sql
+++ b/front/migrations/db/migration_639.sql
@@ -1,0 +1,9 @@
+-- Migration created on 2026-05-13
+ALTER TABLE "public"."sandboxes" ADD COLUMN "baseImage" VARCHAR(255);
+ALTER TABLE "public"."sandboxes" ADD COLUMN "version" VARCHAR(255);
+ALTER TABLE "public"."sandboxes" ADD COLUMN "killRequestedAt" TIMESTAMP WITH TIME ZONE;
+CREATE INDEX CONCURRENTLY "sandboxes_kill_requested_at_idx"
+  ON "public"."sandboxes" ("killRequestedAt")
+  WHERE "killRequestedAt" IS NOT NULL;
+CREATE INDEX CONCURRENTLY "sandboxes_base_image_version_idx"
+  ON "public"."sandboxes" ("baseImage", "version");

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -11,12 +11,16 @@ export class SandboxFactory {
     opts?: {
       status?: SandboxStatus;
       statusChangedAt?: Date | null;
+      baseImage?: string;
+      version?: string;
     }
   ): Promise<SandboxResource> {
     const sandbox = await SandboxResource.makeNew(auth, {
       conversationId: conversation.id,
       providerId: `test-provider-${Date.now()}`,
       status: opts?.status ?? "running",
+      baseImage: opts?.baseImage ?? "dust-base",
+      version: opts?.version ?? "0.0.0-test",
     });
 
     if (opts?.statusChangedAt !== undefined) {


### PR DESCRIPTION
## Description

Currently, when we deploy a new version of the sandbox environment, past and ongoing conversations may still be using a previous version.

Most of the time, it's harmless, but in some situations, eg when we change both sides of the harness, or add breaking changes, conversation can end up in a broken state where the sandbox is unreachable, or an expected contract is broken.

This stack of PRs introduces a new section in kill switches, to force kill all the sandboxes with a different version than the currently deployed. It also comes with a danger-js on changes in lib/ap/sandbox.

It works by adding 3 columns to sandbox model: version, image name and killRequestedAt. Using the kill switch will launch a new temporal workflow that will mark the sandbox as kill requested.

Then, the sandbox gets killed opportunistically either by the reaper or by the next bash tool execution.

This first PR adds the data-model part, the column are nullable and will not be backfilled. But we will start writing to them right-away.

## Tests

Unit tests

## Risk

Low

## Deploy Plan

- Run the migration
- Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25587">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->