### PR TITLE
fix(poke): bypass private-url restriction for super users in conversation fetch

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -97,6 +97,11 @@ export type ConversationAccessType =
   | "conversation_access_restricted_by_private_by_default_url_restriction";
 
 const shouldByPassPrivateByDefaultUrlRestriction = (auth: Authenticator) => {
+  // Dust super users (poke admins) can always access conversations regardless of participant
+  // restrictions — they need this to debug triggered conversations that have no human participant.
+  if (auth.isDustSuperUser()) {
+    return true;
+  }
   const authMethod = auth.authMethod();
   switch (authMethod) {
     case "api_key":


### PR DESCRIPTION
## Description

In poke on workspaces with `privateConversationUrlsByDefault` enabled we can't see the conversations. This Pr fixes it. 

⚠️ the fix is right but I'm not sure we should do it, what's your take?

**Root cause:** `shouldByPassPrivateByDefaultUrlRestriction` only bypassed the participant-restriction check for `api_key`, `system_api_key`, and `internal` auth methods. The poke endpoint uses `fromSuperUserSession`, which produces a `session`-based `Authenticator`, so the bypass was not applied.

Trigger-created conversations have `spaceId = null` and `depth = 0` (which triggers `shouldApplyPrivateByDefaultUrlRestriction = true`) and no explicit `conversationUrlAccessMode` in their metadata (defaulting to `"participants_only"`). Since no human is a participant in an automated-trigger conversation, the poke super user was filtered out and the fetch returned nothing → `conversation_not_found`.

**Fix:** Early-return `true` from `shouldByPassPrivateByDefaultUrlRestriction` when `auth.isDustSuperUser()` is true.

## Risk

Low — only widens access for Dust super users on the poke admin interface; no effect on regular users.
