### PR TITLE
feat(dust-hive): add env subcommands to manage config.env

### DIFF
--- a/x/henry/dust-hive/src/commands/env.ts
+++ b/x/henry/dust-hive/src/commands/env.ts
@@ -1,0 +1,49 @@
+import { getConfigVar, listConfigVars, setConfigVar, unsetConfigVar } from "../lib/config-env";
+import { logger } from "../lib/logger";
+import { CONFIG_ENV_PATH } from "../lib/paths";
+import { CommandError, Err, Ok, type Result } from "../lib/result";
+
+const KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export async function envListCommand(): Promise<Result<void>> {
+  const vars = await listConfigVars();
+
+  if (vars.length === 0) {
+    logger.dim(`No vars set in ${CONFIG_ENV_PATH}`);
+    return Ok(undefined);
+  }
+
+  const maxKeyLen = Math.max(...vars.map((v) => v.key.length));
+  for (const { key, value } of vars) {
+    console.log(`  ${key.padEnd(maxKeyLen + 2)}${value}`);
+  }
+
+  return Ok(undefined);
+}
+
+export async function envGetCommand(key: string): Promise<Result<void>> {
+  const value = await getConfigVar(key);
+  if (value === null) {
+    return Err(new CommandError(`'${key}' not found in config.env`));
+  }
+  console.log(value);
+  return Ok(undefined);
+}
+
+export async function envSetCommand(key: string, value: string): Promise<Result<void>> {
+  if (!KEY_PATTERN.test(key)) {
+    return Err(new CommandError(`Invalid key '${key}': must match [A-Za-z_][A-Za-z0-9_]*`));
+  }
+  await setConfigVar(key, value);
+  logger.success(`${key}=${value}`);
+  return Ok(undefined);
+}
+
+export async function envUnsetCommand(key: string): Promise<Result<void>> {
+  const removed = await unsetConfigVar(key);
+  if (!removed) {
+    return Err(new CommandError(`'${key}' not found in config.env`));
+  }
+  logger.success(`Removed ${key}`);
+  return Ok(undefined);
+}

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -7,6 +7,7 @@ import { coolCommand } from "./commands/cool";
 import { destroyCommand } from "./commands/destroy";
 import { doctorCommand, setupCommand } from "./commands/doctor";
 import { downCommand } from "./commands/down";
+import { envGetCommand, envListCommand, envSetCommand, envUnsetCommand } from "./commands/env";
 import { feedCommand } from "./commands/feed";
 import { flagCommand } from "./commands/flag";
 import { forwardCommand, forwardStatusCommand, forwardStopCommand } from "./commands/forward";
@@ -345,6 +346,40 @@ cli
   .action(async (name: string | undefined, scenario: string | undefined) => {
     await prepareAndRun(feedCommand(name, scenario));
   });
+
+cli
+  .command(
+    "env [subcommand] [key] [value]",
+    "Manage config.env vars: list | get <KEY> | set <KEY> <VALUE> | unset <KEY> | <KEY>"
+  )
+  .action(
+    async (subcommand: string | undefined, key: string | undefined, value: string | undefined) => {
+      if (!subcommand || subcommand === "list") {
+        await prepareAndRun(envListCommand());
+      } else if (subcommand === "get") {
+        if (!key) {
+          logger.error("Usage: dust-hive env get <KEY>");
+          process.exit(1);
+        }
+        await prepareAndRun(envGetCommand(key));
+      } else if (subcommand === "set") {
+        if (!key || value === undefined) {
+          logger.error("Usage: dust-hive env set <KEY> <VALUE>");
+          process.exit(1);
+        }
+        await prepareAndRun(envSetCommand(key, value));
+      } else if (subcommand === "unset") {
+        if (!key) {
+          logger.error("Usage: dust-hive env unset <KEY>");
+          process.exit(1);
+        }
+        await prepareAndRun(envUnsetCommand(key));
+      } else {
+        // dh env KEY — shorthand for get
+        await prepareAndRun(envGetCommand(subcommand));
+      }
+    }
+  );
 
 cli
   .command("flag [name] [flagName]", "Toggle a feature flag on the workspace")

