### PR TITLE
[front] enh: sandbox - reap kill-requested sandboxes

### DIFF
--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -221,6 +221,156 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
   });
 });
 
+describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
+  let authenticator: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockExecuteWithLock.mockImplementation(
+      async (_key: string, fn: () => Promise<unknown>) => fn()
+    );
+    mockGetSandboxProvider.mockReturnValue({
+      destroy: mockProviderDestroy,
+    });
+    mockProviderDestroy.mockResolvedValue(new Ok(undefined));
+    mockDeleteSandboxPolicy.mockResolvedValue(new Ok(undefined));
+    mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
+
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+  });
+
+  it.each([
+    "running",
+    "sleeping",
+    "pending_approval",
+  ] as const)("destroys at the provider and marks deleted regardless of status (%s)", async (status) => {
+    const sandbox = await SandboxFactory.create(authenticator, conversation, {
+      status,
+      killRequestedAt: new Date(),
+    });
+
+    const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
+      authenticator,
+      conversation.sId
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockProviderDestroy).toHaveBeenCalledWith(sandbox.providerId, {
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+
+    const reloaded = await SandboxResource.fetchByConversationId(
+      authenticator,
+      conversation.sId
+    );
+    expect(reloaded?.status).toBe("deleted");
+  });
+
+  it("is a no-op when killRequestedAt is not set", async () => {
+    await SandboxFactory.create(authenticator, conversation, {
+      status: "running",
+    });
+
+    const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
+      authenticator,
+      conversation.sId
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockProviderDestroy).not.toHaveBeenCalled();
+
+    const reloaded = await SandboxResource.fetchByConversationId(
+      authenticator,
+      conversation.sId
+    );
+    expect(reloaded?.status).toBe("running");
+  });
+
+  it("is a no-op when the sandbox is already deleted", async () => {
+    await SandboxFactory.create(authenticator, conversation, {
+      status: "deleted",
+      killRequestedAt: new Date(),
+    });
+
+    const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
+      authenticator,
+      conversation.sId
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockProviderDestroy).not.toHaveBeenCalled();
+  });
+});
+
+describe("SandboxResource.dangerouslyGetKillRequestedConversationIds", () => {
+  let authenticator: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+  });
+
+  it("returns rows with killRequestedAt set and status != deleted", async () => {
+    await SandboxFactory.create(authenticator, conversation, {
+      status: "running",
+      killRequestedAt: new Date(),
+    });
+
+    const rows =
+      await SandboxResource.dangerouslyGetKillRequestedConversationIds({
+        limit: 10,
+      });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.conversationId).toBe(conversation.sId);
+  });
+
+  it("skips deleted rows even when killRequestedAt is set", async () => {
+    await SandboxFactory.create(authenticator, conversation, {
+      status: "deleted",
+      killRequestedAt: new Date(),
+    });
+
+    const rows =
+      await SandboxResource.dangerouslyGetKillRequestedConversationIds({
+        limit: 10,
+      });
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it("skips rows where killRequestedAt is null", async () => {
+    await SandboxFactory.create(authenticator, conversation, {
+      status: "running",
+    });
+
+    const rows =
+      await SandboxResource.dangerouslyGetKillRequestedConversationIds({
+        limit: 10,
+      });
+
+    expect(rows).toHaveLength(0);
+  });
+});
+
 describe("SandboxResource.ensureActive", () => {
   let authenticator: Authenticator;
   let conversation: ConversationType;
@@ -382,5 +532,35 @@ describe("SandboxResource.ensureActive", () => {
     expect(persisted?.baseImage).toBe("test-image");
     expect(persisted?.version).toBe("0.0.1");
     expect(persisted?.providerId).toBe("provider-id");
+  });
+
+  it("destroys and recreates when killRequestedAt is set on the existing row", async () => {
+    const stale = await SandboxFactory.create(authenticator, conversation, {
+      status: "running",
+      baseImage: "stale-image",
+      version: "0.0.0-old",
+      killRequestedAt: new Date(),
+    });
+
+    const result = await SandboxResource.ensureActive(
+      authenticator,
+      conversation
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockProviderDestroy).toHaveBeenCalledWith(stale.providerId, {
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+    expect(mockProviderCreate).toHaveBeenCalled();
+
+    const persisted = await SandboxResource.fetchByConversationId(
+      authenticator,
+      conversation.sId
+    );
+    expect(persisted?.providerId).toBe("provider-id");
+    expect(persisted?.baseImage).toBe("test-image");
+    expect(persisted?.version).toBe("0.0.1");
+    expect(persisted?.killRequestedAt).toBeNull();
+    expect(persisted?.status).toBe("running");
   });
 });

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -65,6 +65,18 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     );
   }
 
