### PR TITLE
Self improving skills: cap number of conversations based on remaining budget

### DIFF
--- a/front/lib/reinforcement/constants.test.ts
+++ b/front/lib/reinforcement/constants.test.ts
@@ -1,0 +1,107 @@
+import {
+  DEFAULT_MAX_CONVERSATIONS_PER_RUN,
+  getMaxConversationsForBudget,
+} from "@app/lib/reinforcement/constants";
+import { describe, expect, it } from "vitest";
+
+// Large value so programmatic credits are not the limiting factor by default.
+const UNLIMITED_PROGRAMMATIC = 999_999_999;
+
+describe("getMaxConversationsForBudget", () => {
+  it("returns 0 when reinforcement consumption equals cap", () => {
+    expect(
+      getMaxConversationsForBudget({
+        globalConsumptionMicroUsd: 100_000_000,
+        globalCapMicroUsd: 100_000_000,
+        remainingProgrammaticCreditsMicroUsd: UNLIMITED_PROGRAMMATIC,
+      })
+    ).toBe(0);
+  });
+
+  it("returns 0 when reinforcement consumption exceeds cap", () => {
+    expect(
+      getMaxConversationsForBudget({
+        globalConsumptionMicroUsd: 110_000_000,
+        globalCapMicroUsd: 100_000_000,
+        remainingProgrammaticCreditsMicroUsd: UNLIMITED_PROGRAMMATIC,
+      })
+    ).toBe(0);
+  });
+
+  it("returns budget-based count for small remaining reinforcement budget", () => {
+    // $1 remaining = 1_000_000 microUSD → 10 conversations at $0.10 each.
+    expect(
+      getMaxConversationsForBudget({
+        globalConsumptionMicroUsd: 99_000_000,
+        globalCapMicroUsd: 100_000_000,
+        remainingProgrammaticCreditsMicroUsd: UNLIMITED_PROGRAMMATIC,
+      })
+    ).toBe(10);
+  });
+
+  it("floors partial conversation budgets", () => {
+    // $0.15 remaining = 150_000 microUSD → 1 conversation (floor of 1.5).
+    expect(
+      getMaxConversationsForBudget({
+        globalConsumptionMicroUsd: 99_850_000,
+        globalCapMicroUsd: 100_000_000,
+        remainingProgrammaticCreditsMicroUsd: UNLIMITED_PROGRAMMATIC,
+      })
+    ).toBe(1);
+  });
+
+  it("returns 0 when remaining budget is less than one conversation", () => {
+    // $0.05 remaining = 50_000 microUSD → 0 conversations.
+    expect(
+      getMaxConversationsForBudget({
+        globalConsumptionMicroUsd: 99_950_000,
+        globalCapMicroUsd: 100_000_000,
+        remainingProgrammaticCreditsMicroUsd: UNLIMITED_PROGRAMMATIC,
+      })
+    ).toBe(0);
+  });
+
+  it("caps at DEFAULT_MAX_CONVERSATIONS_PER_RUN when budget is large", () => {
+    expect(
+      getMaxConversationsForBudget({
+        globalConsumptionMicroUsd: 0,
+        globalCapMicroUsd: 100_000_000,
+        remainingProgrammaticCreditsMicroUsd: UNLIMITED_PROGRAMMATIC,
+      })
+    ).toBe(DEFAULT_MAX_CONVERSATIONS_PER_RUN);
+  });
+
+  it("uses programmatic credits as limit when lower than reinforcement budget", () => {
+    // $0.50 remaining programmatic credits → 5 conversations.
+    expect(
+      getMaxConversationsForBudget({
+        globalConsumptionMicroUsd: 0,
+        globalCapMicroUsd: 100_000_000,
+        remainingProgrammaticCreditsMicroUsd: 500_000,
+      })
+    ).toBe(5);
+  });
+
+  it("returns 0 when programmatic credits are exhausted", () => {
+    expect(
+      getMaxConversationsForBudget({
+        globalConsumptionMicroUsd: 0,
+        globalCapMicroUsd: 100_000_000,
+        remainingProgrammaticCreditsMicroUsd: 0,
+      })
+    ).toBe(0);
+  });
+
+  it("picks the most restrictive limit between reinforcement and programmatic", () => {
+    // Reinforcement remaining: $2 → 20 conversations.
+    // Programmatic remaining: $1 → 10 conversations.
+    // Should pick 10.
+    expect(
+      getMaxConversationsForBudget({
+        globalConsumptionMicroUsd: 98_000_000,
+        globalCapMicroUsd: 100_000_000,
+        remainingProgrammaticCreditsMicroUsd: 1_000_000,
+      })
+    ).toBe(10);
+  });
+});

