### PR TITLE
Contenful cta

### DIFF
--- a/front/components/blog/TableOfContents.tsx
+++ b/front/components/blog/TableOfContents.tsx
@@ -8,6 +8,7 @@ interface TableOfContentsProps {
   items: TocItem[];
   className?: string;
   onItemClick?: () => void;
+  cta?: React.ReactNode;
 }
 
 interface TocItemWithChildren extends TocItem {
@@ -106,6 +107,7 @@ export function TableOfContents({
   items,
   className,
   onItemClick,
+  cta,
 }: TableOfContentsProps) {
   const { activeId, handleClick } = useScrollSpy(items);
   const hierarchy = useMemo(() => buildHierarchy(items), [items]);
@@ -118,30 +120,46 @@ export function TableOfContents({
     onItemClick?.();
   };
 
-  if (items.length === 0) {
+  if (items.length === 0 && !cta) {
     return null;
   }
 
   return (
     <div
       className={classNames(
-        "sticky top-5 max-h-[calc(100vh-8rem)] overflow-y-auto",
+        "sticky top-5 flex max-h-[calc(100vh-2.5rem)] flex-col",
         className ?? null
       )}
     >
-      <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
-        Table of contents
-      </h3>
-      <nav className="space-y-1" aria-label="Table of contents">
-        {hierarchy.map((item) => (
-          <TocItemComponent
-            key={item.id}
-            item={item}
-            activeId={activeId}
-            onItemClick={handleItemClick}
-          />
-        ))}
-      </nav>
+      {items.length > 0 && (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <h3 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground dark:text-muted-foreground-night">
+            Table of contents
+          </h3>
+          <nav className="space-y-1" aria-label="Table of contents">
+            {hierarchy.map((item) => (
+              <TocItemComponent
+                key={item.id}
+                item={item}
+                activeId={activeId}
+                onItemClick={handleItemClick}
+              />
+            ))}
+          </nav>
+        </div>
+      )}
+      {cta && (
+        <div
+          className={classNames(
+            "flex-none",
+            items.length > 0
+              ? "mt-6 border-t border-border pt-6 dark:border-border-night"
+              : null
+          )}
+        >
+          {cta}
+        </div>
+      )}
     </div>
   );
 }

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -633,6 +633,7 @@ function contentfulEntryToBlogPost(
     : sys.createdAt;
 
   const body = isContentfulDocument(fields.body) ? fields.body : EMPTY_DOCUMENT;
+  const cta = isContentfulDocument(fields.cta) ? fields.cta : null;
   const image = isContentfulAsset(fields.image) ? fields.image : undefined;
   const authors = Array.isArray(fields.authors)
     ? fields.authors
@@ -656,6 +657,7 @@ function contentfulEntryToBlogPost(
     title,
     description: generateDescription(body),
     body,
+    cta,
     tags,
     image: contentfulAssetToBlogImage(image, title),
     authors,

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -11,9 +11,14 @@ import { isString } from "@app/types/shared/utils/general";
 import { slugify } from "@app/types/shared/utils/string_utils";
 import type { Options } from "@contentful/rich-text-react-renderer";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
-import type { Block, Document, Inline } from "@contentful/rich-text-types";
+import type {
+  Block,
+  Document,
+  Inline,
+  Text,
+} from "@contentful/rich-text-types";
 import { BLOCKS, INLINES, MARKS } from "@contentful/rich-text-types";
-import { cn } from "@dust-tt/sparkle";
+import { Button, cn } from "@dust-tt/sparkle";
 import Image from "next/image";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
@@ -446,6 +451,112 @@ export function renderRichTextFromContentful(document: Document): ReactNode {
     return null;
   }
   return documentToReactComponents(document, renderOptions);
+}
+
+function ctaEntryHref(entry: {
+  sys?: { contentType?: { sys?: { id?: string } } };
+  fields?: Record<string, unknown>;
+}): string | null {
+  const contentType = entry?.sys?.contentType?.sys?.id;
+  const slug = isString(entry?.fields?.slug) ? entry.fields.slug : null;
+  if (!slug) {
+    return null;
+  }
+  switch (contentType) {
+    case "blogPage":
+      return `/blog/${slug}`;
+    case "customerStory":
+      return `/customers/${slug}`;
+    case "course":
+      return `/academy/${slug}`;
+    case "chapter":
+      return `/academy/chapter/${slug}`;
+    case "lesson":
+      return `/academy/lessons/${slug}`;
+    default:
+      return null;
+  }
+}
+
+function ctaLinkLabel(children: ReactNode): string {
+  return extractTextFromChildren(children).trim();
+}
+
+function hasCtaContent(document: Document | null): document is Document {
+  if (!document?.content) {
+    return false;
+  }
+  const hasLink = (node: Block | Inline | Text): boolean => {
+    if (!isBlockOrInline(node)) {
+      return false;
+    }
+    if (
+      node.nodeType === INLINES.HYPERLINK ||
+      node.nodeType === INLINES.ENTRY_HYPERLINK
+    ) {
+      return true;
+    }
+    return node.content.some(hasLink);
+  };
+  return document.content.some(hasLink);
+}
+
+export function renderCtaFromContentful(document: Document | null): ReactNode {
+  if (!hasCtaContent(document)) {
+    return null;
+  }
+  let linkIndex = 0;
+  const buttonVariantForNextLink = (): "highlight" | "outline" => {
+    const variant = linkIndex === 0 ? "highlight" : "outline";
+    linkIndex += 1;
+    return variant;
+  };
+  const options: Options = {
+    renderMark: {
+      [MARKS.BOLD]: (text) => <strong className="font-semibold">{text}</strong>,
+    },
+    renderNode: {
+      [BLOCKS.PARAGRAPH]: (_node, children) => <>{children}</>,
+      [INLINES.HYPERLINK]: (node, children) => {
+        const url = isString(node.data.uri) ? node.data.uri : "";
+        const isExternal = url.startsWith("http");
+        const label = ctaLinkLabel(children);
+        if (!url || !label) {
+          return null;
+        }
+        return (
+          <Button
+            variant={buttonVariantForNextLink()}
+            size="md"
+            label={label}
+            href={url}
+            target={isExternal ? "_blank" : undefined}
+            rel={isExternal ? "noopener noreferrer" : undefined}
+          />
+        );
+      },
+      [INLINES.ENTRY_HYPERLINK]: (node, children) => {
+        const href = ctaEntryHref(node.data.target);
+        const label = ctaLinkLabel(children);
+        if (!href || !label) {
+          return null;
+        }
+        return (
+          <Button
+            variant={buttonVariantForNextLink()}
+            size="md"
+            label={label}
+            href={href}
+          />
+        );
+      },
+    },
+  };
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-3">
+      {documentToReactComponents(document, options)}
+    </div>
+  );
 }
 
 function extractPlainText(node: Block | Inline | Document): string {

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -553,7 +553,7 @@ export function renderCtaFromContentful(document: Document | null): ReactNode {
     },
   };
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-3">
+    <div className="flex flex-col gap-3 [&>a]:w-full [&>a]:justify-center">
       {documentToReactComponents(document, options)}
     </div>
   );

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -501,7 +501,12 @@ function hasCtaContent(document: Document | null): document is Document {
   return document.content.some(hasLink);
 }
 
-export function renderCtaFromContentful(document: Document | null): ReactNode {
+type CtaLayout = "sidebar" | "inline";
+
+export function renderCtaFromContentful(
+  document: Document | null,
+  layout: CtaLayout = "sidebar"
+): ReactNode {
   if (!hasCtaContent(document)) {
     return null;
   }
@@ -527,7 +532,7 @@ export function renderCtaFromContentful(document: Document | null): ReactNode {
         return (
           <Button
             variant={buttonVariantForNextLink()}
-            size="md"
+            size="sm"
             label={label}
             href={url}
             target={isExternal ? "_blank" : undefined}
@@ -544,7 +549,7 @@ export function renderCtaFromContentful(document: Document | null): ReactNode {
         return (
           <Button
             variant={buttonVariantForNextLink()}
-            size="md"
+            size="sm"
             label={label}
             href={href}
           />
@@ -552,11 +557,66 @@ export function renderCtaFromContentful(document: Document | null): ReactNode {
       },
     },
   };
+  const layoutClass =
+    layout === "inline"
+      ? "flex flex-wrap items-center justify-center gap-3"
+      : "flex flex-col gap-3 [&>a]:w-full [&>a]:justify-center";
   return (
-    <div className="flex flex-col gap-3 [&>a]:w-full [&>a]:justify-center">
+    <div className={layoutClass}>
       {documentToReactComponents(document, options)}
     </div>
   );
+}
+
+function isHeadingBlock(node: Block | Inline | Text): boolean {
+  if (!isBlockOrInline(node)) {
+    return false;
+  }
+  switch (node.nodeType) {
+    case BLOCKS.HEADING_1:
+    case BLOCKS.HEADING_2:
+    case BLOCKS.HEADING_3:
+    case BLOCKS.HEADING_4:
+    case BLOCKS.HEADING_5:
+    case BLOCKS.HEADING_6:
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function splitDocumentForMidCta(
+  document: Document | null
+): { first: Document; second: Document } | null {
+  if (!document?.content || document.content.length < 6) {
+    return null;
+  }
+  const headingIndices: number[] = [];
+  for (let i = 0; i < document.content.length; i++) {
+    if (isHeadingBlock(document.content[i])) {
+      headingIndices.push(i);
+    }
+  }
+  if (headingIndices.length === 0) {
+    return null;
+  }
+  const midIndex = Math.floor(document.content.length / 2);
+  let splitIndex = headingIndices[0];
+  let bestDistance = Math.abs(splitIndex - midIndex);
+  for (const idx of headingIndices) {
+    const distance = Math.abs(idx - midIndex);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      splitIndex = idx;
+    }
+  }
+  if (splitIndex < 2 || splitIndex > document.content.length - 2) {
+    return null;
+  }
+  return {
+    first: { ...document, content: document.content.slice(0, splitIndex) },
+    second: { ...document, content: document.content.slice(splitIndex) },
+  };
 }
 
 function extractPlainText(node: Block | Inline | Document): string {

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -14,6 +14,7 @@ export interface BlogPageFields {
   title: string;
   slug?: string;
   body: Document;
+  cta?: Document;
   image?: Asset;
   publishedAt?: string;
   authors?: Entry<AuthorSkeleton>[];
@@ -42,6 +43,7 @@ export interface BlogPost {
   title: string;
   description: string | null;
   body: Document;
+  cta: Document | null;
   tags: string[];
   image: BlogImage | null;
   authors: BlogAuthor[];

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -10,7 +10,10 @@ import {
   getRelatedPosts,
 } from "@app/lib/contentful/client";
 import { contentfulImageLoader } from "@app/lib/contentful/imageLoader";
-import { renderRichTextFromContentful } from "@app/lib/contentful/richTextRenderer";
+import {
+  renderCtaFromContentful,
+  renderRichTextFromContentful,
+} from "@app/lib/contentful/richTextRenderer";
 import { extractTableOfContents } from "@app/lib/contentful/tableOfContents";
 import type { BlogPostPageProps } from "@app/lib/contentful/types";
 import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
@@ -96,6 +99,7 @@ export default function BlogPost({
   const ogImageUrl = post.image?.url ?? "https://dust.tt/static/og_image.png";
   const canonicalUrl = `https://dust.tt/blog/${post.slug}`;
   const tocItems = extractTableOfContents(post.body);
+  const ctaContent = renderCtaFromContentful(post.cta);
 
   return (
     <>
@@ -235,6 +239,10 @@ export default function BlogPost({
               </span>
             </div>
           </header>
+
+          {ctaContent && (
+            <div className={classNames(WIDE_CLASSES, "mt-3")}>{ctaContent}</div>
+          )}
 
           {post.image && (
             <div className={classNames(WIDE_CLASSES, "mt-2")}>

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -26,6 +26,7 @@ import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
 import type { ReactElement } from "react";
+import { useMemo } from "react";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   // Don't pre-generate any paths at build time to minimize Contentful API calls.
@@ -100,9 +101,18 @@ export default function BlogPost({
   const ogImageUrl = post.image?.url ?? "https://dust.tt/static/og_image.png";
   const canonicalUrl = `https://dust.tt/blog/${post.slug}`;
   const tocItems = extractTableOfContents(post.body);
-  const ctaContent = renderCtaFromContentful(post.cta);
-  const inlineCtaContent = renderCtaFromContentful(post.cta, "inline");
-  const bodySplit = inlineCtaContent ? splitDocumentForMidCta(post.body) : null;
+  const ctaContent = useMemo(
+    () => renderCtaFromContentful(post.cta),
+    [post.cta]
+  );
+  const inlineCtaContent = useMemo(
+    () => renderCtaFromContentful(post.cta, "inline"),
+    [post.cta]
+  );
+  const bodySplit = useMemo(
+    () => (inlineCtaContent ? splitDocumentForMidCta(post.body) : null),
+    [inlineCtaContent, post.body]
+  );
 
   return (
     <>

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -240,10 +240,6 @@ export default function BlogPost({
             </div>
           </header>
 
-          {ctaContent && (
-            <div className={classNames(WIDE_CLASSES, "mt-3")}>{ctaContent}</div>
-          )}
-
           {post.image && (
             <div className={classNames(WIDE_CLASSES, "mt-2")}>
               <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
@@ -266,9 +262,9 @@ export default function BlogPost({
               <div className="min-w-0 lg:col-span-9">
                 {renderRichTextFromContentful(post.body)}
               </div>
-              {tocItems.length > 0 && (
+              {(tocItems.length > 0 || ctaContent) && (
                 <div className="hidden lg:col-span-3 lg:block">
-                  <TableOfContents items={tocItems} />
+                  <TableOfContents items={tocItems} cta={ctaContent} />
                 </div>
               )}
             </div>

--- a/front/pages/blog/[slug].tsx
+++ b/front/pages/blog/[slug].tsx
@@ -13,6 +13,7 @@ import { contentfulImageLoader } from "@app/lib/contentful/imageLoader";
 import {
   renderCtaFromContentful,
   renderRichTextFromContentful,
+  splitDocumentForMidCta,
 } from "@app/lib/contentful/richTextRenderer";
 import { extractTableOfContents } from "@app/lib/contentful/tableOfContents";
 import type { BlogPostPageProps } from "@app/lib/contentful/types";
@@ -100,6 +101,8 @@ export default function BlogPost({
   const canonicalUrl = `https://dust.tt/blog/${post.slug}`;
   const tocItems = extractTableOfContents(post.body);
   const ctaContent = renderCtaFromContentful(post.cta);
+  const inlineCtaContent = renderCtaFromContentful(post.cta, "inline");
+  const bodySplit = inlineCtaContent ? splitDocumentForMidCta(post.body) : null;
 
   return (
     <>
@@ -260,7 +263,17 @@ export default function BlogPost({
           <div className={classNames(WIDE_CLASSES, "mt-4")}>
             <div className="grid gap-8 lg:grid-cols-12">
               <div className="min-w-0 lg:col-span-9">
-                {renderRichTextFromContentful(post.body)}
+                {bodySplit ? (
+                  <>
+                    {renderRichTextFromContentful(bodySplit.first)}
+                    <aside className="my-10 flex justify-center">
+                      {inlineCtaContent}
+                    </aside>
+                    {renderRichTextFromContentful(bodySplit.second)}
+                  </>
+                ) : (
+                  renderRichTextFromContentful(post.body)
+                )}
               </div>
               {(tocItems.length > 0 || ctaContent) && (
                 <div className="hidden lg:col-span-3 lg:block">


### PR DESCRIPTION
## Description

Adds support for an optional Call-To-Action (CTA) field on Contentful blog posts. The CTA accepts rich text and renders any links inside as Sparkle buttons (first link highlighted, subsequent links outlined). The CTA is placed at the bottom of the sticky TOC sidebar, pinned in view while the TOC scrolls internally.

## Tests

Tested manually with Contentful blog posts containing CTA fields. Verified posts without CTAs render unchanged.

## Risk

Low. The `cta` field is optional and guarded by type checks—missing or unset Contentful fields fall back to `null`. Posts without CTAs render exactly as before.

## Deploy Plan

Deploy front