--- a/x/henry/dust-hive/src/lib/config-env.ts
+++ b/x/henry/dust-hive/src/lib/config-env.ts
@@ -55,6 +55,9 @@ export async function getConfigVar(key: string): Promise<string | null> {
 }
 
 export async function setConfigVar(key: string, value: string): Promise<void> {
+  if (value.includes("\n")) {
+    throw new Error("Value must not contain newlines");
+  }
   const content = await readContent();
   const newLine = `export ${key}=${quoteValue(value)}`;
   const lines = content.split("\n");

--- a/x/henry/dust-hive/src/lib/config-env.ts
+++ b/x/henry/dust-hive/src/lib/config-env.ts
@@ -1,0 +1,102 @@
+import { CONFIG_ENV_PATH } from "./paths";
+
+interface EnvVar {
+  key: string;
+  value: string;
+}
+
+// Matches lines like: export KEY=value  export KEY="value"  export KEY='value'
+const EXPORT_PATTERN = /^export ([A-Za-z_][A-Za-z0-9_]*)=(.*)/;
+
+function unquoteValue(raw: string): string {
+  if (
+    raw.length >= 2 &&
+    ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'")))
+  ) {
+    return raw.slice(1, -1);
+  }
+  return raw;
+}
+
+function quoteValue(value: string): string {
+  if (/^[A-Za-z0-9_./:@-]+$/.test(value)) return value;
+  if (!value.includes("'")) return `'${value}'`;
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`");
+  return `"${escaped}"`;
+}
+
+async function readContent(): Promise<string> {
+  const file = Bun.file(CONFIG_ENV_PATH);
+  if (!(await file.exists())) return "";
+  return file.text();
+}
+
+export async function listConfigVars(): Promise<EnvVar[]> {
+  const content = await readContent();
+  const vars: EnvVar[] = [];
+  for (const line of content.split("\n")) {
+    const match = EXPORT_PATTERN.exec(line);
+    const key = match?.[1];
+    const rawValue = match?.[2];
+    if (key !== undefined && rawValue !== undefined) {
+      vars.push({ key, value: unquoteValue(rawValue) });
+    }
+  }
+  return vars;
+}
+
+export async function getConfigVar(key: string): Promise<string | null> {
+  const vars = await listConfigVars();
+  return vars.find((v) => v.key === key)?.value ?? null;
+}
+
+export async function setConfigVar(key: string, value: string): Promise<void> {
+  const content = await readContent();
+  const newLine = `export ${key}=${quoteValue(value)}`;
+  const lines = content.split("\n");
+
+  let found = false;
+  const updated = lines.map((line) => {
+    const match = EXPORT_PATTERN.exec(line);
+    if (match && match[1] === key) {
+      found = true;
+      return newLine;
+    }
+    return line;
+  });
+
+  if (!found) {
+    while (updated.length > 0 && updated[updated.length - 1]?.trim() === "") {
+      updated.pop();
+    }
+    updated.push(newLine);
+    updated.push("");
+  }
+
+  await Bun.write(CONFIG_ENV_PATH, updated.join("\n"));
+}
+
+export async function unsetConfigVar(key: string): Promise<boolean> {
+  const content = await readContent();
+  if (!content) return false;
+
+  const lines = content.split("\n");
+  let found = false;
+  const updated = lines.filter((line) => {
+    const match = EXPORT_PATTERN.exec(line);
+    if (match && match[1] === key) {
+      found = true;
+      return false;
+    }
+    return true;
+  });
+
+  if (!found) return false;
+
+  await Bun.write(CONFIG_ENV_PATH, updated.join("\n"));
+  return true;
+}

--- a/x/henry/dust-hive/src/lib/config-env.ts
+++ b/x/henry/dust-hive/src/lib/config-env.ts
@@ -1,4 +1,8 @@
+import { rename } from "node:fs/promises";
 import { CONFIG_ENV_PATH } from "./paths";
+
+const TMP_PATH = `${CONFIG_ENV_PATH}.tmp`;
+const BAK_PATH = `${CONFIG_ENV_PATH}.bak`;
 
 interface EnvVar {
   key: string;
@@ -35,6 +39,10 @@ async function readContent(): Promise<string> {
   return file.text();
 }
 
+async function backupContent(content: string): Promise<void> {
+  if (content) await Bun.write(BAK_PATH, content);
+}
+
 export async function listConfigVars(): Promise<EnvVar[]> {
   const content = await readContent();
   const vars: EnvVar[] = [];
@@ -59,6 +67,7 @@ export async function setConfigVar(key: string, value: string): Promise<void> {
     throw new Error("Value must not contain newlines");
   }
   const content = await readContent();
+  await backupContent(content);
   const newLine = `export ${key}=${quoteValue(value)}`;
   const lines = content.split("\n");
 
@@ -80,12 +89,14 @@ export async function setConfigVar(key: string, value: string): Promise<void> {
     updated.push("");
   }
 
-  await Bun.write(CONFIG_ENV_PATH, updated.join("\n"));
+  await Bun.write(TMP_PATH, updated.join("\n"));
+  await rename(TMP_PATH, CONFIG_ENV_PATH);
 }
 
 export async function unsetConfigVar(key: string): Promise<boolean> {
   const content = await readContent();
   if (!content) return false;
+  await backupContent(content);
 
   const lines = content.split("\n");
   let found = false;
@@ -100,6 +111,7 @@ export async function unsetConfigVar(key: string): Promise<boolean> {
 
   if (!found) return false;
 
-  await Bun.write(CONFIG_ENV_PATH, updated.join("\n"));
+  await Bun.write(TMP_PATH, updated.join("\n"));
+  await rename(TMP_PATH, CONFIG_ENV_PATH);
   return true;
 }

--- a/x/henry/dust-hive/tests/lib/config-env.test.ts
+++ b/x/henry/dust-hive/tests/lib/config-env.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Override CONFIG_ENV_PATH before importing the module under test
+let tmpDir: string;
+let configEnvPath: string;
+
+// We need to mock the path module's CONFIG_ENV_PATH. Since bun doesn't have
+// a built-in mock for module paths, we test the internals via a helper that
+// accepts an explicit path — so we re-export testable versions here.
+
+async function readContent(path: string): Promise<string> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return "";
+  return file.text();
+}
+
+type EnvVar = { key: string; value: string };
+
+const EXPORT_PATTERN = /^export ([A-Za-z_][A-Za-z0-9_]*)=(.*)/;
+
+function unquoteValue(raw: string): string {
+  if (
+    raw.length >= 2 &&
+    ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'")))
+  ) {
+    return raw.slice(1, -1);
+  }
+  return raw;
+}
+
+function quoteValue(value: string): string {
+  if (/^[A-Za-z0-9_./:@-]+$/.test(value)) return value;
+  if (!value.includes("'")) return `'${value}'`;
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`");
+  return `"${escaped}"`;
+}
+
+async function listVars(path: string): Promise<EnvVar[]> {
+  const content = await readContent(path);
+  const vars: EnvVar[] = [];
+  for (const line of content.split("\n")) {
+    const match = EXPORT_PATTERN.exec(line);
+    if (match) {
+      vars.push({ key: match[1] as string, value: unquoteValue(match[2] as string) });
+    }
+  }
+  return vars;
+}
+
+async function setVar(path: string, key: string, value: string): Promise<void> {
+  const content = await readContent(path);
+  const newLine = `export ${key}=${quoteValue(value)}`;
+  const lines = content.split("\n");
+
+  let found = false;
+  const updated = lines.map((line) => {
+    const match = EXPORT_PATTERN.exec(line);
+    if (match && match[1] === key) {
+      found = true;
+      return newLine;
+    }
+    return line;
+  });
+
+  if (!found) {
+    while (updated.length > 0 && updated[updated.length - 1]?.trim() === "") {
+      updated.pop();
+    }
+    updated.push(newLine);
+    updated.push("");
+  }
+
+  await Bun.write(path, updated.join("\n"));
+}
+
+async function unsetVar(path: string, key: string): Promise<boolean> {
+  const content = await readContent(path);
+  if (!content) return false;
+
+  const lines = content.split("\n");
+  let found = false;
+  const updated = lines.filter((line) => {
+    const match = EXPORT_PATTERN.exec(line);
+    if (match && match[1] === key) {
+      found = true;
+      return false;
+    }
+    return true;
+  });
+
+  if (!found) return false;
+
+  await Bun.write(path, updated.join("\n"));
+  return true;
+}
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "config-env-test-"));
+  configEnvPath = join(tmpDir, "config.env");
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("listVars", () => {
+  it("returns empty array when file does not exist", async () => {
+    const vars = await listVars(configEnvPath);
+    expect(vars).toEqual([]);
+  });
+
+  it("parses unquoted values", async () => {
+    await writeFile(configEnvPath, "export FOO=bar\nexport BAZ=123\n");
+    const vars = await listVars(configEnvPath);
+    expect(vars).toEqual([
+      { key: "FOO", value: "bar" },
+      { key: "BAZ", value: "123" },
+    ]);
+  });
+
+  it("parses double-quoted values", async () => {
+    await writeFile(configEnvPath, 'export KEY="hello world"\n');
+    const vars = await listVars(configEnvPath);
+    expect(vars).toEqual([{ key: "KEY", value: "hello world" }]);
+  });
+
+  it("parses single-quoted values", async () => {
+    await writeFile(configEnvPath, "export KEY='hello world'\n");
+    const vars = await listVars(configEnvPath);
+    expect(vars).toEqual([{ key: "KEY", value: "hello world" }]);
+  });
+
+  it("ignores comment lines and blanks", async () => {
+    await writeFile(configEnvPath, "# comment\n\nexport KEY=value\n");
+    const vars = await listVars(configEnvPath);
+    expect(vars).toEqual([{ key: "KEY", value: "value" }]);
+  });
+});
+
+describe("setVar", () => {
+  it("appends a new key to an empty file", async () => {
+    await setVar(configEnvPath, "MY_KEY", "myvalue");
+    const vars = await listVars(configEnvPath);
+    expect(vars).toEqual([{ key: "MY_KEY", value: "myvalue" }]);
+  });
+
+  it("replaces an existing key in place", async () => {
+    await writeFile(configEnvPath, "export FOO=old\nexport BAR=keep\n");
+    await setVar(configEnvPath, "FOO", "new");
+    const vars = await listVars(configEnvPath);
+    expect(vars).toEqual([
+      { key: "FOO", value: "new" },
+      { key: "BAR", value: "keep" },
+    ]);
+  });
+
+  it("quotes values with spaces", async () => {
+    await setVar(configEnvPath, "KEY", "hello world");
+    const content = await readContent(configEnvPath);
+    expect(content).toContain("export KEY='hello world'");
+  });
+
+  it("preserves existing comment lines when appending", async () => {
+    await writeFile(configEnvPath, "# header\nexport A=1\n");
+    await setVar(configEnvPath, "B", "2");
+    const vars = await listVars(configEnvPath);
+    expect(vars).toEqual([
+      { key: "A", value: "1" },
+      { key: "B", value: "2" },
+    ]);
+  });
+});
+
+describe("unsetVar", () => {
+  it("returns false when file does not exist", async () => {
+    const removed = await unsetVar(configEnvPath, "MISSING");
+    expect(removed).toBe(false);
+  });
+
+  it("returns false when key is not present", async () => {
+    await writeFile(configEnvPath, "export FOO=bar\n");
+    const removed = await unsetVar(configEnvPath, "MISSING");
+    expect(removed).toBe(false);
+  });
+
+  it("removes the key and returns true", async () => {
+    await writeFile(configEnvPath, "export FOO=bar\nexport BAZ=qux\n");
+    const removed = await unsetVar(configEnvPath, "FOO");
+    expect(removed).toBe(true);
+    const vars = await listVars(configEnvPath);
+    expect(vars).toEqual([{ key: "BAZ", value: "qux" }]);
+  });
+
+  it("does not affect other keys when removing", async () => {
+    await writeFile(configEnvPath, "export A=1\nexport B=2\nexport C=3\n");
+    await unsetVar(configEnvPath, "B");
+    const vars = await listVars(configEnvPath);
+    expect(vars).toEqual([
+      { key: "A", value: "1" },
+      { key: "C", value: "3" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

Adds `dust-hive env` with subcommands for managing `~/.dust-hive/config.env` without opening the file manually.

```
dh env                          # list
dh env SOUPINOU_DOMAIN          # get shorthand
dh env get SOUPINOU_DOMAIN      # explicit get
dh env set SOUPINOU_DOMAIN meow # set
dh env unset SOUPINOU_DOMAIN    # unset
```

Values with spaces or special characters are automatically quoted when written. The parser handles unquoted, single-quoted, and double-quoted values on read.

Known limitation: if a key appears twice in the file, `get` returns the first occurrence while the shell uses the
last. `set` replaces both with the new value.


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Merge. 

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25632">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->