+  private static async finalizeDestroyed(
+    sandbox: SandboxResource,
+    ctx: { workspaceId: string },
+    opts: { recordLifecycle: boolean }
+  ): Promise<void> {
+    await sandbox.updateStatus("deleted", { ctx });
+    SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
+    if (opts.recordLifecycle) {
+      recordLifecycleOperation("destroy", ctx);
+    }
+  }
+
   constructor(
     _model: ModelStatic<SandboxModel>,
     blob: Attributes<SandboxModel>
@@ -467,6 +479,9 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           tracingOpts
         );
         if (destroyResult.isErr()) {
+          // We swallow SandboxNotFoundError because it just means the sandbox was removed by the provider
+          // And we only log if failed to destroy because the sandbox will be eventually removed
+          // The most critical part is making sure we go through the "deleted" path
           if (!(destroyResult.error instanceof SandboxNotFoundError)) {
             logger.error(
               {
@@ -735,16 +750,17 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             { sandbox: sandbox.toLogJSON() },
             "Sandbox not found at provider during destroy — marking deleted."
           );
-          await sandbox.updateStatus("deleted", { ctx });
-          SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
+          await SandboxResource.finalizeDestroyed(sandbox, ctx, {
+            recordLifecycle: false,
+          });
           return new Ok(undefined);
         }
         return result;
       }
 
-      await sandbox.updateStatus("deleted", { ctx });
-      SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
-      recordLifecycleOperation("destroy", ctx);
+      await SandboxResource.finalizeDestroyed(sandbox, ctx, {
+        recordLifecycle: true,
+      });
 
       void revokeAllExecTokensForSandbox(sandbox.sId).catch((err) =>
         logger.error(
@@ -825,16 +841,17 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             { sandbox: sandbox.toLogJSON() },
             "Kill-requested sandbox not found at provider — marking deleted."
           );
-          await sandbox.updateStatus("deleted", { ctx });
-          SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
+          await SandboxResource.finalizeDestroyed(sandbox, ctx, {
+            recordLifecycle: false,
+          });
           return new Ok(undefined);
         }
         return result;
       }
 
