### PR TITLE
Add: public endpoint to sync project files.

### DIFF
--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -8,6 +8,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -124,12 +125,12 @@ describe("listGCSMountFiles", () => {
   let auth: Authenticator;
   let conversationId: string;
   let workspaceId: string;
-  let getFilesMock: ReturnType<typeof vi.fn>;
+  let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
-    getFilesMock = vi.fn();
+    getAllFilesByPrefixMock = vi.fn();
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      getFiles: getFilesMock,
+      getAllFilesByPrefix: getAllFilesByPrefixMock,
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const { authenticator, conversationsSpace } = await createResourceTest({});
@@ -169,15 +170,21 @@ describe("listGCSMountFiles", () => {
 
   it("excludes *.processed.<ext> siblings by default", async () => {
     const prefix = `w/${workspaceId}/conversations/${conversationId}/files/`;
-    getFilesMock.mockResolvedValue([
-      gcsFile({ name: `${prefix}report.pdf`, contentType: "application/pdf" }),
-      gcsFile({ name: `${prefix}report.processed.txt` }),
-      gcsFile({ name: `${prefix}photo.jpg`, contentType: "image/jpeg" }),
-      gcsFile({
-        name: `${prefix}photo.processed.jpg`,
-        contentType: "image/jpeg",
-      }),
-    ]);
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        gcsFile({
+          name: `${prefix}report.pdf`,
+          contentType: "application/pdf",
+        }),
+        gcsFile({ name: `${prefix}report.processed.txt` }),
+        gcsFile({ name: `${prefix}photo.jpg`, contentType: "image/jpeg" }),
+        gcsFile({
+          name: `${prefix}photo.processed.jpg`,
+          contentType: "image/jpeg",
+        }),
+      ],
+      pageFetchCount: 1,
+    });
 
     const entries = await listGCSMountFiles(auth, {
       useCase: "conversation",
@@ -201,10 +208,16 @@ describe("listGCSMountFiles", () => {
 
   it("includes *.processed.<ext> siblings when includeProcessed is true", async () => {
     const prefix = `w/${workspaceId}/conversations/${conversationId}/files/`;
-    getFilesMock.mockResolvedValue([
-      gcsFile({ name: `${prefix}report.pdf`, contentType: "application/pdf" }),
-      gcsFile({ name: `${prefix}report.processed.txt` }),
-    ]);
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        gcsFile({
+          name: `${prefix}report.pdf`,
+          contentType: "application/pdf",
+        }),
+        gcsFile({ name: `${prefix}report.processed.txt` }),
+      ],
+      pageFetchCount: 1,
+    });
 
     const entries = await listGCSMountFiles(
       auth,
@@ -219,6 +232,31 @@ describe("listGCSMountFiles", () => {
         "conversation/report.processed.txt",
       ])
     );
+  });
+
+  it("logs a warning when GCS listing used more than one page", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const prefix = `w/${workspaceId}/conversations/${conversationId}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [gcsFile({ name: `${prefix}report.pdf` })],
+      pageFetchCount: 2,
+    });
+
+    await listGCSMountFiles(auth, {
+      useCase: "conversation",
+      conversationId,
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId,
+        prefix,
+        pageFetchCount: 2,
+        objectCount: 1,
+      }),
+      "GCS mount file listing required multiple list requests; prefix has many objects."
+    );
+    warnSpy.mockRestore();
   });
 });
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -191,7 +191,23 @@ export async function listGCSMountFiles(
   const prefix = resolvePrefix(owner, scope);
 
   const bucket = getPrivateUploadBucket();
-  const gcsFiles = await bucket.getFiles({ prefix, maxResults: 200 });
+  const { files: gcsFiles, pageFetchCount } = await bucket.getAllFilesByPrefix({
+    prefix,
+    pageSize: 200,
+  });
+
+  if (pageFetchCount > 1) {
+    logger.warn(
+      {
+        workspaceId: owner.sId,
+        prefix,
+        scope,
+        pageFetchCount,
+        objectCount: gcsFiles.length,
+      },
+      "GCS mount file listing required multiple list requests; prefix has many objects."
+    );
+  }
 
   // GCS folder placeholders are zero-byte objects whose path ends with "/".
   const folderPlaceholders = gcsFiles.filter((f) => f.name.endsWith("/"));

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -11,7 +11,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { stripNullBytes } from "@app/types/shared/utils/string_utils";
-import type { Bucket } from "@google-cloud/storage";
+import type { Bucket, File } from "@google-cloud/storage";
 import { Storage } from "@google-cloud/storage";
 import type formidable from "formidable";
 import fs from "fs";
@@ -165,6 +165,43 @@ export class FileStorage {
     const [files] = await this.bucket.getFiles({ prefix, maxResults });
 
     return files;
+  }
+
+  /**
+   * Lists all objects under `prefix` by following GCS list pagination.
+   */
+  async getAllFilesByPrefix({
+    prefix,
+    pageSize = 1000,
+  }: {
+    prefix: string;
+    pageSize?: number;
+  }): Promise<{ files: File[]; pageFetchCount: number }> {
+    const allFiles: File[] = [];
+    let pageToken: string | undefined;
+    let pageFetchCount = 0;
+
+    do {
+      const [files, nextQuery] = await this.bucket.getFiles({
+        prefix,
+        maxResults: pageSize,
+        pageToken,
+        autoPaginate: false,
+      });
+      pageFetchCount++;
+      allFiles.push(...files);
+
+      const nextToken =
+        nextQuery &&
+        typeof nextQuery === "object" &&
+        "pageToken" in nextQuery &&
+        nextQuery.pageToken
+          ? String(nextQuery.pageToken)
+          : undefined;
+      pageToken = nextToken || undefined;
+    } while (pageToken);
+
+    return { files: allFiles, pageFetchCount };
   }
 
   async getSortedFileVersions({

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -1,0 +1,157 @@
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./index";
+
+const listGCSMountFilesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@app/lib/api/files/gcs_mount/files", () => ({
+  listGCSMountFiles: listGCSMountFilesMock,
+}));
+
+describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
+  beforeEach(() => {
+    listGCSMountFilesMock.mockReset();
+  });
+
+  it("returns 403 if not system key", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: false,
+      method: "GET",
+    });
+
+    const space = await SpaceFactory.project(workspace);
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_oauth_token_error",
+        message: "Only system keys are allowed to use this endpoint.",
+      },
+    });
+  });
+
+  it("returns 400 if space id is missing", async () => {
+    const { req, res } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    req.query.spaceId = undefined;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid space id.",
+      },
+    });
+  });
+
+  it("returns 404 if space does not exist", async () => {
+    const { req, res } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    req.query.spaceId = "non-existent-space-id";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "space_not_found",
+        message: "Space not found.",
+      },
+    });
+  });
+
+  it("returns 400 for a non-project space", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "GCS mount files listing is only available for project spaces.",
+      },
+    });
+  });
+
+  it("returns 405 for unsupported method", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "POST",
+    });
+
+    const space = await SpaceFactory.project(workspace);
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it("returns files for a project space and filters by updatedSince", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    const space = await SpaceFactory.project(workspace);
+    req.query.spaceId = space.sId;
+    req.query.updatedSince = "1000";
+
+    const mockFile = {
+      isDirectory: false as const,
+      fileName: "a.txt",
+      path: "project/a.txt",
+      sizeBytes: 3,
+      lastModifiedMs: 2000,
+      contentType: "text/plain",
+      fileId: null,
+      thumbnailUrl: null,
+    };
+
+    listGCSMountFilesMock.mockResolvedValue([
+      mockFile,
+      {
+        isDirectory: false as const,
+        fileName: "old.txt",
+        path: "project/old.txt",
+        sizeBytes: 1,
+        lastModifiedMs: 500,
+        contentType: "text/plain",
+        fileId: null,
+        thumbnailUrl: null,
+      },
+    ]);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(listGCSMountFilesMock).toHaveBeenCalledWith(expect.anything(), {
+      useCase: "project",
+      projectId: space.sId,
+    });
+    expect(res._getJSONData()).toEqual({
+      files: [mockFile],
+    });
+  });
+});

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -1,0 +1,113 @@
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import {
+  type GCSMountEntry,
+  listGCSMountFiles,
+} from "@app/lib/api/files/gcs_mount/files";
+import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetSpaceGCSMountFilesResponseType = {
+  files: GCSMountEntry[];
+};
+
+/**
+ * @ignoreswagger
+ * System API key only endpoint. Undocumented.
+ */
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetSpaceGCSMountFilesResponseType>>,
+  auth: Authenticator
+): Promise<void> {
+  const { wId, spaceId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid workspace id.",
+      },
+    });
+  }
+  if (!isString(spaceId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid space id.",
+      },
+    });
+  }
+
+  if (!auth.isSystemKey()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_oauth_token_error",
+        message: "Only system keys are allowed to use this endpoint.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const space = await SpaceResource.fetchById(auth, spaceId);
+      if (!space) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "space_not_found",
+            message: "Space not found.",
+          },
+        });
+      }
+
+      if (!space.isProject()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "GCS mount files listing is only available for project spaces.",
+          },
+        });
+      }
+
+      const { updatedSince } = req.query;
+      const updatedSinceMs = isString(updatedSince)
+        ? parseInt(updatedSince, 10)
+        : null;
+      const updatedSinceFilter =
+        updatedSinceMs !== null && !Number.isNaN(updatedSinceMs)
+          ? updatedSinceMs
+          : null;
+
+      let files = await listGCSMountFiles(auth, {
+        useCase: "project",
+        projectId: space.sId,
+      });
+
+      if (updatedSinceFilter !== null) {
+        files = files.filter((e) => e.lastModifiedMs >= updatedSinceFilter);
+      }
+
+      return res.status(200).json({ files });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withPublicAPIAuthentication(handler);


### PR DESCRIPTION
## Description

Project files were indexed to Core directly in `addFileToProject` via `processAndUpsertToDataSource`, with no mechanism for the connector to detect changes or perform incremental re-sync. This stack shifts that responsibility to the `dust_project` connector — mirroring how conversation sync already works.

This PR adds the system-key-only public endpoint the connector needs to discover project files.

**`GET /api/v1/w/[wId]/spaces/[spaceId]/project_files`**

Returns the current list of GCS mount files for a project space with short-lived signed download URLs. Each entry (`ProjectMountFileEntryType`) carries `scopedPath`, `signedUrl`, `fileName`, `contentType`, `fileId`, and `updatedAt`. Restricted to system API keys; returns 400 for non-project spaces.

**Paginated GCS listing**

`FileStorage.getAllFilesByPrefix` replaces the single `getFiles({ maxResults: 200 })` call: it follows GCS `pageToken` until exhausted and returns `{ files, pageFetchCount }`. `listGCSMountFiles` switches to this method and emits a `logger.warn` when more than one page fetch was needed (signals the prefix has many objects).

**Tests**

Updated listing tests use the new mock interface; added a warning test for `pageFetchCount > 1`; full endpoint tests (403 non-system, 400 missing space, 404 unknown space, 400 non-project space, 405 wrong method, 200 happy path).

## Tests

Green (new test file + updated existing tests)

## Risk

Low — read-only endpoint, system-key only

## Deploy Plan

Deploy `front`
