### PR TITLE
Fix frame name

### DIFF
--- a/front/lib/files.ts
+++ b/front/lib/files.ts
@@ -1,5 +1,4 @@
 import capitalize from "lodash/capitalize";
-import chain from "lodash/chain";
 import words from "lodash/words";
 
 export const FILE_ID_PATTERN = "fil_[A-Za-z0-9]{10,}";
@@ -28,13 +27,10 @@ export function formatFilenameForDisplay(filename: string): string {
   const nameWithoutExt = filename.replace(/\.[^/.]+$/, "");
 
   // Split on camelCase, underscores, and hyphens, then join with spaces.
-  const wordsChain = chain(nameWithoutExt)
+  return nameWithoutExt
     .split(/[_-]/) // Split on underscores and hyphens.
     .flatMap((word) => words(word)) // Split camelCase words.
-    .compact() // Remove empty strings.
+    .filter((word) => word.length > 0) // Remove empty strings.
     .map((word) => capitalize(word)) // Capitalize each word.
-    .join(" ")
-    .value();
-
-  return wordsChain;
+    .join(" ");
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Frames are not rendering publicly.

The bug was in `formatFilenameForDisplay`. A recent commit replaced `import _ from "lodash"` with modular imports including `import chain from "lodash/chain"`. The chain wrapper from `lodash/chain` doesn't carry the array/string methods that the full lodash bundle attaches at import time, so `chain(str).split(...)` blew up 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->