### PR TITLE
[Agent Loop] Stop retrying missing conversation finalizers

### DIFF
--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -30,8 +30,8 @@ import { isGlobalAgentId } from "./assistant";
 import { ConversationError } from "./conversation";
 
 /**
- * Error types for getAgentLoopData that indicate soft-deleted resources.
- * These are safe to ignore in callers since the resource was intentionally deleted.
+ * Error types for getAgentLoopData that indicate deleted or unavailable resources.
+ * These are safe to ignore in callers since retrying won't make the data available.
  */
 export const AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES = [
   "conversation_deleted",
@@ -218,13 +218,13 @@ export async function getAgentLoopDataWithAuth(
         error instanceof ConversationError &&
         error.type === "conversation_not_found"
       ) {
-        // Check if the conversation was soft-deleted.
+        // Check if the conversation was deleted or is no longer readable.
         const conv = await ConversationResource.fetchById(
           auth,
           conversationId,
           { includeDeleted: true }
         );
-        if (conv?.visibility === "deleted") {
+        if (!conv || conv.visibility === "deleted") {
           return new Err(new AgentLoopDataError("conversation_deleted"));
         }
       }
@@ -244,13 +244,13 @@ export async function getAgentLoopDataWithAuth(
 
     if (conversationRes.isErr()) {
       if (conversationRes.error.type === "conversation_not_found") {
-        // Check if the conversation was soft-deleted.
+        // Check if the conversation was deleted or is no longer readable.
         const conv = await ConversationResource.fetchById(
           auth,
           conversationId,
           { includeDeleted: true }
         );
-        if (conv?.visibility === "deleted") {
+        if (!conv || conv.visibility === "deleted") {
           return new Err(new AgentLoopDataError("conversation_deleted"));
         }
       }


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8119

When agent-loop data cannot load a conversation, we already check whether it was soft-deleted and let finalizing activities exit quietly. This extends that terminal path to conversations that are hard-deleted or no longer readable, so graceful-stop finalization does not retry indefinitely.

## Risks
Blast radius: agent-loop activities that load conversation data after a conversation disappears.
Risk: low

## Deploy Plan
- pmrr
- deploy front-worker

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25625">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->