### PR TITLE
[Scrub] Jitter workspace scrub wake-up

### DIFF
--- a/front/temporal/scrub_workspace/jitter.test.ts
+++ b/front/temporal/scrub_workspace/jitter.test.ts
@@ -1,0 +1,38 @@
+import {
+  getWorkspaceScrubJitterMinutes,
+  WORKSPACE_SCRUB_JITTER_MAX_HOURS,
+} from "@app/temporal/scrub_workspace/jitter";
+import { describe, expect, it } from "vitest";
+
+const MINUTES_PER_HOUR = 60;
+const SAMPLE_WORKSPACE_COUNT = 10;
+
+describe("getWorkspaceScrubJitterMinutes", () => {
+  it("is deterministic", () => {
+    expect(getWorkspaceScrubJitterMinutes("w123")).toBe(
+      getWorkspaceScrubJitterMinutes("w123")
+    );
+  });
+
+  it("returns a delay in the configured jitter window", () => {
+    const maxJitterMinutes =
+      WORKSPACE_SCRUB_JITTER_MAX_HOURS * MINUTES_PER_HOUR;
+
+    for (const workspaceId of ["w1", "w123", "w-longer-workspace-id"]) {
+      const jitterMinutes = getWorkspaceScrubJitterMinutes(workspaceId);
+
+      expect(jitterMinutes).toBeGreaterThanOrEqual(0);
+      expect(jitterMinutes).toBeLessThan(maxJitterMinutes);
+    }
+  });
+
+  it("spreads nearby workspace IDs", () => {
+    const jitters = new Set(
+      Array.from({ length: SAMPLE_WORKSPACE_COUNT }, (_, index) =>
+        getWorkspaceScrubJitterMinutes(`w${index}`)
+      )
+    );
+
+    expect(jitters.size).toBeGreaterThan(1);
+  });
+});

--- a/front/temporal/scrub_workspace/jitter.ts
+++ b/front/temporal/scrub_workspace/jitter.ts
@@ -1,0 +1,18 @@
+export const WORKSPACE_SCRUB_JITTER_MAX_HOURS = 24;
+
+const MINUTES_PER_HOUR = 60;
+const WORKSPACE_SCRUB_JITTER_MAX_MINUTES =
+  WORKSPACE_SCRUB_JITTER_MAX_HOURS * MINUTES_PER_HOUR;
+const FNV_OFFSET_BASIS = 2_166_136_261;
+const FNV_PRIME = 16_777_619;
+
+export function getWorkspaceScrubJitterMinutes(workspaceId: string): number {
+  let hash = FNV_OFFSET_BASIS;
+
+  for (let i = 0; i < workspaceId.length; i++) {
+    hash ^= workspaceId.charCodeAt(i);
+    hash = Math.imul(hash, FNV_PRIME) >>> 0;
+  }
+
+  return hash % WORKSPACE_SCRUB_JITTER_MAX_MINUTES;
+}

--- a/front/temporal/scrub_workspace/workflows.ts
+++ b/front/temporal/scrub_workspace/workflows.ts
@@ -12,6 +12,7 @@ import {
   LAST_EMAIL_BEFORE_SCRUB_IN_DAYS,
   WORKSPACE_DEFAULT_RETENTION_DAYS,
 } from "./config";
+import { getWorkspaceScrubJitterMinutes } from "./jitter";
 import { runScrubFreeEndedWorkspacesSignal } from "./signals";
 
 const { shouldStillScrubData, getWorkspaceRetentionDays } = proxyActivities<
@@ -76,6 +77,9 @@ export async function scheduleWorkspaceScrubWorkflowV2({
   await sleep(`${LAST_EMAIL_BEFORE_SCRUB_IN_DAYS} days`);
   if (!(await shouldStillScrubData({ workspaceId }))) {
     return false;
+  }
+  if (patched("workspace-scrub-jitter")) {
+    await sleep(`${getWorkspaceScrubJitterMinutes(workspaceId)} minutes`);
   }
 
   await scrubWorkspaceData({ workspaceId });

--- a/front/temporal/scrub_workspace/workflows.ts
+++ b/front/temporal/scrub_workspace/workflows.ts
@@ -80,6 +80,9 @@ export async function scheduleWorkspaceScrubWorkflowV2({
   }
   if (patched("workspace-scrub-jitter")) {
     await sleep(`${getWorkspaceScrubJitterMinutes(workspaceId)} minutes`);
+    if (!(await shouldStillScrubData({ workspaceId }))) {
+      return false;
+    }
   }
 
   await scrubWorkspaceData({ workspaceId });


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/8102.

Adds deterministic 0-24h jitter before scheduled workspace scrubs call `scrubWorkspaceData`, so retention wake-ups do not all execute the heavy delete path at the same time. The new timer is guarded with a Temporal patch marker for replay safety. Immediate workspace scrubs remain immediate.

This does not completely solve the issue, other PRs will follow.

## Risks
Blast radius: scheduled workspace data scrubbing after retention.
Risk: low.

## Deploy Plan
- pmrr
- deploy front workers

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25647">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->