### PR TITLE
Migrate assistant/builder routes to Hono

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -24,6 +24,7 @@ interface HonoRoute {
   methods: HonoMethod[];
 }
 
+// This is only needed during migration, to implement isHonoRoute()
 const HONO_ROUTES: HonoRoute[] = [
   { pattern: "/api/healthz", methods: ["GET"] },
   { pattern: "/api/app-status", methods: ["GET"] },
@@ -33,6 +34,27 @@ const HONO_ROUTES: HonoRoute[] = [
   { pattern: "/api/invitations", methods: ["GET"] },
   { pattern: "/api/kill", methods: ["GET"] },
   { pattern: "/api/workspace-lookup", methods: ["GET"] },
+  {
+    pattern: "/api/w/:wId/assistant/builder/process/generate_schema",
+    methods: ["POST"],
+  },
+  {
+    pattern: "/api/w/:wId/assistant/builder/sidekick/prompt/existing",
+    methods: ["GET"],
+  },
+  {
+    pattern: "/api/w/:wId/assistant/builder/sidekick/prompt/shrink-wrap",
+    methods: ["GET"],
+  },
+  {
+    pattern: "/api/w/:wId/assistant/builder/sidekick/prompt/template",
+    methods: ["GET"],
+  },
+  {
+    pattern: "/api/w/:wId/assistant/builder/slack/channels_linked_with_agent",
+    methods: ["GET"],
+  },
+  { pattern: "/api/w/:wId/assistant/builder/suggestions", methods: ["POST"] },
   { pattern: "/api/w/:wId/feature-flags", methods: ["GET"] },
   { pattern: "/api/w/:wId/members/lookup", methods: ["GET"] },
   { pattern: "/api/w/:wId/members/search", methods: ["GET"] },

--- a/front-api/middleware/public_api_auth.ts
+++ b/front-api/middleware/public_api_auth.ts
@@ -1,5 +1,4 @@
 import type { Context, MiddlewareHandler } from "hono";
-import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 import { verifySandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
 import {
@@ -14,6 +13,8 @@ import { getClientIp } from "@app/lib/utils/request";
 import type { APIErrorWithStatusCode } from "@app/types/error";
 import { getGroupIdsFromHeaders, getRoleFromHeaders } from "@app/types/groups";
 import { getUserEmailFromHeaders } from "@app/types/user";
+
+import { jsonApiError } from "./utils";
 
 type HeaderRecord = Record<string, string | string[] | undefined>;
 
@@ -83,16 +84,6 @@ function validateWorkspaceFromAuth(
     };
   }
   return null;
-}
-
-// APIErrorWithStatusCode.status_code is typed as `number`, but Hono's c.json
-// expects the narrower ContentfulStatusCode. The cast is safe because all our
-// status codes are valid HTTP error codes.
-function jsonApiError(c: Context, err: APIErrorWithStatusCode) {
-  return c.json(
-    { error: err.api_error },
-    err.status_code as ContentfulStatusCode
-  );
 }
 
 function applyClientIp(auth: Authenticator, headers: HeaderRecord): void {

--- a/front-api/middleware/utils.ts
+++ b/front-api/middleware/utils.ts
@@ -1,5 +1,21 @@
 import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { APIErrorWithStatusCode } from "@app/types/error";
+
+/**
+ * Returns a JSON response built from an `APIErrorWithStatusCode`. The
+ * `status_code` field is typed as `number` but Hono's c.json expects the
+ * narrower `ContentfulStatusCode` — the cast is safe because all our status
+ * codes are valid HTTP error codes.
+ */
+export function jsonApiError(c: Context, err: APIErrorWithStatusCode) {
+  return c.json(
+    { error: err.api_error },
+    err.status_code as ContentfulStatusCode
+  );
+}
 
 export function parseCookieHeader(
   header: string | undefined

--- a/front-api/routes/w/assistant/builder/index.ts
+++ b/front-api/routes/w/assistant/builder/index.ts
@@ -1,0 +1,41 @@
+import { Hono } from "hono";
+
+import { getBuilderSuggestions } from "@app/lib/api/assistant/suggestions";
+import { InternalPostBuilderSuggestionsRequestBodySchema } from "@app/types/api/internal/assistant";
+
+import { validate } from "../../../../middleware/validator";
+import { processApp } from "./process";
+import { sidekickApp } from "./sidekick";
+import { slackApp } from "./slack";
+
+// Mounted under /api/w/:wId/assistant/builder.
+
+export const builderApp = new Hono();
+
+builderApp.post(
+  "/suggestions",
+  validate("json", InternalPostBuilderSuggestionsRequestBodySchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const { type, inputs } = c.req.valid("json");
+
+    const suggestionsRes = await getBuilderSuggestions(auth, type, inputs);
+    if (suggestionsRes.isErr()) {
+      return c.json(
+        {
+          error: {
+            type: "internal_server_error",
+            message: suggestionsRes.error.message,
+          },
+        },
+        500
+      );
+    }
+
+    return c.json(suggestionsRes.value);
+  }
+);
+
+builderApp.route("/process", processApp);
+builderApp.route("/sidekick", sidekickApp);
+builderApp.route("/slack", slackApp);

--- a/front-api/routes/w/assistant/builder/process.ts
+++ b/front-api/routes/w/assistant/builder/process.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+
+import { getBuilderJsonSchemaGenerator } from "@app/lib/api/assistant/json_schema_generator";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+} from "@app/lib/assistant";
+import { InternalPostBuilderGenerateSchemaRequestBodySchema } from "@app/types/api/internal/assistant";
+
+import { validate } from "../../../../middleware/validator";
+
+// Mounted under /api/w/:wId/assistant/builder/process.
+
+export const processApp = new Hono();
+
+processApp.post(
+  "/generate_schema",
+  validate("json", InternalPostBuilderGenerateSchemaRequestBodySchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const { instructions } = c.req.valid("json");
+
+    const model = !auth.isUpgraded()
+      ? await getSmallWhitelistedModel(auth)
+      : await getLargeWhitelistedModel(auth);
+    if (!model) {
+      return c.json(
+        {
+          error: {
+            type: "invalid_request_error",
+            message: "No whitelisted models were found for the workspace.",
+          },
+        },
+        400
+      );
+    }
+
+    const schemaRes = await getBuilderJsonSchemaGenerator(auth, {
+      instructions,
+      modelId: model.modelId,
+      providerId: model.providerId,
+    });
+
+    if (schemaRes.isErr()) {
+      return c.json(
+        {
+          error: {
+            type: "internal_server_error",
+            message: `Error generating schema: ${JSON.stringify(schemaRes.error)}`,
+          },
+        },
+        500
+      );
+    }
+
+    return c.json({ schema: schemaRes.value.schema });
+  }
+);

--- a/front-api/routes/w/assistant/builder/sidekick.ts
+++ b/front-api/routes/w/assistant/builder/sidekick.ts
@@ -1,0 +1,89 @@
+import { Hono } from "hono";
+
+import {
+  buildExistingAgentPrompt,
+  buildShrinkWrapPromptForConversation,
+  buildTemplatePrompt,
+} from "@app/lib/api/assistant/builder/sidekick_prompts";
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { TemplateResource } from "@app/lib/resources/template_resource";
+
+import { jsonApiError } from "../../../../middleware/utils";
+
+// Mounted under /api/w/:wId/assistant/builder/sidekick.
+
+export const sidekickApp = new Hono();
+
+sidekickApp.get("/prompt/template", async (c) => {
+  const templateId = c.req.query("templateId");
+  if (!templateId) {
+    return c.json(
+      {
+        error: {
+          type: "unprocessable_entity",
+          message: "The templateId query parameter is invalid or missing.",
+        },
+      },
+      422
+    );
+  }
+
+  const template = await TemplateResource.fetchByExternalId(templateId);
+  if (!template || !template.sidekickInstructions) {
+    return c.json(
+      {
+        error: {
+          type: "template_not_found",
+          message: `Template with id ${templateId} not found.`,
+        },
+      },
+      404
+    );
+  }
+
+  return c.json(buildTemplatePrompt(template));
+});
+
+sidekickApp.get("/prompt/existing", async (c) => {
+  const auth = c.get("auth");
+  const agentConfigurationId = c.req.query("agentConfigurationId");
+  if (!agentConfigurationId) {
+    return c.json(
+      {
+        error: {
+          type: "unprocessable_entity",
+          message:
+            "The agentConfigurationId query parameter is invalid or missing.",
+        },
+      },
+      422
+    );
+  }
+
+  return c.json(await buildExistingAgentPrompt(auth, agentConfigurationId));
+});
+
+sidekickApp.get("/prompt/shrink-wrap", async (c) => {
+  const auth = c.get("auth");
+  const conversationId = c.req.query("conversationId");
+  if (!conversationId) {
+    return c.json(
+      {
+        error: {
+          type: "unprocessable_entity",
+          message: "The conversationId query parameter is invalid or missing.",
+        },
+      },
+      422
+    );
+  }
+
+  const result = await buildShrinkWrapPromptForConversation(
+    auth,
+    conversationId
+  );
+  if (result.isErr()) {
+    return jsonApiError(c, getConversationApiError(result.error));
+  }
+  return c.json(result.value);
+});

--- a/front-api/routes/w/assistant/builder/slack.ts
+++ b/front-api/routes/w/assistant/builder/slack.ts
@@ -1,0 +1,111 @@
+import { Hono } from "hono";
+
+import config from "@app/lib/api/config";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import logger from "@app/logger/logger";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+
+// Mounted under /api/w/:wId/assistant/builder/slack.
+
+export const slackApp = new Hono();
+
+slackApp.get("/channels_linked_with_agent", async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isBuilder()) {
+    return c.json(
+      {
+        error: {
+          type: "data_source_auth_error",
+          message:
+            "Only the users that are `builders` for the current workspace can modify linked Slack channels.",
+        },
+      },
+      403
+    );
+  }
+
+  const [[dataSourceSlack], [dataSourceSlackBot]] = await Promise.all([
+    DataSourceResource.listByConnectorProvider(auth, "slack"),
+    DataSourceResource.listByConnectorProvider(auth, "slack_bot"),
+  ]);
+
+  let isSlackBotEnabled = false;
+  if (dataSourceSlackBot && dataSourceSlackBot.connectorId) {
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+    const configRes = await connectorsAPI.getConnectorConfig(
+      dataSourceSlackBot.connectorId,
+      "botEnabled"
+    );
+    if (configRes.isOk()) {
+      isSlackBotEnabled = configRes.value.configValue === "true";
+    }
+  }
+
+  const provider = isSlackBotEnabled ? "slack_bot" : "slack";
+  const dataSource = isSlackBotEnabled ? dataSourceSlackBot : dataSourceSlack;
+
+  if (!dataSource) {
+    return c.json({ provider, slackChannels: [], slackDataSource: undefined });
+  }
+
+  if (!dataSource.connectorId) {
+    return c.json(
+      {
+        error: {
+          type: "data_source_not_managed",
+          message: "The data source you requested is not managed.",
+        },
+      },
+      400
+    );
+  }
+
+  if (
+    !dataSource.connectorProvider ||
+    (dataSource.connectorProvider !== "slack_bot" &&
+      dataSource.connectorProvider !== "slack")
+  ) {
+    return c.json(
+      {
+        error: {
+          type: "data_source_not_managed",
+          message:
+            "The data source you requested is not managed by a slack connector.",
+        },
+      },
+      400
+    );
+  }
+
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+  const linkedSlackChannelsRes =
+    await connectorsAPI.getSlackChannelsLinkedWithAgent({
+      connectorId: dataSource.connectorId,
+    });
+
+  if (linkedSlackChannelsRes.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message:
+            "An error occurred while fetching the linked Slack channels.",
+        },
+      },
+      500
+    );
+  }
+
+  return c.json({
+    provider,
+    slackChannels: linkedSlackChannelsRes.value.slackChannels,
+    slackDataSource: dataSource.toJSON(),
+  });
+});

