### PR TITLE
Remove datasource upsert in addFileToProject (as the connector will handle it).

### DIFF
--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -5,13 +5,6 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
-import type {
-  UpsertDocumentArgs,
-  UpsertTableArgs,
-} from "@app/lib/api/data_sources";
-import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
-import { PROJECT_CONTEXT_FOLDER_ID } from "@app/lib/api/projects/constants";
-import { fetchProjectDataSource } from "@app/lib/api/projects/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { MessageModel } from "@app/lib/models/agent/conversation";
@@ -20,13 +13,10 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
-import logger from "@app/logger/logger";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
-import { isSupportedDelimitedTextContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
-import { slugify } from "@app/types/shared/utils/string_utils";
 import { Op } from "sequelize";
 
 /**
@@ -253,62 +243,14 @@ export async function addFileToProject(
     });
   }
 
+  // TODO(projects) this is not sufficient, the file mountpoint is not updated on GCS.
   await file.updateUseCase(auth, "project_context", {
     spaceId: space.sId,
     conversationId: undefined,
     sourceConversationId,
   });
 
-  const projectContextDatasource = await fetchProjectDataSource(auth, space);
-  if (projectContextDatasource.isErr()) {
-    return new Err(projectContextDatasource.error);
-  }
-
-  let upsertArgs: UpsertDocumentArgs | UpsertTableArgs;
-
-  const commonArgs = {
-    title: file.fileName,
-    parents: [file.sId, PROJECT_CONTEXT_FOLDER_ID],
-  };
-
-  if (isSupportedDelimitedTextContentType(file.contentType)) {
-    upsertArgs = {
-      parentId: PROJECT_CONTEXT_FOLDER_ID,
-      tableId: file.sId,
-      name: slugify(file.fileName),
-      description: `Project context: ${file.fileName}`,
-      truncate: true,
-      mimeType: file.contentType,
-      ...commonArgs,
-    };
-  } else {
-    upsertArgs = {
-      parent_id: PROJECT_CONTEXT_FOLDER_ID,
-      document_id: file.sId,
-      dataSource: projectContextDatasource.value,
-      auth,
-      mime_type: file.contentType,
-      ...commonArgs,
-    };
-  }
-
-  const rUpsert = await processAndUpsertToDataSource(
-    auth,
-    projectContextDatasource.value,
-    { file, upsertArgs }
-  );
-
-  if (rUpsert.isErr()) {
-    logger.warn(
-      {
-        workspaceId: auth.workspace()?.sId,
-        fileId: file.sId,
-        error: rUpsert.error,
-      },
-      "Project context Core upsert failed; file may still be used raw. Syncing content fragment."
-    );
-  }
-
+  // TODO(projects) once the source of truth for the project's files is GCS, we can remove this.
   const fragmentRes =
     await ContentFragmentResource.upsertLatestProjectFileFragment(
       auth,


### PR DESCRIPTION
## Description

Now that the connector handles Core indexing of project files (#25605), the duplicate `processAndUpsertToDataSource` call in `addFileToProject` can be removed.

- Strip the entire Core upsert block (`fetchProjectDataSource`, `processAndUpsertToDataSource`, `UpsertDocumentArgs`/`UpsertTableArgs` construction) from `front/lib/api/projects/context.ts`
- `addFileToProject` now only: updates GCS use-case metadata and upserts the content fragment (for immediate conversation attachment while the connector hasn't synced yet)
- Two TODO comments mark the remaining transitional code to be cleaned up once the connector is the canonical source of truth

## Tests

Local

## Risk

Low — the removed code was a best-effort upsert (failures were only logged as warnings); the connector sync provides the same result on its next run

## Deploy Plan

Deploy `front` (after #25604 and #25605 are deployed)
