### PR TITLE
fix(conversation_search): index conversations referencing restricted projects

### DIFF
--- a/front/temporal/es_indexation/activities.ts
+++ b/front/temporal/es_indexation/activities.ts
@@ -98,7 +98,13 @@ export async function indexConversationEsActivity({
     return;
   }
 
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  // `dangerouslyRequestAllGroups` is required so the indexer can read conversations
+  // whose `spaceId` or `requestedSpaceIds` reference a restricted project space. Without
+  // it the auth only carries the global group, `canRead` rejects those conversations,
+  // and `fetchById` returns `null` — which would cause the activity to drop the doc.
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
+    dangerouslyRequestAllGroups: true,
+  });
 
   // fetchById excludes deleted conversations (no includeDeleted flag), so null covers both
   // hard-deleted (scrubbed) and soft-deleted cases. Both should be removed from the index.


### PR DESCRIPTION
## Description

The conversation indexing activity built its `Authenticator` via `internalAdminForWorkspace(workspaceId)` without `dangerouslyRequestAllGroups`. That auth only carries the workspace global group, so for any conversation whose `spaceId` or `requestedSpaceIds` references a restricted project space, `baseFetchWithAuthorization`'s `canRead` rejected it, `fetchById` returned `null`, and the activity took the "deleted" branch and called `deleteConversationDocument` — silently dropping the document. As a result, project-linked conversations were missing from the ES index.

Passing `dangerouslyRequestAllGroups: true` (the same pattern used by scrub, migrations, and other system jobs) lets the indexer see every conversation regardless of project membership.

## Deploy Plan

Existing conversations that reference restricted project spaces were already removed from ES by prior runs of the activity. After deploy, reindex affected conversations (workspace-wide or by targeting the affected IDs) to backfill what was dropped.
