### PR TITLE
Refactor routing logic to use SmartRouter for Hono routes

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -1,4 +1,7 @@
 import { Hono } from "hono";
+import { RegExpRouter } from "hono/router/reg-exp-router";
+import { SmartRouter } from "hono/router/smart-router";
+import { TrieRouter } from "hono/router/trie-router";
 
 import { cors } from "./middleware/cors";
 import { appStatusApp } from "./routes/app-status";
@@ -11,104 +14,6 @@ import { killApp } from "./routes/kill";
 import { publicWorkspaceApp } from "./routes/v1/w";
 import { workspaceApp } from "./routes/w";
 import { workspaceLookupApp } from "./routes/workspace-lookup";
-
-// Single source of truth for which routes are served natively by Hono.
-// Anything not listed here is delegated to the Next.js handler. OPTIONS is
-// auto-added for every pattern with any other method so CORS preflights for
-// Hono-served routes are handled by the Hono CORS middleware rather than
-// Next.js.
-type HonoMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS";
-
-interface HonoRoute {
-  pattern: string;
-  methods: HonoMethod[];
-}
-
-// This is only needed during migration, to implement isHonoRoute()
-const HONO_ROUTES: HonoRoute[] = [
-  { pattern: "/api/healthz", methods: ["GET"] },
-  { pattern: "/api/app-status", methods: ["GET"] },
-  { pattern: "/api/auth/login", methods: ["GET"] },
-  { pattern: "/api/auth-context", methods: ["GET"] },
-  { pattern: "/api/create-new-workspace", methods: ["POST"] },
-  { pattern: "/api/invitations", methods: ["GET"] },
-  { pattern: "/api/kill", methods: ["GET"] },
-  { pattern: "/api/workspace-lookup", methods: ["GET"] },
-  {
-    pattern: "/api/w/:wId/assistant/builder/process/generate_schema",
-    methods: ["POST"],
-  },
-  {
-    pattern: "/api/w/:wId/assistant/builder/sidekick/prompt/existing",
-    methods: ["GET"],
-  },
-  {
-    pattern: "/api/w/:wId/assistant/builder/sidekick/prompt/shrink-wrap",
-    methods: ["GET"],
-  },
-  {
-    pattern: "/api/w/:wId/assistant/builder/sidekick/prompt/template",
-    methods: ["GET"],
-  },
-  {
-    pattern: "/api/w/:wId/assistant/builder/slack/channels_linked_with_agent",
-    methods: ["GET"],
-  },
-  { pattern: "/api/w/:wId/assistant/builder/suggestions", methods: ["POST"] },
-  { pattern: "/api/w/:wId/assistant/mentions/parse", methods: ["POST"] },
-  { pattern: "/api/w/:wId/assistant/mentions/suggestions", methods: ["GET"] },
-  {
-    pattern: "/api/w/:wId/assistant/skills/:sId/suggestions",
-    methods: ["GET", "PATCH"],
-  },
-  {
-    pattern: "/api/w/:wId/builder/assistants/:aId/actions",
-    methods: ["GET"],
-  },
-  { pattern: "/api/w/:wId/builder/skills/suggestions", methods: ["POST"] },
-  { pattern: "/api/w/:wId/feature-flags", methods: ["GET"] },
-  { pattern: "/api/w/:wId/mcp", methods: ["GET", "POST"] },
-  { pattern: "/api/w/:wId/mcp/available", methods: ["GET"] },
-  {
-    pattern: "/api/w/:wId/mcp/connections/:connectionType/:cId",
-    methods: ["GET", "DELETE"],
-  },
-  { pattern: "/api/w/:wId/mcp/deregister", methods: ["POST"] },
-  { pattern: "/api/w/:wId/mcp/discover_oauth_metadata", methods: ["POST"] },
-  { pattern: "/api/w/:wId/mcp/heartbeat", methods: ["POST"] },
-  { pattern: "/api/w/:wId/mcp/register", methods: ["POST"] },
-  { pattern: "/api/w/:wId/mcp/request_access", methods: ["POST"] },
-  { pattern: "/api/w/:wId/mcp/usage", methods: ["GET"] },
-  { pattern: "/api/w/:wId/mcp/views", methods: ["GET"] },
-  { pattern: "/api/w/:wId/mcp/:serverId/sync", methods: ["POST"] },
-  {
-    pattern: "/api/w/:wId/mcp/:serverId/tools/:toolName",
-    methods: ["PATCH"],
-  },
-  { pattern: "/api/w/:wId/members/lookup", methods: ["GET"] },
-  { pattern: "/api/w/:wId/members/search", methods: ["GET"] },
-  { pattern: "/api/w/:wId/models", methods: ["GET"] },
-  { pattern: "/api/w/:wId/providers", methods: ["GET"] },
-  { pattern: "/api/w/:wId/provisioning-status", methods: ["GET"] },
-  { pattern: "/api/w/:wId/spaces", methods: ["GET", "POST"] },
-  { pattern: "/api/w/:wId/spaces/:spaceId/mcp/available", methods: ["GET"] },
-  { pattern: "/api/w/:wId/trial-message-usage", methods: ["GET"] },
-  { pattern: "/api/w/:wId/verified-domains", methods: ["GET"] },
-  { pattern: "/api/w/:wId/verify", methods: ["GET"] },
-  { pattern: "/api/w/:wId/welcome", methods: ["GET"] },
-  { pattern: "/api/v1/w/:wId/feature_flags", methods: ["GET"] },
-  { pattern: "/api/v1/w/:wId/spaces", methods: ["GET"] },
-  { pattern: "/api/v1/w/:wId/verified_domains", methods: ["GET"] },
-];
-
-const HONO_ROUTE_REGEXES = HONO_ROUTES.map((r) => {
-  const methods = new Set<HonoMethod>(r.methods);
-  methods.add("OPTIONS");
-  return {
-    methods,
-    regex: new RegExp(`^${r.pattern.replace(/:[^/]+/g, "[^/]+")}$`),
-  };
-});
 
 const apiApp = new Hono();
 apiApp.route("/healthz", healthzApp);
