### PR TITLE
chore: remove step content id from mcp action

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1583,9 +1583,7 @@ export async function createAgentMessageFromText(
         {
           workspaceId: owner.id,
           mcpServerConfigurationId: "",
-          version: 0,
           agentMessageId: agentMessageRow.id,
-          stepContentId: functionCallStepContent.id,
           status: "succeeded",
           citationsAllocated,
           augmentedInputs: {},

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -170,9 +170,7 @@ async function createAgentMessage(
   const action = await AgentMCPActionModel.create({
     workspaceId: workspace.id,
     agentMessageId: agentMessage.id,
-    stepContentId: stepContent.id,
     mcpServerConfigurationId: generateRandomModelSId(),
-    version: 0,
     status: "succeeded",
     citationsAllocated: 0,
     augmentedInputs: {},

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -810,9 +810,7 @@ describe("validateAction", () => {
     const action = await AgentMCPActionModel.create({
       workspaceId: workspace.id,
       agentMessageId,
-      stepContentId: stepContent.id,
       mcpServerConfigurationId: generateRandomModelSId(),
-      version: 0,
       status,
       citationsAllocated: 0,
       augmentedInputs: {},

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -482,7 +482,6 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
     auth,
     {
       stepContents,
-      latestVersionsOnly: true,
     }
   );
 

--- a/front/lib/api/mcp/create_mcp.ts
+++ b/front/lib/api/mcp/create_mcp.ts
@@ -51,10 +51,8 @@ export async function createMCPAction(
       citationsAllocated: stepContext.citationsCount,
       mcpServerConfigurationId: actionConfiguration.id.toString(),
       status,
-      stepContentId: stepContent.id,
       stepContext,
       toolConfiguration,
-      version: 0,
     }
   );
 }

--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -3,7 +3,6 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { FileModel } from "@app/lib/resources/storage/models/files";
@@ -207,9 +206,7 @@ export class AgentMCPActionModel extends WorkspaceAwareModel<AgentMCPActionModel
   declare updatedAt: CreationOptional<Date>;
 
   declare mcpServerConfigurationId: string;
-  declare version: number;
   declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
-  declare stepContentId: ForeignKey<AgentStepContentModel["id"]>;
 
   declare status: ToolExecutionStatus;
 
@@ -240,11 +237,6 @@ AgentMCPActionModel.init(
     mcpServerConfigurationId: {
       type: DataTypes.STRING,
       allowNull: false,
-    },
-    version: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      defaultValue: 0,
     },
     status: {
       type: DataTypes.STRING,
@@ -286,16 +278,6 @@ AgentMCPActionModel.init(
         concurrently: true,
       },
       {
-        fields: ["stepContentId"],
-        concurrently: true,
-      },
-      {
-        fields: ["workspaceId", "agentMessageId", "stepContentId", "version"],
-        name: "agent_mcp_action_workspace_agent_message_step_content_version",
-        unique: true,
-        concurrently: true,
-      },
-      {
         fields: ["workspaceId", "agentMessageId", "status"],
         name: "agent_mcp_action_workspace_agent_message_status",
         concurrently: true,
@@ -316,17 +298,6 @@ AgentMCPActionModel.belongsTo(AgentMessageModel, {
 
 AgentMessageModel.hasMany(AgentMCPActionModel, {
   foreignKey: { name: "agentMessageId", allowNull: false },
-});
-
-AgentMCPActionModel.belongsTo(AgentStepContentModel, {
-  foreignKey: { name: "stepContentId", allowNull: false },
-  as: "stepContent",
-  onDelete: "RESTRICT",
-});
-
-AgentStepContentModel.hasMany(AgentMCPActionModel, {
-  foreignKey: { name: "stepContentId", allowNull: false },
-  as: "agentMCPActions",
 });
 
 export class AgentMCPActionOutputItemModel extends WorkspaceAwareModel<AgentMCPActionOutputItemModel> {

--- a/front/lib/reinforcement/tool_execution.ts
+++ b/front/lib/reinforcement/tool_execution.ts
@@ -99,7 +99,6 @@ async function createReinforcedAction(
       citationsAllocated: 0,
       mcpServerConfigurationId: "agent_sidekick_context",
       status: "ready_allowed_explicitly",
-      stepContentId: stepContent.id,
       stepContext: {
         citationsCount: 0,
         citationsOffset: 0,
@@ -130,7 +129,6 @@ async function createReinforcedAction(
         toolServerId: "agent_sidekick_context",
         retryPolicy: "no_retry",
       },
-      version: 0,
     }
   );
 }

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -147,9 +147,7 @@ describe("listBlockedActionsForConversation", () => {
     const action = await AgentMCPActionModel.create({
       workspaceId: workspace.id,
       agentMessageId,
-      stepContentId: stepContent.id,
       mcpServerConfigurationId: generateRandomModelSId(),
-      version: 0,
       status,
       citationsAllocated: 0,
       augmentedInputs: {},

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -610,10 +610,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     auth: Authenticator,
     {
       stepContents,
-      latestVersionsOnly = false,
     }: {
       stepContents: AgentStepContentResource[];
-      latestVersionsOnly?: boolean;
     }
   ): Promise<AgentMCPActionResource[]> {
     if (stepContents.length === 0) {
@@ -636,19 +634,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           },
         ],
       });
-
-    if (latestVersionsOnly) {
-      const rowsByStepContentId = _.groupBy(
-        agentStepContentToolExecutions,
-        (row) => row.stepContentId.toString()
-      );
-      agentStepContentToolExecutions = removeNulls(
-        Object.values(rowsByStepContentId).map(
-          (rowsForContent) =>
-            _.maxBy(rowsForContent, (row) => row.agentMCPAction.version) ?? null
-        )
-      );
-    }
 
     const stepContentsMap = new Map(stepContents.map((s) => [s.id, s]));
 

--- a/front/migrations/20260512_backfill_step_content_tool_execution.ts
+++ b/front/migrations/20260512_backfill_step_content_tool_execution.ts
@@ -108,8 +108,10 @@ async function backfillWorkspace(
     // SIDE-QUEST : While we're looking up the whole actions table, let's
     // check if some of them have a non-0 version. If we don't find any,
     // we'll be able to drop the column.
-    const nonZeroVersionActions = actions.filter((a) => a.version > 0);
-    appendNonZeroActionsCsv(workspace.sId, nonZeroVersionActions);
+    //
+    // RESULT: zero nonZeroVersionActions found. Removing the column.
+    // const nonZeroVersionActions = actions.filter((a) => a.version > 0);
+    // appendNonZeroActionsCsv(workspace.sId, nonZeroVersionActions);
 
     // Retrieve conversation id for agent message to populate table.
     const messages = await MessageModel.findAll({
@@ -141,7 +143,6 @@ async function backfillWorkspace(
         validActions.map((a) => ({
           workspaceId: workspace.id,
           agentMCPActionId: a.id,
-          stepContentId: a.stepContentId,
           agentMessageId: a.agentMessageId,
           conversationId: messagesMap.get(a.agentMessageId),
         })),

--- a/front/migrations/db/migration_638.sql
+++ b/front/migrations/db/migration_638.sql
@@ -1,0 +1,6 @@
+-- Migration created on mai 15, 2026
+DROP INDEX CONCURRENTLY IF EXISTS "agent_mcp_action_workspace_agent_message_step_content_version";
+DROP INDEX CONCURRENTLY IF EXISTS "agent_mcp_actions_step_content_id";
+
+ALTER TABLE "public"."agent_mcp_actions" DROP COLUMN "version";
+ALTER TABLE "public"."agent_mcp_actions" DROP COLUMN "stepContentId";

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -418,7 +418,6 @@ export class ConversationFactory {
         citationsAllocated: 0,
         mcpServerConfigurationId: toolConfiguration.sId,
         status: "running",
-        stepContentId: stepContent.id,
         stepContext: {
           citationsCount: 0,
           citationsOffset: 0,
@@ -427,7 +426,6 @@ export class ConversationFactory {
           websearchResultCount: 0,
         },
         toolConfiguration,
-        version: 0,
       }
     );
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

### Context

Last PR out of 4 to move the data model of `AgentMCPActions` from a direct link to `AgentStepContent` to a join table.

| # | goal                                                                      |
|---|---------------------------------------------------------------------------|
| 1 #25463 | create join table AgentStepContentToolExecution, and introduce dual write |
| 2 #25514 | backfill the new table                                                    |
| 3 #25562 | switch read to the new table                                              |
| 4 this PR | drop the StepContentId column from the original table                     |

### This PR

This PR removes the now unused `stepContentId` from the `AgentMCPActionModel`. 
It also removes the version attribute that was always set to 0. PR 2 confirmed that no entries in the table was different than 0. This column is useless.

It also drops the two indexes pointing to :
1. stepContentId
2. stepContentId and version at the same time

They are now useless.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Medium. We stop writing to the old table and we lose the pre-backfill data. We have the data in the `AgentStepContentToolExecution` if we ever see an issue, so we'll be able to backfill it back.

## Deploy Plan

Deploy front. 
Wait for prod ready.
Drop indexes and columns with migration 638.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25626">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->