### PR TITLE
Gate Claydar load on explicit cookie consent

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -237,6 +237,14 @@ export default function LandingLayout({
             `}
           </Script>
         )}
+        {cookieValue === "true" && (
+          // Marketing tier requires explicit Accept; skip the geo-based "auto" consent path.
+          <Script
+            id="claydar"
+            src="https://static.claydar.com/init.v1.js?id=clmYho8v0U"
+            strategy="afterInteractive"
+          />
+        )}
         {!hideNavigation && <FooterNavigation />}
       </main>
     </>

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -7,12 +7,10 @@ import "@app/styles/components.css";
 
 import type { NextPage } from "next";
 import type { AppProps } from "next/app";
-import Script from "next/script";
 
 // Important: avoid destructuring process.env on the client.
 // Next.js replaces direct property access (process.env.NEXT_PUBLIC_*) at build time,
 // but destructuring `process.env` does not get inlined.
-const DUST_API_URL = process.env.NEXT_PUBLIC_DUST_API_URL;
 const NODE_ENV = process.env.NODE_ENV;
 const DATADOG_CLIENT_TOKEN = process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN;
 const DATADOG_SERVICE = process.env.NEXT_PUBLIC_DATADOG_SERVICE;
@@ -117,12 +115,6 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
           {getLayout(<Component {...pageProps} />, pageProps)}
         </SparkleContext.Provider>
       </PostHogTracker>
-      {DUST_API_URL !== "https://app.dust.tt" && (
-        <Script
-          src="https://static.claydar.com/init.v1.js?id=clmYho8v0U"
-          strategy="afterInteractive"
-        />
-      )}
     </FetcherProvider>
   );
 }


### PR DESCRIPTION
## Description

Moves Claydar (Clay's website visitor tracking script) from the global app shell (`_app.tsx`) to the marketing site's `LandingLayout` component, gated behind explicit cookie consent. Previously, Claydar loaded unconditionally on all non-production pages. Now it only loads when `dust-cookies-accepted` is explicitly `"true"`, excluding the geo-based `"auto"` consent path used for non-GDPR regions. This ensures Claydar, a B2B marketing tracker, only runs with proper consent under ePrivacy regulations.

## Tests

Manually verify:
- On marketing pages in non-GDPR regions (`auto` consent), Claydar script should NOT load
- On marketing pages with explicit "Accept All Cookies", Claydar script should load
- On marketing pages with refused cookies, Claydar script should NOT load
- On non-marketing pages (app routes), Claydar script should NOT load

## Risk

Breaking Claydar integration could impact website visitor attribution and B2B lead tracking. Verify that Clay dashboard still receives events from the marketing site after deployment.

## Deploy Plan

Deploy front