### PR TITLE
feat: small projects ui fixes

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -7,14 +7,18 @@ import { areOpenProjectsAllowed } from "@app/lib/workspace_policies";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
   Dialog,
   DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  GlobeAltIcon,
   Input,
-  SliderToggle,
+  Label,
+  LockIcon,
   Tooltip,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
@@ -162,36 +166,18 @@ export function CreateProjectModal({
                 </div>
               )}
             </div>
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex flex-col">
-                <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                  Open to everyone
-                </div>
-                <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                  Anyone in the workspace can find and join the project.
-                </div>
+            <div className="flex flex-col items-start gap-1">
+              <Label>Visibility</Label>
+              <VisibilitySwitch
+                isPublic={isPublic}
+                disabled={!areWorkspaceOpenProjectsAllowed}
+                onChange={setIsPublic}
+              />
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                {isPublic
+                  ? "Anyone in the workspace can find and join this project."
+                  : "Only invited members can access this project."}
               </div>
-              {areWorkspaceOpenProjectsAllowed ? (
-                <SliderToggle
-                  size="xs"
-                  selected={isPublic}
-                  onClick={() => setIsPublic((prev) => !prev)}
-                />
-              ) : (
-                <Tooltip
-                  label={OPEN_PROJECTS_DISABLED_TOOLTIP}
-                  trigger={
-                    <div>
-                      <SliderToggle
-                        size="xs"
-                        selected={isPublic}
-                        onClick={() => setIsPublic((prev) => !prev)}
-                        disabled
-                      />
-                    </div>
-                  }
-                />
-              )}
             </div>
           </div>
         </DialogContainer>
@@ -208,4 +194,36 @@ export function CreateProjectModal({
       </DialogContent>
     </Dialog>
   );
+}
+
+interface VisibilitySwitchProps {
+  isPublic: boolean;
+  disabled: boolean;
+  onChange: (isPublic: boolean) => void;
+}
+
+function VisibilitySwitch({
+  isPublic,
+  disabled,
+  onChange,
+}: VisibilitySwitchProps) {
+  const switchList = (
+    <ButtonsSwitchList
+      size="xs"
+      defaultValue={isPublic ? "open" : "restricted"}
+      onValueChange={(value) => onChange(value === "open")}
+      disabled={disabled}
+    >
+      <ButtonsSwitch value="open" label="Open" icon={GlobeAltIcon} />
+      <ButtonsSwitch value="restricted" label="Restricted" icon={LockIcon} />
+    </ButtonsSwitchList>
+  );
+
+  if (disabled) {
+    return (
+      <Tooltip label={OPEN_PROJECTS_DISABLED_TOOLTIP} trigger={switchList} />
+    );
+  }
+
+  return switchList;
 }

--- a/front/components/assistant/conversation/sidebar/ProjectsList.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsList.tsx
@@ -4,6 +4,7 @@ import {
 } from "@app/components/assistant/conversation/ProjectMenu";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { useConversation } from "@app/hooks/conversations";
+import { useSpaceConversations } from "@app/hooks/conversations/useSpaceConversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
@@ -50,6 +51,28 @@ const ProjectListItem = memo(
       workspaceId: owner.sId,
     });
 
+    const { mutateConversations: mutateAllConversations } =
+      useSpaceConversations({
+        workspaceId: owner.sId,
+        spaceId: space.sId,
+        filter: "all",
+        options: { disabled: true },
+      });
+    const { mutateConversations: mutateWithMeConversations } =
+      useSpaceConversations({
+        workspaceId: owner.sId,
+        spaceId: space.sId,
+        filter: "with_me",
+        options: { disabled: true },
+      });
+    const { mutateConversations: mutateGroupConversations } =
+      useSpaceConversations({
+        workspaceId: owner.sId,
+        spaceId: space.sId,
+        filter: "group",
+        options: { disabled: true },
+      });
+
     const isSpaceSelected =
       router.asPath.startsWith(spacePath) ||
       conversation?.spaceId === space.sId;
@@ -90,13 +113,27 @@ const ProjectListItem = memo(
             const conversationObj = JSON.parse(
               conversationData
             ) as ConversationWithoutContentType;
-            await moveConversationToProject(conversationObj, space);
+            const success = await moveConversationToProject(
+              conversationObj,
+              space
+            );
+            if (success) {
+              void mutateAllConversations();
+              void mutateWithMeConversations();
+              void mutateGroupConversations();
+            }
           }
         } catch (error) {
           console.error("Error parsing conversation data:", error);
         }
       },
-      [moveConversationToProject, space]
+      [
+        moveConversationToProject,
+        space,
+        mutateAllConversations,
+        mutateWithMeConversations,
+        mutateGroupConversations,
+      ]
     );
 
     return (

--- a/front/components/assistant/conversation/space/FirstSyncTaskLookbackForm.tsx
+++ b/front/components/assistant/conversation/space/FirstSyncTaskLookbackForm.tsx
@@ -20,7 +20,7 @@ const OPTIONS: {
     value: "max",
     title: "As far back as possible",
     description:
-      "Search with no fixed lower time bound (subject to limits below).",
+      "Search with no fixed lower time bound (subject to limits above).",
   },
 ];
 

--- a/front/hooks/useMoveConversationToProject.tsx
+++ b/front/hooks/useMoveConversationToProject.tsx
@@ -73,7 +73,9 @@ export function useMoveConversationToProject(owner: LightWorkspaceType) {
       }
 
       // Revalidate conversations list to reflect the move
-      void mutateConversations();
+      void mutateConversations((prev) =>
+        prev?.filter((c) => c.sId !== conversation.sId)
+      );
       void mutateSpaceSummary();
       void sendNotification({
         title: "Conversation moved.",


### PR DESCRIPTION
## Description

This PR improves the project UI with some small fixes and enhancements.

- Replaced the SliderToggle with a ButtonsSwitch component for project visibility settings, providing clearer "Open" vs "Restricted" options
- Fix cache invalidation when moving conversations to projects by properly filtering out the moved conversation from the list and invalidating all conversation filter views
- Fixed a typo in the sync task lookback description ("below" → "above")

<img width="570" height="373" alt="Capture d’écran 2026-05-15 à 18 01 36" src="https://github.com/user-attachments/assets/26012fcb-568d-4a4e-9e1a-c399fc95627b" />
<img width="515" height="491" alt="Capture d’écran 2026-05-15 à 18 01 47" src="https://github.com/user-attachments/assets/ec210138-a3cf-4fac-a711-24b771a7b202" />


## Tests

Manually

## Risks

Low

## Deploy Plan

Standard deployment
