### PR TITLE
[front] enh: sandbox - add kill-requester Temporal workflow

### DIFF
--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -52,6 +52,7 @@ vi.mock("@app/lib/lock", () => ({
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
 import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -368,6 +369,141 @@ describe("SandboxResource.dangerouslyGetKillRequestedConversationIds", () => {
       });
 
     expect(rows).toHaveLength(0);
+  });
+});
+
+describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
+  let authenticator: Authenticator;
+  let agentConfigSId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const testSetup = await createResourceTest({ role: "admin" });
+    authenticator = testSetup.authenticator;
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    agentConfigSId = agentConfig.sId;
+  });
+
+  async function makeConversation(): Promise<ConversationType> {
+    return ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfigSId,
+      messagesCreatedAt: [new Date()],
+    });
+  }
+
+  it("marks matching baseImage rows when no version is given", async () => {
+    const c1 = await makeConversation();
+    const c2 = await makeConversation();
+    const other = await makeConversation();
+
+    await SandboxFactory.create(authenticator, c1, {
+      baseImage: "dust-base",
+      version: "1.0.0",
+    });
+    await SandboxFactory.create(authenticator, c2, {
+      baseImage: "dust-base",
+      version: "2.0.0",
+    });
+    await SandboxFactory.create(authenticator, other, {
+      baseImage: "other-image",
+      version: "1.0.0",
+    });
+
+    const affected = await SandboxResource.dangerouslyRequestKillForBaseImage({
+      baseImage: "dust-base",
+      limit: 10,
+    });
+
+    expect(affected).toBe(2);
+    const stillUnmarked = await SandboxResource.fetchByConversationId(
+      authenticator,
+      other.sId
+    );
+    expect(stillUnmarked?.killRequestedAt).toBeNull();
+  });
+
+  it("with version, marks only rows whose version differs (incl. null)", async () => {
+    const cMatch = await makeConversation();
+    const cDifferent = await makeConversation();
+    const cNullVersion = await makeConversation();
+
+    await SandboxFactory.create(authenticator, cMatch, {
+      baseImage: "dust-base",
+      version: "2.0.0",
+    });
+    await SandboxFactory.create(authenticator, cDifferent, {
+      baseImage: "dust-base",
+      version: "1.0.0",
+    });
+    const nullVersionSandbox = await SandboxFactory.create(
+      authenticator,
+      cNullVersion,
+      { baseImage: "dust-base", version: "0.0.0-test" }
+    );
+    await SandboxModel.update(
+      { version: null },
+      { where: { id: nullVersionSandbox.id } }
+    );
+
+    const affected = await SandboxResource.dangerouslyRequestKillForBaseImage({
+      baseImage: "dust-base",
+      version: "2.0.0",
+      limit: 10,
+    });
+
+    expect(affected).toBe(2);
+    const matched = await SandboxResource.fetchByConversationId(
+      authenticator,
+      cMatch.sId
+    );
+    expect(matched?.killRequestedAt).toBeNull();
+  });
+
+  it("skips deleted rows and rows already marked", async () => {
+    const cDeleted = await makeConversation();
+    const cAlreadyMarked = await makeConversation();
+    const cFresh = await makeConversation();
+
+    await SandboxFactory.create(authenticator, cDeleted, {
+      baseImage: "dust-base",
+      status: "deleted",
+    });
+    await SandboxFactory.create(authenticator, cAlreadyMarked, {
+      baseImage: "dust-base",
+      killRequestedAt: new Date("2020-01-01"),
+    });
+    await SandboxFactory.create(authenticator, cFresh, {
+      baseImage: "dust-base",
+    });
+
+    const affected = await SandboxResource.dangerouslyRequestKillForBaseImage({
+      baseImage: "dust-base",
+      limit: 10,
+    });
+
+    expect(affected).toBe(1);
+    const alreadyMarked = await SandboxResource.fetchByConversationId(
+      authenticator,
+      cAlreadyMarked.sId
+    );
+    expect(alreadyMarked?.killRequestedAt?.toISOString()).toBe(
+      new Date("2020-01-01").toISOString()
+    );
+  });
+
+  it("respects the limit", async () => {
+    for (let i = 0; i < 3; i++) {
+      const c = await makeConversation();
+      await SandboxFactory.create(authenticator, c, { baseImage: "dust-base" });
+    }
+
+    const affected = await SandboxResource.dangerouslyRequestKillForBaseImage({
+      baseImage: "dust-base",
+      limit: 2,
+    });
+
+    expect(affected).toBe(2);
   });
 });
 

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -775,6 +775,59 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }
 
   /**
+   * Mark up to `limit` non-deleted sandboxes for the given `baseImage` (and,
+   * when `version` is set, any version different from it) with
+   * `killRequestedAt = now()`. Rows already marked are skipped. Returns the
+   * count of rows updated.
+   *
+   * WORKSPACE_ISOLATION_BYPASS: image rollouts span all workspaces.
+   */
+  static async dangerouslyRequestKillForBaseImage(opts: {
+    baseImage: string;
+    version?: string;
+    limit: number;
+  }): Promise<number> {
+    const versionClause =
+      opts.version !== undefined
+        ? {
+            [Op.or]: [
+              { version: { [Op.is]: null } },
+              { version: { [Op.ne]: opts.version } },
+            ],
+          }
+        : {};
+
+    const candidates = await this.model.findAll({
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+      attributes: ["id"],
+      where: {
+        baseImage: opts.baseImage,
+        status: { [Op.ne]: "deleted" },
+        killRequestedAt: { [Op.is]: null },
+        ...versionClause,
+      },
+      limit: opts.limit,
+    });
+
+    if (candidates.length === 0) {
+      return 0;
+    }
+
+    const ids = candidates.map((c) => c.id);
+    const [affectedCount] = await this.model.update(
+      { killRequestedAt: new Date() },
+      {
+        where: {
+          id: { [Op.in]: ids },
+          killRequestedAt: { [Op.is]: null },
+        },
+      }
+    );
+    return affectedCount;
+  }
+
+  /**
    * Return conversation sIds for sandboxes with `killRequestedAt` set and not
    * yet deleted. The kill-requester workflow marks rows; the reaper (and the
    * bash path) is responsible for actually destroying them.

--- a/front/temporal/sandbox_reaper/kill_requester/activities.test.ts
+++ b/front/temporal/sandbox_reaper/kill_requester/activities.test.ts
@@ -1,0 +1,61 @@
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { requestSandboxKillsActivity } from "@app/temporal/sandbox_reaper/kill_requester/activities";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@temporalio/activity", () => ({
+  Context: {
+    current: vi.fn(() => ({
+      heartbeat: vi.fn(),
+      info: { attempt: 1 },
+      cancellationSignal: { aborted: false },
+    })),
+  },
+}));
+
+describe("requestSandboxKillsActivity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks matching rows and reports the count", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agentConfig =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const [c1, c2] = await Promise.all([
+      ConversationFactory.create(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [new Date()],
+      }),
+      ConversationFactory.create(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [new Date()],
+      }),
+    ]);
+
+    await SandboxFactory.create(authenticator, c1, {
+      baseImage: "dust-base",
+      version: "1.0.0",
+    });
+    await SandboxFactory.create(authenticator, c2, {
+      baseImage: "dust-base",
+      version: "2.0.0",
+    });
+
+    const count = await requestSandboxKillsActivity({
+      baseImage: "dust-base",
+      version: "2.0.0",
+    });
+
+    expect(count).toBe(1);
+    const marked = await SandboxResource.fetchByConversationId(
+      authenticator,
+      c1.sId
+    );
+    expect(marked?.killRequestedAt).not.toBeNull();
+  });
+});

--- a/front/temporal/sandbox_reaper/kill_requester/activities.test.ts
+++ b/front/temporal/sandbox_reaper/kill_requester/activities.test.ts
@@ -1,9 +1,9 @@
-import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { requestSandboxKillsActivity } from "@app/temporal/sandbox_reaper/kill_requester/activities";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@temporalio/activity", () => ({
@@ -46,12 +46,12 @@ describe("requestSandboxKillsActivity", () => {
       version: "2.0.0",
     });
 
-    const count = await requestSandboxKillsActivity({
+    const hasMore = await requestSandboxKillsActivity({
       baseImage: "dust-base",
       version: "2.0.0",
     });
 
-    expect(count).toBe(1);
+    expect(hasMore).toBe(false);
     const marked = await SandboxResource.fetchByConversationId(
       authenticator,
       c1.sId

--- a/front/temporal/sandbox_reaper/kill_requester/activities.ts
+++ b/front/temporal/sandbox_reaper/kill_requester/activities.ts
@@ -1,0 +1,35 @@
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import { BATCH_SIZE } from "@app/temporal/sandbox_reaper/config";
+
+interface RequestSandboxKillsActivityInput {
+  baseImage: string;
+  version?: string;
+}
+
+/**
+ * Mark up to `BATCH_SIZE` non-deleted sandboxes for the given `baseImage` (and
+ * any version different from `version`, if provided) with `killRequestedAt =
+ * now()`. Returns the count of rows updated.
+ *
+ * Already-marked rows (`killRequestedAt IS NOT NULL`) are skipped — re-runs
+ * won't push the timestamp forward.
+ */
+export async function requestSandboxKillsActivity({
+  baseImage,
+  version,
+}: RequestSandboxKillsActivityInput): Promise<number> {
+  const affectedCount =
+    await SandboxResource.dangerouslyRequestKillForBaseImage({
+      baseImage,
+      version,
+      limit: BATCH_SIZE,
+    });
+
+  logger.info(
+    { baseImage, version, affectedCount },
+    "Kill-requester: marked sandboxes."
+  );
+
+  return affectedCount;
+}