-      await sandbox.updateStatus("deleted", { ctx });
-      SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
-      recordLifecycleOperation("destroy", ctx);
+      await SandboxResource.finalizeDestroyed(sandbox, ctx, {
+        recordLifecycle: true,
+      });
 
       void revokeAllExecTokensForSandbox(sandbox.sId).catch((err) =>
         logger.error(

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -450,11 +450,39 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         return new Ok({ sandbox, freshlyCreated: true, wokeFromSleep: false });
       }
 
-      const { status } = existing;
+      let effectiveStatus: SandboxStatus = existing.status;
       let freshlyCreated = false;
       let wokeFromSleep = false;
 
-      switch (status) {
+      // If a kill was requested, destroy the existing sandbox at the provider
+      // (best-effort) and fall through to recreation. This races with the
+      // reaper's killRequested phase; the lifecycle lock keeps it serialised.
+      if (existing.killRequestedAt && existing.status !== "deleted") {
+        logger.info(
+          { sandbox: existing.toLogJSON() },
+          "Sandbox has killRequestedAt — destroying and recreating."
+        );
+        const destroyResult = await provider.destroy(
+          existing.providerId,
+          tracingOpts
+        );
+        if (destroyResult.isErr()) {
+          if (!(destroyResult.error instanceof SandboxNotFoundError)) {
+            logger.error(
+              {
+                sandbox: existing.toLogJSON(),
+                error: destroyResult.error.message,
+              },
+              "Failed to destroy kill-requested sandbox at provider — proceeding with recreation."
+            );
+          }
+        } else {
+          SandboxResource.deleteEgressPolicyAfterDestroy(existing);
+        }
+        effectiveStatus = "deleted";
+      }
+
+      switch (effectiveStatus) {
         case "running":
           break;
 
@@ -531,6 +559,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             providerId: createResult.value.providerId,
             baseImage: createConfig.imageId.imageName,
             version: createConfig.imageId.tag,
+            killRequestedAt: null,
           });
           freshlyCreated = true;
 
@@ -558,7 +587,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         }
 
         default:
-          assertNever(status);
+          assertNever(effectiveStatus);
       }
 
       await existing.updateStatus("running", { ctx });
