### PR TITLE
Fix project mount path self-collision + add cleanup script

### DIFF
--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1079,7 +1079,11 @@ export class FileResource extends BaseResource<FileModel> {
   private async isMountFilePathTaken(mountFilePath: string): Promise<boolean> {
     const existing = await FileResource.model.findOne({
       attributes: ["id"],
-      where: { workspaceId: this.workspaceId, mountFilePath },
+      where: {
+        workspaceId: this.workspaceId,
+        mountFilePath,
+        id: { [Op.ne]: this.id },
+      },
     });
     return existing !== null;
   }

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -94,9 +94,7 @@ export function useProjectFiles({
   const projectFilesFetcher: Fetcher<GetSpaceFilesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    disabled || !spaceId
-      ? null
-      : `/api/w/${owner.sId}/spaces/${spaceId}/files`,
+    disabled || !spaceId ? null : `/api/w/${owner.sId}/spaces/${spaceId}/files`,
     projectFilesFetcher
   );
 

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -94,7 +94,9 @@ export function useProjectFiles({
   const projectFilesFetcher: Fetcher<GetSpaceFilesResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/spaces/${spaceId}/files`,
+    disabled || !spaceId
+      ? null
+      : `/api/w/${owner.sId}/spaces/${spaceId}/files`,
     projectFilesFetcher
   );
 

--- a/front/scripts/cleanup_duplicate_project_mount_paths.ts
+++ b/front/scripts/cleanup_duplicate_project_mount_paths.ts
@@ -182,7 +182,9 @@ makeScript(
                   );
                 }
 
-                await bucket.delete(disambiguatedPath, { ignoreNotFound: true });
+                await bucket.delete(disambiguatedPath, {
+                  ignoreNotFound: true,
+                });
                 if (disambiguatedProcessed) {
                   await bucket.delete(disambiguatedProcessed, {
                     ignoreNotFound: true,

--- a/front/scripts/cleanup_duplicate_project_mount_paths.ts
+++ b/front/scripts/cleanup_duplicate_project_mount_paths.ts
@@ -1,0 +1,218 @@
+import { Op } from "sequelize";
+
+import {
+  disambiguateFileName,
+  getProjectFilesBasePath,
+  makeProcessedMountFileName,
+} from "@app/lib/api/files/mount_path";
+import {
+  getProcessedContentType,
+  hasProcessedVersion,
+} from "@app/lib/api/files/processing";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+const BATCH_SIZE_DEFAULT = 200;
+const CONCURRENCY_DEFAULT = 4;
+
+// Cleanup for the broken backfill run that disambiguated already-mounted project_context files.
+// For each file whose `mountFilePath` matches the disambiguated form for that file
+// (basePath + disambiguateFileName(file)) AND whose un-suffixed sibling exists in GCS, switch the
+// DB back to the un-suffixed path, refresh the un-suffixed GCS object from the canonical, and
+// delete the disambiguated GCS copies. Files whose un-suffixed sibling does not exist are skipped
+// (legitimate disambiguation case).
+makeScript(
+  {
+    wId: {
+      type: "string",
+      describe: "Workspace sId to clean up (omit to run on all workspaces).",
+    },
+    fromWorkspaceModelId: {
+      type: "number",
+      describe:
+        "Skip workspaces with model id below this value (for resuming).",
+    },
+    batchSize: {
+      type: "number",
+      default: BATCH_SIZE_DEFAULT,
+      describe: "Number of files to fetch per DB query.",
+    },
+    concurrency: {
+      type: "number",
+      default: CONCURRENCY_DEFAULT,
+      describe: "Concurrent file cleanups per batch.",
+    },
+  },
+  async (
+    { execute, wId, fromWorkspaceModelId, batchSize, concurrency },
+    logger
+  ) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const workspaceId = workspace.sId;
+
+        const auth =
+          await Authenticator.internalBuilderForWorkspace(workspaceId);
+
+        const hasProjectEnabled = await hasFeatureFlag(auth, "projects");
+        if (!hasProjectEnabled) {
+          throw new Error("Workspace does not have `projects` FF enabled.");
+        }
+
+        logger.info(
+          { workspaceId, execute },
+          "[cleanup_duplicate_project_mount_paths] Starting workspace"
+        );
+
+        const bucket = getPrivateUploadBucket();
+
+        let lastId = 0;
+        let totalProcessed = 0;
+        let totalCleaned = 0;
+        let totalSkipped = 0;
+
+        while (true) {
+          const rows = await FileModel.findAll({
+            attributes: ["id"],
+            where: {
+              workspaceId: workspace.id,
+              useCase: "project_context",
+              mountFilePath: { [Op.ne]: null },
+              id: { [Op.gt]: lastId },
+            },
+            order: [["id", "ASC"]],
+            limit: batchSize,
+          });
+
+          if (rows.length === 0) {
+            break;
+          }
+
+          lastId = rows[rows.length - 1].id;
+
+          const files = await FileResource.fetchByModelIdsWithAuth(
+            auth,
+            rows.map((r) => r.id)
+          );
+
+          await concurrentExecutor(
+            files,
+            async (file) => {
+              totalProcessed++;
+
+              const spaceId = file.useCaseMetadata?.spaceId;
+              if (!spaceId || !file.mountFilePath) {
+                totalSkipped++;
+                return;
+              }
+
+              const basePath = getProjectFilesBasePath({
+                workspaceId: workspace.sId,
+                projectId: spaceId,
+              });
+
+              const disambiguatedPath = `${basePath}${disambiguateFileName(file)}`;
+              // Only act when the current mount path matches the disambiguated form for THIS file.
+              if (file.mountFilePath !== disambiguatedPath) {
+                totalSkipped++;
+                return;
+              }
+
+              const unsuffixedPath = `${basePath}${file.fileName}`;
+
+              const [unsuffixedExists] = await bucket
+                .file(unsuffixedPath)
+                .exists();
+              if (!unsuffixedExists) {
+                // No orphan to merge with — likely a legitimate disambiguation.
+                totalSkipped++;
+                return;
+              }
+
+              if (!execute) {
+                logger.info(
+                  {
+                    fileId: file.sId,
+                    fileName: file.fileName,
+                    from: disambiguatedPath,
+                    to: unsuffixedPath,
+                  },
+                  "[cleanup_duplicate_project_mount_paths] Would un-disambiguate (dry-run)"
+                );
+                totalCleaned++;
+                return;
+              }
+
+              try {
+                // Update DB first so any concurrent uploadContent dual-writes hit the un-suffixed
+                // path instead of the soon-to-be-deleted disambiguated one.
+                await FileModel.update(
+                  { mountFilePath: unsuffixedPath },
+                  { where: { id: file.id, workspaceId: workspace.id } }
+                );
+
+                // Refresh un-suffixed from the canonical original (it may be stale — left over
+                // from the first backfill run, predating any frame edits).
+                await bucket.copyFile(
+                  file.getCloudStoragePath(auth, "original"),
+                  unsuffixedPath
+                );
+
+                let disambiguatedProcessed: string | null = null;
+                if (hasProcessedVersion(file.contentType)) {
+                  const processedContentType = getProcessedContentType(
+                    file.contentType
+                  );
+                  const unsuffixedProcessed = makeProcessedMountFileName({
+                    mountFilePath: unsuffixedPath,
+                    processedContentType,
+                  });
+                  disambiguatedProcessed = makeProcessedMountFileName({
+                    mountFilePath: disambiguatedPath,
+                    processedContentType,
+                  });
+                  await bucket.copyFile(
+                    file.getCloudStoragePath(auth, "processed"),
+                    unsuffixedProcessed
+                  );
+                }
+
+                await bucket.delete(disambiguatedPath, { ignoreNotFound: true });
+                if (disambiguatedProcessed) {
+                  await bucket.delete(disambiguatedProcessed, {
+                    ignoreNotFound: true,
+                  });
+                }
+
+                totalCleaned++;
+              } catch (err) {
+                logger.error(
+                  { err, fileId: file.sId },
+                  "[cleanup_duplicate_project_mount_paths] Failed"
+                );
+              }
+            },
+            { concurrency }
+          );
+        }
+
+        logger.info(
+          {
+            workspaceId,
+            totalProcessed,
+            totalCleaned,
+            totalSkipped,
+            execute,
+          },
+          "[cleanup_duplicate_project_mount_paths] Workspace done"
+        );
+      },
+      { wId, fromWorkspaceId: fromWorkspaceModelId }
+    );
+  }
+);

--- a/front/scripts/cleanup_duplicate_project_mount_paths.ts
+++ b/front/scripts/cleanup_duplicate_project_mount_paths.ts
@@ -1,5 +1,3 @@
-import { Op } from "sequelize";
-
 import {
   disambiguateFileName,
   getProjectFilesBasePath,
@@ -16,6 +14,7 @@ import { FileModel } from "@app/lib/resources/storage/models/files";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { Op } from "sequelize";
 
 const BATCH_SIZE_DEFAULT = 200;
 const CONCURRENCY_DEFAULT = 4;
@@ -61,7 +60,7 @@ makeScript(
 
         const hasProjectEnabled = await hasFeatureFlag(auth, "projects");
         if (!hasProjectEnabled) {
-          throw new Error("Workspace does not have `projects` FF enabled.");
+          return;
         }
 
         logger.info(
@@ -117,87 +116,162 @@ makeScript(
               });
 
               const disambiguatedPath = `${basePath}${disambiguateFileName(file)}`;
-              // Only act when the current mount path matches the disambiguated form for THIS file.
-              if (file.mountFilePath !== disambiguatedPath) {
-                totalSkipped++;
-                return;
-              }
-
               const unsuffixedPath = `${basePath}${file.fileName}`;
 
-              const [unsuffixedExists] = await bucket
-                .file(unsuffixedPath)
-                .exists();
-              if (!unsuffixedExists) {
-                // No orphan to merge with — likely a legitimate disambiguation.
-                totalSkipped++;
-                return;
-              }
-
-              if (!execute) {
-                logger.info(
-                  {
-                    fileId: file.sId,
-                    fileName: file.fileName,
-                    from: disambiguatedPath,
-                    to: unsuffixedPath,
-                  },
-                  "[cleanup_duplicate_project_mount_paths] Would un-disambiguate (dry-run)"
-                );
-                totalCleaned++;
-                return;
-              }
-
-              try {
-                // Update DB first so any concurrent uploadContent dual-writes hit the un-suffixed
-                // path instead of the soon-to-be-deleted disambiguated one.
-                await FileModel.update(
-                  { mountFilePath: unsuffixedPath },
-                  { where: { id: file.id, workspaceId: workspace.id } }
-                );
-
-                // Refresh un-suffixed from the canonical original (it may be stale — left over
-                // from the first backfill run, predating any frame edits).
-                await bucket.copyFile(
-                  file.getCloudStoragePath(auth, "original"),
-                  unsuffixedPath
-                );
-
-                let disambiguatedProcessed: string | null = null;
-                if (hasProcessedVersion(file.contentType)) {
-                  const processedContentType = getProcessedContentType(
-                    file.contentType
-                  );
-                  const unsuffixedProcessed = makeProcessedMountFileName({
-                    mountFilePath: unsuffixedPath,
-                    processedContentType,
-                  });
-                  disambiguatedProcessed = makeProcessedMountFileName({
+              const disambiguatedProcessedPath = hasProcessedVersion(
+                file.contentType
+              )
+                ? makeProcessedMountFileName({
                     mountFilePath: disambiguatedPath,
-                    processedContentType,
-                  });
-                  await bucket.copyFile(
-                    file.getCloudStoragePath(auth, "processed"),
-                    unsuffixedProcessed
-                  );
+                    processedContentType: getProcessedContentType(
+                      file.contentType
+                    ),
+                  })
+                : null;
+              const unsuffixedProcessedPath = hasProcessedVersion(
+                file.contentType
+              )
+                ? makeProcessedMountFileName({
+                    mountFilePath: unsuffixedPath,
+                    processedContentType: getProcessedContentType(
+                      file.contentType
+                    ),
+                  })
+                : null;
+
+              // Case A — DB points at the disambiguated path; un-suffixed sibling in GCS may be an
+              // orphan from an earlier backfill round. Switch DB back to un-suffixed and delete
+              // the disambiguated GCS copies.
+              if (file.mountFilePath === disambiguatedPath) {
+                const [unsuffixedExists] = await bucket
+                  .file(unsuffixedPath)
+                  .exists();
+                if (!unsuffixedExists) {
+                  // No orphan to merge with — likely a legitimate disambiguation.
+                  totalSkipped++;
+                  return;
                 }
 
-                await bucket.delete(disambiguatedPath, {
-                  ignoreNotFound: true,
+                // The un-suffixed GCS object may belong to another DB file with the same name
+                // (legitimate disambiguation, not an orphan from the broken backfill). Skip in
+                // that case — otherwise the update below would hit the unique constraint on
+                // (workspaceId, mountFilePath).
+                const ownedByOther = await FileModel.findOne({
+                  attributes: ["id"],
+                  where: {
+                    workspaceId: workspace.id,
+                    mountFilePath: unsuffixedPath,
+                    id: { [Op.ne]: file.id },
+                  },
                 });
-                if (disambiguatedProcessed) {
-                  await bucket.delete(disambiguatedProcessed, {
+                if (ownedByOther) {
+                  totalSkipped++;
+                  return;
+                }
+
+                if (!execute) {
+                  logger.info(
+                    {
+                      fileId: file.sId,
+                      fileName: file.fileName,
+                      from: disambiguatedPath,
+                      to: unsuffixedPath,
+                    },
+                    "[cleanup_duplicate_project_mount_paths] Would un-disambiguate (dry-run)"
+                  );
+                  totalCleaned++;
+                  return;
+                }
+
+                try {
+                  // Update DB first so any concurrent uploadContent dual-writes hit the
+                  // un-suffixed path instead of the soon-to-be-deleted disambiguated one.
+                  await FileModel.update(
+                    { mountFilePath: unsuffixedPath },
+                    { where: { id: file.id, workspaceId: workspace.id } }
+                  );
+
+                  // Refresh un-suffixed from the canonical original (it may be stale — left over
+                  // from an earlier backfill round, predating any frame edits).
+                  await bucket.copyFile(
+                    file.getCloudStoragePath(auth, "original"),
+                    unsuffixedPath
+                  );
+
+                  if (unsuffixedProcessedPath) {
+                    await bucket.copyFile(
+                      file.getCloudStoragePath(auth, "processed"),
+                      unsuffixedProcessedPath
+                    );
+                  }
+
+                  await bucket.delete(disambiguatedPath, {
                     ignoreNotFound: true,
                   });
+                  if (disambiguatedProcessedPath) {
+                    await bucket.delete(disambiguatedProcessedPath, {
+                      ignoreNotFound: true,
+                    });
+                  }
+
+                  totalCleaned++;
+                } catch (err) {
+                  logger.error(
+                    { err, fileId: file.sId },
+                    "[cleanup_duplicate_project_mount_paths] Case A failed"
+                  );
+                }
+                return;
+              }
+
+              // Case B — DB already points at the un-suffixed path, but a disambiguated GCS copy
+              // for this file's sId may still be hanging around from an earlier backfill round.
+              // Disambiguated paths embed THIS file's sId so they can't be legitimately owned by
+              // another file — safe to delete unconditionally when present.
+              if (file.mountFilePath === unsuffixedPath) {
+                const [disambiguatedExists] = await bucket
+                  .file(disambiguatedPath)
+                  .exists();
+                if (!disambiguatedExists) {
+                  totalSkipped++;
+                  return;
                 }
 
-                totalCleaned++;
-              } catch (err) {
-                logger.error(
-                  { err, fileId: file.sId },
-                  "[cleanup_duplicate_project_mount_paths] Failed"
-                );
+                if (!execute) {
+                  logger.info(
+                    {
+                      fileId: file.sId,
+                      fileName: file.fileName,
+                      orphan: disambiguatedPath,
+                    },
+                    "[cleanup_duplicate_project_mount_paths] Would delete disambiguated orphan (dry-run)"
+                  );
+                  totalCleaned++;
+                  return;
+                }
+
+                try {
+                  await bucket.delete(disambiguatedPath, {
+                    ignoreNotFound: true,
+                  });
+                  if (disambiguatedProcessedPath) {
+                    await bucket.delete(disambiguatedProcessedPath, {
+                      ignoreNotFound: true,
+                    });
+                  }
+                  totalCleaned++;
+                } catch (err) {
+                  logger.error(
+                    { err, fileId: file.sId },
+                    "[cleanup_duplicate_project_mount_paths] Case B failed"
+                  );
+                }
+                return;
               }
+
+              // Mount path is neither the un-suffixed nor the disambiguated form for this file
+              // (e.g., still pointing at a stale conversation path). Skip.
+              totalSkipped++;
             },
             { concurrency }
           );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes the mount file path logic:
- `isMountFilePathTaken` now excludes this.id, so re-running mount path resolution on an already-mounted file doesn't trip disambiguation against itself.
- Adds a script to clean up duplicated

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->