### PR TITLE
Add spaces MCP route to Hono

### DIFF
--- a/front-api/CODING_RULES.md
+++ b/front-api/CODING_RULES.md
@@ -142,35 +142,9 @@ Next handlers produce via `apiError`. For dynamic status codes carried in
 `jsonApiError(c, err)` helper — it centralizes the
 `number → ContentfulStatusCode` cast in one place with a comment.
 
-## TESTING
-
-### [API8] Tests invoke routes via `honoApp.request()`
-
-Tests use the same factories and `getSession` mock as Next tests
-(`createPrivateApiMockRequest`, `SpaceFactory`, etc.). Only the dispatch
-changes — instead of calling a Next handler with mocked `req`/`res`, hit
-the Hono app:
-
-```ts
-import { honoApp } from "@dust-tt/front-api/app";
-
-const response = await honoApp.request(
-  `/api/w/${workspace.sId}/spaces/${space.sId}/mcp/available`
-);
-expect(response.status).toBe(200);
-const body = await response.json();
-```
-
-The auth mock applies because `workspaceAuth` reaches through to
-`getSession`, which is what `createPrivateApiMockRequest` mocks.
-
-Test files currently live in `front/` (next to their Next counterparts)
-because vitest is configured in `front/` only. They reference `front-api`
-via the workspace dep (`@dust-tt/front-api/app`).
-
 ## DEPENDENCIES
 
-### [API9] Avoid Next types in front-api code
+### [API8] Avoid Next types in front-api code
 
 `NextApiRequest` / `NextApiResponse` should not appear in new code. New
 middleware reads what it needs from Hono's `Context` directly

