### PR TITLE
Add userAuth middleware and group session-scoped routes

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -47,8 +47,7 @@ const HONO_ROUTE_REGEXES = HONO_ROUTES.map((r) => {
   };
 });
 
-// Session-scoped routes share sessionAuth + userAuth, applied once here so
-// individual route files don't repeat the wiring.
+// userAuth depends on c.get("session"), so sessionAuth must register first.
 const sessionRoutes = new Hono();
 sessionRoutes.use("*", sessionAuth);
 sessionRoutes.use("*", userAuth);

--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 
 import { cors } from "./middleware/cors";
+import { sessionAuth } from "./middleware/session_auth";
+import { userAuth } from "./middleware/user_auth";
 import { appStatusApp } from "./routes/app-status";
 import { authContextApp } from "./routes/auth-context";
 import { createNewWorkspaceApp } from "./routes/create-new-workspace";
@@ -45,14 +47,21 @@ const HONO_ROUTE_REGEXES = HONO_ROUTES.map((r) => {
   };
 });
 
+// Session-scoped routes share sessionAuth + userAuth, applied once here so
+// individual route files don't repeat the wiring.
+const sessionRoutes = new Hono();
+sessionRoutes.use("*", sessionAuth);
+sessionRoutes.use("*", userAuth);
+sessionRoutes.route("/auth-context", authContextApp);
+sessionRoutes.route("/create-new-workspace", createNewWorkspaceApp);
+sessionRoutes.route("/invitations", invitationsApp);
+sessionRoutes.route("/workspace-lookup", workspaceLookupApp);
+
 const apiApp = new Hono();
 apiApp.route("/healthz", healthzApp);
 apiApp.route("/app-status", appStatusApp);
-apiApp.route("/auth-context", authContextApp);
-apiApp.route("/create-new-workspace", createNewWorkspaceApp);
-apiApp.route("/invitations", invitationsApp);
 apiApp.route("/kill", killApp);
-apiApp.route("/workspace-lookup", workspaceLookupApp);
+apiApp.route("/", sessionRoutes);
 apiApp.route("/w/:wId", workspaceApp);
 apiApp.route("/v1/w/:wId", publicWorkspaceApp);
 

--- a/front-api/middleware/user_auth.ts
+++ b/front-api/middleware/user_auth.ts
@@ -5,16 +5,18 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 
 declare module "hono" {
   interface ContextVariableMap {
-    userResource: UserResource;
+    user: UserResource;
   }
 }
 
 /**
- * Resolves the `UserResource` for the current session and stores it on the
- * Hono context under the `userResource` variable.
+ * Resolves the `UserResource` for the current session (Redis-cached lookup)
+ * and stores it on the Hono context as `user`.
+ *
+ * Kept intentionally lightweight — heavier `getUserWithWorkspaces` is opt-in
+ * per-handler to avoid the workspace fan-out on every session-authed request.
  *
  * Must run after `sessionAuth` — expects `c.get("session")` to be set.
- * Handlers that need workspaces should call `getUserWithWorkspaces` themselves.
  */
 export const userAuth: MiddlewareHandler = async (c, next) => {
   const session = c.get("session");
@@ -32,6 +34,6 @@ export const userAuth: MiddlewareHandler = async (c, next) => {
     );
   }
 
-  c.set("userResource", user);
+  c.set("user", user);
   await next();
 };

--- a/front-api/middleware/user_auth.ts
+++ b/front-api/middleware/user_auth.ts
@@ -1,0 +1,37 @@
+import type { MiddlewareHandler } from "hono";
+
+import { fetchUserFromSession } from "@app/lib/iam/users";
+import type { UserResource } from "@app/lib/resources/user_resource";
+
+declare module "hono" {
+  interface ContextVariableMap {
+    userResource: UserResource;
+  }
+}
+
+/**
+ * Resolves the `UserResource` for the current session and stores it on the
+ * Hono context under the `userResource` variable.
+ *
+ * Must run after `sessionAuth` — expects `c.get("session")` to be set.
+ * Handlers that need workspaces should call `getUserWithWorkspaces` themselves.
+ */
+export const userAuth: MiddlewareHandler = async (c, next) => {
+  const session = c.get("session");
+  const user = await fetchUserFromSession(session);
+
+  if (!user) {
+    return c.json(
+      {
+        error: {
+          type: "not_authenticated",
+          message: "The user could not be resolved from the session.",
+        },
+      },
+      401
+    );
+  }
+
+  c.set("userResource", user);
+  await next();
+};

