### PR TITLE
Create pattern for tests that work with both Hono and Next

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/index.test.ts
@@ -1,5 +1,5 @@
+import { callApi } from "@app/tests/utils/api_request";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
-
 import {
   createPublicApiAuthenticationTests,
   createPublicApiMockRequest,
@@ -10,6 +10,8 @@ import { describe, expect, it } from "vitest";
 
 import handler from "./index";
 
+const ROUTE = "/api/v1/w/:wId/spaces";
+
 describe(
   "public api authentication tests",
   createPublicApiAuthenticationTests(handler)
@@ -17,18 +19,21 @@ describe(
 
 describe("GET /api/v1/w/[wId]/spaces", () => {
   it("returns an empty list when no spaces exist", async () => {
-    const { req, res } = await createPublicApiMockRequest();
+    const { workspace, key } = await createPublicApiMockRequest();
 
-    await handler(req, res);
+    const response = await callApi({
+      route: ROUTE,
+      params: { wId: workspace.sId },
+      bearerToken: key.secret,
+      nextHandler: handler,
+    });
 
-    expect(res._getStatusCode()).toBe(200);
-    expect(res._getJSONData()).toEqual({ spaces: [] });
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ spaces: [] });
   });
 
   it("returns accessible spaces for the workspace", async () => {
-    // Setup
-    const { req, res, workspace, globalGroup } =
-      await createPublicApiMockRequest();
+    const { workspace, globalGroup, key } = await createPublicApiMockRequest();
 
     // Create test spaces
     const globalSpace = await SpaceFactory.global(workspace);
@@ -41,13 +46,16 @@ describe("GET /api/v1/w/[wId]/spaces", () => {
     await GroupSpaceFactory.associate(regularSpace1, globalGroup);
     await GroupSpaceFactory.associate(regularSpace2, globalGroup);
 
-    // Execute request
-    await handler(req, res);
+    const response = await callApi({
+      route: ROUTE,
+      params: { wId: workspace.sId },
+      bearerToken: key.secret,
+      nextHandler: handler,
+    });
 
-    // Verify response
-    expect(res._getStatusCode()).toBe(200);
+    expect(response.status).toBe(200);
 
-    const { spaces } = res._getJSONData();
+    const { spaces } = response.body;
     expectArrayOfObjectsWithSpecificLength(spaces, 3);
 
     expect(spaces).toEqual(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
@@ -1,6 +1,7 @@
 import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { callApi } from "@app/tests/utils/api_request";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -16,17 +17,15 @@ import handler from "./available";
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
   it("returns available servers for regular user", async () => {
-    // Create mock request
-    const { req, res, workspace, globalGroup } =
-      await createPrivateApiMockRequest({
-        method: "GET",
-        role: "user",
-      });
-    // Create workspace and space
+    // Sets up workspace, user, membership, and mocks getSession.
+    const { workspace, globalGroup } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
     const space = await SpaceFactory.regular(workspace);
     await GroupSpaceFactory.associate(space, globalGroup);
 
-    // Get auth
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     // Mock the INTERNAL_MCP_SERVERS to override the "primitive_types_debugger" server config
@@ -50,7 +49,6 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
       configurable: true,
     });
 
-    // Create some servers
     await FeatureFlagFactory.basic(auth, "dev_mcp_actions");
 
     // Internal server in the right workspace
@@ -72,20 +70,16 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
     await SpaceFactory.system(workspace2);
     await RemoteMCPServerFactory.create(workspace2);
 
-    // Add query params
-    req.query = {
-      ...req.query,
-      spaceId: space.sId,
-    };
+    const response = await callApi({
+      route: "/api/w/:wId/spaces/:spaceId/mcp/available",
+      params: { wId: workspace.sId, spaceId: space.sId },
 
-    // Call handler
-    await handler(req, res);
+      nextHandler: handler,
+    });
 
-    // Check response
-    expect(res._getStatusCode()).toBe(200);
-    const response = res._getJSONData();
-    expect(response.success).toBe(true);
-    expect(response.servers).toHaveLength(1); // Only one available server as the other is assigned to the system space
-    expect(response.servers[0].sId).toBe(internalServer.id);
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.servers).toHaveLength(1); // Only one available server — the other is assigned to the system space
+    expect(response.body.servers[0].sId).toBe(internalServer.id);
   });
 });

--- a/front/tests/utils/api_request.ts
+++ b/front/tests/utils/api_request.ts
@@ -1,0 +1,114 @@
+import type { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+
+// Lazy so the front-api dependency graph doesn't load until callApi runs.
+// In tests, vi.mock declarations in helpers (e.g. createPrivateApiMockRequest
+// mocking getSession) only register when their file is imported; if honoApp
+// loads first, workspaceAuth captures the un-mocked auth and requests 401.
+async function getHonoApp() {
+  const { honoApp } = await import("@dust-tt/front-api/app");
+  return honoApp;
+}
+
+/**
+ * Selects which implementation the helper invokes. Default is "next"
+ * Set `TEST_HANDLER=hono` to run the same test body against the legacy Next handler
+ * useful for parity checking during the migration.
+ */
+const TEST_HANDLER = (process.env.TEST_HANDLER ?? "next") as "hono" | "next";
+
+type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+interface ApiCallOptions {
+  /** Route template, with `:name` placeholders. Same string for both modes. */
+  route: string;
+  /** Values to substitute into `:name` placeholders. */
+  params?: Record<string, string>;
+  method?: Method;
+  /** Extra query parameters (added to the URL in Hono mode, to req.query in Next mode). */
+  query?: Record<string, string>;
+  body?: unknown;
+  headers?: Record<string, string>;
+  /** Shorthand for `headers.authorization = "Bearer <token>"`. */
+  bearerToken?: string;
+  /** Next handler imported from the corresponding pages/api/... file. */
+  nextHandler: NextApiHandler;
+}
+
+export interface ApiCallResult {
+  status: number;
+  body: any;
+}
+
+function buildPath(route: string, params: Record<string, string> = {}): string {
+  let path = route;
+  for (const [key, value] of Object.entries(params)) {
+    path = path.replace(`:${key}`, encodeURIComponent(value));
+  }
+  return path;
+}
+
+/**
+ * Invokes an API endpoint via either Hono (default) or the legacy Next
+ * handler, depending on `TEST_HANDLER`. The test body is identical in both
+ * modes — only the dispatch differs.
+ *
+ * In Next mode, `nextHandler` is called with mocked req/res; path params are
+ * passed via `req.query` (matching Next.js convention).
+ *
+ * In Hono mode, `honoApp.request(...)` is called with the substituted URL;
+ * path params end up in `c.req.param(...)`.
+ */
+export async function callApi({
+  route,
+  params = {},
+  method = "GET",
+  query,
+  body,
+  headers,
+  bearerToken,
+  nextHandler,
+}: ApiCallOptions): Promise<ApiCallResult> {
+  const path = buildPath(route, params);
+  const allHeaders: Record<string, string> = {
+    ...(bearerToken ? { authorization: `Bearer ${bearerToken}` } : {}),
+    ...headers,
+  };
+
+  if (TEST_HANDLER === "hono") {
+    const url = query
+      ? `${path}?${new URLSearchParams(query).toString()}`
+      : path;
+    const honoApp = await getHonoApp();
+    const response = await honoApp.request(url, {
+      method,
+      headers: {
+        ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+        ...allHeaders,
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    let parsed: any;
+    const text = await response.text();
+    try {
+      parsed = text ? JSON.parse(text) : undefined;
+    } catch {
+      parsed = text;
+    }
+    return { status: response.status, body: parsed };
+  }
+
+  // Next mode.
+  const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+    method,
+    url: path,
+    query: { ...params, ...query },
+    headers: allHeaders,
+    body,
+  });
+  await nextHandler(req, res);
+  return {
+    status: res._getStatusCode(),
+    body: res._getJSONData(),
+  };
+}

--- a/front/tests/utils/api_request.ts
+++ b/front/tests/utils/api_request.ts
@@ -49,7 +49,7 @@ function buildPath(route: string, params: Record<string, string> = {}): string {
 }
 
 /**
- * Invokes an API endpoint via either Hono (default) or the legacy Next
+ * Invokes an API endpoint via either Hono or the legacy Next
  * handler, depending on `TEST_HANDLER`. The test body is identical in both
  * modes — only the dispatch differs.
  *

--- a/front/tests/utils/api_request.ts
+++ b/front/tests/utils/api_request.ts
@@ -12,7 +12,7 @@ async function getHonoApp() {
 
 /**
  * Selects which implementation the helper invokes. Default is "next"
- * Set `TEST_HANDLER=hono` to run the same test body against the legacy Next handler
+ * Set `TEST_HANDLER=hono` to run the same test body against Hono
  * useful for parity checking during the migration.
  */
 const TEST_HANDLER = (process.env.TEST_HANDLER ?? "next") as "hono" | "next";

--- a/front/vite.globalSetup.ts
+++ b/front/vite.globalSetup.ts
@@ -46,6 +46,7 @@ export default async function setup() {
     CONNECTORS_API: "http://fake-connectors-api",
     DUST_CONNECTORS_SECRET: "fake-connectors-secret",
     DUST_CONNECTORS_WEBHOOKS_SECRET: "fake-connectors-webhooks-secret",
+    TEST_HANDLER: process.env.TEST_HANDLER ?? "next", // "next" or "hono". Set via env var to avoid hardcoding in test files, which would make it more error-prone to switch modes.
 
     // Variables that modify the behavior of certain tests
     UPDATE_MCP_METADATA_SNAPSHOT: process.env.UPDATE_MCP_METADATA_SNAPSHOT,


### PR DESCRIPTION
## Description

Introduces a `callApi` test helper that dispatches API requests to either Hono or Next based on a `TEST_HANDLER` env var, letting the same test body exercise both implementations during the migration. Applies it to the two spaces test files we've migrated so far. Tests default to Next; set `TEST_HANDLER=hono` to run the same test body against Hono.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25657">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->