--- a/front-api/CODING_RULES.md
+++ b/front-api/CODING_RULES.md
@@ -1,0 +1,184 @@
+# [front-api] Coding Rules
+
+Shared rules (GEN1-GEN13, SEC1-SEC2, ERR1-ERR2) in the root `CODING_RULES.md`
+apply automatically. TypeScript rules in `front/CODING_RULES.md` also apply,
+since `front-api` shares the same TS environment and reaches into `front`
+internals via the `@app/*` path map.
+
+This file documents rules and patterns specific to `front-api`.
+
+`front-api` is the Hono-based service that incrementally takes over routes
+from `front` (Next.js). The strangler dispatch lives in
+`front-api/server.ts`: it checks `isHonoRoute` from `front-api/app.ts`;
+matched requests go to Hono, the rest fall through to Next.
+
+## ROUTING
+
+### [API1] Route file layout follows the URL hierarchy
+
+Hono is not file-system routed — the directory tree is purely organizational.
+But we keep it aligned with URL prefixes for discoverability:
+
+```
+front-api/routes/
+  healthz.ts                # GET /api/healthz
+  w/
+    index.ts                # workspaceApp (mounted at /api/w/:wId), applies workspaceAuth
+    spaces/
+      index.ts              # spacesApp (mounted at /api/w/:wId/spaces) — GET /, POST /
+      mcp.ts                # mcpApp (mounted at /api/w/:wId/spaces/:spaceId/mcp)
+      ...
+  v1/
+    w/
+      index.ts              # publicWorkspaceApp, applies publicApiAuth
+      spaces.ts             # public-API spaces handlers
+```
+
+One file per **logical sub-resource**, not per HTTP endpoint. All handlers
+for a sub-resource (GET list, POST create, GET by id, PATCH, DELETE, etc.)
+live in the same file. Split further (e.g.
+`data_source_views/index.ts` + `data_source_views/tables.ts`) only when a
+single file gets large.
+
+Do not mirror Next's `[wId]/[spaceId]/index.ts` deep tree — Hono routes are
+explicit, the tree adds nesting without benefit.
+
+### [API2] Register Hono-served routes in `HONO_ROUTES`
+
+A route only takes effect when its pattern is added to `HONO_ROUTES` in
+`front-api/app.ts`. Without it, `isHonoRoute` returns false and the request
+falls through to Next — even if the Hono route is defined.
+
+```ts
+const HONO_ROUTES: HonoRoute[] = [
+  { pattern: "/api/w/:wId/spaces", methods: ["GET", "POST"] },
+  { pattern: "/api/w/:wId/spaces/:spaceId/mcp/available", methods: ["GET"] },
+  // …
+];
+```
+
+`OPTIONS` is auto-added by the regex builder, so CORS preflights for any
+registered pattern are handled by Hono.
+
+### [API3] Compose sub-apps with `app.route()`
+
+A new sub-resource is wired in by adding one `.route()` call in the parent
+sub-app:
+
+```ts
+// front-api/routes/w/spaces/index.ts
+spacesApp.route("/:spaceId/mcp", mcpApp);
+spacesApp.route("/:spaceId/data_source_views", dsvApp);
+```
+
+Path parameters from the parent mount (`:wId`, `:spaceId`) are propagated
+into the child sub-app's context (`c.req.param("spaceId")` keeps working).
+
+## MIDDLEWARE
+
+### [API4] Apply auth middleware once, at the sub-app boundary
+
+`workspaceAuth` and `publicApiAuth` are applied once at the workspace
+sub-app level, not per-route:
+
+```ts
+// front-api/routes/w/index.ts
+workspaceApp.use("*", workspaceAuth);
+workspaceApp.route("/spaces", spacesApp);
+```
+
+All routes below inherit it. The resolved `Authenticator` is available via
+`c.get("auth")`.
+
+### [API5] Resource-fetching middleware is applied per-handler
+
+Resource middlewares like `spaceResource` carry permission options
+(`requireCanRead`, `requireCanWrite`, etc.) that vary per endpoint. Apply
+them on the individual handler, not on the sub-app:
+
+```ts
+mcpApp.get(
+  "/available",
+  spaceResource({ requireCanRead: true }),
+  async (c) => {
+    const space = c.get("space");
+    // …
+  }
+);
+```
+
+Do not `mcpApp.use("*", spaceResource({...}))` — sibling handlers in the
+same sub-app may need different permission levels.
+
+## VALIDATION
+
+### [API6] Validate request input with `validate(target, schema)`
+
+`front-api/middleware/validator.ts` wraps `@hono/zod-validator` so failures
+produce our standard `{ error: { type, message } }` shape. Use it for any
+target (`json`, `query`, `param`, `header`, `cookie`, `form`):
+
+```ts
+spacesApp.post(
+  "/",
+  validate("json", PostSpaceRequestBodySchema),
+  async (c) => {
+    const body = c.req.valid("json"); // typed by inference
+    // …
+  }
+);
+```
+
+Do not call `c.req.json()` + `safeParse` manually in handlers — that's what
+the wrapper exists to eliminate.
+
+## ERRORS
+
+### [API7] Use the standard error shape
+
+All error responses follow `{ error: { type, message } }` to match what the
+Next handlers produce via `apiError`. For dynamic status codes carried in
+`APIErrorWithStatusCode` (e.g. when forwarding a `Result.Err`), use the
+`jsonApiError(c, err)` helper — it centralizes the
+`number → ContentfulStatusCode` cast in one place with a comment.
+
+## TESTING
+
+### [API8] Tests invoke routes via `honoApp.request()`
+
+Tests use the same factories and `getSession` mock as Next tests
+(`createPrivateApiMockRequest`, `SpaceFactory`, etc.). Only the dispatch
+changes — instead of calling a Next handler with mocked `req`/`res`, hit
+the Hono app:
+
+```ts
+import { honoApp } from "@dust-tt/front-api/app";
+
+const response = await honoApp.request(
+  `/api/w/${workspace.sId}/spaces/${space.sId}/mcp/available`
+);
+expect(response.status).toBe(200);
+const body = await response.json();
+```
+
+The auth mock applies because `workspaceAuth` reaches through to
+`getSession`, which is what `createPrivateApiMockRequest` mocks.
+
+Test files currently live in `front/` (next to their Next counterparts)
+because vitest is configured in `front/` only. They reference `front-api`
+via the workspace dep (`@dust-tt/front-api/app`).
+
+## DEPENDENCIES
+
+### [API9] Avoid Next types in front-api code
+
+`NextApiRequest` / `NextApiResponse` should not appear in new code. New
+middleware reads what it needs from Hono's `Context` directly
+(`c.req.header(...)`, `c.req.param(...)`, `c.req.raw.headers`).
+
+Known exception: the bridge in `workspace_auth.ts`, which still constructs
+a Next-shaped `req`/`res` to call the legacy `getSession(req, res)`. That
+will go away when `getSession` is refactored to take an I/O abstraction.
+
+The strangler entry in `server.ts` keeps `import next from "next"` — that
+disappears when Next is fully retired.

