### PR TITLE
Handle free seats

### DIFF
--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -21,6 +21,7 @@ const DEV_PRODUCT_TOOL_USAGE = "e2028c42-ce77-4712-b08e-12f50d3e90f2";
 const DEV_PRODUCT_WORKSPACE_SEAT = "e1532e1d-4964-4656-b6db-070fafafc44c";
 const DEV_PRODUCT_PRO_SEAT = "db03586f-9e8d-4978-9a62-f51193182be3";
 const DEV_PRODUCT_MAX_SEAT = "51b4ea2f-c4ed-4903-aba6-486d0bf61ac0";
+const DEV_PRODUCT_FREE_SEAT = "e3302b51-66af-40ad-ac0e-544fc38ccfa9";
 const DEV_PRODUCT_MAU = "43db7690-939d-4a70-b4a4-b8ade43431f9";
 const DEV_PRODUCT_MAU_TIER_1 = "efe2988a-4f84-4857-a716-0185c28f3e92";
 const DEV_PRODUCT_MAU_TIER_2 = "a3ca48b5-8187-43ec-a692-eb45bb3f932e";
@@ -52,6 +53,7 @@ const PROD_PRODUCT_TOOL_USAGE = "079aeeba-becc-4013-ae1a-25cd56228f6e";
 const PROD_PRODUCT_WORKSPACE_SEAT = "5c2e2986-1305-4406-96a2-2296e66b5a25";
 const PROD_PRODUCT_PRO_SEAT = "19934ee2-fcf4-40a2-a57a-24f75b0c2b22";
 const PROD_PRODUCT_MAX_SEAT = "8a92cf6a-8e0b-416c-9b46-9c715eff0c89";
+const PROD_PRODUCT_FREE_SEAT = "198511a4-2b27-44b3-b1d1-9839ae6c2b23";
 const PROD_PRODUCT_MAU = "7715e34d-3ec3-475e-b0eb-3d04578a958b";
 const PROD_PRODUCT_MAU_TIER_1 = "d35bf462-98a8-4d3b-8e01-876c7bf6fc57";
 const PROD_PRODUCT_MAU_TIER_2 = "829f5d32-d2ae-4a3a-bb64-0e2630857abc";
@@ -77,8 +79,11 @@ export const PLAN_CODE_CUSTOM_FIELD_KEY = "DUST_PLAN_CODE";
 
 export const PRO_SEAT_CREDIT_NAME = "Pro Seat Credits";
 export const MAX_SEAT_CREDIT_NAME = "Max Seat Credits";
+export const FREE_SEAT_CREDIT_NAME = "Free Seat Credits";
+export const WORKSPACE_SEAT_PRODUCT_NAME = "Workspace Seat";
 export const PRO_SEAT_PRODUCT_NAME = "Pro Seat";
 export const MAX_SEAT_PRODUCT_NAME = "Max Seat";
+export const FREE_SEAT_PRODUCT_NAME = "Free Seat";
 
 // AWU (Agentic Work Units) differs per environment.
 export const DEV_CREDIT_TYPE_AWU_ID = "eb003cc7-4935-467d-a41c-c1738c1c9dc2";
@@ -135,6 +140,8 @@ export const getProductProSeatId = () =>
   devOrProd(DEV_PRODUCT_PRO_SEAT, PROD_PRODUCT_PRO_SEAT);
 export const getProductMaxSeatId = () =>
   devOrProd(DEV_PRODUCT_MAX_SEAT, PROD_PRODUCT_MAX_SEAT);
+export const getProductFreeSeatId = () =>
+  devOrProd(DEV_PRODUCT_FREE_SEAT, PROD_PRODUCT_FREE_SEAT);
 export const getProductMauId = () =>
   devOrProd(DEV_PRODUCT_MAU, PROD_PRODUCT_MAU);
 export const getProductMauCommitId = () =>
