### PR TITLE
feat: add knowledge UI projects

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/content_nodes/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/content_nodes/index.ts
@@ -1,14 +1,18 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
-import { removeContentNodeFromProject } from "@app/lib/api/projects/context";
+import { removeContentNodesFromProject } from "@app/lib/api/projects/context";
 
 import { spaceResource } from "@front-api/middleware/space_resource";
 import { validate } from "@front-api/middleware/validator";
 
-const DeleteContentNodeBodySchema = z.object({
+const ContentNodeItemSchema = z.object({
   nodeId: z.string().min(1, "nodeId is required"),
   nodeDataSourceViewId: z.string().min(1, "nodeDataSourceViewId is required"),
+});
+
+const DeleteContentNodeBodySchema = z.object({
+  items: z.array(ContentNodeItemSchema),
 });
 
 // Mounted under /api/w/:wId/spaces/:spaceId/project_context/content_nodes.
@@ -24,7 +28,7 @@ app.delete(
   async (c) => {
     const auth = c.get("auth");
     const space = c.get("space");
-    const { nodeId, nodeDataSourceViewId } = c.req.valid("json");
+    const { items } = c.req.valid("json");
 
     if (!space.isProject()) {
       return c.json(
@@ -50,10 +54,9 @@ app.delete(
       );
     }
 
-    const r = await removeContentNodeFromProject(auth, {
+    const r = await removeContentNodesFromProject(auth, {
       space,
-      nodeId,
-      nodeDataSourceViewId,
+      nodes: items,
     });
     if (r.isErr()) {
       return c.json(

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -193,12 +193,12 @@ const KnowledgeSearchAndTable = memo(function KnowledgeSearchAndTable({
   );
 });
 
-type AttachKnowledgeDropdownProps = {
+interface AttachKnowledgeDropdownProps {
   buttonLabel: string;
   isDisabled: boolean;
   onUploadFileClick: () => void;
   onShowCompanyDataClick: () => void;
-};
+}
 
 function AttachKnowledgeDropdown({
   buttonLabel,
@@ -213,23 +213,23 @@ function AttachKnowledgeDropdown({
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         <DropdownMenuItem
-          icon={CloudArrowUpIcon}
-          label="Upload file"
-          onClick={onUploadFileClick}
-        />
-        <DropdownMenuItem
           icon={CloudArrowLeftRightIcon}
           label="From Company Data"
           onClick={onShowCompanyDataClick}
+        />
+        <DropdownMenuItem
+          icon={CloudArrowUpIcon}
+          label="Upload file"
+          onClick={onUploadFileClick}
         />
       </DropdownMenuContent>
     </DropdownMenu>
   );
 }
 
-type AttachKnowledgeButtonProps = AttachKnowledgeDropdownProps & {
+interface AttachKnowledgeButtonProps extends AttachKnowledgeDropdownProps {
   canManuallyManageProjectKnowledge: boolean;
-};
+}
 
 function AttachKnowledgeButton({
   buttonLabel,
@@ -265,11 +265,11 @@ function AttachKnowledgeButton({
   );
 }
 
-type NoCompanyDataDialogProps = {
+interface NoCompanyDataDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onGoToCompanyData: () => void;
-};
+}
 
 function NoCompanyDataDialog({
   isOpen,
@@ -342,9 +342,9 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     contentType: string;
     projectId?: string | null;
   } | null>(null);
-  const [showPreviewSheet, setShowPreviewSheet] = useState(false);
-  const [showCompanyDataSheet, setShowCompanyDataSheet] = useState(false);
-  const [showNoCompanyDataDialog, setShowNoCompanyDataDialog] = useState(false);
+  const [activeOverlay, setActiveOverlay] = useState<
+    "preview" | "companyData" | "noCompanyData" | null
+  >(null);
   const isArchived = !!space.archivedAt;
   const canManuallyManageProjectKnowledge =
     isManualProjectKnowledgeManagementAllowed(owner);
@@ -529,7 +529,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
           contentType: item.contentType,
           projectId: space.sId,
         });
-        setShowPreviewSheet(true);
+        setActiveOverlay("preview");
         return;
       }
       if (isContentNodeAttachmentType(item) && item.sourceUrl) {
@@ -730,110 +730,98 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
 
   const hasFiles = attachments.length > 0;
   const isUploading = projectFileUpload.isProcessingFiles;
-  const uploadButtonLabel = isUploading ? "Uploading..." : "Add data";
+  const uploadButtonLabel = isUploading ? "Uploading..." : "Add";
   const isAddKnowledgeDisabled =
     !canManuallyManageProjectKnowledge || isUploading;
 
-  const handleUploadFileClick = useCallback(() => {
+  const handleUploadFileClick = () => {
     fileInputRef.current?.click();
-  }, []);
+  };
 
-  const handleShowCompanyDataClick = useCallback(() => {
-    if (globalSpaceDSVs.length === 0) {
-      setShowNoCompanyDataDialog(true);
-      return;
-    }
-    setShowCompanyDataSheet(true);
-  }, [globalSpaceDSVs.length]);
+  const handleShowCompanyDataClick = () => {
+    setActiveOverlay(
+      globalSpaceDSVs.length === 0 ? "noCompanyData" : "companyData"
+    );
+  };
 
-  const handleCloseCompanyDataSheet = useCallback(() => {
-    setShowCompanyDataSheet(false);
-  }, []);
+  const handleCloseOverlay = () => {
+    setActiveOverlay(null);
+  };
 
-  const handleCloseNoCompanyDataDialog = useCallback(() => {
-    setShowNoCompanyDataDialog(false);
-  }, []);
-
-  const handleGoToCompanyData = useCallback(() => {
+  const handleGoToCompanyData = () => {
     if (!globalSpace) {
       return;
     }
     void router.push(`/w/${owner.sId}/spaces/${globalSpace.sId}`);
-  }, [globalSpace, owner.sId, router]);
+  };
 
   const initialSelectedDataSources = useMemo<DataSourceViewType[]>(() => {
-    const nodeIdsByDsvId = new Map<string, string[]>();
+    const nodeIdsByDataSoureceViewId = new Map<string, string[]>();
     for (const attachment of attachments) {
       if (!isContentNodeAttachmentType(attachment)) {
         continue;
       }
       const existing =
-        nodeIdsByDsvId.get(attachment.nodeDataSourceViewId) ?? [];
-      nodeIdsByDsvId.set(attachment.nodeDataSourceViewId, [
+        nodeIdsByDataSoureceViewId.get(attachment.nodeDataSourceViewId) ?? [];
+      nodeIdsByDataSoureceViewId.set(attachment.nodeDataSourceViewId, [
         ...existing,
         attachment.nodeId,
       ]);
     }
-    return Array.from(nodeIdsByDsvId.entries()).flatMap(([dsvId, nodeIds]) => {
-      const dsv = globalSpaceDSVs.find((v) => v.sId === dsvId);
-      return dsv ? [{ ...dsv, parentsIn: nodeIds }] : [];
-    });
+    return Array.from(nodeIdsByDataSoureceViewId.entries()).flatMap(
+      ([dsvId, nodeIds]) => {
+        const dsv = globalSpaceDSVs.find((v) => v.sId === dsvId);
+        return dsv ? [{ ...dsv, parentsIn: nodeIds }] : [];
+      }
+    );
   }, [attachments, globalSpaceDSVs]);
 
-  const handleCompanyDataSave = useCallback(
-    async (selectionConfigurations: DataSourceViewSelectionConfigurations) => {
-      // 1. Flatten modal selection into a list of nodes.
-      const selectedNodes = Object.values(selectionConfigurations).flatMap(
-        ({ dataSourceView, selectedResources }) =>
-          selectedResources.map((node) => ({
-            title: node.title,
-            nodeId: node.internalId,
-            nodeDataSourceViewId: dataSourceView.sId,
-            sourceUrl: node.sourceUrl,
-          }))
-      );
-
-      // 2. Build identity keys for both sides of the diff.
-      const keyOf = (n: { nodeDataSourceViewId: string; nodeId: string }) =>
-        `${n.nodeDataSourceViewId}:${n.nodeId}`;
-      const currentContentNodes = attachments.filter(
-        isContentNodeAttachmentType
-      );
-      const currentKeys = new Set(currentContentNodes.map(keyOf));
-      const selectedKeys = new Set(selectedNodes.map(keyOf));
-
-      // 3. Diff.
-      const toAdd = selectedNodes.filter((n) => !currentKeys.has(keyOf(n)));
-      const toRemove = currentContentNodes.filter(
-        (n) => !selectedKeys.has(keyOf(n))
-      );
-
-      // 4. Apply both sides
-      await addProjectContextContentNodes(
-        toAdd.map((n) => ({
-          title: n.title,
-          nodeId: n.nodeId,
-          nodeDataSourceViewId: n.nodeDataSourceViewId,
-          ...(n.sourceUrl ? { url: n.sourceUrl } : {}),
+  const handleCompanyDataSave = async (
+    selectionConfigurations: DataSourceViewSelectionConfigurations
+  ) => {
+    // 1. Flatten modal selection into a list of nodes.
+    const selectedNodes = Object.values(selectionConfigurations).flatMap(
+      ({ dataSourceView, selectedResources }) =>
+        selectedResources.map((node) => ({
+          title: node.title,
+          nodeId: node.internalId,
+          nodeDataSourceViewId: dataSourceView.sId,
+          sourceUrl: node.sourceUrl,
         }))
-      );
-      await removeProjectContextContentNodes(
-        toRemove.map((n) => ({
-          nodeId: n.nodeId,
-          nodeDataSourceViewId: n.nodeDataSourceViewId,
-        }))
-      );
+    );
 
-      // 5. Refresh.
-      void mutateProjectContextAttachments();
-    },
-    [
-      addProjectContextContentNodes,
-      attachments,
-      mutateProjectContextAttachments,
-      removeProjectContextContentNodes,
-    ]
-  );
+    // 2. Build identity keys for both sides of the diff.
+    const keyOf = (n: { nodeDataSourceViewId: string; nodeId: string }) =>
+      `${n.nodeDataSourceViewId}:${n.nodeId}`;
+    const currentContentNodes = attachments.filter(isContentNodeAttachmentType);
+    const currentKeys = new Set(currentContentNodes.map(keyOf));
+    const selectedKeys = new Set(selectedNodes.map(keyOf));
+
+    // 3. Diff.
+    const toAdd = selectedNodes.filter((n) => !currentKeys.has(keyOf(n)));
+    const toRemove = currentContentNodes.filter(
+      (n) => !selectedKeys.has(keyOf(n))
+    );
+
+    // 4. Apply both sides
+    await addProjectContextContentNodes(
+      toAdd.map((n) => ({
+        title: n.title,
+        nodeId: n.nodeId,
+        nodeDataSourceViewId: n.nodeDataSourceViewId,
+        ...(n.sourceUrl ? { url: n.sourceUrl } : {}),
+      }))
+    );
+    await removeProjectContextContentNodes(
+      toRemove.map((n) => ({
+        nodeId: n.nodeId,
+        nodeDataSourceViewId: n.nodeDataSourceViewId,
+      }))
+    );
+
+    // 5. Refresh.
+    void mutateProjectContextAttachments();
+  };
 
   if (isProjectContextAttachmentsLoading || isProjectFilesLoading) {
     return (
@@ -860,15 +848,15 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
       <FilePreviewSheet
         owner={owner}
         file={selectedFile}
-        isOpen={showPreviewSheet}
-        onOpenChange={setShowPreviewSheet}
+        isOpen={activeOverlay === "preview"}
+        onOpenChange={(open) => setActiveOverlay(open ? "preview" : null)}
       />
 
       {globalSpace && (
         <SpaceManagedDatasourcesViewsModal
-          isOpen={showCompanyDataSheet}
+          isOpen={activeOverlay === "companyData"}
           isRootSelectable={false}
-          onClose={handleCloseCompanyDataSheet}
+          onClose={handleCloseOverlay}
           onSave={handleCompanyDataSave}
           owner={owner}
           space={globalSpace}
@@ -880,8 +868,8 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
       )}
 
       <NoCompanyDataDialog
-        isOpen={showNoCompanyDataDialog}
-        onClose={handleCloseNoCompanyDataDialog}
+        isOpen={activeOverlay === "noCompanyData"}
+        onClose={handleCloseOverlay}
         onGoToCompanyData={handleGoToCompanyData}
       />
 

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -21,10 +21,10 @@ import config from "@app/lib/api/config";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { useAppRouter } from "@app/lib/platform";
 import {
-  useAddProjectContextContentNode,
+  useAddProjectContextContentNodes,
   useProjectContextAttachments,
   useProjectFiles,
-  useRemoveProjectContextContentNode,
+  useRemoveProjectContextContentNodes,
   useRemoveProjectContextFile,
 } from "@app/lib/swr/projects";
 import { useSpaceDataSourceViews, useSpaces } from "@app/lib/swr/spaces";
@@ -420,12 +420,12 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     spaceId: space.sId,
   });
 
-  const removeProjectContextContentNode = useRemoveProjectContextContentNode({
+  const removeProjectContextContentNodes = useRemoveProjectContextContentNodes({
     owner,
     spaceId: space.sId,
   });
 
-  const addProjectContextContentNode = useAddProjectContextContentNode({
+  const addProjectContextContentNodes = useAddProjectContextContentNodes({
     owner,
     spaceId: space.sId,
   });
@@ -499,10 +499,12 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     });
 
     if (confirmed) {
-      const result = await removeProjectContextContentNode({
-        nodeId: item.nodeId,
-        nodeDataSourceViewId: item.nodeDataSourceViewId,
-      });
+      const result = await removeProjectContextContentNodes([
+        {
+          nodeId: item.nodeId,
+          nodeDataSourceViewId: item.nodeDataSourceViewId,
+        },
+      ]);
       if (result.isOk()) {
         void mutateProjectContextAttachments();
       }
@@ -780,69 +782,56 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
 
   const handleCompanyDataSave = useCallback(
     async (selectionConfigurations: DataSourceViewSelectionConfigurations) => {
-      type SelectedNode = {
-        title: string;
-        nodeId: string;
-        nodeDataSourceViewId: string;
-        sourceUrl: string | null | undefined;
-      };
-      const nextByKey = new Map<string, SelectedNode>();
-      for (const config of Object.values(selectionConfigurations)) {
-        for (const node of config.selectedResources) {
-          const dsvId = config.dataSourceView.sId;
-          nextByKey.set(`${dsvId}:${node.internalId}`, {
+      // 1. Flatten modal selection into a list of nodes.
+      const selectedNodes = Object.values(selectionConfigurations).flatMap(
+        ({ dataSourceView, selectedResources }) =>
+          selectedResources.map((node) => ({
             title: node.title,
             nodeId: node.internalId,
-            nodeDataSourceViewId: dsvId,
+            nodeDataSourceViewId: dataSourceView.sId,
             sourceUrl: node.sourceUrl,
-          });
-        }
-      }
+          }))
+      );
 
-      const currentByKey = new Map<
-        string,
-        { nodeId: string; nodeDataSourceViewId: string }
-      >();
-      for (const attachment of attachments) {
-        if (!isContentNodeAttachmentType(attachment)) {
-          continue;
-        }
-        currentByKey.set(
-          `${attachment.nodeDataSourceViewId}:${attachment.nodeId}`,
-          {
-            nodeId: attachment.nodeId,
-            nodeDataSourceViewId: attachment.nodeDataSourceViewId,
-          }
-        );
-      }
+      // 2. Build identity keys for both sides of the diff.
+      const keyOf = (n: { nodeDataSourceViewId: string; nodeId: string }) =>
+        `${n.nodeDataSourceViewId}:${n.nodeId}`;
+      const currentContentNodes = attachments.filter(
+        isContentNodeAttachmentType
+      );
+      const currentKeys = new Set(currentContentNodes.map(keyOf));
+      const selectedKeys = new Set(selectedNodes.map(keyOf));
 
-      for (const [key, node] of nextByKey.entries()) {
-        if (currentByKey.has(key)) {
-          continue;
-        }
-        await addProjectContextContentNode({
-          title: node.title,
-          nodeId: node.nodeId,
-          nodeDataSourceViewId: node.nodeDataSourceViewId,
-          ...(node.sourceUrl ? { url: node.sourceUrl } : {}),
-        });
-      }
-      for (const [key, node] of currentByKey.entries()) {
-        if (nextByKey.has(key)) {
-          continue;
-        }
-        await removeProjectContextContentNode({
-          nodeId: node.nodeId,
-          nodeDataSourceViewId: node.nodeDataSourceViewId,
-        });
-      }
+      // 3. Diff.
+      const toAdd = selectedNodes.filter((n) => !currentKeys.has(keyOf(n)));
+      const toRemove = currentContentNodes.filter(
+        (n) => !selectedKeys.has(keyOf(n))
+      );
+
+      // 4. Apply both sides
+      await addProjectContextContentNodes(
+        toAdd.map((n) => ({
+          title: n.title,
+          nodeId: n.nodeId,
+          nodeDataSourceViewId: n.nodeDataSourceViewId,
+          ...(n.sourceUrl ? { url: n.sourceUrl } : {}),
+        }))
+      );
+      await removeProjectContextContentNodes(
+        toRemove.map((n) => ({
+          nodeId: n.nodeId,
+          nodeDataSourceViewId: n.nodeDataSourceViewId,
+        }))
+      );
+
+      // 5. Refresh.
       void mutateProjectContextAttachments();
     },
     [
-      addProjectContextContentNode,
+      addProjectContextContentNodes,
       attachments,
       mutateProjectContextAttachments,
-      removeProjectContextContentNode,
+      removeProjectContextContentNodes,
     ]
   );
 

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -6,6 +6,7 @@ import { RenameFileDialog } from "@app/components/assistant/conversation/space/R
 import { ConfirmContext } from "@app/components/Confirm";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { FilePreviewSheet } from "@app/components/spaces/FilePreviewSheet";
+import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import type {
@@ -18,6 +19,7 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import config from "@app/lib/api/config";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import { useAppRouter } from "@app/lib/platform";
 import {
   useAddProjectContextContentNode,
   useProjectContextAttachments,
@@ -25,19 +27,35 @@ import {
   useRemoveProjectContextContentNode,
   useRemoveProjectContextFile,
 } from "@app/lib/swr/projects";
-import { useSpaces } from "@app/lib/swr/spaces";
+import { useSpaceDataSourceViews, useSpaces } from "@app/lib/swr/spaces";
 import { isManualProjectKnowledgeManagementAllowed } from "@app/lib/workspace_policies";
-import type { DataSourceViewContentNode } from "@app/types/data_source_view";
+import type {
+  DataSourceViewSelectionConfigurations,
+  DataSourceViewType,
+} from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
 import type { ProjectType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Avatar,
+  Button,
   CloudArrowLeftRightIcon,
+  CloudArrowUpIcon,
   DataTable,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   EmptyCTA,
   Icon,
   PencilSquareIcon,
+  PlusIcon,
   SearchInput,
   Spinner,
   Tooltip,
@@ -55,7 +73,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { InputBarAttachmentsPicker } from "../input_bar/InputBarAttachmentsPicker";
 
 interface SpaceKnowledgeTabProps {
   owner: WorkspaceType;
@@ -176,6 +193,123 @@ const KnowledgeSearchAndTable = memo(function KnowledgeSearchAndTable({
   );
 });
 
+type AttachKnowledgeDropdownProps = {
+  buttonLabel: string;
+  isDisabled: boolean;
+  onUploadFileClick: () => void;
+  onShowCompanyDataClick: () => void;
+};
+
+function AttachKnowledgeDropdown({
+  buttonLabel,
+  isDisabled,
+  onUploadFileClick,
+  onShowCompanyDataClick,
+}: AttachKnowledgeDropdownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button label={buttonLabel} icon={PlusIcon} disabled={isDisabled} />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem
+          icon={CloudArrowUpIcon}
+          label="Upload file"
+          onClick={onUploadFileClick}
+        />
+        <DropdownMenuItem
+          icon={CloudArrowLeftRightIcon}
+          label="From Company Data"
+          onClick={onShowCompanyDataClick}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+type AttachKnowledgeButtonProps = AttachKnowledgeDropdownProps & {
+  canManuallyManageProjectKnowledge: boolean;
+};
+
+function AttachKnowledgeButton({
+  buttonLabel,
+  canManuallyManageProjectKnowledge,
+  isDisabled,
+  onShowCompanyDataClick,
+  onUploadFileClick,
+}: AttachKnowledgeButtonProps) {
+  if (canManuallyManageProjectKnowledge) {
+    return (
+      <AttachKnowledgeDropdown
+        buttonLabel={buttonLabel}
+        isDisabled={isDisabled}
+        onShowCompanyDataClick={onShowCompanyDataClick}
+        onUploadFileClick={onUploadFileClick}
+      />
+    );
+  }
+  return (
+    <Tooltip
+      label={PROJECT_KNOWLEDGE_MANAGEMENT_DISABLED_TOOLTIP}
+      trigger={
+        <div>
+          <AttachKnowledgeDropdown
+            buttonLabel={buttonLabel}
+            isDisabled={isDisabled}
+            onShowCompanyDataClick={onShowCompanyDataClick}
+            onUploadFileClick={onUploadFileClick}
+          />
+        </div>
+      }
+    />
+  );
+}
+
+type NoCompanyDataDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onGoToCompanyData: () => void;
+};
+
+function NoCompanyDataDialog({
+  isOpen,
+  onClose,
+  onGoToCompanyData,
+}: NoCompanyDataDialogProps) {
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>No data available in Company Data</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          There is no data available in Company Data yet. Go to Company Data to
+          add data.
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Close",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Go to Company Data",
+            variant: "primary",
+            onClick: onGoToCompanyData,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
   const isArchived = !!space.archivedAt;
 
@@ -209,6 +343,8 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     projectId?: string | null;
   } | null>(null);
   const [showPreviewSheet, setShowPreviewSheet] = useState(false);
+  const [showCompanyDataSheet, setShowCompanyDataSheet] = useState(false);
+  const [showNoCompanyDataDialog, setShowNoCompanyDataDialog] = useState(false);
   const isArchived = !!space.archivedAt;
   const canManuallyManageProjectKnowledge =
     isManualProjectKnowledgeManagementAllowed(owner);
@@ -219,6 +355,14 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     kinds: ["global"],
   });
   const globalSpace = spaces.find((space) => space.kind === "global");
+
+  const { spaceDataSourceViews: globalSpaceDSVs } = useSpaceDataSourceViews({
+    workspaceId: owner.sId,
+    spaceId: globalSpace?.sId ?? "",
+    disabled: !globalSpace,
+  });
+
+  const router = useAppRouter();
 
   const {
     attachments: contentNodeAttachments,
@@ -584,9 +728,123 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
 
   const hasFiles = attachments.length > 0;
   const isUploading = projectFileUpload.isProcessingFiles;
-  const uploadButtonLabel = isUploading ? "Uploading..." : "Add";
+  const uploadButtonLabel = isUploading ? "Uploading..." : "Add data";
   const isAddKnowledgeDisabled =
     !canManuallyManageProjectKnowledge || isUploading;
+
+  const handleUploadFileClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleShowCompanyDataClick = useCallback(() => {
+    if (globalSpaceDSVs.length === 0) {
+      setShowNoCompanyDataDialog(true);
+      return;
+    }
+    setShowCompanyDataSheet(true);
+  }, [globalSpaceDSVs.length]);
+
+  const handleCloseCompanyDataSheet = useCallback(() => {
+    setShowCompanyDataSheet(false);
+  }, []);
+
+  const handleCloseNoCompanyDataDialog = useCallback(() => {
+    setShowNoCompanyDataDialog(false);
+  }, []);
+
+  const handleGoToCompanyData = useCallback(() => {
+    if (!globalSpace) {
+      return;
+    }
+    void router.push(`/w/${owner.sId}/spaces/${globalSpace.sId}`);
+  }, [globalSpace, owner.sId, router]);
+
+  const initialSelectedDataSources = useMemo<DataSourceViewType[]>(() => {
+    const nodeIdsByDsvId = new Map<string, string[]>();
+    for (const attachment of attachments) {
+      if (!isContentNodeAttachmentType(attachment)) {
+        continue;
+      }
+      const existing =
+        nodeIdsByDsvId.get(attachment.nodeDataSourceViewId) ?? [];
+      nodeIdsByDsvId.set(attachment.nodeDataSourceViewId, [
+        ...existing,
+        attachment.nodeId,
+      ]);
+    }
+    return Array.from(nodeIdsByDsvId.entries()).flatMap(([dsvId, nodeIds]) => {
+      const dsv = globalSpaceDSVs.find((v) => v.sId === dsvId);
+      return dsv ? [{ ...dsv, parentsIn: nodeIds }] : [];
+    });
+  }, [attachments, globalSpaceDSVs]);
+
+  const handleCompanyDataSave = useCallback(
+    async (selectionConfigurations: DataSourceViewSelectionConfigurations) => {
+      type SelectedNode = {
+        title: string;
+        nodeId: string;
+        nodeDataSourceViewId: string;
+        sourceUrl: string | null | undefined;
+      };
+      const nextByKey = new Map<string, SelectedNode>();
+      for (const config of Object.values(selectionConfigurations)) {
+        for (const node of config.selectedResources) {
+          const dsvId = config.dataSourceView.sId;
+          nextByKey.set(`${dsvId}:${node.internalId}`, {
+            title: node.title,
+            nodeId: node.internalId,
+            nodeDataSourceViewId: dsvId,
+            sourceUrl: node.sourceUrl,
+          });
+        }
+      }
+
+      const currentByKey = new Map<
+        string,
+        { nodeId: string; nodeDataSourceViewId: string }
+      >();
+      for (const attachment of attachments) {
+        if (!isContentNodeAttachmentType(attachment)) {
+          continue;
+        }
+        currentByKey.set(
+          `${attachment.nodeDataSourceViewId}:${attachment.nodeId}`,
+          {
+            nodeId: attachment.nodeId,
+            nodeDataSourceViewId: attachment.nodeDataSourceViewId,
+          }
+        );
+      }
+
+      for (const [key, node] of nextByKey.entries()) {
+        if (currentByKey.has(key)) {
+          continue;
+        }
+        await addProjectContextContentNode({
+          title: node.title,
+          nodeId: node.nodeId,
+          nodeDataSourceViewId: node.nodeDataSourceViewId,
+          ...(node.sourceUrl ? { url: node.sourceUrl } : {}),
+        });
+      }
+      for (const [key, node] of currentByKey.entries()) {
+        if (nextByKey.has(key)) {
+          continue;
+        }
+        await removeProjectContextContentNode({
+          nodeId: node.nodeId,
+          nodeDataSourceViewId: node.nodeDataSourceViewId,
+        });
+      }
+      void mutateProjectContextAttachments();
+    },
+    [
+      addProjectContextContentNode,
+      attachments,
+      mutateProjectContextAttachments,
+      removeProjectContextContentNode,
+    ]
+  );
 
   if (isProjectContextAttachmentsLoading || isProjectFilesLoading) {
     return (
@@ -599,53 +857,6 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
       </div>
     );
   }
-
-  const attachButton = (
-    <InputBarAttachmentsPicker
-      owner={owner}
-      fileUploaderService={projectFileUpload}
-      onNodeSelect={async (node: DataSourceViewContentNode) => {
-        const result = await addProjectContextContentNode({
-          title: node.title,
-          nodeId: node.internalId,
-          nodeDataSourceViewId: node.dataSourceView.sId,
-          ...(node.sourceUrl != null ? { url: node.sourceUrl } : {}),
-        });
-        if (result.isOk()) {
-          void mutateProjectContextAttachments();
-        }
-      }}
-      onNodeUnselect={(_node: DataSourceViewContentNode) => {
-        // Selection state is not tracked locally; project context is updated on select only.
-      }}
-      onFileChange={() => {
-        void mutateProjectFiles();
-      }}
-      attachedNodes={[]}
-      isLoading={isUploading}
-      disabled={isAddKnowledgeDisabled}
-      buttonLabel={uploadButtonLabel}
-      buttonSize="sm"
-      buttonVariant="outline"
-      toolFileUpload={{
-        useCase: "project_context",
-        useCaseMetadata: {
-          spaceId: space.sId,
-        },
-      }}
-      spaceId={globalSpace?.sId}
-      type="dropdown"
-    />
-  );
-
-  const attachButtonWithPolicyTooltip = canManuallyManageProjectKnowledge ? (
-    attachButton
-  ) : (
-    <Tooltip
-      label={PROJECT_KNOWLEDGE_MANAGEMENT_DISABLED_TOOLTIP}
-      trigger={<div>{attachButton}</div>}
-    />
-  );
 
   return (
     <>
@@ -664,6 +875,27 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
         onOpenChange={setShowPreviewSheet}
       />
 
+      {globalSpace && (
+        <SpaceManagedDatasourcesViewsModal
+          isOpen={showCompanyDataSheet}
+          isRootSelectable={false}
+          onClose={handleCloseCompanyDataSheet}
+          onSave={handleCompanyDataSave}
+          owner={owner}
+          space={globalSpace}
+          systemSpace={globalSpace}
+          systemSpaceDataSourceViews={globalSpaceDSVs}
+          initialSelectedDataSources={initialSelectedDataSources}
+          title="Add data from Company Data"
+        />
+      )}
+
+      <NoCompanyDataDialog
+        isOpen={showNoCompanyDataDialog}
+        onClose={handleCloseNoCompanyDataDialog}
+        onGoToCompanyData={handleGoToCompanyData}
+      />
+
       {!isArchived && (
         <input
           ref={fileInputRef}
@@ -679,7 +911,17 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
         <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 py-8">
           <div className="flex gap-2">
             <h3 className="heading-2xl flex-1 items-center">Files</h3>
-            {hasFiles && !isArchived && attachButtonWithPolicyTooltip}
+            {hasFiles && !isArchived && (
+              <AttachKnowledgeButton
+                buttonLabel={uploadButtonLabel}
+                canManuallyManageProjectKnowledge={
+                  canManuallyManageProjectKnowledge
+                }
+                isDisabled={isAddKnowledgeDisabled}
+                onShowCompanyDataClick={handleShowCompanyDataClick}
+                onUploadFileClick={handleUploadFileClick}
+              />
+            )}
           </div>
 
           {!hasFiles ? (
@@ -689,7 +931,19 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
                   ? "This project is archived. No files have been added."
                   : "No files have been added to this project yet."
               }
-              action={isArchived ? null : attachButtonWithPolicyTooltip}
+              action={
+                isArchived ? null : (
+                  <AttachKnowledgeButton
+                    buttonLabel={uploadButtonLabel}
+                    canManuallyManageProjectKnowledge={
+                      canManuallyManageProjectKnowledge
+                    }
+                    isDisabled={isAddKnowledgeDisabled}
+                    onShowCompanyDataClick={handleShowCompanyDataClick}
+                    onUploadFileClick={handleUploadFileClick}
+                  />
+                )
+              }
             />
           ) : (
             <KnowledgeSearchAndTable columns={columns} data={tableData} />

--- a/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
@@ -41,6 +41,7 @@ function useStabilizedValue<T>(
 interface SpaceManagedDataSourcesViewsModalProps {
   initialSelectedDataSources: DataSourceViewType[];
   isOpen: boolean;
+  isRootSelectable?: boolean;
   onClose: () => void;
   onSave: (
     selectionConfigurations: DataSourceViewSelectionConfigurations
@@ -49,17 +50,20 @@ interface SpaceManagedDataSourcesViewsModalProps {
   systemSpaceDataSourceViews: DataSourceViewType[];
   space: SpaceType;
   systemSpace: SpaceType;
+  title?: string;
 }
 
 export default function SpaceManagedDataSourcesViewsModal({
   initialSelectedDataSources,
   isOpen,
+  isRootSelectable = true,
   onClose,
   onSave,
   owner,
   systemSpaceDataSourceViews,
   space,
   systemSpace,
+  title,
 }: SpaceManagedDataSourcesViewsModalProps) {
   const defaultSelectedDataSources = useStabilizedValue(
     initialSelectedDataSources,
@@ -156,7 +160,9 @@ export default function SpaceManagedDataSourcesViewsModal({
     >
       <SheetContent size="lg">
         <SheetHeader>
-          <SheetTitle>Add connected data to space "{space.name}"</SheetTitle>
+          <SheetTitle>
+            {title ?? `Add connected data to space "${space.name}"`}
+          </SheetTitle>
         </SheetHeader>
         <SheetContainer>
           <div className="overflow-x-auto">
@@ -172,7 +178,7 @@ export default function SpaceManagedDataSourcesViewsModal({
                 selectionConfigurations={selectionConfigurations}
                 setSelectionConfigurations={setSelectionConfigurationsCallback}
                 viewType="all"
-                isRootSelectable={true}
+                isRootSelectable={isRootSelectable}
                 space={systemSpace}
                 allowAdminSearch={isAdmin(owner)}
               />

--- a/front/lib/api/actions/servers/project_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/project_manager/tools/index.ts
@@ -35,7 +35,7 @@ import config from "@app/lib/api/config";
 import {
   addContentNodeToProject,
   listProjectContextAttachments,
-  removeContentNodeFromProject,
+  removeContentNodesFromProject,
 } from "@app/lib/api/projects/context";
 import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
@@ -189,10 +189,14 @@ export function createProjectManagerTools(
 
         const { space } = contextRes.value;
 
-        const removeRes = await removeContentNodeFromProject(auth, {
+        const removeRes = await removeContentNodesFromProject(auth, {
           space,
-          nodeId: params.nodeId,
-          nodeDataSourceViewId: params.nodeDataSourceViewId,
+          nodes: [
+            {
+              nodeId: params.nodeId,
+              nodeDataSourceViewId: params.nodeDataSourceViewId,
+            },
+          ],
         });
         if (removeRes.isErr()) {
           return new Err(

--- a/front/lib/api/projects/context.test.ts
+++ b/front/lib/api/projects/context.test.ts
@@ -1,5 +1,5 @@
 import {
-  removeContentNodeFromProject,
+  removeContentNodesFromProject,
   removeFileFromProject,
 } from "@app/lib/api/projects/context";
 import { MessageModel } from "@app/lib/models/agent/conversation";
@@ -118,7 +118,7 @@ describe("removeFileFromProject", () => {
   });
 });
 
-describe("removeContentNodeFromProject", () => {
+describe("removeContentNodesFromProject", () => {
   beforeEach(() => {
     // keep tests isolated; factories already run in their own DB context
   });
@@ -157,10 +157,9 @@ describe("removeContentNodeFromProject", () => {
       sId: "cf_test_node_1",
     });
 
-    const res = await removeContentNodeFromProject(auth, {
+    const res = await removeContentNodesFromProject(auth, {
       space: project,
-      nodeId: "node_1",
-      nodeDataSourceViewId: dsView.sId,
+      nodes: [{ nodeId: "node_1", nodeDataSourceViewId: dsView.sId }],
     });
     expect(res.isOk()).toBe(true);
 
@@ -218,10 +217,9 @@ describe("removeContentNodeFromProject", () => {
       workspaceId: workspace.id,
     });
 
-    const res = await removeContentNodeFromProject(auth, {
+    const res = await removeContentNodesFromProject(auth, {
       space: project,
-      nodeId: "node_2",
-      nodeDataSourceViewId: dsView.sId,
+      nodes: [{ nodeId: "node_2", nodeDataSourceViewId: dsView.sId }],
     });
     expect(res.isOk()).toBe(true);
 
@@ -303,10 +301,9 @@ describe("removeContentNodeFromProject", () => {
       workspaceId: workspace.id,
     });
 
-    const res = await removeContentNodeFromProject(auth, {
+    const res = await removeContentNodesFromProject(auth, {
       space: project,
-      nodeId: "node_3",
-      nodeDataSourceViewId: dsView.sId,
+      nodes: [{ nodeId: "node_3", nodeDataSourceViewId: dsView.sId }],
     });
     expect(res.isOk()).toBe(true);
 

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -430,40 +430,60 @@ export async function removeFileFromProject(
  * - If some fragments are referenced by messages, we keep them but detach them from the space
  *   and mark them expired so conversation rendering can display an appropriate placeholder.
  */
-export async function removeContentNodeFromProject(
+export async function removeContentNodesFromProject(
   auth: Authenticator,
   {
     space,
-    nodeId,
-    nodeDataSourceViewId,
+    nodes,
   }: {
     space: SpaceResource;
-    nodeId: string;
-    nodeDataSourceViewId: string; // data source view sId
+    nodes: Array<{
+      nodeId: string;
+      nodeDataSourceViewId: string; // data source view sId
+    }>;
   }
 ): Promise<Result<void, Error>> {
-  const dsView = await DataSourceViewResource.fetchById(
-    auth,
-    nodeDataSourceViewId
-  );
-  if (!dsView) {
-    return new Err(new Error("Data source view not found."));
+  if (nodes.length === 0) {
+    return new Ok(undefined);
   }
 
   const workspaceId = auth.getNonNullableWorkspace().id;
 
-  const projectFragmentIds = await ContentFragmentModel.findAll({
+  const uniqueDataSourceViewIds = Array.from(
+    new Set(nodes.map((n) => n.nodeDataSourceViewId))
+  );
+  const dataSourceViews = await DataSourceViewResource.fetchByIds(
+    auth,
+    uniqueDataSourceViewIds
+  );
+  const dataSourceViewModelIdById = new Map(
+    dataSourceViews.map((dsv) => [dsv.sId, dsv.id])
+  );
+
+  const pairs = nodes.flatMap((n) => {
+    const dsvModelId = dataSourceViewModelIdById.get(n.nodeDataSourceViewId);
+    return dsvModelId !== undefined
+      ? [{ nodeId: n.nodeId, nodeDataSourceViewModelId: dsvModelId }]
+      : [];
+  });
+  if (pairs.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const projectFragmentModelIds = await ContentFragmentModel.findAll({
     attributes: ["id"],
     where: {
       workspaceId,
       spaceId: space.id,
       fileId: null,
-      nodeId,
-      nodeDataSourceViewId: dsView.id,
+      [Op.or]: pairs.map((p) => ({
+        nodeId: p.nodeId,
+        nodeDataSourceViewId: p.nodeDataSourceViewModelId,
+      })),
     },
   }).then((rows) => rows.map((r) => r.id));
 
-  if (projectFragmentIds.length === 0) {
+  if (projectFragmentModelIds.length === 0) {
     return new Ok(undefined);
   }
 
@@ -471,33 +491,30 @@ export async function removeContentNodeFromProject(
     attributes: ["contentFragmentId"],
     where: {
       workspaceId,
-      contentFragmentId: {
-        [Op.in]: projectFragmentIds,
-      },
+      contentFragmentId: { [Op.in]: projectFragmentModelIds },
     },
   });
 
-  const referencedIds = new Set(
+  const referencedModelIds = new Set(
     removeNulls(messagesReferencing.map((m) => m.contentFragmentId))
   );
-  const orphanIds = projectFragmentIds.filter((id) => !referencedIds.has(id));
+  const orphanIds = projectFragmentModelIds.filter(
+    (id) => !referencedModelIds.has(id)
+  );
 
   if (orphanIds.length > 0) {
     await ContentFragmentModel.destroy({
-      where: {
-        workspaceId,
-        id: { [Op.in]: orphanIds },
-      },
+      where: { workspaceId, id: { [Op.in]: orphanIds } },
     });
   }
 
-  if (referencedIds.size > 0) {
+  if (referencedModelIds.size > 0) {
     await ContentFragmentModel.update(
       { spaceId: null },
       {
         where: {
           workspaceId,
-          id: { [Op.in]: Array.from(referencedIds) },
+          id: { [Op.in]: Array.from(referencedModelIds) },
         },
       }
     );

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -107,9 +107,9 @@ export function useProjectFiles({
 }
 
 export type ProjectContextContentNodeFragment =
-  PostProjectContextContentNodeResponseBody["contentFragment"];
+  PostProjectContextContentNodeResponseBody["contentFragments"][number];
 
-export function useAddProjectContextContentNode({
+export function useAddProjectContextContentNodes({
   owner,
   spaceId,
 }: {
@@ -119,15 +119,18 @@ export function useAddProjectContextContentNode({
   const sendNotification = useSendNotification();
 
   return async (
-    contentFragment: ContentFragmentInputWithContentNode
-  ): Promise<Result<ProjectContextContentNodeFragment, Error>> => {
+    items: ContentFragmentInputWithContentNode[]
+  ): Promise<Result<PostProjectContextContentNodeResponseBody, Error>> => {
+    if (items.length === 0) {
+      return new Ok({ contentFragments: [], errors: [] });
+    }
     try {
       const res = await clientFetch(
         `/api/w/${owner.sId}/spaces/${spaceId}/project_context`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(contentFragment),
+          body: JSON.stringify({ items }),
         }
       );
 
@@ -135,7 +138,7 @@ export function useAddProjectContextContentNode({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to add reference to project",
+          title: "Failed to add references to project",
           description: errorData.message,
         });
         return new Err(new Error(errorData.message));
@@ -143,17 +146,30 @@ export function useAddProjectContextContentNode({
 
       const responseData: PostProjectContextContentNodeResponseBody =
         await res.json();
-      sendNotification({
-        type: "success",
-        title: "Added to project context",
-      });
+      const addedCount = responseData.contentFragments.length;
+      const errorCount = responseData.errors.length;
+      if (errorCount === 0) {
+        sendNotification({
+          type: "success",
+          title:
+            addedCount === 1
+              ? "Added to project context"
+              : `Added ${addedCount} items to project context`,
+        });
+      } else {
+        sendNotification({
+          type: "error",
+          title: "Some items could not be added",
+          description: `${addedCount} added, ${errorCount} failed.`,
+        });
+      }
 
-      return new Ok(responseData.contentFragment);
+      return new Ok(responseData);
     } catch (e) {
       const errorMessage = normalizeError(e).message;
       sendNotification({
         type: "error",
-        title: "Failed to add reference to project",
+        title: "Failed to add references to project",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));
@@ -207,7 +223,7 @@ export function useRemoveProjectContextFile({
   };
 }
 
-export function useRemoveProjectContextContentNode({
+export function useRemoveProjectContextContentNodes({
   owner,
   spaceId,
 }: {
@@ -216,20 +232,19 @@ export function useRemoveProjectContextContentNode({
 }) {
   const sendNotification = useSendNotification();
 
-  return async ({
-    nodeId,
-    nodeDataSourceViewId,
-  }: {
-    nodeId: string;
-    nodeDataSourceViewId: string;
-  }): Promise<Result<void, Error>> => {
+  return async (
+    items: Array<{ nodeId: string; nodeDataSourceViewId: string }>
+  ): Promise<Result<void, Error>> => {
+    if (items.length === 0) {
+      return new Ok(undefined);
+    }
     try {
       const res = await clientFetch(
         `/api/w/${owner.sId}/spaces/${spaceId}/project_context/content_nodes`,
         {
           method: "DELETE",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ nodeId, nodeDataSourceViewId }),
+          body: JSON.stringify({ items }),
         }
       );
 
@@ -237,7 +252,7 @@ export function useRemoveProjectContextContentNode({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to remove content node from project",
+          title: "Failed to remove content nodes from project",
           description: errorData.message,
         });
         return new Err(new Error(errorData.message));
@@ -245,7 +260,10 @@ export function useRemoveProjectContextContentNode({
 
       sendNotification({
         type: "success",
-        title: "Removed from project knowledge",
+        title:
+          items.length === 1
+            ? "Removed from project knowledge"
+            : `Removed ${items.length} items from project knowledge`,
       });
 
       return new Ok(undefined);
@@ -253,7 +271,7 @@ export function useRemoveProjectContextContentNode({
       const errorMessage = normalizeError(e).message;
       sendNotification({
         type: "error",
-        title: "Failed to remove content node from project",
+        title: "Failed to remove content nodes from project",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/content_nodes/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/content_nodes/index.ts
@@ -1,7 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { removeContentNodeFromProject } from "@app/lib/api/projects/context";
+import { removeContentNodesFromProject } from "@app/lib/api/projects/context";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -10,9 +10,13 @@ import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-const DeleteProjectContextContentNodeBodySchema = z.object({
+const DeleteProjectContextContentNodeItemSchema = z.object({
   nodeId: z.string().min(1, "nodeId is required"),
   nodeDataSourceViewId: z.string().min(1, "nodeDataSourceViewId is required"),
+});
+
+const DeleteProjectContextContentNodeBodySchema = z.object({
+  items: z.array(DeleteProjectContextContentNodeItemSchema),
 });
 
 export type DeleteProjectContextContentNodeResponseBody = Record<string, never>;
@@ -84,10 +88,9 @@ async function handler(
         });
       }
 
-      const r = await removeContentNodeFromProject(auth, {
+      const r = await removeContentNodesFromProject(auth, {
         space,
-        nodeId: bodyValidation.data.nodeId,
-        nodeDataSourceViewId: bodyValidation.data.nodeDataSourceViewId,
+        nodes: bodyValidation.data.items,
       });
       if (r.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.test.ts
@@ -203,9 +203,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/project_context", () => {
 
       req.query.spaceId = globalSpace.sId;
       req.body = {
-        title: "Ref",
-        nodeId: "n1",
-        nodeDataSourceViewId: "dsv1",
+        items: [{ title: "Ref", nodeId: "n1", nodeDataSourceViewId: "dsv1" }],
       };
 
       await handler(req, res);
@@ -232,9 +230,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/project_context", () => {
         const project = await SpaceFactory.project(workspace, user.id);
         req.query.spaceId = project.sId;
         req.body = {
-          title: "Ref",
-          nodeId: "n1",
-          nodeDataSourceViewId: "dsv1",
+          items: [{ title: "Ref", nodeId: "n1", nodeDataSourceViewId: "dsv1" }],
         };
 
         await handler(req, res);
@@ -271,20 +267,26 @@ describe("/api/w/[wId]/spaces/[spaceId]/project_context", () => {
 
       req.query.spaceId = project.sId;
       req.body = {
-        title: "My doc",
-        nodeId: "core-node",
-        nodeDataSourceViewId: "dsview-sid",
+        items: [
+          {
+            title: "My doc",
+            nodeId: "core-node",
+            nodeDataSourceViewId: "dsview-sid",
+          },
+        ],
       };
 
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(201);
       const data = res._getJSONData();
-      expect(data.contentFragment.sId).toBe("cf_mock");
-      expect(data.contentFragment.title).toBe("Synced title");
-      expect(data.contentFragment.nodeId).toBe("core-node");
-      expect(data.contentFragment.nodeType).toBe("document");
-      expect(data.contentFragment.nodeDataSourceViewId).toBeDefined();
+      expect(data.contentFragments).toHaveLength(1);
+      expect(data.errors).toHaveLength(0);
+      expect(data.contentFragments[0].sId).toBe("cf_mock");
+      expect(data.contentFragments[0].title).toBe("Synced title");
+      expect(data.contentFragments[0].nodeId).toBe("core-node");
+      expect(data.contentFragments[0].nodeType).toBe("document");
+      expect(data.contentFragments[0].nodeDataSourceViewId).toBeDefined();
       expect(addContentNodeToProjectSpy).toHaveBeenCalledWith(
         expect.anything(),
         {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.ts
@@ -9,6 +9,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { ContentNodeType } from "@app/types/core/content_node";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -20,7 +21,7 @@ export type GetProjectContextResponseBody = {
   attachments: ConversationAttachmentType[];
 };
 
-const PostProjectContextContentNodeBodySchema = z.object({
+const PostProjectContextContentNodeItemSchema = z.object({
   title: z.string().min(1, "title is required"),
   nodeId: z.string().min(1, "nodeId is required"),
   nodeDataSourceViewId: z.string().min(1, "nodeDataSourceViewId is required"),
@@ -28,15 +29,22 @@ const PostProjectContextContentNodeBodySchema = z.object({
   supersededContentFragmentId: z.string().nullable().optional(),
 });
 
+const PostProjectContextContentNodeBodySchema = z.object({
+  items: z.array(PostProjectContextContentNodeItemSchema),
+});
+
+export type PostProjectContextContentNodeFragment = {
+  sId: string;
+  title: string;
+  contentType: string;
+  nodeId: string;
+  nodeDataSourceViewId: string;
+  nodeType: ContentNodeType;
+};
+
 export type PostProjectContextContentNodeResponseBody = {
-  contentFragment: {
-    sId: string;
-    title: string;
-    contentType: string;
-    nodeId: string;
-    nodeDataSourceViewId: string;
-    nodeType: ContentNodeType;
-  };
+  contentFragments: PostProjectContextContentNodeFragment[];
+  errors: Array<{ index: number; message: string }>;
 };
 
 const ProjectContextQuerySchema = z.object({
@@ -161,57 +169,50 @@ async function handler(
         });
       }
 
-      const addRes = await addContentNodeToProject(auth, {
-        space,
-        contentFragment: bodyValidation.data,
-      });
-
-      if (addRes.isErr()) {
-        const err = addRes.error;
-        const status = err.code === "invalid_request_error" ? 400 : 500;
-        return apiError(req, res, {
-          status_code: status,
-          api_error: {
-            type:
-              err.code === "invalid_request_error"
-                ? "invalid_request_error"
-                : "internal_server_error",
-            message: err.message,
-          },
-        });
-      }
-
-      const fr = addRes.value;
-      if (
-        fr.nodeId == null ||
-        fr.nodeDataSourceViewId == null ||
-        fr.nodeType == null
-      ) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Missing node fields on content fragment.",
-          },
-        });
-      }
-
+      const { items } = bodyValidation.data;
       const owner = auth.getNonNullableWorkspace();
-      const nodeDataSourceViewId = DataSourceViewResource.modelIdToSId({
-        id: fr.nodeDataSourceViewId,
-        workspaceId: owner.id,
-      });
 
-      res.status(201).json({
-        contentFragment: {
+      const results = await concurrentExecutor(
+        items,
+        (item) =>
+          addContentNodeToProject(auth, { space, contentFragment: item }),
+        { concurrency: 2 }
+      );
+
+      const contentFragments: PostProjectContextContentNodeFragment[] = [];
+      const errors: Array<{ index: number; message: string }> = [];
+
+      results.forEach((result, index) => {
+        if (result.isErr()) {
+          errors.push({ index, message: result.error.message });
+          return;
+        }
+        const fr = result.value;
+        if (
+          fr.nodeId == null ||
+          fr.nodeDataSourceViewId == null ||
+          fr.nodeType == null
+        ) {
+          errors.push({
+            index,
+            message: "Missing node fields on content fragment.",
+          });
+          return;
+        }
+        contentFragments.push({
           sId: fr.sId,
           title: fr.title,
           contentType: fr.contentType,
           nodeId: fr.nodeId,
-          nodeDataSourceViewId,
+          nodeDataSourceViewId: DataSourceViewResource.modelIdToSId({
+            id: fr.nodeDataSourceViewId,
+            workspaceId: owner.id,
+          }),
           nodeType: fr.nodeType,
-        },
+        });
       });
+
+      res.status(201).json({ contentFragments, errors });
       return;
     }
 


### PR DESCRIPTION
## Description

This PR changes the UI for attaching knowledge content to projects using a data source selection sheet.

- New knowledge attachment UI: Implemented a sheet-based interface in `SpaceKnowledgeTab` for selecting and attaching multiple knowledge items to projects at once
- Batch API support: Refactored backend APIs to support bulk operations, enabling the new multi-select UI workflow

<img width="335" height="180" alt="Capture d’écran 2026-05-15 à 13 51 36" src="https://github.com/user-attachments/assets/c2e7f303-a1c7-49cb-8704-21733dd8adec" />
<img width="577" height="861" alt="Capture d’écran 2026-05-15 à 13 51 56" src="https://github.com/user-attachments/assets/1254a1c4-894c-4413-9a8c-bb08bb3e8323" />


## Tests

Manually tested.

## Risks

- API breaking change: The endpoint contract changed from single-item to batch operations. However this endpoint is only used by the web app for projects. It is not used in the Chrome extension.

## Deploy Plan

Standard deployment.
