### PR TITLE
Compaction: prevent context overflow when compacting

### DIFF
--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -372,8 +372,6 @@ async function generateCompactionSummary(
     truncateTotalChars: 512000, // Simple heuristic to avoid context overflow with most models.
   });
 
-  // TODO(compaction): Ensure we don't exceeds the model context size here, as we have no guarantee
-  // that the current conversation is not exceeding it already.
   // TODO(compaction): We may want to be more mechanical about files available to the model in
   // conversation and projects by including a list as part of the summary.
   // TODO(compaction: We may want to add retries around the LLM call

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -369,6 +369,7 @@ async function generateCompactionSummary(
     includeActions: true,
     includeActionDetails: true,
     skipRunningAgentMessages: true,
+    truncateTotalChars: 512000, // Simple heuristic to avoid context overflow with most models.
   });
 
   // TODO(compaction): Ensure we don't exceeds the model context size here, as we have no guarantee


### PR DESCRIPTION
## Description

Fixes: 

https://github.com/dust-tt/tasks/issues/8113
https://github.com/dust-tt/tasks/issues/7950

Enforce a heuristic of max 512k chars for compaction (for conversation that went way over the context window). This is not perfect but will allow a big chunk of a very long pre-existing conversation (new conversation should never land into that state) and yet will work well with most modern models (Claude Sonnet 4.6, Opus 4.7, gpt 5.5).

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25631">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->