### PR TITLE
Add support for the public spaces API in Hono

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 
 import { cors } from "./middleware/cors";
 import { healthzApp } from "./routes/healthz";
+import { publicWorkspaceApp } from "./routes/v1/w";
 import { workspaceApp } from "./routes/w";
 
 // Single source of truth for which routes are served natively by Hono.
@@ -19,6 +20,7 @@ interface HonoRoute {
 const HONO_ROUTES: HonoRoute[] = [
   { pattern: "/api/healthz", methods: ["GET"] },
   { pattern: "/api/w/:wId/spaces", methods: ["GET", "POST"] },
+  { pattern: "/api/v1/w/:wId/spaces", methods: ["GET"] },
 ];
 
 const HONO_ROUTE_REGEXES = HONO_ROUTES.map((r) => {
@@ -33,6 +35,7 @@ const HONO_ROUTE_REGEXES = HONO_ROUTES.map((r) => {
 const apiApp = new Hono();
 apiApp.route("/healthz", healthzApp);
 apiApp.route("/w/:wId", workspaceApp);
+apiApp.route("/v1/w/:wId", publicWorkspaceApp);
 
 export const honoApp = new Hono();
 honoApp.use("*", cors);

--- a/front-api/middleware/public_api_auth.ts
+++ b/front-api/middleware/public_api_auth.ts
@@ -1,0 +1,287 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { NextApiRequest } from "next";
+
+import { verifySandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
+import {
+  Authenticator,
+  getAPIKey,
+  getApiKeyNameFromHeaders,
+  getSessionFromBearerToken,
+  isSandboxTokenPrefix,
+} from "@app/lib/auth";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { getClientIp } from "@app/lib/utils/request";
+import type { APIErrorWithStatusCode } from "@app/types/error";
+import { getGroupIdsFromHeaders, getRoleFromHeaders } from "@app/types/groups";
+import { getUserEmailFromHeaders } from "@app/types/user";
+
+// Bridge Hono Context to the minimal NextApiRequest shape used by the existing
+// auth helpers. The public API only needs headers + socket (no cookies).
+function buildNextLikeReq(c: Context): NextApiRequest {
+  const headers: Record<string, string> = {};
+  c.req.raw.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  const req = {
+    cookies: {},
+    headers,
+    query: {},
+    socket: { remoteAddress: undefined },
+    method: c.req.method,
+    url: c.req.url,
+  };
+  return req as unknown as NextApiRequest;
+}
+
+function validateWorkspaceFromAuth(
+  auth: Authenticator
+): APIErrorWithStatusCode | null {
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  if (!owner || !plan) {
+    return {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    };
+  }
+  if (!plan.limits.canUseProduct) {
+    return {
+      status_code: 403,
+      api_error: {
+        type: "workspace_can_use_product_required_error",
+        message:
+          "Your current plan does not allow API access. Please upgrade your plan.",
+      },
+    };
+  }
+  const maintenance = owner.metadata?.maintenance;
+  if (maintenance) {
+    if (maintenance === "relocation-done") {
+      return {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: `The workspace was not found. [${maintenance}]`,
+        },
+      };
+    }
+    return {
+      status_code: 503,
+      api_error: {
+        type: "service_unavailable",
+        message: `Service is currently unavailable. [${maintenance}]`,
+      },
+    };
+  }
+  if (
+    WorkspaceResource.isWorkspaceKillSwitchedForAllAPIs(
+      owner.metadata?.killSwitched
+    )
+  ) {
+    return {
+      status_code: 503,
+      api_error: {
+        type: "service_unavailable",
+        message:
+          "Access to this workspace has been disabled for emergency maintenance.",
+      },
+    };
+  }
+  return null;
+}
+
+// APIErrorWithStatusCode.status_code is typed as `number`, but Hono's c.json
+// expects the narrower ContentfulStatusCode. The cast is safe because all our
+// status codes are valid HTTP error codes.
+function jsonApiError(c: Context, err: APIErrorWithStatusCode) {
+  return c.json(
+    { error: err.api_error },
+    err.status_code as ContentfulStatusCode
+  );
+}
+
+function applyClientIp(auth: Authenticator, req: NextApiRequest): void {
+  const ip = getClientIp(req);
+  if (ip !== "internal") {
+    auth.setClientIp(ip);
+  }
+}
+
+/**
+ * Authenticates a public-API request (Authorization header required:
+ * sandbox token, OAuth bearer, or API key) and stashes the resolved
+ * `Authenticator` on the Hono context under `auth`. Mirrors
+ * `withPublicAPIAuthentication` in `front/lib/api/auth_wrappers.ts`.
+ *
+ * The `allowSystemKeyBypassBuilderCheck` option from the original wrapper is
+ * not yet ported — it is only used by `run_dust_app`, and we'll add it as a
+ * factory variant when we migrate that endpoint.
+ */
+export const publicApiAuth: MiddlewareHandler = async (c, next) => {
+  const wId = c.req.param("wId");
+  if (!wId) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_not_found",
+          message: "The workspace was not found.",
+        },
+      },
+      404
+    );
+  }
+
+  const authHeader = c.req.header("authorization");
+  if (!authHeader) {
+    return c.json(
+      {
+        error: {
+          type: "not_authenticated",
+          message:
+            "The request does not have valid authentication credentials.",
+        },
+      },
+      401
+    );
+  }
+
+  const req = buildNextLikeReq(c);
+
+  // 1) Sandbox token.
+  const token = authHeader.replace("Bearer ", "");
+  if (token && isSandboxTokenPrefix(token)) {
+    const payload = await verifySandboxExecToken(token);
+    if (!payload) {
+      return c.json(
+        {
+          error: {
+            type: "invalid_sandbox_token_error",
+            message: "The sandbox token is invalid or expired.",
+          },
+        },
+        401
+      );
+    }
+    const authRes = await Authenticator.fromSandboxToken(payload, wId);
+    if (authRes.isErr()) {
+      return jsonApiError(c, authRes.error);
+    }
+    const auth = authRes.value;
+    applyClientIp(auth, req);
+    c.set("auth", auth);
+    await next();
+    return;
+  }
+
+  // 2) OAuth bearer token (resolves to a workspace user session).
+  const bearerRes = await getSessionFromBearerToken(req);
+  if (bearerRes.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: bearerRes.error,
+          message:
+            "The request does not have valid authentication credentials.",
+        },
+      },
+      401
+    );
+  }
+  const session = bearerRes.value;
+  if (session?.authenticationMethod === "bearer") {
+    const auth = await Authenticator.fromSession(session, wId);
+
+    if (auth.user() === null) {
+      return c.json(
+        {
+          error: {
+            type: "user_not_found",
+            message:
+              "The user does not have an active session or is not authenticated.",
+          },
+        },
+        401
+      );
+    }
+    if (!auth.isUser()) {
+      return c.json(
+        {
+          error: {
+            type: "workspace_auth_error",
+            message: "Only users of the workspace can access this content.",
+          },
+        },
+        401
+      );
+    }
+    const workspaceError = validateWorkspaceFromAuth(auth);
+    if (workspaceError) {
+      return jsonApiError(c, workspaceError);
+    }
+    applyClientIp(auth, req);
+    c.set("auth", auth);
+    await next();
+    return;
+  }
+
+  // 3) API key.
+  const keyRes = await getAPIKey(req);
+  if (keyRes.isErr()) {
+    return jsonApiError(c, keyRes.error);
+  }
+
+  const keyAndWorkspaceAuth = await Authenticator.fromKey(
+    keyRes.value,
+    wId,
+    getGroupIdsFromHeaders(req.headers),
+    getRoleFromHeaders(req.headers)
+  );
+  let { workspaceAuth } = keyAndWorkspaceAuth;
+
+  const workspaceError = validateWorkspaceFromAuth(workspaceAuth);
+  if (workspaceError) {
+    return jsonApiError(c, workspaceError);
+  }
+
+  if (!workspaceAuth.isUser()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only users of the workspace can access this content.",
+        },
+      },
+      401
+    );
+  }
+
+  // x-api-user-email: system-key-only impersonation.
+  const userEmailFromHeader = getUserEmailFromHeaders(req.headers);
+  if (userEmailFromHeader) {
+    workspaceAuth =
+      (await workspaceAuth.exchangeSystemKeyForUserAuthByEmail(workspaceAuth, {
+        userEmail: userEmailFromHeader,
+      })) ?? workspaceAuth;
+  }
+
+  // x-api-key-name: system-key-only key name override (for analytics).
+  const apiKeyNameFromHeader = getApiKeyNameFromHeaders(req.headers);
+  const key = workspaceAuth.key();
+  if (apiKeyNameFromHeader && key && key.isSystem) {
+    workspaceAuth = workspaceAuth.exchangeKey({
+      id: key.id,
+      name: apiKeyNameFromHeader,
+      isSystem: key.isSystem,
+      role: key.role,
+      monthlyCapMicroUsd: key.monthlyCapMicroUsd,
+    });
+  }
+
+  applyClientIp(workspaceAuth, req);
+  c.set("auth", workspaceAuth);
+  await next();
+};

