### PR TITLE
[SPA] Fix shared frame API URL

### DIFF
--- a/extension/global.d.ts
+++ b/extension/global.d.ts
@@ -2,6 +2,7 @@ declare global {
   interface ImportMeta {
     env?: {
       VITE_BASE_PATH?: string;
+      VITE_DUST_API_URL?: string;
       VITE_DUST_CLIENT_FACING_URL?: string;
       VITE_DUST_REGION?: string;
       VITE_DUST_REGION_STORAGE_KEY?: string;

--- a/front-spa/package.json
+++ b/front-spa/package.json
@@ -6,8 +6,8 @@
   },
   "type": "module",
   "scripts": {
-    "dev:poke": "VITE_APP_NAME=poke VITE_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL vite",
-    "dev:app": "VITE_APP_NAME=app VITE_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL vite",
+    "dev:poke": "VITE_APP_NAME=poke VITE_DUST_API_URL=$DUST_CLIENT_FACING_URL vite",
+    "dev:app": "VITE_APP_NAME=app VITE_DUST_API_URL=$DUST_CLIENT_FACING_URL vite",
     "build:poke": "VITE_APP_NAME=poke vite build && cp _headers dist/poke/_headers",
     "build:app": "VITE_APP_NAME=app vite build && cp _headers dist/app/_headers",
     "build": "npm run build:poke && npm run build:app",

--- a/front-spa/vite.config.ts
+++ b/front-spa/vite.config.ts
@@ -305,7 +305,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       port: appDefinition.port,
-      // No proxy - client calls API directly using VITE_DUST_CLIENT_FACING_URL
+      // No proxy - client calls API directly using VITE_DUST_API_URL.
       fs: {
         // Allow serving files from the front directory (for shared code)
         allow: [

--- a/front/global.d.ts
+++ b/front/global.d.ts
@@ -74,7 +74,7 @@ declare global {
       VITE_COMMIT_HASH?: string;
       VITE_DATADOG_CLIENT_TOKEN?: string;
       VITE_DATADOG_SERVICE?: string;
-      VITE_DUST_CLIENT_FACING_URL?: string;
+      VITE_DUST_API_URL?: string;
       VITE_DUST_REGION?: string;
       VITE_DUST_REGION_STORAGE_KEY?: string;
     };

--- a/front/lib/auth/RegionContext.tsx
+++ b/front/lib/auth/RegionContext.tsx
@@ -15,7 +15,7 @@ import { useSWRConfig } from "swr";
 const STORAGE_KEY =
   import.meta.env?.VITE_DUST_REGION_STORAGE_KEY ?? "dust-region-api";
 
-const DEFAULT_URL = import.meta.env?.VITE_DUST_CLIENT_FACING_URL ?? "";
+const DEFAULT_URL = import.meta.env?.VITE_DUST_API_URL ?? "";
 
 const DEFAULT_REGION: RegionType =
   (import.meta.env?.VITE_DUST_REGION as RegionType) ?? "us-central1";


### PR DESCRIPTION
## Description
Fixes regression from https://github.com/dust-tt/dust/pull/25572.

The app SPA still read the removed `VITE_DUST_CLIENT_FACING_URL` as its default API origin. Shared frame pages therefore called `/api/share/frame/...` on the SPA host and got a 404. This switches the SPA default to `VITE_DUST_API_URL`.

## Risks
Blast radius: SPA API base URL resolution for shared pages and region-aware client fetches.
Risk: low

## Deploy Plan
- deploy app SPA

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->