--- a/front-api/routes/w/assistant/index.ts
+++ b/front-api/routes/w/assistant/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import { builderApp } from "./builder";
+
+// Mounted at /api/w/:wId/assistant. workspaceAuth is applied by the parent
+// workspace sub-app.
+export const assistantApp = new Hono();
+
+assistantApp.route("/builder", builderApp);

--- a/front-api/routes/w/index.ts
+++ b/front-api/routes/w/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { workspaceAuth } from "../../middleware/workspace_auth";
+import { assistantApp } from "./assistant";
 import { featureFlagsApp } from "./feature-flags";
 import { membersApp } from "./members";
 import { modelsApp } from "./models";
@@ -18,6 +19,7 @@ export const workspaceApp = new Hono();
 
 workspaceApp.use("*", workspaceAuth);
 
+workspaceApp.route("/assistant", assistantApp);
 workspaceApp.route("/feature-flags", featureFlagsApp);
 workspaceApp.route("/members", membersApp);
 workspaceApp.route("/models", modelsApp);

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -314,6 +314,81 @@ When migrating a new handler, add the marker to the Next file immediately.
 
 Reviewer: If a PR touches a file that is part of a migrated pair (either a Next file with a `@migration-target` marker, or a Hono file that is the target of such a marker), verify the counterpart is also updated in the same PR.
 
