### PR TITLE
Migrate a few builder & assistant routes to Hono

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -55,6 +55,17 @@ const HONO_ROUTES: HonoRoute[] = [
     methods: ["GET"],
   },
   { pattern: "/api/w/:wId/assistant/builder/suggestions", methods: ["POST"] },
+  { pattern: "/api/w/:wId/assistant/mentions/parse", methods: ["POST"] },
+  { pattern: "/api/w/:wId/assistant/mentions/suggestions", methods: ["GET"] },
+  {
+    pattern: "/api/w/:wId/assistant/skills/:sId/suggestions",
+    methods: ["GET", "PATCH"],
+  },
+  {
+    pattern: "/api/w/:wId/builder/assistants/:aId/actions",
+    methods: ["GET"],
+  },
+  { pattern: "/api/w/:wId/builder/skills/suggestions", methods: ["POST"] },
   { pattern: "/api/w/:wId/feature-flags", methods: ["GET"] },
   { pattern: "/api/w/:wId/members/lookup", methods: ["GET"] },
   { pattern: "/api/w/:wId/members/search", methods: ["GET"] },

--- a/front-api/routes/w/assistant/index.ts
+++ b/front-api/routes/w/assistant/index.ts
@@ -1,9 +1,13 @@
 import { Hono } from "hono";
 
 import { builderApp } from "./builder";
+import { mentionsApp } from "./mentions";
+import { skillsApp } from "./skills";
 
 // Mounted at /api/w/:wId/assistant. workspaceAuth is applied by the parent
 // workspace sub-app.
 export const assistantApp = new Hono();
 
 assistantApp.route("/builder", builderApp);
+assistantApp.route("/mentions", mentionsApp);
+assistantApp.route("/skills", skillsApp);