--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -24,6 +24,7 @@ const HONO_ROUTES: HonoRoute[] = [
   { pattern: "/api/app-status", methods: ["GET"] },
   { pattern: "/api/kill", methods: ["GET"] },
   { pattern: "/api/w/:wId/spaces", methods: ["GET", "POST"] },
+  { pattern: "/api/w/:wId/spaces/:spaceId/mcp/available", methods: ["GET"] },
   { pattern: "/api/v1/w/:wId/spaces", methods: ["GET"] },
 ];
 

--- a/front-api/middleware/space_resource.ts
+++ b/front-api/middleware/space_resource.ts
@@ -1,0 +1,121 @@
+import type { MiddlewareHandler } from "hono";
+
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+
+declare module "hono" {
+  interface ContextVariableMap {
+    space: SpaceResource;
+  }
+}
+
+interface SpaceResourceOptions {
+  requireCanAdministrate?: boolean;
+  requireCanReadOrAdministrate?: boolean;
+  requireCanRead?: boolean;
+  requireCanWrite?: boolean;
+}
+
+function hasPermission(
+  auth: Authenticator,
+  space: SpaceResource,
+  options: SpaceResourceOptions
+): boolean {
+  if (options.requireCanAdministrate && !space.canAdministrate(auth)) {
+    return false;
+  }
+  if (
+    options.requireCanReadOrAdministrate &&
+    !space.canReadOrAdministrate(auth)
+  ) {
+    return false;
+  }
+  if (options.requireCanRead && !space.canRead(auth)) {
+    return false;
+  }
+  if (options.requireCanWrite && !space.canWrite(auth)) {
+    return false;
+  }
+  return true;
+}
+
+function deriveAccessMethod(auth: Authenticator): string {
+  const key = auth.key();
+  if (key) {
+    return key.isSystem ? "system_key" : "api_key";
+  }
+  return "ui";
+}
+
+/**
+ * Fetches the `SpaceResource` named by `:spaceId` in the route, validates it
+ * (existence, not a conversations space, requested permissions), emits the
+ * `space.accessed` audit log for restricted spaces, and stashes it on the
+ * context under `space`. Mirrors `withSpaceFromRoute` from
+ * `front/lib/api/resource_wrappers.ts`.
+ *
+ * Apply after the auth middleware so `c.get("auth")` is available.
+ */
+export function spaceResource(
+  options: SpaceResourceOptions
+): MiddlewareHandler {
+  return async (c, next) => {
+    const auth = c.get("auth");
+    const spaceId = c.req.param("spaceId");
+    if (!spaceId) {
+      return c.json(
+        {
+          error: {
+            type: "invalid_request_error",
+            message: "Invalid space id.",
+          },
+        },
+        400
+      );
+    }
+
+    const space = await SpaceResource.fetchById(auth, spaceId);
+    if (
+      !space ||
+      space.isConversations() ||
+      !hasPermission(auth, space, options)
+    ) {
+      return c.json(
+        {
+          error: {
+            type: "space_not_found",
+            message: "The space you requested was not found.",
+          },
+        },
+        404
+      );
+    }
+
+    const spaceJSON = space.toJSON();
+    if (spaceJSON.isRestricted) {
+      void emitAuditLogEvent({
+        auth,
+        action: "space.accessed",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("space", space),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          space_name: space.name,
+          space_kind: spaceJSON.kind,
+          is_restricted: "true",
+          access_method: deriveAccessMethod(auth),
+        },
+      });
+    }
+
+    c.set("space", space);
+    await next();
+  };
+}