@@ -730,6 +759,99 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }
 
   /**
+   * Return conversation sIds for sandboxes with `killRequestedAt` set and not
+   * yet deleted. The kill-requester workflow marks rows; the reaper (and the
+   * bash path) is responsible for actually destroying them.
+   *
+   * WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
+   */
+  static async dangerouslyGetKillRequestedConversationIds(opts: {
+    limit: number;
+  }): Promise<Array<{ conversationId: string; workspaceModelId: ModelId }>> {
+    const rows = await this.model.findAll({
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+      where: {
+        killRequestedAt: { [Op.ne]: null },
+        status: { [Op.ne]: "deleted" },
+      },
+      include: [
+        {
+          model: ConversationModel,
+          attributes: ["sId", "workspaceId"],
+          required: true,
+        },
+      ],
+      order: [["killRequestedAt", "ASC"]],
+      limit: opts.limit,
+    });
+
+    return rows.map((r) => ({
+      conversationId: r.conversation.sId,
+      workspaceModelId: r.conversation.workspaceId,
+    }));
+  }
+
+  /**
+   * Destroy a sandbox that has a kill request set, regardless of its current
+   * status. Acquires the lifecycle lock, re-fetches the sandbox, and only
+   * destroys if it is non-deleted and still has `killRequestedAt`. Treats
+   * `SandboxNotFoundError` as success.
+   *
+   * WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
+   */
+  static async dangerouslyDestroyIfKillRequested(
+    auth: Authenticator,
+    conversationId: string
+  ): Promise<Result<void, Error>> {
+    return this.withLifecycleLock(conversationId, async (provider) => {
+      const sandbox =
+        await SandboxResource.dangerouslyFetchByConversationId(conversationId);
+      if (
+        !sandbox ||
+        sandbox.status === "deleted" ||
+        !sandbox.killRequestedAt
+      ) {
+        return new Ok(undefined);
+      }
+
+      const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
+      const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
+
+      const result = await provider.destroy(sandbox.providerId, tracingOpts);
+      if (result.isErr()) {
+        if (result.error instanceof SandboxNotFoundError) {
+          logger.info(
+            { sandbox: sandbox.toLogJSON() },
+            "Kill-requested sandbox not found at provider — marking deleted."
+          );
+          await sandbox.updateStatus("deleted", { ctx });
+          SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
+          return new Ok(undefined);
+        }
+        return result;
+      }
+
+      await sandbox.updateStatus("deleted", { ctx });
+      SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
+      recordLifecycleOperation("destroy", ctx);
+
+      void revokeAllExecTokensForSandbox(sandbox.sId).catch((err) =>
+        logger.error(
+          { error: err },
+          "Failed to revoke exec tokens on kill-requested sandbox destroy"
+        )
+      );
+
+      logger.info(
+        { sandbox: sandbox.toLogJSON() },
+        "Kill-requested sandbox destroyed."
+      );
+      return new Ok(undefined);
+    });
+  }
+
+  /**
    * Execute a command in this sandbox.
    */
   async exec(
@@ -867,6 +989,9 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       providerId: this.providerId,
       status: this.status,
       lastActivityAt: this.lastActivityAt.toISOString(),
+      baseImage: this.baseImage,
+      version: this.version,
+      killRequestedAt: this.killRequestedAt?.toISOString() ?? null,
     };
   }
 }

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -38,6 +38,53 @@ async function fetchWorkspaceMap(
  * returned a full batch, signalling the workflow to loop for more.
  */
 export async function reapStaleSandboxesActivity(): Promise<boolean> {
+  // Phase 0: Destroy sandboxes flagged with killRequestedAt. These bypass the
+  // sleep→destroy cycle and are reaped immediately regardless of status/age.
+  const killRequestedConversations =
+    await SandboxResource.dangerouslyGetKillRequestedConversationIds({
+      limit: BATCH_SIZE,
+    });
+
+  if (killRequestedConversations.length > 0) {
+    logger.info(
+      { count: killRequestedConversations.length },
+      "Reaper: kill-requested sandboxes found."
+    );
+
+    const workspaceMap = await fetchWorkspaceMap(killRequestedConversations);
+
+    await concurrentExecutor(
+      killRequestedConversations,
+      async ({ conversationId, workspaceModelId }) => {
+        const workspace = workspaceMap.get(workspaceModelId);
+
+        if (!workspace) {
+          logger.warn(
+            { conversationId, workspaceModelId },
+            "Workspace not found, skipping"
+          );
+          return;
+        }
+
+        const auth = await Authenticator.internalBuilderForWorkspace(
+          workspace.sId
+        );
+        const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
+          auth,
+          conversationId
+        );
+        if (result.isErr()) {
+          logger.error(
+            { conversationId, error: result.error.message },
+            "Reaper: failed to destroy kill-requested sandbox — continuing."
+          );
+        }
+        heartbeat();
+      },
+      { concurrency: REAPER_CONCURRENCY }
+    );
+  }
+
   // Phase 1: Sleep running sandboxes that have been idle > SLEEP_THRESHOLD_MS.
   const runningConversations =
     await SandboxResource.dangerouslyGetStaleConversationIds({
@@ -201,6 +248,7 @@ export async function reapStaleSandboxesActivity(): Promise<boolean> {
   }
 
   return (
+    killRequestedConversations.length >= BATCH_SIZE ||
     runningConversations.length >= BATCH_SIZE ||
     pendingConversations.length >= BATCH_SIZE ||
     sleepingConversations.length >= BATCH_SIZE

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -13,6 +13,7 @@ export class SandboxFactory {
       statusChangedAt?: Date | null;
       baseImage?: string;
       version?: string;
+      killRequestedAt?: Date | null;
     }
   ): Promise<SandboxResource> {
     const sandbox = await SandboxResource.makeNew(auth, {
@@ -26,6 +27,13 @@ export class SandboxFactory {
     if (opts?.statusChangedAt !== undefined) {
       await SandboxModel.update(
         { statusChangedAt: opts.statusChangedAt } as Partial<SandboxModel>,
+        { where: { id: sandbox.id } }
+      );
+    }
+
+    if (opts?.killRequestedAt !== undefined) {
+      await SandboxModel.update(
+        { killRequestedAt: opts.killRequestedAt } as Partial<SandboxModel>,
         { where: { id: sandbox.id } }
       );
     }


### PR DESCRIPTION
## Description

See https://github.com/dust-tt/dust/pull/25587 for more context

This PR adds the codepaths to delete a sandbox when killRequestedAt is not null.
Until the next PR is merged, this is dead code.

## Tests

Unit tests


## Risk

Low

## Deploy Plan

- Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25588">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->