### PR TITLE
[gdrive]: Support PDF/PPTX/DOCX in Google Drive get_file_content

### DIFF
--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -14,6 +14,9 @@ export const SUPPORTED_MIMETYPES = [
   "text/plain",
   "text/markdown",
   "text/csv",
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 ];
 
 export const MAX_CONTENT_SIZE = 32000; // Max characters to return for file content
@@ -124,7 +127,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
   },
   get_file_content: {
-    description: `Get the content of a Google Drive file as plain text with offset-based pagination. Supported mimeTypes: ${SUPPORTED_MIMETYPES.join(", ")}. For structured content with element indices/object IDs needed for updates, use ${GET_DOCUMENT_STRUCTURE_TOOL} (Docs) or ${GET_PRESENTATION_STRUCTURE_TOOL} (Slides) instead.`,
+    description: `Get the content of a Google Drive file as text with offset-based pagination. Supports native Google formats (Docs, Slides, Sheets), text files (plain/markdown/csv), and binary documents (PDF, PowerPoint .pptx, Word .docx) via Tika text extraction with OCR. Binary documents are also returned as an attached resource so they can be passed to other tools. Supported mimeTypes: ${SUPPORTED_MIMETYPES.join(", ")}. For structured content with element indices/object IDs needed for updates, use ${GET_DOCUMENT_STRUCTURE_TOOL} (Docs) or ${GET_PRESENTATION_STRUCTURE_TOOL} (Slides) instead.`,
     schema: {
       fileId: z
         .string()

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -127,7 +127,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
   },
   get_file_content: {
-    description: `Get the content of a Google Drive file as text with offset-based pagination. Supports native Google formats (Docs, Slides, Sheets), text files (plain/markdown/csv), and binary documents (PDF, PowerPoint .pptx, Word .docx) via Tika text extraction with OCR. Binary documents are also returned as an attached resource so they can be passed to other tools. Supported mimeTypes: ${SUPPORTED_MIMETYPES.join(", ")}. For structured content with element indices/object IDs needed for updates, use ${GET_DOCUMENT_STRUCTURE_TOOL} (Docs) or ${GET_PRESENTATION_STRUCTURE_TOOL} (Slides) instead.`,
+    description: `Get the content of a Google Drive file (Docs, Slides, Sheets, text, PDF, PowerPoint, Word) as text with offset-based pagination. Supported mimeTypes: ${SUPPORTED_MIMETYPES.join(", ")}. For structured content with element indices/object IDs needed for updates, use ${GET_DOCUMENT_STRUCTURE_TOOL} (Docs) or ${GET_PRESENTATION_STRUCTURE_TOOL} (Slides) instead.`,
     schema: {
       fileId: z
         .string()

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -3,7 +3,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { Common } from "googleapis";
 import { describe, expect, it } from "vitest";
 
-import { handleFileAccessError } from "./index";
+import { buildBinaryFileResource, handleFileAccessError } from "./index";
 
 // Helper to create a mock GaxiosError
 function createGaxiosError(code: number, message: string): Common.GaxiosError {
@@ -167,5 +167,48 @@ describe("handleFileAccessError", () => {
     if (result.isErr()) {
       expect(result.error.message).toBe("Failed to access file");
     }
+  });
+});
+
+describe("buildBinaryFileResource", () => {
+  it("base64-encodes the buffer and preserves the mime type", () => {
+    const buffer = Buffer.from("Hello PDF", "utf-8");
+
+    const block = buildBinaryFileResource({
+      buffer,
+      fileName: "report.pdf",
+      mimeType: "application/pdf",
+    });
+
+    expect(block.type).toBe("resource");
+    expect(block.resource.mimeType).toBe("application/pdf");
+    expect(block.resource.blob).toBe(buffer.toString("base64"));
+    expect(block.resource.uri).toBe("report.pdf");
+    expect(block.resource._meta).toEqual({ text: "File: report.pdf" });
+  });
+
+  it("falls back to 'unknown' when the file name is missing", () => {
+    const block = buildBinaryFileResource({
+      buffer: Buffer.from(""),
+      fileName: null,
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    });
+
+    expect(block.resource.uri).toBe("unknown");
+    expect(block.resource._meta).toEqual({ text: "File: unknown" });
+  });
+
+  it("sanitizes file names with unsafe characters", () => {
+    const block = buildBinaryFileResource({
+      buffer: Buffer.from("x"),
+      fileName: "../../etc/passwd",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+
+    expect(block.resource.uri).not.toContain("/");
+    expect(block.resource.uri).not.toContain("..");
+    expect(block.resource._meta.text).toBe(`File: ${block.resource.uri}`);
   });
 });

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -171,7 +171,7 @@ describe("handleFileAccessError", () => {
 });
 
 describe("buildBinaryFileResource", () => {
-  it("base64-encodes the buffer and preserves the mime type", () => {
+  it("should base64-encode the buffer and preserve the mime type", () => {
     const buffer = Buffer.from("Hello PDF", "utf-8");
 
     const block = buildBinaryFileResource({
@@ -187,7 +187,7 @@ describe("buildBinaryFileResource", () => {
     expect(block.resource._meta).toEqual({ text: "File: report.pdf" });
   });
 
-  it("falls back to 'unknown' when the file name is missing", () => {
+  it("should fall back to 'unknown' when the file name is missing", () => {
     const block = buildBinaryFileResource({
       buffer: Buffer.from(""),
       fileName: null,
@@ -199,7 +199,7 @@ describe("buildBinaryFileResource", () => {
     expect(block.resource._meta).toEqual({ text: "File: unknown" });
   });
 
-  it("sanitizes file names with unsafe characters", () => {
+  it("should sanitize file names with unsafe characters", () => {
     const block = buildBinaryFileResource({
       buffer: Buffer.from("x"),
       fileName: "../../etc/passwd",

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -35,6 +35,16 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Common } from "googleapis";
 import { Readable } from "stream";
 
+export type BinaryFileResourceBlock = {
+  type: "resource";
+  resource: {
+    blob: string;
+    _meta: { text: string };
+    mimeType: string;
+    uri: string;
+  };
+};
+
 /**
  * Builds a resource block for a binary Google Drive file so downstream tools
  * (sandbox upload, file viewer, etc.) can consume the raw bytes alongside any
@@ -48,10 +58,10 @@ export function buildBinaryFileResource({
   buffer: Buffer;
   fileName: string | null | undefined;
   mimeType: string;
-}) {
+}): BinaryFileResourceBlock {
   const safeFileName = sanitizeFilename(fileName ?? "unknown");
   return {
-    type: "resource" as const,
+    type: "resource",
     resource: {
       blob: buffer.toString("base64"),
       _meta: { text: `File: ${safeFileName}` },
@@ -60,6 +70,9 @@ export function buildBinaryFileResource({
     },
   };
 }
+
+const BINARY_TEXT_EXTRACTION_FAILED_PLACEHOLDER =
+  "[Text extraction failed — file attached as binary resource]";
 
 /**
  * Normalizes GaxiosError code to string for comparison.
@@ -409,8 +422,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
       }
 
       let content: string;
-      let binaryResource: ReturnType<typeof buildBinaryFileResource> | null =
-        null;
+      let binaryResource: BinaryFileResourceBlock | null = null;
 
       switch (file.mimeType) {
         case "application/vnd.google-apps.document":
@@ -477,12 +489,19 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
               "Text extraction failed for Google Drive binary file"
             );
           }
-          content = extractionResult.isOk() ? extractionResult.value : "";
-          binaryResource = buildBinaryFileResource({
-            buffer,
-            fileName: file.name,
-            mimeType: file.mimeType,
-          });
+          content = extractionResult.isOk()
+            ? extractionResult.value
+            : BINARY_TEXT_EXTRACTION_FAILED_PLACEHOLDER;
+          // Only attach the raw bytes on the first page — callers paginating
+          // further already have the resource ref from the initial response,
+          // and the base64 blob can be ~85 MB for a 64 MB original.
+          if (offset === 0) {
+            binaryResource = buildBinaryFileResource({
+              buffer,
+              fileName: file.name,
+              mimeType: file.mimeType,
+            });
+          }
           break;
         }
         default:
@@ -504,7 +523,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 
       const responseBlocks: (
         | { type: "text"; text: string }
-        | ReturnType<typeof buildBinaryFileResource>
+        | BinaryFileResourceBlock
       )[] = [
         {
           type: "text" as const,

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -492,16 +492,11 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
           content = extractionResult.isOk()
             ? extractionResult.value
             : EXTRACTION_FAILED_PLACEHOLDER;
-          // Only attach the raw bytes on the first page — callers paginating
-          // further already have the resource ref from the initial response,
-          // and the base64 blob can be ~85 MB for a 64 MB original.
-          if (offset === 0) {
-            binaryResource = buildBinaryFileResource({
-              buffer,
-              fileName: file.name,
-              mimeType: file.mimeType,
-            });
-          }
+          binaryResource = buildBinaryFileResource({
+            buffer,
+            fileName: file.name,
+            mimeType: file.mimeType,
+          });
           break;
         }
         default:

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -71,7 +71,7 @@ export function buildBinaryFileResource({
   };
 }
 
-const BINARY_TEXT_EXTRACTION_FAILED_PLACEHOLDER =
+const EXTRACTION_FAILED_PLACEHOLDER =
   "[Text extraction failed — file attached as binary resource]";
 
 /**
@@ -491,7 +491,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
           }
           content = extractionResult.isOk()
             ? extractionResult.value
-            : BINARY_TEXT_EXTRACTION_FAILED_PLACEHOLDER;
+            : EXTRACTION_FAILED_PLACEHOLDER;
           // Only attach the raw bytes on the first page — callers paginating
           // further already have the resource ref from the initial response,
           // and the base64 blob can be ~85 MB for a 64 MB original.

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -9,6 +9,7 @@ import {
   makeFileAuthorizationError,
   makePersonalAuthenticationError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { extractTextFromBuffer } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
 import {
   getFileFromConversationAttachment,
   sanitizeFilename,
@@ -28,10 +29,37 @@ import {
   MAX_FILE_SIZE,
   SUPPORTED_MIMETYPES,
 } from "@app/lib/api/actions/servers/google_drive/metadata";
+import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Common } from "googleapis";
 import { Readable } from "stream";
+
+/**
+ * Builds a resource block for a binary Google Drive file so downstream tools
+ * (sandbox upload, file viewer, etc.) can consume the raw bytes alongside any
+ * extracted text. Exported for unit testing.
+ */
+export function buildBinaryFileResource({
+  buffer,
+  fileName,
+  mimeType,
+}: {
+  buffer: Buffer;
+  fileName: string | null | undefined;
+  mimeType: string;
+}) {
+  const safeFileName = sanitizeFilename(fileName ?? "unknown");
+  return {
+    type: "resource" as const,
+    resource: {
+      blob: buffer.toString("base64"),
+      _meta: { text: `File: ${safeFileName}` },
+      mimeType,
+      uri: safeFileName,
+    },
+  };
+}
 
 /**
  * Normalizes GaxiosError code to string for comparison.
@@ -381,6 +409,8 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
       }
 
       let content: string;
+      let binaryResource: ReturnType<typeof buildBinaryFileResource> | null =
+        null;
 
       switch (file.mimeType) {
         case "application/vnd.google-apps.document":
@@ -415,6 +445,46 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
           content = downloadRes.data;
           break;
         }
+        case "application/pdf":
+        case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+        case "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
+          // Binary documents: download as an arraybuffer, extract text via Tika
+          // (OCR enabled), and always attach the raw bytes as a resource block
+          // so downstream tools can consume the file even when extraction yields
+          // little or nothing.
+          const downloadRes = await drive.files.get(
+            { fileId, alt: "media" },
+            { responseType: "arraybuffer" }
+          );
+          if (!(downloadRes.data instanceof ArrayBuffer)) {
+            return new Err(
+              new MCPError("Failed to download file content as arraybuffer")
+            );
+          }
+          const buffer = Buffer.from(downloadRes.data);
+
+          const extractionResult = await extractTextFromBuffer(
+            buffer,
+            file.mimeType
+          );
+          if (extractionResult.isErr()) {
+            logger.warn(
+              {
+                fileId,
+                mimeType: file.mimeType,
+                error: extractionResult.error,
+              },
+              "Text extraction failed for Google Drive binary file"
+            );
+          }
+          content = extractionResult.isOk() ? extractionResult.value : "";
+          binaryResource = buildBinaryFileResource({
+            buffer,
+            fileName: file.name,
+            mimeType: file.mimeType,
+          });
+          break;
+        }
         default:
           return new Err(
             new MCPError(`Unsupported file type: ${file.mimeType}`, {
@@ -432,7 +502,10 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
       const hasMore = endIndex < content.length;
       const nextOffset = hasMore ? endIndex : undefined;
 
-      return new Ok([
+      const responseBlocks: (
+        | { type: "text"; text: string }
+        | ReturnType<typeof buildBinaryFileResource>
+      )[] = [
         {
           type: "text" as const,
           text: JSON.stringify(
@@ -457,7 +530,13 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
             2
           ),
         },
-      ]);
+      ];
+
+      if (binaryResource) {
+        responseBlocks.push(binaryResource);
+      }
+
+      return new Ok(responseBlocks);
     } catch (err) {
       return handleDriveAccessError(err, authInfo);
     }


### PR DESCRIPTION
fix https://github.com/dust-tt/tasks/issues/8066

## Description
Follow sharepoint tool pattern for reading PDF, doc, ppx in the google drive read tool
Route binary documents through Tika text extraction (with OCR) while also attaching the raw file as a resource block so downstream tools can consume it. Pagination and response shape are unified across all get_file_content branches.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually, Gdrive tool can now read the content of pdf, pptx, docx files
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25601">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->