### PR TITLE
feat(paywall): add business plan support to trial ended pricing card

### DIFF
--- a/front/components/pages/onboarding/TrialEndedPage.tsx
+++ b/front/components/pages/onboarding/TrialEndedPage.tsx
@@ -2,6 +2,7 @@ import { DontLoseSection } from "@app/components/paywall/DontLoseSection";
 import { TrialPricingCard } from "@app/components/paywall/TrialPricingCard";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
+import { isWhitelistedBusinessPlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import type { BillingPeriod } from "@app/types/plan";
 import { Card, ContentMessage, DustLogo } from "@dust-tt/sparkle";
@@ -11,6 +12,7 @@ import React, { useState } from "react";
 export function TrialEndedPage() {
   const { workspace } = useAuth();
   const router = useAppRouter();
+  const isBusiness = isWhitelistedBusinessPlan(workspace);
   const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("monthly");
 
   const { submit: handleSubscribePlan, isSubmitting } = useSubmitFunction(
@@ -45,6 +47,7 @@ export function TrialEndedPage() {
             onBillingPeriodChange={setBillingPeriod}
             onSubscribe={() => handleSubscribePlan(billingPeriod)}
             isSubmitting={isSubmitting}
+            isBusiness={isBusiness}
           />
         </Card>
       </div>

--- a/front/components/paywall/TrialPricingCard.tsx
+++ b/front/components/paywall/TrialPricingCard.tsx
@@ -1,4 +1,5 @@
 import {
+  BUSINESS_PLAN_COST_MONTHLY,
   PRO_PLAN_COST_MONTHLY,
   PRO_PLAN_COST_YEARLY,
   usePriceWithCurrency,
@@ -17,9 +18,10 @@ interface TrialPricingCardProps {
   onBillingPeriodChange: (period: BillingPeriod) => void;
   onSubscribe: () => void;
   isSubmitting: boolean;
+  isBusiness?: boolean;
 }
 
-const FEATURES = [
+const PRO_FEATURES = [
   "Advanced AI models: GPT-5, Claude 4.5, Gemini, Mistral...",
   "Custom agents: Build AI with your company knowledge",
   "Data connections: Slack, Notion, Google Drive, GitHub...",
@@ -27,15 +29,28 @@ const FEATURES = [
   "Email support: Get help when you need it",
 ];
 
+const BUSINESS_EXTRA_FEATURES = [
+  "US / EU data hosting",
+  "Single Sign-On (SSO) (Okta, Entra ID, Jumpcloud)",
+  "Advanced connections (Salesforce, etc)",
+];
+
 export function TrialPricingCard({
   billingPeriod,
   onBillingPeriodChange,
   onSubscribe,
   isSubmitting,
+  isBusiness = false,
 }: TrialPricingCardProps) {
-  const rawPrice =
-    billingPeriod === "monthly" ? PRO_PLAN_COST_MONTHLY : PRO_PLAN_COST_YEARLY;
+  const rawPrice = isBusiness
+    ? BUSINESS_PLAN_COST_MONTHLY
+    : billingPeriod === "monthly"
+      ? PRO_PLAN_COST_MONTHLY
+      : PRO_PLAN_COST_YEARLY;
   const price = usePriceWithCurrency(rawPrice);
+  const features = isBusiness
+    ? [...PRO_FEATURES, ...BUSINESS_EXTRA_FEATURES]
+    : PRO_FEATURES;
 
   return (
     <div className="flex flex-col gap-6">
@@ -52,20 +67,22 @@ export function TrialPricingCard({
           </span>
         </div>
 
-        {/* Billing toggle */}
-        <ButtonsSwitchList
-          defaultValue={billingPeriod}
-          size="xs"
-          onValueChange={(v) => onBillingPeriodChange(v as BillingPeriod)}
-        >
-          <ButtonsSwitch value="monthly" label="Monthly" />
-          <ButtonsSwitch value="yearly" label="Yearly" />
-        </ButtonsSwitchList>
+        {/* Billing toggle: hidden for seat-based business plan (fixed monthly pricing) */}
+        {!isBusiness && (
+          <ButtonsSwitchList
+            defaultValue={billingPeriod}
+            size="xs"
+            onValueChange={(v) => onBillingPeriodChange(v as BillingPeriod)}
+          >
+            <ButtonsSwitch value="monthly" label="Monthly" />
+            <ButtonsSwitch value="yearly" label="Yearly" />
+          </ButtonsSwitchList>
+        )}
       </div>
 
       {/* Features list */}
       <ul className="flex flex-col gap-3">
-        {FEATURES.map((feature, index) => (
+        {features.map((feature, index) => (
           <li key={index} className="flex items-start gap-2">
             <Icon
               visual={CheckIcon}
@@ -83,7 +100,11 @@ export function TrialPricingCard({
       <Button
         variant="highlight"
         size="md"
-        label="Continue with Pro"
+        label={
+          isBusiness
+            ? "Continue with Enterprise (Seat-based)"
+            : "Continue with Pro"
+        }
         onClick={onSubscribe}
         disabled={isSubmitting}
         className="w-full"


### PR DESCRIPTION
## Description

When a workspace is on a whitelisted business plan, the trial-ended paywall now shows business-specific content: fixed monthly pricing (`BUSINESS_PLAN_COST_MONTHLY`), the billing period toggle is hidden (seat-based plans have no yearly option), the features list includes extra business items (US/EU hosting, SSO, advanced connections), and the CTA reads "Continue with Enterprise (Seat-based)" instead of "Continue with Pro".

Detection uses the existing `isWhitelistedBusinessPlan` helper — no new logic introduced.

## Tests

Tested manually by checking the component renders correctly for both `isBusiness=true` and `isBusiness=false` states.

## Risk

Low — purely presentational change behind a plan-code check. No data model or API changes. Safe to rollback.

## Deploy Plan

Standard front deploy, no migrations or feature flags needed.
