### PR TITLE
Add: sync project files as part of the connector.

### DIFF
--- a/connectors/knip.ts
+++ b/connectors/knip.ts
@@ -6,6 +6,7 @@ const config: KnipConfig = {
     "src/connectors/dust_project/**",
     "src/resources/dust_project_configuration_resource.ts",
     "src/resources/dust_project_conversation_resource.ts",
+    "src/resources/dust_project_mount_file_resource.ts",
     "src/lib/conversation_rendering.ts",
   ],
   project: ["**/*.{js,jsx,ts,tsx}"],

--- a/connectors/migrations/db/migration_122.sql
+++ b/connectors/migrations/db/migration_122.sql
@@ -1,0 +1,15 @@
+-- dust_project: track synced GCS mount files (project Files panel) for incremental sync and deletes
+CREATE TABLE IF NOT EXISTS "public"."dust_project_mount_files" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "connectorId" BIGINT NOT NULL REFERENCES "public"."connectors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "projectId" VARCHAR(255) NOT NULL,
+  "scopedPath" VARCHAR(2048) NOT NULL,
+  "documentId" VARCHAR(255) NOT NULL,
+  "sourceUpdatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  CONSTRAINT "dust_project_mount_files_connector_scoped_path" UNIQUE ("connectorId", "scopedPath")
+);
+
+CREATE INDEX IF NOT EXISTS "dust_project_mount_files_connector_id_source_updated_at"
+  ON "public"."dust_project_mount_files" ("connectorId", "sourceUpdatedAt");

