### PR TITLE
Refactor busness logic out of the credits/purchase.ts handler

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -291,9 +291,28 @@ Signs that logic belongs in the business layer rather than the handler:
 Trivial transformations directly tied to the HTTP shape (assembling a response body from a
 single resource fetch, flattening a serialized result) may stay in the handler.
 
+**Extraction must not drag HTTP concerns into `lib/api/*`.** Per [BACK18], the business layer
+returns domain results — `Result<T, DomainError>`, plain values, or thrown domain errors. It
+must not return `APIErrorWithStatusCode`, hard-code HTTP status numbers, call `apiError(...)`,
+throw HTTP-shaped errors, or otherwise encode response semantics. The handler is the only
+place that maps domain outcomes to status codes and error envelopes.
+
+If a handler is long but the length comes from HTTP error mapping interleaved with the work
+(many `if (...) return apiError(req, res, { status_code: 4xx, ... })` branches whose conditions
+are inseparable from each step), **leave it in the handler**. Extracting it would either leak
+HTTP into the business layer or invent a synthetic domain enum just to deduplicate — both
+worse than a long-but-honest handler. A 100-line handler that reads top-to-bottom is fine. A
+50-line `lib/api/*` function that returns `Result<T, { status_code: number; ... }>` is not.
+
+The right extractions are ones where the domain operation has a meaningful identity on its
+own (would be called from a Temporal activity, a script, or a second handler). The wrong ones
+are "reduce handler line count" extractions that end up modeling HTTP shapes in the lib.
+
 Reviewer: If you detect a handler with non-trivial business logic, request the author to extract
 it into a `lib/api/*` function (creating one if needed). The handler should ideally read as:
-authorize → validate → call business function → respond.
+authorize → validate → call business function → respond. But if the extraction would force
+HTTP status codes or `APIErrorWithStatusCode` into the lib, push back and keep the logic in
+the handler instead.
 
 ### [BACK17] Keep migrated Next and Hono handlers in sync during migration
 

--- a/front/lib/api/credits/purchase.ts
+++ b/front/lib/api/credits/purchase.ts
@@ -1,6 +1,4 @@
-/** @ignoreswagger */
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
-import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { CreditPurchaseBillingTarget } from "@app/lib/credits/committed";
 import {
@@ -20,27 +18,13 @@ import {
 } from "@app/lib/plans/stripe";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import logger from "@app/logger/logger";
-import { apiError } from "@app/logger/withlogging";
 import type { SupportedCurrency } from "@app/types/currency";
 import { isSupportedCurrency } from "@app/types/currency";
-import type { WithAPIErrorResponse } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { StripePricingData } from "@app/types/stripe/pricing";
-import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
-import { fromError } from "zod-validation-error";
 
-export const PostCreditPurchaseRequestBody = z.object({
-  amountDollars: z.number(),
-});
-
-type PostCreditPurchaseResponseBody = {
-  success: boolean;
-  creditsAddedMicroUsd: number;
-  invoiceId: string | null;
-  paymentUrl: string | null;
-};
-
-export type GetCreditPurchaseInfoResponseBody = {
+export type CreditPurchaseInfo = {
   isEnterprise: boolean;
   currency: string;
   discountPercent: number;
@@ -49,396 +33,300 @@ export type GetCreditPurchaseInfoResponseBody = {
   billingCycleStartDay: number | null;
 };
 
-async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<
-      PostCreditPurchaseResponseBody | GetCreditPurchaseInfoResponseBody
-    >
-  >,
-  auth: Authenticator
-): Promise<void> {
-  // Only admins can view/purchase credits.
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can access credit purchases.",
-      },
-    });
+export class CreditPurchaseInfoError extends Error {
+  constructor(readonly type: "subscription_not_found" | "internal") {
+    super(type);
   }
+}
 
+export class CreateCreditPurchaseError extends Error {
+  constructor(
+    readonly type:
+      | "subscription_not_found"
+      | "purchase_not_allowed"
+      | "amount_exceeds_limit"
+      | "internal",
+    readonly details: {
+      reason?: "trialing" | "other";
+      maxAmountMicroUsd?: number;
+    } = {}
+  ) {
+    super(type);
+  }
+}
+
+export type CreatedCreditPurchase = {
+  creditsAddedMicroUsd: number;
+  invoiceId: string | null;
+  paymentUrl: string | null;
+};
+
+export async function getCreditPurchaseInfo(
+  auth: Authenticator
+): Promise<Result<CreditPurchaseInfo, CreditPurchaseInfoError>> {
   const subscription = auth.subscriptionResource();
   if (
     !subscription?.stripeSubscriptionId &&
     !subscription?.isMetronomeOnlyBilled
   ) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "subscription_not_found",
-        message:
-          "No active subscription found. Please subscribe to a plan first.",
-      },
-    });
+    return new Err(new CreditPurchaseInfoError("subscription_not_found"));
   }
 
   const isMetronomeOnly = subscription.isMetronomeOnlyBilled;
+  const workspace = auth.getNonNullableWorkspace();
 