+### [BACK18] Business-layer code must not return HTTP error envelopes
+
+Functions in `lib/api/*` (and other shared business-logic modules) must
+not return `APIErrorWithStatusCode` or anything else that bakes in an HTTP
+status code. HTTP is a transport concern of the handler layer.
+
+The reason: a `lib/api/*` function may be called from many places — Next
+handlers, Hono handlers, Temporal activities, scripts, tests. The status
+code only makes sense at the transport boundary. Putting it in the
+business layer either forces non-HTTP callers to invent fake status codes,
+or (more commonly) leaks one transport's response shape into code that
+should be transport-agnostic.
+
+When a business function needs to signal failure, return a domain error —
+typically `Result<T, SomeDomainError>` where `SomeDomainError` is a class
+or discriminated union of the actual failure conditions. Handlers map the
+domain error to whatever HTTP shape they need.
+
+Example:
+
+```ts
+// BAD — business layer encoding HTTP status codes
+export async function getThing(
+  auth: Authenticator,
+  id: string
+): Promise<Result<Thing, APIErrorWithStatusCode>> {
+  if (!found) {
+    return new Err({
+      status_code: 404,
+      api_error: { type: "thing_not_found", message: "Not found." },
+    });
+  }
+  // ...
+}
+
+// GOOD — domain error, handler maps to HTTP
+export class ThingError extends Error {
+  constructor(readonly type: "not_found" | "unauthorized") {
+    super(type);
+  }
+}
+
+export async function getThing(
+  auth: Authenticator,
+  id: string
+): Promise<Result<Thing, ThingError>> {
+  if (!found) {
+    return new Err(new ThingError("not_found"));
+  }
+  // ...
+}
+
+// Handler does the mapping:
+const result = await getThing(auth, id);
+if (result.isErr()) {
+  switch (result.error.type) {
+    case "not_found": return apiError(req, res, { status_code: 404, ... });
+    case "unauthorized": return apiError(req, res, { status_code: 403, ... });
+  }
+}
+```
+
+**Pragmatic exception:** if the error model is genuinely HTTP-flavored
+(status + error type are tied to HTTP semantics with no underlying domain
+distinction worth modeling), it's better to keep the logic in the handler
+than to invent a synthetic domain enum. A 50-line handler with HTTP
+responses inline is fine; duplicating it across Next and Hono is the
+expected cost of the migration. The wrong move is to extract a lib helper
+that returns `Result<T, APIErrorWithStatusCode>` just to deduplicate —
+that hides the HTTP coupling instead of removing it.
+
+Reviewer: If you see a `lib/api/*` function returning `APIErrorWithStatusCode`,
+require the author to either (a) introduce a domain error type, or (b) move
+the logic back into the handlers and accept the duplication.
+
 ## AUDIT LOGGING
 
 ### [AUDIT1] Every state-changing operation on a security-sensitive resource MUST emit an audit log event

