### PR TITLE
chore: drop indexed agentmcpaction

### DIFF
--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -319,13 +319,13 @@ AgentMessageModel.hasMany(AgentMCPActionModel, {
 });
 
 AgentMCPActionModel.belongsTo(AgentStepContentModel, {
-  foreignKey: { name: "stepContentId", allowNull: false },
+  foreignKey: { name: "stepContentId", allowNull: true },
   as: "stepContent",
   onDelete: "RESTRICT",
 });
 
 AgentStepContentModel.hasMany(AgentMCPActionModel, {
-  foreignKey: { name: "stepContentId", allowNull: false },
+  foreignKey: { name: "stepContentId", allowNull: true },
   as: "agentMCPActions",
 });
 

--- a/front/migrations/db/migration_638.sql
+++ b/front/migrations/db/migration_638.sql
@@ -1,0 +1,2 @@
+-- Migration created on mai 15, 2026
+ALTER TABLE "agent_mcp_actions" ALTER COLUMN "stepContentId" DROP NOT NULL;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

#25626 was reverted. It needs to be split in two parts.

This first part drops the not null constraint on the FK. 
The FK column is still being written to, but is not read anymore.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Apply migration 638.
Deploy

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->