--- a/front/lib/reinforcement/constants.ts
+++ b/front/lib/reinforcement/constants.ts
@@ -36,6 +36,41 @@ export const DEFAULT_REINFORCEMENT_CAP_MICRO_USD = 100_000_000;
 // $20 = 20_000_000 microUSD.
 export const DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD = 20_000_000;
 
+// Estimated cost per conversation analysis (in microUSD).
+// $0.10 = 100_000 microUSD.
+const ESTIMATED_COST_PER_CONVERSATION_MICRO_USD = 100_000;
+
+/**
+ * Compute the maximum number of conversations to analyze based on the
+ * remaining reinforcement budget and remaining programmatic credits.
+ * Takes the most restrictive limit, capped at DEFAULT_MAX_CONVERSATIONS_PER_RUN.
+ */
+export function getMaxConversationsForBudget({
+  globalConsumptionMicroUsd,
+  globalCapMicroUsd,
+  remainingProgrammaticCreditsMicroUsd,
+}: {
+  globalConsumptionMicroUsd: number;
+  globalCapMicroUsd: number;
+  remainingProgrammaticCreditsMicroUsd: number;
+}): number {
+  const remainingReinforcementMicroUsd =
+    globalCapMicroUsd - globalConsumptionMicroUsd;
+  const remainingMicroUsd = Math.min(
+    remainingReinforcementMicroUsd,
+    remainingProgrammaticCreditsMicroUsd
+  );
+  if (remainingMicroUsd <= 0) {
+    return 0;
+  }
+
+  const fromBudget = Math.floor(
+    remainingMicroUsd / ESTIMATED_COST_PER_CONVERSATION_MICRO_USD
+  );
+
+  return Math.min(fromBudget, DEFAULT_MAX_CONVERSATIONS_PER_RUN);
+}
+
 // Scoring weights for conversation selection.
 export const WEIGHT_FEEDBACK = 0.45;
 export const WEIGHT_TOOL_ERRORS = 0.3;

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -164,6 +164,17 @@ export class CreditResource extends BaseResource<CreditModel> {
     });
   }
 
