### PR TITLE
Fix context usage percentage dropping to 0% while a message is processing

### DIFF
--- a/front/hooks/conversations/useConversationContextUsage.ts
+++ b/front/hooks/conversations/useConversationContextUsage.ts
@@ -1,5 +1,6 @@
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetConversationContextUsageResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage";
+import { useMemo, useRef } from "react";
 import type { Fetcher } from "swr";
 
 export const CONTEXT_USAGE_PERCENT_THRESHOLDS = {
@@ -29,13 +30,23 @@ export function useConversationContextUsage({
     options
   );
 
-  const percentage =
-    data &&
-    data.contextUsage !== null &&
-    data.contextSize !== null &&
-    data.contextSize > 0
-      ? Math.round((data.contextUsage / data.contextSize) * 100)
-      : 0;
+  const lastValidPercentageRef = useRef<number>(0);
+
+  const percentage = useMemo(() => {
+    if (
+      data &&
+      data.contextUsage !== null &&
+      data.contextSize !== null &&
+      data.contextSize > 0
+    ) {
+      const computed = Math.round((data.contextUsage / data.contextSize) * 100);
+      lastValidPercentageRef.current = computed;
+      return computed;
+    }
+    // API is in pending state (new run has no usages yet) — keep the last
+    // known value to avoid a jarring drop to 0% while the message processes.
+    return lastValidPercentageRef.current;
+  }, [data]);
 
   return {
     contextUsage: data ?? null,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
@@ -39,6 +39,7 @@ function makeRunWithUsages(usages: RunUsageType[]) {
 function makeConversationResource({
   latestAgentMessageRun,
   latestCompactionMessageRun,
+  previousAgentMessageRun = null,
 }: {
   latestAgentMessageRun: {
     rank: number;
@@ -48,9 +49,16 @@ function makeConversationResource({
     rank: number;
     run: ReturnType<typeof makeRunWithUsages>;
   } | null;
+  previousAgentMessageRun?: {
+    rank: number;
+    run: ReturnType<typeof makeRunWithUsages>;
+  } | null;
 }) {
   return {
-    getLatestAgentMessageRun: vi.fn().mockResolvedValue(latestAgentMessageRun),
+    getLatestAgentMessageRun: vi
+      .fn()
+      .mockResolvedValueOnce(latestAgentMessageRun)
+      .mockResolvedValueOnce(previousAgentMessageRun),
     getLatestCompactionMessageRun: vi
       .fn()
       .mockResolvedValue(latestCompactionMessageRun),
@@ -182,16 +190,48 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/context-usage", () => {
     expect(compactionRun.listRunUsages).toHaveBeenCalledOnce();
   });
 
-  it("returns pending usage when the latest agent run has no usage rows yet", async () => {
+  it("falls back to the previous agent run when the latest has no usage rows yet", async () => {
+    const { req, res } = await setupTest();
+
+    const latestRun = makeRunWithUsages([]);
+    const previousRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 555, completionTokens: 55 }),
+    ]);
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: { rank: 20, run: latestRun },
+      latestCompactionMessageRun: null,
+      previousAgentMessageRun: { rank: 18, run: previousRun },
+    });
+
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toMatchObject({
+      model: MODEL,
+      contextUsage: 555,
+    });
+    expect(latestRun.listRunUsages).toHaveBeenCalledOnce();
+    expect(previousRun.listRunUsages).toHaveBeenCalledOnce();
+    expect(conversation.getLatestAgentMessageRun).toHaveBeenCalledTimes(2);
+    expect(conversation.getLatestAgentMessageRun).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      { maxRank: 19 }
+    );
+  });
+
+  it("returns pending usage when the latest agent run has no usage rows and there is no previous run", async () => {
     const { req, res } = await setupTest();
 
     const agentRun = makeRunWithUsages([]);
     const conversation = makeConversationResource({
-      latestAgentMessageRun: {
-        rank: 20,
-        run: agentRun,
-      },
+      latestAgentMessageRun: { rank: 20, run: agentRun },
       latestCompactionMessageRun: null,
+      // previousAgentMessageRun defaults to null — first message in the conversation
     });
 
     vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
@@ -207,6 +247,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/context-usage", () => {
       contextSize: null,
     });
     expect(agentRun.listRunUsages).toHaveBeenCalledOnce();
+    expect(conversation.getLatestAgentMessageRun).toHaveBeenCalledTimes(2);
   });
 
   it("returns pending usage when the conversation has no run data yet", async () => {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -89,12 +89,25 @@ async function handler(
           return res.status(200).json(PENDING_CONTEXT_USAGE_RESPONSE);
         }
 
-        const usages = await lastAgentRun.run.listRunUsages(auth);
+        let usages = await lastAgentRun.run.listRunUsages(auth);
+
+        if (usages.length === 0) {
+          // The latest run has no usage rows yet (still processing). Fall back to the previous
+          // completed run so the indicator stays stable instead of dropping to 0%.
+          const previousAgentRun = await conversation.getLatestAgentMessageRun(
+            auth,
+            { maxRank: lastAgentRun.rank - 1 }
+          );
+          if (previousAgentRun) {
+            usages = await previousAgentRun.run.listRunUsages(auth);
+          }
+        }
+
         if (usages.length === 0) {
           return res.status(200).json(PENDING_CONTEXT_USAGE_RESPONSE);
         }
 
-        // Take the max promptTokens across usages of the latest run — this represents the peak
+        // Take the max promptTokens across usages of the run — this represents the peak
         // context usage as seen by the model.
         const maxUsage = usages.reduce((max, u) =>
           u.promptTokens > max.promptTokens ? u : max


### PR DESCRIPTION
## Description

When an agent message is processing, the context usage indicator could drop to 0% and then jump to a different value once the message completed.

The root cause was a two-layer problem. The API endpoint (`context-usage.ts`) returns `null` values while the latest agent run exists but has no usage rows yet (the LLM call hasn't completed). The frontend hook then computes the percentage as 0 whenever any of those values are null. The refetch is triggered either by `agent_action_success` events or by SWR's default `revalidateOnFocus` behavior, which explains why the bug was intermittent.

Two fixes:

In `context-usage.ts`, when the latest agent run has no usage rows yet, the endpoint now falls back to the previous completed run's data using the existing `maxRank` parameter on `getLatestAgentMessageRun`. This gives the API a stable value to return during processing instead of propagating nulls.

In `useConversationContextUsage.ts`, a `useRef` caches the last valid computed percentage. If the API still returns a pending response (first message ever, compaction edge cases), the hook returns the cached value instead of 0. First load of a conversation still correctly shows 0.

## Tests

Locally.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25675">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->