### PR TITLE
Add CODEOWNERS for front data models and DB migrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# GitHub CODEOWNERS — see https://docs.github.com/articles/about-code-owners
+#
+# Rules are evaluated last-match-wins. To enforce that listed reviewers are
+# required, enable "Require review from Code Owners" in branch protection
+# for the default branch.
+
+# Data models and DB schema migrations in front.
+# Any change touching these paths must be reviewed by @dust-tt/data-model-owners.
+/front/lib/models/                    @dust-tt/data-model-owners
+/front/lib/resources/storage/models/  @dust-tt/data-model-owners
+/front/migrations/db/                 @dust-tt/data-model-owners


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR introduces  `.github/CODEOWNERS` requiring review from `@dust-tt/data-model-owners` on changes to:
- `front/lib/models/`
- `front/lib/resources/storage/models/`
- `front/migrations/db/`

## Deploy Plan

- [ ] Enable **Require review from Code Owners** in branch protection for `main` so the rule blocks merge instead of only auto-requesting review.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25682">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->