### PR TITLE
[Projects] Delete project todos during space scrub

### DIFF
--- a/front/lib/resources/project_task_resource.test.ts
+++ b/front/lib/resources/project_task_resource.test.ts
@@ -1,11 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import {
-  ProjectTaskModel,
-  ProjectTaskSourceModel,
-  ProjectTaskVersionModel,
-} from "@app/lib/resources/storage/models/project_task";
+import type { ProjectTaskModel } from "@app/lib/resources/storage/models/project_task";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -674,28 +670,22 @@ describe("ProjectTaskResource", () => {
         makeTodoBlob(otherSpace.id, user.id)
       );
 
-      await ProjectTaskResource.deleteAllBySpace(auth, { spaceId: space.id });
+      await ProjectTaskResource.deleteAllBySpace(auth, {
+        spaceModelId: space.id,
+      });
 
       await expect(
-        ProjectTaskModel.count({
-          where: { workspaceId: workspace.id, spaceId: space.id },
-        })
-      ).resolves.toBe(0);
+        ProjectTaskResource.fetchByModelIdWithDeleted(auth, todo.id)
+      ).resolves.toBeNull();
+
+      const sources = await ProjectTaskResource.fetchSourcesForTaskIds(auth, {
+        sIds: [todo.sId],
+      });
+      expect(sources.get(todo.sId) ?? []).toHaveLength(0);
+
       await expect(
-        ProjectTaskVersionModel.count({
-          where: { workspaceId: workspace.id, spaceId: space.id },
-        })
-      ).resolves.toBe(0);
-      await expect(
-        ProjectTaskSourceModel.count({
-          where: { workspaceId: workspace.id, projectTodoId: todo.id },
-        })
-      ).resolves.toBe(0);
-      await expect(
-        ProjectTaskModel.count({
-          where: { workspaceId: workspace.id, id: otherTodo.id },
-        })
-      ).resolves.toBe(1);
+        ProjectTaskResource.fetchByModelIdWithDeleted(auth, otherTodo.id)
+      ).resolves.not.toBeNull();
     });
   });
 });

--- a/front/lib/resources/project_task_resource.test.ts
+++ b/front/lib/resources/project_task_resource.test.ts
@@ -1,7 +1,9 @@
 import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ProjectTaskModel } from "@app/lib/resources/storage/models/project_task";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -663,6 +665,21 @@ describe("ProjectTaskResource", () => {
           sourceUrl: null,
         },
       });