--- a/connectors/src/admin/db.ts
+++ b/connectors/src/admin/db.ts
@@ -9,6 +9,7 @@ import { DiscordConfigurationModel } from "@connectors/lib/models/discord";
 import {
   DustProjectConfigurationModel,
   DustProjectConversationModel,
+  DustProjectMountFileModel,
 } from "@connectors/lib/models/dust_project";
 import {
   GithubCodeDirectoryModel,
@@ -158,6 +159,7 @@ async function main(): Promise<void> {
   await GongUserModel.sync({ alter: true });
   await DustProjectConfigurationModel.sync({ alter: true });
   await DustProjectConversationModel.sync({ alter: true });
+  await DustProjectMountFileModel.sync({ alter: true });
 
   // enable the `unaccent` extension
   // biome-ignore lint/plugin/noRawSql: DB setup requires raw SQL for extensions

--- a/connectors/src/connectors/dust_project/lib/constants.ts
+++ b/connectors/src/connectors/dust_project/lib/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Folder id for project context files in the dust_project Core data source
+ * (must match front `PROJECT_CONTEXT_FOLDER_ID`).
+ */
+export const PROJECT_CONTEXT_FOLDER_ID = "project-context-folder";
+
+/** Display title for the project context folder node (matches front). */
+export const PROJECT_CONTEXT_FOLDER_NAME = "Context";

--- a/connectors/src/connectors/dust_project/lib/sync_project_mount_files.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_project_mount_files.ts
@@ -1,0 +1,267 @@
+import { PROJECT_CONTEXT_FOLDER_ID } from "@connectors/connectors/dust_project/lib/constants";
+import {
+  handleTextExtraction,
+  handleTextFile,
+} from "@connectors/connectors/shared/file";
+import {
+  deleteDataSourceDocument,
+  MAX_FILE_SIZE_TO_DOWNLOAD,
+  renderDocumentTitleAndContent,
+  upsertDataSourceDocument,
+} from "@connectors/lib/data_sources";
+import logger from "@connectors/logger/logger";
+import { DustProjectMountFileResource } from "@connectors/resources/dust_project_mount_file_resource";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
+import { isTextExtractionSupportedContentType } from "@connectors/types";
+import type { ProjectMountFileEntryType } from "@dust-tt/client";
+import axios, { isAxiosError } from "axios";
+import { createHash } from "crypto";
+
+export function stableMountDocumentId({
+  workspaceId,
+  scopedPath,
+  fileId,
+}: {
+  workspaceId: string;
+  scopedPath: string;
+  fileId: string | null;
+}): string {
+  if (fileId) {
+    return fileId;
+  }
+  const h = createHash("sha256")
+    .update(`${workspaceId}:${scopedPath}`, "utf8")
+    .digest("hex")
+    .slice(0, 32);
+  return `dpf_${h}`;
+}
+
+async function downloadSignedFile(url: string): Promise<ArrayBuffer> {
+  const res = await axios.get<ArrayBuffer>(url, {
+    responseType: "arraybuffer",
+    maxContentLength: MAX_FILE_SIZE_TO_DOWNLOAD,
+    maxBodyLength: MAX_FILE_SIZE_TO_DOWNLOAD,
+    timeout: 120_000,
+  });
+  return res.data;
+}
+
+async function deleteMountDocumentFromCoreBestEffort({
+  dataSourceConfig,
+  documentId,
+  loggerArgs,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  documentId: string;
+  loggerArgs: Record<string, string | number>;
+}): Promise<void> {
+  try {
+    await deleteDataSourceDocument(dataSourceConfig, documentId, loggerArgs);
+  } catch (e) {
+    if (isAxiosError(e) && e.response?.status === 404) {
+      return;
+    }
+    throw e;
+  }
+}
+
+/**
+ * Removes a project mount file from Core and the connector tracking table.
+ */
+export async function deleteProjectMountFile({
+  connectorId,
+  dataSourceConfig,
+  projectId,
+  mountRow,
+}: {
+  connectorId: ModelId;
+  dataSourceConfig: DataSourceConfig;
+  projectId: string;
+  mountRow: DustProjectMountFileResource;
+}): Promise<void> {
+  const localLogger = logger.child({
+    connectorId,
+    projectId,
+    scopedPath: mountRow.scopedPath,
+  });
+  try {
+    await deleteMountDocumentFromCoreBestEffort({
+      dataSourceConfig,
+      documentId: mountRow.documentId,
+      loggerArgs: {
+        projectId,
+        scopedPath: mountRow.scopedPath,
+      },
+    });
+    await mountRow.delete();
+    localLogger.info("Deleted project mount file from data source");
+  } catch (error) {
+    localLogger.error({ error }, "Failed to delete project mount file");
+    throw error;
+  }
+}
+
+/**
+ * Downloads a project GCS mount file via signed URL, extracts content, and upserts to the
+ * project data source under {@link PROJECT_CONTEXT_FOLDER_ID}.
+ */
+export async function syncProjectMountFile({
+  connectorId,
+  dataSourceConfig,
+  projectId,
+  workspaceId,
+  entry,
+  syncType,
+}: {
+  connectorId: ModelId;
+  dataSourceConfig: DataSourceConfig;
+  projectId: string;
+  workspaceId: string;
+  entry: ProjectMountFileEntryType;
+  syncType: "batch" | "incremental";
+}): Promise<void> {
+  const localLogger = logger.child({
+    connectorId,
+    projectId,
+    path: entry.path,
+  });
+
+  const signedFileUrl = entry.signedDownloadUrl;
+  if (!signedFileUrl) {
+    localLogger.warn(
+      "Skipping mount file: missing signedDownloadUrl from project_files API"
+    );
+    return;
+  }
+
+  if (entry.sizeBytes > MAX_FILE_SIZE_TO_DOWNLOAD) {
+    localLogger.info("Skipping mount file: exceeds max download size");
+    return;
+  }
+
+  const mimeType = entry.contentType || "application/octet-stream";
+  const documentId = stableMountDocumentId({
+    workspaceId,
+    scopedPath: entry.path,
+    fileId: entry.fileId,
+  });
+
+  const sourceUpdatedAt = new Date(entry.lastModifiedMs);
+  const tags = [
+    `title:${entry.fileName}`,
+    `project:${projectId}`,
+    `mountPath:${entry.path}`,
+  ];
+
+  const existing =
+    await DustProjectMountFileResource.fetchByConnectorIdAndScopedPath(
+      connectorId,
+      entry.path
+    );
+
+  const buffer = await downloadSignedFile(signedFileUrl);
+
+  if (isTextExtractionSupportedContentType(mimeType)) {
+    const sectionRes = await handleTextExtraction(
+      buffer,
+      localLogger,
+      mimeType
+    );
+    if (sectionRes.isErr()) {
+      localLogger.warn(
+        { error: sectionRes.error },
+        "Text extraction failed for mount file"
+      );
+      return;
+    }
+    const documentContent = await renderDocumentTitleAndContent({
+      dataSourceConfig,
+      title: entry.fileName,
+      createdAt: sourceUpdatedAt,
+      updatedAt: sourceUpdatedAt,
+      content: sectionRes.value,
+    });
+    await upsertDataSourceDocument({
+      dataSourceConfig,
+      documentId,
+      documentContent,
+      documentUrl: undefined,
+      timestampMs: entry.lastModifiedMs,
+      tags,
+      parents: [documentId, PROJECT_CONTEXT_FOLDER_ID],
+      parentId: PROJECT_CONTEXT_FOLDER_ID,
+      upsertContext: { sync_type: syncType },
+      title: entry.fileName,
+      mimeType,
+      async: true,
+      loggerArgs: {
+        projectId,
+        path: entry.path,
+      },
+    });
+  } else if (mimeType.startsWith("text/")) {
+    const textRes = handleTextFile(buffer, MAX_FILE_SIZE_TO_DOWNLOAD);
+    if (textRes.isErr()) {
+      localLogger.warn(
+        { error: textRes.error },
+        "Plain text mount file skipped"
+      );
+      return;
+    }
+    const documentContent = await renderDocumentTitleAndContent({
+      dataSourceConfig,
+      title: entry.fileName,
+      createdAt: sourceUpdatedAt,
+      updatedAt: sourceUpdatedAt,
+      content: textRes.value,
+    });
+    await upsertDataSourceDocument({
+      dataSourceConfig,
+      documentId,
+      documentContent,
+      documentUrl: undefined,
+      timestampMs: entry.lastModifiedMs,
+      tags,
+      parents: [documentId, PROJECT_CONTEXT_FOLDER_ID],
+      parentId: PROJECT_CONTEXT_FOLDER_ID,
+      upsertContext: { sync_type: syncType },
+      title: entry.fileName,
+      mimeType,
+      async: true,
+      loggerArgs: { projectId, path: entry.path },
+    });
+  } else {
+    localLogger.info(
+      { mimeType },
+      "Skipping mount file: unsupported type for extraction"
+    );
+    return;
+  }
+
+  if (existing) {
+    if (existing.documentId !== documentId) {
+      await deleteMountDocumentFromCoreBestEffort({
+        dataSourceConfig,
+        documentId: existing.documentId,
+        loggerArgs: { projectId, scopedPath: entry.path },
+      });
+    }
+    const upd = await existing.updateRow({
+      documentId,
+      sourceUpdatedAt,
+    });
+    if (upd.isErr()) {
+      throw upd.error;
+    }
+  } else {
+    await DustProjectMountFileResource.makeNew({
+      connectorId,
+      projectId,
+      scopedPath: entry.path,
+      documentId,
+      sourceUpdatedAt,
+    });
+  }
+
+  localLogger.info({ documentId }, "Synced project mount file");
+}

--- a/connectors/src/connectors/dust_project/temporal/activities.ts
+++ b/connectors/src/connectors/dust_project/temporal/activities.ts
@@ -3,6 +3,10 @@ import {
   syncConversation,
 } from "@connectors/connectors/dust_project/lib/sync_conversation";
 import { syncProjectMetadata } from "@connectors/connectors/dust_project/lib/sync_metadata";
+import {
+  deleteProjectMountFile,
+  syncProjectMountFile,
+} from "@connectors/connectors/dust_project/lib/sync_project_mount_files";
 import { launchDustProjectIncrementalSyncWorkflow } from "@connectors/connectors/dust_project/temporal/client";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { getDustAPI } from "@connectors/lib/api/dust_api";
@@ -15,8 +19,13 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { DustProjectConfigurationResource } from "@connectors/resources/dust_project_configuration_resource";
 import { DustProjectConversationResource } from "@connectors/resources/dust_project_conversation_resource";
+import { DustProjectMountFileResource } from "@connectors/resources/dust_project_mount_file_resource";
 import type { ModelId } from "@connectors/types";
 import { concurrentExecutor } from "@connectors/types";
+import type {
+  ProjectMountFileEntryType,
+  ProjectMountListEntryType,
+} from "@dust-tt/client";
 
 /**
  * Full sync activity: Syncs all conversations for a project.
@@ -353,6 +362,241 @@ async function dustProjectConversationsGarbageCollectActivity({
   }
 }
 
+function isMountFileEntry(
+  e: ProjectMountListEntryType
+): e is ProjectMountFileEntryType {
+  return !e.isDirectory;
+}
+
+/**
+ * Full sync: list all project mount files, remove tracking rows (and Core) for deleted paths, sync each file.
+ */
+export async function dustProjectMountFilesFullSyncActivity({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}): Promise<void> {
+  const localLogger = logger.child({ connectorId });
+
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const configuration =
+    await DustProjectConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`Configuration not found for connector ${connectorId}`);
+  }
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  localLogger.info(
+    { projectId: configuration.projectId },
+    "Starting full sync for dust_project mount files"
+  );
+
+  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+  const listRes = await dustAPI.getSpaceProjectFiles({
+    spaceId: configuration.projectId,
+  });
+
+  if (listRes.isErr()) {
+    throw new Error(
+      `Failed to fetch project mount files: ${listRes.error.message}`
+    );
+  }
+
+  const fileEntries = listRes.value.files.filter(isMountFileEntry);
+  const fetchedPaths = new Set(fileEntries.map((e) => e.path));
+
+  const syncedRows =
+    await DustProjectMountFileResource.fetchByConnectorId(connectorId);
+  const toRemove = syncedRows.filter((r) => !fetchedPaths.has(r.scopedPath));
+
+  if (toRemove.length > 0) {
+    await concurrentExecutor(
+      toRemove,
+      async (row) => {
+        await deleteProjectMountFile({
+          connectorId,
+          dataSourceConfig,
+          projectId: configuration.projectId,
+          mountRow: row,
+        });
+      },
+      { concurrency: 5 }
+    );
+  }
+
+  await concurrentExecutor(
+    fileEntries,
+    async (entry) => {
+      await syncProjectMountFile({
+        connectorId,
+        dataSourceConfig,
+        projectId: configuration.projectId,
+        workspaceId: dataSourceConfig.workspaceId,
+        entry,
+        syncType: "batch",
+      });
+    },
+    { concurrency: 3 }
+  );
+
+  localLogger.info(
+    { projectId: configuration.projectId, count: fileEntries.length },
+    "Completed full sync for dust_project mount files"
+  );
+}
+
+/**
+ * Incremental sync: fetch mount files updated since last synced watermark, then GC removed files.
+ */
+export async function dustProjectMountFilesIncrementalSyncActivity({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}): Promise<void> {
+  const localLogger = logger.child({ connectorId });
+
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const configuration =
+    await DustProjectConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`Configuration not found for connector ${connectorId}`);
+  }
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  const maxSourceUpdatedAt =
+    await DustProjectMountFileResource.getMaxSourceUpdatedAt(connectorId);
+
+  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+  const listRes = await dustAPI.getSpaceProjectFiles({
+    spaceId: configuration.projectId,
+    updatedSince:
+      maxSourceUpdatedAt != null ? maxSourceUpdatedAt.getTime() + 1 : undefined,
+  });
+
+  if (listRes.isErr()) {
+    throw new Error(
+      `Failed to fetch project mount files: ${listRes.error.message}`
+    );
+  }
+
+  const fileEntries = listRes.value.files.filter(isMountFileEntry);
+
+  localLogger.info(
+    {
+      projectId: configuration.projectId,
+      count: fileEntries.length,
+      lastSourceUpdatedAt: maxSourceUpdatedAt,
+    },
+    "Fetched project mount files for incremental sync"
+  );
+
+  await concurrentExecutor(
+    fileEntries,
+    async (entry) => {
+      await syncProjectMountFile({
+        connectorId,
+        dataSourceConfig,
+        projectId: configuration.projectId,
+        workspaceId: dataSourceConfig.workspaceId,
+        entry,
+        syncType: "incremental",
+      });
+    },
+    { concurrency: 3 }
+  );
+
+  await dustProjectMountFilesGarbageCollectActivity({ connectorId });
+}
+
+/**
+ * Remove Core + DB rows for mount files that no longer exist under the project prefix in GCS.
+ */
+export async function dustProjectMountFilesGarbageCollectActivity({
+  connectorId,
+}: {
+  connectorId: ModelId;
+}): Promise<void> {
+  const localLogger = logger.child({ connectorId });
+
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const configuration =
+    await DustProjectConfigurationResource.fetchByConnectorId(connectorId);
+  if (!configuration) {
+    throw new Error(`Configuration not found for connector ${connectorId}`);
+  }
+
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  try {
+    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+    const listRes = await dustAPI.getSpaceProjectFiles({
+      spaceId: configuration.projectId,
+    });
+
+    if (listRes.isErr()) {
+      throw new Error(
+        `Failed to list project mount files for GC: ${listRes.error.message}`
+      );
+    }
+
+    const existingPaths = new Set(
+      listRes.value.files.filter(isMountFileEntry).map((e) => e.path)
+    );
+
+    const syncedRows =
+      await DustProjectMountFileResource.fetchByConnectorId(connectorId);
+    const toDelete = syncedRows.filter((r) => !existingPaths.has(r.scopedPath));
+
+    if (toDelete.length === 0) {
+      localLogger.info(
+        { projectId: configuration.projectId },
+        "No orphaned mount files to garbage-collect"
+      );
+      return;
+    }
+
+    await concurrentExecutor(
+      toDelete,
+      async (row) => {
+        await deleteProjectMountFile({
+          connectorId,
+          dataSourceConfig,
+          projectId: configuration.projectId,
+          mountRow: row,
+        });
+      },
+      { concurrency: 5 }
+    );
+
+    localLogger.info(
+      {
+        projectId: configuration.projectId,
+        deletedCount: toDelete.length,
+      },
+      "Garbage collection completed for project mount files"
+    );
+  } catch (error) {
+    localLogger.error(
+      { error, projectId: configuration.projectId },
+      "Garbage collection failed for project mount files"
+    );
+  }
+}
+
 /**
  * Sync metadata activity: Fetches and syncs project metadata (description).
  * On fetch/upsert failure, throws so the Temporal workflow fails.
@@ -437,7 +681,7 @@ export async function dustProjectSyncMetadataActivity({
 }
 
 /**
- * Marks a successful dust_project sync run (conversations + metadata activities).
+ * Marks a successful dust_project sync run (conversations, mount files, metadata).
  * Updates connector sync status via `syncSucceeded` and sets `lastSyncedAt` on the dust project configuration.
  */
 export async function dustProjectMarkSyncedActivity({

--- a/connectors/src/connectors/dust_project/temporal/workflows.ts
+++ b/connectors/src/connectors/dust_project/temporal/workflows.ts
@@ -5,6 +5,8 @@ import { proxyActivities } from "@temporalio/workflow";
 const {
   dustProjectConversationsFullSyncActivity,
   dustProjectConversationsIncrementalSyncActivity,
+  dustProjectMountFilesFullSyncActivity,
+  dustProjectMountFilesIncrementalSyncActivity,
   dustProjectSyncMetadataActivity,
   dustProjectMarkSyncedActivity,
 } = proxyActivities<typeof activities>({
@@ -34,6 +36,7 @@ export async function dustProjectFullSyncWorkflow({
   connectorId: ModelId;
 }): Promise<void> {
   await dustProjectConversationsFullSyncActivity({ connectorId });
+  await dustProjectMountFilesFullSyncActivity({ connectorId });
   await dustProjectSyncMetadataActivity({ connectorId });
   await dustProjectMarkSyncedActivity({ connectorId });
 }
@@ -48,6 +51,7 @@ export async function dustProjectIncrementalSyncWorkflow({
   connectorId: ModelId;
 }): Promise<void> {
   await dustProjectConversationsIncrementalSyncActivity({ connectorId });
+  await dustProjectMountFilesIncrementalSyncActivity({ connectorId });
   await dustProjectSyncMetadataActivity({ connectorId });
   await dustProjectMarkSyncedActivity({ connectorId });
 }

--- a/connectors/src/lib/models/dust_project.ts
+++ b/connectors/src/lib/models/dust_project.ts
@@ -104,3 +104,58 @@ DustProjectConversationModel.init(
     relationship: "hasMany",
   }
 );
+
+export class DustProjectMountFileModel extends ConnectorBaseModel<DustProjectMountFileModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare projectId: string;
+  /** Scoped mount path from Front list API (e.g. `project/report.pdf`). */
+  declare scopedPath: string;
+  /** Core document id used for upsert/delete. */
+  declare documentId: string;
+  declare sourceUpdatedAt: Date;
+}
+
+DustProjectMountFileModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    projectId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    scopedPath: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    documentId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    sourceUpdatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: connectorsSequelize,
+    indexes: [
+      { fields: ["connectorId", "scopedPath"], unique: true },
+      { fields: ["connectorId", "sourceUpdatedAt"] },
+      {
+        fields: ["connectorId", "projectId", "scopedPath"],
+        name: "dust_project_mount_files_connector_project_scoped",
+      },
+    ],
+    modelName: "dust_project_mount_files",
+    relationship: "hasMany",
+  }
+);

