### PR TITLE
Context pruning: Interaction split in between successive users "blocks"

### DIFF
--- a/front/lib/api/assistant/conversation/interactions.test.ts
+++ b/front/lib/api/assistant/conversation/interactions.test.ts
@@ -16,7 +16,7 @@ describe("groupMessagesIntoInteractions", () => {
     expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1"]);
   });
 
-  it("keeps consecutive user and content_fragment messages in the same user turn", () => {
+  it("splits consecutive user and content_fragment messages in separate turns", () => {
     const interactions = groupMessagesIntoInteractions([
       msg("content_fragment", "cf1"),
       msg("user", "u1"),
@@ -26,11 +26,8 @@ describe("groupMessagesIntoInteractions", () => {
       msg("function", "f1"),
       msg("function", "f2"),
     ]);
-    expect(interactions).toHaveLength(1);
-    expect(interactions[0].messages.map((m) => m.tag)).toEqual([
-      "cf1",
-      "u1",
-      "cf2",
+    expect(interactions).toHaveLength(4);
+    expect(interactions[3].messages.map((m) => m.tag)).toEqual([
       "u2",
       "a1",
       "f1",

--- a/front/lib/api/assistant/conversation/interactions.test.ts
+++ b/front/lib/api/assistant/conversation/interactions.test.ts
@@ -16,7 +16,7 @@ describe("groupMessagesIntoInteractions", () => {
     expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1"]);
   });
 
-  it("splits consecutive user and content_fragment messages in separate turns", () => {
+  it("keeps content fragments with the following user while splitting user turns", () => {
     const interactions = groupMessagesIntoInteractions([
       msg("content_fragment", "cf1"),
       msg("user", "u1"),
@@ -26,13 +26,52 @@ describe("groupMessagesIntoInteractions", () => {
       msg("function", "f1"),
       msg("function", "f2"),
     ]);
-    expect(interactions).toHaveLength(4);
-    expect(interactions[3].messages.map((m) => m.tag)).toEqual([
+    expect(interactions).toHaveLength(2);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["cf1", "u1"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual([
+      "cf2",
       "u2",
       "a1",
       "f1",
       "f2",
     ]);
+  });
+
+  it("keeps each content fragment with the user message following it", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("content_fragment", "cf1"),
+      msg("user", "u1"),
+      msg("content_fragment", "cf2"),
+      msg("user", "u2"),
+      msg("content_fragment", "cf3"),
+      msg("user", "u3"),
+      msg("user", "u4"),
+      msg("content_fragment", "cf4"),
+      msg("user", "u5"),
+      msg("assistant", "a1"),
+    ]);
+
+    expect(interactions).toHaveLength(5);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["cf1", "u1"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["cf2", "u2"]);
+    expect(interactions[2].messages.map((m) => m.tag)).toEqual(["cf3", "u3"]);
+    expect(interactions[3].messages.map((m) => m.tag)).toEqual(["u4"]);
+    expect(interactions[4].messages.map((m) => m.tag)).toEqual([
+      "cf4",
+      "u5",
+      "a1",
+    ]);
+  });
+
+  it("splits consecutive user messages in separate turns", () => {
+    const interactions = groupMessagesIntoInteractions([
+      msg("user", "u1"),
+      msg("user", "u2"),
+      msg("assistant", "a1"),
+    ]);
+    expect(interactions).toHaveLength(2);
+    expect(interactions[0].messages.map((m) => m.tag)).toEqual(["u1"]);
+    expect(interactions[1].messages.map((m) => m.tag)).toEqual(["u2", "a1"]);
   });
 
   it("starts a new interaction when a user turn follows an agent turn", () => {

--- a/front/lib/api/assistant/conversation/interactions.ts
+++ b/front/lib/api/assistant/conversation/interactions.ts
@@ -4,8 +4,8 @@ import type {
 } from "@app/lib/api/assistant/conversation_rendering/pruning";
 
 /**
- * Group messages into interactions (user turn + agent responses),
- * using turn type (user/content_fragment vs assistant/function) as the delimiter.
+ * Group messages into interactions (user turn + agent responses), using turn type
+ * (user/content_fragment vs assistant/function) as the delimiter.
  *
  * A compaction message acts as an interaction boundary: it closes the current interaction and
  * starts a new one. Pre-compaction messages should already have been filtered out by
@@ -56,16 +56,21 @@ export function groupMessagesIntoInteractions<T extends MinimalMessageType>(
     // We close when:
     // - it's the last message, or
     // - the next message is a "user" turn while the current message is an "agent" turn,
-    // - the next message is a compaction boundary.
-    // This ensures that all consecutive user/content_fragment messages remain in the same
-    // user turn, followed by all agent/tool messages for that interaction.
+    // - the next message is a "user" turn while the current message is a "user" turn (otherwise
+    //   triggers can accumulate and exhaust context),
+    // - the next message is a compaction boundary (above).
+    // This ensures that all consecutive user/content_fragment messages remain in the same user
+    // turn, followed by all agent/tool messages for that interaction.
     const shouldClose = (() => {
       if (isLastMessage) {
         return true;
       }
       const currentTurn = turnTypeForMessage(message);
       const nextTurn = turnTypeForMessage(messages[i + 1]);
-      return currentTurn === "agent" && nextTurn === "user";
+      return (
+        (currentTurn === "agent" && nextTurn === "user") ||
+        (currentTurn === "user" && nextTurn === "user")
+      );
     })();
 
     if (shouldClose) {

--- a/front/lib/api/assistant/conversation/interactions.ts
+++ b/front/lib/api/assistant/conversation/interactions.ts
@@ -20,27 +20,12 @@ export function groupMessagesIntoInteractions<T extends MinimalMessageType>(
   const interactions: Interaction<T>[] = [];
   let currentInteraction: T[] = [];
 
-  // Determine the high-level turn type for a message.
-  // - "user": user messages and content fragments
-  // - "agent": assistant messages and tool/function results
-  // - "compaction": compaction summary boundary
-  const turnTypeForMessage = (message: T): "user" | "agent" | "compaction" => {
-    if (message.role === "compaction") {
-      return "compaction";
-    }
-    if (message.role === "user" || message.role === "content_fragment") {
-      return "user";
-    }
-    // Includes "assistant" and "function" roles.
-    return "agent";
-  };
-
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
 
     // A compaction message closes the current interaction (if any) and starts a new one. The
     // compaction summary is the first message of the next interaction.
-    if (turnTypeForMessage(message) === "compaction") {
+    if (message.role === "compaction") {
       if (currentInteraction.length > 0) {
         interactions.push({ messages: currentInteraction });
       }
@@ -55,23 +40,28 @@ export function groupMessagesIntoInteractions<T extends MinimalMessageType>(
     // Decide if we should close the current interaction.
     // We close when:
     // - it's the last message, or
-    // - the next message is a "user" turn while the current message is an "agent" turn,
-    // - the next message is a "user" turn while the current message is a "user" turn (otherwise
-    //   triggers can accumulate and exhaust context),
+    // - the next message is a user message or content fragment while the current message is an
+    //   agent message,
+    // - the next message is a user message or content fragment while the current message is a user
+    //   message (otherwise triggers can accumulate and exhaust context),
     // - the next message is a compaction boundary (above).
-    // This ensures that all consecutive user/content_fragment messages remain in the same user
-    // turn, followed by all agent/tool messages for that interaction.
+    // This keeps content fragments attached to the following user message while splitting
+    // successive user turns.
     const shouldClose = (() => {
       if (isLastMessage) {
         return true;
       }
-      const currentTurn = turnTypeForMessage(message);
-      const nextTurn = turnTypeForMessage(messages[i + 1]);
+      const currentRole = message.role;
+      const nextRole = messages[i + 1].role;
+
+      const currentIsAgent =
+        currentRole === "agent" ||
+        currentRole === "assistant" ||
+        currentRole === "function";
+      const nextIsUser = nextRole === "user" || nextRole === "content_fragment";
+
       return (
-        (currentTurn === "agent" && nextTurn === "user") ||
-        // TODO(spolu): we may want to remove it after we support pruning any type of message inside
-        // the last interaction.
-        (currentTurn === "user" && nextTurn === "user")
+        (currentIsAgent && nextIsUser) || (currentRole === "user" && nextIsUser)
       );
     })();
 

--- a/front/lib/api/assistant/conversation/interactions.ts
+++ b/front/lib/api/assistant/conversation/interactions.ts
@@ -69,6 +69,8 @@ export function groupMessagesIntoInteractions<T extends MinimalMessageType>(
       const nextTurn = turnTypeForMessage(messages[i + 1]);
       return (
         (currentTurn === "agent" && nextTurn === "user") ||
+        // TODO(spolu): we may want to remove it after we support pruning any type of message inside
+        // the last interaction.
         (currentTurn === "user" && nextTurn === "user")
       );
     })();


### PR DESCRIPTION
## Description

First fix. Once a context gets exceeded on a trigger-based conversation there was no coming back as we were aggregating together the user messages into the same interaction without any capability to prune user messages.

This splits successive user messages into different interactions so that they can get pruned. It might be better as we iterate to go back to aggregated user messages together BUT the ability to prune messages from an interaction as needed.

This should remove some error as a started as we iterate.

This means we separate user message from content fragment potentially which is not super desirable. I think the end-state is to allow removing messages from interactions if the interaction post pruning is still too big.

## Tests

Tested locally. Covered by tests.

## Risk

Low. Changes cases where we have multiple successive user messages which is not "modal"

## Deploy Plan

- deploy `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25598">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->