+  /**
+   * Return the total remaining balance across all active credits (in microUSD).
+   */
+  static async getRemainingMicroUsd(auth: Authenticator): Promise<number> {
+    const activeCredits = await this.listActive(auth);
+    return activeCredits.reduce(
+      (sum, c) => sum + (c.initialAmountMicroUsd - c.consumedAmountMicroUsd),
+      0
+    );
+  }
+
   static async fetchByIds(auth: Authenticator, ids: string[]) {
     return this.baseFetch(auth, {
       where: {

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -582,13 +582,10 @@ export async function getReinforcementSettingsActivity({
     await checkProgrammaticUsageLimits(auth)
   ).isErr();
 
-  // Compute remaining programmatic credits: sum of remaining across all active
-  // credits, capped by the daily usage allowance.
-  const activeCredits = await CreditResource.listActive(auth);
-  const remainingCreditsMicroUsd = activeCredits.reduce(
-    (sum, c) => sum + (c.initialAmountMicroUsd - c.consumedAmountMicroUsd),
-    0
-  );
+  // Compute remaining programmatic budget: total remaining credits capped by
+  // the daily usage allowance.
+  const remainingCreditsMicroUsd =
+    await CreditResource.getRemainingMicroUsd(auth);
   const remainingDailyCapMicroUsd = await getRemainingDailyCapMicroUsd(auth);
   const remainingProgrammaticCreditsMicroUsd = Math.min(
     remainingCreditsMicroUsd,

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -10,6 +10,8 @@ import {
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
+import { getRemainingDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/daily_cap";
+import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import {
   AgentMessageModel,
@@ -31,6 +33,7 @@ import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import {
   DEFAULT_MAX_CONVERSATIONS_PER_RUN,
   DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
+  getMaxConversationsForBudget,
 } from "@app/lib/reinforcement/constants";
 import { getReinforcementMonthlyCapMicroUsd } from "@app/lib/reinforcement/consumption";
 import {
@@ -57,6 +60,7 @@ import {
   isReinforcementBatchModeAllowed,
 } from "@app/lib/reinforcement/workspace_check";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import type { SelfImprovingSkillsUsageCreateBlob } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
@@ -555,6 +559,8 @@ export async function getReinforcementSettingsActivity({
       batchModeAllowed: boolean;
       globalConsumptionMicroUsd: number;
       globalCapMicroUsd: number;
+      programmaticUsageLimitReached: boolean;
+      maxConversationsForBudget: number;
     }
 > {
   const auth = await getAuthForWorkspace(workspaceId);
@@ -572,12 +578,31 @@ export async function getReinforcementSettingsActivity({
     );
   const globalCapMicroUsd = getReinforcementMonthlyCapMicroUsd(workspace);
 
+  const programmaticUsageLimitReached = (
+    await checkProgrammaticUsageLimits(auth)
+  ).isErr();
+
+  // Compute remaining programmatic credits: sum of remaining across all active
+  // credits, capped by the daily usage allowance.
+  const activeCredits = await CreditResource.listActive(auth);
+  const remainingCreditsMicroUsd = activeCredits.reduce(
+    (sum, c) => sum + (c.initialAmountMicroUsd - c.consumedAmountMicroUsd),
+    0
+  );
+  const remainingDailyCapMicroUsd = await getRemainingDailyCapMicroUsd(auth);
+  const remainingProgrammaticCreditsMicroUsd = Math.min(
+    remainingCreditsMicroUsd,
+    remainingDailyCapMicroUsd
+  );
+
   logger.info(
     {
       workspaceId,
       globalConsumptionMicroUsd,
       globalCapMicroUsd,
       capReached: globalConsumptionMicroUsd >= globalCapMicroUsd,
+      programmaticUsageLimitReached,
+      remainingProgrammaticCreditsMicroUsd,
     },
     "ReinforcedSkills: workspace consumption check"
   );
@@ -587,6 +612,12 @@ export async function getReinforcementSettingsActivity({
     batchModeAllowed: await isReinforcementBatchModeAllowed(auth),
     globalConsumptionMicroUsd,
     globalCapMicroUsd,
+    programmaticUsageLimitReached,
+    maxConversationsForBudget: getMaxConversationsForBudget({
+      globalConsumptionMicroUsd,
+      globalCapMicroUsd,
+      remainingProgrammaticCreditsMicroUsd,
+    }),
   };
 }
 

--- a/front/temporal/reinforcement/workflows.ts
+++ b/front/temporal/reinforcement/workflows.ts
@@ -327,17 +327,26 @@ export async function reinforcementWorkspaceWorkflow({
     // Cap reached: activity already logged the details. Stop immediately.
     return;
   }
+  if (settings.programmaticUsageLimitReached) {
+    // Programmatic usage limit reached: stop to avoid consuming credits the
+    // workspace no longer has.
+    return;
+  }
 
   // Resolve effective batch mode: the caller may request batch mode, but the
   // workspace setting can override it to streaming.
   const effectiveBatchMode = useBatchMode && settings.batchModeAllowed;
 
   // Phase 1: Discover conversations with skills.
+  // Limit the number of conversations based on the remaining reinforcement
+  // budget (estimated $0.10 per conversation).
+  const maxConversations = settings.maxConversationsForBudget;
   const conversationsWithSkills =
     await getRecentConversationsWithSkillsActivity({
       workspaceId,
       lookbackDays: conversationLookbackDays,
       skillId,
+      maxConversations,
     });
 
   if (conversationsWithSkills.length === 0) {


### PR DESCRIPTION
## Description

The purpose 

 - check we have remaining programmatic usage
 - estimate a conv will cost $0.10 to restrict the number of conversations to analyse (based on both global programatic credit remaining and the reinforcement budget remaining)


closes https://github.com/dust-tt/tasks/issues/8038
closes https://github.com/dust-tt/tasks/issues/8060

## Tests

added a unit test

## Risk

low

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25696">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->