--- a/front-api/routes/w/spaces/index.ts
+++ b/front-api/routes/w/spaces/index.ts
@@ -13,7 +13,8 @@ import { areOpenProjectsAllowed } from "@app/lib/workspace_policies";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { ProjectType, SpaceType } from "@app/types/space";
 
-import { validate } from "../../middleware/validator";
+import { validate } from "../../../middleware/validator";
+import { mcpApp } from "./mcp";
 
 const PostSpaceRequestBodySchema = z.intersection(
   z.object({
@@ -175,3 +176,8 @@ spacesApp.post("/", validate("json", PostSpaceRequestBodySchema), async (c) => {
   const responseBody: PostSpacesResponseBody = { space: space.toJSON() };
   return c.json(responseBody, 201);
 });
+
+// Per-space sub-resource sub-apps. New families of routes under a specific
+// space (data source views, members, etc.) live in their own sibling files
+// and are mounted here.
+spacesApp.route("/:spaceId/mcp", mcpApp);

--- a/front-api/routes/w/spaces/mcp.ts
+++ b/front-api/routes/w/spaces/mcp.ts
@@ -1,0 +1,67 @@
+import { Hono } from "hono";
+
+import type { MCPServerType } from "@app/lib/api/mcp";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+
+import { spaceResource } from "../../../middleware/space_resource";
+
+export type GetMCPServersResponseBody = {
+  success: boolean;
+  servers: MCPServerType[];
+};
+
+export const mcpApp = new Hono();
+
+// Mounted under /api/w/:wId/spaces/:spaceId/mcp.
+
+// Lists MCP servers available to add to the space — i.e. servers that exist
+// in the workspace but are not yet attached to this space nor to the global
+// space.
+mcpApp.get("/available", spaceResource({ requireCanRead: true }), async (c) => {
+  const auth = c.get("auth");
+  const space = c.get("space");
+
+  const [
+    internalInstalledServers,
+    remoteInstalledServers,
+    workspaceServerViews,
+  ] = await Promise.all([
+    InternalMCPServerInMemoryResource.listByWorkspace(auth),
+    RemoteMCPServerResource.listByWorkspace(auth),
+    MCPServerViewResource.listByWorkspace(auth),
+  ]);
+
+  const globalServersId = workspaceServerViews
+    .filter((s) => s.space.kind === "global")
+    .map((s) => s.toJSON().server.sId);
+
+  const spaceServerViews = workspaceServerViews.filter(
+    (s) => s.space.id === space.id
+  );
+  const spaceServersId = spaceServerViews.map((s) => s.toJSON().server.sId);
+
+  const availableServer: MCPServerType[] = [];
+
+  for (const srv of internalInstalledServers) {
+    if (!spaceServersId.includes(srv.id) && !globalServersId.includes(srv.id)) {
+      availableServer.push(srv.toJSON());
+    }
+  }
+
+  for (const srv of remoteInstalledServers) {
+    if (
+      !spaceServersId.includes(srv.sId) &&
+      !globalServersId.includes(srv.sId)
+    ) {
+      availableServer.push(srv.toJSON());
+    }
+  }
+
+  const body: GetMCPServersResponseBody = {
+    success: true,
+    servers: availableServer,
+  };
+  return c.json(body);
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
@@ -10,22 +10,23 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-import { honoApp } from "@dust-tt/front-api/app";
 import { describe, expect, it } from "vitest";
+
+import handler from "./available";
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
   it("returns available servers for regular user", async () => {
-    // Sets up workspace, user, membership, and mocks getSession to return that
-    // user's session. We don't use the returned req/res — the request goes
-    // through the Hono app below.
-    const { workspace, globalGroup } = await createPrivateApiMockRequest({
-      method: "GET",
-      role: "user",
-    });
-
+    // Create mock request
+    const { req, res, workspace, globalGroup } =
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+    // Create workspace and space
     const space = await SpaceFactory.regular(workspace);
     await GroupSpaceFactory.associate(space, globalGroup);
 
+    // Get auth
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     // Mock the INTERNAL_MCP_SERVERS to override the "primitive_types_debugger" server config
@@ -49,6 +50,7 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
       configurable: true,
     });
 
+    // Create some servers
     await FeatureFlagFactory.basic(auth, "dev_mcp_actions");
 
     // Internal server in the right workspace
@@ -70,14 +72,20 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
     await SpaceFactory.system(workspace2);
     await RemoteMCPServerFactory.create(workspace2);
 
-    const response = await honoApp.request(
-      `/api/w/${workspace.sId}/spaces/${space.sId}/mcp/available`
-    );
+    // Add query params
+    req.query = {
+      ...req.query,
+      spaceId: space.sId,
+    };
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.success).toBe(true);
-    expect(body.servers).toHaveLength(1); // Only one available server — the other is assigned to the system space
-    expect(body.servers[0].sId).toBe(internalServer.id);
+    // Call handler
+    await handler(req, res);
+
+    // Check response
+    expect(res._getStatusCode()).toBe(200);
+    const response = res._getJSONData();
+    expect(response.success).toBe(true);
+    expect(response.servers).toHaveLength(1); // Only one available server as the other is assigned to the system space
+    expect(response.servers[0].sId).toBe(internalServer.id);
   });
 });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
