### PR TITLE
Hide usage seat columns if no seat subscription

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -13,6 +13,7 @@ import { useAppRouter } from "@app/lib/platform";
 import { useAwuPoolSummary, useCreditPurchaseInfo } from "@app/lib/swr/credits";
 import { useMembersUsage } from "@app/lib/swr/memberships";
 import {
+  useMetronomeContract,
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
 } from "@app/lib/swr/workspaces";
@@ -173,6 +174,12 @@ export function UsagePage() {
     workspaceId: owner.sId,
   });
 
+  const { contract } = useMetronomeContract({
+    workspaceId: owner.sId,
+  });
+
+  const hasSeatSubscription = contract?.hasSeatSubscription ?? false;
+
   const plan = subscription.plan;
   const isManualInvitationsEnabled =
     owner.metadata?.disableManualInvitations !== true;
@@ -312,52 +319,55 @@ export function UsagePage() {
               />
             )}
           </div>
-          <div className="flex flex-row justify-end">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="outline"
-                  label={
-                    seatTypeFilter === "none"
-                      ? "No seat"
-                      : seatTypeFilter
-                        ? seatTypeFilter.charAt(0).toUpperCase() +
-                          seatTypeFilter.slice(1)
-                        : "All seats"
-                  }
-                  size="sm"
-                  isSelect
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  label="All seats"
-                  onClick={() => setSeatTypeFilter(null)}
-                />
-                <DropdownMenuItem
-                  label="No seat"
-                  onClick={() => setSeatTypeFilter("none")}
-                />
-                <DropdownMenuItem
-                  label="Free"
-                  onClick={() => setSeatTypeFilter("free")}
-                />
-                <DropdownMenuItem
-                  label="Pro"
-                  onClick={() => setSeatTypeFilter("pro")}
-                />
-                <DropdownMenuItem
-                  label="Max"
-                  onClick={() => setSeatTypeFilter("max")}
-                />
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+          {hasSeatSubscription && (
+            <div className="flex flex-row justify-end">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    label={
+                      seatTypeFilter === "none"
+                        ? "No seat"
+                        : seatTypeFilter
+                          ? seatTypeFilter.charAt(0).toUpperCase() +
+                            seatTypeFilter.slice(1)
+                          : "All seats"
+                    }
+                    size="sm"
+                    isSelect
+                  />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    label="All seats"
+                    onClick={() => setSeatTypeFilter(null)}
+                  />
+                  <DropdownMenuItem
+                    label="No seat"
+                    onClick={() => setSeatTypeFilter("none")}
+                  />
+                  <DropdownMenuItem
+                    label="Free"
+                    onClick={() => setSeatTypeFilter("free")}
+                  />
+                  <DropdownMenuItem
+                    label="Pro"
+                    onClick={() => setSeatTypeFilter("pro")}
+                  />
+                  <DropdownMenuItem
+                    label="Max"
+                    onClick={() => setSeatTypeFilter("max")}
+                  />
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
           <MembersUsageTable
             members={membersUsage}
             isLoading={isMembersUsageLoading}
             searchTerm={searchTerm}
             seatTypeFilter={seatTypeFilter}
+            showSeatColumns={hasSeatSubscription}
           />
         </Page.Vertical>
 

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -125,150 +125,163 @@ function WorkspaceUsageBar({ consumed, limit }: WorkspaceUsageBarProps) {
   );
 }
 
-const columns: ColumnDef<RowData, string>[] = [
-  {
-    id: "name" as const,
-    header: "Name",
-    accessorFn: (row) => row.name,
-    cell: (info: Info) => (
-      <DataTable.CellContent
-        avatarUrl={info.row.original.image ?? undefined}
-        roundedAvatar
-      >
-        <div>
-          <div>{info.row.original.name}</div>
-          {info.row.original.email && (
-            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-              {info.row.original.email}
-            </div>
-          )}
-        </div>
-      </DataTable.CellContent>
-    ),
-  },
-  {
-    id: "seatType" as const,
-    header: "Seat",
-    accessorFn: (row) => row.seatType ?? "",
-    cell: (info: Info) => {
-      const seatType = info.row.original.seatType;
-      return (
-        <DataTable.CellContent>
-          <span className="flex items-center gap-1.5 text-sm font-semibold capitalize text-muted-foreground dark:text-muted-foreground-night">
-            <SeatTypeIcon seatType={seatType} />
-            {seatType ?? "—"}
-          </span>
-        </DataTable.CellContent>
-      );
-    },
-    meta: {
-      className: "w-24",
-    },
-  },
-  {
-    id: "billingFrequency" as const,
-    header: "Period",
-    accessorFn: (row) => row.billingFrequency ?? "",
-    cell: (info: Info) => {
-      const freq = info.row.original.billingFrequency;
-      let label: string;
-      switch (freq) {
-        case "MONTHLY":
-          label = "Monthly";
-          break;
-        case "ANNUAL":
-          label = "Annual";
-          break;
-        case null:
-          label = "—";
-          break;
-        default:
-          assertNeverAndIgnore(freq);
-          label = "—";
-      }
-      return (
-        <DataTable.CellContent>
-          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            {label}
-          </span>
-        </DataTable.CellContent>
-      );
-    },
-    meta: {
-      className: "w-24",
-    },
-  },
-  {
-    id: "seatUsagePercent" as const,
-    header: "Seat usage",
-    accessorFn: (row) => (row.seatUsagePercent ?? 0).toString(),
-    cell: (info: Info) => {
-      const pct = info.row.original.seatUsagePercent;
-      let textColor: string | undefined;
-      if (pct !== null) {
-        if (pct >= 100) {
-          textColor = "#ef4444";
-        } else if (pct >= 80) {
-          textColor = "#FE9C1A";
-        }
-      }
-      return (
-        <DataTable.CellContent>
-          {pct !== null ? (
-            <span
-              className="flex items-center gap-1.5 text-sm font-semibold tabular-nums"
-              style={textColor ? { color: textColor } : undefined}
-            >
-              {`${Math.round(pct)}%`}
-              <CircleProgress percentage={pct} />
-            </span>
-          ) : (
-            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              —
-            </span>
-          )}
-        </DataTable.CellContent>
-      );
-    },
-    meta: {
-      className: "w-32",
-    },
-    enableSorting: true,
-    sortingFn: (a, b) =>
-      (a.original.seatUsagePercent ?? -1) - (b.original.seatUsagePercent ?? -1),
-  },
-  {
-    id: "consumedWorkplacePoolCredits" as const,
-    header: () => (
-      <span className="flex items-center gap-1.5">
-        <Icon visual={ActionCreditCoinsIcon} size="xs" />
-        Workspace usage
-      </span>
-    ),
-    accessorFn: (row) => row.consumedWorkplacePoolCredits.toString(),
-    cell: (info: Info) => (
-      <div className="w-full pr-3">
-        <WorkspaceUsageBar
-          consumed={info.row.original.consumedWorkplacePoolCredits}
-          limit={null}
-        />
+const nameColumn: ColumnDef<RowData, string> = {
+  id: "name" as const,
+  header: "Name",
+  accessorFn: (row) => row.name,
+  cell: (info: Info) => (
+    <DataTable.CellContent
+      avatarUrl={info.row.original.image ?? undefined}
+      roundedAvatar
+    >
+      <div>
+        <div>{info.row.original.name}</div>
+        {info.row.original.email && (
+          <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+            {info.row.original.email}
+          </div>
+        )}
       </div>
-    ),
-    meta: {
-      className: "w-64",
-    },
-    enableSorting: true,
-    sortingFn: (a, b) =>
-      a.original.consumedWorkplacePoolCredits -
-      b.original.consumedWorkplacePoolCredits,
+    </DataTable.CellContent>
+  ),
+};
+
+const seatTypeColumn: ColumnDef<RowData, string> = {
+  id: "seatType" as const,
+  header: "Seat",
+  accessorFn: (row) => row.seatType ?? "",
+  cell: (info: Info) => {
+    const seatType = info.row.original.seatType;
+    return (
+      <DataTable.CellContent>
+        <span className="flex items-center gap-1.5 text-sm font-semibold capitalize text-muted-foreground dark:text-muted-foreground-night">
+          <SeatTypeIcon seatType={seatType} />
+          {seatType ?? "—"}
+        </span>
+      </DataTable.CellContent>
+    );
   },
-];
+  meta: {
+    className: "w-24",
+  },
+};
+
+const billingFrequencyColumn: ColumnDef<RowData, string> = {
+  id: "billingFrequency" as const,
+  header: "Period",
+  accessorFn: (row) => row.billingFrequency ?? "",
+  cell: (info: Info) => {
+    const freq = info.row.original.billingFrequency;
+    let label: string;
+    switch (freq) {
+      case "MONTHLY":
+        label = "Monthly";
+        break;
+      case "ANNUAL":
+        label = "Annual";
+        break;
+      case null:
+        label = "—";
+        break;
+      default:
+        assertNeverAndIgnore(freq);
+        label = "—";
+    }
+    return (
+      <DataTable.CellContent>
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {label}
+        </span>
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-24",
+  },
+};
+
+const seatUsagePercentColumn: ColumnDef<RowData, string> = {
+  id: "seatUsagePercent" as const,
+  header: "Seat usage",
+  accessorFn: (row) => (row.seatUsagePercent ?? 0).toString(),
+  cell: (info: Info) => {
+    const pct = info.row.original.seatUsagePercent;
+    let textColor: string | undefined;
+    if (pct !== null) {
+      if (pct >= 100) {
+        textColor = "#ef4444";
+      } else if (pct >= 80) {
+        textColor = "#FE9C1A";
+      }
+    }
+    return (
+      <DataTable.CellContent>
+        {pct !== null ? (
+          <span
+            className="flex items-center gap-1.5 text-sm font-semibold tabular-nums"
+            style={textColor ? { color: textColor } : undefined}
+          >
+            {`${Math.round(pct)}%`}
+            <CircleProgress percentage={pct} />
+          </span>
+        ) : (
+          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            —
+          </span>
+        )}
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "w-32",
+  },
+  enableSorting: true,
+  sortingFn: (a, b) =>
+    (a.original.seatUsagePercent ?? -1) - (b.original.seatUsagePercent ?? -1),
+};
+
+const consumedWorkplacePoolCreditsColumn: ColumnDef<RowData, string> = {
+  id: "consumedWorkplacePoolCredits" as const,
+  header: () => (
+    <span className="flex items-center gap-1.5">
+      <Icon visual={ActionCreditCoinsIcon} size="xs" />
+      Workspace usage
+    </span>
+  ),
+  accessorFn: (row) => row.consumedWorkplacePoolCredits.toString(),
+  cell: (info: Info) => (
+    <div className="w-full pr-3">
+      <WorkspaceUsageBar
+        consumed={info.row.original.consumedWorkplacePoolCredits}
+        limit={null}
+      />
+    </div>
+  ),
+  meta: {
+    className: "w-64",
+  },
+  enableSorting: true,
+  sortingFn: (a, b) =>
+    a.original.consumedWorkplacePoolCredits -
+    b.original.consumedWorkplacePoolCredits,
+};
+
+function buildColumns(showSeatColumns: boolean): ColumnDef<RowData, string>[] {
+  return [
+    nameColumn,
+    ...(showSeatColumns
+      ? [seatTypeColumn, billingFrequencyColumn, seatUsagePercentColumn]
+      : []),
+    consumedWorkplacePoolCreditsColumn,
+  ];
+}
 
 interface MembersUsageTableProps {
   members: MemberUsageType[];
   isLoading: boolean;
   searchTerm: string;
   seatTypeFilter: MembershipSeatType | "none" | null;
+  showSeatColumns: boolean;
 }
 
 export function MembersUsageTable({
@@ -276,6 +289,7 @@ export function MembersUsageTable({
   isLoading,
   searchTerm,
   seatTypeFilter,
+  showSeatColumns,
 }: MembersUsageTableProps) {
   if (isLoading) {
     return (
@@ -320,5 +334,5 @@ export function MembersUsageTable({
     billingFrequency: m.billingFrequency,
   }));
 
-  return <DataTable data={rows} columns={columns} />;
+  return <DataTable data={rows} columns={buildColumns(showSeatColumns)} />;
 }

--- a/front/pages/api/w/[wId]/metronome/contract.test.ts
+++ b/front/pages/api/w/[wId]/metronome/contract.test.ts
@@ -122,6 +122,7 @@ describe("/api/w/[wId]/metronome/contract", () => {
           planFamily: "pro",
           mauTiers: null,
           contractEndingAtMs: new Date("2025-05-01T00:00:00.000Z").getTime(),
+          hasSeatSubscription: false,
         },
       });
       expect(vi.mocked(getMetronomeContractById)).toHaveBeenCalledWith({

--- a/front/pages/api/w/[wId]/metronome/contract.ts
+++ b/front/pages/api/w/[wId]/metronome/contract.ts
@@ -7,6 +7,7 @@ import {
   reactivateWorkspaceContract,
 } from "@app/lib/metronome/contract_lifecycle";
 import { parseMauTiers } from "@app/lib/metronome/mau_sync";
+import { hasContractSeatSubscription } from "@app/lib/metronome/seats";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -25,6 +26,8 @@ export type MetronomeContractSummary = {
   mauTiers: Array<{ start: number; end: number | null }> | null;
   /** ms epoch — set when the contract is scheduled to end (cancellation or fixed term). */
   contractEndingAtMs: number | null;
+  /** True if the contract has at least one seat-billed subscription */
+  hasSeatSubscription: boolean;
 };
 
 export type GetMetronomeContractResponseBody = {
@@ -130,6 +133,7 @@ async function handleGet(
       planFamily,
       mauTiers,
       contractEndingAtMs,
+      hasSeatSubscription: hasContractSeatSubscription(contract),
     },
   });
 }


### PR DESCRIPTION
## Description

* Filtering out seat columns from view if you do not have a seat-based subscription

## Tests

<img width="1059" height="176" alt="Screenshot 2026-05-15 at 10 19 19 AM" src="https://github.com/user-attachments/assets/14ca4981-96b4-41fc-b17a-35dfe2e24d31" />

## Risk

* Low (not customer facing) 

## Deploy Plan

* Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25641">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->