### PR TITLE
Add requireRole middleware for handler-level role checks

### DIFF
--- a/front-api/middleware/require_role.ts
+++ b/front-api/middleware/require_role.ts
@@ -1,0 +1,37 @@
+import type { MiddlewareHandler } from "hono";
+
+import type { Authenticator } from "@app/lib/auth";
+
+type Role = "user" | "builder" | "admin";
+
+const ROLE_CHECK: Record<Role, (auth: Authenticator) => boolean> = {
+  user: (auth) => auth.isUser(),
+  builder: (auth) => auth.isBuilder(),
+  admin: (auth) => auth.isAdmin(),
+};
+
+/**
+ * Asserts the authenticated user has at least the given role. Apply after
+ * the auth middleware so `c.get("auth")` is available.
+ *
+ * The error message is intentionally generic; if a route needs a more
+ * specific message (e.g. tying it to a particular resource), do the check
+ * inline in the handler instead.
+ */
+export function requireRole(role: Role): MiddlewareHandler {
+  return async (c, next) => {
+    const auth = c.get("auth");
+    if (!ROLE_CHECK[role](auth)) {
+      return c.json(
+        {
+          error: {
+            type: "workspace_auth_error",
+            message: `This operation requires ${role} access to the workspace.`,
+          },
+        },
+        403
+      );
+    }
+    await next();
+  };
+}

--- a/front-api/routes/w/assistant/builder/slack.ts
+++ b/front-api/routes/w/assistant/builder/slack.ts
@@ -5,107 +5,104 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 
+import { requireRole } from "../../../../middleware/require_role";
+
 // Mounted under /api/w/:wId/assistant/builder/slack.
 
 export const slackApp = new Hono();
 
