### PR TITLE
Branching: block child conversation until GCS copy and compaction both complete

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -29,7 +29,10 @@ import {
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
-import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import {
+  launchAgentLoopWorkflow,
+  launchCompactionWorkflow,
+} from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
@@ -2969,6 +2972,7 @@ describe("compactConversation", () => {
     conversation = fetched.value;
 
     vi.clearAllMocks();
+    vi.mocked(launchCompactionWorkflow).mockResolvedValue(new Ok(undefined));
   });
 
   it("should create a compaction message on an idle conversation", async () => {
@@ -3014,7 +3018,7 @@ describe("compactConversation", () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.status_code).toBe(409);
+      expect(result.error.code).toBe("just_compacted");
     }
   });
 
@@ -3057,7 +3061,7 @@ describe("compactConversation", () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.status_code).toBe(409);
+      expect(result.error.code).toBe("running_agent");
     }
   });
 });
@@ -4350,6 +4354,7 @@ describe("conversation fetch forkingData", () => {
           parentConversationTitle,
           sourceMessageId: sourceMessage.sId,
           branchedAt: branchedAt.getTime(),
+          gcsMountStatus: "pending",
           user: auth.getNonNullableUser().toJSON(),
         },
       });
@@ -4368,6 +4373,7 @@ describe("conversation fetch forkingData", () => {
           parentConversationTitle,
           sourceMessageId: sourceMessage.sId,
           branchedAt: branchedAt.getTime(),
+          gcsMountStatus: "pending",
           user: auth.getNonNullableUser().toJSON(),
         },
       });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -633,6 +633,20 @@ export async function postUserMessage(
     });
   }
 
