### PR TITLE
Remove some NextApiRequest references from Hono middleware

### DIFF
--- a/front-api/middleware/public_api_auth.ts
+++ b/front-api/middleware/public_api_auth.ts
@@ -1,6 +1,5 @@
 import type { Context, MiddlewareHandler } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import type { NextApiRequest } from "next";
 
 import { verifySandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
 import {
@@ -16,22 +15,14 @@ import type { APIErrorWithStatusCode } from "@app/types/error";
 import { getGroupIdsFromHeaders, getRoleFromHeaders } from "@app/types/groups";
 import { getUserEmailFromHeaders } from "@app/types/user";
 
-// Bridge Hono Context to the minimal NextApiRequest shape used by the existing
-// auth helpers. The public API only needs headers + socket (no cookies).
-function buildNextLikeReq(c: Context): NextApiRequest {
+type HeaderRecord = Record<string, string | string[] | undefined>;
+
+function readHeaders(c: Context): HeaderRecord {
   const headers: Record<string, string> = {};
   c.req.raw.headers.forEach((value, key) => {
     headers[key] = value;
   });
-  const req = {
-    cookies: {},
-    headers,
-    query: {},
-    socket: { remoteAddress: undefined },
-    method: c.req.method,
-    url: c.req.url,
-  };
-  return req as unknown as NextApiRequest;
+  return headers;
 }
 
 function validateWorkspaceFromAuth(
@@ -104,8 +95,8 @@ function jsonApiError(c: Context, err: APIErrorWithStatusCode) {
   );
 }
 
-function applyClientIp(auth: Authenticator, req: NextApiRequest): void {
-  const ip = getClientIp(req);
+function applyClientIp(auth: Authenticator, headers: HeaderRecord): void {
+  const ip = getClientIp({ headers });
   if (ip !== "internal") {
     auth.setClientIp(ip);
   }
@@ -149,7 +140,7 @@ export const publicApiAuth: MiddlewareHandler = async (c, next) => {
     );
   }
 
-  const req = buildNextLikeReq(c);
+  const headers = readHeaders(c);
 
   // 1) Sandbox token.
   const token = authHeader.replace("Bearer ", "");
@@ -171,14 +162,14 @@ export const publicApiAuth: MiddlewareHandler = async (c, next) => {
       return jsonApiError(c, authRes.error);
     }
     const auth = authRes.value;
-    applyClientIp(auth, req);
+    applyClientIp(auth, headers);
     c.set("auth", auth);
     await next();
     return;
   }
 
   // 2) OAuth bearer token (resolves to a workspace user session).
-  const bearerRes = await getSessionFromBearerToken(req);
+  const bearerRes = await getSessionFromBearerToken(authHeader);
   if (bearerRes.isErr()) {
     return c.json(
       {
@@ -222,14 +213,14 @@ export const publicApiAuth: MiddlewareHandler = async (c, next) => {
     if (workspaceError) {
       return jsonApiError(c, workspaceError);
     }
-    applyClientIp(auth, req);
+    applyClientIp(auth, headers);
     c.set("auth", auth);
     await next();
     return;
   }
 
   // 3) API key.
-  const keyRes = await getAPIKey(req);
+  const keyRes = await getAPIKey(authHeader);
   if (keyRes.isErr()) {
     return jsonApiError(c, keyRes.error);
   }
@@ -237,8 +228,8 @@ export const publicApiAuth: MiddlewareHandler = async (c, next) => {
   const keyAndWorkspaceAuth = await Authenticator.fromKey(
     keyRes.value,
     wId,
-    getGroupIdsFromHeaders(req.headers),
-    getRoleFromHeaders(req.headers)
+    getGroupIdsFromHeaders(headers),
+    getRoleFromHeaders(headers)
   );
   let { workspaceAuth } = keyAndWorkspaceAuth;
 
@@ -260,7 +251,7 @@ export const publicApiAuth: MiddlewareHandler = async (c, next) => {
   }
 
   // x-api-user-email: system-key-only impersonation.
-  const userEmailFromHeader = getUserEmailFromHeaders(req.headers);
+  const userEmailFromHeader = getUserEmailFromHeaders(headers);
   if (userEmailFromHeader) {
     workspaceAuth =
       (await workspaceAuth.exchangeSystemKeyForUserAuthByEmail(workspaceAuth, {
@@ -269,7 +260,7 @@ export const publicApiAuth: MiddlewareHandler = async (c, next) => {
   }
 
   // x-api-key-name: system-key-only key name override (for analytics).
-  const apiKeyNameFromHeader = getApiKeyNameFromHeaders(req.headers);
+  const apiKeyNameFromHeader = getApiKeyNameFromHeaders(headers);
   const key = workspaceAuth.key();
   if (apiKeyNameFromHeader && key && key.isSystem) {
     workspaceAuth = workspaceAuth.exchangeKey({
@@ -281,7 +272,7 @@ export const publicApiAuth: MiddlewareHandler = async (c, next) => {
     });
   }
 
-  applyClientIp(workspaceAuth, req);
+  applyClientIp(workspaceAuth, headers);
   c.set("auth", workspaceAuth);
   await next();
 };

--- a/front-api/middleware/workspace_auth.ts
+++ b/front-api/middleware/workspace_auth.ts
@@ -102,7 +102,9 @@ export const workspaceAuth: MiddlewareHandler = async (c, next) => {
 
   // Try bearer token first, then fall back to cookie-based session.
   // Mirrors withLogging in front/logger/withlogging.ts.
-  const bearerRes = await getSessionFromBearerToken(req);
+  const bearerRes = await getSessionFromBearerToken(
+    c.req.header("authorization")
+  );
   if (bearerRes.isErr()) {
     return c.json(
       {

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -434,7 +434,7 @@ export function withPublicAPIAuthentication<T>(
       }
 
       // API key authentication.
-      const keyRes = await getAPIKey(req);
+      const keyRes = await getAPIKey(req.headers.authorization);
       if (keyRes.isErr()) {
         return apiError(req, res, keyRes.error);
       }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1324,14 +1324,12 @@ export async function getSession(
 }
 
 /**
- * Gets the Bearer token from the request.
- * @param req
- * @returns
+ * Extracts the Bearer token from an Authorization header value.
  */
 export async function getBearerToken(
-  req: NextApiRequest
+  authHeader: string | undefined
 ): Promise<Result<string, APIErrorWithStatusCode>> {
-  if (!req.headers.authorization) {
+  if (!authHeader) {
     return new Err({
       status_code: 401,
       api_error: {
@@ -1341,9 +1339,7 @@ export async function getBearerToken(
     });
   }
 
-  const parse = req.headers.authorization.match(
-    /^Bearer\s+([A-Za-z0-9-._~+/]+=*)$/i
-  );
+  const parse = authHeader.match(/^Bearer\s+([A-Za-z0-9-._~+/]+=*)$/i);
   if (!parse || !parse[1]) {
     return new Err({
       status_code: 401,
@@ -1374,9 +1370,9 @@ export type BearerTokenError =
  * or Ok(null) if no bearer token is present, or Ok(session) on success.
  */
 export async function getSessionFromBearerToken(
-  req: NextApiRequest
+  authHeader: string | undefined
 ): Promise<Result<SessionWithUser | null, BearerTokenError>> {
-  const bearerTokenRes = await getBearerToken(req);
+  const bearerTokenRes = await getBearerToken(authHeader);
   if (bearerTokenRes.isErr()) {
     return new Ok(null);
   }
@@ -1429,14 +1425,13 @@ export async function getSessionFromBearerToken(
 }
 
 /**
- * Retrieves the API Key from the request.
- * @param req NextApiRequest request object
+ * Retrieves the API Key from the Authorization header value.
  * @returns Result<Key, APIErrorWithStatusCode>
  */
 export async function getAPIKey(
-  req: NextApiRequest
+  authHeader: string | undefined
 ): Promise<Result<KeyResource, APIErrorWithStatusCode>> {
-  const token = await getBearerToken(req);
+  const token = await getBearerToken(authHeader);
 
   if (token.isErr()) {
     return new Err(token.error);

--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -119,7 +119,9 @@ export function withLogging<T>(
 
     // Try bearer token first, then fall back to cookie-based session.
     const sessionResult = await tracer.trace("auth.getSession", async () => {
-      const bearerTokenRes = await getSessionFromBearerToken(req);
+      const bearerTokenRes = await getSessionFromBearerToken(
+        req.headers.authorization
+      );
       if (bearerTokenRes.isErr() || bearerTokenRes.value) {
         return bearerTokenRes;
       }

--- a/front/pages/api/lookup/[resource]/index.ts
+++ b/front/pages/api/lookup/[resource]/index.ts
@@ -107,7 +107,7 @@ async function handler(
     });
   }
 
-  const bearerTokenRes = await getBearerToken(req);
+  const bearerTokenRes = await getBearerToken(req.headers.authorization);
   if (bearerTokenRes.isErr()) {
     return apiError(req, res, {
       status_code: 401,


### PR DESCRIPTION
## Description

`getBearerToken`, `getSessionFromBearerToken`, and `getAPIKey` only ever read `req.headers.authorization`. Their signatures still took a full `NextApiRequest`, which forced `front-api` to build fake `NextApiRequest`
objects from Hono contexts just to call them.

This change narrows the signatures to `authHeader: string | undefined`, mirroring what we already did for `getPaginationParams`. After it, `public_api_auth.ts` no longer needs a `NextApiRequest` shim at all, and
`workspace_auth.ts` keeps its bridge only for `getSession` (we'll tackle later)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low, should be no-op refactor.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25595">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->