### PR TITLE
[front] fix audio tooltip and adjust compaction popover design

### DIFF
--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -117,7 +117,8 @@ export function ContextUsageIndicator({
         <PopoverContent side="top" className="w-auto p-3">
           <div className="flex flex-col items-start gap-3">
             <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              {contextUsagePercentage}% of context used. <LinkWrapper
+              {contextUsagePercentage}% of context used.{" "}
+              <LinkWrapper
                 href={COMPACTION_GUIDE_URL}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -126,21 +127,21 @@ export function ContextUsageIndicator({
                 Learn more
               </LinkWrapper>
             </span>
-              {contextUsagePercentage >
-                CONTEXT_USAGE_PERCENT_THRESHOLDS["enable_compaction"] && (
-                <Button
-                  variant="outline"
-                  size="xs"
-                  label={isCompacting ? "Compacting" : "Compact now"}
-                  onClick={() => {
-                    if (contextUsage?.model) {
-                      void compact(contextUsage.model);
-                    }
-                  }}
-                  disabled={isCompacting || !contextUsage?.model}
-                  isLoading={isCompacting}
-                />
-              )}
+            {contextUsagePercentage >
+              CONTEXT_USAGE_PERCENT_THRESHOLDS["enable_compaction"] && (
+              <Button
+                variant="outline"
+                size="xs"
+                label={isCompacting ? "Compacting" : "Compact now"}
+                onClick={() => {
+                  if (contextUsage?.model) {
+                    void compact(contextUsage.model);
+                  }
+                }}
+                disabled={isCompacting || !contextUsage?.model}
+                isLoading={isCompacting}
+              />
+            )}
           </div>
         </PopoverContent>
       </PopoverRoot>

--- a/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
+++ b/front/components/assistant/conversation/input_bar/ContextUsageIndicator.tsx
@@ -114,12 +114,18 @@ export function ContextUsageIndicator({
             }
           />
         </PopoverTrigger>
-        <PopoverContent side="top" align="end" className="w-auto p-3">
+        <PopoverContent side="top" className="w-auto p-3">
           <div className="flex flex-col items-start gap-3">
             <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              {contextUsagePercentage}% of context used.
+              {contextUsagePercentage}% of context used. <LinkWrapper
+                href={COMPACTION_GUIDE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ml-0.5 text-sm underline"
+              >
+                Learn more
+              </LinkWrapper>
             </span>
-            <div className="flex items-center gap-3">
               {contextUsagePercentage >
                 CONTEXT_USAGE_PERCENT_THRESHOLDS["enable_compaction"] && (
                 <Button
@@ -135,15 +141,6 @@ export function ContextUsageIndicator({
                   isLoading={isCompacting}
                 />
               )}
-              <LinkWrapper
-                href={COMPACTION_GUIDE_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm text-highlight underline hover:text-highlight-light dark:text-highlight-night dark:hover:text-highlight-light-night"
-              >
-                Learn more
-              </LinkWrapper>
-            </div>
           </div>
         </PopoverContent>
       </PopoverRoot>

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -83,7 +83,7 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
     ref
   ) => (
     <TooltipProvider>
-      <TooltipRoot>
+      <TooltipRoot disableHoverableContent>
         <TooltipTrigger asChild={tooltipTriggerAsChild}>
           {trigger}
         </TooltipTrigger>

--- a/sparkle/src/components/VoicePicker.tsx
+++ b/sparkle/src/components/VoicePicker.tsx
@@ -147,7 +147,10 @@ export function VoicePicker({
     }
 
     stopEvent(event);
-    await onRecordStop();
+
+    if (status === "recording") {
+      await onRecordStop();
+    }
   }
 
   async function handleClick(

--- a/sparkle/src/components/VoicePicker.tsx
+++ b/sparkle/src/components/VoicePicker.tsx
@@ -142,14 +142,12 @@ export function VoicePicker({
       return;
     }
 
-    stopEvent(event);
-
-    if (disabled || interactionMode !== "hold") {
+    if (disabled || interactionMode !== "hold" || status !== "recording") {
       return;
     }
-    if (status === "recording") {
-      await onRecordStop();
-    }
+
+    stopEvent(event);
+    await onRecordStop();
   }
 
   async function handleClick(


### PR DESCRIPTION
## Description
This PR is to fix the tooltip for mic shown only once, and somehow shown on compaction button hover. Also I took this opportunity to improve the compaction popover (FYI @ClementAupiais)

before:
<img width="544" height="290" alt="CleanShot 2026-05-15 at 15 14 32@2x" src="https://github.com/user-attachments/assets/1b725701-f928-46a3-b821-93e016318fbc" />
<img width="644" height="258" alt="CleanShot 2026-05-15 at 15 14 21@2x" src="https://github.com/user-attachments/assets/9238330b-7091-4326-9097-8a982b96223b" />


after:
<img width="528" height="192" alt="CleanShot 2026-05-15 at 15 11 59@2x" src="https://github.com/user-attachments/assets/03544a6e-9175-4cbc-87c6-0e660d275ce0" />
<img width="540" height="228" alt="CleanShot 2026-05-15 at 15 12 39@2x" src="https://github.com/user-attachments/assets/1f1058d8-6d64-4355-bab5-3e8a27dd1728" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested on both laptop and iphone
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25634">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->