### PR TITLE
[front] fix: update comment on JIT tools snippet logic

### DIFF
--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -206,9 +206,7 @@ export function getAttachmentFromFileContentFragment(
     return null;
   }
 
-  // Here, snippet not null is actually to detect file attachments that are prior to the JIT
-  // actions, and differentiate them from the newer file attachments that do have a snippet.
-  // Former ones cannot be used in JIT.
+  // We rely on snippet not being null to detect file that have been processed (e.g. uploaded to GCS for tables).
   const canDoJIT = cf.snippet !== null;
   const isInProjectContext = cf.isInProjectContext === true;
   const shouldSuppressTabularHints = shouldSuppressTabularAttachmentHints({
@@ -289,6 +287,7 @@ export function makeFileAttachment({
   path?: string | null;
   creator?: AttachmentCreator | null;
 }): FileAttachmentType {
+  // We rely on snippet not being null to detect file that have been processed (e.g. uploaded to GCS for tables).
   const canDoJIT = snippet !== null;
   const isIncludable = isConversationIncludableFileContentType(contentType);
   const isQueryable = canDoJIT && isQueryableContentType(contentType);

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -206,6 +206,10 @@ export function getAttachmentFromFileContentFragment(
     return null;
   }
 
+  // Here, snippet not null is actually to detect file attachments that are prior to the JIT
+  // actions, and differentiate them from the newer file attachments that do have a snippet.
+  // Former ones cannot be used in JIT.
+  const canDoJIT = cf.snippet !== null;
   const isInProjectContext = cf.isInProjectContext === true;
   const shouldSuppressTabularHints = shouldSuppressTabularAttachmentHints({
     contentType: cf.contentType,
@@ -213,11 +217,13 @@ export function getAttachmentFromFileContentFragment(
     skipFileProcessing: cf.skipFileProcessing === true,
   });
   const isQueryable =
-    !shouldSuppressTabularHints && isQueryableContentType(cf.contentType);
+    !shouldSuppressTabularHints &&
+    canDoJIT &&
+    isQueryableContentType(cf.contentType);
   const isIncludable =
     !shouldSuppressTabularHints &&
     isConversationIncludableFileContentType(cf.contentType);
-  const isSearchable = isSearchableContentType(cf.contentType);
+  const isSearchable = canDoJIT && isSearchableContentType(cf.contentType);
   const creator: AttachmentCreator | null = cf.context.fullName
     ? {
         type: "user",
@@ -283,12 +289,13 @@ export function makeFileAttachment({
   path?: string | null;
   creator?: AttachmentCreator | null;
 }): FileAttachmentType {
+  const canDoJIT = snippet !== null;
   const isIncludable = isConversationIncludableFileContentType(contentType);
-  const isQueryable = isQueryableContentType(contentType);
+  const isQueryable = canDoJIT && isQueryableContentType(contentType);
   // Files offloaded to disk because their tool output was too large are never indexed in Qdrant,
   // so they must not be advertised as searchable to the model.
   const isSearchable =
-    isSearchableContentType(contentType) && !skipDataSourceIndexing;
+    canDoJIT && isSearchableContentType(contentType) && !skipDataSourceIndexing;
 
   return {
     fileId,

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -206,10 +206,6 @@ export function getAttachmentFromFileContentFragment(
     return null;
   }
 
-  // Here, snippet not null is actually to detect file attachments that are prior to the JIT
-  // actions, and differentiate them from the newer file attachments that do have a snippet.
-  // Former ones cannot be used in JIT.
-  const canDoJIT = cf.snippet !== null;
   const isInProjectContext = cf.isInProjectContext === true;
   const shouldSuppressTabularHints = shouldSuppressTabularAttachmentHints({
     contentType: cf.contentType,
@@ -217,13 +213,11 @@ export function getAttachmentFromFileContentFragment(
     skipFileProcessing: cf.skipFileProcessing === true,
   });
   const isQueryable =
-    !shouldSuppressTabularHints &&
-    canDoJIT &&
-    isQueryableContentType(cf.contentType);
+    !shouldSuppressTabularHints && isQueryableContentType(cf.contentType);
   const isIncludable =
     !shouldSuppressTabularHints &&
     isConversationIncludableFileContentType(cf.contentType);
-  const isSearchable = canDoJIT && isSearchableContentType(cf.contentType);
+  const isSearchable = isSearchableContentType(cf.contentType);
   const creator: AttachmentCreator | null = cf.context.fullName
     ? {
         type: "user",
@@ -289,13 +283,12 @@ export function makeFileAttachment({
   path?: string | null;
   creator?: AttachmentCreator | null;
 }): FileAttachmentType {
-  const canDoJIT = snippet !== null;
   const isIncludable = isConversationIncludableFileContentType(contentType);
-  const isQueryable = canDoJIT && isQueryableContentType(contentType);
+  const isQueryable = isQueryableContentType(contentType);
   // Files offloaded to disk because their tool output was too large are never indexed in Qdrant,
   // so they must not be advertised as searchable to the model.
   const isSearchable =
-    canDoJIT && isSearchableContentType(contentType) && !skipDataSourceIndexing;
+    isSearchableContentType(contentType) && !skipDataSourceIndexing;
 
   return {
     fileId,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/7841
- Remove the legacy null-snippet check that prevented conversation file attachments from being marked queryable for JIT tools.
- Short-term fix: will be made obsolete soon due to changes in how conversation files are handled. For the specific problem the user faces in the issue we need a full sandbox before being able to handle properly so shipping this as is to unblock.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->