-slackApp.get("/channels_linked_with_agent", async (c) => {
-  const auth = c.get("auth");
+slackApp.get(
+  "/channels_linked_with_agent",
+  requireRole("builder"),
+  async (c) => {
+    const auth = c.get("auth");
 
-  if (!auth.isBuilder()) {
-    return c.json(
-      {
-        error: {
-          type: "data_source_auth_error",
-          message:
-            "Only the users that are `builders` for the current workspace can modify linked Slack channels.",
+    const [[dataSourceSlack], [dataSourceSlackBot]] = await Promise.all([
+      DataSourceResource.listByConnectorProvider(auth, "slack"),
+      DataSourceResource.listByConnectorProvider(auth, "slack_bot"),
+    ]);
+
+    let isSlackBotEnabled = false;
+    if (dataSourceSlackBot && dataSourceSlackBot.connectorId) {
+      const connectorsAPI = new ConnectorsAPI(
+        config.getConnectorsAPIConfig(),
+        logger
+      );
+      const configRes = await connectorsAPI.getConnectorConfig(
+        dataSourceSlackBot.connectorId,
+        "botEnabled"
+      );
+      if (configRes.isOk()) {
+        isSlackBotEnabled = configRes.value.configValue === "true";
+      }
+    }
+
+    const provider = isSlackBotEnabled ? "slack_bot" : "slack";
+    const dataSource = isSlackBotEnabled ? dataSourceSlackBot : dataSourceSlack;
+
+    if (!dataSource) {
+      return c.json({
+        provider,
+        slackChannels: [],
+        slackDataSource: undefined,
+      });
+    }
+
+    if (!dataSource.connectorId) {
+      return c.json(
+        {
+          error: {
+            type: "data_source_not_managed",
+            message: "The data source you requested is not managed.",
+          },
         },
-      },
-      403
-    );
-  }
+        400
+      );
+    }
 
-  const [[dataSourceSlack], [dataSourceSlackBot]] = await Promise.all([
-    DataSourceResource.listByConnectorProvider(auth, "slack"),
-    DataSourceResource.listByConnectorProvider(auth, "slack_bot"),
-  ]);
+    if (
+      !dataSource.connectorProvider ||
+      (dataSource.connectorProvider !== "slack_bot" &&
+        dataSource.connectorProvider !== "slack")
+    ) {
+      return c.json(
+        {
+          error: {
+            type: "data_source_not_managed",
+            message:
+              "The data source you requested is not managed by a slack connector.",
+          },
+        },
+        400
+      );
+    }
 
-  let isSlackBotEnabled = false;
-  if (dataSourceSlackBot && dataSourceSlackBot.connectorId) {
     const connectorsAPI = new ConnectorsAPI(
       config.getConnectorsAPIConfig(),
       logger
     );
-    const configRes = await connectorsAPI.getConnectorConfig(
-      dataSourceSlackBot.connectorId,
-      "botEnabled"
-    );
-    if (configRes.isOk()) {
-      isSlackBotEnabled = configRes.value.configValue === "true";
+    const linkedSlackChannelsRes =
+      await connectorsAPI.getSlackChannelsLinkedWithAgent({
+        connectorId: dataSource.connectorId,
+      });
+
+    if (linkedSlackChannelsRes.isErr()) {
+      return c.json(
+        {
+          error: {
+            type: "internal_server_error",
+            message:
+              "An error occurred while fetching the linked Slack channels.",
+          },
+        },
+        500
+      );
     }
-  }
 
-  const provider = isSlackBotEnabled ? "slack_bot" : "slack";
-  const dataSource = isSlackBotEnabled ? dataSourceSlackBot : dataSourceSlack;
-
-  if (!dataSource) {
-    return c.json({ provider, slackChannels: [], slackDataSource: undefined });
-  }
-
-  if (!dataSource.connectorId) {
-    return c.json(
-      {
-        error: {
-          type: "data_source_not_managed",
-          message: "The data source you requested is not managed.",
-        },
-      },
-      400
-    );
-  }
-
-  if (
-    !dataSource.connectorProvider ||
-    (dataSource.connectorProvider !== "slack_bot" &&
-      dataSource.connectorProvider !== "slack")
-  ) {
-    return c.json(
-      {
-        error: {
-          type: "data_source_not_managed",
-          message:
-            "The data source you requested is not managed by a slack connector.",
-        },
-      },
-      400
-    );
-  }
-
-  const connectorsAPI = new ConnectorsAPI(
-    config.getConnectorsAPIConfig(),
-    logger
-  );
-  const linkedSlackChannelsRes =
-    await connectorsAPI.getSlackChannelsLinkedWithAgent({
-      connectorId: dataSource.connectorId,
+    return c.json({
+      provider,
+      slackChannels: linkedSlackChannelsRes.value.slackChannels,
+      slackDataSource: dataSource.toJSON(),
     });
-
-  if (linkedSlackChannelsRes.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message:
-            "An error occurred while fetching the linked Slack channels.",
-        },
-      },
-      500
-    );
   }
-
-  return c.json({
-    provider,
-    slackChannels: linkedSlackChannelsRes.value.slackChannels,
-    slackDataSource: dataSource.toJSON(),
-  });
-});
+);

--- a/front-api/routes/w/mcp/request_access.ts
+++ b/front-api/routes/w/mcp/request_access.ts
@@ -9,6 +9,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 
+import { requireRole } from "../../../middleware/require_role";
 import { validate } from "../../../middleware/validator";
 
 export const PostRequestActionsAccessBodySchema = z.object({
@@ -27,23 +28,11 @@ export const requestAccessApp = new Hono();
 
 requestAccessApp.post(
   "/",
+  requireRole("user"),
   validate("json", PostRequestActionsAccessBodySchema),
   async (c) => {
     const auth = c.get("auth");
     const user = auth.getNonNullableUser();
-
-    if (!auth.isUser()) {
-      return c.json(
-        {
-          error: {
-            type: "mcp_auth_error",
-            message: "You are not authorized to submit actions requests.",
-          },
-        },
-        401
-      );
-    }
-
     const { emailMessage, mcpServerViewId } = c.req.valid("json");
     const emailRequester = user.email;
 

--- a/front-api/routes/w/mcp/server.test.ts
+++ b/front-api/routes/w/mcp/server.test.ts
@@ -42,7 +42,7 @@ describe("POST /api/w/:wId/mcp/:serverId/sync", () => {
 
     expect(response.status).toBe(403);
     const body = await response.json();
-    expect(body.error.type).toBe("data_source_auth_error");
-    expect(body.error.message).toContain("Only users that are `admins`");
+    expect(body.error.type).toBe("workspace_auth_error");
+    expect(body.error.message).toContain("admin");
   });
 });

--- a/front-api/routes/w/mcp/server.ts
+++ b/front-api/routes/w/mcp/server.ts
@@ -8,6 +8,7 @@ import type { MCPServerType } from "@app/lib/api/mcp";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 
+import { requireRole } from "../../../middleware/require_role";
 import { validate } from "../../../middleware/validator";
 
 export type SyncMCPServerResponseBody = {
@@ -39,23 +40,10 @@ export type PatchMCPServerToolsPermissionsResponseBody = {
 export const serverApp = new Hono();
 
 // POST /sync — admin-only, refreshes the cached metadata for a remote MCP server.
-serverApp.post("/sync", async (c) => {
+serverApp.post("/sync", requireRole("admin"), async (c) => {
   const auth = c.get("auth");
   // serverId is guaranteed present: the parent route is mounted at /:serverId.
   const serverId = c.req.param("serverId") ?? "";
-
-  if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "data_source_auth_error",
-          message:
-            "Only users that are `admins` for the current workspace can manage MCP servers.",
-        },
-      },
-      403
-    );
-  }
 
   const server = await RemoteMCPServerResource.fetchById(auth, serverId);
   if (!server) {
@@ -102,24 +90,12 @@ serverApp.post("/sync", async (c) => {
 // PATCH /tools/:toolName — update per-tool permission / enabled flag.
 serverApp.patch(
   "/tools/:toolName",
+  requireRole("user"),
   validate("json", UpdateMCPToolSettingsBodySchema),
   async (c) => {
     const auth = c.get("auth");
     const serverId = c.req.param("serverId") ?? "";
     const toolName = c.req.param("toolName") ?? "";
-
-    if (!auth.isUser()) {
-      return c.json(
-        {
-          error: {
-            type: "mcp_auth_error",
-            message:
-              "You are not authorized to make request to inspect an MCP server.",
-          },
-        },
-        401
-      );
-    }
 
     const { id } = getServerTypeAndIdFromSId(serverId);
     if (!id) {

--- a/front-api/routes/w/providers.ts
+++ b/front-api/routes/w/providers.ts
@@ -4,6 +4,8 @@ import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import type { ProviderType } from "@app/types/provider";
 import { redactString } from "@app/types/shared/utils/string_utils";
 
+import { requireRole } from "../../middleware/require_role";
+
 export type GetProvidersResponseBody = {
   providers: ProviderType[];
 };
@@ -19,22 +21,8 @@ function redactConfig(config: string) {
 
 export const providersApp = new Hono();
 
-providersApp.get("/", async (c) => {
+providersApp.get("/", requireRole("builder"), async (c) => {
   const auth = c.get("auth");
-
-  if (!auth.isBuilder()) {
-    return c.json(
-      {
-        error: {
-          type: "provider_auth_error",
-          message:
-            "Only the users that are `builders` for the current workspace can list providers.",
-        },
-      },
-      403
-    );
-  }
-
   const owner = auth.getNonNullableWorkspace();
   const providers = await ProviderModel.findAll({
     where: {


### PR DESCRIPTION
## Description

Extracts the repetitive `if (!auth.isBuilder()) return 403 ...` pattern from
Hono handlers into a declarative `requireRole(...)` middleware. Five
handlers updated.

## Changes

**New: `front-api/middleware/require_role.ts`**

```ts
requireRole("user" | "builder" | "admin")
```

Returns a MiddlewareHandler that reads auth from context, checks the
corresponding auth.isUser() / isBuilder() / isAdmin(), and short-
circuits with a 403 workspace_auth_error if the role isn't met. Apply
after the auth middleware (so c.get("auth") is available).

Handlers updated

```
┌───────────────────────────────────────────────┬────────────────────────┬───────────────────────────────────────┐
│                     File                      │          Was           │                  Now                  │
├───────────────────────────────────────────────┼────────────────────────┼───────────────────────────────────────┤
│ routes/w/providers.ts                         │ inline isBuilder check │ requireRole("builder") on the handler │
├───────────────────────────────────────────────┼────────────────────────┼───────────────────────────────────────┤
│ routes/w/assistant/builder/slack.ts           │ inline isBuilder check │ requireRole("builder")                │
├───────────────────────────────────────────────┼────────────────────────┼───────────────────────────────────────┤
│ routes/w/mcp/server.ts POST /sync             │ inline isAdmin check   │ requireRole("admin")                  │
├───────────────────────────────────────────────┼────────────────────────┼───────────────────────────────────────┤
│ routes/w/mcp/server.ts PATCH /tools/:toolName │ inline isUser check    │ requireRole("user")                   │
├───────────────────────────────────────────────┼────────────────────────┼───────────────────────────────────────┤
│ routes/w/mcp/request_access.ts                │ inline isUser check    │ requireRole("user")                   │
└───────────────────────────────────────────────┴────────────────────────┴───────────────────────────────────────┘
```

Each handler dropped its 10-15 line role-check block; the requirement is
now declared in the route registration line next to validate(...) and
similar route-level middleware.

Trade-off: error response is now generic

The replaced inline checks each had endpoint-specific error types and
messages:

- provider_auth_error — "Only the users that are `builders` ... can list providers."
- data_source_auth_error (slack) — "Only the users that are `builders` ... can modify linked Slack channels."
- data_source_auth_error (mcp sync) — "Only users that are `admins` ... can manage MCP servers."
- mcp_auth_error (tools/:toolName) — "You are not authorized to make request to inspect an MCP server."
- mcp_auth_error (request_access) — "You are not authorized to submit actions requests."

All five now produce the same shape:

```ts
{
  "error": {
    "type": "workspace_auth_error",
    "message": "This operation requires <role> access to the workspace."
  }
}
```

The status code is consistent across all five (403). Where a route needs a
more specific error (e.g., tied to a particular resource or operation), do
the check inline in the handler rather than using requireRole.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->