-  switch (req.method) {
-    case "GET": {
-      let isEnterprise = false;
-      let currency = "usd";
-      let creditPurchaseLimits: CreditPurchaseLimits | null = null;
-      let billingCycleStartDay: number | null = null;
+  let isEnterprise = false;
+  let currency = "usd";
+  let creditPurchaseLimits: CreditPurchaseLimits | null = null;
+  let billingCycleStartDay: number | null = null;
 
-      if (isMetronomeOnly) {
-        isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
-        creditPurchaseLimits = await getCreditPurchaseLimits(auth, {
-          type: "metronome",
-          subscription,
-        });
+  if (isMetronomeOnly) {
+    isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
+    creditPurchaseLimits = await getCreditPurchaseLimits(auth, {
+      type: "metronome",
+      subscription,
+    });
 
-        // Bill in the same currency as the contract / Stripe customer.
-        const workspace = auth.getNonNullableWorkspace();
-        if (workspace.metronomeCustomerId) {
-          const currencyResult =
-            await resolveCurrencyForExistingMetronomeCustomer({
-              metronomeCustomerId: workspace.metronomeCustomerId,
-              stripeSubscriptionId: null,
-            });
-          if (currencyResult.isErr()) {
-            logger.warn(
-              {
-                workspaceId: workspace.sId,
-                error: currencyResult.error.message,
-              },
-              "[Credit Purchase] Failed to resolve currency for Metronome-only workspace, defaulting to usd"
-            );
-            return apiError(req, res, {
-              status_code: 500,
-              api_error: {
-                type: "internal_server_error",
-                message:
-                  "Failed to resolve billing currency for this workspace.",
-              },
-            });
-          }
-          currency = currencyResult.value;
-        }
-
-        if (subscription.startDate) {
-          billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
-        }
-      } else {
-        const stripeSubscription = await getStripeSubscription(
-          subscription.stripeSubscriptionId!
-        );
-
-        if (stripeSubscription) {
-          isEnterprise = isEnterpriseSubscription(stripeSubscription);
-          currency = isSupportedCurrency(stripeSubscription.currency)
-            ? stripeSubscription.currency
-            : "usd";
-          creditPurchaseLimits = await getCreditPurchaseLimits(auth, {
-            type: "stripe-subscription",
-            stripeSubscription,
-          });
-        }
-
-        // Get billingCycleStartDay from subscription start date (use UTC to match client-side).
-        // Prioritize subscription.startDate to align with getBillingCycle used in the header.
-        if (subscription.startDate) {
-          billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
-        } else if (stripeSubscription?.current_period_start) {
-          billingCycleStartDay = new Date(
-            stripeSubscription.current_period_start * 1000
-          ).getUTCDate();
-        }
-      }
-
-      const programmaticConfig =
-        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-      const discountPercent = programmaticConfig?.defaultDiscountPercent ?? 0;
-
-      const creditPricing = await getStripePricingData(
-        getCreditPurchasePriceId()
-      );
-
-      return res.status(200).json({
-        isEnterprise,
-        currency,
-        discountPercent,
-        creditPricing,
-        creditPurchaseLimits,
-        billingCycleStartDay,
+    if (workspace.metronomeCustomerId) {
+      // Bill in the same currency as the contract / Stripe customer.
+      const currencyResult = await resolveCurrencyForExistingMetronomeCustomer({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        stripeSubscriptionId: null,
       });
-    }
-
-    case "POST": {
-      const workspace = auth.getNonNullableWorkspace();
-      const bodyValidation = PostCreditPurchaseRequestBody.safeParse(req.body);
-      if (!bodyValidation.success) {
-        const pathError = fromError(bodyValidation.error).toString();
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
-          },
-        });
-      }
-
-      const { amountDollars } = bodyValidation.data;
-
-      // Validate amount is positive.
-      if (amountDollars <= 0) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Amount must be greater than 0.",
-          },
-        });
-      }
-
-      // Convert dollars to micro USD for internal storage.
-      const amountMicroUsd = Math.round(amountDollars * 1_000_000);
-
-      // Resolve enterprise + limits depending on the billing path.
-      let isEnterprise: boolean;
-      let limits: CreditPurchaseLimits;
-      let metronomeStripeCustomerId: string | null = null;
-      let metronomeCurrency: SupportedCurrency = "usd";
-
-      if (isMetronomeOnly) {
-        isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
-        limits = await getCreditPurchaseLimits(auth, {
-          type: "metronome",
-          subscription,
-        });
-
-        // Resolve the Stripe customer linked to the Metronome customer's
-        // billing config — this is where we'll issue the one-off invoice.
-        if (!workspace.metronomeCustomerId) {
-          logger.error(
-            { workspaceId: workspace.sId },
-            "[Credit Purchase] Metronome-only workspace has no metronomeCustomerId"
-          );
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Workspace is not provisioned in Metronome.",
-            },
-          });
-        }
-        const stripeCustomerIdResult =
-          await getMetronomeCustomerStripeCustomerId(
-            workspace.metronomeCustomerId
-          );
-        if (stripeCustomerIdResult.isErr() || !stripeCustomerIdResult.value) {
-          logger.error(
-            {
-              workspaceId: workspace.sId,
-              metronomeCustomerId: workspace.metronomeCustomerId,
-              error: stripeCustomerIdResult.isErr()
-                ? stripeCustomerIdResult.error.message
-                : "no stripe billing config",
-            },
-            "[Credit Purchase] Failed to resolve Stripe customer for Metronome-only workspace"
-          );
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message:
-                "No Stripe billing configuration found for this workspace.",
-            },
-          });
-        }
-        metronomeStripeCustomerId = stripeCustomerIdResult.value;
-
-        // Bill in the same currency as the contract / Stripe customer.
-        const currencyResult =
-          await resolveCurrencyForExistingMetronomeCustomer({
-            metronomeCustomerId: workspace.metronomeCustomerId,
-            stripeSubscriptionId: null,
-          });
-        if (currencyResult.isErr()) {
-          logger.error(
-            {
-              workspaceId: workspace.sId,
-              error: currencyResult.error.message,
-            },
-            "[Credit Purchase] Failed to resolve currency for Metronome-only workspace"
-          );
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Failed to resolve billing currency for this workspace.",
-            },
-          });
-        }
-        metronomeCurrency = currencyResult.value;
-      } else {
-        const stripeSubscription = await getStripeSubscription(
-          subscription.stripeSubscriptionId!
-        );
-        if (!stripeSubscription) {
-          logger.error(
-            {
-              workspaceId: workspace.sId,
-              stripeError: true,
-              stripeSubscriptionId: subscription.stripeSubscriptionId,
-            },
-            "Failed to retrieve Stripe subscription"
-          );
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "subscription_not_found",
-              message: "[Credit Purchase] Stripe subscription not found.",
-            },
-          });
-        }
-        isEnterprise = isEnterpriseSubscription(stripeSubscription);
-        limits = await getCreditPurchaseLimits(auth, {
-          type: "stripe-subscription",
-          stripeSubscription,
-        });
-      }
-
-      if (!limits.canPurchase) {
-        const message =
-          limits.reason === "trialing"
-            ? "Credit purchases are not available during trial. Please contact support."
-            : "Credit purchases require an active subscription. Please ensure your payment method is up to date.";
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message,
-          },
-        });
-      }
-
-      if (amountMicroUsd > limits.maxAmountMicroUsd) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Amount exceeds maximum allowed: $${limits.maxAmountMicroUsd / 1_000_000}. Please contact support for higher limits.`,
-          },
-        });
-      }
-
-      // Fetch discount from programmatic usage configuration.
-      const programmaticConfig =
-        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-      let discountPercent =
-        programmaticConfig?.defaultDiscountPercent &&
-        programmaticConfig.defaultDiscountPercent > 0
-          ? programmaticConfig.defaultDiscountPercent
-          : undefined;
-
-      // Validate discount does not exceed maximum (should be enforced at config level, but double-check).
-      if (
-        discountPercent !== undefined &&
-        discountPercent > MAX_DISCOUNT_PERCENT
-      ) {
-        logger.error(
+      if (currencyResult.isErr()) {
+        logger.warn(
           {
             workspaceId: workspace.sId,
-            discountPercent,
-            maxDiscountPercent: MAX_DISCOUNT_PERCENT,
+            error: currencyResult.error.message,
           },
-          "[Credit Purchase] Discount exceeds maximum allowed"
+          "[Credit Purchase] Failed to resolve currency for Metronome-only workspace"
         );
-        discountPercent = undefined;
+        return new Err(new CreditPurchaseInfoError("internal"));
       }
+      currency = currencyResult.value;
+    }
 
-      const user = auth.getNonNullableUser();
+    if (subscription.startDate) {
+      billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
+    }
+  } else {
+    const stripeSubscription = await getStripeSubscription(
+      subscription.stripeSubscriptionId!
+    );
 
-      const billingTarget: CreditPurchaseBillingTarget =
-        isMetronomeOnly && metronomeStripeCustomerId
-          ? {
-              type: "metronome",
-              stripeCustomerId: metronomeStripeCustomerId,
-              currency: metronomeCurrency,
-            }
-          : {
-              type: "stripe-subscription",
-              stripeSubscriptionId: subscription.stripeSubscriptionId!,
-            };
-
-      if (isEnterprise) {
-        const result = await createEnterpriseCreditPurchase({
-          auth,
-          billingTarget,
-          amountMicroUsd,
-          discountPercent,
-          boughtByUserId: user.id,
-        });
-
-        if (result.isErr()) {
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Failed to process credit purchase.",
-            },
-          });
-        }
-
-        return res.status(200).json({
-          success: true,
-          creditsAddedMicroUsd: amountMicroUsd,
-          invoiceId: null,
-          paymentUrl: null,
-        });
-      }
-
-      const result = await createProCreditPurchase({
-        auth,
-        billingTarget,
-        amountMicroUsd,
-        discountPercent,
-        boughtByUserId: user.id,
-      });
-
-      if (result.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to process credit purchase.",
-          },
-        });
-      }
-
-      return res.status(200).json({
-        success: true,
-        creditsAddedMicroUsd: amountMicroUsd,
-        invoiceId: result.value.invoiceId,
-        paymentUrl: result.value.paymentUrl,
+    if (stripeSubscription) {
+      isEnterprise = isEnterpriseSubscription(stripeSubscription);
+      currency = isSupportedCurrency(stripeSubscription.currency)
+        ? stripeSubscription.currency
+        : "usd";
+      creditPurchaseLimits = await getCreditPurchaseLimits(auth, {
+        type: "stripe-subscription",
+        stripeSubscription,
       });
     }
 
-    default:
-      return apiError(req, res, {
-        status_code: 405,
-        api_error: {
-          type: "method_not_supported_error",
-          message: "The method passed is not supported.",
-        },
-      });
+    // Use subscription.startDate to align with getBillingCycle used in the
+    // header; fall back to Stripe's current period start.
+    if (subscription.startDate) {
+      billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
+    } else if (stripeSubscription?.current_period_start) {
+      billingCycleStartDay = new Date(
+        stripeSubscription.current_period_start * 1000
+      ).getUTCDate();
+    }
   }
+
+  const programmaticConfig =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const discountPercent = programmaticConfig?.defaultDiscountPercent ?? 0;
+
+  const creditPricing = await getStripePricingData(getCreditPurchasePriceId());
+
+  return new Ok({
+    isEnterprise,
+    currency,
+    discountPercent,
+    creditPricing,
+    creditPurchaseLimits,
+    billingCycleStartDay,
+  });
 }
 
-export default withSessionAuthenticationForWorkspace(handler, {
-  doesNotRequireCanUseProduct: true,
-});
+export async function createCreditPurchase(
+  auth: Authenticator,
+  { amountDollars }: { amountDollars: number }
+): Promise<Result<CreatedCreditPurchase, CreateCreditPurchaseError>> {
+  const subscription = auth.subscriptionResource();
+  if (
+    !subscription?.stripeSubscriptionId &&
+    !subscription?.isMetronomeOnlyBilled
+  ) {
+    return new Err(new CreateCreditPurchaseError("subscription_not_found"));
+  }
+
+  const isMetronomeOnly = subscription.isMetronomeOnlyBilled;
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+  const amountMicroUsd = Math.round(amountDollars * 1_000_000);
+
+  let isEnterprise: boolean;
+  let limits: CreditPurchaseLimits;
+  let metronomeStripeCustomerId: string | null = null;
+  let metronomeCurrency: SupportedCurrency = "usd";
+
+  if (isMetronomeOnly) {
+    isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
+    limits = await getCreditPurchaseLimits(auth, {
+      type: "metronome",
+      subscription,
+    });
+
+    if (!workspace.metronomeCustomerId) {
+      logger.error(
+        { workspaceId: workspace.sId },
+        "[Credit Purchase] Metronome-only workspace has no metronomeCustomerId"
+      );
+      return new Err(new CreateCreditPurchaseError("internal"));
+    }
+    const stripeCustomerIdResult = await getMetronomeCustomerStripeCustomerId(
+      workspace.metronomeCustomerId
+    );
+    if (stripeCustomerIdResult.isErr() || !stripeCustomerIdResult.value) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          error: stripeCustomerIdResult.isErr()
+            ? stripeCustomerIdResult.error.message
+            : "no stripe billing config",
+        },
+        "[Credit Purchase] Failed to resolve Stripe customer for Metronome-only workspace"
+      );
+      return new Err(new CreateCreditPurchaseError("internal"));
+    }
+    metronomeStripeCustomerId = stripeCustomerIdResult.value;
+
+    const currencyResult = await resolveCurrencyForExistingMetronomeCustomer({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      stripeSubscriptionId: null,
+    });
+    if (currencyResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          error: currencyResult.error.message,
+        },
+        "[Credit Purchase] Failed to resolve currency for Metronome-only workspace"
+      );
+      return new Err(new CreateCreditPurchaseError("internal"));
+    }
+    metronomeCurrency = currencyResult.value;
+  } else {
+    const stripeSubscription = await getStripeSubscription(
+      subscription.stripeSubscriptionId!
+    );
+    if (!stripeSubscription) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          stripeError: true,
+          stripeSubscriptionId: subscription.stripeSubscriptionId,
+        },
+        "Failed to retrieve Stripe subscription"
+      );
+      return new Err(new CreateCreditPurchaseError("subscription_not_found"));
+    }
+    isEnterprise = isEnterpriseSubscription(stripeSubscription);
+    limits = await getCreditPurchaseLimits(auth, {
+      type: "stripe-subscription",
+      stripeSubscription,
+    });
+  }
+
+  if (!limits.canPurchase) {
+    return new Err(
+      new CreateCreditPurchaseError("purchase_not_allowed", {
+        reason: limits.reason === "trialing" ? "trialing" : "other",
+      })
+    );
+  }
+
+  if (amountMicroUsd > limits.maxAmountMicroUsd) {
+    return new Err(
+      new CreateCreditPurchaseError("amount_exceeds_limit", {
+        maxAmountMicroUsd: limits.maxAmountMicroUsd,
+      })
+    );
+  }
+
+  const programmaticConfig =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+  let discountPercent =
+    programmaticConfig?.defaultDiscountPercent &&
+    programmaticConfig.defaultDiscountPercent > 0
+      ? programmaticConfig.defaultDiscountPercent
+      : undefined;
+
+  // Defense in depth: enforced at config level, but double-check here.
+  if (discountPercent !== undefined && discountPercent > MAX_DISCOUNT_PERCENT) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        discountPercent,
+        maxDiscountPercent: MAX_DISCOUNT_PERCENT,
+      },
+      "[Credit Purchase] Discount exceeds maximum allowed"
+    );
+    discountPercent = undefined;
+  }
+
+  const billingTarget: CreditPurchaseBillingTarget =
+    isMetronomeOnly && metronomeStripeCustomerId
+      ? {
+          type: "metronome",
+          stripeCustomerId: metronomeStripeCustomerId,
+          currency: metronomeCurrency,
+        }
+      : {
+          type: "stripe-subscription",
+          stripeSubscriptionId: subscription.stripeSubscriptionId!,
+        };
+
+  if (isEnterprise) {
+    const result = await createEnterpriseCreditPurchase({
+      auth,
+      billingTarget,
+      amountMicroUsd,
+      discountPercent,
+      boughtByUserId: user.id,
+    });
+
+    if (result.isErr()) {
+      return new Err(new CreateCreditPurchaseError("internal"));
+    }
+
+    return new Ok({
+      creditsAddedMicroUsd: amountMicroUsd,
+      invoiceId: null,
+      paymentUrl: null,
+    });
+  }
+
+  const result = await createProCreditPurchase({
+    auth,
+    billingTarget,
+    amountMicroUsd,
+    discountPercent,
+    boughtByUserId: user.id,
+  });
+
+  if (result.isErr()) {
+    return new Err(new CreateCreditPurchaseError("internal"));
+  }
+
+  return new Ok({
+    creditsAddedMicroUsd: amountMicroUsd,
+    invoiceId: result.value.invoiceId,
+    paymentUrl: result.value.paymentUrl,
+  });
+}

--- a/front/lib/api/credits/purchase.ts
+++ b/front/lib/api/credits/purchase.ts
@@ -1,0 +1,444 @@
+/** @ignoreswagger */
+import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { CreditPurchaseBillingTarget } from "@app/lib/credits/committed";
+import {
+  createEnterpriseCreditPurchase,
+  createProCreditPurchase,
+} from "@app/lib/credits/committed";
+import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
+import { getCreditPurchaseLimits } from "@app/lib/credits/limits";
+import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
+import { resolveCurrencyForExistingMetronomeCustomer } from "@app/lib/metronome/contracts";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
+import {
+  getCreditPurchasePriceId,
+  getStripePricingData,
+  getStripeSubscription,
+  isEnterpriseSubscription,
+} from "@app/lib/plans/stripe";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { SupportedCurrency } from "@app/types/currency";
+import { isSupportedCurrency } from "@app/types/currency";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { StripePricingData } from "@app/types/stripe/pricing";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+export const PostCreditPurchaseRequestBody = z.object({
+  amountDollars: z.number(),
+});
+
+type PostCreditPurchaseResponseBody = {
+  success: boolean;
+  creditsAddedMicroUsd: number;
+  invoiceId: string | null;
+  paymentUrl: string | null;
+};
+
+export type GetCreditPurchaseInfoResponseBody = {
+  isEnterprise: boolean;
+  currency: string;
+  discountPercent: number;
+  creditPricing: StripePricingData | null;
+  creditPurchaseLimits: CreditPurchaseLimits | null;
+  billingCycleStartDay: number | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      PostCreditPurchaseResponseBody | GetCreditPurchaseInfoResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  // Only admins can view/purchase credits.
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access credit purchases.",
+      },
+    });
+  }
+
+  const subscription = auth.subscriptionResource();
+  if (
+    !subscription?.stripeSubscriptionId &&
+    !subscription?.isMetronomeOnlyBilled
+  ) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "subscription_not_found",
+        message:
+          "No active subscription found. Please subscribe to a plan first.",
+      },
+    });
+  }
+
+  const isMetronomeOnly = subscription.isMetronomeOnlyBilled;
+
+  switch (req.method) {
+    case "GET": {
+      let isEnterprise = false;
+      let currency = "usd";
+      let creditPurchaseLimits: CreditPurchaseLimits | null = null;
+      let billingCycleStartDay: number | null = null;
+
+      if (isMetronomeOnly) {
+        isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
+        creditPurchaseLimits = await getCreditPurchaseLimits(auth, {
+          type: "metronome",
+          subscription,
+        });
+
+        // Bill in the same currency as the contract / Stripe customer.
+        const workspace = auth.getNonNullableWorkspace();
+        if (workspace.metronomeCustomerId) {
+          const currencyResult =
+            await resolveCurrencyForExistingMetronomeCustomer({
+              metronomeCustomerId: workspace.metronomeCustomerId,
+              stripeSubscriptionId: null,
+            });
+          if (currencyResult.isErr()) {
+            logger.warn(
+              {
+                workspaceId: workspace.sId,
+                error: currencyResult.error.message,
+              },
+              "[Credit Purchase] Failed to resolve currency for Metronome-only workspace, defaulting to usd"
+            );
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message:
+                  "Failed to resolve billing currency for this workspace.",
+              },
+            });
+          }
+          currency = currencyResult.value;
+        }
+
+        if (subscription.startDate) {
+          billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
+        }
+      } else {
+        const stripeSubscription = await getStripeSubscription(
+          subscription.stripeSubscriptionId!
+        );
+
+        if (stripeSubscription) {
+          isEnterprise = isEnterpriseSubscription(stripeSubscription);
+          currency = isSupportedCurrency(stripeSubscription.currency)
+            ? stripeSubscription.currency
+            : "usd";
+          creditPurchaseLimits = await getCreditPurchaseLimits(auth, {
+            type: "stripe-subscription",
+            stripeSubscription,
+          });
+        }
+
+        // Get billingCycleStartDay from subscription start date (use UTC to match client-side).
+        // Prioritize subscription.startDate to align with getBillingCycle used in the header.
+        if (subscription.startDate) {
+          billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
+        } else if (stripeSubscription?.current_period_start) {
+          billingCycleStartDay = new Date(
+            stripeSubscription.current_period_start * 1000
+          ).getUTCDate();
+        }
+      }
+
+      const programmaticConfig =
+        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+      const discountPercent = programmaticConfig?.defaultDiscountPercent ?? 0;
+
+      const creditPricing = await getStripePricingData(
+        getCreditPurchasePriceId()
+      );
+
+      return res.status(200).json({
+        isEnterprise,
+        currency,
+        discountPercent,
+        creditPricing,
+        creditPurchaseLimits,
+        billingCycleStartDay,
+      });
+    }
+
+    case "POST": {
+      const workspace = auth.getNonNullableWorkspace();
+      const bodyValidation = PostCreditPurchaseRequestBody.safeParse(req.body);
+      if (!bodyValidation.success) {
+        const pathError = fromError(bodyValidation.error).toString();
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const { amountDollars } = bodyValidation.data;
+
+      // Validate amount is positive.
+      if (amountDollars <= 0) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Amount must be greater than 0.",
+          },
+        });
+      }
+
+      // Convert dollars to micro USD for internal storage.
+      const amountMicroUsd = Math.round(amountDollars * 1_000_000);
+
+      // Resolve enterprise + limits depending on the billing path.
+      let isEnterprise: boolean;
+      let limits: CreditPurchaseLimits;
+      let metronomeStripeCustomerId: string | null = null;
+      let metronomeCurrency: SupportedCurrency = "usd";
+
+      if (isMetronomeOnly) {
+        isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
+        limits = await getCreditPurchaseLimits(auth, {
+          type: "metronome",
+          subscription,
+        });
+
+        // Resolve the Stripe customer linked to the Metronome customer's
+        // billing config — this is where we'll issue the one-off invoice.
+        if (!workspace.metronomeCustomerId) {
+          logger.error(
+            { workspaceId: workspace.sId },
+            "[Credit Purchase] Metronome-only workspace has no metronomeCustomerId"
+          );
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Workspace is not provisioned in Metronome.",
+            },
+          });
+        }
+        const stripeCustomerIdResult =
+          await getMetronomeCustomerStripeCustomerId(
+            workspace.metronomeCustomerId
+          );
+        if (stripeCustomerIdResult.isErr() || !stripeCustomerIdResult.value) {
+          logger.error(
+            {
+              workspaceId: workspace.sId,
+              metronomeCustomerId: workspace.metronomeCustomerId,
+              error: stripeCustomerIdResult.isErr()
+                ? stripeCustomerIdResult.error.message
+                : "no stripe billing config",
+            },
+            "[Credit Purchase] Failed to resolve Stripe customer for Metronome-only workspace"
+          );
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message:
+                "No Stripe billing configuration found for this workspace.",
+            },
+          });
+        }
+        metronomeStripeCustomerId = stripeCustomerIdResult.value;
+
+        // Bill in the same currency as the contract / Stripe customer.
+        const currencyResult =
+          await resolveCurrencyForExistingMetronomeCustomer({
+            metronomeCustomerId: workspace.metronomeCustomerId,
+            stripeSubscriptionId: null,
+          });
+        if (currencyResult.isErr()) {
+          logger.error(
+            {
+              workspaceId: workspace.sId,
+              error: currencyResult.error.message,
+            },
+            "[Credit Purchase] Failed to resolve currency for Metronome-only workspace"
+          );
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to resolve billing currency for this workspace.",
+            },
+          });
+        }
+        metronomeCurrency = currencyResult.value;
+      } else {
+        const stripeSubscription = await getStripeSubscription(
+          subscription.stripeSubscriptionId!
+        );
+        if (!stripeSubscription) {
+          logger.error(
+            {
+              workspaceId: workspace.sId,
+              stripeError: true,
+              stripeSubscriptionId: subscription.stripeSubscriptionId,
+            },
+            "Failed to retrieve Stripe subscription"
+          );
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "subscription_not_found",
+              message: "[Credit Purchase] Stripe subscription not found.",
+            },
+          });
+        }
+        isEnterprise = isEnterpriseSubscription(stripeSubscription);
+        limits = await getCreditPurchaseLimits(auth, {
+          type: "stripe-subscription",
+          stripeSubscription,
+        });
+      }
+
+      if (!limits.canPurchase) {
+        const message =
+          limits.reason === "trialing"
+            ? "Credit purchases are not available during trial. Please contact support."
+            : "Credit purchases require an active subscription. Please ensure your payment method is up to date.";
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message,
+          },
+        });
+      }
+
+      if (amountMicroUsd > limits.maxAmountMicroUsd) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Amount exceeds maximum allowed: $${limits.maxAmountMicroUsd / 1_000_000}. Please contact support for higher limits.`,
+          },
+        });
+      }
+
+      // Fetch discount from programmatic usage configuration.
+      const programmaticConfig =
+        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+      let discountPercent =
+        programmaticConfig?.defaultDiscountPercent &&
+        programmaticConfig.defaultDiscountPercent > 0
+          ? programmaticConfig.defaultDiscountPercent
+          : undefined;
+
+      // Validate discount does not exceed maximum (should be enforced at config level, but double-check).
+      if (
+        discountPercent !== undefined &&
+        discountPercent > MAX_DISCOUNT_PERCENT
+      ) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            discountPercent,
+            maxDiscountPercent: MAX_DISCOUNT_PERCENT,
+          },
+          "[Credit Purchase] Discount exceeds maximum allowed"
+        );
+        discountPercent = undefined;
+      }
+
+      const user = auth.getNonNullableUser();
+
+      const billingTarget: CreditPurchaseBillingTarget =
+        isMetronomeOnly && metronomeStripeCustomerId
+          ? {
+              type: "metronome",
+              stripeCustomerId: metronomeStripeCustomerId,
+              currency: metronomeCurrency,
+            }
+          : {
+              type: "stripe-subscription",
+              stripeSubscriptionId: subscription.stripeSubscriptionId!,
+            };
+
+      if (isEnterprise) {
+        const result = await createEnterpriseCreditPurchase({
+          auth,
+          billingTarget,
+          amountMicroUsd,
+          discountPercent,
+          boughtByUserId: user.id,
+        });
+
+        if (result.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to process credit purchase.",
+            },
+          });
+        }
+
+        return res.status(200).json({
+          success: true,
+          creditsAddedMicroUsd: amountMicroUsd,
+          invoiceId: null,
+          paymentUrl: null,
+        });
+      }
+
+      const result = await createProCreditPurchase({
+        auth,
+        billingTarget,
+        amountMicroUsd,
+        discountPercent,
+        boughtByUserId: user.id,
+      });
+
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to process credit purchase.",
+          },
+        });
+      }
+
+      return res.status(200).json({
+        success: true,
+        creditsAddedMicroUsd: amountMicroUsd,
+        invoiceId: result.value.invoiceId,
+        paymentUrl: result.value.paymentUrl,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler, {
+  doesNotRequireCanUseProduct: true,
+});

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -1,53 +1,108 @@
 /** @ignoreswagger */
-import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  CreateCreditPurchaseError,
+  CreatedCreditPurchase,
+  CreditPurchaseInfo,
+  CreditPurchaseInfoError,
+} from "@app/lib/api/credits/purchase";
+import {
+  createCreditPurchase,
+  getCreditPurchaseInfo,
+} from "@app/lib/api/credits/purchase";
 import type { Authenticator } from "@app/lib/auth";
