### PR TITLE
fix(poke): use substring match for workspace name search

### DIFF
--- a/front/pages/api/poke/workspaces/index.test.ts
+++ b/front/pages/api/poke/workspaces/index.test.ts
@@ -17,13 +17,13 @@ async function createNamedWorkspace(name: string) {
 
 describe("GET /api/poke/workspaces — workspace name search", () => {
   it("matches by prefix", async () => {
-    const workspace = await createNamedWorkspace("Bouygues Construction");
+    const workspace = await createNamedWorkspace("Zorbix Industries");
     const { req, res } = await createPrivateApiMockRequest({
       method: "GET",
       isSuperUser: true,
       workspace,
     });
-    req.query.search = encodeURIComponent("Bouygues");
+    req.query.search = encodeURIComponent("Zorbix");
     req.query.limit = "20";
 
     await handler(req, res);
@@ -36,13 +36,13 @@ describe("GET /api/poke/workspaces — workspace name search", () => {
   });
 
   it("matches by a word in the middle of the name", async () => {
-    const workspace = await createNamedWorkspace("Bouygues Construction");
+    const workspace = await createNamedWorkspace("Zorbix Industries");
     const { req, res } = await createPrivateApiMockRequest({
       method: "GET",
       isSuperUser: true,
       workspace,
     });
-    req.query.search = encodeURIComponent("Construction");
+    req.query.search = encodeURIComponent("Industries");
     req.query.limit = "20";
 
     await handler(req, res);
@@ -55,13 +55,13 @@ describe("GET /api/poke/workspaces — workspace name search", () => {
   });
 
   it("matches case-insensitively", async () => {
-    const workspace = await createNamedWorkspace("Bouygues Construction");
+    const workspace = await createNamedWorkspace("Zorbix Industries");
     const { req, res } = await createPrivateApiMockRequest({
       method: "GET",
       isSuperUser: true,
       workspace,
     });
-    req.query.search = encodeURIComponent("construction");
+    req.query.search = encodeURIComponent("industries");
     req.query.limit = "20";
 
     await handler(req, res);

--- a/front/pages/api/poke/workspaces/index.test.ts
+++ b/front/pages/api/poke/workspaces/index.test.ts
@@ -1,0 +1,75 @@
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+import handler from "./index";
+
+async function createNamedWorkspace(name: string) {
+  const workspace = await WorkspaceFactory.basic();
+  const resource = await WorkspaceResource.fetchById(workspace.sId);
+  if (!resource) {
+    throw new Error("Workspace not found after creation");
+  }
+  await WorkspaceResource.updateName(resource.id, name);
+  return workspace;
+}
+
+describe("GET /api/poke/workspaces — workspace name search", () => {
+  it("matches by prefix", async () => {
+    const workspace = await createNamedWorkspace("Bouygues Construction");
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: true,
+      workspace,
+    });
+    req.query.search = encodeURIComponent("Bouygues");
+    req.query.limit = "20";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { workspaces } = res._getJSONData();
+    expect(
+      workspaces.some((w: { sId: string }) => w.sId === workspace.sId)
+    ).toBe(true);
+  });
+
+  it("matches by a word in the middle of the name", async () => {
+    const workspace = await createNamedWorkspace("Bouygues Construction");
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: true,
+      workspace,
+    });
+    req.query.search = encodeURIComponent("Construction");
+    req.query.limit = "20";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { workspaces } = res._getJSONData();
+    expect(
+      workspaces.some((w: { sId: string }) => w.sId === workspace.sId)
+    ).toBe(true);
+  });
+
+  it("matches case-insensitively", async () => {
+    const workspace = await createNamedWorkspace("Bouygues Construction");
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: true,
+      workspace,
+    });
+    req.query.search = encodeURIComponent("construction");
+    req.query.limit = "20";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { workspaces } = res._getJSONData();
+    expect(
+      workspaces.some((w: { sId: string }) => w.sId === workspace.sId)
+    ).toBe(true);
+  });
+});

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -229,12 +229,12 @@ async function handler(
             [Op.or]: [
               {
                 sId: {
-                  [Op.iLike]: `${searchTerm}%`,
+                  [Op.iLike]: `%${searchTerm}%`,
                 },
               },
               {
                 name: {
-                  [Op.iLike]: `${searchTerm}%`,
+                  [Op.iLike]: `%${searchTerm}%`,
                 },
               },
             ],


### PR DESCRIPTION
## Summary

- The poke workspace search bar previously only matched workspace names that **started with** the search term (prefix match)
- This caused searches like \`industries\` to miss workspaces named \`Zorbix Industries\`
- Changed both \`name\` and \`sId\` ILIKE patterns from \`${term}%\` to \`%${term}%\` to enable full substring matching

## Test plan

- [ ] Added 3 functional tests covering: prefix match, mid-name word match, and case-insensitive match
- [ ] All 3 tests pass (`NODE_ENV=test npm test -- pages/api/poke/workspaces/index.test.ts`)
- [ ] Biome lint: clean
- [ ] TypeScript type check: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)