### PR TITLE
[Agent Loop] Delay tool abort during worker shutdown

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -87,6 +87,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { isInShutdown } from "@app/lib/shutdown_signal";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
@@ -115,6 +116,9 @@ const MCP_NOTIFICATION_EVENT_NAME = "mcp-notification";
 const MCP_TOOL_DONE_EVENT_NAME = "TOOL_DONE" as const;
 const MCP_TOOL_ERROR_EVENT_NAME = "TOOL_ERROR" as const;
 const MCP_TOOL_HEARTBEAT_EVENT_NAME = "TOOL_HEARTBEAT" as const;
+const TOOL_EXECUTION_CANCELLED_MESSAGE = "The tool execution was cancelled.";
+const TOOL_EXECUTION_INTERRUPTED_MESSAGE =
+  "A tool was interrupted before Dust could confirm the result. Please check whether it completed, then retry.";
 
 const EMPTY_INPUT_SCHEMA: JSONSchema = {
   properties: {},
@@ -528,7 +532,9 @@ export async function* tryCallMCPTool(
     } catch (toolError) {
       if (abortSignal?.aborted) {
         return makeMCPToolExit({
-          message: "The tool execution was cancelled.",
+          message: isInShutdown()
+            ? TOOL_EXECUTION_INTERRUPTED_MESSAGE
+            : TOOL_EXECUTION_CANCELLED_MESSAGE,
           isError: true,
         });
       }

--- a/front/lib/shutdown_signal.ts
+++ b/front/lib/shutdown_signal.ts
@@ -5,16 +5,32 @@
  * - The prestop hook (which signals shutdown)
  * - The readiness probe (which should fail when shutting down)
  * - Connection draining (which needs the pod to stay alive)
+ * - Worker shutdown handlers
  */
 
 let isShuttingDown = false;
+const shutdownController = new AbortController();
+let shutdownAbortTimeout: NodeJS.Timeout | undefined;
 
 /**
  * Marks the pod as shutting down.
- * This should be called by the prestop hook to signal that the pod is terminating.
  */
 export function markShuttingDown(): void {
   isShuttingDown = true;
+  abortShutdownSignal();
+}
+
+/**
+ * Marks the pod as shutting down, but lets active work use most of the grace period.
+ */
+export function markShuttingDownWithDelayedAbort(abortDelayMs: number): void {
+  isShuttingDown = true;
+
+  if (shutdownController.signal.aborted || shutdownAbortTimeout) {
+    return;
+  }
+
+  shutdownAbortTimeout = setTimeout(abortShutdownSignal, abortDelayMs);
 }
 
 /**
@@ -23,4 +39,21 @@ export function markShuttingDown(): void {
  */
 export function isInShutdown(): boolean {
   return isShuttingDown;
+}
+
+export function getShutdownSignal(): AbortSignal {
+  return shutdownController.signal;
+}
+
+function abortShutdownSignal(): void {
+  if (shutdownAbortTimeout) {
+    clearTimeout(shutdownAbortTimeout);
+    shutdownAbortTimeout = undefined;
+  }
+
+  if (shutdownController.signal.aborted) {
+    return;
+  }
+
+  shutdownController.abort();
 }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -9,6 +9,7 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { getShutdownSignal } from "@app/lib/shutdown_signal";
 import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
@@ -192,7 +193,10 @@ async function executeToolStreaming(
     step: number;
   }
 ): Promise<ToolExecutionResult> {
-  const abortSignal = Context.current().cancellationSignal;
+  const abortSignal = AbortSignal.any([
+    Context.current().cancellationSignal,
+    getShutdownSignal(),
+  ]);
 
   const eventStream = runToolWithStreaming(
     auth,

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -3,6 +3,7 @@ import {
   resource,
 } from "@app/lib/api/instrumentation/init";
 import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporter";
+import { markShuttingDownWithDelayedAbort } from "@app/lib/shutdown_signal";
 import { getTemporalAgentWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
@@ -32,8 +33,11 @@ import {
 import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
-// We need to give the worker some time to finish the current activity before shutting down.
-const SHUTDOWN_GRACE_TIME = "2 minutes";
+// Must match front-agent-loop-worker's terminationGracePeriodSeconds.
+const SHUTDOWN_GRACE_TIME_MS = 120 * 1_000;
+const SHUTDOWN_ABORT_BUFFER_MS = 10 * 1_000;
+const SHUTDOWN_TOOL_ABORT_DELAY_MS =
+  SHUTDOWN_GRACE_TIME_MS - SHUTDOWN_ABORT_BUFFER_MS;
 
 export async function runAgentLoopWorker() {
   const { connection, namespace } = await getTemporalAgentWorkerConnection();
@@ -63,7 +67,7 @@ export async function runAgentLoopWorker() {
     taskQueue: QUEUE_NAME,
     connection,
     namespace,
-    shutdownGraceTime: SHUTDOWN_GRACE_TIME,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     // This also bounds the time until an activity may receive a cancellation signal.
     // See https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling
     maxHeartbeatThrottleInterval: "20 seconds",
@@ -106,7 +110,10 @@ export async function runAgentLoopWorker() {
   });
 
   // TODO(2025-11-12 INSTRUMENTATION): Drain Langfuse data before shutdown.
-  process.on("SIGTERM", () => worker.shutdown());
+  process.on("SIGTERM", () => {
+    markShuttingDownWithDelayedAbort(SHUTDOWN_TOOL_ABORT_DELAY_MS);
+    void worker.shutdown();
+  });
 
   try {
     await worker.run(); // this resolves after shutdown completes


### PR DESCRIPTION
## Description
Restores the shutdown-aware tool activity handling from https://github.com/dust-tt/dust/pull/24257 after https://github.com/dust-tt/dust/pull/25653 reverted it, with the fix below.

Agent-loop workers receive SIGTERM at the start of their 120s Kubernetes termination grace period. Keep stopping Temporal polling immediately, but delay the shared shutdown abort signal until 10s before pod termination so in-flight tool calls can still complete during most deploy rollouts.

If a tool is still running near pod termination, it is aborted and returned as an in-band interrupted-tool result instead of falling through to a heartbeat timeout workflow failure.

## Risks
Blast radius: agent-loop tool executions running during front-agent-loop-worker deploys or pod shutdowns.
Risk: low

## Deploy Plan
- deploy front