--- a/connectors/src/resources/connector/dust_project.ts
+++ b/connectors/src/resources/connector/dust_project.ts
@@ -8,6 +8,7 @@ import type {
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import { DustProjectConfigurationResource } from "@connectors/resources/dust_project_configuration_resource";
 import { DustProjectConversationResource } from "@connectors/resources/dust_project_conversation_resource";
+import { DustProjectMountFileResource } from "@connectors/resources/dust_project_mount_file_resource";
 import type { ModelId } from "@connectors/types";
 import type { Transaction } from "sequelize";
 
@@ -30,6 +31,10 @@ export class DustProjectConnectorStrategy
     connector: ConnectorResource,
     transaction: Transaction
   ): Promise<void> {
+    await DustProjectMountFileResource.deleteByConnector(
+      connector,
+      transaction
+    );
     await DustProjectConversationResource.deleteByConnector(
       connector,
       transaction

--- a/connectors/src/resources/dust_project_mount_file_resource.ts
+++ b/connectors/src/resources/dust_project_mount_file_resource.ts
@@ -1,0 +1,168 @@
+import { DustProjectMountFileModel } from "@connectors/lib/models/dust_project";
+import logger from "@connectors/logger/logger";
+import { BaseResource } from "@connectors/resources/base_resource";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
+import type { ModelId } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface DustProjectMountFileResource
+  extends ReadonlyAttributesType<DustProjectMountFileModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class DustProjectMountFileResource extends BaseResource<DustProjectMountFileModel> {
+  static model: ModelStatic<DustProjectMountFileModel> =
+    DustProjectMountFileModel;
+
+  constructor(
+    model: ModelStatic<DustProjectMountFileModel>,
+    blob: Attributes<DustProjectMountFileModel>
+  ) {
+    super(DustProjectMountFileModel, blob);
+  }
+
+  async postFetchHook(): Promise<void> {
+    return;
+  }
+
+  static async makeNew({
+    connectorId,
+    projectId,
+    scopedPath,
+    documentId,
+    sourceUpdatedAt,
+    transaction,
+  }: {
+    connectorId: ModelId;
+    projectId: string;
+    scopedPath: string;
+    documentId: string;
+    sourceUpdatedAt: Date;
+    transaction?: Transaction;
+  }): Promise<DustProjectMountFileResource> {
+    const model = await DustProjectMountFileModel.create(
+      {
+        connectorId,
+        projectId,
+        scopedPath,
+        documentId,
+        sourceUpdatedAt,
+      },
+      { transaction }
+    );
+
+    return new DustProjectMountFileResource(DustProjectMountFileModel, {
+      ...model.get({ plain: true }),
+    });
+  }
+
+  static async fetchByConnectorId(
+    connectorId: ModelId
+  ): Promise<DustProjectMountFileResource[]> {
+    const models = await DustProjectMountFileModel.findAll({
+      where: { connectorId },
+    });
+
+    return models.map(
+      (m) =>
+        new DustProjectMountFileResource(DustProjectMountFileModel, {
+          ...m.get({ plain: true }),
+        })
+    );
+  }
+
+  static async fetchByConnectorIdAndScopedPath(
+    connectorId: ModelId,
+    scopedPath: string
+  ): Promise<DustProjectMountFileResource | null> {
+    const model = await DustProjectMountFileModel.findOne({
+      where: { connectorId, scopedPath },
+    });
+
+    if (!model) {
+      return null;
+    }
+
+    return new DustProjectMountFileResource(DustProjectMountFileModel, {
+      ...model.get({ plain: true }),
+    });
+  }
+
+  static async getMaxSourceUpdatedAt(
+    connectorId: ModelId
+  ): Promise<Date | null> {
+    return DustProjectMountFileModel.max<
+      Date | null,
+      DustProjectMountFileModel
+    >("sourceUpdatedAt", {
+      where: { connectorId },
+    });
+  }
+
+  async updateRow({
+    documentId,
+    sourceUpdatedAt,
+    transaction,
+  }: {
+    documentId: string;
+    sourceUpdatedAt: Date;
+    transaction?: Transaction;
+  }): Promise<Result<void, Error>> {
+    try {
+      await DustProjectMountFileModel.update(
+        { documentId, sourceUpdatedAt },
+        { where: { id: this.id }, transaction }
+      );
+      return new Ok(undefined);
+    } catch (err) {
+      logger.error(
+        { connectorId: this.connectorId, error: err },
+        "Error updating dust_project_mount_file"
+      );
+      return new Err(normalizeError(err));
+    }
+  }
+
+  async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
+    try {
+      await DustProjectMountFileModel.destroy({
+        where: { id: this.id },
+        transaction,
+      });
+      return new Ok(undefined);
+    } catch (err) {
+      logger.error(
+        { connectorId: this.connectorId, error: err },
+        "Error deleting dust_project_mount_file"
+      );
+      return new Err(normalizeError(err));
+    }
+  }
+
+  static async deleteByConnector(
+    connector: ConnectorResource,
+    transaction?: Transaction
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: { connectorId: connector.id },
+      transaction,
+    });
+    return new Ok(undefined);
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      id: this.id,
+      connectorId: this.connectorId,
+      projectId: this.projectId,
+      scopedPath: this.scopedPath,
+      documentId: this.documentId,
+      sourceUpdatedAt: this.sourceUpdatedAt,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+}

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -36,6 +36,8 @@ export type GCSMountFileEntry = GCSMountEntryBase & {
   contentType: string;
   fileId: string | null;
   thumbnailUrl: string | null;
+  /** Present when the listing endpoint adds read-signed URLs (e.g. system project_files API). */
+  signedDownloadUrl?: string | null;
 };
 
 export type GCSMountEntry = GCSMountDirectoryEntry | GCSMountFileEntry;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -1,18 +1,30 @@
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./index";
 
 const listGCSMountFilesMock = vi.hoisted(() => vi.fn());
+const getConversationFileMountSignedUrlMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@app/lib/api/files/gcs_mount/files", () => ({
-  listGCSMountFiles: listGCSMountFilesMock,
-}));
+vi.mock("@app/lib/api/files/gcs_mount/files", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/files/gcs_mount/files")>();
+  return {
+    ...actual,
+    listGCSMountFiles: listGCSMountFilesMock,
+    getConversationFileMountSignedUrl: getConversationFileMountSignedUrlMock,
+  };
+});
 
 describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
   beforeEach(() => {
     listGCSMountFilesMock.mockReset();
+    getConversationFileMountSignedUrlMock.mockReset();
+    getConversationFileMountSignedUrlMock.mockResolvedValue(
+      new Ok("https://signed.example/read")
+    );
   });
 
   it("returns 403 if not system key", async () => {
@@ -129,6 +141,11 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
       thumbnailUrl: null,
     };
 
+    const mockFileWithUrl = {
+      ...mockFile,
+      signedDownloadUrl: "https://signed.example/read",
+    };
+
     listGCSMountFilesMock.mockResolvedValue([
       mockFile,
       {
@@ -151,7 +168,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
       projectId: space.sId,
     });
     expect(res._getJSONData()).toEqual({
-      files: [mockFile],
+      files: [mockFileWithUrl],
     });
   });
 });

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -1,10 +1,14 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import {
   type GCSMountEntry,
+  getConversationFileMountSignedUrl,
+  getGCSPathFromScopedPath,
   listGCSMountFiles,
 } from "@app/lib/api/files/gcs_mount/files";
