### PR TITLE
[LLM] Strip version from Vertex model id for token counting

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -198,10 +198,12 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
       return undefined;
     }
 
+    const model = this.useVertex ? this.getModel().split("@")[0] : this.modelId;
+
     return (body: MessageCountTokensParams) =>
       this.inferenceClient.messages.countTokens({
         ...body,
-        model: this.getModel(),
+        model,
       });
   }
 

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -4,13 +4,12 @@ import type {
   MessageCreateParamsNonStreaming,
 } from "@anthropic-ai/sdk/resources";
 import type { BetaMessageStreamParams } from "@anthropic-ai/sdk/resources/beta/messages";
-import AnthropicVertex from "@anthropic-ai/vertex-sdk";
-import config from "@app/lib/api/config";
+import type AnthropicVertex from "@anthropic-ai/vertex-sdk";
+
 import type { AnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
 import {
   ANTHROPIC_PROVIDER_ID,
   overwriteLLMParameters,
-  VERTEX_MODEL_ID_MAP,
 } from "@app/lib/api/llm/clients/anthropic/types";
 import {
   toAutoThinkingConfig,
@@ -31,6 +30,11 @@ import {
   handleInvalidToolJsonAnthropicError,
   isAnthropicErrorUnableToParseToolParam,
 } from "@app/lib/api/llm/clients/anthropic/utils/errors";
+import {
+  getInferenceClient,
+  getModel,
+  getModelForTokenCount,
+} from "@app/lib/api/llm/clients/anthropic/utils/vertex";
 import { LLM } from "@app/lib/api/llm/llm";
 import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
 import { handleGenericError } from "@app/lib/api/llm/types/errors";
@@ -124,14 +128,10 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
       apiKey: ANTHROPIC_API_KEY,
     });
 
-    // Vertex does not support batches
-    this.inferenceClient = this.useVertex
-      ? // Routing everything to Europe first to check that Vertex works correctly.
-        new AnthropicVertex({
-          region: "europe-west1",
-          projectId: config.getVertexAiProjectId(),
-        })
-      : this.client;
+    // Vertex does not support batches.
+    this.inferenceClient = getInferenceClient(this.useVertex, {
+      anthropicClient: this.client,
+    });
   }
 
   private async buildBaseRequestPayload({
@@ -198,21 +198,15 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
       return undefined;
     }
 
-    const model = this.useVertex ? this.getModel().split("@")[0] : this.modelId;
+    const model = getModelForTokenCount(this.useVertex, {
+      modelId: this.modelId,
+    });
 
     return (body: MessageCountTokensParams) =>
       this.inferenceClient.messages.countTokens({
         ...body,
         model,
       });
-  }
-
-  private getModel(): string {
-    if (!this.useVertex) {
-      return this.modelId;
-    }
-
-    return VERTEX_MODEL_ID_MAP[this.modelId] ?? this.modelId;
   }
 
   protected async *sendRequest(
@@ -231,7 +225,7 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
         ? { ...basePayload.output_config, format: outputFormat }
         : basePayload.output_config,
       cache_control: { type: "ephemeral" },
-      model: this.getModel(),
+      model: getModel(this.useVertex, { modelId: this.modelId }),
     };
 
     try {

--- a/front/lib/api/llm/clients/anthropic/types.ts
+++ b/front/lib/api/llm/clients/anthropic/types.ts
@@ -101,7 +101,11 @@ export const isAnthropicWhitelistedModelId = (
   );
 };
 
-export const VERTEX_MODEL_ID_MAP: Partial<Record<ModelIdType, string>> = {
+// Typed as `${string}@${string}` so the model id and version can be split on `@`
+// — the Vertex token counting API only requires the name.
+export const VERTEX_MODEL_ID_MAP: Partial<
+  Record<ModelIdType, `${string}@${string}`>
+> = {
   [CLAUDE_4_5_SONNET_20250929_MODEL_ID]: "claude-sonnet-4-5@20250929",
   [CLAUDE_SONNET_4_6_MODEL_ID]: "claude-sonnet-4-6@default",
   [CLAUDE_OPUS_4_6_MODEL_ID]: "claude-opus-4-6@default",

--- a/front/lib/api/llm/clients/anthropic/utils/vertex.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/vertex.ts
@@ -1,0 +1,42 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import AnthropicVertex from "@anthropic-ai/vertex-sdk";
+
+import config from "@app/lib/api/config";
+import { VERTEX_MODEL_ID_MAP } from "@app/lib/api/llm/clients/anthropic/types";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+
+export function getInferenceClient(
+  useVertex: boolean,
+  { anthropicClient }: { anthropicClient: Anthropic }
+): Anthropic | AnthropicVertex {
+  if (!useVertex) {
+    return anthropicClient;
+  }
+
+  return new AnthropicVertex({
+    region: "europe-west1",
+    projectId: config.getVertexAiProjectId(),
+  });
+}
+
+export function getModel(
+  useVertex: boolean,
+  { modelId }: { modelId: ModelIdType }
+): string {
+  if (!useVertex) {
+    return modelId;
+  }
+
+  return VERTEX_MODEL_ID_MAP[modelId] ?? modelId;
+}
+
+export function getModelForTokenCount(
+  useVertex: boolean,
+  { modelId }: { modelId: ModelIdType }
+): string {
+  if (!useVertex) {
+    return modelId;
+  }
+
+  return getModel(useVertex, { modelId }).split("@")[0];
+}


### PR DESCRIPTION
## Description

When using Vertex, the Anthropic token counting API expects only the model name (e.g. `claude-sonnet-4-5`), not the Vertex-style `name@version` string we pass for inference. Now all token count fail:

<img width="1252" height="132" alt="Screenshot 2026-05-18 at 10 48 52" src="https://github.com/user-attachments/assets/9f0c86f1-4c47-4204-bf74-429cfe91d678" />


## Tests

Tested manually against the Vertex Anthropic client.

## Risk

Low — change is limited to the model id passed to `countTokens` when `useVertex` is true; non-Vertex paths are unchanged.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`