### PR TITLE
[Core] Keep sqlite database IDs out of URLs

### DIFF
--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -520,7 +520,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalidates_long_database_id_from_request_body() {
+    async fn invalidates_long_database_id_from_request_body() -> Result<()> {
         let database_id = make_long_database_id();
         let state = Arc::new(WorkerState::new(Box::new(
             GoogleCloudStorageDatabasesStore::new(),
@@ -537,7 +537,7 @@ mod tests {
             );
         }
 
-        let server = TestServer::new(make_router(state.clone())).unwrap();
+        let server = TestServer::new(make_router(state.clone()))?;
         let response = server
             .post("/databases/invalidate")
             .json(&json!({
@@ -547,5 +547,7 @@ mod tests {
 
         response.assert_status_ok();
         assert!(state.registry.lock().await.is_empty());
+
+        Ok(())
     }
 }

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -391,8 +391,8 @@ async fn expire_all(State(state): State<Arc<WorkerState>>) -> (StatusCode, Json<
 
 fn make_router(state: Arc<WorkerState>) -> Router {
     Router::new()
-        .route("/databases/query", post(databases_query_by_id))
-        .route("/databases/invalidate", post(databases_delete_by_id))
+        .route("/databases/by-id/query", post(databases_query_by_id))
+        .route("/databases/by-id/invalidate", post(databases_delete_by_id))
         .route("/databases", delete(expire_all))
         .route("/databases/{database_id}", post(databases_query))
         .route("/databases/{database_id}", delete(databases_delete))
@@ -539,7 +539,7 @@ mod tests {
 
         let server = TestServer::new(make_router(state.clone()))?;
         let response = server
-            .post("/databases/invalidate")
+            .post("/databases/by-id/invalidate")
             .json(&json!({
                 "database_id": database_id,
             }))

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -223,10 +223,47 @@ struct DbQueryPayload {
     timeout_ms: Option<u64>,
 }
 
+#[derive(Deserialize)]
+struct DbQueryByIdPayload {
+    database_id: String,
+    query: String,
+    tables: Vec<Table>,
+    timeout_ms: Option<u64>,
+}
+
+#[derive(Deserialize)]
+struct DbInvalidatePayload {
+    database_id: String,
+}
+
 async fn databases_query(
     Path(database_id): Path<String>,
     State(state): State<Arc<WorkerState>>,
     Json(payload): Json<DbQueryPayload>,
+) -> (StatusCode, Json<APIResponse>) {
+    run_database_query(database_id, state, payload).await
+}
+
+async fn databases_query_by_id(
+    State(state): State<Arc<WorkerState>>,
+    Json(payload): Json<DbQueryByIdPayload>,
+) -> (StatusCode, Json<APIResponse>) {
+    run_database_query(
+        payload.database_id,
+        state,
+        DbQueryPayload {
+            query: payload.query,
+            tables: payload.tables,
+            timeout_ms: payload.timeout_ms,
+        },
+    )
+    .await
+}
+
+async fn run_database_query(
+    database_id: String,
+    state: Arc<WorkerState>,
+    payload: DbQueryPayload,
 ) -> (StatusCode, Json<APIResponse>) {
     let database = {
         let mut registry = state.registry.lock().await;
@@ -310,6 +347,20 @@ async fn databases_delete(
     Path(database_id): Path<String>,
     State(state): State<Arc<WorkerState>>,
 ) -> (StatusCode, Json<APIResponse>) {
+    run_database_delete(database_id, state).await
+}
+
+async fn databases_delete_by_id(
+    State(state): State<Arc<WorkerState>>,
+    Json(payload): Json<DbInvalidatePayload>,
+) -> (StatusCode, Json<APIResponse>) {
+    run_database_delete(payload.database_id, state).await
+}
+
+async fn run_database_delete(
+    database_id: String,
+    state: Arc<WorkerState>,
+) -> (StatusCode, Json<APIResponse>) {
     state.invalidate_database(&database_id).await;
 
     (
@@ -338,6 +389,19 @@ async fn expire_all(State(state): State<Arc<WorkerState>>) -> (StatusCode, Json<
     )
 }
 
+fn make_router(state: Arc<WorkerState>) -> Router {
+    Router::new()
+        .route("/databases/query", post(databases_query_by_id))
+        .route("/databases/invalidate", post(databases_delete_by_id))
+        .route("/databases", delete(expire_all))
+        .route("/databases/{database_id}", post(databases_query))
+        .route("/databases/{database_id}", delete(databases_delete))
+        .layer(OtelInResponseLayer::default())
+        // Start OpenTelemetry trace on incoming request.
+        .layer(OtelAxumLayer::default())
+        .with_state(state)
+}
+
 fn main() {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(32)
@@ -352,14 +416,7 @@ fn main() {
 
         let state = Arc::new(WorkerState::new(databases_store));
 
-        let router = Router::new()
-            .route("/databases", delete(expire_all))
-            .route("/databases/{database_id}", post(databases_query))
-            .route("/databases/{database_id}", delete(databases_delete))
-            .layer(OtelInResponseLayer::default())
-            // Start OpenTelemetry trace on incoming request.
-            .layer(OtelAxumLayer::default())
-            .with_state(state.clone());
+        let router = make_router(state.clone());
 
         let health_check_router = Router::new()
             .route("/", get(index))
@@ -440,5 +497,55 @@ fn main() {
             error!(error = %e, "sqlite_worker server error");
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum_test::TestServer;
+
+    const TEST_LONG_DATABASE_TABLE_COUNT: usize = 128;
+    const TEST_TABLE_UNIQUE_ID_PREFIX: &str = concat!(
+        "2015170__345b17988d792986f8229fd27f68a0f439c900a28ec691362fdbbfd405a133a6",
+        "__fil_"
+    );
+
+    fn make_long_database_id() -> String {
+        (0..TEST_LONG_DATABASE_TABLE_COUNT)
+            .map(|i| format!("{TEST_TABLE_UNIQUE_ID_PREFIX}{i}"))
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+
+    #[tokio::test]
+    async fn invalidates_long_database_id_from_request_body() {
+        let database_id = make_long_database_id();
+        let state = Arc::new(WorkerState::new(Box::new(
+            GoogleCloudStorageDatabasesStore::new(),
+        )));
+
+        {
+            let mut registry = state.registry.lock().await;
+            registry.insert(
+                database_id.clone(),
+                DatabaseEntry {
+                    database: Arc::new(Mutex::new(SqliteDatabase::new())),
+                    last_accessed: Instant::now(),
+                },
+            );
+        }
+
+        let server = TestServer::new(make_router(state.clone())).unwrap();
+        let response = server
+            .post("/databases/invalidate")
+            .json(&json!({
+                "database_id": database_id,
+            }))
+            .await;
+
+        response.assert_status_ok();
+        assert!(state.registry.lock().await.is_empty());
     }
 }

--- a/core/src/sqlite_workers/client.rs
+++ b/core/src/sqlite_workers/client.rs
@@ -92,7 +92,7 @@ impl SqliteWorker {
         query: &str,
     ) -> Result<Vec<QueryResult>, SqliteWorkerError> {
         let worker_url = self.url();
-        let uri = format!("{}/databases/query", worker_url);
+        let uri = format!("{}/databases/by-id/query", worker_url);
 
         let req = reqwest::Client::new()
             .post(&uri)
@@ -144,7 +144,7 @@ impl SqliteWorker {
         database_unique_id: &str,
     ) -> Result<(), SqliteWorkerError> {
         let worker_url = self.url();
-        let uri = format!("{}/databases/invalidate", worker_url);
+        let uri = format!("{}/databases/by-id/invalidate", worker_url);
 
         let req = reqwest::Client::new()
             .post(&uri)

--- a/core/src/sqlite_workers/client.rs
+++ b/core/src/sqlite_workers/client.rs
@@ -37,6 +37,23 @@ pub enum SqliteWorkerError {
     UnexpectedError(anyhow::Error),
 }
 
+impl SqliteWorkerError {
+    fn is_not_found(&self) -> bool {
+        match self {
+            SqliteWorkerError::ServerError(_, _, status, _) => {
+                *status == StatusCode::NOT_FOUND.as_u16()
+            }
+            SqliteWorkerError::UnexpectedServerError(_, status, _) => {
+                *status == StatusCode::NOT_FOUND.as_u16()
+            }
+            SqliteWorkerError::BodyParsingError(_, _, status) => {
+                *status == StatusCode::NOT_FOUND.as_u16()
+            }
+            _ => false,
+        }
+    }
+}
+
 impl From<hyper::http::Error> for SqliteWorkerError {
     fn from(e: hyper::http::Error) -> Self {
         SqliteWorkerError::UnexpectedError(anyhow!(e))
@@ -75,17 +92,33 @@ impl SqliteWorker {
         query: &str,
     ) -> Result<Vec<QueryResult>, SqliteWorkerError> {
         let worker_url = self.url();
-        let uri = format!("{}/databases/{}", worker_url, encode(database_unique_id));
+        let uri = format!("{}/databases/query", worker_url);
 
         let req = reqwest::Client::new()
             .post(&uri)
             .header("Content-Type", "application/json")
             .json(&json!({
+                "database_id": database_unique_id,
                 "tables": tables.iter().map(|lt| &lt.table).collect::<Vec<_>>(),
                 "query": query,
             }));
 
-        let body_bytes = get_response_body(req, &uri).await?;
+        let body_bytes = match get_response_body(req, &uri).await {
+            Ok(body_bytes) => body_bytes,
+            Err(e) if e.is_not_found() => {
+                let uri = format!("{}/databases/{}", worker_url, encode(database_unique_id));
+                let req = reqwest::Client::new()
+                    .post(&uri)
+                    .header("Content-Type", "application/json")
+                    .json(&json!({
+                        "tables": tables.iter().map(|lt| &lt.table).collect::<Vec<_>>(),
+                        "query": query,
+                    }));
+
+                get_response_body(req, &uri).await?
+            }
+            Err(e) => return Err(e),
+        };
 
         #[derive(Deserialize)]
         struct ExecuteQueryResponseBody {
@@ -111,11 +144,25 @@ impl SqliteWorker {
         database_unique_id: &str,
     ) -> Result<(), SqliteWorkerError> {
         let worker_url = self.url();
-        let uri = format!("{}/databases/{}", worker_url, encode(database_unique_id));
+        let uri = format!("{}/databases/invalidate", worker_url);
 
-        let req = reqwest::Client::new().delete(&uri);
+        let req = reqwest::Client::new()
+            .post(&uri)
+            .header("Content-Type", "application/json")
+            .json(&json!({
+                "database_id": database_unique_id,
+            }));
 
-        let _ = get_response_body(req, &uri).await?;
+        match get_response_body(req, &uri).await {
+            Ok(_) => (),
+            Err(e) if e.is_not_found() => {
+                let uri = format!("{}/databases/{}", worker_url, encode(database_unique_id));
+                let req = reqwest::Client::new().delete(&uri);
+
+                let _ = get_response_body(req, &uri).await?;
+            }
+            Err(e) => return Err(e),
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Description
Core keeps an in-memory sqlite-worker cache for table queries. The cache key is built by joining all queried table unique IDs with `/`, so queries over many tables can create a very long ID containing many slashes.

The table upsert workflow writes new rows, then asks sqlite-worker to invalidate any cached query databases that used the updated table. Before this PR, Core put the full cache ID in the request URL (`/databases/{id}`). For very long IDs, reqwest could not build the URL, so Core returned `Failed to upsert rows`, and the front `upsertTableActivity` kept retrying with the error seen in logs.

This adds body-based sqlite-worker query and invalidate endpoints, moves the Core client to those fixed paths, and keeps a legacy path fallback for mixed-version rollout.

## Risks
Blast radius: local table query cache creation and invalidation in Core/sqlite-worker.
Risk: standard

## Deploy Plan
- deploy sqlite-worker
- deploy core-api after sqlite-worker rollout if deployed separately
- no migrations

## Tests
- [x] `cargo test --bin sqlite-worker invalidates_long_database_id_from_request_body`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25695">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->