+      const conversation = await ConversationResource.makeNew(
+        auth,
+        {
+          sId: generateRandomModelSId(),
+          title: "Project task cleanup",
+          visibility: "test",
+          spaceId: space.id,
+          requestedSpaceIds: [space.id],
+          metadata: {},
+        },
+        space
+      );
+      await todo.addConversation(auth, {
+        conversationModelId: conversation.id,
+      });
       await todo.softDelete(auth);
 
       const otherTodo = await ProjectTaskResource.makeNew(
@@ -682,6 +699,12 @@ describe("ProjectTaskResource", () => {
         sIds: [todo.sId],
       });
       expect(sources.get(todo.sId) ?? []).toHaveLength(0);
+
+      const conversations =
+        await ProjectTaskResource.fetchConversationIdsForTaskIds(auth, {
+          sIds: [todo.sId],
+        });
+      expect(conversations.has(todo.sId)).toBe(false);
 
       await expect(
         ProjectTaskResource.fetchByModelIdWithDeleted(auth, otherTodo.id)

--- a/front/lib/resources/project_task_resource.test.ts
+++ b/front/lib/resources/project_task_resource.test.ts
@@ -1,7 +1,11 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import type { ProjectTaskModel } from "@app/lib/resources/storage/models/project_task";
+import {
+  ProjectTaskModel,
+  ProjectTaskSourceModel,
+  ProjectTaskVersionModel,
+} from "@app/lib/resources/storage/models/project_task";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -41,6 +45,7 @@ describe("ProjectTaskResource", () => {
   let user: UserResource;
   let auth: Authenticator;
   let space: SpaceResource;
+  let otherSpace: SpaceResource;
 
   beforeEach(async () => {
     const setup = await createResourceTest({ role: "user" });
@@ -48,6 +53,7 @@ describe("ProjectTaskResource", () => {
     user = setup.user;
     auth = setup.authenticator;
     space = setup.globalSpace;
+    otherSpace = setup.systemSpace;
   });
 
   describe("makeNew", () => {
@@ -646,6 +652,50 @@ describe("ProjectTaskResource", () => {
       // The main row is gone — no observable version leakage through the public API.
       const fetched = await ProjectTaskResource.fetchBySId(auth, sId);
       expect(fetched).toBeNull();
+    });
+  });
+
+  describe("deleteAllBySpace", () => {
+    it("should delete soft-deleted todos and their child rows", async () => {
+      const todo = await ProjectTaskResource.makeNewWithSource(auth, {
+        blob: makeTodoBlob(space.id, user.id),
+        itemId: "item-delete-space",
+        source: {
+          sourceType: "slack",
+          sourceId: "slack-delete-space",
+          sourceTitle: null,
+          sourceUrl: null,
+        },
+      });
+      await todo.softDelete(auth);
+
+      const otherTodo = await ProjectTaskResource.makeNew(
+        auth,
+        makeTodoBlob(otherSpace.id, user.id)
+      );
+
+      await ProjectTaskResource.deleteAllBySpace(auth, { spaceId: space.id });
+
+      await expect(
+        ProjectTaskModel.count({
+          where: { workspaceId: workspace.id, spaceId: space.id },
+        })
+      ).resolves.toBe(0);
+      await expect(
+        ProjectTaskVersionModel.count({
+          where: { workspaceId: workspace.id, spaceId: space.id },
+        })
+      ).resolves.toBe(0);
+      await expect(
+        ProjectTaskSourceModel.count({
+          where: { workspaceId: workspace.id, projectTodoId: todo.id },
+        })
+      ).resolves.toBe(0);
+      await expect(
+        ProjectTaskModel.count({
+          where: { workspaceId: workspace.id, id: otherTodo.id },
+        })
+      ).resolves.toBe(1);
     });
   });
 });

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -463,12 +463,12 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
         where: childWhere,
         transaction,
       });
+      await ProjectTaskVersionModel.destroy({
+        where: childWhere,
+        transaction,
+      });
     }
 
-    await ProjectTaskVersionModel.destroy({
-      where: { workspaceId, spaceId },
-      transaction,
-    });
     await ProjectTaskModel.destroy({
       where: { workspaceId, spaceId },
       transaction,

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -433,6 +433,48 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
     return todos.map((todo) => new this(ProjectTaskModel, todo.get()));
   }
 
+  static async deleteAllBySpace(
+    auth: Authenticator,
+    { spaceId }: { spaceId: ModelId },
+    transaction?: Transaction
+  ): Promise<void> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const todoIds = (
+      await ProjectTaskModel.findAll({
+        attributes: ["id"],
+        where: { workspaceId, spaceId },
+        raw: true,
+        transaction,
+      })
+    ).map((todo) => todo.id);
+
+    if (todoIds.length > 0) {
+      const childWhere = {
+        workspaceId,
+        projectTodoId: { [Op.in]: todoIds },
+      };
+
+      await ProjectTaskConversationModel.destroy({
+        where: childWhere,
+        transaction,
+      });
+      await ProjectTaskSourceModel.destroy({
+        where: childWhere,
+        transaction,
+      });
+    }
+
+    await ProjectTaskVersionModel.destroy({
+      where: { workspaceId, spaceId },
+      transaction,
+    });
+    await ProjectTaskModel.destroy({
+      where: { workspaceId, spaceId },
+      transaction,
+    });
+  }
+
   // Batch variant: fetches the current todo row for each itemId in one pass.
   // Returns a map from itemId to the matching ProjectTaskResource — missing
   // entries mean no todo yet exists for that item.

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -435,7 +435,7 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
 
   static async deleteAllBySpace(
     auth: Authenticator,
-    { spaceId }: { spaceId: ModelId },
+    { spaceModelId }: { spaceModelId: ModelId },
     transaction?: Transaction
   ): Promise<void> {
     const workspaceId = auth.getNonNullableWorkspace().id;
@@ -443,7 +443,7 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
     const todoIds = (
       await ProjectTaskModel.findAll({
         attributes: ["id"],
-        where: { workspaceId, spaceId },
+        where: { workspaceId, spaceId: spaceModelId },
         raw: true,
         transaction,
       })
@@ -470,7 +470,7 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
     }
 
     await ProjectTaskModel.destroy({
-      where: { workspaceId, spaceId },
+      where: { workspaceId, spaceId: spaceModelId },
       transaction,
     });
   }

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -183,21 +183,9 @@ export async function scrubSpaceActivity({
   // TakeawaySourcesModel, so the join-table rows must be removed first.
   await TakeawaysResource.deleteAllForSpace(auth, { spaceModelId: space.id });
 
-  // Delete all project todos for this space, before the conversations as it's linked to convo
-  const projectTodos = await ProjectTaskResource.fetchBySpace(auth, {
-    spaceId: space.id,
-    timeScope: "all",
-  });
-  await concurrentExecutor(
-    projectTodos,
-    async (todo) => {
-      const res = await todo.delete(auth, {});
-      if (res.isErr()) {
-        throw res.error;
-      }
-    },
-    { concurrency: 8 }
-  );
+  // Delete all project todos for this space before conversations, as project
+  // todo conversation rows reference conversations.
+  await ProjectTaskResource.deleteAllBySpace(auth, { spaceId: space.id });
 
   // Delete all conversations in the space.
   // Won't scale if there's tons of conversations in spaces.
@@ -221,21 +209,6 @@ export async function scrubSpaceActivity({
     );
     await concurrentExecutor(
       projectTodoStates,
-      async (todoState) => {
-        const result = await todoState.delete(auth, {});
-        if (result.isErr()) {
-          throw result.error;
-        }
-      },
-      { concurrency: 8 }
-    );
-
-    const projectTodos = await ProjectTaskResource.fetchBySpace(auth, {
-      spaceId: space.id,
-      timeScope: "all",
-    });
-    await concurrentExecutor(
-      projectTodos,
       async (todoState) => {
         const result = await todoState.delete(auth, {});
         if (result.isErr()) {

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -185,7 +185,9 @@ export async function scrubSpaceActivity({
 
   // Delete all project todos for this space before conversations, as project
   // todo conversation rows reference conversations.
-  await ProjectTaskResource.deleteAllBySpace(auth, { spaceId: space.id });
+  await ProjectTaskResource.deleteAllBySpace(auth, {
+    spaceModelId: space.id,
+  });
 
   // Delete all conversations in the space.
   // Won't scale if there's tons of conversations in spaces.


### PR DESCRIPTION
## Description
Deletes all project task rows for a space during `scrubSpaceActivity`, including soft-deleted todos that `fetchBySpace(..., timeScope: "all")` intentionally hides. The resource cleanup also removes project task child rows and versions before the space hard delete, preventing `project_todos_spaceId_fkey` from blocking vault deletion.

## Risks
Blast radius: project space hard-delete scrub cleanup for project tasks.
Risk: low

## Deploy Plan
- deploy front workers

## Tests
- [ ] `NODE_ENV=test npm test -- lib/resources/project_task_resource.test.ts` blocked locally by test DB bootstrap failing on unrelated `agent_suggestions_agentConfigurationId_fkey` type mismatch