-import type { CreditPurchaseBillingTarget } from "@app/lib/credits/committed";
-import {
-  createEnterpriseCreditPurchase,
-  createProCreditPurchase,
-} from "@app/lib/credits/committed";
-import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
-import { getCreditPurchaseLimits } from "@app/lib/credits/limits";
-import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
-import { resolveCurrencyForExistingMetronomeCustomer } from "@app/lib/metronome/contracts";
-import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
-import {
-  getCreditPurchasePriceId,
-  getStripePricingData,
-  getStripeSubscription,
-  isEnterpriseSubscription,
-} from "@app/lib/plans/stripe";
-import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { SupportedCurrency } from "@app/types/currency";
-import { isSupportedCurrency } from "@app/types/currency";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { StripePricingData } from "@app/types/stripe/pricing";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 export const PostCreditPurchaseRequestBody = z.object({
-  amountDollars: z.number(),
+  amountDollars: z.number().positive(),
 });
 
-type PostCreditPurchaseResponseBody = {
-  success: boolean;
-  creditsAddedMicroUsd: number;
-  invoiceId: string | null;
-  paymentUrl: string | null;
+type PostCreditPurchaseResponseBody = CreatedCreditPurchase & {
+  success: true;
 };
 
-export type GetCreditPurchaseInfoResponseBody = {
-  isEnterprise: boolean;
-  currency: string;
-  discountPercent: number;
-  creditPricing: StripePricingData | null;
-  creditPurchaseLimits: CreditPurchaseLimits | null;
-  billingCycleStartDay: number | null;
-};
+export type GetCreditPurchaseInfoResponseBody = CreditPurchaseInfo;
+
+function infoErrorToApi(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  err: CreditPurchaseInfoError
+) {
+  switch (err.type) {
+    case "subscription_not_found":
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "subscription_not_found",
+          message:
+            "No active subscription found. Please subscribe to a plan first.",
+        },
+      });
+    case "internal":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to resolve billing currency for this workspace.",
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+function purchaseErrorToApi(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  err: CreateCreditPurchaseError
+) {
+  switch (err.type) {
+    case "subscription_not_found":
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "subscription_not_found",
+          message: "[Credit Purchase] Stripe subscription not found.",
+        },
+      });
+    case "purchase_not_allowed":
+      return apiError(req, res, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            err.details.reason === "trialing"
+              ? "Credit purchases are not available during trial. Please contact support."
+              : "Credit purchases require an active subscription. Please ensure your payment method is up to date.",
+        },
+      });
+    case "amount_exceeds_limit": {
+      const maxDollars = (err.details.maxAmountMicroUsd ?? 0) / 1_000_000;
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Amount exceeds maximum allowed: $${maxDollars}. Please contact support for higher limits.`,
+        },
+      });
+    }
+    case "internal":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to process credit purchase.",
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
 
 async function handler(
   req: NextApiRequest,
@@ -58,7 +113,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  // Only admins can view/purchase credits.
   if (!auth.isAdmin()) {
     return apiError(req, res, {
       status_code: 403,
@@ -70,115 +124,16 @@ async function handler(
     });
   }
 
-  const subscription = auth.subscriptionResource();
-  if (
-    !subscription?.stripeSubscriptionId &&
-    !subscription?.isMetronomeOnlyBilled
-  ) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "subscription_not_found",
-        message:
-          "No active subscription found. Please subscribe to a plan first.",
-      },
-    });
-  }
-
-  const isMetronomeOnly = subscription.isMetronomeOnlyBilled;
-
   switch (req.method) {
     case "GET": {
-      let isEnterprise = false;
-      let currency = "usd";
-      let creditPurchaseLimits: CreditPurchaseLimits | null = null;
-      let billingCycleStartDay: number | null = null;
-
-      if (isMetronomeOnly) {
-        isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
-        creditPurchaseLimits = await getCreditPurchaseLimits(auth, {
-          type: "metronome",
-          subscription,
-        });
-
-        // Bill in the same currency as the contract / Stripe customer.
-        const workspace = auth.getNonNullableWorkspace();
-        if (workspace.metronomeCustomerId) {
-          const currencyResult =
-            await resolveCurrencyForExistingMetronomeCustomer({
-              metronomeCustomerId: workspace.metronomeCustomerId,
-              stripeSubscriptionId: null,
-            });
-          if (currencyResult.isErr()) {
-            logger.warn(
-              {
-                workspaceId: workspace.sId,
-                error: currencyResult.error.message,
-              },
-              "[Credit Purchase] Failed to resolve currency for Metronome-only workspace, defaulting to usd"
-            );
-            return apiError(req, res, {
-              status_code: 500,
-              api_error: {
-                type: "internal_server_error",
-                message:
-                  "Failed to resolve billing currency for this workspace.",
-              },
-            });
-          }
-          currency = currencyResult.value;
-        }
-
-        if (subscription.startDate) {
-          billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
-        }
-      } else {
-        const stripeSubscription = await getStripeSubscription(
-          subscription.stripeSubscriptionId!
-        );
-
-        if (stripeSubscription) {
-          isEnterprise = isEnterpriseSubscription(stripeSubscription);
-          currency = isSupportedCurrency(stripeSubscription.currency)
-            ? stripeSubscription.currency
-            : "usd";
-          creditPurchaseLimits = await getCreditPurchaseLimits(auth, {
-            type: "stripe-subscription",
-            stripeSubscription,
-          });
-        }
-
-        // Get billingCycleStartDay from subscription start date (use UTC to match client-side).
-        // Prioritize subscription.startDate to align with getBillingCycle used in the header.
-        if (subscription.startDate) {
-          billingCycleStartDay = new Date(subscription.startDate).getUTCDate();
-        } else if (stripeSubscription?.current_period_start) {
-          billingCycleStartDay = new Date(
-            stripeSubscription.current_period_start * 1000
-          ).getUTCDate();
-        }
+      const infoRes = await getCreditPurchaseInfo(auth);
+      if (infoRes.isErr()) {
+        return infoErrorToApi(req, res, infoRes.error);
       }
-
-      const programmaticConfig =
-        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-      const discountPercent = programmaticConfig?.defaultDiscountPercent ?? 0;
-
-      const creditPricing = await getStripePricingData(
-        getCreditPurchasePriceId()
-      );
-
-      return res.status(200).json({
-        isEnterprise,
-        currency,
-        discountPercent,
-        creditPricing,
-        creditPurchaseLimits,
-        billingCycleStartDay,
-      });
+      return res.status(200).json(infoRes.value);
     }
 
     case "POST": {
-      const workspace = auth.getNonNullableWorkspace();
       const bodyValidation = PostCreditPurchaseRequestBody.safeParse(req.body);
       if (!bodyValidation.success) {
         const pathError = fromError(bodyValidation.error).toString();
@@ -191,241 +146,12 @@ async function handler(
         });
       }
 
-      const { amountDollars } = bodyValidation.data;
-
-      // Validate amount is positive.
-      if (amountDollars <= 0) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Amount must be greater than 0.",
-          },
-        });
+      const purchaseRes = await createCreditPurchase(auth, bodyValidation.data);
+      if (purchaseRes.isErr()) {
+        return purchaseErrorToApi(req, res, purchaseRes.error);
       }
 
-      // Convert dollars to micro USD for internal storage.
-      const amountMicroUsd = Math.round(amountDollars * 1_000_000);
-
-      // Resolve enterprise + limits depending on the billing path.
-      let isEnterprise: boolean;
-      let limits: CreditPurchaseLimits;
-      let metronomeStripeCustomerId: string | null = null;
-      let metronomeCurrency: SupportedCurrency = "usd";
-
-      if (isMetronomeOnly) {
-        isEnterprise = isEntreprisePlanPrefix(subscription.getPlan().code);
-        limits = await getCreditPurchaseLimits(auth, {
-          type: "metronome",
-          subscription,
-        });
-
-        // Resolve the Stripe customer linked to the Metronome customer's
-        // billing config — this is where we'll issue the one-off invoice.
-        if (!workspace.metronomeCustomerId) {
-          logger.error(
-            { workspaceId: workspace.sId },
-            "[Credit Purchase] Metronome-only workspace has no metronomeCustomerId"
-          );
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Workspace is not provisioned in Metronome.",
-            },
-          });
-        }
-        const stripeCustomerIdResult =
-          await getMetronomeCustomerStripeCustomerId(
-            workspace.metronomeCustomerId
-          );
-        if (stripeCustomerIdResult.isErr() || !stripeCustomerIdResult.value) {
-          logger.error(
-            {
-              workspaceId: workspace.sId,
-              metronomeCustomerId: workspace.metronomeCustomerId,
-              error: stripeCustomerIdResult.isErr()
-                ? stripeCustomerIdResult.error.message
-                : "no stripe billing config",
-            },
-            "[Credit Purchase] Failed to resolve Stripe customer for Metronome-only workspace"
-          );
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message:
-                "No Stripe billing configuration found for this workspace.",
-            },
-          });
-        }
-        metronomeStripeCustomerId = stripeCustomerIdResult.value;
-
-        // Bill in the same currency as the contract / Stripe customer.
-        const currencyResult =
-          await resolveCurrencyForExistingMetronomeCustomer({
-            metronomeCustomerId: workspace.metronomeCustomerId,
-            stripeSubscriptionId: null,
-          });
-        if (currencyResult.isErr()) {
-          logger.error(
-            {
-              workspaceId: workspace.sId,
-              error: currencyResult.error.message,
-            },
-            "[Credit Purchase] Failed to resolve currency for Metronome-only workspace"
-          );
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Failed to resolve billing currency for this workspace.",
-            },
-          });
-        }
-        metronomeCurrency = currencyResult.value;
-      } else {
-        const stripeSubscription = await getStripeSubscription(
-          subscription.stripeSubscriptionId!
-        );
-        if (!stripeSubscription) {
-          logger.error(
-            {
-              workspaceId: workspace.sId,
-              stripeError: true,
-              stripeSubscriptionId: subscription.stripeSubscriptionId,
-            },
-            "Failed to retrieve Stripe subscription"
-          );
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "subscription_not_found",
-              message: "[Credit Purchase] Stripe subscription not found.",
-            },
-          });
-        }
-        isEnterprise = isEnterpriseSubscription(stripeSubscription);
-        limits = await getCreditPurchaseLimits(auth, {
-          type: "stripe-subscription",
-          stripeSubscription,
-        });
-      }
-
-      if (!limits.canPurchase) {
-        const message =
-          limits.reason === "trialing"
-            ? "Credit purchases are not available during trial. Please contact support."
-            : "Credit purchases require an active subscription. Please ensure your payment method is up to date.";
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message,
-          },
-        });
-      }
-
-      if (amountMicroUsd > limits.maxAmountMicroUsd) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Amount exceeds maximum allowed: $${limits.maxAmountMicroUsd / 1_000_000}. Please contact support for higher limits.`,
-          },
-        });
-      }
-
-      // Fetch discount from programmatic usage configuration.
-      const programmaticConfig =
-        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-      let discountPercent =
-        programmaticConfig?.defaultDiscountPercent &&
-        programmaticConfig.defaultDiscountPercent > 0
-          ? programmaticConfig.defaultDiscountPercent
-          : undefined;
-
-      // Validate discount does not exceed maximum (should be enforced at config level, but double-check).
-      if (
-        discountPercent !== undefined &&
-        discountPercent > MAX_DISCOUNT_PERCENT
-      ) {
-        logger.error(
-          {
-            workspaceId: workspace.sId,
-            discountPercent,
-            maxDiscountPercent: MAX_DISCOUNT_PERCENT,
-          },
-          "[Credit Purchase] Discount exceeds maximum allowed"
-        );
-        discountPercent = undefined;
-      }
-
-      const user = auth.getNonNullableUser();
-
-      const billingTarget: CreditPurchaseBillingTarget =
-        isMetronomeOnly && metronomeStripeCustomerId
-          ? {
-              type: "metronome",
-              stripeCustomerId: metronomeStripeCustomerId,
-              currency: metronomeCurrency,
-            }
-          : {
-              type: "stripe-subscription",
-              stripeSubscriptionId: subscription.stripeSubscriptionId!,
-            };
-
-      if (isEnterprise) {
-        const result = await createEnterpriseCreditPurchase({
-          auth,
-          billingTarget,
-          amountMicroUsd,
-          discountPercent,
-          boughtByUserId: user.id,
-        });
-
-        if (result.isErr()) {
-          return apiError(req, res, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Failed to process credit purchase.",
-            },
-          });
-        }
-
-        return res.status(200).json({
-          success: true,
-          creditsAddedMicroUsd: amountMicroUsd,
-          invoiceId: null,
-          paymentUrl: null,
-        });
-      }
-
-      const result = await createProCreditPurchase({
-        auth,
-        billingTarget,
-        amountMicroUsd,
-        discountPercent,
-        boughtByUserId: user.id,
-      });
-
-      if (result.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to process credit purchase.",
-          },
-        });
-      }
-
-      return res.status(200).json({
-        success: true,
-        creditsAddedMicroUsd: amountMicroUsd,
-        invoiceId: result.value.invoiceId,
-        paymentUrl: result.value.paymentUrl,
-      });
+      return res.status(200).json({ success: true, ...purchaseRes.value });
     }
 
     default:


