### PR TITLE
[front] Wake up UI nits: polish sidebar and banner text

### DIFF
--- a/front/components/assistant/conversation/WakeUpBanner.tsx
+++ b/front/components/assistant/conversation/WakeUpBanner.tsx
@@ -7,6 +7,7 @@ import {
   ActionTrashIcon,
   ContentMessageAction,
   ContentMessageInline,
+  Tooltip,
 } from "@dust-tt/sparkle";
 
 interface WakeUpBannerProps {
@@ -40,9 +41,15 @@ export const WakeUpBanner = ({
           normal foreground color, let the schedule text inherit the muted
           color. */}
       <div className="flex min-w-0 items-center gap-2">
-        <span className="min-w-0 truncate text-foreground dark:text-foreground-night">
-          {wakeUp.reason}
-        </span>
+        <Tooltip
+          label={wakeUp.reason}
+          tooltipTriggerAsChild
+          trigger={
+            <span className="min-w-0 truncate text-foreground dark:text-foreground-night">
+              {wakeUp.reason}
+            </span>
+          }
+        />
         <span className="shrink-0">{scheduleDescription}</span>
       </div>
       {isOwner && (

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -196,7 +196,13 @@ const NavigationListItem = React.forwardRef<
               </span>
             )}
             {suffix && (
-              <div className="s-flex s-grow s-flex-shrink-0 s-items-center">
+              <div
+                className={cn(
+                  "s-flex s-grow s-flex-shrink-0 s-items-center",
+                  moreMenu &&
+                    "group-focus-within/menu-item:s-hidden group-hover/menu-item:s-hidden"
+                )}
+              >
                 {suffix}
               </div>
             )}


### PR DESCRIPTION
## Description

- Avoid overlap in sidebar between wake-up clock icon and overflow action by hiding the icon on hover/focus (same behavior as unread pill)

<img width="276" height="112" alt="Screenshot 2026-05-18 at 1 59 53 PM" src="https://github.com/user-attachments/assets/5db62e27-e2e0-4301-94e8-576965fcdb57" />

- Show the full wake-up reason in a tooltip: when the line is too long we currently cannot find the reason in its entirety

<img width="738" height="245" alt="Screenshot 2026-05-18 at 1 57 51 PM" src="https://github.com/user-attachments/assets/01d08da0-6be8-49e3-beea-cc347980788d" />


## Tests

- Tested locally

## Risk

- Low

## Deploy Plan

- Deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25692">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->