### PR TITLE
[Run Agent] Do not page on recoverable child agent failures

### DIFF
--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -49,7 +49,11 @@ import { serializeMention } from "@app/lib/mentions/format";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentErrorCategory,
+  GenericErrorContent,
+  LightAgentConfigurationType,
+} from "@app/types/assistant/agent";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { CitationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
@@ -71,6 +75,25 @@ import _ from "lodash";
 import type z from "zod";
 
 const ABORT_SIGNAL_CANCEL_REASON = "CancelledFailure: CANCELLED";
+const UNTRACKED_CHILD_AGENT_ERROR_CATEGORIES = [
+  "retryable_model_error",
+  "context_window_exceeded",
+  "empty_content",
+  "provider_internal_error",
+] satisfies AgentErrorCategory[];
+const UNTRACKED_CHILD_AGENT_ERROR_CODES = ["max_step_reached"] as const;
+
+function shouldTrackChildAgentError(error: GenericErrorContent): boolean {
+  const category = error.metadata?.category;
+  if (
+    typeof category === "string" &&
+    UNTRACKED_CHILD_AGENT_ERROR_CATEGORIES.some((c) => c === category)
+  ) {
+    return false;
+  }
+
+  return !UNTRACKED_CHILD_AGENT_ERROR_CODES.some((code) => code === error.code);
+}
 
 function canRunChildAgent(agent: LightAgentConfigurationType): boolean {
   switch (agent.status) {
@@ -566,11 +589,7 @@ const runAgent = async (
         // Certain types of agent errors should not be tracked as run_agent tool execution
         // errors (they will be exposed to the model and will be tracked as errors from the
         // agentic loop in the sub agent conversation).
-        const tracked = ![
-          "retryable_model_error",
-          "context_window_exceeded",
-          "provider_internal_error",
-        ].includes(event.error.metadata?.category);
+        const tracked = shouldTrackChildAgentError(event.error);
         return await finalizeAndReturn(
           new Err(
             new MCPError(errorMessage, {

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -80,6 +80,7 @@ const UNTRACKED_CHILD_AGENT_ERROR_CATEGORIES = [
   "context_window_exceeded",
   "empty_content",
   "provider_internal_error",
+  "stream_error",
 ] satisfies AgentErrorCategory[];
 const UNTRACKED_CHILD_AGENT_ERROR_CODES = ["max_step_reached"] as const;
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -40,6 +40,7 @@ import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import {
   getByokUserFacingLLMErrorMessage,
   getUserFacingLLMErrorMessage,
+  LLM_ERROR_TYPE_TO_CATEGORY,
 } from "@app/lib/api/llm/types/errors";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
@@ -684,7 +685,9 @@ export async function runModel(
             {
               code: "multi_actions_error",
               message: errorMessage,
-              metadata: null,
+              metadata: {
+                category: LLM_ERROR_TYPE_TO_CATEGORY[type],
+              },
             },
             errorDustRunId
           );
@@ -874,7 +877,10 @@ export async function runModel(
       code: "max_step_reached",
       message:
         "The agent reached the maximum number of steps. This error can be safely retried.",
-      metadata: null,
+      metadata: {
+        category: "empty_content",
+        errorTitle: "Too many steps",
+      },
     });
     return null;
   }


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/25577.

`run_agent` returns child `agent_error` messages as tool output to the parent model, so the parent can retry or choose another plan. This preserves LLM error categories on child agent errors and marks recoverable child failures, including provider/internal errors, stream/network errors, and max-step failures, as untracked at the parent `run_agent` layer.

## Risks

Blast radius: `run_agent` alerting/log severity for child agent failures.
Risk: low

## Deploy Plan
- pmrr (not urgent)
- deploy front-agent-loop-worker
