### PR TITLE
Bumping claude Opus/Sonnet 4.6/4.7 context size to 400k

### DIFF
--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -193,7 +193,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
   modelId: CLAUDE_OPUS_4_6_MODEL_ID,
   displayName: "Claude Opus 4.6",
-  contextSize: 200_000,
+  contextSize: 400_000,
   recommendedTopK: 16,
   recommendedExhaustiveTopK: 64,
   largeModel: true,
@@ -224,7 +224,7 @@ export const CLAUDE_OPUS_4_7_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
   modelId: CLAUDE_OPUS_4_7_MODEL_ID,
   displayName: "Claude Opus 4.7",
-  contextSize: 200_000,
+  contextSize: 400_000,
   recommendedTopK: 16,
   recommendedExhaustiveTopK: 64,
   largeModel: true,
@@ -260,7 +260,7 @@ export const CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   // 200k, reducing it temporarily to avoid "prompt too long" errors on dust agent
   // due to reasoning tokens not being counted when estimating prompt size in countTokensForMessages
   // Keeping 190k while Anthropic token count API rate limit hasn't been increased
-  contextSize: 190_000,
+  contextSize: 400_000,
   recommendedTopK: 16,
   recommendedExhaustiveTopK: 64,
   largeModel: true,


### PR DESCRIPTION
## Description

Bump Claude family context size to 400k instead of 200k (supports 1m).

## Tests

N/A

## Risk

Increased cost but will give more oxygen for longer agentic loops.

## Deploy Plan

- deploy `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25603">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->