### PR TITLE
[migration] Add BACK17 coding rule and DangerJS check for Next→Hono handler

### DIFF
--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -30,9 +30,10 @@ jobs:
           # Define monitored paths
           MONITORED_PATHS=(
             'front/lib/'
+            'front/pages/api/'
+            'front-api/'
             'connectors/src/lib/models/'
             'connectors/src/resources/storage/models/'
-            'front/pages/api/v1/'
             'sdks/js/'
             'front/package.json'
             'extension/package.json'

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -295,6 +295,25 @@ Reviewer: If you detect a handler with non-trivial business logic, request the a
 it into a `lib/api/*` function (creating one if needed). The handler should ideally read as:
 authorize → validate → call business function → respond.
 
+### [BACK17] Keep migrated Next and Hono handlers in sync during migration
+
+Any Next handler that has been migrated to Hono must carry a migration marker at the top of the file:
+
+```
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: <path/to/hono/route.ts>
+```
+
+The Hono file does not need a marker — its existence is enough.
+
+If you modify either side of a migrated pair, you must update the other side as well. DangerJS enforces this: if a PR modifies one side without the other, the check fails.
+
+If a change is intentionally one-sided (e.g. deleting the Next handler, or cleanup that only applies to one framework), add the `skip-migration-check` label to the PR.
+
+When migrating a new handler, add the marker to the Next file immediately.
+
+Reviewer: If a PR touches a file that is part of a migrated pair (either a Next file with a `@migration-target` marker, or a Hono file that is the target of such a marker), verify the counterpart is also updated in the same PR.
+
 ## AUDIT LOGGING
 
 ### [AUDIT1] Every state-changing operation on a security-sensitive resource MUST emit an audit log event

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "child_process";
 import { danger, fail, warn } from "danger";
 import fs from "fs";
 
@@ -7,6 +8,15 @@ const documentationAckLabel = "documentation-ack";
 const rawSqlAckLabel = "raw-sql-ack";
 const sparkleVersionAckLabel = "sparkle-version-ack";
 const sseAckLabel = "sse-ack";
+const skipMigrationCheckLabel = "skip-migration-check";
+
+// `git grep` exit codes used by the Hono migration sync check.
+const GIT_GREP_MATCH = 0;
+const GIT_GREP_NO_MATCH = 1;
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
 
 const REMOVE_INDEX_WARNING =
   "\n\nBefore deleting an index, make sure it is actually not used by running:" +
@@ -328,6 +338,82 @@ function warnTriggersWorkflowChanges() {
   );
 }
 
+function failMigrationSync(file: string, counterpart: string) {
+  fail(
+    `\`${file}\` was modified but its migration counterpart \`${counterpart}\` was not. ` +
+      `Both sides of a migrated handler must be updated together (see BACK17). ` +
+      `Add the \`${skipMigrationCheckLabel}\` label if this is intentional.`
+  );
+}
+
+function warnMigrationSync(file: string, counterpart: string) {
+  warn(
+    `\`${file}\` was modified but its migration counterpart \`${counterpart}\` was not. ` +
+      `The \`${skipMigrationCheckLabel}\` label is set — ensure this is intentional.`
+  );
+}
+
+function checkHonoMigrationSync() {
+  const diffFiles = danger.git.modified_files.concat(danger.git.created_files);
+
+  // For each API file in the diff, find its migration counterpart (if any)
+  // and check the counterpart is also in the diff.
+  //
+  // - Next file (`front/pages/api/...`): read it for a `@migration-target:`
+  //   marker pointing at a Hono path.
+  // - Hono file (`front-api/...`): `git grep` Next markers for one that
+  //   targets this Hono path.
+  //
+  // Danger runs with cwd=`front/`, so `git grep` results and `fs.readFileSync`
+  // paths are cwd-relative; `danger.git.modified_files` is repo-root relative.
+  // We prepend `front/` when crossing that boundary.
+  const checks: { file: string; counterpart: string }[] = [];
+
+  for (const file of diffFiles) {
+    if (file.startsWith("front/pages/api/")) {
+      const localPath = file.replace(/^front\//, "");
+      try {
+        const content = fs.readFileSync(localPath, "utf8");
+        const match = content.match(/^\s*\/\/\s*@migration-target:\s*(.+)$/m);
+        if (match) {
+          checks.push({ file, counterpart: match[1].trim() });
+        }
+      } catch (err) {
+        warn(
+          `Failed to read \`${file}\` while checking for migration marker: ${errMessage(err)}`
+        );
+      }
+    } else if (file.startsWith("front-api/")) {
+      const result = spawnSync(
+        "git",
+        ["grep", "-l", "-F", `@migration-target: ${file}`, "--", "pages/api/"],
+        { encoding: "utf8" }
+      );
+      if (result.status === GIT_GREP_MATCH) {
+        for (const nextFile of result.stdout.split("\n").filter(Boolean)) {
+          checks.push({ file, counterpart: `front/${nextFile}` });
+        }
+      } else if (result.status !== GIT_GREP_NO_MATCH) {
+        warn(
+          `Failed to look up Next counterpart for \`${file}\` ` +
+            `(git grep exited ${result.status}): ${result.stderr?.trim() ?? "unknown error"}`
+        );
+      }
+    }
+  }
+
+  for (const { file, counterpart } of checks) {
+    if (diffFiles.includes(counterpart)) {
+      continue;
+    }
+    if (hasLabel(skipMigrationCheckLabel)) {
+      warnMigrationSync(file, counterpart);
+    } else {
+      failMigrationSync(file, counterpart);
+    }
+  }
+}
+
 async function checkDiffFiles() {
   const diffFiles = danger.git.modified_files
     .concat(danger.git.created_files)
@@ -447,6 +533,9 @@ async function checkDiffFiles() {
   if (modifiedSseSharedModels.length > 0) {
     checkSSESharedModelsLabel();
   }
+
+  // Hono migration sync check (self-gates on diff contents).
+  checkHonoMigrationSync();
 }
 
 void checkDiffFiles();

--- a/front/pages/api/healthz.ts
+++ b/front/pages/api/healthz.ts
@@ -1,3 +1,6 @@
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/healthz.ts
+
 /** @ignoreswagger */
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -1,3 +1,6 @@
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/spaces.ts
+
 /**
  * @swagger
  * /api/w/{wId}/spaces:


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/8083

## Description
Adds a migration-marker convention for Next handlers that have been migrated to Hono, and a DangerJS rule that fails when one side of a migrated pair is touched without the other (escape hatch: `skip-migration-check` label).
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Will have to test this and evaluate efficacy as we go! But as evidenced in this PR by adding the two migration tags, it's working as expected :) 
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
None, coding rules only
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25602">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->