@@ -10,23 +10,22 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { honoApp } from "@dust-tt/front-api/app";
 import { describe, expect, it } from "vitest";
-
-import handler from "./available";
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
   it("returns available servers for regular user", async () => {
-    // Create mock request
-    const { req, res, workspace, globalGroup } =
-      await createPrivateApiMockRequest({
-        method: "GET",
-        role: "user",
-      });
-    // Create workspace and space
+    // Sets up workspace, user, membership, and mocks getSession to return that
+    // user's session. We don't use the returned req/res — the request goes
+    // through the Hono app below.
+    const { workspace, globalGroup } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
     const space = await SpaceFactory.regular(workspace);
     await GroupSpaceFactory.associate(space, globalGroup);
 
-    // Get auth
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     // Mock the INTERNAL_MCP_SERVERS to override the "primitive_types_debugger" server config
@@ -50,7 +49,6 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
       configurable: true,
     });
 
-    // Create some servers
     await FeatureFlagFactory.basic(auth, "dev_mcp_actions");
 
     // Internal server in the right workspace
@@ -72,20 +70,14 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
     await SpaceFactory.system(workspace2);
     await RemoteMCPServerFactory.create(workspace2);
 
-    // Add query params
-    req.query = {
-      ...req.query,
-      spaceId: space.sId,
-    };
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/spaces/${space.sId}/mcp/available`
+    );
 
-    // Call handler
-    await handler(req, res);
-
-    // Check response
-    expect(res._getStatusCode()).toBe(200);
-    const response = res._getJSONData();
-    expect(response.success).toBe(true);
-    expect(response.servers).toHaveLength(1); // Only one available server as the other is assigned to the system space
-    expect(response.servers[0].sId).toBe(internalServer.id);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.servers).toHaveLength(1); // Only one available server — the other is assigned to the system space
+    expect(body.servers[0].sId).toBe(internalServer.id);
   });
 });


### PR DESCRIPTION
## Description

Adds `GET /api/w/:wId/spaces/:spaceId/mcp/available` to the Hono strangler, introduces the resource-fetching middleware pattern (`spaceResource`), restructures `routes/w/spaces` into a sub-app-per-resource layout, and documents the front-api conventions.

Also, add CODING_RULES.md for front-api.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25627">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->