### PR TITLE
Add display label for reinforcement data

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -114,7 +114,7 @@ export const FEEDBACK_DISTRIBUTION_LEGEND = [
 
 export type AnalyticsVisibleOrigin = Exclude<
   UserMessageOrigin,
-  "reinforced_skill_notification" | "reinforcement" | "branch_anchor"
+  "reinforced_skill_notification" | "branch_anchor"
 >;
 
 export const USER_MESSAGE_ORIGIN_LABELS: Record<
@@ -141,6 +141,10 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
   zapier: { label: "Zapier", color: buildColorClass("blue", 700) },
   zendesk: { label: "Zendesk", color: buildColorClass("golden", 700) },
   powerpoint: { label: "PowerPoint", color: buildColorClass("violet", 300) },
+  reinforcement: {
+    label: "Self-improving skills",
+    color: buildColorClass("emerald", 700),
+  },
   transcript: { label: "Transcript", color: buildColorClass("golden", 500) },
   triggered: { label: "Trigger", color: buildColorClass("orange", 700) },
   triggered_programmatic: {


### PR DESCRIPTION
## Description

Add the display label to now show "reinforcement" but "Self-improving skills"

<img width="1015" height="331" alt="Screenshot 2026-05-18 at 13 37 42" src="https://github.com/user-attachments/assets/5e027094-7de1-41ff-8bfe-9c6a1dcbb8ea" />


## Tests

tested locally

## Risk

low

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25690">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->