+  if (
+    conversation.forkingData?.forkedFrom &&
+    conversation.forkingData.forkedFrom.gcsMountStatus !== "copied"
+  ) {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "User messages cannot be posted while files are being copied to this conversation.",
+      },
+    });
+  }
+
   const canInteractRes = await WakeUpResource.canUserInteract(
     auth,
     conversation

--- a/front/lib/api/assistant/conversation/compaction.ts
+++ b/front/lib/api/assistant/conversation/compaction.ts
@@ -25,34 +25,42 @@ import {
   isCompactionMessageType,
 } from "@app/types/assistant/conversation";
 import type { SupportedModel } from "@app/types/assistant/models/types";
-import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
+export class CompactionError extends Error {
+  constructor(
+    readonly code:
+      | "running_agent"
+      | "running_compaction"
+      | "just_compacted"
+      | "workflow_launch_failed"
+  ) {
+    super(code);
+  }
+}
+
 /**
- * Create a CompactionMessage in the conversation and launch the compaction workflow.
+ * Create a CompactionMessage in the conversation and publish the compaction_message_new event.
+ * Does NOT launch any workflow — the caller is responsible for starting the actual compaction.
  *
  * The CompactionMessage is created with status "created" inside the conversation advisory lock,
- * ensuring it's serialized with other conversation operations. The workflow is launched
- * fire-and-forget after the transaction commits.
+ * ensuring it's serialized with other conversation operations.
  */
-export async function compactConversation(
+export async function createAndPublishCompactionMessage(
   auth: Authenticator,
   {
     conversation,
-    model,
     sourceConversation,
   }: {
     conversation: ConversationType;
-    model: SupportedModel;
     sourceConversation?: CompactionSourceConversation;
   }
 ): Promise<
-  Result<{ compactionMessage: CompactionMessageType }, APIErrorWithStatusCode>
+  Result<{ compactionMessage: CompactionMessageType }, CompactionError>
 > {
   const owner = auth.getNonNullableWorkspace();
 
-  // Block compaction while an agent message is running or a compaction is running.
   const runningAgentMessage = conversation.content
     .flat()
     .find(
@@ -68,23 +76,11 @@ export async function compactConversation(
   const lastMessage = conversation.content.at(-1)?.at(-1);
 
   if (runningAgentMessage) {
-    return new Err({
-      status_code: 409,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Answer the pending agent message first.",
-      },
-    });
+    return new Err(new CompactionError("running_agent"));
   }
 
   if (runningCompaction) {
-    return new Err({
-      status_code: 409,
-      api_error: {
-        type: "invalid_request_error",
-        message: "A compaction is already in progress. Please wait.",
-      },
-    });
+    return new Err(new CompactionError("running_compaction"));
   }
 
   if (
@@ -92,22 +88,14 @@ export async function compactConversation(
     isCompactionMessageType(lastMessage) &&
     lastMessage.status === "succeeded"
   ) {
-    return new Err({
-      status_code: 409,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "This conversation was just compacted. Send a new message before compacting again.",
-      },
-    });
+    return new Err(new CompactionError("just_compacted"));
   }
 
   const { compactionMessage } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
-    // Re-check the existence of a compaction message or running agent message inside the critical
-    // section of the advisory lock to avoid stacking compaction with other compaction or running
-    // agent loop.
+    // Re-check inside the critical section of the advisory lock to avoid stacking compaction with
+    // other compaction or running agent loop.
     const [runningCompactionMessage, runningAgentMessage] = await Promise.all([
       MessageModel.findOne({
         where: {
@@ -165,14 +153,7 @@ export async function compactConversation(
   });
 
   if (!compactionMessage) {
-    return new Err({
-      status_code: 409,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "Cannot compact while another compaction or an agent message is running.",
-      },
-    });
+    return new Err(new CompactionError("running_compaction"));
   }
 
   await publishConversationEvent(
@@ -185,7 +166,99 @@ export async function compactConversation(
     { conversationId: conversation.sId }
   );
 
-  void launchCompactionWorkflow({
+  return new Ok({ compactionMessage });
+}
+
+/**
+ * Conditionally fail a CompactionMessage if it is still in "created" state.
+ * Returns the updated CompactionMessageType if the update happened, null if already processed.
+ * This is idempotent: calling it multiple times is safe.
+ */
+export async function failCompactionMessageIfCreated(
+  auth: Authenticator,
+  { compactionMessageId }: { compactionMessageId: string }
+): Promise<CompactionMessageType | null> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const messageRow = await MessageModel.findOne({
+    where: { sId: compactionMessageId, workspaceId: owner.id },
+    include: [
+      {
+        model: CompactionMessageModel,
+        as: "compactionMessage",
+        required: true,
+        where: { status: "created" },
+      },
+    ],
+  });
+
+  if (!messageRow?.compactionMessage) {
+    return null;
+  }
+
+  const [updatedCount] = await CompactionMessageModel.update(
+    { status: "failed" },
+    {
+      where: {
+        id: messageRow.compactionMessage.id,
+        status: "created",
+        workspaceId: owner.id,
+      },
+    }
+  );
+
+  if (updatedCount === 0) {
+    return null;
+  }
+
+  return {
+    type: "compaction_message",
+    id: messageRow.id,
+    compactionMessageId: messageRow.compactionMessage.id,
+    sId: messageRow.sId,
+    created: messageRow.createdAt.getTime(),
+    visibility: messageRow.visibility,
+    version: messageRow.version,
+    rank: messageRow.rank,
+    branchId: messageRow.getBranchId(),
+    sourceConversationId: messageRow.compactionMessage.sourceConversationId,
+    status: "failed",
+    content: null,
+  };
+}
+
+/**
+ * Create a CompactionMessage in the conversation and launch the compaction workflow.
+ *
+ * If the workflow fails to launch, the CompactionMessage is immediately failed so the conversation
+ * is not left permanently blocked.
+ */
+export async function compactConversation(
+  auth: Authenticator,
+  {
+    conversation,
+    model,
+    sourceConversation,
+  }: {
+    conversation: ConversationType;
+    model: SupportedModel;
+    sourceConversation?: CompactionSourceConversation;
+  }
+): Promise<
+  Result<{ compactionMessage: CompactionMessageType }, CompactionError>
+> {
+  const createResult = await createAndPublishCompactionMessage(auth, {
+    conversation,
+    sourceConversation,
+  });
+
+  if (createResult.isErr()) {
+    return createResult;
+  }
+
+  const { compactionMessage } = createResult.value;
+
+  const launchResult = await launchCompactionWorkflow({
     auth,
     conversationId: conversation.sId,
     compactionMessageId: compactionMessage.sId,
@@ -193,6 +266,26 @@ export async function compactConversation(
     model,
     sourceConversation,
   });
+
+  if (launchResult.isErr()) {
+    const failedMessage = await failCompactionMessageIfCreated(auth, {
+      compactionMessageId: compactionMessage.sId,
+    });
+
+    if (failedMessage) {
+      await publishConversationEvent(
+        {
+          type: "compaction_message_done",
+          created: Date.now(),
+          messageId: failedMessage.sId,
+          message: failedMessage,
+        },
+        { conversationId: conversation.sId }
+      );
+    }
+
+    return new Err(new CompactionError("workflow_launch_failed"));
+  }
 
   return new Ok({ compactionMessage });
 }

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -33,7 +33,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
-import { launchCompactionWorkflow } from "@app/temporal/agent_loop/client";
+import { launchConversationForkWorkflow } from "@app/temporal/conversation_fork_queue/client";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -63,7 +63,13 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/temporal/agent_loop/client", () => ({
   launchAgentLoopWorkflow: vi.fn(),
-  launchCompactionWorkflow: vi.fn(),
+}));
+
+vi.mock("@app/temporal/conversation_fork_queue/client", () => ({
+  launchConversationForkWorkflow: vi.fn(async () => {
+    const { Ok } = await import("@app/types/shared/result");
+    return new Ok(undefined);
+  }),
 }));
 
 async function createUserMessage(
@@ -514,6 +520,7 @@ describe("createConversationFork", () => {
         sourceMessageId: sourceMessage.sId,
         branchedAt: expect.any(Number),
         user: user.toJSON(),
+        gcsMountStatus: "pending",
       },
     });
     expect(childConversation.content).toHaveLength(1);
@@ -525,10 +532,10 @@ describe("createConversationFork", () => {
         ? childConversation.content[0]![0]!.status
         : null
     ).toBe("created");
-    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+    expect(vi.mocked(launchConversationForkWorkflow)).toHaveBeenCalledWith(
       expect.objectContaining({
-        auth,
-        conversationId: childConversation.sId,
+        destConversationId: childConversation.sId,
+        sourceConversationId: parentConversation.sId,
         sourceConversation: {
           conversationId: parentConversation.sId,
           messageRank: sourceMessage.rank,
@@ -615,10 +622,10 @@ describe("createConversationFork", () => {
     });
 
     expect(result.isErr()).toBe(false);
-    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+    expect(vi.mocked(launchConversationForkWorkflow)).toHaveBeenCalledWith(
       expect.objectContaining({
-        auth,
-        conversationId: expect.any(String),
+        destConversationId: expect.any(String),
+        sourceConversationId: parentConversation.sId,
         model: {
           providerId: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG.providerId,
           modelId: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
@@ -972,10 +979,10 @@ describe("createConversationFork", () => {
     expect(processAndUpsertToDataSourceSpy.mock.calls[0]?.[2].file.sId).toBe(
       copiedFiles[0]?.sId
     );
-    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+    expect(vi.mocked(launchConversationForkWorkflow)).toHaveBeenCalledWith(
       expect.objectContaining({
-        auth,
-        conversationId: childConversation.sId,
+        destConversationId: childConversation.sId,
+        sourceConversationId: parentConversation.sId,
         sourceConversation: expect.objectContaining({
           conversationId: parentConversation.sId,
           messageRank: sourceMessage.rank,
@@ -1118,10 +1125,10 @@ const untouched = "prefix${referencedFile.sId}suffix";`
 const frameFileId = "${copiedFrameAttachment!.fileId}";
 const untouched = "prefix${referencedFile.sId}suffix";`
     );
-    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+    expect(vi.mocked(launchConversationForkWorkflow)).toHaveBeenCalledWith(
       expect.objectContaining({
-        auth,
-        conversationId: childConversation.sId,
+        destConversationId: childConversation.sId,
+        sourceConversationId: parentConversation.sId,
         sourceConversation: expect.objectContaining({
           conversationId: parentConversation.sId,
           messageRank: sourceMessage.rank,
@@ -1345,10 +1352,10 @@ const untouched = "prefix${referencedFile.sId}suffix";`
     expect(processAndUpsertToDataSourceSpy.mock.calls[0]?.[2].file.sId).toBe(
       copiedFiles[0]?.sId
     );
-    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+    expect(vi.mocked(launchConversationForkWorkflow)).toHaveBeenCalledWith(
       expect.objectContaining({
-        auth,
-        conversationId: childConversation.sId,
+        destConversationId: childConversation.sId,
+        sourceConversationId: parentConversation.sId,
         sourceConversation: expect.objectContaining({
           conversationId: parentConversation.sId,
           messageRank: sourceMessage.rank,
@@ -1607,10 +1614,10 @@ const untouched = "prefix${referencedFile.sId}suffix";`
       childConversation,
       "node_before_fork"
     );
-    expect(vi.mocked(launchCompactionWorkflow)).toHaveBeenCalledWith(
+    expect(vi.mocked(launchConversationForkWorkflow)).toHaveBeenCalledWith(
       expect.objectContaining({
-        auth,
-        conversationId: childConversation.sId,
+        destConversationId: childConversation.sId,
+        sourceConversationId: parentConversation.sId,
         sourceConversation: expect.objectContaining({
           conversationId: parentConversation.sId,
           messageRank: sourceMessage.rank,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -5,10 +5,14 @@ import {
   isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
-import { compactConversation } from "@app/lib/api/assistant/conversation/compaction";
+import {
+  createAndPublishCompactionMessage,
+  failCompactionMessageIfCreated,
+} from "@app/lib/api/assistant/conversation/compaction";
 import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/conversation/compaction_attachment_id_replacements";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import {
@@ -17,7 +21,7 @@ import {
 } from "@app/lib/api/files/upsert";
 import { getFileContent } from "@app/lib/api/files/utils";
 import { getSmallWhitelistedModel } from "@app/lib/assistant";
-import type { Authenticator } from "@app/lib/auth";
+import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -33,7 +37,10 @@ import type {
   ContentFragmentInputWithContentNode,
   ContentFragmentInputWithFileIdType,
 } from "@app/types/api/internal/assistant";
-import type { CompactionAttachmentIdReplacements } from "@app/types/assistant/compaction";
+import type {
+  CompactionAttachmentIdReplacements,
+  CompactionSourceConversation,
+} from "@app/types/assistant/compaction";
 import type {
   ConversationType,
   ConversationWithoutContentType,
@@ -696,30 +703,8 @@ export async function createConversationFork(
     childConversationId.value.childConversationId
   );
 
-  const launchForkWorkflowResult = await launchConversationForkWorkflow({
-    workspaceId: auth.getNonNullableWorkspace().sId,
-    sourceConversationId: parentConversation.sId,
-    destConversationId: childConversationId.value.childConversationId,
-  });
-  if (launchForkWorkflowResult.isErr()) {
-    logger.error(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        parentConversationId: parentConversation.sId,
-        childConversationId: childConversationId.value.childConversationId,
-        error: launchForkWorkflowResult.error,
-      },
-      "Failed to launch conversation fork workflow."
-    );
-
-    return new Err(
-      new DustError(
-        "failed_to_copy_files",
-        "Failed to copy files from source conversation."
-      )
-    );
-  }
-
+  // Prepare the child conversation before launching the workflow, so both GCS copy and compaction
+  // can be managed by a single Temporal workflow (no race between two independently launched ones).
   const childConversation = await getConversation(
     auth,
     childConversationId.value.childConversationId
@@ -765,7 +750,8 @@ export async function createConversationFork(
         sourceMessageRank: childConversationId.value.sourceMessageRank,
       })
     : undefined;
-  const sourceConversation = {
+
+  const sourceConversation: CompactionSourceConversation = {
     conversationId: parentConversation.sId,
     messageRank: childConversationId.value.sourceMessageRank,
     ...(attachmentIdReplacements &&
@@ -774,27 +760,84 @@ export async function createConversationFork(
       : {}),
   };
 
-  const compactionResult = await compactConversation(auth, {
-    conversation: childConversation.value,
-    model: childConversationId.value.forkCompactionModel,
-    sourceConversation,
-  });
+  // Create the CompactionMessage before launching the workflow so the child conversation is
+  // immediately blocked from posting on arrival. The workflow then runs GCS copy and compaction
+  // in parallel; posting unblocks only when both complete.
+  const compactionMessageResult = await createAndPublishCompactionMessage(
+    auth,
+    {
+      conversation: childConversation.value,
+      sourceConversation,
+    }
+  );
 
-  if (compactionResult.isErr()) {
+  if (compactionMessageResult.isErr()) {
     logger.error(
       {
         workspaceId: auth.getNonNullableWorkspace().sId,
         parentConversationId: conversationId,
         childConversationId: childConversation.value.sId,
-        error: compactionResult.error,
+        error: compactionMessageResult.error,
       },
-      "Failed to initialize forked conversation compaction."
+      "Failed to create compaction message for forked conversation. Launching GCS-only workflow."
     );
-    return new Ok({
-      conversationId: childConversation.value.sId,
-      parentConversationTitle: parentConversation.title,
-      spaceId: parentConversation.space?.sId ?? null,
-    });
+  }
+
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const authType: AuthenticatorType = auth.toJSON();
+
+  const launchForkWorkflowResult = await launchConversationForkWorkflow({
+    workspaceId,
+    sourceConversationId: parentConversation.sId,
+    destConversationId: childConversation.value.sId,
+    ...(compactionMessageResult.isOk()
+      ? {
+          authType,
+          compactionMessageId:
+            compactionMessageResult.value.compactionMessage.sId,
+          compactionMessageVersion:
+            compactionMessageResult.value.compactionMessage.version,
+          model: childConversationId.value.forkCompactionModel,
+          sourceConversation,
+        }
+      : {}),
+  });
+
+  if (launchForkWorkflowResult.isErr()) {
+    if (compactionMessageResult.isOk()) {
+      const failedMessage = await failCompactionMessageIfCreated(auth, {
+        compactionMessageId:
+          compactionMessageResult.value.compactionMessage.sId,
+      });
+      if (failedMessage) {
+        await publishConversationEvent(
+          {
+            type: "compaction_message_done",
+            created: Date.now(),
+            messageId: failedMessage.sId,
+            message: failedMessage,
+          },
+          { conversationId: childConversation.value.sId }
+        );
+      }
+    }
+
+    logger.error(
+      {
+        workspaceId,
+        parentConversationId: parentConversation.sId,
+        childConversationId: childConversation.value.sId,
+        error: launchForkWorkflowResult.error,
+      },
+      "Failed to launch conversation fork workflow."
+    );
+
+    return new Err(
+      new DustError(
+        "failed_to_copy_files",
+        "Failed to copy files from source conversation."
+      )
+    );
   }
 
   return new Ok({

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -36,6 +36,7 @@ function createForkedData(user: NonNullable<UserMessageType["user"]>) {
       sourceMessageId: "msg_parent_source",
       branchedAt: Date.now(),
       user,
+      gcsMountStatus: "copied" as const,
     },
   };
 }

--- a/front/lib/models/agent/conversation_fork.ts
+++ b/front/lib/models/agent/conversation_fork.ts
@@ -17,6 +17,7 @@ export class ConversationForkModel extends WorkspaceAwareModel<ConversationForkM
   declare createdByUserId: ForeignKey<UserModel["id"]>;
   declare sourceMessageId: ForeignKey<MessageModel["id"]>;
   declare branchedAt: Date;
+  declare gcsMountStatus: CreationOptional<"pending" | "copied">;
 
   declare parentConversation?: NonAttribute<ConversationModel>;
   declare childConversation?: NonAttribute<ConversationModel>;
@@ -39,6 +40,11 @@ ConversationForkModel.init(
     branchedAt: {
       type: DataTypes.DATE,
       allowNull: false,
+    },
+    gcsMountStatus: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "pending",
     },
   },
   {

--- a/front/lib/resources/conversation_fork_resource.ts
+++ b/front/lib/resources/conversation_fork_resource.ts
@@ -34,6 +34,7 @@ export type ConversationForkType = {
   createdByUserId: string;
   sourceMessageId: string;
   branchedAt: number;
+  gcsMountStatus: "pending" | "copied";
 };
 
 type ConversationForkResourceIds = Pick<
@@ -337,6 +338,22 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     });
   }
 
+  static async markGcsMountCopied(
+    auth: Authenticator,
+    { childConversationModelId }: { childConversationModelId: ModelId }
+  ): Promise<void> {
+    const owner = auth.getNonNullableWorkspace();
+    await this.model.update(
+      { gcsMountStatus: "copied" },
+      {
+        where: {
+          childConversationId: childConversationModelId,
+          workspaceId: owner.id,
+        },
+      }
+    );
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
@@ -374,6 +391,7 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
       createdByUserId: this.resourceIds.createdByUserId,
       sourceMessageId: this.resourceIds.sourceMessageId,
       branchedAt: this.branchedAt.getTime(),
+      gcsMountStatus: this.gcsMountStatus,
     };
   }
 }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -208,6 +208,7 @@ describe("ConversationResource", () => {
           sourceMessageId: sourceMessage.sId,
           branchedAt: branchedAt.getTime(),
           user: auth.getNonNullableUser().toJSON(),
+          gcsMountStatus: "pending",
         },
       });
 
@@ -240,6 +241,7 @@ describe("ConversationResource", () => {
             sourceMessageId: sourceMessage.sId,
             branchedAt: branchedAt.getTime(),
             user: auth.getNonNullableUser().toJSON(),
+            gcsMountStatus: "pending",
           },
         });
       }
@@ -339,6 +341,7 @@ describe("ConversationResource", () => {
           sourceMessageId: sourceMessage.sId,
           branchedAt: branchedAt.getTime(),
           user: adminAuth.getNonNullableUser().toJSON(),
+          gcsMountStatus: "pending",
         },
       });
     });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -147,7 +147,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       {
         association: "forkedFrom" as const,
         required: false,
-        attributes: ["branchedAt", "childConversationId"],
+        attributes: ["branchedAt", "childConversationId", "gcsMountStatus"],
         include: [
           {
             association: "parentConversation" as const,
@@ -207,6 +207,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         UserResource.model,
         fork.createdByUser.get()
       ).toJSON(),
+      gcsMountStatus: fork.gcsMountStatus,
     };
   }
 
@@ -420,6 +421,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
                 sourceMessageId,
                 branchedAt: branchedAtMs,
                 user,
+                gcsMountStatus: fork.gcsMountStatus,
               },
             },
             title: fork.childConversation.title,

--- a/front/migrations/20260518_backfill_gcs_mount_status_conversation_forks.ts
+++ b/front/migrations/20260518_backfill_gcs_mount_status_conversation_forks.ts
@@ -1,0 +1,30 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+import { QueryTypes } from "sequelize";
+
+makeScript({}, async ({ execute }, logger) => {
+  const [{ count: pendingCountStr }] = await frontSequelize.query<{
+    count: string;
+  }>(
+    `SELECT COUNT(*) AS count FROM "conversation_forks" WHERE "gcsMountStatus" = 'pending'`,
+    { type: QueryTypes.SELECT }
+  );
+  const pendingCount = parseInt(pendingCountStr);
+
+  logger.info(
+    { pendingCount, execute },
+    execute
+      ? `Backfilling ${pendingCount} rows to 'copied'`
+      : `Would backfill ${pendingCount} rows (dry run)`
+  );
+
+  if (!execute) {
+    return;
+  }
+
+  await frontSequelize.query(
+    `UPDATE "conversation_forks" SET "gcsMountStatus" = 'copied' WHERE "gcsMountStatus" = 'pending'`
+  );
+
+  logger.info({}, "Done");
+});

--- a/front/migrations/db/migration_641.sql
+++ b/front/migrations/db/migration_641.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 18, 2026
+ALTER TABLE "public"."conversation_forks" ADD COLUMN "gcsMountStatus" VARCHAR(255) NOT NULL DEFAULT 'pending';

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -186,6 +186,7 @@
  *         - parentConversationTitle
  *         - sourceMessageId
  *         - branchedAt
+ *         - gcsMountStatus
  *         - user
  *       properties:
  *         parentConversationId:
@@ -197,6 +198,9 @@
  *           type: string
  *         branchedAt:
  *           type: integer
+ *         gcsMountStatus:
+ *           type: string
+ *           enum: [pending, copied]
  *         user:
  *           $ref: '#/components/schemas/PrivateConversationForkUser'
  *     PrivateConversationForkedChild:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -57,7 +57,10 @@
  *       400:
  *         description: Invalid request body
  */
-import { compactConversation } from "@app/lib/api/assistant/conversation/compaction";
+import {
+  CompactionError,
+  compactConversation,
+} from "@app/lib/api/assistant/conversation/compaction";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -146,10 +149,44 @@ async function handler(
         model,
       });
       if (result.isErr()) {
-        return apiError(req, res, {
-          status_code: result.error.status_code,
-          api_error: result.error.api_error,
-        });
+        if (!(result.error instanceof CompactionError)) {
+          throw result.error;
+        }
+        switch (result.error.code) {
+          case "running_agent":
+            return apiError(req, res, {
+              status_code: 409,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Answer the pending agent message first.",
+              },
+            });
+          case "running_compaction":
+            return apiError(req, res, {
+              status_code: 409,
+              api_error: {
+                type: "invalid_request_error",
+                message: "A compaction is already in progress. Please wait.",
+              },
+            });
+          case "just_compacted":
+            return apiError(req, res, {
+              status_code: 409,
+              api_error: {
+                type: "invalid_request_error",
+                message:
+                  "This conversation was just compacted. Send a new message before compacting again.",
+              },
+            });
+          case "workflow_launch_failed":
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to start compaction workflow.",
+              },
+            });
+        }
       }
 
       return res.status(200).json({

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -159,6 +159,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
         sourceMessageId: sourceMessage.sId,
         branchedAt: expect.any(Number),
         user: auth.getNonNullableUser().toJSON(),
+        gcsMountStatus: "pending",
       },
     });
     expect(conversation.depth).toBe(1);
@@ -204,6 +205,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
         sourceMessageId: sourceMessage.sId,
         branchedAt: expect.any(Number),
         user: auth.getNonNullableUser().toJSON(),
+        gcsMountStatus: "pending",
       },
     });
   });

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -10117,6 +10117,7 @@
           "parentConversationTitle",
           "sourceMessageId",
           "branchedAt",
+          "gcsMountStatus",
           "user"
         ],
         "properties": {
@@ -10132,6 +10133,13 @@
           },
           "branchedAt": {
             "type": "integer"
+          },
+          "gcsMountStatus": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "copied"
+            ]
           },
           "user": {
             "$ref": "#/components/schemas/PrivateConversationForkUser"

--- a/front/temporal/agent_loop/lib/compaction.test.ts
+++ b/front/temporal/agent_loop/lib/compaction.test.ts
@@ -74,6 +74,7 @@ describe("runCompaction", () => {
     conversation = fetchedConversationResult.value;
 
     vi.clearAllMocks();
+    vi.mocked(launchCompactionWorkflow).mockResolvedValue(new Ok(undefined));
     vi.mocked(createGCSMountFile).mockImplementation(
       async (_auth, scope, { relativeFilePath, content, contentType }) =>
         new Ok({

--- a/front/temporal/conversation_fork_queue/activities.ts
+++ b/front/temporal/conversation_fork_queue/activities.ts
@@ -1,7 +1,13 @@
+import { failCompactionMessageIfCreated } from "@app/lib/api/assistant/conversation/compaction";
+import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import { copyConversationGCSMount } from "@app/lib/api/files/gcs_mount/files";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
+import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
+import { ApplicationFailure } from "@temporalio/common";
+
+export { compactionActivity } from "@app/temporal/agent_loop/activities/compaction";
 
 export async function copyConversationGCSMountActivity({
   workspaceId,
@@ -20,24 +26,19 @@ export async function copyConversationGCSMountActivity({
   ]);
 
   if (!source || !dest) {
-    logger.warn(
-      {
-        workspaceId,
-        sourceConversationId,
-        destConversationId,
-        sourceFound: !!source,
-        destFound: !!dest,
-      },
-      "[conversation_fork_queue] Source or destination conversation not found. Skipping mount copy."
+    throw ApplicationFailure.nonRetryable(
+      `[conversation_fork_queue] Source or destination conversation not found: sourceFound=${!!source} destFound=${!!dest}`
     );
-
-    return;
   }
 
   const result = await copyConversationGCSMount(auth, { source, dest });
   if (result.isErr()) {
     throw result.error;
   }
+
+  await ConversationForkResource.markGcsMountCopied(auth, {
+    childConversationModelId: dest.id,
+  });
 
   logger.info(
     {
@@ -48,4 +49,47 @@ export async function copyConversationGCSMountActivity({
     },
     "[conversation_fork_queue] Copied GCS mount files between conversations."
   );
+}
+
+export async function failForkCompactionMessageActivity(
+  authType: AuthenticatorType,
+  {
+    conversationId,
+    compactionMessageId,
+  }: {
+    conversationId: string;
+    compactionMessageId: string;
+  }
+): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    logger.error(
+      { error: authResult.error, conversationId, compactionMessageId },
+      "[conversation_fork_queue] Failed to deserialize authenticator for compaction message failure."
+    );
+    return;
+  }
+
+  const auth = authResult.value;
+
+  const failedMessage = await failCompactionMessageIfCreated(auth, {
+    compactionMessageId,
+  });
+
+  if (failedMessage) {
+    await publishConversationEvent(
+      {
+        type: "compaction_message_done",
+        created: Date.now(),
+        messageId: failedMessage.sId,
+        message: failedMessage,
+      },
+      { conversationId }
+    );
+
+    logger.info(
+      { conversationId, compactionMessageId },
+      "[conversation_fork_queue] Failed compaction message for fork workflow failure."
+    );
+  }
 }

--- a/front/temporal/conversation_fork_queue/client.ts
+++ b/front/temporal/conversation_fork_queue/client.ts
@@ -1,8 +1,11 @@
+import type { AuthenticatorType } from "@app/lib/auth";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/conversation_fork_queue/config";
 import { makeConversationForkWorkflowId } from "@app/temporal/conversation_fork_queue/helpers";
 import { conversationForkWorkflow } from "@app/temporal/conversation_fork_queue/workflows";
+import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
+import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -12,10 +15,20 @@ export async function launchConversationForkWorkflow({
   workspaceId,
   sourceConversationId,
   destConversationId,
+  authType,
+  compactionMessageId,
+  compactionMessageVersion,
+  model,
+  sourceConversation,
 }: {
   workspaceId: string;
   sourceConversationId: string;
   destConversationId: string;
+  authType?: AuthenticatorType;
+  compactionMessageId?: string;
+  compactionMessageVersion?: number;
+  model?: SupportedModel;
+  sourceConversation?: CompactionSourceConversation;
 }): Promise<Result<undefined, Error>> {
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = makeConversationForkWorkflowId({
@@ -25,7 +38,18 @@ export async function launchConversationForkWorkflow({
 
   try {
     await client.workflow.start(conversationForkWorkflow, {
-      args: [{ workspaceId, sourceConversationId, destConversationId }],
+      args: [
+        {
+          workspaceId,
+          sourceConversationId,
+          destConversationId,
+          authType,
+          compactionMessageId,
+          compactionMessageVersion,
+          model,
+          sourceConversation,
+        },
+      ],
       taskQueue: QUEUE_NAME,
       workflowId,
       memo: {

--- a/front/temporal/conversation_fork_queue/workflows.ts
+++ b/front/temporal/conversation_fork_queue/workflows.ts
@@ -1,8 +1,11 @@
+import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/conversation_fork_queue/activities";
+import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
+import type { SupportedModel } from "@app/types/assistant/models/types";
 import { proxyActivities } from "@temporalio/workflow";
 
-const { copyConversationGCSMountActivity } = proxyActivities<typeof activities>(
-  {
+const { copyConversationGCSMountActivity, failForkCompactionMessageActivity } =
+  proxyActivities<typeof activities>({
     startToCloseTimeout: "10 minutes",
     retry: {
       maximumAttempts: 3,
@@ -10,21 +13,70 @@ const { copyConversationGCSMountActivity } = proxyActivities<typeof activities>(
       backoffCoefficient: 2,
       maximumInterval: "1m",
     },
-  }
-);
+  });
+
+// Compaction is not idempotent: do not retry on failure.
+const { compactionActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+  retry: { maximumAttempts: 1 },
+});
 
 export async function conversationForkWorkflow({
   workspaceId,
   sourceConversationId,
   destConversationId,
+  authType,
+  compactionMessageId,
+  compactionMessageVersion,
+  model,
+  sourceConversation,
 }: {
   workspaceId: string;
   sourceConversationId: string;
   destConversationId: string;
+  authType?: AuthenticatorType;
+  compactionMessageId?: string;
+  compactionMessageVersion?: number;
+  model?: SupportedModel;
+  sourceConversation?: CompactionSourceConversation;
 }): Promise<void> {
-  await copyConversationGCSMountActivity({
-    workspaceId,
-    sourceConversationId,
-    destConversationId,
-  });
+  if (
+    authType !== undefined &&
+    compactionMessageId !== undefined &&
+    compactionMessageVersion !== undefined &&
+    model !== undefined
+  ) {
+    try {
+      await Promise.all([
+        copyConversationGCSMountActivity({
+          workspaceId,
+          sourceConversationId,
+          destConversationId,
+        }),
+        compactionActivity(authType, {
+          conversationId: destConversationId,
+          compactionMessageId,
+          compactionMessageVersion,
+          model,
+          sourceConversation,
+        }),
+      ]);
+    } catch (e) {
+      try {
+        await failForkCompactionMessageActivity(authType, {
+          conversationId: destConversationId,
+          compactionMessageId,
+        });
+      } catch {
+        // best-effort cleanup; original error is still rethrown below
+      }
+      throw e;
+    }
+  } else {
+    await copyConversationGCSMountActivity({
+      workspaceId,
+      sourceConversationId,
+      destConversationId,
+    });
+  }
 }

--- a/front/types/assistant/conversation.test.ts
+++ b/front/types/assistant/conversation.test.ts
@@ -21,6 +21,7 @@ describe("getConversationDisplayTitle", () => {
       image: null,
       lastLoginAt: null,
     },
+    gcsMountStatus: "copied" as const,
   };
 
   it("returns the persisted title when present", () => {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -490,6 +490,7 @@ export type ConversationForkedFromType = {
   sourceMessageId: string;
   branchedAt: number;
   user: UserType;
+  gcsMountStatus: "pending" | "copied";
 };
 
 /**


### PR DESCRIPTION
## Description

Two race conditions in conversation forking:

1. GCS file copy and compaction were launched as two independent Temporal workflows. If the process crashed between the two launches, compaction never ran. Also, compaction could finish first, flipping the `CompactionMessage` to `"succeeded"` and unblocking posting while GCS copy was still in flight.
2. `compactConversation` returned `APIErrorWithStatusCode`, violating BACK18.

## Fix

**Two-layer block**: posting on a forked child conversation is now gated on *both* `gcsMountStatus = "copied"` (GCS done) *and* `CompactionMessage.status != "created"` (compaction done). Both are cleared by a single durable Temporal workflow, so neither can race.

1. A `gcsMountStatus` column (`pending | copied`) is added to `conversation_forks`. New rows default to `pending`; a backfill script sets existing rows to `copied`. The posting guard checks this alongside the existing CompactionMessage check.

2. `createAndPublishCompactionMessage` is called before the fork workflow launches, so the child is blocked from the moment it is created, not after some async setup.

3. The fork Temporal workflow now runs `copyConversationGCSMountActivity` and `compactionActivity` in **parallel** (`Promise.all`). Posting only unblocks once both succeed. `compactionActivity` is configured with `maximumAttempts: 1` since it is not idempotent.

4. `failForkCompactionMessageActivity` is called in a `try/catch` if either activity fails. It atomically marks the `CompactionMessage` as `"failed"` (`WHERE status = 'created'`) and publishes the SSE event, so the child is never permanently stuck.

5. `compactConversation` now awaits the workflow launch and fails the `CompactionMessage` immediately if the launch errors. The `APIErrorWithStatusCode` return type is replaced with a `CompactionError` domain type (BACK18).

## Changes

- `migration_641.sql`: adds `gcsMountStatus VARCHAR NOT NULL DEFAULT 'pending'` to `conversation_forks`
- `20260518_backfill_gcs_mount_status_conversation_forks.ts`: sets all existing `pending` rows to `copied`
- `conversation_fork.ts` / `conversation_fork_resource.ts` / `conversation_resource.ts`: expose `gcsMountStatus` through the resource and type layer
- `conversation.ts`: posting guard checks `gcsMountStatus !== "copied"` in addition to a running CompactionMessage
- `compaction.ts`: new `CompactionError` class; `compactConversation` split into `createAndPublishCompactionMessage` + `failCompactionMessageIfCreated`; `compactConversation` now awaits the workflow launch
- `compactions.ts`: handler updated to switch on `CompactionError.code`
- `forks.ts`: calls `createAndPublishCompactionMessage` before workflow launch; passes auth and compaction params to `launchConversationForkWorkflow`
- `activities.ts`: re-exports `compactionActivity`; adds `failForkCompactionMessageActivity`
- `client.ts`: extended with optional compaction params
- `workflows.ts`: parallel `Promise.all` for GCS copy and compaction; `try/catch` calls fail activity on error

## Deploy Plan

1. Run migration (`migration_641.sql`)
2. Run backfill (`20260518_backfill_gcs_mount_status_conversation_forks.ts`)
3. Deploy front and fork worker
4. Re-run backfill to catch any forks created during the deploy window whose GCS copy completed on the old worker (which does not mark `gcsMountStatus = 'copied'`)