--- a/front/lib/api/assistant/builder/sidekick_prompts.ts
+++ b/front/lib/api/assistant/builder/sidekick_prompts.ts
@@ -1,0 +1,370 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { renderConversationAsTextWithFeedback } from "@app/lib/api/assistant/conversation/render_conversation_with_feedback";
+import type { AgentMessageFeedbackWithMetadataType } from "@app/lib/api/assistant/feedback";
+import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
+import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { TemplateResource } from "@app/lib/resources/template_resource";
+import logger from "@app/logger/logger";
+import { ConversationError } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const FEEDBACK_LIMIT = 50;
+const OLDER_FEEDBACK_LIMIT = 10;
+const OLDER_FEEDBACK_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000; // 3 months
+const INSIGHTS_DAYS = 30;
+const MAX_PENDING_SUGGESTIONS_IN_FIRST_MESSAGE = 20;
+
+// ─── Template prompt ─────────────────────────────────────────────────────
+
+export function buildTemplatePrompt({
+  handle,
+  sidekickInstructions,
+  agentFacingDescription,
+}: TemplateResource): string {
+  return `<dust_system>
+The user is creating a new agent based on the "${handle}" template.
+NEVER call \`get_agent_config\` in this first message.
+Here is a brief description of what the agent should do:
+
+<description>
+${agentFacingDescription}
+</description>
+
+Follow the <using_templates> section from your instructions to act on the sidekickInstructions below.
+
+<sidekickInstructions>
+${sidekickInstructions}
+</sidekickInstructions>
+</dust_system>`;
+}
+
+// ─── Existing-agent prompt ───────────────────────────────────────────────
+
+function buildExistingAgentMessage({
+  feedbackMarkdown,
+  insightsMarkdown,
+  pendingSuggestions,
+}: {
+  feedbackMarkdown: string | null;
+  insightsMarkdown: string | null;
+  pendingSuggestions: Array<{ sId: string; kind: string }>;
+}): string {
+  const dataSections = [feedbackMarkdown, insightsMarkdown]
+    .filter(Boolean)
+    .join("\n\n");
+
+  const suggestionDirectives =
+    pendingSuggestions.length > 0 &&
+    pendingSuggestions
+      .map((s) => `:agent_suggestion[]{sId=${s.sId} kind=${s.kind}}`)
+      .join("\n");
+
+  const pendingSuggestionsSection = suggestionDirectives
+    ? `
+<pending_suggestions>
+Output these directives verbatim so the suggestion cards render:
+${suggestionDirectives}
+</pending_suggestions>`
+    : "";
+
+  return `<dust_system>
+This is an existing agent.
+
+## Opening message
+Do NOT call \`get_agent_config\` in this first message. Based only on the information provided in <existing_agent_data_section>:
+- If pending suggestions exist (see <pending_suggestions> below), output their directives to render them as cards.
+- If negative feedback patterns exist in the current agent version, mention it as the top issue. Feedback from previous versions are provided for reference, but should not be mentioned in the opening message.
+
+In addition, ask the user if you should suggest additional improvements or if there is something specific they'd like to work on.
+Keep the first message to 1–2 sentences (plus any suggestion cards from <pending_suggestions>). Response must fit in the sidekick panel without scrolling.
+Do not make assumptions about the users's intent. Given that this is an existing agent, the user is likely to be asking for specific improvements or to work on a specific issue.
+
+<existing_agent_data_section>
+${dataSections ? `\n${dataSections}\n` : ""}
+</existing_agent_data_section>
+${pendingSuggestionsSection}
+</dust_system>`;
+}
+
+function formatFeedbackItem(f: AgentMessageFeedbackWithMetadataType): string {
+  const direction = f.thumbDirection === "up" ? "POSITIVE" : "NEGATIVE";
+  const content = f.content ? `: ${f.content}` : "";
+  return `- [${direction}]${content}`;
+}
+
+function appendFeedbackSection(
+  lines: string[],
+  title: string,
+  items: AgentMessageFeedbackWithMetadataType[]
+): void {
+  if (items.length === 0) {
+    return;
+  }
+  const positive = items.filter((f) => f.thumbDirection === "up").length;
+  const negative = items.filter((f) => f.thumbDirection === "down").length;
+  lines.push(
+    "",
+    `${title} (${items.length} total, ${positive} positive, ${negative} negative):`
+  );
+  for (const f of items) {
+    lines.push(formatFeedbackItem(f));
+  }
+}
+
+async function fetchFeedbackMarkdown(
+  auth: Authenticator,
+  agentConfigurationId: string
+): Promise<string | null> {
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "light",
+  });
+
+  if (!agentConfiguration) {
+    return null;
+  }
+
+  const currentVersion = agentConfiguration.version;
+
+  const feedbacksRes = await getAgentFeedbacks({
+    auth,
+    agentConfigurationId,
+    withMetadata: true,
+    paginationParams: {
+      limit: FEEDBACK_LIMIT,
+      orderColumn: "id",
+      orderDirection: "desc",
+    },
+    filter: "active",
+  });
+
+  if (feedbacksRes.isErr()) {
+    logger.warn(
+      { err: feedbacksRes.error },
+      "Failed to fetch feedback for sidekick first message"
+    );
+    return null;
+  }
+
+  const feedbacks = feedbacksRes.value.filter(
+    (f): f is AgentMessageFeedbackWithMetadataType => true
+  );
+
+  if (feedbacks.length === 0) {
+    return null;
+  }
+
+  const latestVersionFeedback = feedbacks.filter(
+    (f) => f.agentConfigurationVersion === currentVersion
+  );
+
+  const cutoffMs = Date.now() - OLDER_FEEDBACK_MAX_AGE_MS;
+  const olderFeedback = feedbacks
+    .filter(
+      (f) =>
+        f.agentConfigurationVersion !== currentVersion &&
+        new Date(f.createdAt).getTime() >= cutoffMs
+    )
+    .slice(0, OLDER_FEEDBACK_LIMIT);
+
+  if (latestVersionFeedback.length === 0 && olderFeedback.length === 0) {
+    return null;
+  }
+
+  const lines = ["<feedback>"];
+  appendFeedbackSection(
+    lines,
+    `Current version (v${currentVersion})`,
+    latestVersionFeedback
+  );
+  appendFeedbackSection(lines, "Previous versions", olderFeedback);
+  lines.push("</feedback>");
+  return lines.join("\n");
+}
+
+async function fetchInsightsMarkdown(
+  auth: Authenticator,
+  agentConfigurationId: string
+): Promise<string | null> {
+  const owner = auth.getNonNullableWorkspace();
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    agentId: agentConfigurationId,
+    days: INSIGHTS_DAYS,
+  });
+
+  const overviewResult = await fetchAgentOverview(baseQuery, INSIGHTS_DAYS);
+
+  if (overviewResult.isErr()) {
+    logger.warn(
+      { err: overviewResult.error },
+      "Failed to fetch insights for sidekick first message"
+    );
+    return null;
+  }
+
+  const o = overviewResult.value;
+  return [
+    "<insights>",
+    `Period: last ${INSIGHTS_DAYS} days`,
+    `Active users: ${o.activeUsers}`,
+    `Conversations: ${o.conversationCount}`,
+    `Messages: ${o.messageCount}`,
+    `Feedback: ${o.positiveFeedbacks} positive, ${o.negativeFeedbacks} negative`,
+    "</insights>",
+  ].join("\n");
+}
+
+/**
+ * Builds the sidekick first-message for an existing agent. Fetches feedback,
+ * insights, and pending suggestions in parallel and assembles them into the
+ * dust_system prompt.
+ */
+export async function buildExistingAgentPrompt(
+  auth: Authenticator,
+  agentConfigurationId: string
+): Promise<string> {
+  const [feedbackMarkdown, insightsMarkdown, pendingSuggestions] =
+    await Promise.all([
+      fetchFeedbackMarkdown(auth, agentConfigurationId),
+      fetchInsightsMarkdown(auth, agentConfigurationId),
+      AgentSuggestionResource.listByAgentConfigurationId(
+        auth,
+        agentConfigurationId,
+        {
+          states: ["pending"],
+          limit: MAX_PENDING_SUGGESTIONS_IN_FIRST_MESSAGE,
+        }
+      ),
+    ]);
+
+  return buildExistingAgentMessage({
+    feedbackMarkdown,
+    insightsMarkdown,
+    pendingSuggestions: pendingSuggestions.map((s) => ({
+      sId: s.sId,
+      kind: s.kind,
+    })),
+  });
+}
+
+// ─── Shrink-wrap prompt ──────────────────────────────────────────────────
+
+export function buildShrinkWrapPrompt(
+  shrinkWrappedConversation: string
+): string {
+  return `<dust_system>
+Your task is to analyze the conversation below and suggest a configuration for a new agent
+that can replicate its workflow with different inputs.
+
+Think of it as distilling a multi-turn conversation into an efficient, single-execution agent.
+
+Read the conversation timeline chronologically. The final messages best reflect the user's true
+intent — when users refined mid-conversation ("actually do X", "also add Y", "change the format"),
+the new agent must handle the FULL final scope, not intermediate states.
+
+Identify:
+- Primary use case: What problem is ultimately being solved? (look at the final output)
+- Required parameters: What INPUTS varied or were provided across the conversation?
+- Required capabilities: What tools, skills, or data sources were invoked?
+
+<conversation_data>
+The conversation is a chronological timeline: each message has an index, sId, sender (user or
+agent name), actions (tool invocations), and content.
+- If content ismarked "(truncated)", call \`inspect_message\` only if you need the full content.
+- Call \`inspect_message\` when you need the exact argument shape for a tool (e.g. query,
+  childAgent.uri, filters) to write generalized instructions — extract the shape, not literal values.
+- Never call \`inspect_message\` speculatively on every message, on user messages unless truncated,
+  or on simple text-only responses.
+</conversation_data>
+
+<sub-agent_handling>
+If \`inspect_conversation\` returns a \`childConversationId\` in any action and it is relevant to the final output, call
+\`inspect_conversation\` on that child before deciding whether you need \`inspect_message\`
+on any of its messages. Do NOT duplicate sub-agent logic via instruction suggestions — prefer to reuse existing
+agents via sub-agent configuration.
+</sub-agent_handling>
+
+<generalizing>
+It is imperative you refer to <generalization_over_examples> to avoid hardcoding literal values.
+When users iterated on a conversation output (e.g., changed topic, added constraint, refined format), the final agent
+should gather ALL parameters that were eventually needed — not branch conditionally on them.
+
+Example:
+- Conversation: "write poem about flowers" → "actually mountains" → "include the word 'door'"
+- WRONG: conditionals for each refinement
+- RIGHT: "Gather the poem topic and any specific words to include. Write a poem incorporating those."
+</generalizing>
+
+<identifying_knowledge_sources>
+Step 1 — Scan \`inspect_conversation\` for knowledge-access actions. Look for tool names:
+- \`semantic_search\` (server: \`search\`), \`retrieve_recent_documents\` (server: \`project_manager\`) → semantic / recent retrieval
+- \`cat\`, \`find\`, \`list\`, \`locate_in_tree\` → filesystem browsing (server: \`data_sources_file_system\`)
+- \`query_tables\`, \`get_database_schema\` → table/SQL access
+- \`run_agent\` → sub-agent (inspect child conversation separately)
+
+Step 2 — Call \`inspect_message\` on those specific messages. In the tool call Input JSON, look for:
+- \`dataSources[].uri\` — exact data source URI (most reliable)
+- \`query\` — what was retrieved (use to explain WHY to recommend the source)
+
+Step 3 — Corroborate with citations. \`:cite[ref]\` directives in agent responses confirm which
+sources were actually used. Prioritize sources that appear in both tool inputs AND citations.
+
+Step 4 — Recommend with context, never auto-add. For each source, suggest it with a one-line
+reason tied to its role: e.g. "Notion: used to retrieve project briefs for the report".
+</identifying_knowledge_sources>
+
+<mapping_to_suggestions>
+- Tools/Skills: Suggest based on the Actions list in the conversation.
+- Knowledge: Follow <identifying_knowledge_sources>; one-line reason per source, never auto-add.
+</mapping_to_suggestions>
+
+Here is the conversation to analyze:
+
+<conversation>
+${shrinkWrappedConversation}
+</conversation>
+
+Before suggesting agent instructions, confirm your understanding:
+- Goal: What problem this agent solves
+- Inputs: What parameters/data users will provide
+- Outputs: What the agent will produce
+
+Unless the conversation is very short and unambiguous, wait for confirmation before generating
+the full suggestion set.
+</dust_system>`;
+}
+
+/**
+ * Builds the shrink-wrap sidekick first-message for an existing conversation.
+ * Returns Err with a `ConversationError` (or the original render error) if
+ * the conversation can't be accessed or rendered.
+ */
+export async function buildShrinkWrapPromptForConversation(
+  auth: Authenticator,
+  conversationId: string
+): Promise<Result<string, Error>> {
+  const conversationRes = await renderConversationAsTextWithFeedback(auth, {
+    conversationId,
+  });
+
+  if (conversationRes.isErr()) {
+    // Distinguish "not found" vs. "access restricted" for the UI.
+    const canAccess = await ConversationResource.canAccess(
+      auth,
+      conversationId
+    );
+    const error =
+      canAccess === "conversation_access_restricted"
+        ? new ConversationError("conversation_access_restricted")
+        : conversationRes.error;
+    return new Err(error);
+  }
+
+  return new Ok(buildShrinkWrapPrompt(conversationRes.value.text));
+}

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -1,6 +1,7 @@
 import { apiError } from "@app/logger/withlogging";
 import type { ConversationErrorType } from "@app/types/assistant/conversation";
 import { ConversationError } from "@app/types/assistant/conversation";