@@ -155,6 +162,10 @@ export const getProductSeatSubscriptionCreditsId = () =>
 
 export const PRO_SEAT_MONTHLY_AWU_CREDITS = 8000;
 export const MAX_SEAT_MONTHLY_AWU_CREDITS = 40000;
+// One-shot per-seat AWU grant carried by the Free Seat subscription. Modeled
+// as a long-duration recurring credit (see metronome_setup.ts) so it behaves
+// like a lifetime grant for each free user.
+export const FREE_SEAT_LIFETIME_AWU_CREDITS = 300;
 
 // AWU commit priorities — lower number is consumed first.
 // Seat allocations are consumed before purchased top-ups.
@@ -172,8 +183,9 @@ export function getAwuAllocationForSeatType(
       return MAX_SEAT_MONTHLY_AWU_CREDITS;
     case "pro":
       return PRO_SEAT_MONTHLY_AWU_CREDITS;
-    case "workspace":
     case "free":
+      return FREE_SEAT_LIFETIME_AWU_CREDITS;
+    case "workspace":
       return 0;
     default:
       return assertNever(seatType);
@@ -186,6 +198,7 @@ export const getSeatProductIds = (): Set<string> =>
     getProductWorkspaceSeatId(),
     getProductProSeatId(),
     getProductMaxSeatId(),
+    getProductFreeSeatId(),
   ]);
 
 // tier product accessors — ordered array for indexed access.