+import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
@@ -96,7 +100,40 @@ async function handler(
         files = files.filter((e) => e.lastModifiedMs >= updatedSinceFilter);
       }
 
-      return res.status(200).json({ files });
+      const owner = auth.getNonNullableWorkspace();
+      const gcsPrefix = getProjectFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: space.sId,
+      });
+
+      const filesWithSignedUrls = await concurrentExecutor(
+        files,
+        async (entry) => {
+          if (entry.isDirectory) {
+            return entry;
+          }
+          const gcsPath = getGCSPathFromScopedPath({
+            prefix: gcsPrefix,
+            scopedPath: entry.path,
+            useCase: "project",
+          });
+          if (!gcsPath) {
+            return { ...entry, signedDownloadUrl: null };
+          }
+          const signed = await getConversationFileMountSignedUrl(
+            auth,
+            { useCase: "project", projectId: space.sId },
+            gcsPath
+          );
+          return {
+            ...entry,
+            signedDownloadUrl: signed.isOk() ? signed.value : null,
+          };
+        },
+        { concurrency: 8 }
+      );
+
+      return res.status(200).json({ files: filesWithSignedUrls });
     }
 
     default:

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -75,6 +75,7 @@ import {
   GetFeedbacksResponseSchema,
   GetMCPServerViewsResponseSchema,
   GetMentionSuggestionsResponseBodySchema,
+  GetProjectFilesResponseSchema,
   GetSpaceConversationIdsResponseSchema,
   GetSpaceConversationsForDataSourceResponseSchema,
   GetSpaceMetadataResponseSchema,
@@ -1522,6 +1523,27 @@ export class DustAPI {
     });
 
     return this._resultFromResponse(GetSpaceMetadataResponseSchema, res);