--- a/front/temporal/sandbox_reaper/kill_requester/activities.ts
+++ b/front/temporal/sandbox_reaper/kill_requester/activities.ts
@@ -10,7 +10,7 @@ interface RequestSandboxKillsActivityInput {
 /**
  * Mark up to `BATCH_SIZE` non-deleted sandboxes for the given `baseImage` (and
  * any version different from `version`, if provided) with `killRequestedAt =
- * now()`. Returns the count of rows updated.
+ * now()`. Returns whether more rows likely remain (i.e. the batch was full).
  *
  * Already-marked rows (`killRequestedAt IS NOT NULL`) are skipped — re-runs
  * won't push the timestamp forward.
@@ -18,7 +18,7 @@ interface RequestSandboxKillsActivityInput {
 export async function requestSandboxKillsActivity({
   baseImage,
   version,
-}: RequestSandboxKillsActivityInput): Promise<number> {
+}: RequestSandboxKillsActivityInput): Promise<boolean> {
   const affectedCount =
     await SandboxResource.dangerouslyRequestKillForBaseImage({
       baseImage,
@@ -31,5 +31,5 @@ export async function requestSandboxKillsActivity({
     "Kill-requester: marked sandboxes."
   );
 
-  return affectedCount;
+  return affectedCount === BATCH_SIZE;
 }

--- a/front/temporal/sandbox_reaper/kill_requester/client.ts
+++ b/front/temporal/sandbox_reaper/kill_requester/client.ts
@@ -1,0 +1,41 @@
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { QUEUE_NAME } from "@app/temporal/sandbox_reaper/config";
+import { sandboxKillRequesterWorkflow } from "@app/temporal/sandbox_reaper/kill_requester/workflows";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+interface LaunchSandboxKillRequesterWorkflowInput {
+  baseImage: string;
+  version?: string;
+}
+
+export async function launchSandboxKillRequesterWorkflow({
+  baseImage,
+  version,
+}: LaunchSandboxKillRequesterWorkflowInput): Promise<
+  Result<{ workflowId: string }, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = `sandbox-kill-requester-${baseImage}-${
+    version ?? "all"
+  }-${Date.now()}`;
+
+  try {
+    await client.workflow.start(sandboxKillRequesterWorkflow, {
+      args: [{ baseImage, version }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: { baseImage, version: version ?? "all" },
+    });
+  } catch (err) {
+    logger.error(
+      { workflowId, baseImage, version, error: err },
+      "Failed to start sandbox kill requester workflow."
+    );
+    return new Err(normalizeError(err));
+  }
+
+  return new Ok({ workflowId });
+}

--- a/front/temporal/sandbox_reaper/kill_requester/workflows.ts
+++ b/front/temporal/sandbox_reaper/kill_requester/workflows.ts
@@ -1,0 +1,32 @@
+import type * as activities from "@app/temporal/sandbox_reaper/kill_requester/activities";
+import { proxyActivities } from "@temporalio/workflow";
+
+const { requestSandboxKillsActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+  retry: {
+    maximumAttempts: 3,
+  },
+});
+
+interface SandboxKillRequesterWorkflowInput {
+  baseImage: string;
+  version?: string;
+}
+
+export async function sandboxKillRequesterWorkflow({
+  baseImage,
+  version,
+}: SandboxKillRequesterWorkflowInput): Promise<{ updatedCount: number }> {
+  let updatedCount = 0;
+  // Loop until the activity reports an empty batch, signalling all matching
+  // rows have been marked.
+  for (;;) {
+    const affected = await requestSandboxKillsActivity({ baseImage, version });
+    updatedCount += affected;
+    if (affected === 0) {
+      break;
+    }
+  }
+
+  return { updatedCount };
+}

--- a/front/temporal/sandbox_reaper/kill_requester/workflows.ts
+++ b/front/temporal/sandbox_reaper/kill_requester/workflows.ts
@@ -16,17 +16,9 @@ interface SandboxKillRequesterWorkflowInput {
 export async function sandboxKillRequesterWorkflow({
   baseImage,
   version,
-}: SandboxKillRequesterWorkflowInput): Promise<{ updatedCount: number }> {
-  let updatedCount = 0;
-  // Loop until the activity reports an empty batch, signalling all matching
-  // rows have been marked.
-  for (;;) {
-    const affected = await requestSandboxKillsActivity({ baseImage, version });
-    updatedCount += affected;
-    if (affected === 0) {
-      break;
-    }
+}: SandboxKillRequesterWorkflowInput): Promise<void> {
+  let hasMore = true;
+  while (hasMore) {
+    hasMore = await requestSandboxKillsActivity({ baseImage, version });
   }
-
-  return { updatedCount };
 }

--- a/front/temporal/sandbox_reaper/worker.ts
+++ b/front/temporal/sandbox_reaper/worker.ts
@@ -5,8 +5,9 @@ import {
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
-import * as activities from "@app/temporal/sandbox_reaper/activities";
+import * as reaperActivities from "@app/temporal/sandbox_reaper/activities";
 import { launchSandboxReaperSchedule } from "@app/temporal/sandbox_reaper/client";
+import * as killRequesterActivities from "@app/temporal/sandbox_reaper/kill_requester/activities";
 import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
@@ -19,7 +20,7 @@ export async function runSandboxReaperWorker() {
       workerName: "sandbox_reaper",
       getWorkflowsPath: () => require.resolve("./workflows"),
     }),
-    activities,
+    activities: { ...reaperActivities, ...killRequesterActivities },
     taskQueue: QUEUE_NAME,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     connection,

--- a/front/temporal/sandbox_reaper/workflows.ts
+++ b/front/temporal/sandbox_reaper/workflows.ts
@@ -15,3 +15,5 @@ export async function sandboxReaperWorkflow(): Promise<void> {
     hasMore = await reapStaleSandboxesActivity();
   }
 }
+
+export { sandboxKillRequesterWorkflow } from "@app/temporal/sandbox_reaper/kill_requester/workflows";


### PR DESCRIPTION
## Description

See https://github.com/dust-tt/dust/pull/25587 for more context

This PR adds the temporal workflow + sandbox resource code to mark as killRequested sandboxes that do NOT match the version passed as a parameter but match the base image name.

## Tests

- Unit tests


## Risk

Low

## Deploy Plan

- Deploy front
- Run backfill

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25589">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->