### PR TITLE
Switch over user/workspace credits to use active AWU usage

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -99,7 +99,7 @@ function CreditPoolUsageBar({
       <div
         className="flex h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10"
         role="progressbar"
-        aria-label="User and programmatic usage"
+        aria-label="Credit pool usage"
         aria-valuenow={Math.round(totalConsumedPercentage)}
         aria-valuemin={0}
         aria-valuemax={100}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -104,11 +104,7 @@ interface WorkspaceUsageBarProps {
 
 function WorkspaceUsageBar({ consumed, limit }: WorkspaceUsageBarProps) {
   const percentage =
-    limit === null
-      ? 0
-      : limit > 0
-        ? Math.min((consumed / limit) * 100, 100)
-        : 0;
+    limit !== null && limit > 0 ? Math.min((consumed / limit) * 100, 100) : 0;
 
   return (
     <div className="flex w-full flex-col gap-1">
@@ -172,14 +168,14 @@ const columns: ColumnDef<RowData, string>[] = [
     accessorFn: (row) => (row.seatUsagePercent ?? 0).toString(),
     cell: (info: Info) => {
       const pct = info.row.original.seatUsagePercent;
-      const textColor =
-        pct === null
-          ? undefined
-          : pct >= 100
-            ? "#ef4444"
-            : pct >= 80
-              ? "#FE9C1A"
-              : undefined;
+      let textColor: string | undefined;
+      if (pct !== null) {
+        if (pct >= 100) {
+          textColor = "#ef4444";
+        } else if (pct >= 80) {
+          textColor = "#FE9C1A";
+        }
+      }
       return (
         <DataTable.CellContent>
           {pct !== null ? (

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -1,7 +1,9 @@
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import type { MembershipSeatType } from "@app/types/memberships";
 import {
+  ActionCreditCoinsIcon,
   DataTable,
+  Icon,
   LoadingBlock,
   SeatFreeIcon,
   SeatMaxIcon,
@@ -17,7 +19,7 @@ type RowData = {
   image: string | null;
   seatType: MembershipSeatType | null;
   seatUsagePercent: number | null;
-  consumedMicroUsd: number;
+  consumedWorkplacePoolCredits: number;
   onClick?: () => void;
 };
 
@@ -91,9 +93,37 @@ function SeatTypeIcon({ seatType }: SeatTypeIconProps) {
   return <Icon />;
 }
 
-function formatMicroUsd(amountMicroUsd: number): string {
-  const dollars = amountMicroUsd / 1_000_000;
-  return `$${dollars.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+function formatCredits(credits: number): string {
+  return credits.toLocaleString("en-US", { maximumFractionDigits: 1 });
+}
+
+interface WorkspaceUsageBarProps {
+  consumed: number;
+  limit: number | null;
+}
+
+function WorkspaceUsageBar({ consumed, limit }: WorkspaceUsageBarProps) {
+  const percentage =
+    limit === null
+      ? 0
+      : limit > 0
+        ? Math.min((consumed / limit) * 100, 100)
+        : 0;
+
+  return (
+    <div className="flex w-full flex-col gap-1">
+      <div className="flex justify-between text-xs tabular-nums text-foreground dark:text-foreground-night">
+        <span>{formatCredits(consumed)}</span>
+        <span>{limit === null ? "∞" : formatCredits(limit)}</span>
+      </div>
+      <div className="h-0.5 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10">
+        <div
+          className="h-full transition-all"
+          style={{ width: `${percentage}%`, backgroundColor: "#596170" }}
+        />
+      </div>
+    </div>
+  );
 }
 
 const columns: ColumnDef<RowData, string>[] = [
@@ -142,12 +172,23 @@ const columns: ColumnDef<RowData, string>[] = [
     accessorFn: (row) => (row.seatUsagePercent ?? 0).toString(),
     cell: (info: Info) => {
       const pct = info.row.original.seatUsagePercent;
+      const textColor =
+        pct === null
+          ? undefined
+          : pct >= 100
+            ? "#ef4444"
+            : pct >= 80
+              ? "#FE9C1A"
+              : undefined;
       return (
         <DataTable.CellContent>
           {pct !== null ? (
-            <span className="flex items-center gap-1.5 text-sm font-semibold tabular-nums text-muted-foreground dark:text-muted-foreground-night">
-              <CircleProgress percentage={pct} />
+            <span
+              className="flex items-center gap-1.5 text-sm font-semibold tabular-nums"
+              style={textColor ? { color: textColor } : undefined}
+            >
               {`${Math.round(pct)}%`}
+              <CircleProgress percentage={pct} />
             </span>
           ) : (
             <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
@@ -165,22 +206,29 @@ const columns: ColumnDef<RowData, string>[] = [
       (a.original.seatUsagePercent ?? -1) - (b.original.seatUsagePercent ?? -1),
   },
   {
-    id: "consumedMicroUsd" as const,
-    header: "Workspace usage",
-    accessorFn: (row) => row.consumedMicroUsd.toString(),
+    id: "consumedWorkplacePoolCredits" as const,
+    header: () => (
+      <span className="flex items-center gap-1.5">
+        <Icon visual={ActionCreditCoinsIcon} size="xs" />
+        Workspace usage
+      </span>
+    ),
+    accessorFn: (row) => row.consumedWorkplacePoolCredits.toString(),
     cell: (info: Info) => (
-      <DataTable.CellContent>
-        <span className="text-sm tabular-nums text-muted-foreground dark:text-muted-foreground-night">
-          {formatMicroUsd(info.row.original.consumedMicroUsd)}
-        </span>
-      </DataTable.CellContent>
+      <div className="w-full pr-3">
+        <WorkspaceUsageBar
+          consumed={info.row.original.consumedWorkplacePoolCredits}
+          limit={null}
+        />
+      </div>
     ),
     meta: {
-      className: "w-36 text-right",
+      className: "w-56",
     },
     enableSorting: true,
     sortingFn: (a, b) =>
-      a.original.consumedMicroUsd - b.original.consumedMicroUsd,
+      a.original.consumedWorkplacePoolCredits -
+      b.original.consumedWorkplacePoolCredits,
   },
 ];
 
@@ -236,7 +284,7 @@ export function MembersUsageTable({
     image: m.image,
     seatType: m.seatType,
     seatUsagePercent: m.seatUsagePercent,
-    consumedMicroUsd: m.consumedMicroUsd,
+    consumedWorkplacePoolCredits: m.consumedWorkplacePoolCredits,
   }));
 
   return <DataTable data={rows} columns={columns} />;

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -11,6 +11,7 @@ import {
   getMetricLlmProviderCostAwuId,
   getSeatProductIds,
 } from "@app/lib/metronome/constants";
+import { buildSeatAllocationByUserId } from "@app/lib/metronome/seats";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -115,29 +116,50 @@ export async function handleAwuPoolSummaryRequest(
           !seatProductIds.has(entry.product.id)
       );
 
-      // Sum remaining balance across active AWU entries. Using entry.balance
-      // so that consumption outside the billing window (e.g. usage
-      // from a prior period) is correctly reflected in the remaining balance.
-      let balanceCredits = 0;
+      // Sum the remaining balance of each active pool credit.
+      // entry.balance accounts for prior-period consumption (e.g. a carried-over prepaid
+      // top-off that was partially consumed in a previous billing cycle). Upcoming and
+      // expired schedule segments contribute 0 to the balance, so this is safe for
+      // multi-period recurring credits too.
+      let totalCredits = 0;
       for (const entry of awuBalances) {
-        balanceCredits += entry.balance ?? 0;
+        const isActive = (entry.access_schedule?.schedule_items ?? []).some(
+          (item) => {
+            const itemStartMs = new Date(item.starting_at).getTime();
+            const itemEndMs = new Date(item.ending_before).getTime();
+            return itemStartMs <= now && now < itemEndMs;
+          }
+        );
+        if (isActive) {
+          totalCredits += entry.balance ?? 0;
+        }
       }
 
-      // Query the AWU metric grouped by is_programmatic_usage to split consumption.
-      // "NONE" window gives a single aggregate over the entire billing period.
-      // Metronome requires midnight UTC boundaries for usage queries.
-      const usageResult = await listMetronomeUsageWithGroups({
-        customerId: metronomeCustomerId,
-        billableMetricId: getMetricLlmProviderCostAwuId(),
-        startingOn: floorToMidnightUTC(
-          new Date(currentInvoice.start_timestamp)
-        ).toISOString(),
-        endingBefore: ceilToMidnightUTC(
-          new Date(currentInvoice.end_timestamp)
-        ).toISOString(),
-        windowSize: "NONE",
-        groupKey: ["is_programmatic_usage"],
-      });
+      const startingOn = floorToMidnightUTC(
+        new Date(currentInvoice.start_timestamp)
+      ).toISOString();
+      const endingBefore = ceilToMidnightUTC(
+        new Date(currentInvoice.end_timestamp)
+      ).toISOString();
+
+      // Query usage per user and seat allocations in parallel.
+      // Per-user breakdown is needed to compute pool overflow correctly:
+      // seat credits cover each user up to their allocation; only the excess
+      // draws from the workspace pool.
+      const [usageResult, seatAllocationByUserId] = await Promise.all([
+        listMetronomeUsageWithGroups({
+          customerId: metronomeCustomerId,
+          billableMetricId: getMetricLlmProviderCostAwuId(),
+          startingOn,
+          endingBefore,
+          windowSize: "NONE",
+          groupKey: ["user_id", "usage_type"],
+        }),
+        buildSeatAllocationByUserId({
+          metronomeCustomerId,
+          contractId: metronomeContractId,
+        }),
+      ]);
 
       if (usageResult.isErr()) {
         return apiError(req, res, {
@@ -149,21 +171,33 @@ export async function handleAwuPoolSummaryRequest(
         });
       }
 
-      let consumedByUsersCredits = 0;
+      // Aggregate per-user consumption from the usage metric.
+      const perUserCredits = new Map<string, number>();
       let consumedByProgrammaticCredits = 0;
+
       for (const row of usageResult.value) {
         const credits = row.value ?? 0;
-        if (row.group?.["is_programmatic_usage"] === "true") {
+        const usageType = row.group?.["usage_type"];
+        if (usageType === "programmatic") {
           consumedByProgrammaticCredits += credits;
         } else {
-          consumedByUsersCredits += credits;
+          const userId = row.group?.["user_id"];
+          if (userId) {
+            perUserCredits.set(
+              userId,
+              (perUserCredits.get(userId) ?? 0) + credits
+            );
+          }
         }
       }
 
-      // totalCredits = balance + consumed_in_period so that
-      // totalCredits - consumed = balance (the actual remaining).
-      const totalCredits =
-        balanceCredits + consumedByUsersCredits + consumedByProgrammaticCredits;
+      // Pool user consumption = sum of each user's overflow beyond their seat allocation.
+      // Users without a seat: all their usage is pool consumption.
+      let consumedByUsersCredits = 0;
+      for (const [userId, userCredits] of perUserCredits) {
+        const seatAllocation = seatAllocationByUserId.get(userId) ?? 0;
+        consumedByUsersCredits += Math.max(0, userCredits - seatAllocation);
+      }
 
       return res.status(200).json({
         totalCredits,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -3,14 +3,10 @@ import {
   ceilToMidnightUTC,
   floorToMidnightUTC,
   listMetronomeDraftInvoices,
-  listMetronomeSeatBalances,
   listMetronomeUsageWithGroups,
 } from "@app/lib/metronome/client";
-import {
-  getCreditTypeAwuId,
-  getMetricLlmProviderCostAwuId,
-} from "@app/lib/metronome/constants";
-import { AWU_TO_MICRO_USD } from "@app/lib/metronome/types";
+import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
+import { buildSeatAllocationByUserId } from "@app/lib/metronome/seats";
 import {
   MembershipResource,
   type MembershipsPaginationParams,
@@ -30,8 +26,8 @@ export type MemberUsageType = {
   seatType: MembershipSeatType | null;
   // Percentage of seat allocation consumed (0–100), null when seat balances are unavailable.
   seatUsagePercent: number | null;
-  // Pool consumption only: total usage minus what was covered by the seat credit.
-  consumedMicroUsd: number;
+  // Pool consumption only (AWU credits): total usage minus what was covered by the seat credit.
+  consumedWorkplacePoolCredits: number;
 };
 
 export type GetMembersUsageResponseBody = {
@@ -73,7 +69,7 @@ function buildUrlWithParams(
   return url.pathname + url.search;
 }
 
-async function fetchPerUserUsageMicroUsd({
+async function fetchPerUserUsageCredits({
   metronomeCustomerId,
   metronomeContractId,
 }: {
@@ -119,7 +115,7 @@ async function fetchPerUserUsageMicroUsd({
     startingOn,
     endingBefore,
     windowSize: "NONE",
-    groupKey: ["user_id"],
+    groupKey: ["user_id", "usage_type"],
   });
 
   if (usageResult.isErr()) {
@@ -129,12 +125,12 @@ async function fetchPerUserUsageMicroUsd({
   const perUser = new Map<string, number>();
   for (const entry of usageResult.value) {
     const userId = entry.group?.["user_id"];
-    // Skip programmatic events — they carry user_id="unknown" (see events.ts).
-    if (!userId || userId === "unknown" || entry.value === null) {
+    const usageType = entry.group?.["usage_type"];
+    if (!userId || usageType !== "user" || entry.value === null) {
       continue;
     }
     const existing = perUser.get(userId) ?? 0;
-    perUser.set(userId, existing + entry.value * AWU_TO_MICRO_USD);
+    perUser.set(userId, existing + entry.value);
   }
   return perUser;
 }
@@ -173,80 +169,41 @@ export async function handleGetMembersUsageRequest(
       const { metronomeCustomerId } = workspace;
       const metronomeContractId = subscription?.metronomeContractId ?? null;
 
-      const [membershipsResult, perUserTotalMicroUsd, seatBalancesResult] =
+      const [membershipsResult, perUserTotalCredits, seatAllocationByUserId] =
         await Promise.all([
           MembershipResource.getActiveMemberships({
             workspace,
             paginationParams,
           }),
-          fetchPerUserUsageMicroUsd({
+          fetchPerUserUsageCredits({
             metronomeCustomerId: metronomeCustomerId ?? null,
             metronomeContractId,
           }),
           metronomeCustomerId && metronomeContractId
-            ? listMetronomeSeatBalances({
+            ? buildSeatAllocationByUserId({
                 metronomeCustomerId,
-                metronomeContractId,
+                contractId: metronomeContractId,
               })
-            : Promise.resolve(null),
+            : Promise.resolve(new Map<string, number>()),
         ]);
 
       const { memberships, total, nextPageParams } = membershipsResult;
-
-      if (seatBalancesResult !== null && seatBalancesResult.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: `Failed to retrieve Metronome seat balances: ${seatBalancesResult.error.message}`,
-          },
-        });
-      }
-
-      // Build seat_id → balance map. seat_id is the user's sId.
-      // Each entry has a `balances` array; we pick the AWU credit type entry.
-      const awuCreditTypeId = getCreditTypeAwuId();
-      const seatBalanceByUserId = new Map<
-        string,
-        { balance: number; startingBalance: number }
-      >();
-      if (seatBalancesResult !== null) {
-        for (const entry of seatBalancesResult.value) {
-          const awuBalance = entry.balances.find(
-            (b) => b.credit_type_id === awuCreditTypeId
-          );
-          if (awuBalance) {
-            seatBalanceByUserId.set(entry.seat_id, {
-              balance: awuBalance.balance,
-              startingBalance: awuBalance.starting_balance,
-            });
-          }
-        }
-      }
 
       const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
         if (!m.user) {
           return [];
         }
         const userId = m.user.sId;
-        const totalMicroUsd = perUserTotalMicroUsd.get(userId) ?? 0;
-        const seat = seatBalanceByUserId.get(userId) ?? null;
+        const totalCredits = perUserTotalCredits.get(userId) ?? 0;
+        const seatAllocation = seatAllocationByUserId.get(userId) ?? 0;
 
         let seatUsagePercent: number | null = null;
-        let poolConsumedMicroUsd = totalMicroUsd;
+        let poolConsumedCredits = totalCredits;
 
-        if (seat !== null && seat.startingBalance > 0) {
-          const seatConsumed = seat.startingBalance - seat.balance;
-          seatUsagePercent = Math.min(
-            100,
-            (seatConsumed / seat.startingBalance) * 100
-          );
-          // Pool usage is total minus what was covered by the seat credit.
-          const seatConsumedMicroUsd = seatConsumed * AWU_TO_MICRO_USD;
-          poolConsumedMicroUsd = Math.max(
-            0,
-            totalMicroUsd - seatConsumedMicroUsd
-          );
+        if (seatAllocation > 0) {
+          const seatConsumed = Math.min(totalCredits, seatAllocation);
+          seatUsagePercent = (seatConsumed / seatAllocation) * 100;
+          poolConsumedCredits = Math.max(0, totalCredits - seatAllocation);
         }
 
         return [
@@ -257,7 +214,7 @@ export async function handleGetMembersUsageRequest(
             image: m.user.imageUrl ?? null,
             seatType: m.seatType ?? null,
             seatUsagePercent,
-            consumedMicroUsd: poolConsumedMicroUsd,
+            consumedWorkplacePoolCredits: poolConsumedCredits,
           },
         ];
       });

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -153,6 +153,28 @@ export const getProductSeatSubscriptionCreditsId = () =>
     PROD_PRODUCT_SEAT_SUBSCRIPTION_CREDITS
   );
 
+export const PRO_SEAT_MONTHLY_AWU_CREDITS = 8000;
+export const MAX_SEAT_MONTHLY_AWU_CREDITS = 40000;
+
+export function getAwuAllocationForSeatType(
+  seatType: MembershipSeatType | null
+): number {
+  if (seatType === null) {
+    return 0;
+  }
+  switch (seatType) {
+    case "max":
+      return MAX_SEAT_MONTHLY_AWU_CREDITS;
+    case "pro":
+      return PRO_SEAT_MONTHLY_AWU_CREDITS;
+    case "workspace":
+    case "free":
+      return 0;
+    default:
+      return assertNever(seatType);
+  }
+}
+
 export const getSeatProductIds = (): Set<string> =>
   new Set([
     getProductSeatSubscriptionCreditsId(),

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -10,6 +10,7 @@ import {
 } from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
@@ -264,42 +265,53 @@ export async function buildSeatAllocationByUserId({
     return new Map();
   }
 
+  const subscriptions = contractResult.value.subscriptions ?? [];
+
+  const results = await concurrentExecutor(
+    subscriptions,
+    async (sub) => {
+      if (sub.quantity_management_mode !== "SEAT_BASED" || !sub.id) {
+        return null;
+      }
+      const seatType = getSeatTypeForProductId(sub.subscription_rate.product);
+      if (!seatType) {
+        return null;
+      }
+      const awuAllocation = getAwuAllocationForSeatType(seatType);
+      if (awuAllocation === 0) {
+        return null;
+      }
+
+      const seatIdsResult = await getMetronomeSubscriptionAssignedSeatIds({
+        metronomeCustomerId,
+        contractId,
+        subscriptionId: sub.id,
+      });
+      if (seatIdsResult.isErr()) {
+        logger.warn(
+          {
+            error: seatIdsResult.error,
+            metronomeCustomerId,
+            contractId,
+            subscriptionId: sub.id,
+            seatType,
+          },
+          "[Metronome] buildSeatAllocationByUserId: failed to fetch seat IDs"
+        );
+        return null;
+      }
+
+      return { seatIds: seatIdsResult.value, awuAllocation };
+    },
+    { concurrency: 10 }
+  );
+
   const allocationByUserId = new Map<string, number>();
-
-  for (const sub of contractResult.value.subscriptions ?? []) {
-    if (sub.quantity_management_mode !== "SEAT_BASED" || !sub.id) {
-      continue;
-    }
-    const seatType = getSeatTypeForProductId(sub.subscription_rate.product);
-    if (!seatType) {
-      continue;
-    }
-    const awuAllocation = getAwuAllocationForSeatType(seatType);
-    if (awuAllocation === 0) {
-      continue;
-    }
-
-    const seatIdsResult = await getMetronomeSubscriptionAssignedSeatIds({
-      metronomeCustomerId,
-      contractId,
-      subscriptionId: sub.id,
-    });
-    if (seatIdsResult.isErr()) {
-      logger.warn(
-        {
-          error: seatIdsResult.error,
-          metronomeCustomerId,
-          contractId,
-          subscriptionId: sub.id,
-          seatType,
-        },
-        "[Metronome] buildSeatAllocationByUserId: failed to fetch seat IDs"
-      );
-      continue;
-    }
-
-    for (const seatId of seatIdsResult.value) {
-      allocationByUserId.set(seatId, awuAllocation);
+  for (const result of results) {
+    if (result) {
+      for (const seatId of result.seatIds) {
+        allocationByUserId.set(seatId, result.awuAllocation);
+      }
     }
   }
 

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -4,7 +4,10 @@ import {
   updateSubscriptionQuantity,
   updateSubscriptionSeats,
 } from "@app/lib/metronome/client";
-import { getSeatTypeForProductId } from "@app/lib/metronome/constants";
+import {
+  getAwuAllocationForSeatType,
+  getSeatTypeForProductId,
+} from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
@@ -230,4 +233,75 @@ export async function syncSeatCount({
   }
 
   return new Ok(undefined);
+}
+
+/**
+ * Query Metronome to determine which seat (pro/max) each user is assigned to,
+ * then return a map of userId → AWU allocation for the current period.
+ *
+ * Only covers SEAT_BASED subscriptions — Metronome tracks individual seat
+ * assignments for those. QUANTITY_ONLY subscriptions don't expose per-user
+ * assignments via the API, so users on those plans are omitted (allocation = 0).
+ *
+ * Returns an empty map on any error so callers degrade gracefully.
+ */
+export async function buildSeatAllocationByUserId({
+  metronomeCustomerId,
+  contractId,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+}): Promise<Map<string, number>> {
+  const contractResult = await getMetronomeContractById({
+    metronomeCustomerId,
+    metronomeContractId: contractId,
+  });
+  if (contractResult.isErr()) {
+    logger.warn(
+      { error: contractResult.error, metronomeCustomerId, contractId },
+      "[Metronome] buildSeatAllocationByUserId: failed to fetch contract"
+    );
+    return new Map();
+  }
+
+  const allocationByUserId = new Map<string, number>();
+
+  for (const sub of contractResult.value.subscriptions ?? []) {
+    if (sub.quantity_management_mode !== "SEAT_BASED" || !sub.id) {
+      continue;
+    }
+    const seatType = getSeatTypeForProductId(sub.subscription_rate.product);
+    if (!seatType) {
+      continue;
+    }
+    const awuAllocation = getAwuAllocationForSeatType(seatType);
+    if (awuAllocation === 0) {
+      continue;
+    }
+
+    const seatIdsResult = await getMetronomeSubscriptionAssignedSeatIds({
+      metronomeCustomerId,
+      contractId,
+      subscriptionId: sub.id,
+    });
+    if (seatIdsResult.isErr()) {
+      logger.warn(
+        {
+          error: seatIdsResult.error,
+          metronomeCustomerId,
+          contractId,
+          subscriptionId: sub.id,
+          seatType,
+        },
+        "[Metronome] buildSeatAllocationByUserId: failed to fetch seat IDs"
+      );
+      continue;
+    }
+
+    for (const seatId of seatIdsResult.value) {
+      allocationByUserId.set(seatId, awuAllocation);
+    }
+  }
+
+  return allocationByUserId;
 }


### PR DESCRIPTION
## Description

  Fix AWU pool and seat usage calculations; add per-member usage table
  
  Pool total credits (awu_pool_summary.ts)
  Switch from schedule_items.amount (original grant) to entry.balance (remaining balance) when computing totalCredits. For monthly credits the result is identical, but
  for carried-over prepaid credits this correctly reflects what's actually available rather than the original allocation.

  Seat allocation per user (seats.ts, constants.ts)
  Replace listMetronomeSeatBalances — which aggregates AWU credits across all seat subscriptions into one combined balance — with a new buildSeatAllocationByUserId
  function that queries Metronome for which specific subscription (pro/max) each user is currently assigned to, then uses the known per-seat AWU allocation (8k/40k).
  This fixes incorrect seat usage percentages caused by summing pro and max credits together for users who appear in both.

  Members usage table (MembersUsageTable.tsx, members_usage.ts)
  Add a workspace pool consumption column per member with a consumed/limit bar. Seat usage column now shows percentage first with threshold-aware text color (yellow at
  ≥80%, red at ≥100%), followed by the circle progress indicator. Pool bar renders empty when the limit is infinite.
## Tests

<img width="987" height="589" alt="Screenshot 2026-05-15 at 4 29 19 PM" src="https://github.com/user-attachments/assets/acabc9d8-2f85-4470-a703-2429ee5b3191" />

## Risk

* Low (not customer facing yet)

## Deploy Plan

* Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25658">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->