### PR TITLE
Add AWU top off api

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -10,7 +10,7 @@ import {
 } from "@app/lib/auth/AuthContext";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
-import { useAwuPoolSummary, useCreditPurchaseInfo } from "@app/lib/swr/credits";
+import { useAwuPoolSummary, useAwuPurchaseInfo } from "@app/lib/swr/credits";
 import { useMembersUsage } from "@app/lib/swr/memberships";
 import {
   useMetronomeContract,
@@ -154,13 +154,14 @@ export function UsagePage() {
     resetDate,
     isAwuPoolSummaryLoading,
     isAwuPoolSummaryError,
-    mutateAwuPoolSummary,
   } = useAwuPoolSummary({
     workspaceId: owner.sId,
   });
 
-  const { currency, discountPercent, creditPricing, creditPurchaseLimits } =
-    useCreditPurchaseInfo({ workspaceId: owner.sId });
+  const { awuPurchaseInfo, isAwuPurchaseInfoLoading } = useAwuPurchaseInfo({
+    workspaceId: owner.sId,
+    disabled: !showBuyCreditDialog,
+  });
 
   const { membersUsage, isMembersUsageLoading } = useMembersUsage({
     workspaceId: owner.sId,
@@ -215,14 +216,9 @@ export function UsagePage() {
       <BuyAwuCreditsDialog
         isOpen={showBuyCreditDialog}
         onClose={() => setShowBuyCreditDialog(false)}
-        onPurchaseSuccess={() => {
-          void mutateAwuPoolSummary();
-        }}
         workspaceId={owner.sId}
-        currency={currency}
-        discountPercent={discountPercent}
-        creditPricing={creditPricing}
-        creditPurchaseLimits={creditPurchaseLimits}
+        awuPurchaseInfo={awuPurchaseInfo}
+        isAwuPurchaseInfoLoading={isAwuPurchaseInfoLoading}
         currentBalanceCredits={currentBalanceCredits}
       />
 

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -1,13 +1,12 @@
+import { useAwuPurchase } from "@app/hooks/useAwuPurchase";
 import config from "@app/lib/api/config";
-import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
+import type { AwuPurchaseInfo } from "@app/lib/credits/awu_purchase";
 import {
-  AWU_CREDITS_PER_DOLLAR,
-  MAX_CREDIT_PURCHASE_AMOUNT_MICRO_USD,
-  MICRO_USD_PER_DOLLAR,
-  MIN_CREDIT_PURCHASE_AMOUNT_MICRO_USD,
-} from "@app/lib/metronome/types";
-import { CURRENCY_SYMBOLS, isSupportedCurrency } from "@app/types/currency";
-import type { StripePricingData } from "@app/types/stripe/pricing";
+  MAX_AWU_PURCHASE_CREDITS_PER_CYCLE,
+  MIN_AWU_PURCHASE_CREDITS,
+} from "@app/lib/credits/awu_purchase_constants";
+import { AWU_CREDITS_PER_DOLLAR } from "@app/lib/metronome/types";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   ActionCreditCoinsIcon,
   Button,
@@ -92,10 +91,8 @@ interface BuyAwuCreditsDialogProps {
   onClose: () => void;
   onPurchaseSuccess?: () => void;
   workspaceId: string;
-  currency: string;
-  discountPercent: number;
-  creditPricing: StripePricingData | null;
-  creditPurchaseLimits: CreditPurchaseLimits | null;
+  awuPurchaseInfo: AwuPurchaseInfo | null;
+  isAwuPurchaseInfoLoading: boolean;
   currentBalanceCredits?: number;
 }
 
@@ -104,10 +101,8 @@ export function BuyAwuCreditsDialog({
   onClose,
   onPurchaseSuccess,
   workspaceId,
-  currency,
-  discountPercent,
-  creditPricing,
-  creditPurchaseLimits,
+  awuPurchaseInfo,
+  isAwuPurchaseInfoLoading,
   currentBalanceCredits,
 }: BuyAwuCreditsDialogProps) {
   const [amountDollars, setAmountDollars] = useState<string>("");
@@ -115,6 +110,7 @@ export function BuyAwuCreditsDialog({
   const [purchaseState, setPurchaseState] = useState<PurchaseState>("idle");
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [paymentUrl, setPaymentUrl] = useState<string | null>(null);
+  const { purchaseAwuCredits } = useAwuPurchase({ workspaceId });
 
   const resetModalStateAndClose = useCallback(() => {
     setAmountDollars("");
@@ -126,24 +122,24 @@ export function BuyAwuCreditsDialog({
   }, [onClose]);
 
   const maxAmountDollars = useMemo(() => {
-    if (!creditPurchaseLimits?.canPurchase) {
+    if (!awuPurchaseInfo?.canPurchase) {
       return null;
     }
     return Math.floor(
-      creditPurchaseLimits.maxAmountMicroUsd / MICRO_USD_PER_DOLLAR
+      awuPurchaseInfo.remainingCycleCredits / AWU_CREDITS_PER_DOLLAR
     );
-  }, [creditPurchaseLimits]);
+  }, [awuPurchaseInfo]);
 
   const maxAmountFormatted = useMemo(() => {
-    if (!creditPurchaseLimits?.canPurchase) {
+    if (maxAmountDollars === null) {
       return null;
     }
-    return `$${Math.floor(creditPurchaseLimits.maxAmountMicroUsd / MICRO_USD_PER_DOLLAR).toLocaleString()}`;
-  }, [creditPurchaseLimits]);
+    return `$${maxAmountDollars.toLocaleString()}`;
+  }, [maxAmountDollars]);
 
   const effectiveMaxDollars =
     maxAmountDollars ??
-    Math.floor(MAX_CREDIT_PURCHASE_AMOUNT_MICRO_USD / MICRO_USD_PER_DOLLAR);
+    Math.floor(MAX_AWU_PURCHASE_CREDITS_PER_CYCLE / AWU_CREDITS_PER_DOLLAR);
 
   const setAmountWithClamp = useCallback(
     (dollars: number) => {
@@ -157,30 +153,28 @@ export function BuyAwuCreditsDialog({
   const amountExceedsMax = parsedAmount > effectiveMaxDollars;
   const addedCredits = parsedAmount * AWU_CREDITS_PER_DOLLAR;
 
-  const displayCurrency = isSupportedCurrency(currency) ? currency : "usd";
-  const currencySymbol = CURRENCY_SYMBOLS[displayCurrency];
-  const needsConversion = displayCurrency !== "usd";
-
-  let amountInDisplayCurrency = parsedAmount;
-  if (needsConversion && creditPricing) {
-    const usdUnit = creditPricing.currencyOptions.usd?.unitAmount ?? 0;
-    const displayUnit =
-      creditPricing.currencyOptions[displayCurrency]?.unitAmount ?? 0;
-    if (usdUnit > 0 && displayUnit > 0) {
-      amountInDisplayCurrency = parsedAmount * (displayUnit / usdUnit);
-    }
-  }
-
-  const effectiveDiscount = discountPercent || 0;
-  const discountAmount = amountInDisplayCurrency * (effectiveDiscount / 100);
-  const totalInDisplayCurrency = amountInDisplayCurrency - discountAmount;
-
   const canPurchase = isValidAmount && !amountExceedsMax;
 
-  // TODO: implement AWU-specific purchase endpoint.
   const handlePurchase = async () => {
-    setPurchaseState("success");
-    onPurchaseSuccess?.();
+    setPurchaseState("processing");
+    const amountCredits = Math.round(addedCredits);
+    const result = await purchaseAwuCredits(amountCredits);
+    switch (result.status) {
+      case "success":
+        setPurchaseState("success");
+        onPurchaseSuccess?.();
+        break;
+      case "redirect":
+        setPaymentUrl(result.paymentUrl);
+        setPurchaseState("redirect");
+        break;
+      case "error":
+        setErrorMessage(result.message);
+        setPurchaseState("error");
+        break;
+      default:
+        assertNeverAndIgnore(result);
+    }
   };
 
   const renderContent = () => {
@@ -354,7 +348,7 @@ export function BuyAwuCreditsDialog({
                       )}
                       <SummaryRow
                         label="Cost"
-                        value={`${currencySymbol}${formatCost(totalInDisplayCurrency)}`}
+                        value={`$${formatCost(parsedAmount)}`}
                       />
                     </div>
                   )}
@@ -468,11 +462,28 @@ export function BuyAwuCreditsDialog({
     }
   };
 
-  // Cannot purchase: trialing.
+  if (isAwuPurchaseInfoLoading) {
+    return (
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent size="md">
+          <DialogHeader>
+            <DialogTitle>Credit pool top-up</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
+            <div className="flex justify-center py-8">
+              <Spinner size="lg" />
+            </div>
+          </DialogContainer>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // Cannot purchase: legacy plan.
   if (
-    creditPurchaseLimits &&
-    !creditPurchaseLimits.canPurchase &&
-    creditPurchaseLimits.reason === "trialing"
+    awuPurchaseInfo &&
+    !awuPurchaseInfo.canPurchase &&
+    awuPurchaseInfo.reason === "legacy_plan"
   ) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -480,20 +491,19 @@ export function BuyAwuCreditsDialog({
           <DialogHeader>
             <DialogTitle>Credit pool top-up</DialogTitle>
             <DialogDescription>
-              Credit purchases are not available during your trial period.
+              AWU credit purchases are not available for your current plan.
             </DialogDescription>
           </DialogHeader>
           <DialogContainer>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Credit purchases become available once you upgrade to a paid plan.
-              If you need credits during your trial, please{" "}
+              Please{" "}
               <a
-                href={`mailto:${supportEmail}?subject=Credit%20purchase%20during%20trial`}
+                href={`mailto:${supportEmail}?subject=AWU%20credit%20purchase`}
                 className="text-action-500 hover:underline"
               >
                 contact support
-              </a>
-              .
+              </a>{" "}
+              for assistance.
             </p>
           </DialogContainer>
           <DialogFooter
@@ -508,11 +518,11 @@ export function BuyAwuCreditsDialog({
     );
   }
 
-  // Cannot purchase: payment issue.
+  // Cannot purchase: no Stripe customer.
   if (
-    creditPurchaseLimits &&
-    !creditPurchaseLimits.canPurchase &&
-    creditPurchaseLimits.reason === "payment_issue"
+    awuPurchaseInfo &&
+    !awuPurchaseInfo.canPurchase &&
+    awuPurchaseInfo.reason === "no_stripe_customer"
   ) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -520,20 +530,19 @@ export function BuyAwuCreditsDialog({
           <DialogHeader>
             <DialogTitle>Credit pool top-up</DialogTitle>
             <DialogDescription>
-              Credit purchases require an active subscription.
+              No billing configuration found for this workspace.
             </DialogDescription>
           </DialogHeader>
           <DialogContainer>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Please ensure your subscription is active and your payment method
-              is up to date. If you need assistance, please{" "}
+              Please{" "}
               <a
-                href={`mailto:${supportEmail}?subject=Credit%20purchase%20-%20payment%20issue`}
+                href={`mailto:${supportEmail}?subject=AWU%20credit%20purchase%20-%20billing%20setup`}
                 className="text-action-500 hover:underline"
               >
                 contact support
-              </a>
-              .
+              </a>{" "}
+              to set up billing for your workspace.
             </p>
           </DialogContainer>
           <DialogFooter
@@ -550,9 +559,9 @@ export function BuyAwuCreditsDialog({
 
   // Cannot purchase: pending payment.
   if (
-    creditPurchaseLimits &&
-    !creditPurchaseLimits.canPurchase &&
-    creditPurchaseLimits.reason === "pending_payment"
+    awuPurchaseInfo &&
+    !awuPurchaseInfo.canPurchase &&
+    awuPurchaseInfo.reason === "pending_purchase"
   ) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -597,10 +606,8 @@ export function BuyAwuCreditsDialog({
 
   // Limit exhausted for this billing cycle.
   if (
-    creditPurchaseLimits &&
-    creditPurchaseLimits.canPurchase &&
-    creditPurchaseLimits.maxAmountMicroUsd <
-      MIN_CREDIT_PURCHASE_AMOUNT_MICRO_USD
+    awuPurchaseInfo?.canPurchase &&
+    awuPurchaseInfo.remainingCycleCredits < MIN_AWU_PURCHASE_CREDITS
   ) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -19,7 +19,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  ExternalLinkIcon,
   Icon,
   Input,
   Spinner,
@@ -31,7 +30,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useCallback, useMemo, useState } from "react";
 
-type PurchaseState = "idle" | "processing" | "success" | "redirect" | "error";
+type PurchaseState = "idle" | "processing" | "success" | "error";
 type TopUpTab = "one-time" | "automatic";
 
 const QUICK_SELECT_AMOUNTS = [10, 50, 100] as const;
@@ -110,7 +109,6 @@ export function BuyAwuCreditsDialog({
   const [selectedTab, setSelectedTab] = useState<TopUpTab>("one-time");
   const [purchaseState, setPurchaseState] = useState<PurchaseState>("idle");
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const [paymentUrl, setPaymentUrl] = useState<string | null>(null);
   const { purchaseAwuCredits } = useAwuPurchase({ workspaceId });
 
   const resetModalStateAndClose = useCallback(() => {
@@ -118,7 +116,6 @@ export function BuyAwuCreditsDialog({
     setSelectedTab("one-time");
     setPurchaseState("idle");
     setErrorMessage("");
-    setPaymentUrl(null);
     onClose();
   }, [onClose]);
 
@@ -170,10 +167,6 @@ export function BuyAwuCreditsDialog({
         setPurchaseState("success");
         onPurchaseSuccess?.();
         break;
-      case "redirect":
-        setPaymentUrl(result.paymentUrl);
-        setPurchaseState("redirect");
-        break;
       case "error":
         setErrorMessage(result.message);
         setPurchaseState("error");
@@ -214,26 +207,6 @@ export function BuyAwuCreditsDialog({
                 <span className="font-semibold">
                   Invoice has been sent by email.
                 </span>
-              </p>
-            </div>
-          </div>
-        );
-
-      case "redirect":
-        return (
-          <div className="flex flex-col items-center justify-center gap-4 py-8">
-            <Icon
-              visual={ExternalLinkIcon}
-              size="lg"
-              className="text-primary dark:text-primary-night"
-            />
-            <div className="text-center">
-              <p className="text-lg font-medium text-foreground dark:text-foreground-night">
-                Payment confirmation required
-              </p>
-              <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
-                Please complete the payment to finalize your credit purchase or
-                contact support to cancel pending invoices.
               </p>
             </div>
           </div>
@@ -413,25 +386,6 @@ export function BuyAwuCreditsDialog({
             }}
           />
         );
-      case "redirect":
-        return (
-          <DialogFooter
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-              onClick: resetModalStateAndClose,
-            }}
-            rightButtonProps={{
-              label: "Go to Payment",
-              variant: "primary",
-              onClick: () => {
-                if (paymentUrl) {
-                  window.open(paymentUrl, "_blank")?.focus();
-                }
-              },
-            }}
-          />
-        );
       case "error":
         return (
           <DialogFooter
@@ -485,11 +439,10 @@ export function BuyAwuCreditsDialog({
     );
   }
 
-  // Once a purchase is in flight (processing / redirect / success / error),
-  // drive the dialog from local state and ignore the refreshed
-  // awuPurchaseInfo — the just-created invoice would otherwise flip it to
-  // `pending_purchase` and bump the user off the "Payment confirmation
-  // required" screen before they can click through.
+  // Once a purchase is in flight (processing / success / error), drive the
+  // dialog from local state and ignore the refreshed awuPurchaseInfo — the
+  // just-created Metronome commit would otherwise flip it to
+  // `pending_purchase` and bump the user off the success screen.
   const isPurchaseInFlight = purchaseState !== "idle";
 
   // Cannot purchase: legacy plan.

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -5,7 +5,8 @@ import {
   MAX_AWU_PURCHASE_CREDITS_PER_CYCLE,
   MIN_AWU_PURCHASE_CREDITS,
 } from "@app/lib/credits/awu_purchase_constants";
-import { AWU_CREDITS_PER_DOLLAR } from "@app/lib/metronome/types";
+import { AWU_PRICE_PER_CREDIT } from "@app/lib/metronome/types";
+import { CURRENCY_SYMBOLS } from "@app/types/currency";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   ActionCreditCoinsIcon,
@@ -33,7 +34,7 @@ import { useCallback, useMemo, useState } from "react";
 type PurchaseState = "idle" | "processing" | "success" | "redirect" | "error";
 type TopUpTab = "one-time" | "automatic";
 
-const QUICK_SELECT_AMOUNTS_DOLLARS = [10, 50, 100] as const;
+const QUICK_SELECT_AMOUNTS = [10, 50, 100] as const;
 
 const supportEmail = config.getSupportEmailAddress().email;
 
@@ -105,7 +106,7 @@ export function BuyAwuCreditsDialog({
   isAwuPurchaseInfoLoading,
   currentBalanceCredits,
 }: BuyAwuCreditsDialogProps) {
-  const [amountDollars, setAmountDollars] = useState<string>("");
+  const [amountInput, setAmountInput] = useState<string>("");
   const [selectedTab, setSelectedTab] = useState<TopUpTab>("one-time");
   const [purchaseState, setPurchaseState] = useState<PurchaseState>("idle");
   const [errorMessage, setErrorMessage] = useState<string>("");
@@ -113,7 +114,7 @@ export function BuyAwuCreditsDialog({
   const { purchaseAwuCredits } = useAwuPurchase({ workspaceId });
 
   const resetModalStateAndClose = useCallback(() => {
-    setAmountDollars("");
+    setAmountInput("");
     setSelectedTab("one-time");
     setPurchaseState("idle");
     setErrorMessage("");
@@ -121,37 +122,42 @@ export function BuyAwuCreditsDialog({
     onClose();
   }, [onClose]);
 
-  const maxAmountDollars = useMemo(() => {
+  const currency = awuPurchaseInfo?.canPurchase
+    ? awuPurchaseInfo.currency
+    : "usd";
+  const currencySymbol = CURRENCY_SYMBOLS[currency];
+  const pricePerCredit = AWU_PRICE_PER_CREDIT[currency];
+  const creditsPerCurrencyUnit = 1 / pricePerCredit;
+
+  const maxAmountInCurrency = useMemo(() => {
     if (!awuPurchaseInfo?.canPurchase) {
       return null;
     }
-    return Math.floor(
-      awuPurchaseInfo.remainingCycleCredits / AWU_CREDITS_PER_DOLLAR
-    );
-  }, [awuPurchaseInfo]);
+    return Math.floor(awuPurchaseInfo.remainingCycleCredits * pricePerCredit);
+  }, [awuPurchaseInfo, pricePerCredit]);
 
   const maxAmountFormatted = useMemo(() => {
-    if (maxAmountDollars === null) {
+    if (maxAmountInCurrency === null) {
       return null;
     }
-    return `$${maxAmountDollars.toLocaleString()}`;
-  }, [maxAmountDollars]);
+    return `${currencySymbol}${maxAmountInCurrency.toLocaleString()}`;
+  }, [maxAmountInCurrency, currencySymbol]);
 
-  const effectiveMaxDollars =
-    maxAmountDollars ??
-    Math.floor(MAX_AWU_PURCHASE_CREDITS_PER_CYCLE / AWU_CREDITS_PER_DOLLAR);
+  const effectiveMaxAmount =
+    maxAmountInCurrency ??
+    Math.floor(MAX_AWU_PURCHASE_CREDITS_PER_CYCLE * pricePerCredit);
 
   const setAmountWithClamp = useCallback(
-    (dollars: number) => {
-      setAmountDollars(String(Math.min(dollars, effectiveMaxDollars)));
+    (amount: number) => {
+      setAmountInput(String(Math.min(amount, effectiveMaxAmount)));
     },
-    [effectiveMaxDollars]
+    [effectiveMaxAmount]
   );
 
-  const parsedAmount = parseFloat(amountDollars) || 0;
+  const parsedAmount = parseFloat(amountInput) || 0;
   const isValidAmount = parsedAmount > 0;
-  const amountExceedsMax = parsedAmount > effectiveMaxDollars;
-  const addedCredits = parsedAmount * AWU_CREDITS_PER_DOLLAR;
+  const amountExceedsMax = parsedAmount > effectiveMaxAmount;
+  const addedCredits = parsedAmount * creditsPerCurrencyUnit;
 
   const canPurchase = isValidAmount && !amountExceedsMax;
 
@@ -275,23 +281,23 @@ export function BuyAwuCreditsDialog({
                     <div className="flex items-center gap-3">
                       <div className="relative">
                         <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
-                          $
+                          {currencySymbol}
                         </span>
                         <Input
                           id="amount"
                           type="number"
                           placeholder="0"
-                          value={amountDollars}
+                          value={amountInput}
                           onChange={(e) => {
                             const val = parseFloat(e.target.value);
                             if (!isNaN(val)) {
                               setAmountWithClamp(val);
                             } else {
-                              setAmountDollars(e.target.value);
+                              setAmountInput(e.target.value);
                             }
                           }}
                           min="0"
-                          max={effectiveMaxDollars}
+                          max={effectiveMaxAmount}
                           step="1"
                           className="w-32 pl-7 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                         />
@@ -303,10 +309,10 @@ export function BuyAwuCreditsDialog({
                         </span>
                       )}
                       <div className="ml-auto flex gap-2">
-                        {QUICK_SELECT_AMOUNTS_DOLLARS.map((amount) => (
+                        {QUICK_SELECT_AMOUNTS.map((amount) => (
                           <Button
                             key={amount}
-                            label={`$${amount}`}
+                            label={`${currencySymbol}${amount}`}
                             variant="outline"
                             size="sm"
                             onClick={() => setAmountWithClamp(amount)}
@@ -348,7 +354,7 @@ export function BuyAwuCreditsDialog({
                       )}
                       <SummaryRow
                         label="Cost"
-                        value={`$${formatCost(parsedAmount)}`}
+                        value={`${currencySymbol}${formatCost(parsedAmount)}`}
                       />
                     </div>
                   )}
@@ -479,8 +485,16 @@ export function BuyAwuCreditsDialog({
     );
   }
 
+  // Once a purchase is in flight (processing / redirect / success / error),
+  // drive the dialog from local state and ignore the refreshed
+  // awuPurchaseInfo — the just-created invoice would otherwise flip it to
+  // `pending_purchase` and bump the user off the "Payment confirmation
+  // required" screen before they can click through.
+  const isPurchaseInFlight = purchaseState !== "idle";
+
   // Cannot purchase: legacy plan.
   if (
+    !isPurchaseInFlight &&
     awuPurchaseInfo &&
     !awuPurchaseInfo.canPurchase &&
     awuPurchaseInfo.reason === "legacy_plan"
@@ -520,6 +534,7 @@ export function BuyAwuCreditsDialog({
 
   // Cannot purchase: no Stripe customer.
   if (
+    !isPurchaseInFlight &&
     awuPurchaseInfo &&
     !awuPurchaseInfo.canPurchase &&
     awuPurchaseInfo.reason === "no_stripe_customer"
@@ -559,6 +574,7 @@ export function BuyAwuCreditsDialog({
 
   // Cannot purchase: pending payment.
   if (
+    !isPurchaseInFlight &&
     awuPurchaseInfo &&
     !awuPurchaseInfo.canPurchase &&
     awuPurchaseInfo.reason === "pending_purchase"
@@ -606,6 +622,7 @@ export function BuyAwuCreditsDialog({
 
   // Limit exhausted for this billing cycle.
   if (
+    !isPurchaseInFlight &&
     awuPurchaseInfo?.canPurchase &&
     awuPurchaseInfo.remainingCycleCredits < MIN_AWU_PURCHASE_CREDITS
   ) {

--- a/front/hooks/useAwuPurchase.ts
+++ b/front/hooks/useAwuPurchase.ts
@@ -27,7 +27,6 @@ function subscribeToAwuPurchaseLoading(callback: () => void) {
 
 export type AwuPurchaseOutcome =
   | { status: "success" }
-  | { status: "redirect"; paymentUrl: string }
   | { status: "error"; message: string };
 
 export function useAwuPurchase({ workspaceId }: { workspaceId: string }) {
@@ -72,14 +71,9 @@ export function useAwuPurchase({ workspaceId }: { workspaceId: string }) {
           return { status: "error", message };
         }
 
-        const data = await response.json();
+        await response.json();
 
         void mutateAwuPurchaseInfo();
-
-        if (data.paymentUrl) {
-          return { status: "redirect", paymentUrl: data.paymentUrl };
-        }
-
         resetAwuPostPurchaseRefreshCount(workspaceId);
         void mutateAwuPoolSummary();
 

--- a/front/hooks/useAwuPurchase.ts
+++ b/front/hooks/useAwuPurchase.ts
@@ -1,0 +1,99 @@
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  resetAwuPostPurchaseRefreshCount,
+  useAwuPoolSummary,
+  useAwuPurchaseInfo,
+} from "@app/lib/swr/credits";
+import { useCallback, useSyncExternalStore } from "react";
+
+const awuPurchaseLoadingState = new Map<string, boolean>();
+const awuPurchaseLoadingListeners = new Set<() => void>();
+
+function setAwuPurchaseLoading(workspaceId: string, loading: boolean) {
+  awuPurchaseLoadingState.set(workspaceId, loading);
+  awuPurchaseLoadingListeners.forEach((listener) => listener());
+}
+
+function getAwuPurchaseLoading(workspaceId: string): boolean {
+  return awuPurchaseLoadingState.get(workspaceId) ?? false;
+}
+
+function subscribeToAwuPurchaseLoading(callback: () => void) {
+  awuPurchaseLoadingListeners.add(callback);
+  return () => {
+    awuPurchaseLoadingListeners.delete(callback);
+  };
+}
+
+export type AwuPurchaseOutcome =
+  | { status: "success" }
+  | { status: "redirect"; paymentUrl: string }
+  | { status: "error"; message: string };
+
+export function useAwuPurchase({ workspaceId }: { workspaceId: string }) {
+  const isPurchasing = useSyncExternalStore(
+    subscribeToAwuPurchaseLoading,
+    () => getAwuPurchaseLoading(workspaceId),
+    () => false
+  );
+
+  const { mutateAwuPoolSummary } = useAwuPoolSummary({
+    workspaceId,
+    disabled: true,
+  });
+
+  const { mutateAwuPurchaseInfo } = useAwuPurchaseInfo({
+    workspaceId,
+    disabled: true,
+  });
+
+  const purchaseAwuCredits = useCallback(
+    async (amountCredits: number): Promise<AwuPurchaseOutcome> => {
+      if (getAwuPurchaseLoading(workspaceId)) {
+        return { status: "error", message: "Purchase already in progress" };
+      }
+
+      setAwuPurchaseLoading(workspaceId, true);
+
+      try {
+        const response = await clientFetch(
+          `/api/w/${workspaceId}/subscriptions/awu-purchase`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ amountCredits }),
+          }
+        );
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => null);
+          const message =
+            errorData?.error?.message ?? "Failed to purchase AWU credits";
+          return { status: "error", message };
+        }
+
+        const data = await response.json();
+
+        void mutateAwuPurchaseInfo();
+
+        if (data.paymentUrl) {
+          return { status: "redirect", paymentUrl: data.paymentUrl };
+        }
+
+        resetAwuPostPurchaseRefreshCount(workspaceId);
+        void mutateAwuPoolSummary();
+
+        return { status: "success" };
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to purchase AWU credits";
+        return { status: "error", message };
+      } finally {
+        setAwuPurchaseLoading(workspaceId, false);
+      }
+    },
+    [workspaceId, mutateAwuPoolSummary, mutateAwuPurchaseInfo]
+  );
+
+  return { isPurchasing, purchaseAwuCredits };
+}

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -1,0 +1,347 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getBillingCycle } from "@app/lib/client/subscription";
+import {
+  createMetronomeCredit,
+  getMetronomeCustomerStripeCustomerId,
+} from "@app/lib/metronome/client";
+import {
+  AWU_PRIORITY_PURCHASED_COMMIT,
+  getCreditTypeAwuId,
+  getProductPrepaidCommitId,
+} from "@app/lib/metronome/constants";
+import { resolveCurrencyForExistingMetronomeCustomer } from "@app/lib/metronome/contracts";
+import { isLegacyPlan } from "@app/lib/metronome/plan_type";
+import { AWU_CREDITS_PER_DOLLAR } from "@app/lib/metronome/types";
+import {
+  finalizeInvoice,
+  getStripeClient,
+  makeAwuPurchaseInvoiceForCustomer,
+  payInvoice,
+} from "@app/lib/plans/stripe";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type Stripe from "stripe";
+import {
+  MAX_AWU_PURCHASE_CREDITS_PER_CYCLE,
+  MIN_AWU_PURCHASE_CREDITS,
+} from "./awu_purchase_constants";
+
+export type AwuPurchaseInfo =
+  | {
+      canPurchase: false;
+      reason:
+        | "not_metronome_billed"
+        | "legacy_plan"
+        | "no_stripe_customer"
+        | "pending_purchase";
+    }
+  | { canPurchase: true; remainingCycleCredits: number };
+
+export type AwuPurchaseResult = {
+  invoiceId: string;
+  amountCredits: number;
+  amountCents: number;
+  paymentUrl: string | null;
+};
+
+export type AwuPurchaseError =
+  | { code: "not_metronome_billed" }
+  | { code: "legacy_plan" }
+  | { code: "no_stripe_customer" }
+  | { code: "pending_purchase" }
+  | { code: "invalid_amount"; message: string }
+  | { code: "purchase_failed"; message: string };
+
+type AwuEligibilityErrorCode = Extract<
+  AwuPurchaseInfo,
+  { canPurchase: false }
+>["reason"];
+
+type AwuEligibilityOk = {
+  metronomeCustomerId: string;
+  stripeCustomerId: string;
+  stripe: Stripe;
+};
+
+async function checkAwuPurchaseEligibility(
+  auth: Authenticator
+): Promise<Result<AwuEligibilityOk, { code: AwuEligibilityErrorCode }>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+
+  if (!subscription?.metronomeContractId || !workspace.metronomeCustomerId) {
+    return new Err({ code: "not_metronome_billed" });
+  }
+
+  const { metronomeCustomerId } = workspace;
+
+  const onLegacyPlan = await isLegacyPlan(workspace.sId);
+  if (onLegacyPlan) {
+    return new Err({ code: "legacy_plan" });
+  }
+
+  const stripeCustomerResult =
+    await getMetronomeCustomerStripeCustomerId(metronomeCustomerId);
+  if (stripeCustomerResult.isErr() || !stripeCustomerResult.value) {
+    return new Err({ code: "no_stripe_customer" });
+  }
+  const stripeCustomerId = stripeCustomerResult.value;
+
+  const stripe = getStripeClient();
+  const openInvoices = await stripe.invoices.list({
+    customer: stripeCustomerId,
+    status: "open",
+  });
+  const hasPending = openInvoices.data.some(
+    (inv) => inv.metadata?.awu_purchase === "true"
+  );
+  if (hasPending) {
+    return new Err({ code: "pending_purchase" });
+  }
+
+  return new Ok({ metronomeCustomerId, stripeCustomerId, stripe });
+}
+
+export async function getAwuPurchaseInfo(
+  auth: Authenticator
+): Promise<AwuPurchaseInfo> {
+  const eligibility = await checkAwuPurchaseEligibility(auth);
+  if (eligibility.isErr()) {
+    return { canPurchase: false, reason: eligibility.error.code };
+  }
+
+  const { stripeCustomerId, stripe } = eligibility.value;
+  const subscription = auth.subscription()!;
+
+  const billingCycle = getBillingCycle(subscription.startDate);
+  if (!billingCycle) {
+    return {
+      canPurchase: true,
+      remainingCycleCredits: MAX_AWU_PURCHASE_CREDITS_PER_CYCLE,
+    };
+  }
+
+  const cycleStartSeconds = Math.floor(
+    billingCycle.cycleStart.getTime() / 1000
+  );
+  const paidInvoices = await stripe.invoices.list({
+    customer: stripeCustomerId,
+    status: "paid",
+    created: { gte: cycleStartSeconds },
+  });
+  const alreadyPurchasedThisCycleCredits = paidInvoices.data
+    .filter((inv) => inv.metadata?.awu_purchase === "true")
+    .reduce((sum, inv) => sum + (inv.amount_paid ?? 0), 0);
+
+  return {
+    canPurchase: true,
+    remainingCycleCredits: Math.max(
+      0,
+      MAX_AWU_PURCHASE_CREDITS_PER_CYCLE - alreadyPurchasedThisCycleCredits
+    ),
+  };
+}
+
+export async function purchaseAwuCredits(
+  auth: Authenticator,
+  { amountCredits }: { amountCredits: number }
+): Promise<Result<AwuPurchaseResult, AwuPurchaseError>> {
+  const eligibility = await checkAwuPurchaseEligibility(auth);
+  if (eligibility.isErr()) {
+    return new Err({ code: eligibility.error.code });
+  }
+
+  const { metronomeCustomerId, stripeCustomerId, stripe } = eligibility.value;
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription()!;
+
+  if (amountCredits < MIN_AWU_PURCHASE_CREDITS) {
+    return new Err({
+      code: "invalid_amount",
+      message: `Minimum purchase is ${MIN_AWU_PURCHASE_CREDITS.toLocaleString()} credits ($${MIN_AWU_PURCHASE_CREDITS / AWU_CREDITS_PER_DOLLAR})`,
+    });
+  }
+
+  const billingCycle = getBillingCycle(subscription.startDate);
+  if (!billingCycle) {
+    return new Err({
+      code: "invalid_amount",
+      message: "Could not determine billing cycle from subscription start date",
+    });
+  }
+  const cycleStartSeconds = Math.floor(
+    billingCycle.cycleStart.getTime() / 1000
+  );
+  const paidInvoices = await stripe.invoices.list({
+    customer: stripeCustomerId,
+    status: "paid",
+    created: { gte: cycleStartSeconds },
+  });
+  const alreadyPurchasedThisCycleCredits = paidInvoices.data
+    .filter((inv) => inv.metadata?.awu_purchase === "true")
+    .reduce((sum, inv) => sum + (inv.amount_paid ?? 0), 0);
+
+  const remaining =
+    MAX_AWU_PURCHASE_CREDITS_PER_CYCLE - alreadyPurchasedThisCycleCredits;
+  if (amountCredits > remaining) {
+    return new Err({
+      code: "invalid_amount",
+      message: `Purchase would exceed the cycle limit. You can purchase up to ${remaining.toLocaleString()} more credits this cycle.`,
+    });
+  }
+
+  const currencyResult = await resolveCurrencyForExistingMetronomeCustomer({
+    metronomeCustomerId,
+    stripeSubscriptionId: null,
+  });
+  if (currencyResult.isErr()) {
+    logger.error(
+      { workspaceId: workspace.sId, error: currencyResult.error.message },
+      "[AWU Purchase] Failed to resolve currency"
+    );
+    return new Err({
+      code: "purchase_failed",
+      message: currencyResult.error.message,
+    });
+  }
+
+  const invoiceResult = await makeAwuPurchaseInvoiceForCustomer({
+    stripeCustomerId,
+    workspaceId: workspace.sId,
+    currency: currencyResult.value,
+    amountCredits,
+  });
+  if (invoiceResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        amountCredits,
+        error: invoiceResult.error.error_message,
+      },
+      "[AWU Purchase] Failed to create Stripe invoice"
+    );
+    return new Err({
+      code: "purchase_failed",
+      message: invoiceResult.error.error_message,
+    });
+  }
+  const invoice = invoiceResult.value;
+
+  const finalizeResult = await finalizeInvoice(invoice);
+  if (finalizeResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+        error: finalizeResult.error.error_message,
+      },
+      "[AWU Purchase] Failed to finalize Stripe invoice"
+    );
+    return new Err({
+      code: "purchase_failed",
+      message: finalizeResult.error.error_message,
+    });
+  }
+
+  const payResult = await payInvoice(finalizeResult.value);
+  if (payResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        invoiceId: invoice.id,
+        error: payResult.error.error_message,
+      },
+      "[AWU Purchase] Failed to pay Stripe invoice"
+    );
+    return new Err({
+      code: "purchase_failed",
+      message: payResult.error.error_message,
+    });
+  }
+
+  const { paymentUrl } = payResult.value;
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      invoiceId: invoice.id,
+      amountCredits,
+      requiresAction: paymentUrl !== null,
+    },
+    "[AWU Purchase] Invoice created and paid, credits will be granted via webhook"
+  );
+
+  return new Ok({
+    invoiceId: invoice.id,
+    amountCredits,
+    amountCents: amountCredits,
+    paymentUrl,
+  });
+}
+
+/**
+ * Called by the Stripe webhook (invoice.paid) to grant AWU credits in Metronome
+ * once payment is confirmed.
+ */
+export async function grantAwuCreditsFromPaidInvoice({
+  invoice,
+  auth,
+}: {
+  invoice: Stripe.Invoice;
+  auth: Authenticator;
+}): Promise<void> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const amountCreditsStr = invoice.metadata?.awu_amount_credits;
+  if (!amountCreditsStr) {
+    logger.error(
+      { invoiceId: invoice.id, workspaceId: workspace.sId },
+      "[AWU Purchase] Paid invoice missing awu_amount_credits metadata"
+    );
+    return;
+  }
+  const amountCredits = parseInt(amountCreditsStr, 10);
+  if (isNaN(amountCredits) || amountCredits <= 0) {
+    logger.error(
+      { invoiceId: invoice.id, workspaceId: workspace.sId, amountCreditsStr },
+      "[AWU Purchase] Invalid awu_amount_credits in invoice metadata"
+    );
+    return;
+  }
+
+  if (!workspace.metronomeCustomerId) {
+    logger.error(
+      { invoiceId: invoice.id, workspaceId: workspace.sId },
+      "[AWU Purchase] Workspace has no Metronome customer ID"
+    );
+    return;
+  }
+
+  const now = new Date();
+  const oneYearFromNow = new Date(now);
+  oneYearFromNow.setUTCFullYear(oneYearFromNow.getUTCFullYear() + 1);
+
+  const grantResult = await createMetronomeCredit({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    productId: getProductPrepaidCommitId(),
+    creditTypeId: getCreditTypeAwuId(),
+    amount: amountCredits,
+    startingAt: now.toISOString(),
+    endingBefore: oneYearFromNow.toISOString(),
+    name: `AWU credit top-up: ${amountCredits.toLocaleString()} credits`,
+    idempotencyKey: `awuPurchase-${workspace.sId}-${invoice.id}`,
+    priority: AWU_PRIORITY_PURCHASED_COMMIT,
+  });
+
+  if (grantResult.isErr()) {
+    throw new Error(
+      `[AWU Purchase] Failed to grant Metronome credits: ${grantResult.error.message} (invoiceId=${invoice.id}, workspaceId=${workspace.sId}, amountCredits=${amountCredits})`
+    );
+  }
+
+  logger.info(
+    { invoiceId: invoice.id, workspaceId: workspace.sId, amountCredits },
+    "[AWU Purchase] Successfully granted AWU credits from webhook"
+  );
+}

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -16,6 +16,7 @@ import { AWU_PRICE_PER_CREDIT } from "@app/lib/metronome/types";
 import { getStripeClient } from "@app/lib/plans/stripe";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
+import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type Stripe from "stripe";
@@ -90,11 +91,15 @@ async function checkAwuPurchaseEligibility(
   const workspace = auth.getNonNullableWorkspace();
   const subscription = auth.subscription();
 
-  if (!subscription?.metronomeContractId || !workspace.metronomeCustomerId) {
+  const { metronomeCustomerId } = workspace;
+
+  if (
+    !subscription ||
+    !metronomeCustomerId ||
+    isSubscriptionMetronomeBilled(subscription)
+  ) {
     return new Err({ code: "not_metronome_billed" });
   }
-
-  const { metronomeCustomerId } = workspace;
 
   const onLegacyPlan = await isLegacyPlan(workspace.sId);
   if (onLegacyPlan) {

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -9,9 +9,8 @@ import {
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
 } from "@app/lib/metronome/constants";
-import { resolveCurrencyForExistingMetronomeCustomer } from "@app/lib/metronome/contracts";
-import { isLegacyPlan } from "@app/lib/metronome/plan_type";
-import { AWU_CREDITS_PER_DOLLAR } from "@app/lib/metronome/types";
+import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
+import { getActiveContract, isLegacyPlan } from "@app/lib/metronome/plan_type";
 import {
   finalizeInvoice,
   getStripeClient,
@@ -19,6 +18,7 @@ import {
   payInvoice,
 } from "@app/lib/plans/stripe";
 import logger from "@app/logger/logger";
+import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type Stripe from "stripe";
@@ -36,7 +36,11 @@ export type AwuPurchaseInfo =
         | "no_stripe_customer"
         | "pending_purchase";
     }
-  | { canPurchase: true; remainingCycleCredits: number };
+  | {
+      canPurchase: true;
+      remainingCycleCredits: number;
+      currency: SupportedCurrency;
+    };
 
 export type AwuPurchaseResult = {
   invoiceId: string;
@@ -63,6 +67,28 @@ type AwuEligibilityOk = {
   stripeCustomerId: string;
   stripe: Stripe;
 };
+
+/**
+ * Resolves the billing currency from the active Metronome contract's rate
+ * card — the source of truth for Metronome-billed workspaces. The Stripe
+ * customer's `currency` field is unreliable (only set after the first paid
+ * invoice) and its `address.country` may not be populated, so deriving
+ * currency from the contract guarantees the invoice matches what Metronome
+ * is configured to bill.
+ */
+async function resolveAwuPurchaseCurrency(
+  workspaceId: string
+): Promise<Result<SupportedCurrency, Error>> {
+  const contract = await getActiveContract(workspaceId);
+  if (!contract) {
+    return new Err(new Error("No active Metronome contract found"));
+  }
+  const creditTypeResult = await getCreditTypeFromContract(contract);
+  if (creditTypeResult.isErr()) {
+    return new Err(creditTypeResult.error);
+  }
+  return new Ok(creditTypeResult.value.currency);
+}
 
 async function checkAwuPurchaseEligibility(
   auth: Authenticator
@@ -112,13 +138,25 @@ export async function getAwuPurchaseInfo(
   }
 
   const { stripeCustomerId, stripe } = eligibility.value;
+  const workspace = auth.getNonNullableWorkspace();
   const subscription = auth.subscription()!;
+
+  const currencyResult = await resolveAwuPurchaseCurrency(workspace.sId);
+  if (currencyResult.isErr()) {
+    logger.error(
+      { workspaceId: workspace.sId, error: currencyResult.error.message },
+      "[AWU Purchase] Failed to resolve currency"
+    );
+    return { canPurchase: false, reason: "no_stripe_customer" };
+  }
+  const currency = currencyResult.value;
 
   const billingCycle = getBillingCycle(subscription.startDate);
   if (!billingCycle) {
     return {
       canPurchase: true,
       remainingCycleCredits: MAX_AWU_PURCHASE_CREDITS_PER_CYCLE,
+      currency,
     };
   }
 
@@ -140,6 +178,7 @@ export async function getAwuPurchaseInfo(
       0,
       MAX_AWU_PURCHASE_CREDITS_PER_CYCLE - alreadyPurchasedThisCycleCredits
     ),
+    currency,
   };
 }
 
@@ -152,14 +191,14 @@ export async function purchaseAwuCredits(
     return new Err({ code: eligibility.error.code });
   }
 
-  const { metronomeCustomerId, stripeCustomerId, stripe } = eligibility.value;
+  const { stripeCustomerId, stripe } = eligibility.value;
   const workspace = auth.getNonNullableWorkspace();
   const subscription = auth.subscription()!;
 
   if (amountCredits < MIN_AWU_PURCHASE_CREDITS) {
     return new Err({
       code: "invalid_amount",
-      message: `Minimum purchase is ${MIN_AWU_PURCHASE_CREDITS.toLocaleString()} credits ($${MIN_AWU_PURCHASE_CREDITS / AWU_CREDITS_PER_DOLLAR})`,
+      message: `Minimum purchase is ${MIN_AWU_PURCHASE_CREDITS.toLocaleString()} credits.`,
     });
   }
 
@@ -191,10 +230,7 @@ export async function purchaseAwuCredits(
     });
   }
 
-  const currencyResult = await resolveCurrencyForExistingMetronomeCustomer({
-    metronomeCustomerId,
-    stripeSubscriptionId: null,
-  });
+  const currencyResult = await resolveAwuPurchaseCurrency(workspace.sId);
   if (currencyResult.isErr()) {
     logger.error(
       { workspaceId: workspace.sId, error: currencyResult.error.message },

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -1,22 +1,19 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycle } from "@app/lib/client/subscription";
 import {
-  createMetronomeCredit,
+  addPaymentGatedCommitToContract,
   getMetronomeCustomerStripeCustomerId,
 } from "@app/lib/metronome/client";
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
+  CURRENCY_TO_CREDIT_TYPE_ID,
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
 } from "@app/lib/metronome/constants";
 import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
 import { getActiveContract, isLegacyPlan } from "@app/lib/metronome/plan_type";
-import {
-  finalizeInvoice,
-  getStripeClient,
-  makeAwuPurchaseInvoiceForCustomer,
-  payInvoice,
-} from "@app/lib/plans/stripe";
+import { AWU_PRICE_PER_CREDIT } from "@app/lib/metronome/types";
+import { getStripeClient } from "@app/lib/plans/stripe";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
@@ -43,10 +40,7 @@ export type AwuPurchaseInfo =
     };
 
 export type AwuPurchaseResult = {
-  invoiceId: string;
   amountCredits: number;
-  amountCents: number;
-  paymentUrl: string | null;
 };
 
 export type AwuPurchaseError =
@@ -191,9 +185,11 @@ export async function purchaseAwuCredits(
     return new Err({ code: eligibility.error.code });
   }
 
-  const { stripeCustomerId, stripe } = eligibility.value;
+  const { metronomeCustomerId, stripeCustomerId, stripe } = eligibility.value;
   const workspace = auth.getNonNullableWorkspace();
+  // checkAwuPurchaseEligibility already verified both are set.
   const subscription = auth.subscription()!;
+  const metronomeContractId = subscription.metronomeContractId!;
 
   if (amountCredits < MIN_AWU_PURCHASE_CREDITS) {
     return new Err({
@@ -241,143 +237,71 @@ export async function purchaseAwuCredits(
       message: currencyResult.error.message,
     });
   }
+  const currency = currencyResult.value;
 
-  const invoiceResult = await makeAwuPurchaseInvoiceForCustomer({
-    stripeCustomerId,
-    workspaceId: workspace.sId,
-    currency: currencyResult.value,
-    amountCredits,
-  });
-  if (invoiceResult.isErr()) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        amountCredits,
-        error: invoiceResult.error.error_message,
-      },
-      "[AWU Purchase] Failed to create Stripe invoice"
-    );
-    return new Err({
-      code: "purchase_failed",
-      message: invoiceResult.error.error_message,
-    });
-  }
-  const invoice = invoiceResult.value;
-
-  const finalizeResult = await finalizeInvoice(invoice);
-  if (finalizeResult.isErr()) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        invoiceId: invoice.id,
-        error: finalizeResult.error.error_message,
-      },
-      "[AWU Purchase] Failed to finalize Stripe invoice"
-    );
-    return new Err({
-      code: "purchase_failed",
-      message: finalizeResult.error.error_message,
-    });
-  }
-
-  const payResult = await payInvoice(finalizeResult.value);
-  if (payResult.isErr()) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        invoiceId: invoice.id,
-        error: payResult.error.error_message,
-      },
-      "[AWU Purchase] Failed to pay Stripe invoice"
-    );
-    return new Err({
-      code: "purchase_failed",
-      message: payResult.error.error_message,
-    });
-  }
-
-  const { paymentUrl } = payResult.value;
-
-  logger.info(
-    {
-      workspaceId: workspace.sId,
-      invoiceId: invoice.id,
-      amountCredits,
-      requiresAction: paymentUrl !== null,
-    },
-    "[AWU Purchase] Invoice created and paid, credits will be granted via webhook"
-  );
-
-  return new Ok({
-    invoiceId: invoice.id,
-    amountCredits,
-    amountCents: amountCredits,
-    paymentUrl,
-  });
-}
-
-/**
- * Called by the Stripe webhook (invoice.paid) to grant AWU credits in Metronome
- * once payment is confirmed.
- */
-export async function grantAwuCreditsFromPaidInvoice({
-  invoice,
-  auth,
-}: {
-  invoice: Stripe.Invoice;
-  auth: Authenticator;
-}): Promise<void> {
-  const workspace = auth.getNonNullableWorkspace();
-
-  const amountCreditsStr = invoice.metadata?.awu_amount_credits;
-  if (!amountCreditsStr) {
-    logger.error(
-      { invoiceId: invoice.id, workspaceId: workspace.sId },
-      "[AWU Purchase] Paid invoice missing awu_amount_credits metadata"
-    );
-    return;
-  }
-  const amountCredits = parseInt(amountCreditsStr, 10);
-  if (isNaN(amountCredits) || amountCredits <= 0) {
-    logger.error(
-      { invoiceId: invoice.id, workspaceId: workspace.sId, amountCreditsStr },
-      "[AWU Purchase] Invalid awu_amount_credits in invoice metadata"
-    );
-    return;
-  }
-
-  if (!workspace.metronomeCustomerId) {
-    logger.error(
-      { invoiceId: invoice.id, workspaceId: workspace.sId },
-      "[AWU Purchase] Workspace has no Metronome customer ID"
-    );
-    return;
-  }
+  // Metronome wants invoice unit prices in the credit type's units: cents
+  // for USD, whole units for EUR (matches the rate-card convention; see
+  // `metronomeAmount`). AWU_PRICE_PER_CREDIT is per-credit in the
+  // currency's natural unit ($0.01 / €0.0087):
+  //   USD: 0.01 USD * 100 = 1 cent per credit
+  //   EUR: 0.0087 EUR per credit (Metronome allows decimal unit prices)
+  const invoiceUnitPrice =
+    currency === "usd"
+      ? AWU_PRICE_PER_CREDIT.usd * 100
+      : AWU_PRICE_PER_CREDIT.eur;
 
   const now = new Date();
   const oneYearFromNow = new Date(now);
   oneYearFromNow.setUTCFullYear(oneYearFromNow.getUTCFullYear() + 1);
 
-  const grantResult = await createMetronomeCredit({
-    metronomeCustomerId: workspace.metronomeCustomerId,
+  const editResult = await addPaymentGatedCommitToContract({
+    metronomeCustomerId,
+    metronomeContractId,
     productId: getProductPrepaidCommitId(),
-    creditTypeId: getCreditTypeAwuId(),
-    amount: amountCredits,
-    startingAt: now.toISOString(),
-    endingBefore: oneYearFromNow.toISOString(),
-    name: `AWU credit top-up: ${amountCredits.toLocaleString()} credits`,
-    idempotencyKey: `awuPurchase-${workspace.sId}-${invoice.id}`,
+    accessAmount: amountCredits,
+    accessCreditTypeId: getCreditTypeAwuId(),
+    accessStartingAt: now,
+    accessEndingBefore: oneYearFromNow,
+    invoiceUnitPrice,
+    invoiceQuantity: amountCredits,
+    invoiceCreditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[currency],
+    invoiceTimestamp: now,
     priority: AWU_PRIORITY_PURCHASED_COMMIT,
+    name: `Credit top-up: ${amountCredits.toLocaleString()} credits`,
+    uniquenessKey: `awuPurchase-${workspace.sId}-${now.getTime()}`,
+    // Stamped on the Stripe invoice Metronome pushes downstream so the
+    // existing eligibility check (`isAwuPurchaseInvoice`) still recognises
+    // pending AWU purchases.
+    stripeInvoiceMetadata: {
+      awu_purchase: "true",
+      awu_amount_credits: String(amountCredits),
+      workspace_id: workspace.sId,
+    },
   });
 
-  if (grantResult.isErr()) {
-    throw new Error(
-      `[AWU Purchase] Failed to grant Metronome credits: ${grantResult.error.message} (invoiceId=${invoice.id}, workspaceId=${workspace.sId}, amountCredits=${amountCredits})`
+  if (editResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        amountCredits,
+        error: editResult.error.message,
+      },
+      "[AWU Purchase] Failed to add payment-gated commit"
     );
+    return new Err({
+      code: "purchase_failed",
+      message: editResult.error.message,
+    });
   }
 
   logger.info(
-    { invoiceId: invoice.id, workspaceId: workspace.sId, amountCredits },
-    "[AWU Purchase] Successfully granted AWU credits from webhook"
+    {
+      workspaceId: workspace.sId,
+      editId: editResult.value.editId,
+      amountCredits,
+    },
+    "[AWU Purchase] Payment-gated commit created — Metronome will invoice and unlock on payment"
   );
+
+  return new Ok({ amountCredits });
 }

--- a/front/lib/credits/awu_purchase_constants.ts
+++ b/front/lib/credits/awu_purchase_constants.ts
@@ -1,0 +1,3 @@
+// TODO: Replace static cap with a dynamic formula once we finalize rules for AWU purchase limits
+export const MAX_AWU_PURCHASE_CREDITS_PER_CYCLE = 1_000_000;
+export const MIN_AWU_PURCHASE_CREDITS = 100;

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1168,6 +1168,140 @@ export async function createMetronomeCommit({
 }
 
 /**
+ * Add a Stripe payment-gated PREPAID commit to an existing contract via
+ * `v2.contracts.edit`. Metronome will create the commit, generate the
+ * invoice, push it to Stripe, and unlock the commit once payment is
+ * collected (no manual grant needed on our side).
+ *
+ * `invoiceUnitPrice` is the per-credit fiat price in the invoice credit
+ * type's units — cents for USD, whole units for other fiat currencies
+ * (matches Metronome's fiat unit convention; see `metronomeAmount`).
+ * `invoiceQuantity` is the number of credits being invoiced. Passing
+ * unit_price + quantity (instead of a flat `amount`) lets Metronome
+ * construct Stripe `price_data` on push and auto-provision the Stripe
+ * Product for FIXED Metronome products that have never been invoiced
+ * via Stripe before.
+ *
+ * `tax_type` is intentionally omitted: each Metronome product carries a
+ * default tax category that Stripe uses, and overriding it from here
+ * would force Metronome to resolve a per-line Stripe Product mapping it
+ * doesn't have.
+ */
+export async function addPaymentGatedCommitToContract({
+  metronomeCustomerId,
+  metronomeContractId,
+  productId,
+  accessAmount,
+  accessCreditTypeId,
+  accessStartingAt,
+  accessEndingBefore,
+  invoiceUnitPrice,
+  invoiceQuantity,
+  invoiceCreditTypeId,
+  invoiceTimestamp,
+  priority,
+  name,
+  uniquenessKey,
+  stripeInvoiceMetadata,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  productId: string;
+  accessAmount: number;
+  accessCreditTypeId: string;
+  accessStartingAt: Date;
+  accessEndingBefore: Date;
+  invoiceUnitPrice: number;
+  invoiceQuantity: number;
+  invoiceCreditTypeId: string;
+  invoiceTimestamp: Date;
+  priority: number;
+  name: string;
+  uniquenessKey: string;
+  stripeInvoiceMetadata: Record<string, string>;
+}): Promise<Result<{ editId: string }, Error>> {
+  try {
+    const response = await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+      uniqueness_key: uniquenessKey,
+      add_commits: [
+        {
+          product_id: productId,
+          type: "PREPAID",
+          name,
+          priority,
+          applicable_product_tags: ["usage"],
+          access_schedule: {
+            credit_type_id: accessCreditTypeId,
+            schedule_items: [
+              {
+                amount: accessAmount,
+                starting_at: floorToHourISO(accessStartingAt),
+                ending_before: floorToHourISO(accessEndingBefore),
+              },
+            ],
+          },
+          invoice_schedule: {
+            credit_type_id: invoiceCreditTypeId,
+            schedule_items: [
+              {
+                unit_price: invoiceUnitPrice,
+                quantity: invoiceQuantity,
+                timestamp: floorToHourISO(invoiceTimestamp),
+              },
+            ],
+          },
+          payment_gate_config: {
+            payment_gate_type: "STRIPE",
+            stripe_config: {
+              payment_type: "INVOICE",
+              invoice_metadata: stripeInvoiceMetadata,
+            },
+          },
+        },
+      ],
+    });
+
+    logger.info(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        editId: response.data.id,
+        accessAmount,
+        invoiceUnitPrice,
+        invoiceQuantity,
+      },
+      "[Metronome] Payment-gated commit added to contract"
+    );
+
+    return new Ok({ editId: response.data.id });
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      logger.info(
+        { metronomeCustomerId, metronomeContractId, uniquenessKey },
+        "[Metronome] Payment-gated commit edit already exists (idempotent)"
+      );
+      return new Ok({ editId: "" });
+    }
+
+    const error = normalizeError(err);
+    logger.error(
+      {
+        error,
+        metronomeCustomerId,
+        metronomeContractId,
+        accessAmount,
+        invoiceUnitPrice,
+        invoiceQuantity,
+      },
+      "[Metronome] Failed to add payment-gated commit to contract"
+    );
+    return new Err(error);
+  }
+}
+
+/**
  * Find a customer-level commit by its uniqueness_key.
  * Used to recover the id after a 409 conflict on creation.
  * Scoped via covering_date so we don't paginate through expired commits.

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -156,6 +156,11 @@ export const getProductSeatSubscriptionCreditsId = () =>
 export const PRO_SEAT_MONTHLY_AWU_CREDITS = 8000;
 export const MAX_SEAT_MONTHLY_AWU_CREDITS = 40000;
 
+// AWU commit priorities — lower number is consumed first.
+// Seat allocations are consumed before purchased top-ups.
+export const AWU_PRIORITY_SEAT_ALLOCATION = 200;
+export const AWU_PRIORITY_PURCHASED_COMMIT = 300;
+
 export function getAwuAllocationForSeatType(
   seatType: MembershipSeatType | null
 ): number {

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -114,8 +114,12 @@ export const MICRO_USD_PER_DOLLAR = 1_000_000;
 export const MIN_CREDIT_PURCHASE_AMOUNT_MICRO_USD = MICRO_USD_PER_DOLLAR;
 // Hard cap used by purchase UIs
 export const MAX_CREDIT_PURCHASE_AMOUNT_MICRO_USD = 1_000_000_000;
-export const AWU_TO_MICRO_USD = 10_000;
-export const AWU_CREDITS_PER_DOLLAR = MICRO_USD_PER_DOLLAR / AWU_TO_MICRO_USD;
+// Price per AWU credit in each supported currency. Must stay in sync with
+// scripts/metronome_setup.ts (AWU_IN_USD_CENTS / AWU_IN_EUR).
+export const AWU_PRICE_PER_CREDIT: Record<SupportedCurrency, number> = {
+  usd: 0.01,
+  eur: 0.0087,
+};
 
 export interface MetronomeUsageListResponse {
   billableMetricId: string;

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,5 +1,6 @@
 import config from "@app/lib/api/config";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
+import { AWU_CREDITS_PER_DOLLAR } from "@app/lib/metronome/types";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { PHONE_TRIAL_ENABLED } from "@app/lib/plans/trial/constants";
@@ -929,17 +930,24 @@ export function getDefaultPaymentMethodId(
 }
 
 /**
- * Checks if a Stripe invoice is for a credit purchase.
+ * Checks if a Stripe invoice is for a programmatic credit purchase.
  */
 export function isCreditPurchaseInvoice(invoice: Stripe.Invoice): boolean {
   return invoice.metadata?.credit_purchase === "true";
 }
 
 /**
- * Checks if a Stripe invoice is for a credit purchase.
+ * Checks if a Stripe invoice is for a Metronome first-period charge.
  */
 export function isFirstPeriodInvoice(invoice: Stripe.Invoice): boolean {
   return invoice.metadata?.metronome_first_period === "true";
+}
+
+/**
+ * Checks if a Stripe invoice is for an AWU credit pool purchase.
+ */
+export function isAwuPurchaseInvoice(invoice: Stripe.Invoice): boolean {
+  return invoice.metadata?.awu_purchase === "true";
 }
 
 /**
@@ -1414,6 +1422,39 @@ export async function getInvoicePaymentUrl(
   const stripe = getStripeClient();
   const invoice = await stripe.invoices.retrieve(invoiceId);
   return invoice.hosted_invoice_url ?? null;
+}
+
+/**
+ * Creates a one-off AWU credit purchase invoice on a Stripe customer
+ */
+export async function makeAwuPurchaseInvoiceForCustomer({
+  stripeCustomerId,
+  workspaceId,
+  currency,
+  amountCredits,
+}: {
+  stripeCustomerId: string;
+  workspaceId: string;
+  currency: SupportedCurrency;
+  amountCredits: number;
+}): Promise<Result<Stripe.Invoice, { error_message: string }>> {
+  const amountDollars = amountCredits / AWU_CREDITS_PER_DOLLAR;
+
+  return makeInvoice({
+    target: { kind: "customer", stripeCustomerId, currency },
+    metadata: {
+      awu_purchase: "true",
+      awu_amount_credits: String(amountCredits),
+      workspace_id: workspaceId,
+    },
+    lineItem: {
+      priceId: getCreditPurchasePriceId(),
+      quantity: amountCredits,
+      description: `${amountCredits.toLocaleString()} credits for ($${amountDollars.toFixed(2)})`,
+    },
+    collectionMethod: "charge_automatically",
+    requestThreeDSecure: "challenge",
+  });
 }
 
 export function getAnnualizedSubscriptionValueMicroUsd(

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,6 +1,5 @@
 import config from "@app/lib/api/config";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
-import { AWU_PRICE_PER_CREDIT } from "@app/lib/metronome/types";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { PHONE_TRIAL_ENABLED } from "@app/lib/plans/trial/constants";
@@ -13,7 +12,7 @@ import {
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
-import { CURRENCY_SYMBOLS, SUPPORTED_CURRENCIES } from "@app/types/currency";
+import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import type { BillingPeriod, SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
@@ -1422,40 +1421,6 @@ export async function getInvoicePaymentUrl(
   const stripe = getStripeClient();
   const invoice = await stripe.invoices.retrieve(invoiceId);
   return invoice.hosted_invoice_url ?? null;
-}
-
-/**
- * Creates a one-off AWU credit purchase invoice on a Stripe customer
- */
-export async function makeAwuPurchaseInvoiceForCustomer({
-  stripeCustomerId,
-  workspaceId,
-  currency,
-  amountCredits,
-}: {
-  stripeCustomerId: string;
-  workspaceId: string;
-  currency: SupportedCurrency;
-  amountCredits: number;
-}): Promise<Result<Stripe.Invoice, { error_message: string }>> {
-  const amountInCurrency = amountCredits * AWU_PRICE_PER_CREDIT[currency];
-  const currencySymbol = CURRENCY_SYMBOLS[currency];
-
-  return makeInvoice({
-    target: { kind: "customer", stripeCustomerId, currency },
-    metadata: {
-      awu_purchase: "true",
-      awu_amount_credits: String(amountCredits),
-      workspace_id: workspaceId,
-    },
-    lineItem: {
-      priceId: getCreditPurchasePriceId(),
-      quantity: amountCredits,
-      description: `${amountCredits.toLocaleString()} credits for (${currencySymbol}${amountInCurrency.toFixed(2)})`,
-    },
-    collectionMethod: "charge_automatically",
-    requestThreeDSecure: "challenge",
-  });
 }
 
 export function getAnnualizedSubscriptionValueMicroUsd(

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,6 +1,6 @@
 import config from "@app/lib/api/config";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
-import { AWU_CREDITS_PER_DOLLAR } from "@app/lib/metronome/types";
+import { AWU_PRICE_PER_CREDIT } from "@app/lib/metronome/types";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { PHONE_TRIAL_ENABLED } from "@app/lib/plans/trial/constants";
@@ -13,7 +13,7 @@ import {
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
-import { SUPPORTED_CURRENCIES } from "@app/types/currency";
+import { CURRENCY_SYMBOLS, SUPPORTED_CURRENCIES } from "@app/types/currency";
 import type { BillingPeriod, SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
@@ -1438,7 +1438,8 @@ export async function makeAwuPurchaseInvoiceForCustomer({
   currency: SupportedCurrency;
   amountCredits: number;
 }): Promise<Result<Stripe.Invoice, { error_message: string }>> {
-  const amountDollars = amountCredits / AWU_CREDITS_PER_DOLLAR;
+  const amountInCurrency = amountCredits * AWU_PRICE_PER_CREDIT[currency];
+  const currencySymbol = CURRENCY_SYMBOLS[currency];
 
   return makeInvoice({
     target: { kind: "customer", stripeCustomerId, currency },
@@ -1450,7 +1451,7 @@ export async function makeAwuPurchaseInvoiceForCustomer({
     lineItem: {
       priceId: getCreditPurchasePriceId(),
       quantity: amountCredits,
-      description: `${amountCredits.toLocaleString()} credits for ($${amountDollars.toFixed(2)})`,
+      description: `${amountCredits.toLocaleString()} credits for (${currencySymbol}${amountInCurrency.toFixed(2)})`,
     },
     collectionMethod: "charge_automatically",
     requestThreeDSecure: "challenge",

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -2,6 +2,7 @@ import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_s
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetCreditPurchaseInfoResponseBody } from "@app/pages/api/w/[wId]/credits/purchase";
+import type { GetAwuPurchaseInfoResponseBody } from "@app/pages/api/w/[wId]/subscriptions/awu-purchase";
 import type {
   GetCreditsResponseBody,
   PendingCreditData,
@@ -202,6 +203,26 @@ export function useCreditPurchaseInfo({
   };
 }
 
+const awuPostPurchaseRefreshState = new Map<string, number>();
+const awuPostPurchaseRefreshListeners = new Set<() => void>();
+
+function getAwuPostPurchaseRefreshCount(workspaceId: string): number {
+  return awuPostPurchaseRefreshState.get(workspaceId) ?? Infinity;
+}
+
+function incrementAwuPostPurchaseRefreshCount(workspaceId: string): void {
+  const current = awuPostPurchaseRefreshState.get(workspaceId) ?? Infinity;
+  if (current < 5) {
+    awuPostPurchaseRefreshState.set(workspaceId, current + 1);
+    awuPostPurchaseRefreshListeners.forEach((listener) => listener());
+  }
+}
+
+export function resetAwuPostPurchaseRefreshCount(workspaceId: string): void {
+  awuPostPurchaseRefreshState.set(workspaceId, 0);
+  awuPostPurchaseRefreshListeners.forEach((listener) => listener());
+}
+
 export function useAwuPoolSummary({
   workspaceId,
   disabled,
@@ -215,7 +236,17 @@ export function useAwuPoolSummary({
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
     `/api/w/${workspaceId}/credits/awu-pool-summary`,
     awuFetcher,
-    { disabled }
+    {
+      disabled,
+      refreshInterval: () => {
+        const count = getAwuPostPurchaseRefreshCount(workspaceId);
+        if (count < 5) {
+          incrementAwuPostPurchaseRefreshCount(workspaceId);
+          return 5000;
+        }
+        return 0;
+      },
+    }
   );
 
   return {
@@ -227,5 +258,31 @@ export function useAwuPoolSummary({
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,
     mutateAwuPoolSummary: mutate,
+  };
+}
+
+export function useAwuPurchaseInfo({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const awuPurchaseInfoFetcher: Fetcher<GetAwuPurchaseInfoResponseBody> =
+    fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/subscriptions/awu-purchase`,
+    awuPurchaseInfoFetcher,
+    { disabled }
+  );
+
+  return {
+    awuPurchaseInfo: data ?? null,
+    isAwuPurchaseInfoLoading: !error && !data && !disabled,
+    isAwuPurchaseInfoValidating: isValidating,
+    isAwuPurchaseInfoError: error,
+    mutateAwuPurchaseInfo: mutate,
   };
 }

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -299,6 +299,44 @@ async function handler(
         case "invoice.finalized":
           break;
 
+        // Payment-gated commit lifecycle. Metronome activates the commit
+        // itself on success, so we don't grant credits here — just log the
+        // outcome for observability (and surface failures with their
+        // Stripe error message). AWU credit top-ups go through this flow
+        // via `addPaymentGatedCommitToContract`.
+        case "payment_gate.payment_status": {
+          const {
+            customer_id: customerId,
+            contract_id: contractId,
+            invoice_id: invoiceId,
+            payment_status: paymentStatus,
+            error_message: errorMessage,
+          } = event.properties;
+          if (paymentStatus === "succeeded") {
+            logger.info(
+              { customerId, contractId, invoiceId, paymentStatus },
+              "[Metronome Webhook] Payment-gated commit paid"
+            );
+          } else {
+            logger.warn(
+              {
+                customerId,
+                contractId,
+                invoiceId,
+                paymentStatus,
+                errorMessage,
+              },
+              "[Metronome Webhook] Payment-gated commit payment failed"
+            );
+          }
+          break;
+        }
+
+        case "payment_gate.payment_pending_action_required":
+        case "payment_gate.threshold_reached":
+        case "payment_gate.external_initiate":
+          break;
+
         case "credit.segment.start": {
           const {
             customer_id: customerId,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -9,6 +9,7 @@ import { getRedisCacheClient } from "@app/lib/api/redis";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
+import { grantAwuCreditsFromPaidInvoice } from "@app/lib/credits/awu_purchase";
 import {
   deleteCreditFromVoidedInvoice,
   startCreditFromEnterpriseOneOffInvoice,
@@ -43,6 +44,7 @@ import {
   createCustomerPortalSession,
   getStripeClient,
   getStripeSubscription,
+  isAwuPurchaseInvoice,
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
   isFirstPeriodInvoice,
@@ -847,6 +849,11 @@ async function handler(
               auth: ctx.auth,
               isEnterprise: ctx.isEnterprise,
             });
+          } else if (isAwuPurchaseInvoice(invoice)) {
+            await grantAwuCreditsFromPaidInvoice({
+              invoice,
+              auth: ctx.auth,
+            });
           } else {
             await ctx.subscription.clearPaymentFailingStatus();
           }
@@ -863,11 +870,18 @@ async function handler(
           const isMetronomeInvoice = typeof invoice.subscription !== "string";
           const isCreditPurchase = isCreditPurchaseInvoice(invoice);
           const isFirstPeriod = isFirstPeriodInvoice(invoice);
+          const isAwuPurchase = isAwuPurchaseInvoice(invoice);
 
           // Only Metronome subscription invoices need the force-charge.
           // Stripe-subscription invoices have their own auto-charge flow;
-          // credit-purchase invoices have their own flow too.
-          if (isMetronomeInvoice && !isCreditPurchase && !isFirstPeriod) {
+          // credit-purchase, first-period, and AWU purchase invoices have
+          // their own flow too.
+          if (
+            isMetronomeInvoice &&
+            !isCreditPurchase &&
+            !isFirstPeriod &&
+            !isAwuPurchase
+          ) {
             await forceChargeMetronomeFinalizedInvoice(invoice);
           }
           break;

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -9,7 +9,6 @@ import { getRedisCacheClient } from "@app/lib/api/redis";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import { grantAwuCreditsFromPaidInvoice } from "@app/lib/credits/awu_purchase";
 import {
   deleteCreditFromVoidedInvoice,
   startCreditFromEnterpriseOneOffInvoice,
@@ -850,10 +849,11 @@ async function handler(
               isEnterprise: ctx.isEnterprise,
             });
           } else if (isAwuPurchaseInvoice(invoice)) {
-            await grantAwuCreditsFromPaidInvoice({
-              invoice,
-              auth: ctx.auth,
-            });
+            // AWU credit purchases are now provisioned as Metronome
+            // payment-gated commits — Metronome itself unlocks the commit
+            // on `invoice.paid`, no external grant needed here. Kept for
+            // observability; the metadata still flags the invoice so the
+            // pending-purchase eligibility check works.
           } else {
             await ctx.subscription.clearPaymentFailingStatus();
           }

--- a/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
@@ -1,0 +1,174 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { AwuPurchaseInfo } from "@app/lib/credits/awu_purchase";
+import {
+  getAwuPurchaseInfo,
+  purchaseAwuCredits,
+} from "@app/lib/credits/awu_purchase";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+export type GetAwuPurchaseInfoResponseBody = AwuPurchaseInfo;
+
+const PostAwuPurchaseBody = z.object({
+  amountCredits: z.number().int().positive(),
+});
+
+export type PostAwuPurchaseResponseBody = {
+  invoiceId: string;
+  amountCredits: number;
+  amountCents: number;
+  paymentUrl: string | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      PostAwuPurchaseResponseBody | GetAwuPurchaseInfoResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can purchase AWU credits.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      try {
+        const info = await getAwuPurchaseInfo(auth);
+        return res.status(200).json(info);
+      } catch (err) {
+        logger.error(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            error: normalizeError(err),
+          },
+          "[AWU Purchase] Failed to get purchase info"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to get AWU purchase info.",
+          },
+        });
+      }
+    }
+
+    case "POST": {
+      const bodyValidation = PostAwuPurchaseBody.safeParse(req.body);
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
+          },
+        });
+      }
+
+      const { amountCredits } = bodyValidation.data;
+
+      const result = await purchaseAwuCredits(auth, { amountCredits });
+
+      if (result.isErr()) {
+        const err = result.error;
+        switch (err.code) {
+          case "not_metronome_billed":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message:
+                  "AWU credit purchases are only available for Metronome-billed workspaces.",
+              },
+            });
+          case "legacy_plan":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message:
+                  "AWU credit purchases are not available for legacy plan workspaces.",
+              },
+            });
+          case "no_stripe_customer":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message:
+                  "No Stripe customer found for this workspace. Please contact support.",
+              },
+            });
+          case "pending_purchase":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message:
+                  "A pending AWU credit purchase already exists for this workspace. Please wait for it to complete.",
+              },
+            });
+          case "invalid_amount":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: err.message,
+              },
+            });
+          case "purchase_failed":
+            logger.error(
+              {
+                workspaceId: auth.getNonNullableWorkspace().sId,
+                amountCredits,
+                error: err.message,
+              },
+              "[AWU Purchase] Purchase failed"
+            );
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: err.message,
+              },
+            });
+          default:
+            assertNever(err);
+        }
+      }
+
+      return res.status(200).json(result.value);
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler, {
+  doesNotRequireCanUseProduct: true,
+});

--- a/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
@@ -22,10 +22,7 @@ const PostAwuPurchaseBody = z.object({
 });
 
 export type PostAwuPurchaseResponseBody = {
-  invoiceId: string;
   amountCredits: number;
-  amountCents: number;
-  paymentUrl: string | null;
 };
 
 async function handler(

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -14,6 +14,7 @@
 
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import {
+  AWU_PRIORITY_SEAT_ALLOCATION,
   CREDIT_TYPE_EUR_ID,
   CREDIT_TYPE_USD_ID,
   DEV_CREDIT_TYPE_AWU_ID,
@@ -1078,7 +1079,7 @@ function getPerSeatIndividualAwuCredits({
       unit_price: quantityPerSeat,
     },
     commit_duration: { value: 1, unit: "PERIODS" },
-    priority: 200,
+    priority: AWU_PRIORITY_SEAT_ALLOCATION,
     starting_at_offset: { unit: "DAYS", value: 0 },
     applicable_product_tags: [USAGE_TAG],
     recurrence_frequency: "MONTHLY",


### PR DESCRIPTION
## Description

* Add AWU-specific purchase apis (get and post) to facilitate buying workspace pool commits. Modeling after the programmatic credit API workflow, but making it metronome AWU specific.
* Hooking it up to the existing modal on the usage page
* Intentionally not sharing logic with the existing programmatic credit workflow as the logic is different and this will eventually replace that workflow

## Tests

<img width="451" height="331" alt="Screenshot 2026-05-17 at 12 42 23 PM" src="https://github.com/user-attachments/assets/7ccf8ece-0b57-45e0-8c76-f8a8eb567770" />
<img width="990" height="468" alt="Screenshot 2026-05-17 at 12 42 03 PM" src="https://github.com/user-attachments/assets/5f7b3962-7c96-4279-b24e-b05370d4562a" />

## Risk

* Low (not customer facing yet)
<img width="451" height="331" alt="Screenshot 2026-05-17 at 12 42 23 PM" src="https://github.com/user-attachments/assets/873847f8-b58b-4e30-abf0-97c9fa0c8a25" />

## Deploy Plan

* Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25670">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->