--- a/front-api/routes/w/assistant/mentions.test.ts
+++ b/front-api/routes/w/assistant/mentions.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+
+// Mock Elasticsearch so `suggestionsOfMentions` doesn't hit a real cluster.
+vi.mock("@app/lib/api/elasticsearch", async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    withEs: vi.fn(async (fn: any) => {
+      const mockClient = {
+        search: vi
+          .fn()
+          .mockResolvedValue({ hits: { hits: [], total: { value: 0 } } }),
+      };
+      return {
+        isOk: () => true,
+        isErr: () => false,
+        value: await fn(mockClient),
+      };
+    }),
+  };
+});
+
+import { honoApp } from "../../../app";
+
+async function setup() {
+  const { workspace, auth } = await createPrivateApiMockRequest({
+    role: "builder",
+  });
+  const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+    name: "Test Agent",
+    description: "Test Agent Description",
+  });
+  return { workspace, auth, agentConfig };
+}
+
+function parse(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(`/api/w/${workspace.sId}/assistant/mentions/parse`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function suggestions(
+  workspace: { sId: string },
+  query: Record<string, string | string[]>
+) {
+  const search = new URLSearchParams();
+  for (const [k, v] of Object.entries(query)) {
+    if (Array.isArray(v)) {
+      for (const x of v) {
+        search.append(k, x);
+      }
+    } else {
+      search.append(k, v);
+    }
+  }
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/mentions/suggestions?${search}`
+  );
+}
+
+describe("POST /api/w/:wId/assistant/mentions/parse", () => {
+  it("parses agent mentions in markdown", async () => {
+    const { workspace, agentConfig } = await setup();
+    const response = await parse(workspace, {
+      markdown: `Hello @${agentConfig.name}, can you help me?`,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.markdown).toContain(":mention[");
+    expect(body.markdown).toContain(agentConfig.sId);
+  });
+
+  it("handles multiple mentions", async () => {
+    const { workspace, auth, agentConfig } = await setup();
+    const agentConfig2 = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Another Agent",
+      description: "Another Agent Description",
+    });
+
+    const response = await parse(workspace, {
+      markdown: `Hello @${agentConfig.name} and @${agentConfig2.name}`,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.markdown).toContain(agentConfig.sId);
+    expect(body.markdown).toContain(agentConfig2.sId);
+  });
+
+  it("handles case-insensitive mentions", async () => {
+    const { workspace, agentConfig } = await setup();
+    const response = await parse(workspace, {
+      markdown: `Hello @${agentConfig.name.toUpperCase()}`,
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).markdown).toContain(agentConfig.sId);
+  });
+
+  it("does not match partial mentions", async () => {
+    const { workspace, agentConfig } = await setup();
+    const response = await parse(workspace, {
+      markdown: `Hello @${agentConfig.name}Test`,
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).markdown).not.toContain(":mention[");
+  });
+
+  it("handles mentions at start of text", async () => {
+    const { workspace, agentConfig } = await setup();
+    const response = await parse(workspace, {
+      markdown: `@${agentConfig.name} hello`,
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).markdown).toContain(agentConfig.sId);
+  });
+
+  it("handles mentions with punctuation", async () => {
+    const { workspace, agentConfig } = await setup();
+    const response = await parse(workspace, {
+      markdown: `Hello @${agentConfig.name}! How are you?`,
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).markdown).toContain(agentConfig.sId);
+  });
+
+  it("returns 400 for missing markdown field", async () => {
+    const { workspace } = await setup();
+    const response = await parse(workspace, {});
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+});
+
+describe("GET /api/w/:wId/assistant/mentions/suggestions", () => {
+  it("returns agent suggestions", async () => {
+    const { workspace, agentConfig } = await setup();
+    const response = await suggestions(workspace, { query: "test" });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.suggestions)).toBe(true);
+    expect(
+      body.suggestions.some(
+        (s: { type: string; id: string }) =>
+          s.type === "agent" && s.id === agentConfig.sId
+      )
+    ).toBe(true);
+  });
+
+  it("filters suggestions by query", async () => {
+    const { workspace, auth } = await setup();
+    const alpha = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Alpha Agent",
+      description: "Alpha Description",
+    });
+    const beta = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Beta Agent",
+      description: "Beta Description",
+    });
+
+    const response = await suggestions(workspace, { query: "alpha" });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const ids = body.suggestions
+      .filter((s: { type: string }) => s.type === "agent")
+      .map((s: { id: string }) => s.id);
+    expect(ids).toContain(alpha.sId);
+    expect(ids).not.toContain(beta.sId);
+  });
+
+  it("supports select=agents", async () => {
+    const { workspace } = await setup();
+    const response = await suggestions(workspace, {
+      query: "test",
+      select: "agents",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(
+      body.suggestions.filter((s: { type: string }) => s.type === "agent")
+        .length
+    ).toBeGreaterThan(0);
+  });
+
+  it("supports select=users", async () => {
+    const { workspace } = await setup();
+    const response = await suggestions(workspace, {
+      query: "test",
+      select: "users",
+    });
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray((await response.json()).suggestions)).toBe(true);
+  });
+
+  it("supports select repeated as agents+users", async () => {
+    const { workspace } = await setup();
+    const response = await suggestions(workspace, {
+      query: "test",
+      select: ["agents", "users"],
+    });
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray((await response.json()).suggestions)).toBe(true);
+  });
+
+  it("handles empty query", async () => {
+    const { workspace } = await setup();
+    const response = await suggestions(workspace, { query: "" });
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray((await response.json()).suggestions)).toBe(true);
+  });
+});

--- a/front-api/routes/w/assistant/mentions.ts
+++ b/front-api/routes/w/assistant/mentions.ts
@@ -1,0 +1,54 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { suggestionsOfMentions } from "@app/lib/api/assistant/conversation/mention_suggestions";
+import { parseMentionsInMarkdown } from "@app/lib/api/assistant/parse_mentions";
+
+import { validate } from "../../../middleware/validator";
+
+const ParseMentionsRequestBodySchema = z.object({
+  markdown: z.string(),
+});
+
+// Mounted under /api/w/:wId/assistant/mentions.
+
+export const mentionsApp = new Hono();
+
+mentionsApp.post(
+  "/parse",
+  validate("json", ParseMentionsRequestBodySchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const { markdown } = c.req.valid("json");
+
+    const processedMarkdown = await parseMentionsInMarkdown({ auth, markdown });
+    return c.json({ markdown: processedMarkdown });
+  }
+);
+
+mentionsApp.get("/suggestions", async (c) => {
+  const auth = c.get("auth");
+
+  const query = c.req.query("query")?.trim().toLowerCase() ?? "";
+  const current = c.req.query("current") === "true";
+  const spaceId = c.req.query("spaceId");
+
+  // `select` may appear multiple times in the query string. Default to both
+  // agents and users when absent.
+  const selectValues = c.req.queries("select");
+  const select = !selectValues
+    ? { agents: true, users: true }
+    : {
+        agents: selectValues.includes("agents"),
+        users: selectValues.includes("users"),
+      };
+
+  const suggestions = await suggestionsOfMentions(auth, {
+    query,
+    select,
+    current,
+    spaceId,
+  });
+
+  return c.json({ suggestions });
+});

--- a/front-api/routes/w/assistant/skills.test.ts
+++ b/front-api/routes/w/assistant/skills.test.ts
@@ -1,0 +1,507 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import type { SkillSuggestionState } from "@app/types/suggestions/skill_suggestion";
+
+vi.mock("@app/lib/reinforcement/workspace_check", () => ({
+  hasReinforcementEnabled: vi.fn().mockResolvedValue(true),
+}));
+
+const postSkillSuggestionStatusUpdateMock = vi
+  .fn()
+  .mockResolvedValue(undefined);
+
+vi.mock("@app/lib/reinforcement/aggregate_suggestions", () => ({
+  postSkillSuggestionStatusUpdate: (...args: unknown[]) =>
+    postSkillSuggestionStatusUpdateMock(...args),
+}));
+
+import { honoApp } from "../../../app";
+
+async function setup(options: { role?: MembershipRoleType } = {}) {
+  const role = options.role ?? "builder";
+  const { workspace, auth } = await createPrivateApiMockRequest({ role });
+
+  const skill = await SkillFactory.create(auth);
+  // Refresh authenticator to pick up the skill's editor group membership.
+  await auth.refresh();
+
+  return { workspace, auth, skill };
+}
+
+function patch(workspace: { sId: string }, sId: string, body: unknown) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/skills/${sId}/suggestions`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function get(
+  workspace: { sId: string },
+  sId: string,
+  query: Record<string, string | string[]> = {}
+) {
+  const search = new URLSearchParams();
+  for (const [k, v] of Object.entries(query)) {
+    if (Array.isArray(v)) {
+      for (const x of v) {
+        search.append(k, x);
+      }
+    } else {
+      search.append(k, v);
+    }
+  }
+  const qs = search.toString();
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/skills/${sId}/suggestions${qs ? `?${qs}` : ""}`
+  );
+}
+
+describe("PATCH /api/w/:wId/assistant/skills/:sId/suggestions", () => {
+  it("returns 404 for non-existent skill", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "builder",
+    });
+
+    const response = await patch(workspace, "non-existent-skill", {
+      suggestionIds: ["test-id"],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("skill_not_found");
+  });
+
+  it("returns 400 for missing suggestionIds", async () => {
+    const { workspace, skill } = await setup();
+    const response = await patch(workspace, skill.sId, { state: "approved" });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for empty suggestionIds array", async () => {
+    const { workspace, skill } = await setup();
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for missing state", async () => {
+    const { workspace, skill } = await setup();
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: ["test-id"],
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for invalid state value", async () => {
+    const { workspace, skill } = await setup();
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: ["test-id"],
+      state: "invalid_state",
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 when trying to set state to pending", async () => {
+    const { workspace, skill } = await setup();
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: ["test-id"],
+      state: "pending",
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 for non-existent suggestion", async () => {
+    const { workspace, skill } = await setup();
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: ["non-existent-id"],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe(
+      "agent_suggestion_not_found"
+    );
+  });
+
+  it("returns 400 when suggestion belongs to a different skill", async () => {
+    const { workspace, auth, skill } = await setup();
+    const otherSkill = await SkillFactory.create(auth, { name: "Other Skill" });
+    await auth.refresh();
+
+    const suggestion = await SkillSuggestionFactory.create(auth, otherSkill);
+
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toContain(
+      "do not belong to the specified skill configuration"
+    );
+  });
+
+  it.each<Exclude<SkillSuggestionState, "pending">>([
+    "approved",
+    "rejected",
+    "outdated",
+  ])("updates suggestion state to %s", async (newState) => {
+    const { workspace, auth, skill } = await setup();
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [suggestion.sId],
+      state: newState,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.suggestions).toHaveLength(1);
+    expect(body.suggestions[0].state).toBe(newState);
+    expect(body.suggestions[0].sId).toBe(suggestion.sId);
+
+    const fetched = await SkillSuggestionResource.fetchById(
+      auth,
+      suggestion.sId
+    );
+    expect(fetched?.state).toBe(newState);
+  });
+
+  it("returns the full suggestion object with all fields", async () => {
+    const { workspace, auth, skill } = await setup();
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      suggestion: {
+        instructionEdits: [
+          {
+            targetBlockId: "abc12345",
+            content: "<p>Updated instructions</p>",
+            type: "replace",
+          },
+        ],
+      },
+      analysis: "Test analysis",
+      state: "pending",
+      source: "reinforcement",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.suggestions).toHaveLength(1);
+    expect(body.suggestions[0]).toMatchObject({
+      sId: suggestion.sId,
+      state: "approved",
+      kind: "edit",
+      analysis: "Test analysis",
+      source: "reinforcement",
+      suggestion: {
+        instructionEdits: [
+          {
+            targetBlockId: "abc12345",
+            content: "<p>Updated instructions</p>",
+            type: "replace",
+          },
+        ],
+      },
+    });
+    expect(body.suggestions[0].createdAt).toBeDefined();
+    expect(body.suggestions[0].updatedAt).toBeDefined();
+  });
+
+  it("admin can update suggestions in their workspace", async () => {
+    const { workspace, auth, skill } = await setup({ role: "admin" });
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).suggestions[0].state).toBe("approved");
+  });
+
+  it("returns 403 for non-editor of the skill", async () => {
+    const { workspace } = await setup();
+
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "builder",
+    });
+    const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const otherSkill = await SkillFactory.create(ownerAuth, {
+      name: "Other Skill",
+    });
+    await ownerAuth.refresh();
+    const suggestion = await SkillSuggestionFactory.create(
+      ownerAuth,
+      otherSkill,
+      { state: "pending" }
+    );
+
+    const response = await patch(workspace, otherSkill.sId, {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe(
+      "agent_group_permission_error"
+    );
+  });
+
+  it("updates multiple suggestions in a single request", async () => {
+    const { workspace, auth, skill } = await setup();
+    const s1 = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+    const s2 = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [s1.sId, s2.sId],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.suggestions).toHaveLength(2);
+    expect(
+      body.suggestions.every((s: { state: string }) => s.state === "approved")
+    ).toBe(true);
+
+    const fetched1 = await SkillSuggestionResource.fetchById(auth, s1.sId);
+    const fetched2 = await SkillSuggestionResource.fetchById(auth, s2.sId);
+    expect(fetched1?.state).toBe("approved");
+    expect(fetched2?.state).toBe("approved");
+  });
+
+  it("triggers postSkillSuggestionStatusUpdate when approving", async () => {
+    postSkillSuggestionStatusUpdateMock.mockClear();
+    const { workspace, auth, skill } = await setup();
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(200);
+    expect(postSkillSuggestionStatusUpdateMock).toHaveBeenCalledTimes(1);
+    const [, suggestions, state] =
+      postSkillSuggestionStatusUpdateMock.mock.calls[0];
+    expect(state).toBe("approved");
+    expect(suggestions.map((s: { sId: string }) => s.sId)).toEqual([
+      suggestion.sId,
+    ]);
+  });
+
+  it("triggers postSkillSuggestionStatusUpdate when rejecting", async () => {
+    postSkillSuggestionStatusUpdateMock.mockClear();
+    const { workspace, auth, skill } = await setup();
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [suggestion.sId],
+      state: "rejected",
+    });
+
+    expect(response.status).toBe(200);
+    expect(postSkillSuggestionStatusUpdateMock).toHaveBeenCalledTimes(1);
+    expect(postSkillSuggestionStatusUpdateMock.mock.calls[0][2]).toBe(
+      "rejected"
+    );
+  });
+
+  it("does not trigger postSkillSuggestionStatusUpdate when marking outdated", async () => {
+    postSkillSuggestionStatusUpdateMock.mockClear();
+    const { workspace, auth, skill } = await setup();
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [suggestion.sId],
+      state: "outdated",
+    });
+
+    expect(response.status).toBe(200);
+    expect(postSkillSuggestionStatusUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when reinforcement is disabled", async () => {
+    const { hasReinforcementEnabled } = await import(
+      "@app/lib/reinforcement/workspace_check"
+    );
+    vi.mocked(hasReinforcementEnabled).mockResolvedValueOnce(false);
+
+    const { workspace, auth, skill } = await setup();
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      suggestionIds: [suggestion.sId],
+      state: "approved",
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.message).toContain(
+      "Self-improving skills are not enabled"
+    );
+  });
+});
+
+describe("GET /api/w/:wId/assistant/skills/:sId/suggestions", () => {
+  it("returns skill's suggestions", async () => {
+    const { workspace, auth, skill } = await setup();
+    const suggestion = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+
+    const response = await get(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.suggestions).toHaveLength(1);
+    expect(body.suggestions[0].sId).toBe(suggestion.sId);
+  });
+
+  it("does not return other skill's suggestions", async () => {
+    const { workspace, auth, skill } = await setup();
+    const skill2 = await SkillFactory.create(auth, { name: "Test Skill 2" });
+    await auth.refresh();
+
+    const s1 = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+    });
+    await SkillSuggestionFactory.create(auth, skill2, { state: "pending" });
+
+    const response = await get(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.suggestions).toHaveLength(1);
+    expect(body.suggestions[0].sId).toBe(s1.sId);
+  });
+
+  it("filters on kind and state correctly", async () => {
+    const { workspace, auth, skill } = await setup();
+    const matching = await SkillSuggestionFactory.create(auth, skill, {
+      state: "pending",
+      kind: "edit",
+    });
+    await SkillSuggestionFactory.create(auth, skill, {
+      state: "approved",
+      kind: "edit",
+    });
+
+    const response = await get(workspace, skill.sId, {
+      states: ["pending"],
+      kind: "edit",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.suggestions).toHaveLength(1);
+    expect(body.suggestions[0].sId).toBe(matching.sId);
+    expect(body.suggestions[0].kind).toBe("edit");
+    expect(body.suggestions[0].state).toBe("pending");
+  });
+
+  it("limits the number of returned suggestions", async () => {
+    const { workspace, auth, skill } = await setup();
+    await SkillSuggestionFactory.create(auth, skill, { state: "pending" });
+    await SkillSuggestionFactory.create(auth, skill, { state: "pending" });
+    await SkillSuggestionFactory.create(auth, skill, { state: "pending" });
+
+    const response = await get(workspace, skill.sId, { limit: "2" });
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).suggestions).toHaveLength(2);
+  });
+
+  it("returns 403 for non-editor of the skill", async () => {
+    const { workspace } = await setup();
+
+    const skillOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, skillOwner, {
+      role: "builder",
+    });
+    const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      skillOwner.sId,
+      workspace.sId
+    );
+    const otherSkill = await SkillFactory.create(ownerAuth, {
+      name: "Other Skill",
+    });
+    await ownerAuth.refresh();
+    await SkillSuggestionFactory.create(ownerAuth, otherSkill, {
+      state: "pending",
+    });
+
+    const response = await get(workspace, otherSkill.sId);
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe(
+      "agent_group_permission_error"
+    );
+  });
+
+  it("returns empty suggestions when reinforcement is disabled", async () => {
+    const { hasReinforcementEnabled } = await import(
+      "@app/lib/reinforcement/workspace_check"
+    );
+    vi.mocked(hasReinforcementEnabled).mockResolvedValueOnce(false);
+
+    const { workspace, auth, skill } = await setup();
+    await SkillSuggestionFactory.create(auth, skill, { state: "pending" });
+
+    const response = await get(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).suggestions).toHaveLength(0);
+  });
+});

--- a/front-api/routes/w/assistant/skills.ts
+++ b/front-api/routes/w/assistant/skills.ts
@@ -1,0 +1,225 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { postSkillSuggestionStatusUpdate } from "@app/lib/reinforcement/aggregate_suggestions";
+import { hasReinforcementEnabled } from "@app/lib/reinforcement/workspace_check";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import { SkillSuggestionSchema } from "@app/types/suggestions/skill_suggestion";
+
+import { validate } from "../../../middleware/validator";
+
+declare module "hono" {
+  interface ContextVariableMap {
+    skill: SkillResource;
+  }
+}
+
+const StateSchema = z.enum(["pending", "approved", "rejected", "outdated"]);
+
+const GetSkillSuggestionsQuerySchema = z.object({
+  // Hono returns query params as strings; accept comma-separated or repeated.
+  states: z
+    .preprocess((v) => (typeof v === "string" ? [v] : v), z.array(StateSchema))
+    .optional(),
+  kind: z.enum(["edit"]).optional(),
+  limit: z.string().optional(),
+});
+
+export type GetSkillSuggestionsQuery = z.infer<
+  typeof GetSkillSuggestionsQuerySchema
+>;
+
+export const GetSkillSuggestionsResponseBodySchema = z.object({
+  suggestions: z.array(SkillSuggestionSchema),
+});
+export type GetSkillSuggestionsResponseBody = z.infer<
+  typeof GetSkillSuggestionsResponseBodySchema
+>;
+
+const PatchSkillSuggestionRequestBodySchema = z.object({
+  suggestionIds: z.array(z.string()).min(1),
+  state: z.enum(["approved", "rejected", "outdated"]),
+});
+
+export type PatchSkillSuggestionRequestBody = z.infer<
+  typeof PatchSkillSuggestionRequestBodySchema
+>;
+
+export const PatchSkillSuggestionResponseBodySchema = z.object({
+  suggestions: z.array(SkillSuggestionSchema),
+});
+export type PatchSkillSuggestionResponseBody = z.infer<
+  typeof PatchSkillSuggestionResponseBodySchema
+>;
+
+// Mounted under /api/w/:wId/assistant/skills.
+
+export const skillsApp = new Hono();
+
+// Shared skill fetch + canWrite check for everything under /:sId/*.
+skillsApp.use("/:sId/*", async (c, next) => {
+  const auth = c.get("auth");
+  const sId = c.req.param("sId");
+
+  const skill = await SkillResource.fetchById(auth, sId);
+  if (!skill) {
+    return c.json(
+      {
+        error: {
+          type: "skill_not_found",
+          message: "The skill configuration was not found.",
+        },
+      },
+      404
+    );
+  }
+
+  if (!skill.canWrite(auth)) {
+    return c.json(
+      {
+        error: {
+          type: "agent_group_permission_error",
+          message:
+            "Only editors of the skill or workspace admins can view suggestions.",
+        },
+      },
+      403
+    );
+  }
+
+  c.set("skill", skill);
+  await next();
+});
+
+skillsApp.get("/:sId/suggestions", async (c) => {
+  const auth = c.get("auth");
+  const skill = c.get("skill");
+
+  if (!(await hasReinforcementEnabled(auth))) {
+    return c.json({ suggestions: [] });
+  }
+
+  // Hono path-param fetch returns single-value query; for `states` we want all
+  // repeats too. Build the input object explicitly.
+  const queryInput = {
+    states: c.req.queries("states"),
+    kind: c.req.query("kind"),
+    limit: c.req.query("limit"),
+  };
+  const queryValidation = GetSkillSuggestionsQuerySchema.safeParse(queryInput);
+  if (!queryValidation.success) {
+    return c.json(
+      {
+        error: {
+          type: "invalid_request_error",
+          message: `Invalid query parameters: ${queryValidation.error.message}`,
+        },
+      },
+      400
+    );
+  }
+
+  const { states, kind, limit } = queryValidation.data;
+
+  const parsedLimit = limit ? parseInt(limit, 10) : undefined;
+  if (parsedLimit !== undefined && isNaN(parsedLimit)) {
+    return c.json(
+      {
+        error: {
+          type: "invalid_request_error",
+          message: "Invalid limit parameter: must be a number",
+        },
+      },
+      400
+    );
+  }
+
+  const suggestions = await SkillSuggestionResource.listBySkillConfigurationId(
+    auth,
+    skill.sId,
+    {
+      states,
+      sources: ["reinforcement"],
+      kind,
+      limit: parsedLimit,
+    }
+  );
+
+  return c.json({ suggestions: suggestions.map((s) => s.toJSON()) });
+});
+
+skillsApp.patch(
+  "/:sId/suggestions",
+  validate("json", PatchSkillSuggestionRequestBodySchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const skill = c.get("skill");
+
+    if (!(await hasReinforcementEnabled(auth))) {
+      return c.json(
+        {
+          error: {
+            type: "invalid_request_error",
+            message:
+              "Self-improving skills are not enabled for this workspace.",
+          },
+        },
+        400
+      );
+    }
+
+    const { suggestionIds, state } = c.req.valid("json");
+
+    const suggestions = await SkillSuggestionResource.fetchByIds(
+      auth,
+      suggestionIds
+    );
+
+    if (suggestions.length !== suggestionIds.length) {
+      return c.json(
+        {
+          error: {
+            type: "agent_suggestion_not_found",
+            message: "One or more skill suggestions were not found.",
+          },
+        },
+        404
+      );
+    }
+
+    for (const suggestion of suggestions) {
+      if (suggestion.skillConfigurationSId !== skill.sId) {
+        return c.json(
+          {
+            error: {
+              type: "invalid_request_error",
+              message:
+                "One or more skill suggestions do not belong to the specified skill configuration.",
+            },
+          },
+          400
+        );
+      }
+    }
+
+    await SkillSuggestionResource.bulkUpdateState(auth, suggestions, state);
+
+    if (state === "approved" || state === "rejected") {
+      await postSkillSuggestionStatusUpdate(auth, suggestions, state);
+    }
+
+    // Bulk update doesn't mutate the resources, so we need to refetch here.
+    const updatedSuggestions = await SkillSuggestionResource.fetchByIds(
+      auth,
+      suggestionIds
+    );
+
+    return c.json({
+      suggestions: updatedSuggestions.map(
+        (s): SkillSuggestionType => s.toJSON()
+      ),
+    });
+  }
+);

--- a/front-api/routes/w/builder/assistants.ts
+++ b/front-api/routes/w/builder/assistants.ts
@@ -1,0 +1,68 @@
+import { Hono } from "hono";
+
+import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
+import {
+  buildInitialActions,
+  getAccessibleSourcesAndAppsForActions,
+} from "@app/lib/agent_builder/server_side_props_helpers";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+
+export type GetActionsResponseBody = {
+  actions: AgentBuilderMCPConfiguration[];
+};
+
+// Mounted under /api/w/:wId/builder/assistants.
+
+export const assistantsApp = new Hono();
+
+assistantsApp.get("/:aId/actions", async (c) => {
+  const auth = c.get("auth");
+  const aId = c.req.param("aId");
+
+  try {
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "full",
+    });
+    if (!agentConfiguration) {
+      return c.json(
+        {
+          error: {
+            type: "agent_configuration_not_found",
+            message: "Agent configuration not found.",
+          },
+        },
+        404
+      );
+    }
+
+    const { dataSourceViews, mcpServerViews } =
+      await getAccessibleSourcesAndAppsForActions(auth);
+    const mcpServerViewsJSON = mcpServerViews.map((v) => v.toJSON());
+
+    const actions = await buildInitialActions({
+      dataSourceViews,
+      configuration: agentConfiguration,
+      mcpServerViews: mcpServerViewsJSON,
+    });
+
+    if (
+      agentConfiguration.scope !== "visible" &&
+      agentConfiguration.scope !== "hidden"
+    ) {
+      throw new Error("Invalid agent scope");
+    }
+
+    return c.json({ actions });
+  } catch {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: "Failed to fetch builder state.",
+        },
+      },
+      500
+    );
+  }
+});

--- a/front-api/routes/w/builder/index.ts
+++ b/front-api/routes/w/builder/index.ts
@@ -1,0 +1,11 @@
+import { Hono } from "hono";
+
+import { assistantsApp } from "./assistants";
+import { skillsApp } from "./skills";
+
+// Mounted at /api/w/:wId/builder. workspaceAuth is applied by the parent
+// workspace sub-app.
+export const builderRootApp = new Hono();
+
+builderRootApp.route("/assistants", assistantsApp);
+builderRootApp.route("/skills", skillsApp);

--- a/front-api/routes/w/builder/skills.test.ts
+++ b/front-api/routes/w/builder/skills.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Err, Ok } from "@app/types/shared/result";
+
+vi.mock("@app/lib/api/skills/description_suggestion", () => ({
+  getSkillDescriptionSuggestion: vi.fn(),
+}));
+
+import { getSkillDescriptionSuggestion } from "@app/lib/api/skills/description_suggestion";
+
+import { honoApp } from "../../../app";
+
+async function setup() {
+  const { workspace } = await createPrivateApiMockRequest({
+    role: "builder",
+    method: "POST",
+  });
+  return { workspace };
+}
+
+function post(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(`/api/w/${workspace.sId}/builder/skills/suggestions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId/builder/skills/suggestions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns suggestion with valid inputs", async () => {
+    const { workspace } = await setup();
+    vi.mocked(getSkillDescriptionSuggestion).mockResolvedValue(
+      new Ok("Analyzes and visualizes your data")
+    );
+
+    const response = await post(workspace, {
+      instructions: "Help users analyze data",
+      agentFacingDescription: "Use when user wants data analysis",
+      tools: [{ name: "query_db", description: "Query the database" }],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      suggestion: "Analyzes and visualizes your data",
+    });
+  });
+
+  it("returns suggestion with empty tools array", async () => {
+    const { workspace } = await setup();
+    vi.mocked(getSkillDescriptionSuggestion).mockResolvedValue(
+      new Ok("Helps you write better content")
+    );
+
+    const response = await post(workspace, {
+      instructions: "Help users with writing",
+      agentFacingDescription: "Use for writing tasks",
+      tools: [],
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      suggestion: "Helps you write better content",
+    });
+  });
+
+  it("returns 500 when suggestion generation fails", async () => {
+    const { workspace } = await setup();
+    vi.mocked(getSkillDescriptionSuggestion).mockResolvedValue(
+      new Err(new Error("Model unavailable"))
+    );
+
+    const response = await post(workspace, {
+      instructions: "Help users",
+      agentFacingDescription: "Use for help",
+      tools: [],
+    });
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error.type).toBe("internal_server_error");
+    expect(body.error.message).toBe("Model unavailable");
+  });
+
+  it("returns 400 for missing instructions", async () => {
+    const { workspace } = await setup();
+    const response = await post(workspace, {
+      agentFacingDescription: "Use for analysis",
+      tools: [],
+    });
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for missing agentFacingDescription", async () => {
+    const { workspace } = await setup();
+    const response = await post(workspace, {
+      instructions: "Help users",
+      tools: [],
+    });
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for missing tools", async () => {
+    const { workspace } = await setup();
+    const response = await post(workspace, {
+      instructions: "Help users",
+      agentFacingDescription: "Use for help",
+    });
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 400 for invalid tools format", async () => {
+    const { workspace } = await setup();
+    const response = await post(workspace, {
+      instructions: "Help users",
+      agentFacingDescription: "Use for help",
+      tools: [{ name: "tool1" }], // Missing description
+    });
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+});

--- a/front-api/routes/w/builder/skills.ts
+++ b/front-api/routes/w/builder/skills.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { getSkillDescriptionSuggestion } from "@app/lib/api/skills/description_suggestion";
+
+import { validate } from "../../../middleware/validator";
+
+const PostSkillSuggestionsRequestBodySchema = z.object({
+  instructions: z.string(),
+  agentFacingDescription: z.string(),
+  tools: z.array(z.object({ name: z.string(), description: z.string() })),
+});
+
+export type PostSkillSuggestionsRequestBody = z.infer<
+  typeof PostSkillSuggestionsRequestBodySchema
+>;
+
+// Mounted under /api/w/:wId/builder/skills.
+
+export const skillsApp = new Hono();
+
+skillsApp.post(
+  "/suggestions",
+  validate("json", PostSkillSuggestionsRequestBodySchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const inputs = c.req.valid("json");
+
+    const suggestionRes = await getSkillDescriptionSuggestion(auth, inputs);
+    if (suggestionRes.isErr()) {
+      return c.json(
+        {
+          error: {
+            type: "internal_server_error",
+            message: suggestionRes.error.message,
+          },
+        },
+        500
+      );
+    }
+
+    return c.json({ suggestion: suggestionRes.value });
+  }
+);

--- a/front-api/routes/w/index.ts
+++ b/front-api/routes/w/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 
 import { workspaceAuth } from "../../middleware/workspace_auth";
 import { assistantApp } from "./assistant";
+import { builderRootApp } from "./builder";
 import { featureFlagsApp } from "./feature-flags";
 import { membersApp } from "./members";
 import { modelsApp } from "./models";
@@ -20,6 +21,7 @@ export const workspaceApp = new Hono();
 workspaceApp.use("*", workspaceAuth);
 
 workspaceApp.route("/assistant", assistantApp);
+workspaceApp.route("/builder", builderRootApp);
 workspaceApp.route("/feature-flags", featureFlagsApp);
 workspaceApp.route("/members", membersApp);
 workspaceApp.route("/models", modelsApp);

--- a/front/pages/api/w/[wId]/assistant/mentions/parse.ts
+++ b/front/pages/api/w/[wId]/assistant/mentions/parse.ts
@@ -1,4 +1,6 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/assistant/mentions.ts
 
 import { parseMentionsInMarkdown } from "@app/lib/api/assistant/parse_mentions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/mentions/suggestions.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/assistant/mentions.ts
 /**
  * @swagger
  * /api/w/{wId}/assistant/mentions/suggestions:

--- a/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/skills/[sId]/suggestions.ts
@@ -1,4 +1,6 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/assistant/skills.ts
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { postSkillSuggestionStatusUpdate } from "@app/lib/reinforcement/aggregate_suggestions";

--- a/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
@@ -1,4 +1,6 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/builder/assistants.ts
 import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
 import {
   buildInitialActions,

--- a/front/pages/api/w/[wId]/builder/skills/suggestions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/suggestions.ts
@@ -1,4 +1,6 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+// @migration-target: front-api/routes/w/builder/skills.ts
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { SkillDescriptionSuggestionInputs } from "@app/lib/api/skills/description_suggestion";
 import { getSkillDescriptionSuggestion } from "@app/lib/api/skills/description_suggestion";


### PR DESCRIPTION
## Description

Migrated these routes and their tests:

front-api/routes/w/builder/assistants.ts
front-api/routes/w/builder/skills.ts
front-api/routes/w/assistant/mentions.ts
front-api/routes/w/assistant/mentions.ts
front-api/routes/w/assistant/skills.ts

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25665">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->