@@ -126,6 +31,24 @@ export const honoApp = new Hono();
 honoApp.use("*", cors);
 honoApp.route("/api", apiApp);
 
+// Dispatch index for isHonoRoute(). Built from honoApp's flattened route
+// table — registering a Hono route is the single source of truth for whether
+// a request goes to Hono vs Next. Filters out middleware (method "ALL"), so
+// only concrete handlers count.
+//
+// SmartRouter tries RegExpRouter first (O(1) via a single compiled regex)
+// and falls back to TrieRouter for path combinations RegExp can't handle
+// (e.g., two routes diverging at the same depth with different param names).
+const dispatchRouter = new SmartRouter<true>({
+  routers: [new RegExpRouter<true>(), new TrieRouter<true>()],
+});
+for (const route of honoApp.routes) {
+  if (route.method === "ALL") continue;
+  dispatchRouter.add(route.method, route.path, true);
+}
+
+const PREFLIGHT_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+
 export function isHonoRoute(
   method: string | undefined,
   url: string | undefined
@@ -137,7 +60,18 @@ export function isHonoRoute(
   const queryStart = url.indexOf("?");
   const path = queryStart === -1 ? url : url.slice(0, queryStart);
 
-  return HONO_ROUTE_REGEXES.some(
-    (r) => r.methods.has(method as HonoMethod) && r.regex.test(path)
-  );
+  if (dispatchRouter.match(method, path)[0].length > 0) {
+    return true;
+  }
+
+  // CORS preflight: route OPTIONS to Hono whenever any non-OPTIONS method is
+  // registered for the path, so the cors middleware can short-circuit.
+  if (method === "OPTIONS") {
+    for (const m of PREFLIGHT_METHODS) {
+      if (dispatchRouter.match(m, path)[0].length > 0) {
+        return true;
+      }
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
## Description

Listing all the ported routes in app.ts was becoming unmaintainable, so switch to an automatic fallback.

Downside is that we can no longer instantly see the set of ported routes, but we track them separately.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25667">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->