### PR TITLE
feat: add parent sandbox action to jwt for fast retrieve

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -595,21 +595,6 @@ describe("tryCallMCPTool", () => {
       timeoutMs: undefined,
     };
 
-    // Create agent loop run context
-    const agentLoopRunContext: AgentLoopRunContextType = {
-      agentConfiguration: agentConfig,
-      agentMessage,
-      conversation,
-      stepContext: {
-        citationsCount: 10,
-        citationsOffset: 0,
-        retrievalTopK: 10,
-        resumeState: null,
-        websearchResultCount: 0,
-      },
-      toolConfiguration,
-    };
-
     // Create a mock action for the notification event
     const mockAction: AgentMCPActionWithOutputType = {
       id: agentMessage.agentMessageId as number, // Use the agentMessageId as the action id
@@ -634,6 +619,22 @@ describe("tryCallMCPTool", () => {
       displayLabels: null,
       output: null,
       generatedFiles: [],
+    };
+
+    // Create agent loop run context
+    const agentLoopRunContext: AgentLoopRunContextType = {
+      agentConfiguration: agentConfig,
+      agentMessage,
+      conversation,
+      stepContext: {
+        citationsCount: 10,
+        citationsOffset: 0,
+        retrievalTopK: 10,
+        resumeState: null,
+        websearchResultCount: 0,
+      },
+      currentAction: mockAction,
+      toolConfiguration,
     };
 
     // Call tryCallMCPTool

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -3,6 +3,7 @@ import type {
   LightMCPToolConfigurationType,
   MCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
+import type { AgentMCPActionType } from "@app/types/actions";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
@@ -116,7 +117,7 @@ export type ActionGeneratedFileType =
 export type AgentLoopRunContextType = {
   agentConfiguration: AgentConfigurationType;
   agentMessage: AgentMessageType;
-  clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
+  currentAction: AgentMCPActionType;
   conversation: ConversationType;
   stepContext: StepContext;
   toolConfiguration: LightMCPToolConfigurationType;

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -233,6 +233,7 @@ describe("runSandboxBashTool", () => {
           },
           agentMessage: { sId: "message-id" },
           conversation: { sId: "conversation-id" },
+          currentAction: { sId: "sandbox-action-id" },
         },
       },
       signal: new AbortController().signal,

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -228,7 +228,8 @@ export async function runSandboxBashTool(
   const conversation = agentLoopContext?.runContext?.conversation;
   const agentConfiguration = agentLoopContext?.runContext?.agentConfiguration;
   const agentMessage = agentLoopContext?.runContext?.agentMessage;
-  if (!conversation || !agentConfiguration || !agentMessage) {
+  const sandboxAction = agentLoopContext?.runContext?.currentAction;
+  if (!conversation || !agentConfiguration || !agentMessage || !sandboxAction) {
     return new Err(new MCPError("No conversation context available."));
   }
 
@@ -247,6 +248,7 @@ export async function runSandboxBashTool(
     sandbox,
     execId,
     expiryMs: DEFAULT_EXEC_TIMEOUT_MS,
+    sandboxAction,
   });
 
   const metricsCtx = { workspaceId: auth.getNonNullableWorkspace().sId };

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -78,6 +78,7 @@ export async function* runToolWithStreaming(
   const agentLoopRunContext: AgentLoopRunContextType = {
     agentConfiguration,
     agentMessage,
+    currentAction: action.toJSON(),
     conversation,
     stepContext: action.stepContext,
     toolConfiguration,

--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -60,11 +60,11 @@ async function setupTest() {
   });
 
   const mockAction: AgentMCPActionType = {
-    id: agentMessage.agentMessageId as number, // Use the agentMessageId as the action id
+    id: agentMessage.agentMessageId,
     sId: generateRandomModelSId(),
     createdAt: Date.now(),
     updatedAt: Date.now(),
-    agentMessageId: agentMessage.agentMessageId as number,
+    agentMessageId: agentMessage.agentMessageId,
     internalMCPServerName: "search",
     toolName: "semantic_search",
     mcpServerId: sandboxServer.id,

--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -4,13 +4,16 @@ import {
   verifySandboxExecToken,
 } from "@app/lib/api/sandbox/access_tokens";
 import { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { AgentMCPActionType } from "@app/types/actions";
 import jwt from "jsonwebtoken";
 import { describe, expect, it, vi } from "vitest";
 
@@ -51,13 +54,47 @@ async function setupTest() {
     agentConfig,
   });
 
-  return { auth, agentConfig, agentMessage, conversation, sandbox };
+  const sandboxServer = await InternalMCPServerInMemoryResource.makeNew(auth, {
+    name: "sandbox",
+    useCase: null,
+  });
+
+  const mockAction: AgentMCPActionType = {
+    id: agentMessage.agentMessageId as number, // Use the agentMessageId as the action id
+    sId: generateRandomModelSId(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    agentMessageId: agentMessage.agentMessageId as number,
+    internalMCPServerName: "search",
+    toolName: "semantic_search",
+    mcpServerId: sandboxServer.id,
+    functionCallName: "semantic_search",
+    functionCallId: generateRandomModelSId(),
+    params: {
+      query: "test query",
+      relativeTimeFrame: "all",
+      dataSources: [],
+    },
+    citationsAllocated: 0,
+    status: "running",
+    step: 0,
+    executionDurationMs: null,
+    displayLabels: null,
+  };
+
+  return { auth, agentConfig, agentMessage, conversation, sandbox, mockAction };
 }
 
 describe("sandbox access tokens", () => {
   it("round-trip: generate → verify → check claims", async () => {
-    const { auth, agentConfig, agentMessage, conversation, sandbox } =
-      await setupTest();
+    const {
+      auth,
+      agentConfig,
+      agentMessage,
+      conversation,
+      sandbox,
+      mockAction,
+    } = await setupTest();
 
     const token = await generateSandboxExecToken(auth, {
       agentConfiguration: agentConfig,
@@ -65,6 +102,7 @@ describe("sandbox access tokens", () => {
       conversation,
       sandbox,
       execId: "test-exec-id",
+      sandboxAction: mockAction,
     });
 
     expect(token.startsWith(SANDBOX_TOKEN_PREFIX)).toBe(true);
@@ -81,8 +119,14 @@ describe("sandbox access tokens", () => {
   });
 
   it("tampered token is rejected", async () => {
-    const { auth, agentConfig, agentMessage, conversation, sandbox } =
-      await setupTest();
+    const {
+      auth,
+      agentConfig,
+      agentMessage,
+      conversation,
+      sandbox,
+      mockAction,
+    } = await setupTest();
 
     const token = await generateSandboxExecToken(auth, {
       agentConfiguration: agentConfig,
@@ -90,6 +134,7 @@ describe("sandbox access tokens", () => {
       conversation,
       sandbox,
       execId: "test-exec-id",
+      sandboxAction: mockAction,
     });
 
     // Decode, modify, re-sign with a wrong secret.
@@ -106,8 +151,14 @@ describe("sandbox access tokens", () => {
   });
 
   it("token without sbt- prefix is rejected", async () => {
-    const { auth, agentConfig, agentMessage, conversation, sandbox } =
-      await setupTest();
+    const {
+      auth,
+      agentConfig,
+      agentMessage,
+      conversation,
+      sandbox,
+      mockAction,
+    } = await setupTest();
 
     const token = await generateSandboxExecToken(auth, {
       agentConfiguration: agentConfig,
@@ -115,6 +166,7 @@ describe("sandbox access tokens", () => {
       conversation,
       sandbox,
       execId: "test-exec-id",
+      sandboxAction: mockAction,
     });
     const raw = token.slice(SANDBOX_TOKEN_PREFIX.length);
 

--- a/front/lib/api/sandbox/access_tokens.ts
+++ b/front/lib/api/sandbox/access_tokens.ts
@@ -3,6 +3,7 @@ import { runOnRedis } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
+import type { AgentMCPActionType } from "@app/types/actions";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
@@ -25,6 +26,7 @@ const SandboxExecTokenPayloadSchema = z.object({
   mId: z.string(),
   sbId: z.string(),
   execId: z.string(),
+  actionId: z.string(),
 });
 
 export type SandboxExecTokenPayload = z.infer<
@@ -100,6 +102,7 @@ export async function generateSandboxExecToken(
     conversation,
     sandbox,
     execId,
+    sandboxAction,
     expiryMs = 2 * 60 * 1000, // Default to 2 minutes
   }: {
     agentConfiguration: AgentConfigurationType;
@@ -107,6 +110,7 @@ export async function generateSandboxExecToken(
     conversation: ConversationType;
     sandbox: SandboxResource;
     execId: string;
+    sandboxAction: AgentMCPActionType;
     expiryMs?: number;
   }
 ): Promise<string> {
@@ -117,6 +121,7 @@ export async function generateSandboxExecToken(
     aId: agentConfiguration.sId,
     mId: agentMessage.sId,
     sbId: sandbox.sId,
+    actionId: sandboxAction.sId,
     execId,
   };
 

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1441,6 +1441,7 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
         mId: "test-message-id-user",
         sbId: "test-sandbox-id-user",
         execId: "test-exec-id-user",
+        actionId: "test-action-id",
       },
       workspace.sId
     );
@@ -1511,6 +1512,7 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
         mId: "test-message-id-admin",
         sbId: "test-sandbox-id-admin",
         execId: "test-exec-id-admin",
+        actionId: "test-action-id",
       },
       workspace.sId
     );

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/call_tool.ts
@@ -31,14 +31,6 @@ import type { CallMCPToolResponseType } from "@dust-tt/client";
 import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-const DEFAULT_SANDBOX_STEP_CONTEXT = {
-  citationsCount: 0,
-  citationsOffset: 0,
-  resumeState: null,
-  retrievalTopK: 10,
-  websearchResultCount: 10,
-} as const;
-
 async function extractSandboxClaims(
   req: NextApiRequest
 ): Promise<SandboxExecTokenPayload | null> {
@@ -74,6 +66,15 @@ async function buildSandboxAgentLoopContext(
   }
 
   const conversation = conversationResult.value;
+
+  // Fetch the parent action's stepContext (the running sandbox bash tool).
+  const parentAction = await AgentMCPActionResource.fetchById(
+    auth,
+    claims.actionId
+  );
+  if (!parentAction) {
+    return undefined;
+  }
 
   const agentMessage = conversation.content
     .flat()
@@ -139,23 +140,15 @@ async function buildSandboxAgentLoopContext(
     ...toolConfiguration
   } = fullToolConfiguration;
 
-  // Fetch the parent action's stepContext (the running sandbox bash tool).
-  // There is at most one running sandbox action per agent message.
-  const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
-    agentMessage.agentMessageId,
-  ]);
-  const parentAction = actions.find(
-    (a) =>
-      a.status === "running" && a.toolConfiguration.mcpServerName === "sandbox"
-  );
-  const stepContext = parentAction?.stepContext ?? DEFAULT_SANDBOX_STEP_CONTEXT;
-
   return {
     runContext: {
       agentConfiguration,
       agentMessage,
       conversation,
-      stepContext,
+      // TODO(adrien 2026-18-05): migrate currentAction to actual current action
+      // once we have a proper mcp action (in ~2/3 PRs).
+      currentAction: parentAction.toJSON(),
+      stepContext: parentAction.stepContext,
       toolConfiguration,
     },
   };

--- a/front/tests/utils/SandboxTokenFactory.ts
+++ b/front/tests/utils/SandboxTokenFactory.ts
@@ -1,6 +1,8 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { generateSandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
 import { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -9,6 +11,7 @@ import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { AgentMCPActionType } from "@app/types/actions";
 
 process.env.DUST_SANDBOX_JWT_SECRET ??= "test-sandbox-jwt-secret";
 
@@ -58,12 +61,41 @@ export async function createSandboxTokenTestContext({
     throw new Error("Expected sandbox token test conversation agent message.");
   }
 
+  const sandboxServer = await InternalMCPServerInMemoryResource.makeNew(auth, {
+    name: "sandbox",
+    useCase: null,
+  });
+
+  const mockAction: AgentMCPActionType = {
+    id: agentMessage.agentMessageId as number, // Use the agentMessageId as the action id
+    sId: generateRandomModelSId(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    agentMessageId: agentMessage.agentMessageId as number,
+    internalMCPServerName: "search",
+    toolName: "semantic_search",
+    mcpServerId: sandboxServer.id,
+    functionCallName: "semantic_search",
+    functionCallId: generateRandomModelSId(),
+    params: {
+      query: "test query",
+      relativeTimeFrame: "all",
+      dataSources: [],
+    },
+    citationsAllocated: 0,
+    status: "running",
+    step: 0,
+    executionDurationMs: null,
+    displayLabels: null,
+  };
+
   const token = await generateSandboxExecToken(auth, {
     agentConfiguration: agentConfig,
     agentMessage,
     conversation,
     sandbox,
     execId: `test-exec-${sandbox.sId}`,
+    sandboxAction: mockAction,
   });
 
   return {

--- a/front/tests/utils/SandboxTokenFactory.ts
+++ b/front/tests/utils/SandboxTokenFactory.ts
@@ -67,11 +67,11 @@ export async function createSandboxTokenTestContext({
   });
 
   const mockAction: AgentMCPActionType = {
-    id: agentMessage.agentMessageId as number, // Use the agentMessageId as the action id
+    id: agentMessage.agentMessageId,
     sId: generateRandomModelSId(),
     createdAt: Date.now(),
     updatedAt: Date.now(),
-    agentMessageId: agentMessage.agentMessageId as number,
+    agentMessageId: agentMessage.agentMessageId,
     internalMCPServerName: "search",
     toolName: "semantic_search",
     mcpServerId: sandboxServer.id,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

For the tool execution in sandbox, we'll need to be able to fast retrieve the parent sandbox action that summoned the current bash execution.

This PR adds a new `actionId` claim in the token. This is done by adding a `currentAction` claim in the `agentLoopRunContext`. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Unit tests

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25684">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->