+import type { APIErrorWithStatusCode } from "@app/types/error";
 import { isOverflowingDBString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -15,33 +16,40 @@ const STATUS_FOR_ERROR_TYPE: Record<ConversationErrorType, number> = {
   conversation_context_usage_not_found: 404,
 };
 
-export function apiErrorForConversation(
-  req: NextApiRequest,
-  res: NextApiResponse,
-  error: Error
-) {
+/**
+ * Maps a conversation error to the standard `{ status_code, api_error }`
+ * shape. Use this from any framework (Next or Hono) — only the response
+ * dispatch differs.
+ */
+export function getConversationApiError(error: Error): APIErrorWithStatusCode {
   if (error instanceof ConversationError) {
-    return apiError(req, res, {
+    return {
       status_code: STATUS_FOR_ERROR_TYPE[error.type],
       api_error: {
         type: error.type,
         message: error.message,
       },
-    });
+    };
   }
-
-  return apiError(
-    req,
-    res,
-    {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "An internal server error occurred.",
-      },
+  return {
+    status_code: 500,
+    api_error: {
+      type: "internal_server_error",
+      message: "An internal server error occurred.",
     },
-    error
-  );
+  };
+}
+
+export function apiErrorForConversation(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  error: Error
+) {
+  const apiErr = getConversationApiError(error);
+  if (error instanceof ConversationError) {
+    return apiError(req, res, apiErr);
+  }
+  return apiError(req, res, apiErr, error);
 }
 
 export function isUserMessageContextOverflowing(context: {

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -1,4 +1,6 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/assistant/builder/process.ts
 import { getBuilderJsonSchemaGenerator } from "@app/lib/api/assistant/json_schema_generator";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {

--- a/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/existing.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/existing.ts
@@ -1,202 +1,13 @@
 /** @ignoreswagger */
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { AgentMessageFeedbackWithMetadataType } from "@app/lib/api/assistant/feedback";
-import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
-import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/assistant/builder/sidekick.ts
+import { buildExistingAgentPrompt } from "@app/lib/api/assistant/builder/sidekick_prompts";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-const FEEDBACK_LIMIT = 50;
-const OLDER_FEEDBACK_LIMIT = 10;
-const OLDER_FEEDBACK_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000; // 3 months
-const INSIGHTS_DAYS = 30;
-const MAX_PENDING_SUGGESTIONS_IN_FIRST_MESSAGE = 20;
-
-function buildFirstMessage({
-  feedbackMarkdown,
-  insightsMarkdown,
-  pendingSuggestions,
-}: {
-  feedbackMarkdown: string | null;
-  insightsMarkdown: string | null;
-  pendingSuggestions: Array<{ sId: string; kind: string }>;
-}): string {
-  const dataSections = [feedbackMarkdown, insightsMarkdown]
-    .filter(Boolean)
-    .join("\n\n");
-
-  const suggestionDirectives =
-    pendingSuggestions.length > 0 &&
-    pendingSuggestions
-      .map((s) => `:agent_suggestion[]{sId=${s.sId} kind=${s.kind}}`)
-      .join("\n");
-
-  const pendingSuggestionsSection = suggestionDirectives
-    ? `
-<pending_suggestions>
-Output these directives verbatim so the suggestion cards render:
-${suggestionDirectives}
-</pending_suggestions>`
-    : "";
-
-  return `<dust_system>
-This is an existing agent.
-
-## Opening message
-Do NOT call \`get_agent_config\` in this first message. Based only on the information provided in <existing_agent_data_section>:
-- If pending suggestions exist (see <pending_suggestions> below), output their directives to render them as cards.
-- If negative feedback patterns exist in the current agent version, mention it as the top issue. Feedback from previous versions are provided for reference, but should not be mentioned in the opening message.
-
-In addition, ask the user if you should suggest additional improvements or if there is something specific they'd like to work on.
-Keep the first message to 1–2 sentences (plus any suggestion cards from <pending_suggestions>). Response must fit in the sidekick panel without scrolling.
-Do not make assumptions about the users's intent. Given that this is an existing agent, the user is likely to be asking for specific improvements or to work on a specific issue.
-
-<existing_agent_data_section>
-${dataSections ? `\n${dataSections}\n` : ""}
-</existing_agent_data_section>
-${pendingSuggestionsSection}
-</dust_system>`;
-}
-
-function formatFeedbackItem(f: AgentMessageFeedbackWithMetadataType): string {
-  const direction = f.thumbDirection === "up" ? "POSITIVE" : "NEGATIVE";
-  const content = f.content ? `: ${f.content}` : "";
-  return `- [${direction}]${content}`;
-}
-
-function appendFeedbackSection(
-  lines: string[],
-  title: string,
-  items: AgentMessageFeedbackWithMetadataType[]
-): void {
-  if (items.length === 0) {
-    return;
-  }
-  const positive = items.filter((f) => f.thumbDirection === "up").length;
-  const negative = items.filter((f) => f.thumbDirection === "down").length;
-  lines.push(
-    "",
-    `${title} (${items.length} total, ${positive} positive, ${negative} negative):`
-  );
-  for (const f of items) {
-    lines.push(formatFeedbackItem(f));
-  }
-}
-
-async function fetchFeedbackMarkdown(
-  auth: Authenticator,
-  agentConfigurationId: string
-): Promise<string | null> {
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: agentConfigurationId,
-    variant: "light",
-  });
-
-  if (!agentConfiguration) {
-    return null;
-  }
-
-  const currentVersion = agentConfiguration.version;
-
-  const feedbacksRes = await getAgentFeedbacks({
-    auth,
-    agentConfigurationId,
-    withMetadata: true,
-    paginationParams: {
-      limit: FEEDBACK_LIMIT,
-      orderColumn: "id",
-      orderDirection: "desc",
-    },
-    filter: "active",
-  });
-
-  if (feedbacksRes.isErr()) {
-    logger.warn(
-      { err: feedbacksRes.error },
-      "Failed to fetch feedback for sidekick first message"
-    );
-    return null;
-  }
-
-  const feedbacks = feedbacksRes.value.filter(
-    (f): f is AgentMessageFeedbackWithMetadataType => true
-  );
-
-  if (feedbacks.length === 0) {
-    return null;
-  }
-
-  const latestVersionFeedback = feedbacks.filter(
-    (f) => f.agentConfigurationVersion === currentVersion
-  );
-
-  const cutoffMs = Date.now() - OLDER_FEEDBACK_MAX_AGE_MS;
-  const olderFeedback = feedbacks
-    .filter(
-      (f) =>
-        f.agentConfigurationVersion !== currentVersion &&
-        new Date(f.createdAt).getTime() >= cutoffMs
-    )
-    .slice(0, OLDER_FEEDBACK_LIMIT);
-
-  if (latestVersionFeedback.length === 0 && olderFeedback.length === 0) {
-    return null;
-  }
-
-  const lines = ["<feedback>"];
-
-  appendFeedbackSection(
-    lines,
-    `Current version (v${currentVersion})`,
-    latestVersionFeedback
-  );
-  appendFeedbackSection(lines, "Previous versions", olderFeedback);
-
-  lines.push("</feedback>");
-  return lines.join("\n");
-}
-
-async function fetchInsightsMarkdown(
-  auth: Authenticator,
-  agentConfigurationId: string
-): Promise<string | null> {
-  const owner = auth.getNonNullableWorkspace();
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: agentConfigurationId,
-    days: INSIGHTS_DAYS,
-  });
-
-  const overviewResult = await fetchAgentOverview(baseQuery, INSIGHTS_DAYS);
-
-  if (overviewResult.isErr()) {
-    logger.warn(
-      { err: overviewResult.error },
-      "Failed to fetch insights for sidekick first message"
-    );
-    return null;
-  }
-
-  const o = overviewResult.value;
-  const lines = [
-    "<insights>",
-    `Period: last ${INSIGHTS_DAYS} days`,
-    `Active users: ${o.activeUsers}`,
-    `Conversations: ${o.conversationCount}`,
-    `Messages: ${o.messageCount}`,
-    `Feedback: ${o.positiveFeedbacks} positive, ${o.negativeFeedbacks} negative`,
-    "</insights>",
-  ];
-
-  return lines.join("\n");
-}
 
 async function handler(
   req: NextApiRequest,
@@ -218,30 +29,9 @@ async function handler(
         });
       }
 
