### PR TITLE
Fix data source view patching

### DIFF
--- a/front/types/api/public/spaces.ts
+++ b/front/types/api/public/spaces.ts
@@ -11,9 +11,10 @@ const ParentsInSchema = z.object({
   parentsIn: z.array(z.string()),
 });
 
+// It's important to have ParentsInSchema first, as ParentsToAddRemoveSchema only has optional fields and would always match if it were first.
 export const PatchDataSourceViewSchema = z.union([
-  ParentsToAddRemoveSchema,
   ParentsInSchema,
+  ParentsToAddRemoveSchema,
 ]);
 
 export type PatchDataSourceViewType = z.infer<typeof PatchDataSourceViewSchema>;


### PR DESCRIPTION
## Description

The seemingly innocuous [migration to zod](https://github.com/dust-tt/dust/pull/25325/changes#diff-cdd3b6025975edf8c60875d616fcaf661f40d9ddcd054c34cec32bd5c4e3ef2dL5) ended up breaking this:
- ParentsToAddRemoveSchema has all optional params
- It's listed first so it's always matched!
- In io-ts, it worked by some fluke because it carries the unknown params, so it worked even though it also always matched the first

Fix is to switch the ordering.

This is similar to https://github.com/dust-tt/dust/pull/25268

Fixes https://github.com/dust-tt/tasks/issues/8112

## Tests

Manually tested

## Risk

Low

## Deploy Plan

Front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25623">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->