### PR DESCRIPTION
## Description

What changed:

1. New front/lib/api/credits/purchase.ts — two domain functions, no HTTP concerns:
  - getCreditPurchaseInfo(auth) → Result<CreditPurchaseInfo, CreditPurchaseInfoError> with 2 error variants (subscription_not_found, internal).
  - createCreditPurchase(auth, { amountDollars }) → Result<CreatedCreditPurchase, CreateCreditPurchaseError> with 4 error variants (subscription_not_found, purchase_not_allowed w/ optional reason, amount_exceeds_limit w/ maxAmountMicroUsd, internal).
  - All logger.error/warn calls preserved at the same failure sites so ops visibility doesn't regress.
2. front/pages/api/w/[wId]/credits/purchase.ts — 444 → 168 lines. Reads as:
  - Admin check (HTTP authorization stays in handler)
  - Method dispatch
  - GET: getCreditPurchaseInfo(auth) → infoErrorToApi mapper → 200
  - POST: zod body validation (now uses .positive() to absorb the amount > 0 check) → createCreditPurchase(auth, body) → purchaseErrorToApi mapper → 200
  - Two small mapper functions (infoErrorToApi, purchaseErrorToApi) with exhaustive switch + assertNever, one case per domain error variant.

Minor behavior change: the amountDollars <= 0 check is now part of the zod schema (.positive()), so its error message comes from zod-validation-error rather than the hand-rolled "Amount must be greater than 0." The HTTP status (400) and error type (invalid_request_error) are unchanged.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->