### PR TITLE
[front] fix: guard extractDataSourceIds against external MCP table shapes

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -23,6 +23,7 @@ import {
 } from "@app/types/assistant/agent_run";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
 import {
   startActiveObservation,
   updateActiveObservation,
@@ -44,7 +45,7 @@ function extractDataSourceIds(
   const ds = inputs.dataSources;
   const tables = inputs.tables;
   const lastUriSegment = (v: unknown): string | undefined =>
-    typeof v === "string" ? v.split("/").pop() : undefined;
+    isString(v) ? v.split("/").pop() : undefined;
   if (Array.isArray(ds) && ds.length > 0) {
     result.accessed_data_source_ids = ds
       .map((d: { uri?: unknown }) => lastUriSegment(d.uri) ?? "")
@@ -58,7 +59,7 @@ function extractDataSourceIds(
         if (segment) {
           return segment;
         }
-        return typeof t.tableId === "string" ? t.tableId : "";
+        return isString(t.tableId) ? t.tableId : "";
       })
       .filter(Boolean)
       .join(",");

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -33,22 +33,34 @@ import assert from "assert";
 const CONVERSATION_CACHE_TTL_MS = 5000;
 
 // Extracts sIds of accessed datasources/tables from tool augmentedInputs.
-// All datasource-accessing tools use a standard `dataSources` or `tables` array
-// of { uri } objects whose last path segment is the configuration sId.
+// Dust-internal MCP servers receive { uri } objects whose last path segment is
+// the configuration sId. External MCP servers (e.g. Airtable) bypass that
+// augmentation and may send entries like { tableId, fieldIds } with no uri, so
+// uri access must be guarded and we fall back to tableId when available.
 function extractDataSourceIds(
   inputs: Record<string, unknown>
 ): Record<string, string> {
   const result: Record<string, string> = {};
   const ds = inputs.dataSources;
   const tables = inputs.tables;
+  const lastUriSegment = (v: unknown): string | undefined =>
+    typeof v === "string" ? v.split("/").pop() : undefined;
   if (Array.isArray(ds) && ds.length > 0) {
     result.accessed_data_source_ids = ds
-      .map((d: { uri: string }) => d.uri.split("/").pop() ?? "")
+      .map((d: { uri?: unknown }) => lastUriSegment(d.uri) ?? "")
+      .filter(Boolean)
       .join(",");
   }
   if (Array.isArray(tables) && tables.length > 0) {
     result.accessed_table_ids = tables
-      .map((t: { uri: string }) => t.uri.split("/").pop() ?? "")
+      .map((t: { uri?: unknown; tableId?: unknown }) => {
+        const segment = lastUriSegment(t.uri);
+        if (segment) {
+          return segment;
+        }
+        return typeof t.tableId === "string" ? t.tableId : "";
+      })
+      .filter(Boolean)
       .join(",");
   }
   return result;


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/8046#event-25489048539
## Description
External MCP servers (e.g. Airtable) send tables/dataSources entries without a uri field, so extractDataSourceIds crashed the tool.executed audit emit and killed the Temporal activity (issue #8046). Guard uri access, fall back to tableId when present, and require both to be strings before use.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Will verify the issue no longer occurs post-merge
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25593">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->