--- a/front-api/routes/auth-context.ts
+++ b/front-api/routes/auth-context.ts
@@ -1,16 +1,12 @@
 import { Hono } from "hono";
 
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
-import { fetchUserFromSession } from "@app/lib/iam/users";
-
-import { sessionAuth } from "../middleware/session_auth";
 
 export const authContextApp = new Hono();
 
-authContextApp.use("*", sessionAuth);
-
 authContextApp.get("/", async (c) => {
   const session = c.get("session");
+  const user = c.get("userResource");
 
   if (session.workspaceId) {
     const redirect = await getWorkspaceRegionRedirect(session.workspaceId);
@@ -26,19 +22,6 @@ authContextApp.get("/", async (c) => {
         400
       );
     }
-  }
-
-  const user = await fetchUserFromSession(session);
-  if (!user) {
-    return c.json(
-      {
-        error: {
-          type: "user_not_found",
-          message: "User not found.",
-        },
-      },
-      403
-    );
   }
 
   return c.json({

--- a/front-api/routes/auth-context.ts
+++ b/front-api/routes/auth-context.ts
@@ -6,7 +6,7 @@ export const authContextApp = new Hono();
 
 authContextApp.get("/", async (c) => {
   const session = c.get("session");
-  const user = c.get("userResource");
+  const user = c.get("user");
 
   if (session.workspaceId) {
     const redirect = await getWorkspaceRegionRedirect(session.workspaceId);

--- a/front-api/routes/create-new-workspace.ts
+++ b/front-api/routes/create-new-workspace.ts
@@ -8,11 +8,11 @@ export const createNewWorkspaceApp = new Hono();
 
 createNewWorkspaceApp.post("/", async (c) => {
   const session = c.get("session");
-  const userResource = c.get("userResource");
+  const user = c.get("user");
 
-  const user = await getUserWithWorkspaces(userResource);
+  const userWithWorkspaces = await getUserWithWorkspaces(user);
 
-  if (user.workspaces.length > 0) {
+  if (userWithWorkspaces.workspaces.length > 0) {
     return c.json(
       {
         error: {
@@ -27,7 +27,7 @@ createNewWorkspaceApp.post("/", async (c) => {
   const workspace = await createWorkspace(session);
 
   await createAndTrackMembership({
-    user: userResource,
+    user,
     workspace,
     role: "admin",
     origin: "invited",

--- a/front-api/routes/create-new-workspace.ts
+++ b/front-api/routes/create-new-workspace.ts
@@ -1,31 +1,16 @@
 import { Hono } from "hono";
 
 import { createAndTrackMembership } from "@app/lib/api/membership";
-import { getUserFromSession } from "@app/lib/iam/session";
+import { getUserWithWorkspaces } from "@app/lib/api/user";
 import { createWorkspace } from "@app/lib/iam/workspaces";
-import { UserResource } from "@app/lib/resources/user_resource";
-
-import { sessionAuth } from "../middleware/session_auth";
 
 export const createNewWorkspaceApp = new Hono();
 
-createNewWorkspaceApp.use("*", sessionAuth);
-
 createNewWorkspaceApp.post("/", async (c) => {
   const session = c.get("session");
+  const userResource = c.get("userResource");
 
-  const user = await getUserFromSession(session);
-  if (!user) {
-    return c.json(
-      {
-        error: {
-          type: "invalid_request_error",
-          message: "The user is not found.",
-        },
-      },
-      401
-    );
-  }
+  const user = await getUserWithWorkspaces(userResource);
 
   if (user.workspaces.length > 0) {
     return c.json(
@@ -40,18 +25,9 @@ createNewWorkspaceApp.post("/", async (c) => {
   }
 
   const workspace = await createWorkspace(session);
-  const u = await UserResource.fetchByModelId(user.id);
-  if (!u) {
-    return c.json(
-      {
-        error: { type: "user_not_found", message: "The user was not found." },
-      },
-      404
-    );
-  }
 
   await createAndTrackMembership({
-    user: u,
+    user: userResource,
     workspace,
     role: "admin",
     origin: "invited",

--- a/front-api/routes/invitations.ts
+++ b/front-api/routes/invitations.ts
@@ -9,7 +9,7 @@ import type { PendingInvitationOption } from "@app/types/membership_invitation";
 export const invitationsApp = new Hono();
 
 invitationsApp.get("/", async (c) => {
-  const user = c.get("userResource");
+  const user = c.get("user");
 
   const invitationResources =
     await MembershipInvitationResource.listPendingForEmail({

--- a/front-api/routes/invitations.ts
+++ b/front-api/routes/invitations.ts
@@ -2,29 +2,14 @@ import { Hono } from "hono";
 
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import { fetchInvitationsFromOtherRegion } from "@app/lib/api/regions/lookup";
-import { getUserFromSession } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import logger from "@app/logger/logger";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 
-import { sessionAuth } from "../middleware/session_auth";
-
 export const invitationsApp = new Hono();
 
-invitationsApp.use("*", sessionAuth);
-
 invitationsApp.get("/", async (c) => {
-  const session = c.get("session");
-
-  const user = await getUserFromSession(session);
-  if (!user) {
-    return c.json(
-      {
-        error: { type: "user_not_found", message: "User not found." },
-      },
-      404
-    );
-  }
+  const user = c.get("userResource");
 
   const invitationResources =
     await MembershipInvitationResource.listPendingForEmail({

--- a/front-api/routes/workspace-lookup.ts
+++ b/front-api/routes/workspace-lookup.ts
@@ -1,12 +1,13 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
-import { fetchRevokedWorkspace } from "@app/lib/api/user";
-import { getUserFromSession } from "@app/lib/iam/session";
+import {
+  fetchRevokedWorkspace,
+  getUserWithWorkspaces,
+} from "@app/lib/api/user";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 
-import { sessionAuth } from "../middleware/session_auth";
 import { validate } from "../middleware/validator";
 
 const GetWorkspaceLookupQuerySchema = z.object({
@@ -15,28 +16,15 @@ const GetWorkspaceLookupQuerySchema = z.object({
 
 export const workspaceLookupApp = new Hono();
 
-workspaceLookupApp.use("*", sessionAuth);
-
 workspaceLookupApp.get(
   "/",
   validate("query", GetWorkspaceLookupQuerySchema),
   async (c) => {
-    const session = c.get("session");
-
-    const user = await getUserFromSession(session);
-    if (!user) {
-      return c.json(
-        {
-          error: { type: "user_not_found", message: "User not found." },
-        },
-        404
-      );
-    }
-
+    const userResource = c.get("userResource");
     const { flow } = c.req.valid("query");
 
     if (flow === "no-auto-join") {
-      const [, userEmailDomain] = user.email.split("@");
+      const [, userEmailDomain] = userResource.email.split("@");
       const result =
         await WorkspaceResource.fetchByDomainWithInfo(userEmailDomain);
       const workspace = result?.workspace ?? null;
@@ -61,6 +49,7 @@ workspaceLookupApp.get(
       });
     }
 
+    const user = await getUserWithWorkspaces(userResource);
     const result = await fetchRevokedWorkspace(user);
     if (result.isErr()) {
       return c.json(

--- a/front-api/routes/workspace-lookup.ts
+++ b/front-api/routes/workspace-lookup.ts
@@ -20,11 +20,11 @@ workspaceLookupApp.get(
   "/",
   validate("query", GetWorkspaceLookupQuerySchema),
   async (c) => {
-    const userResource = c.get("userResource");
+    const user = c.get("user");
     const { flow } = c.req.valid("query");
 
     if (flow === "no-auto-join") {
-      const [, userEmailDomain] = userResource.email.split("@");
+      const [, userEmailDomain] = user.email.split("@");
       const result =
         await WorkspaceResource.fetchByDomainWithInfo(userEmailDomain);
       const workspace = result?.workspace ?? null;
@@ -49,8 +49,11 @@ workspaceLookupApp.get(
       });
     }
 
-    const user = await getUserWithWorkspaces(userResource);
-    const result = await fetchRevokedWorkspace(user);
+    // TODO(2026-05-15 PERF): fetchRevokedWorkspace re-fetches the
+    // UserResource we already have on the context. Refactor it to take a
+    // UserResource directly and drop this getUserWithWorkspaces call.
+    const userWithWorkspaces = await getUserWithWorkspaces(user);
+    const result = await fetchRevokedWorkspace(userWithWorkspaces);
     if (result.isErr()) {
       return c.json(
         {


### PR DESCRIPTION
Follow-up to #25615 addressing David's review comments.

- Introduce front-api/middleware/user_auth.ts which resolves a UserResource via fetchUserFromSession after sessionAuth, sets it on the context, and returns 401 if the user can't be resolved.
- Group /auth-context, /create-new-workspace, /invitations, and /workspace-lookup into a sessionRoutes sub-app in front-api/app.ts so sessionAuth + userAuth are applied once at the group boundary.
- Drop the per-handler sessionAuth wiring and per-handler null checks from the four routes; handlers now read the UserResource from context.
- In create-new-workspace, pass the UserResource directly to createAndTrackMembership instead of re-fetching it by model id.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25660">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->