--- a/front-api/package.json
+++ b/front-api/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "tsx ./server.ts",
-    "start": "NODE_ENV=production tsx ./server.ts"
+    "start": "NODE_ENV=production tsx ./server.ts",
+    "tsgo": "tsgo"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.10",

--- a/front-api/routes/v1/w/index.ts
+++ b/front-api/routes/v1/w/index.ts
@@ -1,0 +1,13 @@
+import { Hono } from "hono";
+
+import { publicApiAuth } from "../../../middleware/public_api_auth";
+import { publicSpacesApp } from "./spaces";
+
+// Mounted at /api/v1/w/:wId. Every route below inherits publicApiAuth, which
+// resolves the Authenticator from sandbox token, OAuth bearer, or API key
+// and stashes it on the context.
+export const publicWorkspaceApp = new Hono();
+
+publicWorkspaceApp.use("*", publicApiAuth);
+
+publicWorkspaceApp.route("/spaces", publicSpacesApp);

--- a/front-api/routes/v1/w/spaces.ts
+++ b/front-api/routes/v1/w/spaces.ts
@@ -1,0 +1,24 @@
+import { Hono } from "hono";
+
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceType } from "@app/types/space";
+
+export type GetPublicSpacesResponseBody = {
+  spaces: SpaceType[];
+};
+
+export const publicSpacesApp = new Hono();
+
+// Mounted under /api/v1/w/:wId/spaces. publicApiAuth is applied by the parent
+// v1 workspace sub-app, so c.get("auth") is always available here.
+publicSpacesApp.get("/", async (c) => {
+  const auth = c.get("auth");
+
+  const allSpaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
+  const spaces = allSpaces.filter((space) => space.kind !== "conversations");
+
+  const body: GetPublicSpacesResponseBody = {
+    spaces: spaces.map((space) => space.toJSON()),
+  };
+  return c.json(body);
+});

--- a/front-api/tsconfig.json
+++ b/front-api/tsconfig.json
@@ -5,5 +5,5 @@
       "@app/*": ["../front/*"]
     }
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "../front/global.d.ts"]
 }


### PR DESCRIPTION
## Description

Adds the public `GET /api/v1/w/:wId/spaces` endpoint to the Hono strangler, along with the auth middleware needed to serve any public API route from Hono going forward. The Next.js handler is left in place — `isHonoRoute`
diverts only this exact path/method to Hono.

## Tests

Manual call to v1 API.

## Risk

None to Prod

## Deploy Plan

None