### PR TITLE
fix(mcp): guard against undefined file facet in microsoft_drive get_file_content and update_word_document

### DIFF
--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -128,6 +128,13 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       // Get the file metadata
       const response = await client.api(endpoint).get();
       const downloadUrl = response["@microsoft.graph.downloadUrl"];
+      if (!response.file) {
+        return new Err(
+          new MCPError(
+            "The specified item is not a file (it may be a folder or other non-file resource)."
+          )
+        );
+      }
       const mimeType = response.file.mimeType;
 
       // Verify it's a Word document
@@ -229,6 +236,13 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       }
 
       const downloadUrl = response["@microsoft.graph.downloadUrl"];
+      if (!response.file) {
+        return new Err(
+          new MCPError(
+            "The specified item is not a file (it may be a folder or other non-file resource)."
+          )
+        );
+      }
       const mimeType = response.file.mimeType;
       const fileName = response.name;
 


### PR DESCRIPTION
## Description

Fixes a crash in the `microsoft_drive` MCP server where calling `get_file_content` or `update_word_document` with a non-file item (e.g. a folder, SharePoint site, or OneNote section) would throw `Cannot read properties of undefined (reading 'mimeType')`.

The Microsoft Graph API only includes the `file` facet on drive items that are actual files — it is absent for folders and other container types. Both handlers now check for `response.file` before accessing it and return a clean `MCPError` if the item is not a file.

## Tests


## Risk

Low — purely defensive guards on an already-crashing code path. No behaviour change for valid file items.