-      const [feedbackMarkdown, insightsMarkdown, pendingSuggestions] =
-        await Promise.all([
-          fetchFeedbackMarkdown(auth, agentConfigurationId),
-          fetchInsightsMarkdown(auth, agentConfigurationId),
-          AgentSuggestionResource.listByAgentConfigurationId(
-            auth,
-            agentConfigurationId,
-            {
-              states: ["pending"],
-              limit: MAX_PENDING_SUGGESTIONS_IN_FIRST_MESSAGE,
-            }
-          ),
-        ]);
-
-      return res.status(200).json(
-        buildFirstMessage({
-          feedbackMarkdown,
-          insightsMarkdown,
-          pendingSuggestions: pendingSuggestions.map((s) => ({
-            sId: s.sId,
-            kind: s.kind,
-          })),
-        })
-      );
+      return res
+        .status(200)
+        .json(await buildExistingAgentPrompt(auth, agentConfigurationId));
     }
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/shrink-wrap.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/shrink-wrap.ts
@@ -1,99 +1,14 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/assistant/builder/sidekick.ts
+import { buildShrinkWrapPromptForConversation } from "@app/lib/api/assistant/builder/sidekick_prompts";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
-
-import { renderConversationAsTextWithFeedback } from "@app/lib/api/assistant/conversation/render_conversation_with_feedback";
-
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
-import { ConversationError } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export function buildFirstMessage(shrinkWrappedConversation: string): string {
-  return `<dust_system>
-Your task is to analyze the conversation below and suggest a configuration for a new agent
-that can replicate its workflow with different inputs.
-
-Think of it as distilling a multi-turn conversation into an efficient, single-execution agent.
-
-Read the conversation timeline chronologically. The final messages best reflect the user's true
-intent — when users refined mid-conversation ("actually do X", "also add Y", "change the format"),
-the new agent must handle the FULL final scope, not intermediate states.
-
-Identify:
-- Primary use case: What problem is ultimately being solved? (look at the final output)
-- Required parameters: What INPUTS varied or were provided across the conversation?
-- Required capabilities: What tools, skills, or data sources were invoked?
-
-<conversation_data>
-The conversation is a chronological timeline: each message has an index, sId, sender (user or
-agent name), actions (tool invocations), and content.
-- If content ismarked "(truncated)", call \`inspect_message\` only if you need the full content.
-- Call \`inspect_message\` when you need the exact argument shape for a tool (e.g. query,
-  childAgent.uri, filters) to write generalized instructions — extract the shape, not literal values.
-- Never call \`inspect_message\` speculatively on every message, on user messages unless truncated,
-  or on simple text-only responses.
-</conversation_data>
-
-<sub-agent_handling>
-If \`inspect_conversation\` returns a \`childConversationId\` in any action and it is relevant to the final output, call
-\`inspect_conversation\` on that child before deciding whether you need \`inspect_message\`
-on any of its messages. Do NOT duplicate sub-agent logic via instruction suggestions — prefer to reuse existing
-agents via sub-agent configuration.
-</sub-agent_handling>
-
-<generalizing>
-It is imperative you refer to <generalization_over_examples> to avoid hardcoding literal values.
-When users iterated on a conversation output (e.g., changed topic, added constraint, refined format), the final agent
-should gather ALL parameters that were eventually needed — not branch conditionally on them.
-
-Example:
-- Conversation: "write poem about flowers" → "actually mountains" → "include the word 'door'"
-- WRONG: conditionals for each refinement
-- RIGHT: "Gather the poem topic and any specific words to include. Write a poem incorporating those."
-</generalizing>
-
-<identifying_knowledge_sources>
-Step 1 — Scan \`inspect_conversation\` for knowledge-access actions. Look for tool names:
-- \`semantic_search\` (server: \`search\`), \`retrieve_recent_documents\` (server: \`project_manager\`) → semantic / recent retrieval
-- \`cat\`, \`find\`, \`list\`, \`locate_in_tree\` → filesystem browsing (server: \`data_sources_file_system\`)
-- \`query_tables\`, \`get_database_schema\` → table/SQL access
-- \`run_agent\` → sub-agent (inspect child conversation separately)
-
-Step 2 — Call \`inspect_message\` on those specific messages. In the tool call Input JSON, look for:
-- \`dataSources[].uri\` — exact data source URI (most reliable)
-- \`query\` — what was retrieved (use to explain WHY to recommend the source)
-
-Step 3 — Corroborate with citations. \`:cite[ref]\` directives in agent responses confirm which
-sources were actually used. Prioritize sources that appear in both tool inputs AND citations.
-
-Step 4 — Recommend with context, never auto-add. For each source, suggest it with a one-line
-reason tied to its role: e.g. "Notion: used to retrieve project briefs for the report".
-</identifying_knowledge_sources>
-
-<mapping_to_suggestions>
-- Tools/Skills: Suggest based on the Actions list in the conversation.
-- Knowledge: Follow <identifying_knowledge_sources>; one-line reason per source, never auto-add.
-</mapping_to_suggestions>
-
-Here is the conversation to analyze:
-
-<conversation>
-${shrinkWrappedConversation}
-</conversation>
-
-Before suggesting agent instructions, confirm your understanding:
-- Goal: What problem this agent solves
-- Inputs: What parameters/data users will provide
-- Outputs: What the agent will produce
-
-Unless the conversation is very short and unambiguous, wait for confirmation before generating
-the full suggestion set.
-</dust_system>`;
-}
 
 async function handler(
   req: NextApiRequest,
@@ -114,26 +29,14 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const conversationRes = await renderConversationAsTextWithFeedback(auth, {
-        conversationId,
-      });
-
-      if (conversationRes.isErr()) {
-        // Distinguish between "not found" and "access restricted" for the UI.
-        const canAccess = await ConversationResource.canAccess(
-          auth,
-          conversationId
-        );
-        const error =
-          canAccess === "conversation_access_restricted"
-            ? new ConversationError("conversation_access_restricted")
-            : conversationRes.error;
-        return apiErrorForConversation(req, res, error);
+      const result = await buildShrinkWrapPromptForConversation(
+        auth,
+        conversationId
+      );
+      if (result.isErr()) {
+        return apiErrorForConversation(req, res, result.error);
       }
-
-      return res
-        .status(200)
-        .json(buildFirstMessage(conversationRes.value.text));
+      return res.status(200).json(result.value);
     }
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/template.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/sidekick/prompt/template.ts
@@ -1,4 +1,7 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/assistant/builder/sidekick.ts
+import { buildTemplatePrompt } from "@app/lib/api/assistant/builder/sidekick_prompts";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { TemplateResource } from "@app/lib/resources/template_resource";
@@ -6,28 +9,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-function buildTemplateAgentInitMessage({
-  handle,
-  sidekickInstructions,
-  agentFacingDescription,
-}: TemplateResource): string {
-  return `<dust_system>
-The user is creating a new agent based on the "${handle}" template.
-NEVER call \`get_agent_config\` in this first message.
-Here is a brief description of what the agent should do:
-
-<description>
-${agentFacingDescription}
-</description>
-
-Follow the <using_templates> section from your instructions to act on the sidekickInstructions below.
-
-<sidekickInstructions>
-${sidekickInstructions}
-</sidekickInstructions>
-</dust_system>`;
-}
 
 async function handler(
   req: NextApiRequest,
@@ -60,7 +41,7 @@ async function handler(
         });
       }
 
