### PR TITLE
chore(ci): upgrade upload-artifact to v7 and download-artifact to v8

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ on:
         type: choice
         default:
         options:
-          - connectors
-          - core
           - front
           - front-edge
+          - connectors
+          - core
           - front-sse
           - prodbox
           - oauth
@@ -83,7 +83,7 @@ jobs:
           exit 1
 
   prepare:
-    needs: [check-branch]
+    needs: [ check-branch ]
     runs-on: ubuntu-latest
     outputs:
       short_sha: ${{ steps.short_sha.outputs.short_sha }}
@@ -98,7 +98,7 @@ jobs:
         run: echo "long_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   notify-start:
-    needs: [prepare]
+    needs: [ prepare ]
     runs-on: ubuntu-latest
     outputs:
       thread_ts: ${{ steps.build_message.outputs.thread_ts }}
@@ -142,7 +142,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    needs: [prepare, notify-start, create-matrix]
+    needs: [ prepare, notify-start, create-matrix ]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -211,7 +211,7 @@ jobs:
           thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
 
   deploy:
-    needs: [prepare, notify-start, build, deploy-app, deploy-poke, ensure-sandbox-images]
+    needs: [ prepare, notify-start, build, deploy-app, deploy-poke, ensure-sandbox-images ]
     if: ${{ !failure() && !cancelled() && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
@@ -303,7 +303,7 @@ jobs:
   # Starts in parallel with Docker build to save time.
   deploy-app:
     if: (inputs.component == 'front' || inputs.component == 'front-edge') && inputs.deploy_spa_app
-    needs: [notify-start]
+    needs: [ notify-start ]
     uses: ./.github/workflows/deploy-spa.yaml
     with:
       app: "app"
@@ -314,7 +314,7 @@ jobs:
 
   deploy-poke:
     if: (inputs.component == 'front' || inputs.component == 'front-edge') && inputs.deploy_spa_poke
-    needs: [notify-start]
+    needs: [ notify-start ]
     uses: ./.github/workflows/deploy-spa.yaml
     with:
       app: "poke"

--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        region: [eu, us]
+        region: [ eu, us ]
     steps:
       - name: Configure E2B for ${{ matrix.region }}
         run: |
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload check result
         if: success()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sandbox-img-check-${{ matrix.region }}
           path: check-result.json
@@ -125,20 +125,20 @@ jobs:
         run: rm -f /tmp/service-account.json
 
   summary:
-    needs: [check-and-build]
+    needs: [ check-and-build ]
     if: always() && needs['check-and-build'].result == 'success'
     runs-on: ubuntu-latest
     outputs:
       built-count: ${{ steps.count.outputs.built }}
     steps:
       - name: Download check results (eu)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sandbox-img-check-eu
           path: check-eu
 
       - name: Download check results (us)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sandbox-img-check-us
           path: check-us


### PR DESCRIPTION
## Description

Bump pinned action hashes in CI workflows, to remove the warnings on node20 we have

- `actions/upload-artifact`: `ea165f8d` (v4.6.2) → `043fb46d` (v7.0.1) in `sandbox-img-registry.yml` (already at v7.0.1 in `package-extension.yaml`)
- `actions/download-artifact`: `d3f86a10` (v4.3.0) → `3e5f45b2` (v8) in `sandbox-img-registry.yml`

Also includes minor normalization in `deploy.yml` (option ordering)

## Tests

Deploying `front` when this is merged

## Risk

Worst case we can't deploy, we rollback. But the changes are simple

## Deploy Plan
