### PR TITLE
Make truncateTotalChars trauncate entire body, not just message content

### DIFF
--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -125,7 +125,7 @@ export function renderConversationAsText(
       continue;
     }
 
-    totalChars += rendered.contentLength;
+    totalChars += rendered.text.length;
     parts.unshift(rendered.text);
 
     // A succeeded compaction message is a history boundary. Include it and stop.


### PR DESCRIPTION
## Description

* Right now truncateTotalChars only truncates the content, not the entire text length. This means input/output params are not truncated

## Tests

* Local validation compaction at least worked

## Risk

* Low

## Deploy Plan

* Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25656">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->