### PR TITLE
[Slack Bot] Rate limit chatbot webhook storms

### DIFF
--- a/connectors/src/api/webhooks/slack/utils.ts
+++ b/connectors/src/api/webhooks/slack/utils.ts
@@ -1,17 +1,17 @@
 import { botAnswerMessage } from "@connectors/connectors/slack/bot";
 import { getBotUserIdResponse } from "@connectors/connectors/slack/lib/bot_user_helpers";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
+import { throttleWithRedis } from "@connectors/lib/throttle";
 import type { Logger } from "@connectors/logger/logger";
 import { apiError } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
-import { rateLimiter } from "@connectors/types/shared/rate_limiter";
 import tracer from "dd-trace";
 import type { Request, Response } from "express";
 
 const SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL = 10;
-const SLACK_CHATBOT_RATE_LIMIT_TIMEFRAME_SECONDS = 60;
+const SLACK_CHATBOT_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 
 /**
  * Webhook payload example. Can be handy for working on it.
@@ -202,14 +202,27 @@ export async function handleChatBot(
   // We need to answer 200 quickly to Slack, otherwise they will retry the HTTP request.
   res.status(200).send();
 
-  const actorId = slackUserId ?? slackBotId;
-  const remainingMessages = await rateLimiter({
-    key: `slack-chatbot:${slackTeamId}:${slackChannel}:${actorId}`,
-    maxPerTimeframe: SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL,
-    timeframeSeconds: SLACK_CHATBOT_RATE_LIMIT_TIMEFRAME_SECONDS,
-    logger,
-  });
-  if (remainingMessages === 0) {
+  const actorId = slackUserId || slackBotId;
+  if (!actorId) {
+    throw new Error("Failed to get Slack actor id.");
+  }
+
+  const shouldProcessMessage = await throttleWithRedis(
+    {
+      limit: SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL,
+      windowInMs: SLACK_CHATBOT_RATE_LIMIT_WINDOW_MS,
+    },
+    `slack-chatbot:${slackTeamId}:${actorId}`,
+    { canBeIgnored: true },
+    async () => true,
+    {
+      source: "slack-chatbot-webhook",
+      slackTeamId,
+      slackChannel,
+      actorId,
+    }
+  );
+  if (!shouldProcessMessage) {
     logger.warn(
       {
         slackTeamId,
@@ -220,7 +233,7 @@ export async function handleChatBot(
         slackThreadTs,
         rateLimitMaxPerActorChannel:
           SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL,
-        rateLimitTimeframeSeconds: SLACK_CHATBOT_RATE_LIMIT_TIMEFRAME_SECONDS,
+        rateLimitWindowMs: SLACK_CHATBOT_RATE_LIMIT_WINDOW_MS,
       },
       "Rate limited Slack Chat Bot message"
     );

--- a/connectors/src/api/webhooks/slack/utils.ts
+++ b/connectors/src/api/webhooks/slack/utils.ts
@@ -220,8 +220,7 @@ export async function handleChatBot(
         slackThreadTs,
         rateLimitMaxPerActorChannel:
           SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL,
-        rateLimitTimeframeSeconds:
-          SLACK_CHATBOT_RATE_LIMIT_TIMEFRAME_SECONDS,
+        rateLimitTimeframeSeconds: SLACK_CHATBOT_RATE_LIMIT_TIMEFRAME_SECONDS,
       },
       "Rate limited Slack Chat Bot message"
     );

--- a/connectors/src/api/webhooks/slack/utils.ts
+++ b/connectors/src/api/webhooks/slack/utils.ts
@@ -10,7 +10,7 @@ import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
 import tracer from "dd-trace";
 import type { Request, Response } from "express";
 
-const SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL = 10;
+const SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR = 10;
 const SLACK_CHATBOT_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 
 /**
@@ -209,7 +209,7 @@ export async function handleChatBot(
 
   const shouldProcessMessage = await throttleWithRedis(
     {
-      limit: SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL,
+      limit: SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR,
       windowInMs: SLACK_CHATBOT_RATE_LIMIT_WINDOW_MS,
     },
     `slack-chatbot:${slackTeamId}:${actorId}`,
@@ -231,8 +231,7 @@ export async function handleChatBot(
         slackBotId,
         slackMessageTs,
         slackThreadTs,
-        rateLimitMaxPerActorChannel:
-          SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL,
+        rateLimitMaxPerActor: SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR,
         rateLimitWindowMs: SLACK_CHATBOT_RATE_LIMIT_WINDOW_MS,
       },
       "Rate limited Slack Chat Bot message"

--- a/connectors/src/api/webhooks/slack/utils.ts
+++ b/connectors/src/api/webhooks/slack/utils.ts
@@ -6,8 +6,12 @@ import { apiError } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
+import { rateLimiter } from "@connectors/types/shared/rate_limiter";
 import tracer from "dd-trace";
 import type { Request, Response } from "express";
+
+const SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL = 10;
+const SLACK_CHATBOT_RATE_LIMIT_TIMEFRAME_SECONDS = 60;
 
 /**
  * Webhook payload example. Can be handy for working on it.
@@ -197,6 +201,33 @@ export async function handleChatBot(
 
   // We need to answer 200 quickly to Slack, otherwise they will retry the HTTP request.
   res.status(200).send();
+
+  const actorId = slackUserId ?? slackBotId;
+  const remainingMessages = await rateLimiter({
+    key: `slack-chatbot:${slackTeamId}:${slackChannel}:${actorId}`,
+    maxPerTimeframe: SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL,
+    timeframeSeconds: SLACK_CHATBOT_RATE_LIMIT_TIMEFRAME_SECONDS,
+    logger,
+  });
+  if (remainingMessages === 0) {
+    logger.warn(
+      {
+        slackTeamId,
+        slackChannel,
+        slackUserId,
+        slackBotId,
+        slackMessageTs,
+        slackThreadTs,
+        rateLimitMaxPerActorChannel:
+          SLACK_CHATBOT_RATE_LIMIT_MAX_PER_ACTOR_CHANNEL,
+        rateLimitTimeframeSeconds:
+          SLACK_CHATBOT_RATE_LIMIT_TIMEFRAME_SECONDS,
+      },
+      "Rate limited Slack Chat Bot message"
+    );
+    return;
+  }
+
   const params = {
     slackTeamId,
     slackChannel,


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/dust/issues/25611
Context: [slack thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1778756758454749)

Adds Redis-backed per-team/actor throttling in the Slack Chat Bot webhook handler after ACKing Slack and before invoking botAnswerMessage. Excess events are dropped so repeated workflow/app mention storms do not create conversations or Slack streaming work, while Slack still receives 200 and does not retry.

## Risks
Blast radius: Slack Chat Bot app mentions and DM handling.
Risk: low

## Deploy Plan
- pmrr
- deploy connectors