@@ -202,14 +215,11 @@ export const getProductMauTierIds = (): string[] => [
 
 /**
  * Map a membership seat type to the Metronome product that bills it.
- * Returns `undefined` for seat types that are not billed (e.g. "free").
  */
-export function getProductIdForSeatType(
-  seatType: MembershipSeatType
-): string | undefined {
+export function getProductIdForSeatType(seatType: MembershipSeatType): string {
   switch (seatType) {
     case "free":
-      return undefined;
+      return getProductFreeSeatId();
     case "workspace":
       return getProductWorkspaceSeatId();
     case "pro":
@@ -230,14 +240,17 @@ export function getSeatTypeForProductId(
   product: Subscription.SubscriptionRate.Product
 ): MembershipSeatType | undefined {
   // Compare on product name as it's more stable than the id, changing across products redeplpyments.
-  if (product.name === "Workspace Seat") {
+  if (product.name === WORKSPACE_SEAT_PRODUCT_NAME) {
     return "workspace";
   }
-  if (product.name === "Pro Seat") {
+  if (product.name === PRO_SEAT_PRODUCT_NAME) {
     return "pro";
   }
-  if (product.name === "Max Seat") {
+  if (product.name === MAX_SEAT_PRODUCT_NAME) {
     return "max";
+  }
+  if (product.name === FREE_SEAT_PRODUCT_NAME) {
+    return "free";
   }
   return undefined;
 }

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -61,14 +61,12 @@ async function fetchCachedContract({
  * against race conditions.
  *
  * For each subscription on the contract whose product matches a known seat
- * product (workspace / pro / max), we look up the membership seat type that
- * bills against it and:
+ * product (workspace / pro / max / free), we look up the membership seat type
+ * that bills against it and:
  * - QUANTITY_ONLY: send the count of active members with that seat type.
  * - SEAT_BASED: fetch the currently assigned seat IDs via
  *   `getSubscriptionSeatsHistory`, then send the add/remove delta to reconcile
  *   against the desired set of user sIds.
- *
- * Memberships with `seatType = "free"` never contribute to any quantity.
  *
  * Called from:
  * - membership create/revoke/update hooks
@@ -139,13 +137,12 @@ export async function syncSeatCount({
   }
 
   // Surface memberships whose seat type has no matching subscription on the
-  // contract — these will not be billed. "free" is intentionally excluded
-  // (free seats never contribute to any quantity, per the function contract).
+  // contract — these will not be billed.
   const coveredSeatTypes = new Set(
     seatSubscriptions.map(({ seatType }) => seatType)
   );
   for (const [seatType, sIds] of sIdsBySeatType) {
-    if (seatType === "free" || coveredSeatTypes.has(seatType)) {
+    if (coveredSeatTypes.has(seatType)) {
       continue;
     }
     logger.warn(
@@ -183,7 +180,7 @@ export async function syncSeatCount({
       );
 
       if (addSeatIds.length === 0 && removeSeatIds.length === 0) {
-        return new Ok(undefined);
+        continue;
       }
 
       logger.info(

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -19,6 +19,9 @@ import {
   CREDIT_TYPE_USD_ID,
   DEV_CREDIT_TYPE_AWU_ID,
   DEV_CREDIT_TYPE_PROG_USD_ID,
+  FREE_SEAT_CREDIT_NAME,
+  FREE_SEAT_LIFETIME_AWU_CREDITS,
+  FREE_SEAT_PRODUCT_NAME,
   MAX_SEAT_CREDIT_NAME,
   MAX_SEAT_PRODUCT_NAME,
   PLAN_CODE_CUSTOM_FIELD_KEY,
@@ -26,6 +29,7 @@ import {
   PRO_SEAT_PRODUCT_NAME,
   PROD_CREDIT_TYPE_AWU_ID,
   PROD_CREDIT_TYPE_PROG_USD_ID,
+  WORKSPACE_SEAT_PRODUCT_NAME,
 } from "@app/lib/metronome/constants";
 import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
 import {
@@ -344,7 +348,7 @@ const PRODUCTS: ProductDef[] = [
   // and new (MONTHLY) per-seat plans. Seats synced from membership create/revoke
   // hooks; price/frequency differs between rate cards.
   {
-    name: "Workspace Seat",
+    name: WORKSPACE_SEAT_PRODUCT_NAME,
     type: "SUBSCRIPTION",
   },
   // Pro Seat / Max Seat — SUBSCRIPTION products for the new Business / Enterprise
@@ -356,6 +360,13 @@ const PRODUCTS: ProductDef[] = [
   },
   {
     name: MAX_SEAT_PRODUCT_NAME,
+    type: "SUBSCRIPTION",
+  },
+  // Free Seat — SUBSCRIPTION product priced at $0/seat. Carries a one-shot
+  // lifetime AWU credit (300 AWU per seat) so free users have a small drawdown
+  // pool without being billed.
+  {
+    name: FREE_SEAT_PRODUCT_NAME,
     type: "SUBSCRIPTION",
   },
   // MAU product — single subscription for simple (non-tiered) enterprise contracts.
@@ -526,7 +537,7 @@ function getRateCards(): RateCardDef[] {
       ],
       rates: [
         {
-          product_name: "Workspace Seat",
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -557,7 +568,7 @@ function getRateCards(): RateCardDef[] {
       ],
       rates: [
         {
-          product_name: "Workspace Seat",
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -588,7 +599,7 @@ function getRateCards(): RateCardDef[] {
       ],
       rates: [
         {
-          product_name: "Workspace Seat",
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -663,7 +674,7 @@ function getRateCards(): RateCardDef[] {
       ],
       rates: [
         {
-          product_name: "Workspace Seat",
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -695,7 +706,7 @@ function getRateCards(): RateCardDef[] {
       ],
       rates: [
         {
-          product_name: "Workspace Seat",
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -727,7 +738,7 @@ function getRateCards(): RateCardDef[] {
       ],
       rates: [
         {
-          product_name: "Workspace Seat",
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -800,7 +811,7 @@ function getRateCards(): RateCardDef[] {
       ],
       rates: [
         {
-          product_name: "Workspace Seat",
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -830,7 +841,7 @@ function getRateCards(): RateCardDef[] {
       ],
       rates: [
         {
-          product_name: "Workspace Seat",
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -875,6 +886,14 @@ function getRateCards(): RateCardDef[] {
           price: 14900,
           billing_frequency: "MONTHLY",
         },
+        {
+          product_name: FREE_SEAT_PRODUCT_NAME,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 0,
+          billing_frequency: "MONTHLY",
+        },
         ...buildAwuAiUsageRates(),
         ...buildAwuToolUsageRates(),
       ],
@@ -909,6 +928,15 @@ function getRateCards(): RateCardDef[] {
           entitled: true,
           rate_type: "FLAT",
           price: 149,
+          billing_frequency: "MONTHLY",
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: FREE_SEAT_PRODUCT_NAME,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 0,
           billing_frequency: "MONTHLY",
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
@@ -979,7 +1007,7 @@ function getFreeExcessRecurringCredits(): RecurringCreditDef {
 // Seat subscription definition shared by all legacy packages.
 const LEGACY_SEAT_SUBSCRIPTION: PackageSubscription = {
   temporary_id: "legacy-seat-sub",
-  product_name: "Workspace Seat",
+  product_name: WORKSPACE_SEAT_PRODUCT_NAME,
   billing_frequency: "MONTHLY",
   collection_schedule: "ADVANCE",
   quantity_management_mode: "QUANTITY_ONLY",
@@ -993,7 +1021,7 @@ const LEGACY_SEAT_SUBSCRIPTION: PackageSubscription = {
 // Seat subscription definition shared by all legacy packages.
 const LEGACY_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
   temporary_id: "legacy-seat-annual-sub",
-  product_name: "Workspace Seat",
+  product_name: WORKSPACE_SEAT_PRODUCT_NAME,
   billing_frequency: "ANNUAL",
   collection_schedule: "ADVANCE",
   quantity_management_mode: "QUANTITY_ONLY",
@@ -1009,7 +1037,7 @@ const LEGACY_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
 // Workspace Seat product so legacy and new plans share a single seat product.
 const WORKSPACE_SEAT_MONTHLY_SUBSCRIPTION: PackageSubscription = {
   temporary_id: "workspace-seat-monthly-sub",
-  product_name: "Workspace Seat",
+  product_name: WORKSPACE_SEAT_PRODUCT_NAME,
   billing_frequency: "MONTHLY",
   collection_schedule: "ADVANCE",
   quantity_management_mode: "QUANTITY_ONLY",
@@ -1048,6 +1076,25 @@ const MAX_SEAT_SUBSCRIPTION: PackageSubscription = {
   quantity_management_mode: "SEAT_BASED",
   seat_config: { seat_group_key: "user_id" },
   proration: {
+    is_prorated: true,
+    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
+  },
+};
+
+// Free Seat SEAT_BASED subscription — priced at $0, used to track free users
+// in Metronome so each free seat carries its own lifetime AWU credit pool.
+const FREE_SEAT_SUBSCRIPTION_TEMPORARY_ID = "free-seat-sub";
+
+const FREE_SEAT_SUBSCRIPTION: PackageSubscription = {
+  temporary_id: FREE_SEAT_SUBSCRIPTION_TEMPORARY_ID,
+  product_name: FREE_SEAT_PRODUCT_NAME,
+  billing_frequency: "MONTHLY",
+  collection_schedule: "ADVANCE",
+  quantity_management_mode: "SEAT_BASED",
+  seat_config: { seat_group_key: "user_id" },
+  proration: {
+    // Free seats cost $0 so proration is moot, but keep is_prorated: true to
+    // match the other SEAT_BASED subscriptions.
     is_prorated: true,
     invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
   },
@@ -1095,6 +1142,34 @@ function getPerSeatIndividualAwuCredits({
 // Per-seat credit amounts (AWU/month) per the new pricing design.
 const PRO_SEAT_MONTHLY_AWU_CREDITS = 8000;
 const MAX_SEAT_MONTHLY_AWU_CREDITS = 40000;
+
+// Per-seat INDIVIDUAL AWU credit attached to the Free Seat SEAT_BASED
+// subscription. The credit recurs annually with a very long `commit_duration`
+// so each commit effectively never expires within the contract's lifetime —
+// the closest expression of a "lifetime" per-seat grant in Metronome's
+// recurring-credit model. Not prorated on seat increase: a new free seat
+// always gets the full 300 AWU grant regardless of when in the period it was
+// added.
+function getFreeSeatLifetimeAwuCredits(): RecurringCreditDef {
+  return {
+    product_name: "Seat Individual Credits",
+    access_amount: {
+      credit_type_id: getCreditTypeAwuId(),
+      unit_price: FREE_SEAT_LIFETIME_AWU_CREDITS,
+    },
+    commit_duration: { value: 1200, unit: "PERIODS" },
+    priority: 200,
+    starting_at_offset: { unit: "DAYS", value: 0 },
+    applicable_product_tags: [USAGE_TAG],
+    recurrence_frequency: "ANNUAL",
+    name: FREE_SEAT_CREDIT_NAME,
+    subscription_config: {
+      subscription_temporary_id: FREE_SEAT_SUBSCRIPTION_TEMPORARY_ID,
+      allocation: "INDIVIDUAL",
+      apply_seat_increase_config: { is_prorated: false },
+    },
+  };
+}
 
 // Billing cycle config shared by all packages — anchored to contract start date.
 const BILLING_CYCLE_CONFIG = {
@@ -1233,7 +1308,11 @@ function getPackages(): PackageDef[] {
       name: "Business USD",
       aliases: [{ name: "business-usd" }],
       rate_card_name: "Business USD",
-      subscriptions: [PRO_SEAT_SUBSCRIPTION, MAX_SEAT_SUBSCRIPTION],
+      subscriptions: [
+        PRO_SEAT_SUBSCRIPTION,
+        MAX_SEAT_SUBSCRIPTION,
+        FREE_SEAT_SUBSCRIPTION,
+      ],
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
         getPerSeatIndividualAwuCredits({
@@ -1246,6 +1325,7 @@ function getPackages(): PackageDef[] {
           quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
           name: MAX_SEAT_CREDIT_NAME,
         }),
+        getFreeSeatLifetimeAwuCredits(),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1253,7 +1333,11 @@ function getPackages(): PackageDef[] {
       name: "Business EUR",
       aliases: [{ name: "business-eur" }],
       rate_card_name: "Business EUR",
-      subscriptions: [PRO_SEAT_SUBSCRIPTION, MAX_SEAT_SUBSCRIPTION],
+      subscriptions: [
+        PRO_SEAT_SUBSCRIPTION,
+        MAX_SEAT_SUBSCRIPTION,
+        FREE_SEAT_SUBSCRIPTION,
+      ],
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
         getPerSeatIndividualAwuCredits({
@@ -1266,6 +1350,7 @@ function getPackages(): PackageDef[] {
           quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
           name: MAX_SEAT_CREDIT_NAME,
         }),
+        getFreeSeatLifetimeAwuCredits(),
       ],
       ...BILLING_CYCLE_CONFIG,
     },


### PR DESCRIPTION
## Description

Introduce a billable representation for free memberships in Metronome so they
stop being silently skipped. Adds a new `Free Seat` SUBSCRIPTION product
(SEAT_BASED, `user_id` seat group) priced at $0, attached to the **Business
USD** and **Business EUR** packages, with a per-seat AWU credit modeled as a
lifetime grant.

The lifetime grant is implemented as a recurring credit with
`recurrence_frequency: ANNUAL` and a very long `commit_duration`
(`{ value: 1200, unit: "PERIODS" }`) — the closest expression of a
"lifetime" per-seat credit in Metronome's recurring-credit model. Each Free
Seat receives **300 AWU** with `apply_seat_increase_config.is_prorated:
false`.

Changes:

- `scripts/metronome_setup.ts`
  - New `Free Seat` SUBSCRIPTION product in `PRODUCTS`.
  - $0 Free Seat rate on Business USD / Business EUR rate cards.
  - New `FREE_SEAT_SUBSCRIPTION` (SEAT_BASED, MONTHLY, `user_id` group).
  - New `getFreeSeatLifetimeAwuCredits()` helper; subscription + credit
    attached to the Business USD / Business EUR packages.
- `lib/metronome/constants.ts`
  - New `FREE_SEAT_PRODUCT_NAME`, `FREE_SEAT_CREDIT_NAME`,
    `FREE_SEAT_LIFETIME_AWU_CREDITS = 300`.
  - New `DEV_PRODUCT_FREE_SEAT` / `PROD_PRODUCT_FREE_SEAT` placeholder UUIDs
    (must be backfilled after running the setup script in each env) and
    `getProductFreeSeatId()` accessor.
  - `getProductIdForSeatType("free")` now returns the Free Seat product id;
    return type tightened to `string`.
  - `getSeatTypeForProductId` recognizes `"Free Seat"`.
  - `getAwuAllocationForSeatType("free")` returns `300`.
  - `getSeatProductIds()` includes the Free Seat product.
- `lib/metronome/seats.ts`
  - Dropped the `seatType === "free"` skip in the uncovered-seat-type
    warning loop now that free seats have a real subscription.
  - Updated `syncSeatCount` docstring (workspace / pro / max / free).

## Tests

- `npx tsgo --noEmit` from `front/` passes.
- Manual verification still pending — needs a dry-run + execute of
  `metronome_setup.ts` against the sandbox to:
  1. Create the `Free Seat` product and resolve a stable id.
  2. Bump the Business USD / Business EUR packages to a new version
     containing the Free Seat subscription + the lifetime credit.
  3. Confirm seat sync round-trips free memberships through Metronome
     (assignment via `updateSubscriptionSeats`, credit drawdown attributable
     to the seat's `user_id`).

## Risk

- **Package version bump:** Business USD / Business EUR packages will be
  recreated on the next setup run because their subscription/recurring-credit
  signatures changed. Existing contracts on the old versions are unaffected;
  new contracts created after deploy pick up the new version. No
  retroactive migration of existing customers in this PR.
- **Placeholder product IDs:** `DEV_PRODUCT_FREE_SEAT` and
  `PROD_PRODUCT_FREE_SEAT` are zero-UUID placeholders. Any code path that
  resolves the Free Seat product id before the setup script runs in that
  environment will hit Metronome with an invalid id. `getProductIdForSeatType`
  is currently unreferenced, so the live blast radius is limited to
  `getSeatProductIds()`, which only gates filtering — a bad id silently
  drops the product from the set. Still: backfill the constants immediately
  after running the setup script.
- **`getAwuAllocationForSeatType("free")` semantics:** previously returned
  `0`, now returns `300`. Used by `buildSeatAllocationByUserId` to compute
  per-user pool overflow in `lib/api/credits/awu_pool_summary.ts` and
  `lib/api/credits/members_usage.ts`. The function treats allocation as
  per-period, while free seats are lifetime — over time the displayed
  remaining allocation will overstate what's left for a heavy free user.
  Acceptable for now; a follow-up could read the actual remaining commit
  from Metronome.
- Rollback is a code revert + re-run of the setup script (which will bump
  the package version again without Free Seat). Existing contracts are
  unaffected.

## Deploy Plan

1. Merge this PR.
2. Run `npx tsx front/scripts/metronome_setup.ts` (dry-run) against
   **sandbox** and review the diff.
3. Run with `--execute` against sandbox. Copy the printed
   `DEV_PRODUCT_FREE_SEAT` id into `front/lib/metronome/constants.ts` and
   open a follow-up PR.
4. Repeat steps 2–3 against **production** to populate
   `PROD_PRODUCT_FREE_SEAT`.
5. Until both constants are backfilled, no new code paths should depend on
   `getProductFreeSeatId()` resolving to a real id.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25689">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->