### PR TITLE
Conversation rendering: poke URL on error logs to ease debugging

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -171,6 +171,7 @@ export async function renderConversationForModel(
     tokensMargin: TOKENS_MARGIN,
     messageCount: messages.length,
     interactionCount: interactions.length,
+    pokeUrl: `https://https://poke.dust.tt/${conversation.owner.sId}/conversation/${conversation.sId}`,
   };
 
   if (currentInteractionTokens > availableTokens) {


### PR DESCRIPTION
## Description

Small ease of life improvement: pokeURL for conversations that are failing on context window exhaustion

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25694">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->