-      return res.status(200).json(buildTemplateAgentInitMessage(template));
+      return res.status(200).json(buildTemplatePrompt(template));
     }
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent.ts
@@ -1,4 +1,6 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/assistant/builder/slack.ts
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -21,14 +23,23 @@ export type GetSlackChannelsLinkedWithAgentResponseBody = {
   slackDataSource?: DataSourceType;
 };
 
-export async function handleSlackChannelsLinkedWithAgent(
+async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<GetSlackChannelsLinkedWithAgentResponseBody>
   >,
-  auth: Authenticator,
-  connectorProvider: Extract<ConnectorProvider, "slack" | "slack_bot">
+  auth: Authenticator
 ): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
   if (!auth.isBuilder()) {
     return apiError(req, res, {
       status_code: 403,
@@ -44,6 +55,7 @@ export async function handleSlackChannelsLinkedWithAgent(
     DataSourceResource.listByConnectorProvider(auth, "slack"),
     DataSourceResource.listByConnectorProvider(auth, "slack_bot"),
   ]);
+
   let isSlackBotEnabled = false;
   if (dataSourceSlackBot && dataSourceSlackBot.connectorId) {
     const connectorsAPI = new ConnectorsAPI(
@@ -89,60 +101,36 @@ export async function handleSlackChannelsLinkedWithAgent(
       status_code: 400,
       api_error: {
         type: "data_source_not_managed",
-        message: `The data source you requested is not managed by a ${connectorProvider} connector.`,
+        message:
+          "The data source you requested is not managed by a slack connector.",
       },
     });
   }
 
-  switch (req.method) {
-    case "GET":
-      const connectorsAPI = new ConnectorsAPI(
-        config.getConnectorsAPIConfig(),
-        logger
-      );
-      const linkedSlackChannelsRes =
-        await connectorsAPI.getSlackChannelsLinkedWithAgent({
-          connectorId: dataSource.connectorId,
-        });
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+  const linkedSlackChannelsRes =
+    await connectorsAPI.getSlackChannelsLinkedWithAgent({
+      connectorId: dataSource.connectorId,
+    });
 
-      if (linkedSlackChannelsRes.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: `An error occurred while fetching the linked Slack channels.`,
-          },
-        });
-      }
-
-      res.status(200).json({
-        provider,
-        slackChannels: linkedSlackChannelsRes.value.slackChannels,
-        slackDataSource: dataSource.toJSON(),
-      });
-
-      break;
-
-    default:
-      return apiError(req, res, {
-        status_code: 405,
-        api_error: {
-          type: "method_not_supported_error",
-          message:
-            "The method passed is not supported, GET or POST is expected.",
-        },
-      });
+  if (linkedSlackChannelsRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "An error occurred while fetching the linked Slack channels.",
+      },
+    });
   }
