### PR TITLE
[front] enh: batch agent skill linking on agent save

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2417,7 +2417,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         ...skill.skillReference,
         workspaceId: workspace.id,
         agentConfigurationId: agentConfiguration.id,
-      })),
+      }))
     );
   }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2396,6 +2396,31 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
+  static async addManyToAgent(
+    auth: Authenticator,
+    {
+      agentConfiguration,
+      skills,
+    }: {
+      agentConfiguration: LightAgentConfigurationType;
+      skills: SkillResource[];
+    }
+  ): Promise<void> {
+    if (skills.length === 0) {
+      return;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    await AgentSkillModel.bulkCreate(
+      skills.map((skill) => ({
+        ...skill.skillReference,
+        workspaceId: workspace.id,
+        agentConfigurationId: agentConfiguration.id,
+      })),
+    );
+  }
+
   async enableForAgent(
     auth: Authenticator,
     {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -263,6 +263,41 @@ describe("POST /api/w/[wId]/assistant/agent_configurations - Skills with restric
       restrictedSpace.sId
     );
   });
+
+  it("should add multiple skills when creating an agent", async () => {
+    const { req, res, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "POST",
+    });
+
+    await SpaceFactory.defaults(auth);
+
+    const customSkill = await SkillFactory.create(auth, {
+      name: "Custom skill to add",
+    });
+
+    req.body = {
+      assistant: {
+        ...TEST_AGENT_PARAMS,
+        name: "Test Agent with Multiple Skills",
+        editors: [{ sId: user.sId }],
+        skills: [{ sId: customSkill.sId }, { sId: "frames" }],
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    const skills = await SkillResource.listByAgentConfiguration(
+      auth,
+      data.agentConfiguration
+    );
+
+    expect(skills.map((skill) => skill.sId).sort()).toEqual(
+      [customSkill.sId, "frames"].sort()
+    );
+  });
 });
 
 describe("POST /api/w/[wId]/assistant/agent_configurations - additionalRequestedSpaceIds", () => {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -142,7 +142,6 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { PostOrPatchAgentConfigurationRequestBody } from "@app/types/api/internal/agent_configuration";
@@ -594,13 +593,12 @@ export async function createOrUpgradeAgentConfiguration({
     actionConfigs.push(res.value);
   }
 
-  // Create skill associations
+  // Create skill associations.
   const owner = auth.getNonNullableWorkspace();
-  await concurrentExecutor(
-    assistant.skills ?? [],
-    async (skill) => {
-      // Validate the skill exists and belongs to this workspace
-      const skillResource = await SkillResource.fetchById(auth, skill.sId);
+  const skillById = new Map(skills.map((skill) => [skill.sId, skill]));
+  const skillsToAdd = removeNulls(
+    (assistant.skills ?? []).map((skill) => {
+      const skillResource = skillById.get(skill.sId);
       if (!skillResource) {
         logger.warn(
           {
@@ -610,13 +608,16 @@ export async function createOrUpgradeAgentConfiguration({
           },
           "Skill not found when creating agent configuration, skipping"
         );
-        return;
+        return null;
       }
 
-      await skillResource.addToAgent(auth, agentConfigurationRes.value);
-    },
-    { concurrency: 10 }
+      return skillResource;
+    })
   );
+  await SkillResource.addManyToAgent(auth, {
+    agentConfiguration: agentConfigurationRes.value,
+    skills: skillsToAdd,
+  });
 
   const agentConfiguration: AgentConfigurationType = {
     ...agentConfigurationRes.value,


### PR DESCRIPTION
## Description

- Batch agent-skill linking when creating or upgrading an agent configuration instead of refetching and inserting each skill inside a concurrent executor.
- Reuse the already fetched skill resources (n less db queries, if n is the number of skills on the agent), batch the creation of rows in `agent_skills` (n - 1 less db queries)

## Tests

- Added a test
- Tested locally

## Risk

- Low

## Deploy Plan

- Deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25691">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->