+  }
+
+  async getSpaceProjectFiles({
+    spaceId,
+    updatedSince,
+  }: {
+    spaceId: string;
+    updatedSince?: number | null;
+  }) {
+    const query = new URLSearchParams();
+    if (updatedSince !== undefined && updatedSince !== null) {
+      query.append("updatedSince", String(updatedSince));
+    }
+
+    const res = await this.request({
+      method: "GET",
+      path: `spaces/${spaceId}/project_files`,
+      query,
+    });
+
+    return this._resultFromResponse(GetProjectFilesResponseSchema, res);
   }
 
   async postFeedback(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2657,6 +2657,47 @@ export type GetSpaceMetadataResponseType = z.infer<
   typeof GetSpaceMetadataResponseSchema
 >;
 
+export const ProjectMountFileEntrySchema = z.object({
+  isDirectory: z.literal(false),
+  fileName: z.string(),
+  path: z.string(),
+  sizeBytes: z.number(),
+  lastModifiedMs: z.number(),
+  contentType: z.string(),
+  fileId: z.string().nullable(),
+  thumbnailUrl: z.string().nullable(),
+  signedDownloadUrl: z.string().nullable(),
+});
+export type ProjectMountFileEntryType = z.infer<
+  typeof ProjectMountFileEntrySchema
+>;
+
+export const ProjectMountDirectoryEntrySchema = z.object({
+  isDirectory: z.literal(true),
+  fileName: z.string(),
+  path: z.string(),
+  sizeBytes: z.number(),
+  lastModifiedMs: z.number(),
+});
+export type ProjectMountDirectoryEntryType = z.infer<
+  typeof ProjectMountDirectoryEntrySchema
+>;
+
+export const ProjectMountListEntrySchema = z.discriminatedUnion("isDirectory", [
+  ProjectMountDirectoryEntrySchema,
+  ProjectMountFileEntrySchema,
+]);
+export type ProjectMountListEntryType = z.infer<
+  typeof ProjectMountListEntrySchema
+>;
+
+export const GetProjectFilesResponseSchema = z.object({
+  files: z.array(ProjectMountListEntrySchema),
+});
+export type GetProjectFilesResponseType = z.infer<
+  typeof GetProjectFilesResponseSchema
+>;
+
 const GetDocumentsResponseSchema = z.object({
   documents: z.array(CoreAPIDocumentSchema),
   total: z.number(),


### PR DESCRIPTION
## Description

The connector now owns indexing of project files to Core, using the `GET /project_files` endpoint from #25604 as its source of truth.

**`dust_project_mount_files` table** (`migration_122.sql`)

Tracks each synced file per connector: `scopedPath` (unique per connector), `documentId`, and `sourceUpdatedAt`. The `(connectorId, sourceUpdatedAt)` index enables efficient incremental sync watermarking.

**`sync_project_mount_files.ts`**

- `stableMountDocumentId` — stable Core document id: uses `fileId` when available (survives re-uploads); falls back to `sha256(workspaceId:scopedPath).slice(0,32)` prefixed `dpf_`
- `syncProjectMountFile` — downloads from the signed URL, processes via the existing shared `handleTextExtraction` / `handleTextFile` helpers, upserts to Core under `PROJECT_CONTEXT_FOLDER_ID`, upserts the `DustProjectMountFileResource` row with `sourceUpdatedAt`
- `deleteProjectMountFile` — deletes from Core (404 swallowed) and removes the tracking row
- `syncProjectMountFiles` — calls `GET /project_files`, syncs all returned files, hard-deletes stale rows whose `scopedPath` no longer appears; incremental mode skips files whose `sourceUpdatedAt` is unchanged

Called from the existing `syncProjectActivity` at the end of each full sync.

## Tests

Local

## Risk

Medium — new sync path; files indexed by the old `front`-side upsert and the new connector path will coexist until the next full re-sync. `stableMountDocumentId` uses `fileId` when set to avoid duplicating Core documents.

## Deploy Plan

Run connector migration (`migration_122.sql`), deploy `connectors`