-}
 
-async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<GetSlackChannelsLinkedWithAgentResponseBody>
-  >,
-  auth: Authenticator
-): Promise<void> {
-  return handleSlackChannelsLinkedWithAgent(req, res, auth, "slack");
+  return res.status(200).json({
+    provider,
+    slackChannels: linkedSlackChannelsRes.value.slackChannels,
+    slackDataSource: dataSource.toJSON(),
+  });
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -1,4 +1,6 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/assistant/builder.ts
 import { getBuilderSuggestions } from "@app/lib/api/assistant/suggestions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
-// @migration-target: front-api/routes/w/assistant/builder.ts
+// @migration-target: front-api/routes/w/assistant/builder/index.ts
 import { getBuilderSuggestions } from "@app/lib/api/assistant/suggestions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/tests/sidekick-evals/test-suites/shrink-wrap.ts
+++ b/front/tests/sidekick-evals/test-suites/shrink-wrap.ts
@@ -1,5 +1,5 @@
+import { buildShrinkWrapPrompt } from "@app/lib/api/assistant/builder/sidekick_prompts";
 import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
-import { buildFirstMessage } from "@app/pages/api/w/[wId]/assistant/builder/sidekick/prompt/shrink-wrap";
 import {
   mockAgentMessage,
   mockConversation,
@@ -231,7 +231,7 @@ Missing null check on payment.user.subscription in PaymentService.processRefund(
 
 function buildShrinkWrapInitialMessage(messages: MockMessage[]): string {
   const conversationText = buildConversationString(messages);
-  return buildFirstMessage(conversationText);
+  return buildShrinkWrapPrompt(conversationText);
 }
 
 function buildShrinkWrapConversationWithClarifyingInstructions(


### PR DESCRIPTION
## Description

- Migrates the five endpoints under `/api/w/:wId/assistant/builder/*` to  Hono.
- Extracts the substantive sidekick-prompt logic into a shared `lib/api/*` module used by both Next and Hono handlers.
- Adds a new rule ([BACK18]) about keeping HTTP error shapes out of the business layer.

### Migrated endpoints

  | Path | Method |
  |------|--------|
  | `/api/w/:wId/assistant/builder/suggestions` | POST |
  | `/api/w/:wId/assistant/builder/process/generate_schema` | POST |
  | `/api/w/:wId/assistant/builder/slack/channels_linked_with_agent` | GET |
  | `/api/w/:wId/assistant/builder/sidekick/prompt/template` | GET |
  | `/api/w/:wId/assistant/builder/sidekick/prompt/existing` | GET |
  | `/api/w/:wId/assistant/builder/sidekick/prompt/shrink-wrap` | GET |

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25664">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->