### PR TITLE
feat(workers): enable source maps for front temporal workers

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -136,9 +136,25 @@ RUN --mount=type=cache,id=next-cache,target=/app/front/.next/cache \
 # Workers-specific build stage
 FROM base-deps AS workers-build
 
+ARG COMMIT_HASH
+ARG DATADOG_API_KEY
+ARG NEXT_PUBLIC_DATADOG_SERVICE
+
 # Build temporal workers and esbuild workers (workers only)
 RUN FRONT_DATABASE_URI="postgres://fake:fake@localhost:5432/fake" npm run build:temporal-bundles
 RUN npm run build:workers
+
+# Upload worker source maps to Datadog for Error Tracking (map files kept in image for --enable-source-maps)
+RUN if [ -n "$DATADOG_API_KEY" ] && [ -n "$NEXT_PUBLIC_DATADOG_SERVICE" ]; then \
+  DATADOG_SITE=datadoghq.eu \
+  DATADOG_API_KEY=$DATADOG_API_KEY \
+  npx --yes @datadog/datadog-ci sourcemaps upload ./dist \
+  --minified-path-prefix=/app/front/dist/ \
+  --repository-url=https://github.com/dust-tt/dust \
+  --project-path=front \
+  --release-version=$COMMIT_HASH \
+  --service=$NEXT_PUBLIC_DATADOG_SERVICE; \
+fi
 
 # Frontend image (Next.js standalone) for front deployment
 FROM node:24.14.0 AS front
@@ -253,4 +269,4 @@ ENV DD_VERSION=${COMMIT_HASH}
 ENV DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust/
 ENV DD_GIT_COMMIT_SHA=${COMMIT_HASH_LONG}
 
-CMD ["node", "--require", "dd-trace/init", "dist/start_worker.js"]
+CMD ["node", "--enable-source-maps", "--require", "dd-trace/init", "dist/start_worker.js"]

--- a/front/esbuild.worker.ts
+++ b/front/esbuild.worker.ts
@@ -11,6 +11,7 @@ async function buildWorker() {
       platform: "node",
       target: "node22",
       outfile: "dist/start_worker.js",
+      sourcemap: true,
       alias: {
         "@app": ".",
       },

--- a/front/workers-build/scripts/esbuild.worker.ts
+++ b/front/workers-build/scripts/esbuild.worker.ts
@@ -12,6 +12,7 @@ async function buildWorker() {
       platform: "node",
       target: "node22",
       outfile: "dist/start_worker.js",
+      sourcemap: true,
       alias: {
         "@app": "..",
       },


### PR DESCRIPTION
## Description

Worker logs in Datadog (`front-agent-loop-worker` and friends) show bundled/minified stack traces because esbuild doesn't generate source maps by default and Node doesn't apply them at runtime.

Three fixes applied (Option A+B):

1. **Generate source maps** — added `sourcemap: true` to `front/esbuild.worker.ts` (and the local-dev `workers-build/scripts/esbuild.worker.ts` for consistency). esbuild now emits `dist/start_worker.js.map` alongside the bundle.

2. **Runtime remapping** — added `--enable-source-maps` to the workers CMD. Node 22 rewrites Error stack traces using the `.map` file before pino/dd-trace captures them, so logs and APM traces show original TypeScript paths immediately.

3. **Datadog Error Tracking upload** — in the `workers-build` Dockerfile stage, added a conditional `datadog-ci sourcemaps upload` step (guarded by `DATADOG_API_KEY` + `NEXT_PUBLIC_DATADOG_SERVICE`, matching the existing Next.js pattern). Map files are **not** deleted after upload so `--enable-source-maps` continues to work at runtime.

Previous attempt at something similar: PR #22079 targeted connectors workers and was closed as "might not be needed with the change in connectors bundling". The connectors Dockerfile today has DD upload (Option B) but no runtime remapping.

## Tests



## Risk

Low. `--enable-source-maps` has no functional impact beyond stack trace formatting; any Node 22 overhead is negligible. The DD upload step is conditional and a failure there does not affect the worker binary.
