### PR TITLE
feat: rename projects to pods in UI

### DIFF
--- a/connectors/src/connectors/dust_project/lib/sync_metadata.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_metadata.ts
@@ -32,11 +32,11 @@ export async function syncProjectMetadata({
   });
 
   if (!metadata) {
-    localLogger.info("No metadata found for project. Skipping sync.");
+    localLogger.info("No metadata found for pod. Skipping sync.");
     return;
   }
 
-  localLogger.info("Syncing project metadata (only description for now)");
+  localLogger.info("Syncing pod metadata (only description for now)");
 
   const metadataText = formatProjectMetadata(metadata);
 
@@ -77,7 +77,7 @@ export async function syncProjectMetadata({
     upsertContext: {
       sync_type: "batch",
     },
-    title: "Project metadata",
+    title: "Pod metadata",
     mimeType: "text/markdown",
     async: true,
   });

--- a/connectors/src/connectors/dust_project/lib/sync_project_mount_files.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_project_mount_files.ts
@@ -94,9 +94,9 @@ export async function deleteProjectMountFile({
       },
     });
     await mountRow.delete();
-    localLogger.info("Deleted project mount file from data source");
+    localLogger.info("Deleted pod mount file from data source");
   } catch (error) {
-    localLogger.error({ error }, "Failed to delete project mount file");
+    localLogger.error({ error }, "Failed to delete pod mount file");
     throw error;
   }
 }
@@ -263,5 +263,5 @@ export async function syncProjectMountFile({
     });
   }
 
-  localLogger.info({ documentId }, "Synced project mount file");
+  localLogger.info({ documentId }, "Synced pod mount file");
 }

--- a/extension/ui/components/conversation/ConversationLayout.tsx
+++ b/extension/ui/components/conversation/ConversationLayout.tsx
@@ -61,7 +61,7 @@ export const ConversationLayout = ({
                 variant="ghost"
                 icon={ArrowLeftIcon}
                 onClick={() => navigate(backHref)}
-                tooltip="Go back to pod homepage"
+                tooltip="Go back to Pod homepage"
               />
             ) : (
               <Button

--- a/extension/ui/components/conversation/ConversationLayout.tsx
+++ b/extension/ui/components/conversation/ConversationLayout.tsx
@@ -61,7 +61,7 @@ export const ConversationLayout = ({
                 variant="ghost"
                 icon={ArrowLeftIcon}
                 onClick={() => navigate(backHref)}
-                tooltip="Go back to project homepage"
+                tooltip="Go back to pod homepage"
               />
             ) : (
               <Button

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
@@ -25,7 +25,7 @@ app.post(
         {
           error: {
             type: "invalid_request_error",
-            message: "You can only join projects, not regular spaces.",
+            message: "You can only join pods, not regular spaces.",
           },
         },
         400
@@ -37,8 +37,7 @@ app.post(
         {
           error: {
             type: "workspace_auth_error",
-            message:
-              "This project is restricted. You need to be invited to join.",
+            message: "This pod is restricted. You need to be invited to join.",
           },
         },
         403
@@ -51,7 +50,7 @@ app.post(
           error: {
             type: "invalid_request_error",
             message:
-              "You cannot join this project, its members are not managed manually.",
+              "You cannot join this pod, its members are not managed manually.",
           },
         },
         403
@@ -63,7 +62,7 @@ app.post(
         {
           error: {
             type: "invalid_request_error",
-            message: "You are already a member of this project.",
+            message: "You are already a member of this pod.",
           },
         },
         400
@@ -80,8 +79,7 @@ app.post(
         {
           error: {
             type: "internal_server_error",
-            message:
-              "There should be exactly one member group for the project.",
+            message: "There should be exactly one member group for the pod.",
           },
         },
         500

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
@@ -25,7 +25,7 @@ app.post(
         {
           error: {
             type: "invalid_request_error",
-            message: "You can only join pods, not regular spaces.",
+            message: "You can only join Pods, not regular spaces.",
           },
         },
         400
@@ -37,7 +37,7 @@ app.post(
         {
           error: {
             type: "workspace_auth_error",
-            message: "This pod is restricted. You need to be invited to join.",
+            message: "This Pod is restricted. You need to be invited to join.",
           },
         },
         403
@@ -50,7 +50,7 @@ app.post(
           error: {
             type: "invalid_request_error",
             message:
-              "You cannot join this pod, its members are not managed manually.",
+              "You cannot join this Pod, its members are not managed manually.",
           },
         },
         403
@@ -62,7 +62,7 @@ app.post(
         {
           error: {
             type: "invalid_request_error",
-            message: "You are already a member of this pod.",
+            message: "You are already a member of this Pod.",
           },
         },
         400
@@ -79,7 +79,7 @@ app.post(
         {
           error: {
             type: "internal_server_error",
-            message: "There should be exactly one member group for the pod.",
+            message: "There should be exactly one member group for the Pod.",
           },
         },
         500

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
@@ -60,7 +60,7 @@ describe("POST /api/w/:wId/spaces/:spaceId/leave", () => {
       expect(response.status).toBe(400);
       const body = await response.json();
       expect(body.error.type).toBe("invalid_request_error");
-      expect(body.error.message).toContain("only leave projects");
+      expect(body.error.message).toContain("only leave Pods");
     });
 
     it("returns 403 when user is not a member of the project", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
@@ -23,7 +23,7 @@ app.post(
         {
           error: {
             type: "invalid_request_error",
-            message: "You can only leave pods, not regular spaces.",
+            message: "You can only leave Pods, not regular spaces.",
           },
         },
         400
@@ -35,7 +35,7 @@ app.post(
         {
           error: {
             type: "workspace_auth_error",
-            message: "You are not a member of this pod.",
+            message: "You are not a member of this Pod.",
           },
         },
         403
@@ -56,7 +56,7 @@ app.post(
             error: {
               type: "workspace_auth_error",
               message:
-                "You cannot leave this pod as you are the last editor. Please add another editor first.",
+                "You cannot leave this Pod as you are the last editor. Please add another editor first.",
             },
           },
           403

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
@@ -23,7 +23,7 @@ app.post(
         {
           error: {
             type: "invalid_request_error",
-            message: "You can only leave projects, not regular spaces.",
+            message: "You can only leave pods, not regular spaces.",
           },
         },
         400
@@ -35,7 +35,7 @@ app.post(
         {
           error: {
             type: "workspace_auth_error",
-            message: "You are not a member of this project.",
+            message: "You are not a member of this pod.",
           },
         },
         403
@@ -56,7 +56,7 @@ app.post(
             error: {
               type: "workspace_auth_error",
               message:
-                "You cannot leave this project as you are the last editor. Please add another editor first.",
+                "You cannot leave this pod as you are the last editor. Please add another editor first.",
             },
           },
           403

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/star.ts
@@ -27,7 +27,7 @@ app.post(
         {
           error: {
             type: "invalid_request_error",
-            message: "Pod star is only available for Pod spaces.",
+            message: "You can only star Pods.",
           },
         },
         400

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/star.ts
@@ -27,7 +27,7 @@ app.post(
         {
           error: {
             type: "invalid_request_error",
-            message: "Pod star is only available for pod spaces.",
+            message: "Pod star is only available for Pod spaces.",
           },
         },
         400

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/star.ts
@@ -27,7 +27,7 @@ app.post(
         {
           error: {
             type: "invalid_request_error",
-            message: "Project star is only available for project spaces.",
+            message: "Pod star is only available for pod spaces.",
           },
         },
         400

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -177,7 +177,7 @@ export function AgentBuilderSpacesBlock({
       <div className="flex items-start justify-between">
         <div>
           <h2 className="heading-lg text-foreground dark:text-foreground-night">
-            {isProjectsEnabled ? "Spaces and Projects" : "Spaces"}
+            {isProjectsEnabled ? "Spaces and Pods" : "Spaces"}
           </h2>
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             Set what knowledge and capabilities the agent can access.

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -88,11 +88,11 @@ export function SpaceSelectionSheet({
       <SheetContent>
         <SheetHeader>
           <SheetTitle>
-            {isProjectsEnabled ? "Add Spaces and Projects" : "Add Spaces"}
+            {isProjectsEnabled ? "Add Spaces and Pods" : "Add Spaces"}
           </SheetTitle>
           <SheetDescription>
             {isProjectsEnabled
-              ? `Choose the spaces and projects you want the ${entityName} to have access to.`
+              ? `Choose the spaces and Pods you want the ${entityName} to have access to.`
               : `Choose the spaces you want the ${entityName} to have access to.`}
           </SheetDescription>
           <SearchInput
@@ -100,7 +100,7 @@ export function SpaceSelectionSheet({
             onChange={(query) => setSearchQuery(query)}
             value={searchQuery}
             placeholder={
-              isProjectsEnabled ? "Search spaces and projects" : "Search spaces"
+              isProjectsEnabled ? "Search spaces and Pods" : "Search spaces"
             }
             className="mt-4"
           />
@@ -290,7 +290,7 @@ export function SpaceSelectionPageContent({
           </ListGroup>
           {isProjectsEnabled && (
             <>
-              <ListItemSection size="sm">Projects</ListItemSection>
+              <ListItemSection size="sm">Pods</ListItemSection>
               <ListGroup>
                 {projectsTableData.map((row) => {
                   const ProjectIcon = getSpaceIcon(row.space);
@@ -350,7 +350,7 @@ export function SpaceSelectionPageContent({
           {searchQuery.length > 0
             ? "No results found for your search"
             : isProjectsEnabled
-              ? "No spaces and projects available"
+              ? "No spaces and Pods available"
               : "No spaces available"}
         </div>
       )}

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
@@ -96,7 +96,7 @@ export function DataSourceSpaceSelector({
       {projectItems.length > 0 && (
         <>
           <div className="heading-sm bg-muted-background p-2 dark:bg-muted-background-night/50 text-foreground dark:text-foreground-night">
-            From pods:
+            From Pods:
           </div>
           <DataSourceList
             items={projectItems}

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
@@ -96,7 +96,7 @@ export function DataSourceSpaceSelector({
       {projectItems.length > 0 && (
         <>
           <div className="heading-sm bg-muted-background p-2 dark:bg-muted-background-night/50 text-foreground dark:text-foreground-night">
-            From projects:
+            From pods:
           </div>
           <DataSourceList
             items={projectItems}

--- a/front/components/agent_builder/capabilities/mcp/utils/validationMessages.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/validationMessages.ts
@@ -25,7 +25,7 @@ export const VALIDATION_MESSAGES = {
     invalid: "Please select a valid secret",
   },
   dustProject: {
-    required: "Please select one project",
-    invalid: "Selected project is not valid",
+    required: "Please select one pod",
+    invalid: "Selected pod is not valid",
   },
 } as const;

--- a/front/components/agent_builder/capabilities/mcp/utils/validationMessages.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/validationMessages.ts
@@ -25,7 +25,7 @@ export const VALIDATION_MESSAGES = {
     invalid: "Please select a valid secret",
   },
   dustProject: {
-    required: "Please select one pod",
-    invalid: "Selected pod is not valid",
+    required: "Please select one Pod",
+    invalid: "Selected Pod is not valid",
   },
 } as const;

--- a/front/components/agent_builder/capabilities/shared/ProjectSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProjectSection.tsx
@@ -121,8 +121,8 @@ export function ProjectSection() {
         title="Select Pod"
         error={fieldState.error?.message}
       >
-        <ProjectMessage title="No pods available">
-          No pods are available in your workspace. Create a pod first to use
+        <ProjectMessage title="No Pods available">
+          No Pods are available in your workspace. Create a Pod first to use
           this feature.
         </ProjectMessage>
       </ConfigurationSectionContainer>
@@ -136,15 +136,15 @@ export function ProjectSection() {
     >
       <div className="flex h-full flex-col gap-3">
         <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Choose the pod that the agent can access. The agent will have access
-          to pod metadata and context from the selected pod.
+          Choose the Pod that the agent can access. The agent will have access
+          to Pod metadata and context from the selected Pod.
         </div>
 
         <div className="inline-flex">
           <DropdownMenu open={searchOpen} onOpenChange={setSearchOpen}>
             <DropdownMenuTrigger asChild>
               <Button
-                label={selectedProject?.name ?? "Select pod..."}
+                label={selectedProject?.name ?? "Select Pod..."}
                 icon={
                   selectedProject ? getSpaceIcon(selectedProject) : undefined
                 }
@@ -184,7 +184,7 @@ export function ProjectSection() {
                 })
               ) : (
                 <div className="px-3 py-4 text-center text-xs italic text-muted-foreground dark:text-muted-foreground-night">
-                  {searchQuery ? "No matches" : "No pods"}
+                  {searchQuery ? "No matches" : "No Pods"}
                 </div>
               )}
             </DropdownMenuContent>

--- a/front/components/agent_builder/capabilities/shared/ProjectSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProjectSection.tsx
@@ -105,7 +105,7 @@ export function ProjectSection() {
   if (isSpacesLoading) {
     return (
       <ConfigurationSectionContainer
-        title="Select Project"
+        title="Select Pod"
         error={fieldState.error?.message}
       >
         <div className="flex h-32 w-full items-center justify-center">
@@ -118,12 +118,12 @@ export function ProjectSection() {
   if (allProjects.length === 0) {
     return (
       <ConfigurationSectionContainer
-        title="Select Project"
+        title="Select Pod"
         error={fieldState.error?.message}
       >
-        <ProjectMessage title="No projects available">
-          No projects are available in your workspace. Create a project first to
-          use this feature.
+        <ProjectMessage title="No pods available">
+          No pods are available in your workspace. Create a pod first to use
+          this feature.
         </ProjectMessage>
       </ConfigurationSectionContainer>
     );
@@ -131,20 +131,20 @@ export function ProjectSection() {
 
   return (
     <ConfigurationSectionContainer
-      title="Select Project"
+      title="Select Pod"
       error={fieldState.error?.message}
     >
       <div className="flex h-full flex-col gap-3">
         <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Choose the project that the agent can access. The agent will have
-          access to project metadata and context from the selected project.
+          Choose the pod that the agent can access. The agent will have access
+          to pod metadata and context from the selected pod.
         </div>
 
         <div className="inline-flex">
           <DropdownMenu open={searchOpen} onOpenChange={setSearchOpen}>
             <DropdownMenuTrigger asChild>
               <Button
-                label={selectedProject?.name ?? "Select project..."}
+                label={selectedProject?.name ?? "Select pod..."}
                 icon={
                   selectedProject ? getSpaceIcon(selectedProject) : undefined
                 }
@@ -184,7 +184,7 @@ export function ProjectSection() {
                 })
               ) : (
                 <div className="px-3 py-4 text-center text-xs italic text-muted-foreground dark:text-muted-foreground-night">
-                  {searchQuery ? "No matches" : "No projects"}
+                  {searchQuery ? "No matches" : "No pods"}
                 </div>
               )}
             </DropdownMenuContent>

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -161,7 +161,7 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
   },
   agent_sidekick: { label: "Sidekick", color: buildColorClass("emerald", 300) },
   project_kickoff: {
-    label: "Project Kickoff",
+    label: "Pod Kickoff",
     color: buildColorClass("lime", 300),
   },
 };

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -445,7 +445,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     return (
       <div className="mx-auto flex flex-col w-full py-4 sm:max-w-conversation">
         <EmptyCTA
-          message="This conversation belongs to an archived project. No new messages can be sent."
+          message="This conversation belongs to an archived pod. No new messages can be sent."
           action={null}
         />
       </div>

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -445,7 +445,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     return (
       <div className="mx-auto flex flex-col w-full py-4 sm:max-w-conversation">
         <EmptyCTA
-          message="This conversation belongs to an archived pod. No new messages can be sent."
+          message="This conversation belongs to an archived Pod. No new messages can be sent."
           action={null}
         />
       </div>

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -416,7 +416,7 @@ export function ConversationMenu({
             <DropdownMenuSub>
               <DropdownMenuSubTrigger
                 icon={ArrowRightIcon}
-                label={canMoveOutOfProject ? "Move to..." : "Move to project"}
+                label={canMoveOutOfProject ? "Move to..." : "Move to pod"}
                 disabled={
                   canMoveOutOfProject ? false : !filteredProjects.length
                 }
@@ -436,7 +436,7 @@ export function ConversationMenu({
                         }
                       />
                       <DropdownMenuSeparator />
-                      <DropdownMenuLabel label="Projects" />
+                      <DropdownMenuLabel label="Pods" />
                     </>
                   )}
                   {filteredProjects.map((project) => (

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -416,7 +416,7 @@ export function ConversationMenu({
             <DropdownMenuSub>
               <DropdownMenuSubTrigger
                 icon={ArrowRightIcon}
-                label={canMoveOutOfProject ? "Move to..." : "Move to pod"}
+                label={canMoveOutOfProject ? "Move to..." : "Move to Pod"}
                 disabled={
                   canMoveOutOfProject ? false : !filteredProjects.length
                 }

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -31,7 +31,7 @@ interface CreateProjectModalProps {
 }
 
 const OPEN_PROJECTS_DISABLED_TOOLTIP =
-  "Open projects are disabled by your workspace admin.";
+  "Open pods are disabled by your workspace admin.";
 
 export function CreateProjectModal({
   isOpen,
@@ -101,8 +101,8 @@ export function CreateProjectModal({
         spaceKind: "project",
       },
       {
-        title: "Project created",
-        description: `Project "${trimmedName}" has been created.`,
+        title: "Pod created",
+        description: `Pod "${trimmedName}" has been created.`,
       }
     );
 
@@ -142,14 +142,14 @@ export function CreateProjectModal({
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Create a new Project</DialogTitle>
+          <DialogTitle>Create a new Pod</DialogTitle>
         </DialogHeader>
         <DialogContainer>
           <div className="flex w-full flex-col gap-y-4">
             <div className="flex flex-col">
               <Input
-                label="Project name"
-                placeholder="Enter project name"
+                label="Pod name"
+                placeholder="Enter pod name"
                 value={projectName}
                 name="projectName"
                 onChange={(e) => {
@@ -162,7 +162,7 @@ export function CreateProjectModal({
               />
               {nameNotAvailable && (
                 <div className="mt-1 text-xs text-warning-500 dark:text-warning-500">
-                  A project or space with this name already exists.
+                  A pod or space with this name already exists.
                 </div>
               )}
             </div>
@@ -175,8 +175,8 @@ export function CreateProjectModal({
               />
               <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
                 {isPublic
-                  ? "Anyone in the workspace can find and join this project."
-                  : "Only invited members can access this project."}
+                  ? "Anyone in the workspace can find and join this pod."
+                  : "Only invited members can access this pod."}
               </div>
             </div>
           </div>

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -31,7 +31,7 @@ interface CreateProjectModalProps {
 }
 
 const OPEN_PROJECTS_DISABLED_TOOLTIP =
-  "Open pods are disabled by your workspace admin.";
+  "Open Pods are disabled by your workspace admin.";
 
 export function CreateProjectModal({
   isOpen,
@@ -149,7 +149,7 @@ export function CreateProjectModal({
             <div className="flex flex-col">
               <Input
                 label="Pod name"
-                placeholder="Enter pod name"
+                placeholder="Enter Pod name"
                 value={projectName}
                 name="projectName"
                 onChange={(e) => {
@@ -162,7 +162,7 @@ export function CreateProjectModal({
               />
               {nameNotAvailable && (
                 <div className="mt-1 text-xs text-warning-500 dark:text-warning-500">
-                  A pod or space with this name already exists.
+                  A Pod or space with this name already exists.
                 </div>
               )}
             </div>
@@ -175,8 +175,8 @@ export function CreateProjectModal({
               />
               <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
                 {isPublic
-                  ? "Anyone in the workspace can find and join this pod."
-                  : "Only invited members can access this pod."}
+                  ? "Anyone in the workspace can find and join this Pod."
+                  : "Only invited members can access this Pod."}
               </div>
             </div>
           </div>

--- a/front/components/assistant/conversation/EditProjectTitleDialog.tsx
+++ b/front/components/assistant/conversation/EditProjectTitleDialog.tsx
@@ -113,7 +113,7 @@ export const EditProjectTitleDialog = ({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Edit project title</DialogTitle>
+          <DialogTitle>Edit pod title</DialogTitle>
         </DialogHeader>
         <DialogContainer>
           <Input
@@ -133,7 +133,7 @@ export const EditProjectTitleDialog = ({
           />
           {nameNotAvailable && (
             <div className="text-xs text-warning-500">
-              A project or space with this name already exists.
+              A pod or space with this name already exists.
             </div>
           )}
         </DialogContainer>

--- a/front/components/assistant/conversation/EditProjectTitleDialog.tsx
+++ b/front/components/assistant/conversation/EditProjectTitleDialog.tsx
@@ -113,12 +113,12 @@ export const EditProjectTitleDialog = ({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Edit pod title</DialogTitle>
+          <DialogTitle>Edit Pod name</DialogTitle>
         </DialogHeader>
         <DialogContainer>
           <Input
             ref={inputRef}
-            placeholder="Enter new title..."
+            placeholder="Enter new name..."
             value={title}
             onChange={(e) => {
               setTitle(e.target.value);
@@ -133,7 +133,7 @@ export const EditProjectTitleDialog = ({
           />
           {nameNotAvailable && (
             <div className="text-xs text-warning-500">
-              A pod or space with this name already exists.
+              A Pod or space with this name already exists.
             </div>
           )}
         </DialogContainer>

--- a/front/components/assistant/conversation/LeaveProjectDialog.tsx
+++ b/front/components/assistant/conversation/LeaveProjectDialog.tsx
@@ -31,7 +31,7 @@ export const LeaveProjectDialog = ({
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Leave this pod?</DialogTitle>
+          <DialogTitle>Leave this Pod?</DialogTitle>
           <DialogDescription>
             {isRestricted ? (
               <>
@@ -39,7 +39,7 @@ export const LeaveProjectDialog = ({
                 <strong>{spaceName}</strong>.
               </>
             ) : (
-              "You can rejoin this pod anytime."
+              "You can rejoin this Pod anytime."
             )}
           </DialogDescription>
         </DialogHeader>

--- a/front/components/assistant/conversation/LeaveProjectDialog.tsx
+++ b/front/components/assistant/conversation/LeaveProjectDialog.tsx
@@ -31,7 +31,7 @@ export const LeaveProjectDialog = ({
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Leave this project?</DialogTitle>
+          <DialogTitle>Leave this pod?</DialogTitle>
           <DialogDescription>
             {isRestricted ? (
               <>
@@ -39,7 +39,7 @@ export const LeaveProjectDialog = ({
                 <strong>{spaceName}</strong>.
               </>
             ) : (
-              "You can rejoin this project anytime."
+              "You can rejoin this pod anytime."
             )}
           </DialogDescription>
         </DialogHeader>

--- a/front/components/assistant/conversation/MentionInvalid.tsx
+++ b/front/components/assistant/conversation/MentionInvalid.tsx
@@ -71,7 +71,7 @@ export function MentionInvalid({
       // Different message for project conversations (non-editor can't add members)
       const isProjectConv = isProjectConversation(conversation);
       const message = isProjectConv
-        ? "is not a member of this pod and only pod editors can add new members."
+        ? "is not a member of this Pod and only Pod editors can add new members."
         : "doesn't have access to this conversation's spaces and won't be able to view it nor be invited.";
 
       return (

--- a/front/components/assistant/conversation/MentionInvalid.tsx
+++ b/front/components/assistant/conversation/MentionInvalid.tsx
@@ -71,7 +71,7 @@ export function MentionInvalid({
       // Different message for project conversations (non-editor can't add members)
       const isProjectConv = isProjectConversation(conversation);
       const message = isProjectConv
-        ? "is not a member of this project and only project editors can add new members."
+        ? "is not a member of this pod and only pod editors can add new members."
         : "doesn't have access to this conversation's spaces and won't be able to view it nor be invited.";
 
       return (
@@ -104,7 +104,7 @@ export function MentionInvalid({
             <div>
               <span className="font-semibold">{mention.label}</span> can't be
               invoked as it is configured to use at least one space that the
-              conversation cannot use. Projects conversations cannot use private
+              conversation cannot use. Pods conversations cannot use private
               spaces.
             </div>
             <div className="ml-auto">

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -74,7 +74,7 @@ export function MentionValidationRequired({
   }
 
   const title = isProjectMembership
-    ? `Add ${mention.label} to this project?`
+    ? `Add ${mention.label} to this pod?`
     : `Invite ${mention.label} to this conversation?`;
 
   const description = isAgentMessageWithStreaming(message) ? (
@@ -82,11 +82,11 @@ export function MentionValidationRequired({
       <span className="font-semibold">@{message.configuration.name}</span>{" "}
       mentioned <span className="font-semibold">{mention.label}</span>.
       {isProjectMembership
-        ? " Do you want to add them to this project?"
+        ? " Do you want to add them to this pod?"
         : " Do you want to invite them? They'll see the full history and be able to reply."}
     </>
   ) : isProjectMembership ? (
-    "They'll have access to all project conversations."
+    "They'll have access to all pod conversations."
   ) : (
     "They'll see the full history and be able to reply."
   );
@@ -109,7 +109,7 @@ export function MentionValidationRequired({
             <Button
               variant="highlight"
               size="sm"
-              label={isProjectMembership ? "Add to project" : "Invite"}
+              label={isProjectMembership ? "Add to pod" : "Invite"}
               disabled={isSubmitting}
               isLoading={isSubmitting}
               onClick={handleApprove}

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -74,7 +74,7 @@ export function MentionValidationRequired({
   }
 
   const title = isProjectMembership
-    ? `Add ${mention.label} to this pod?`
+    ? `Add ${mention.label} to this Pod?`
     : `Invite ${mention.label} to this conversation?`;
 
   const description = isAgentMessageWithStreaming(message) ? (
@@ -82,11 +82,11 @@ export function MentionValidationRequired({
       <span className="font-semibold">@{message.configuration.name}</span>{" "}
       mentioned <span className="font-semibold">{mention.label}</span>.
       {isProjectMembership
-        ? " Do you want to add them to this pod?"
+        ? " Do you want to add them to this Pod?"
         : " Do you want to invite them? They'll see the full history and be able to reply."}
     </>
   ) : isProjectMembership ? (
-    "They'll have access to all pod conversations."
+    "They'll have access to all Pod conversations."
   ) : (
     "They'll see the full history and be able to reply."
   );
@@ -109,7 +109,7 @@ export function MentionValidationRequired({
             <Button
               variant="highlight"
               size="sm"
-              label={isProjectMembership ? "Add to pod" : "Invite"}
+              label={isProjectMembership ? "Add to Pod" : "Invite"}
               disabled={isSubmitting}
               isLoading={isSubmitting}
               onClick={handleApprove}

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -268,7 +268,7 @@ export function ProjectMenu({
             shouldWaitBeforeFetching={shouldWaitBeforeFetching}
           />
           <DropdownMenuSeparator />
-          <DropdownMenuLabel label="Project" />
+          <DropdownMenuLabel label="Pod" />
           {canRename && (
             <DropdownMenuItem
               label="Rename"

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -273,7 +273,7 @@ function SearchResults({
     <div className="h-full overflow-y-auto">
       <NavigationList className="px-2">
         <NavigationListCollapsibleSection
-          label="Projects"
+          label="Pods"
           type="collapse"
           open={projectsSectionOpen}
           onOpenChange={setProjectsSectionOpen}
@@ -758,7 +758,7 @@ export function AgentSidebarMenu({
     return (
       <NavigationList className="px-2">
         <NavigationListCollapsibleSection
-          label={showCount ? `Projects (${projectCountInSummary})` : "Projects"}
+          label={showCount ? `Pods (${projectCountInSummary})` : "Pods"}
           type="collapse"
           visibleItems={VISIBLE_PROJECTS}
           overflowCount={hiddenOverflowCount}
@@ -797,7 +797,7 @@ export function AgentSidebarMenu({
             })
           ) : (
             <NavigationListItem
-              label="Create a Project"
+              label="Create a Pod"
               icon={PlusIcon}
               onClick={() => setIsCreateProjectModalOpen(true)}
             />

--- a/front/components/assistant/conversation/files_panel/FilesTab.tsx
+++ b/front/components/assistant/conversation/files_panel/FilesTab.tsx
@@ -149,7 +149,7 @@ function FileCards({
                     {row.isInProjectContext && (
                       <Tooltip
                         tooltipTriggerAsChild
-                        label="Saved to Project"
+                        label="Saved to Pod"
                         trigger={
                           <span className="inline-flex">
                             <Icon visual={SpaceClosedIcon} size="md" />
@@ -194,7 +194,7 @@ function FileCards({
                   {row.isInProjectContext && (
                     <Tooltip
                       tooltipTriggerAsChild
-                      label="Saved to Project"
+                      label="Saved to Pod"
                       trigger={
                         <span className="inline-flex">
                           <Icon

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -243,7 +243,7 @@ const ProjectFileItem = ({
   const fileKind = getSingularFileCategoryLabelForContentType(item.contentType);
   const description = projectName
     ? `${fileKind} in "${projectName}" knowledge`
-    : `${fileKind} in project knowledge`;
+    : `${fileKind} in pod knowledge`;
   return (
     <DropdownMenuCheckboxItem
       label={item.title}
@@ -499,7 +499,7 @@ export const InputBarAttachmentsPicker = ({
         value: key,
         label:
           key === PROJECT_FILTER_KEY
-            ? "Projects"
+            ? "Pods"
             : getDisplayNameForDataSource(r.dataSource, true),
       });
     }
@@ -515,7 +515,7 @@ export const InputBarAttachmentsPicker = ({
     if (projectFilesWithResults.length > 0) {
       options.set(PROJECT_FILTER_KEY, {
         value: PROJECT_FILTER_KEY,
-        label: "Projects",
+        label: "Pods",
       });
     }
 

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -243,7 +243,7 @@ const ProjectFileItem = ({
   const fileKind = getSingularFileCategoryLabelForContentType(item.contentType);
   const description = projectName
     ? `${fileKind} in "${projectName}" knowledge`
-    : `${fileKind} in pod knowledge`;
+    : `${fileKind} in Pod knowledge`;
   return (
     <DropdownMenuCheckboxItem
       label={item.title}

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -359,14 +359,14 @@ export function FrameRenderer({
     const confirmed = await confirm({
       title: (
         <>
-          Save to <strong>{projectInfo?.name ?? "pod"}</strong>?
+          Save to <strong>{projectInfo?.name ?? "Pod"}</strong>?
         </>
       ),
       message: (
         <>
           <div>
-            The Frame will be part of the pod knowledge, and be able to be
-            edited by any pod member.
+            The Frame will be part of the Pod knowledge, and be able to be
+            edited by any Pod member.
           </div>
           <div>This action cannot be undone.</div>
         </>
@@ -391,22 +391,22 @@ export function FrameRenderer({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to save to pod",
+          title: "Failed to save to Pod",
           description: errorData.message,
         });
         return;
       }
       sendNotification({
         type: "success",
-        title: "Saved to pod",
-        description: `Frame saved to "${projectInfo?.name ?? "pod"}".`,
+        title: "Saved to Pod",
+        description: `Frame saved to "${projectInfo?.name ?? "Pod"}".`,
       });
       // Invalidate file metadata so parent and this component get updated projectId.
       await mutateFileMetadata();
     } catch (e) {
       sendNotification({
         type: "error",
-        title: "Failed to save to pod",
+        title: "Failed to save to Pod",
         description: e instanceof Error ? e.message : "An error occurred",
       });
     } finally {
@@ -464,7 +464,7 @@ export function FrameRenderer({
                 variant="ghost"
                 disabled={true}
                 label="Saved"
-                tooltip={`Saved in "${projectInfo?.name ?? "unknown pod"}"`}
+                tooltip={`Saved in "${projectInfo?.name ?? "unknown Pod"}"`}
               />
             )}
             {projectSaveState === "supported" && (
@@ -473,7 +473,7 @@ export function FrameRenderer({
                 variant="ghost"
                 label={isSavingToProject ? "Saving…" : "Save"}
                 isLoading={isSavingToProject}
-                tooltip={`Save to "${projectInfo?.name ?? "unknown pod"}"`}
+                tooltip={`Save to "${projectInfo?.name ?? "unknown Pod"}"`}
                 onClick={handleSaveToProject}
               />
             )}

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -359,14 +359,14 @@ export function FrameRenderer({
     const confirmed = await confirm({
       title: (
         <>
-          Save to <strong>{projectInfo?.name ?? "project"}</strong>?
+          Save to <strong>{projectInfo?.name ?? "pod"}</strong>?
         </>
       ),
       message: (
         <>
           <div>
-            The Frame will be part of the project knowledge, and be able to be
-            edited by any project member.
+            The Frame will be part of the pod knowledge, and be able to be
+            edited by any pod member.
           </div>
           <div>This action cannot be undone.</div>
         </>
@@ -391,22 +391,22 @@ export function FrameRenderer({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to save to project",
+          title: "Failed to save to pod",
           description: errorData.message,
         });
         return;
       }
       sendNotification({
         type: "success",
-        title: "Saved to project",
-        description: `Frame saved to "${projectInfo?.name ?? "project"}".`,
+        title: "Saved to pod",
+        description: `Frame saved to "${projectInfo?.name ?? "pod"}".`,
       });
       // Invalidate file metadata so parent and this component get updated projectId.
       await mutateFileMetadata();
     } catch (e) {
       sendNotification({
         type: "error",
-        title: "Failed to save to project",
+        title: "Failed to save to pod",
         description: e instanceof Error ? e.message : "An error occurred",
       });
     } finally {
@@ -464,7 +464,7 @@ export function FrameRenderer({
                 variant="ghost"
                 disabled={true}
                 label="Saved"
-                tooltip={`Saved in "${projectInfo?.name ?? "unknown project"}"`}
+                tooltip={`Saved in "${projectInfo?.name ?? "unknown pod"}"`}
               />
             )}
             {projectSaveState === "supported" && (
@@ -473,7 +473,7 @@ export function FrameRenderer({
                 variant="ghost"
                 label={isSavingToProject ? "Saving…" : "Save"}
                 isLoading={isSavingToProject}
-                tooltip={`Save to "${projectInfo?.name ?? "unknown project"}"`}
+                tooltip={`Save to "${projectInfo?.name ?? "unknown pod"}"`}
                 onClick={handleSaveToProject}
               />
             )}

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
@@ -75,7 +75,7 @@ export function PublicInteractiveContentHeader({
           )}
           {user && projectUrl && (
             <Button
-              label="Go to project"
+              label="Go to pod"
               href={projectUrl}
               variant="outline"
               // TODO(projects) this does not show the correct icon for open projects.

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
@@ -75,7 +75,7 @@ export function PublicInteractiveContentHeader({
           )}
           {user && projectUrl && (
             <Button
-              label="Go to pod"
+              label="Go to Pod"
               href={projectUrl}
               variant="outline"
               // TODO(projects) this does not show the correct icon for open projects.

--- a/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
@@ -114,7 +114,7 @@ export function ProjectsBrowsePopover({ owner }: ProjectsBrowsePopoverProps) {
           <div className="shrink-0 p-3 pb-2">
             <SearchInput
               name="browse-projects-search"
-              placeholder="Search pods..."
+              placeholder="Search Pods..."
               value={searchQuery}
               onChange={setSearchQuery}
             />
@@ -124,7 +124,7 @@ export function ProjectsBrowsePopover({ owner }: ProjectsBrowsePopoverProps) {
               <ProjectBrowseItemSkeleton count={5} />
             ) : filteredProjects.length === 0 ? (
               <div className="px-2 py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
-                No pods found
+                No Pods found
               </div>
             ) : (
               <>

--- a/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
@@ -114,7 +114,7 @@ export function ProjectsBrowsePopover({ owner }: ProjectsBrowsePopoverProps) {
           <div className="shrink-0 p-3 pb-2">
             <SearchInput
               name="browse-projects-search"
-              placeholder="Search projects..."
+              placeholder="Search pods..."
               value={searchQuery}
               onChange={setSearchQuery}
             />
@@ -124,7 +124,7 @@ export function ProjectsBrowsePopover({ owner }: ProjectsBrowsePopoverProps) {
               <ProjectBrowseItemSkeleton count={5} />
             ) : filteredProjects.length === 0 ? (
               <div className="px-2 py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
-                No projects found
+                No pods found
               </div>
             ) : (
               <>

--- a/front/components/assistant/conversation/space/ManageUsersPanel.tsx
+++ b/front/components/assistant/conversation/space/ManageUsersPanel.tsx
@@ -123,7 +123,7 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
           name: props.space.name,
         },
         {
-          title: "Successfully updated pod members",
+          title: "Successfully updated Pod members",
           description: "Pod members were successfully updated.",
         }
       );

--- a/front/components/assistant/conversation/space/ManageUsersPanel.tsx
+++ b/front/components/assistant/conversation/space/ManageUsersPanel.tsx
@@ -123,8 +123,8 @@ export function ManageUsersPanel(props: ManageUsersPanelProps) {
           name: props.space.name,
         },
         {
-          title: "Successfully updated project members",
-          description: "Project members were successfully updated.",
+          title: "Successfully updated pod members",
+          description: "Pod members were successfully updated.",
         }
       );
 

--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -95,18 +95,18 @@ export function ProjectHeaderActions({
             <DropdownMenuContent collisionPadding={8}>
               {!canLeaveProject ? (
                 <DropdownTooltipTrigger
-                  description="You are the last editor of this pod and cannot leave it."
+                  description="You are the last editor of this Pod and cannot leave it."
                   side="left"
                 >
                   <DropdownMenuItem
-                    label="Leave the pod"
+                    label="Leave the Pod"
                     icon={XMarkIcon}
                     disabled={true}
                   />
                 </DropdownTooltipTrigger>
               ) : (
                 <DropdownMenuItem
-                  label="Leave the pod"
+                  label="Leave the Pod"
                   icon={XMarkIcon}
                   onClick={openLeaveDialog}
                 />

--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -95,18 +95,18 @@ export function ProjectHeaderActions({
             <DropdownMenuContent collisionPadding={8}>
               {!canLeaveProject ? (
                 <DropdownTooltipTrigger
-                  description="You are the last editor of this project and cannot leave it."
+                  description="You are the last editor of this pod and cannot leave it."
                   side="left"
                 >
                   <DropdownMenuItem
-                    label="Leave the project"
+                    label="Leave the pod"
                     icon={XMarkIcon}
                     disabled={true}
                   />
                 </DropdownTooltipTrigger>
               ) : (
                 <DropdownMenuItem
-                  label="Leave the project"
+                  label="Leave the pod"
                   icon={XMarkIcon}
                   onClick={openLeaveDialog}
                 />

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -80,7 +80,7 @@ interface SpaceKnowledgeTabProps {
 }
 
 const PROJECT_KNOWLEDGE_MANAGEMENT_DISABLED_TOOLTIP =
-  "Adding files to projects is disabled by your workspace admin.";
+  "Adding files to pods is disabled by your workspace admin.";
 
 // TODO(2026-05 FILE SYSTEM): Remove once the file explorer supports rendering
 // path-only files natively. Sentinel id needed today to squeeze path-only entries
@@ -493,7 +493,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     }
     const confirmed = await confirm({
       title: "Remove content node?",
-      message: `Are you sure you want to remove "${item.title}" from this project?`,
+      message: `Are you sure you want to remove "${item.title}" from this pod?`,
       validateLabel: "Remove",
       validateVariant: "warning",
     });
@@ -903,8 +903,8 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
             <EmptyCTA
               message={
                 isArchived
-                  ? "This project is archived. No files have been added."
-                  : "No files have been added to this project yet."
+                  ? "This pod is archived. No files have been added."
+                  : "No files have been added to this pod yet."
               }
               action={
                 isArchived ? null : (

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -80,7 +80,7 @@ interface SpaceKnowledgeTabProps {
 }
 
 const PROJECT_KNOWLEDGE_MANAGEMENT_DISABLED_TOOLTIP =
-  "Adding files to pods is disabled by your workspace admin.";
+  "Adding files to Pods is disabled by your workspace admin.";
 
 // TODO(2026-05 FILE SYSTEM): Remove once the file explorer supports rendering
 // path-only files natively. Sentinel id needed today to squeeze path-only entries
@@ -493,7 +493,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     }
     const confirmed = await confirm({
       title: "Remove content node?",
-      message: `Are you sure you want to remove "${item.title}" from this pod?`,
+      message: `Are you sure you want to remove "${item.title}" from this Pod?`,
       validateLabel: "Remove",
       validateVariant: "warning",
     });
@@ -903,8 +903,8 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
             <EmptyCTA
               message={
                 isArchived
-                  ? "This pod is archived. No files have been added."
-                  : "No files have been added to this pod yet."
+                  ? "This Pod is archived. No files have been added."
+                  : "No files have been added to this Pod yet."
               }
               action={
                 isArchived ? null : (

--- a/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
+++ b/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
@@ -55,7 +55,7 @@ export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
     >
       <DialogTrigger asChild>
         <div className="flex w-full flex-col items-start">
-          <Button icon={TrashIcon} variant="warning" label="Delete pod" />
+          <Button icon={TrashIcon} variant="warning" label="Delete Pod" />
         </div>
       </DialogTrigger>
       <DialogContent size="md">
@@ -71,7 +71,7 @@ export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
             <DialogContainer className="flex flex-col gap-4">
               <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                 Type <strong>delete</strong> below to confirm. This permanently
-                removes all pod content and cannot be undone.
+                removes all Pod content and cannot be undone.
               </p>
               <Input
                 name="delete-confirm"

--- a/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
+++ b/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
@@ -55,7 +55,7 @@ export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
     >
       <DialogTrigger asChild>
         <div className="flex w-full flex-col items-start">
-          <Button icon={TrashIcon} variant="warning" label="Delete project" />
+          <Button icon={TrashIcon} variant="warning" label="Delete pod" />
         </div>
       </DialogTrigger>
       <DialogContent size="md">
@@ -71,7 +71,7 @@ export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
             <DialogContainer className="flex flex-col gap-4">
               <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                 Type <strong>delete</strong> below to confirm. This permanently
-                removes all project content and cannot be undone.
+                removes all pod content and cannot be undone.
               </p>
               <Input
                 name="delete-confirm"

--- a/front/components/assistant/conversation/space/about/MembersTable.tsx
+++ b/front/components/assistant/conversation/space/about/MembersTable.tsx
@@ -65,7 +65,7 @@ export function MembersTable({
       const updatedMembers = selectedMembers.filter((m) => m.sId !== userId);
       if (!updatedMembers.some((m) => m.isEditor)) {
         sendNotifications({
-          title: "Projects must have at least one editor.",
+          title: "Pods must have at least one editor.",
           description: "You cannot remove the last editor.",
           type: "error",
         });
@@ -85,7 +85,7 @@ export function MembersTable({
         },
         {
           title: "Successfully removed member",
-          description: "Project member was successfully removed.",
+          description: "Pod member was successfully removed.",
         }
       );
       if (updateMember) {
@@ -114,7 +114,7 @@ export function MembersTable({
 
       if (updatedMembers.filter((m) => m.isEditor).length === 0) {
         sendNotifications({
-          title: "Projects must have at least one editor.",
+          title: "Pods must have at least one editor.",
           description: "You cannot remove the last editor.",
           type: "error",
         });
@@ -139,8 +139,8 @@ export function MembersTable({
             ? "Successfully added editor"
             : "Successfully removed editor",
           description: newIsEditorValue
-            ? "Project editor was successfully added."
-            : "Project editor was successfully removed.",
+            ? "Pod editor was successfully added."
+            : "Pod editor was successfully removed.",
         }
       );
       if (updateMember) {
@@ -288,13 +288,13 @@ export function MembersTable({
                       editorSettingItem,
                       {
                         kind: "item",
-                        label: "Remove from project",
+                        label: "Remove from pod",
                         icon: TrashIcon,
                         variant: "warning",
                         onClick: async () => {
                           const confirmed = await confirm({
                             title: "Remove member",
-                            message: `Are you sure you want to remove "${info.row.original.name}" from this project?`,
+                            message: `Are you sure you want to remove "${info.row.original.name}" from this pod?`,
                             validateLabel: "Remove",
                             validateVariant: "warning",
                           });

--- a/front/components/assistant/conversation/space/about/MembersTable.tsx
+++ b/front/components/assistant/conversation/space/about/MembersTable.tsx
@@ -288,13 +288,13 @@ export function MembersTable({
                       editorSettingItem,
                       {
                         kind: "item",
-                        label: "Remove from pod",
+                        label: "Remove from Pod",
                         icon: TrashIcon,
                         variant: "warning",
                         onClick: async () => {
                           const confirmed = await confirm({
                             title: "Remove member",
-                            message: `Are you sure you want to remove "${info.row.original.name}" from this pod?`,
+                            message: `Are you sure you want to remove "${info.row.original.name}" from this Pod?`,
                             validateLabel: "Remove",
                             validateVariant: "warning",
                           });

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -48,7 +48,7 @@ interface SpaceAboutTabProps {
 }
 
 const OPEN_PROJECTS_DISABLED_TOOLTIP =
-  "Open pods are disabled by your workspace admin.";
+  "Open Pods are disabled by your workspace admin.";
 
 export function SpaceAboutTab({
   owner,
@@ -124,8 +124,8 @@ export function SpaceAboutTab({
       return;
     }
     const confirmed = await confirm({
-      title: "Update pod name?",
-      message: `The pod name will be changed to "${newProjectName}".`,
+      title: "Update Pod name?",
+      message: `The Pod name will be changed to "${newProjectName}".`,
       validateVariant: "warning",
     });
 
@@ -143,8 +143,8 @@ export function SpaceAboutTab({
         name: newProjectName,
       },
       {
-        title: "Successfully updated pod name",
-        description: "pod name was successfully updated.",
+        title: "Successfully updated Pod name",
+        description: "Pod name was successfully updated.",
       }
     );
 
@@ -178,7 +178,7 @@ export function SpaceAboutTab({
     const newIsPublic = !isPublic;
     const title = newIsPublic ? "Switch to public?" : "Switch to restricted?";
     const message = newIsPublic
-      ? "All workspace members will be able to join and see everything in this pod — including existing conversations and files."
+      ? "All workspace members will be able to join and see everything in this Pod — including existing conversations and files."
       : "Access will be limited to invited members only.";
 
     const confirmed = await confirm({
@@ -201,7 +201,7 @@ export function SpaceAboutTab({
         name: space.name,
       },
       {
-        title: "Successfully updated pod visibility",
+        title: "Successfully updated Pod visibility",
         description: "Pod visibility was successfully updated.",
       }
     );
@@ -234,13 +234,13 @@ export function SpaceAboutTab({
                 {projectMetadata?.archivedAt ? (
                   <DropdownMenuItem
                     icon={ArrowUpOnSquareIcon}
-                    label="Unarchive pod"
+                    label="Unarchive Pod"
                     onClick={handleArchiveToggle}
                   />
                 ) : (
                   <DropdownMenuItem
                     icon={ArchiveIcon}
-                    label="Archive pod"
+                    label="Archive Pod"
                     variant="warning"
                     onClick={handleArchiveToggle}
                   />
@@ -251,7 +251,7 @@ export function SpaceAboutTab({
         </div>
         {space.archivedAt && (
           <ContentMessage variant="info" size="lg">
-            This pod has been archived.
+            This Pod has been archived.
           </ContentMessage>
         )}
         <div className="flex w-full flex-col gap-2">
@@ -265,7 +265,7 @@ export function SpaceAboutTab({
                 setNameToCheck(e.target.value);
                 setIsEditingName(e.target.value.trim() !== space.name.trim());
               }}
-              placeholder="Enter pod name"
+              placeholder="Enter Pod name"
               containerClassName="flex-1"
             />
             {isEditingName && (
@@ -290,7 +290,7 @@ export function SpaceAboutTab({
           </div>
           {isEditingName && nameNotAvailable && (
             <div className="text-xs text-warning-500">
-              A pod or space with this name already exists.
+              A Pod or space with this name already exists.
             </div>
           )}
         </div>
@@ -308,7 +308,7 @@ export function SpaceAboutTab({
               placeholder={
                 isProjectMetadataLoading
                   ? "Loading..."
-                  : "Describe what this pod is about..."
+                  : "Describe what this Pod is about..."
               }
               disabled={isProjectMetadataLoading || !isProjectEditor}
               minRows={3}
@@ -341,7 +341,7 @@ export function SpaceAboutTab({
               <ProjectSettingsOptionLabel
                 icon={GlobeAltIcon}
                 title="Open to everyone"
-                description="Anyone in the workspace can find and join the pod."
+                description="Anyone in the workspace can find and join the Pod."
               />
               <div className="flex shrink-0 items-center gap-2">
                 {isVisibilityToggleDisabled ? (
@@ -438,7 +438,7 @@ export function SpaceAboutTab({
             ) : (
               <>
                 <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                  This pod will be removed from the sidebar. Its data stays
+                  This Pod will be removed from the sidebar. Its data stays
                   intact and can still be used as a data source.
                 </p>
                 <Button
@@ -453,7 +453,7 @@ export function SpaceAboutTab({
             <h4 className="heading-base">Delete</h4>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               This permanently removes all content—conversations, folders,
-              websites, and data sources. Assistants using this pod's tools will
+              websites, and data sources. Assistants using this Pod's tools will
               be impacted. This cannot be undone.
             </p>
             <DeleteSpaceDialog owner={owner} space={space} />

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -48,7 +48,7 @@ interface SpaceAboutTabProps {
 }
 
 const OPEN_PROJECTS_DISABLED_TOOLTIP =
-  "Open projects are disabled by your workspace admin.";
+  "Open pods are disabled by your workspace admin.";
 
 export function SpaceAboutTab({
   owner,
@@ -124,8 +124,8 @@ export function SpaceAboutTab({
       return;
     }
     const confirmed = await confirm({
-      title: "Update project name?",
-      message: `The project name will be changed to "${newProjectName}".`,
+      title: "Update pod name?",
+      message: `The pod name will be changed to "${newProjectName}".`,
       validateVariant: "warning",
     });
 
@@ -143,8 +143,8 @@ export function SpaceAboutTab({
         name: newProjectName,
       },
       {
-        title: "Successfully updated project name",
-        description: "Project name was successfully updated.",
+        title: "Successfully updated pod name",
+        description: "pod name was successfully updated.",
       }
     );
 
@@ -178,7 +178,7 @@ export function SpaceAboutTab({
     const newIsPublic = !isPublic;
     const title = newIsPublic ? "Switch to public?" : "Switch to restricted?";
     const message = newIsPublic
-      ? "All workspace members will be able to join and see everything in this project — including existing conversations and files."
+      ? "All workspace members will be able to join and see everything in this pod — including existing conversations and files."
       : "Access will be limited to invited members only.";
 
     const confirmed = await confirm({
@@ -201,8 +201,8 @@ export function SpaceAboutTab({
         name: space.name,
       },
       {
-        title: "Successfully updated project visibility",
-        description: "Project visibility was successfully updated.",
+        title: "Successfully updated pod visibility",
+        description: "Pod visibility was successfully updated.",
       }
     );
 
@@ -234,13 +234,13 @@ export function SpaceAboutTab({
                 {projectMetadata?.archivedAt ? (
                   <DropdownMenuItem
                     icon={ArrowUpOnSquareIcon}
-                    label="Unarchive project"
+                    label="Unarchive pod"
                     onClick={handleArchiveToggle}
                   />
                 ) : (
                   <DropdownMenuItem
                     icon={ArchiveIcon}
-                    label="Archive project"
+                    label="Archive pod"
                     variant="warning"
                     onClick={handleArchiveToggle}
                   />
@@ -251,7 +251,7 @@ export function SpaceAboutTab({
         </div>
         {space.archivedAt && (
           <ContentMessage variant="info" size="lg">
-            This project has been archived.
+            This pod has been archived.
           </ContentMessage>
         )}
         <div className="flex w-full flex-col gap-2">
@@ -265,7 +265,7 @@ export function SpaceAboutTab({
                 setNameToCheck(e.target.value);
                 setIsEditingName(e.target.value.trim() !== space.name.trim());
               }}
-              placeholder="Enter project name"
+              placeholder="Enter pod name"
               containerClassName="flex-1"
             />
             {isEditingName && (
@@ -290,7 +290,7 @@ export function SpaceAboutTab({
           </div>
           {isEditingName && nameNotAvailable && (
             <div className="text-xs text-warning-500">
-              A project or space with this name already exists.
+              A pod or space with this name already exists.
             </div>
           )}
         </div>
@@ -308,7 +308,7 @@ export function SpaceAboutTab({
               placeholder={
                 isProjectMetadataLoading
                   ? "Loading..."
-                  : "Describe what this project is about..."
+                  : "Describe what this pod is about..."
               }
               disabled={isProjectMetadataLoading || !isProjectEditor}
               minRows={3}
@@ -341,7 +341,7 @@ export function SpaceAboutTab({
               <ProjectSettingsOptionLabel
                 icon={GlobeAltIcon}
                 title="Open to everyone"
-                description="Anyone in the workspace can find and join the project."
+                description="Anyone in the workspace can find and join the pod."
               />
               <div className="flex shrink-0 items-center gap-2">
                 {isVisibilityToggleDisabled ? (
@@ -438,7 +438,7 @@ export function SpaceAboutTab({
             ) : (
               <>
                 <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                  This project will be removed from the sidebar. Its data stays
+                  This pod will be removed from the sidebar. Its data stays
                   intact and can still be used as a data source.
                 </p>
                 <Button
@@ -453,8 +453,8 @@ export function SpaceAboutTab({
             <h4 className="heading-base">Delete</h4>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               This permanently removes all content—conversations, folders,
-              websites, and data sources. Assistants using this project's tools
-              will be impacted. This cannot be undone.
+              websites, and data sources. Assistants using this pod's tools will
+              be impacted. This cannot be undone.
             </p>
             <DeleteSpaceDialog owner={owner} space={space} />
           </div>

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
@@ -12,7 +12,7 @@ export function SpaceConversationsActions({
   const suggestions = [
     {
       id: "onboarding-tasks",
-      label: "Get your pod off the ground",
+      label: "Get your Pod off the ground",
       icon: CheckIcon,
       description:
         "Add context, connect your knowledge, and bring the right people in. Flying solo? It still keeps everything in one place.",

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
@@ -12,7 +12,7 @@ export function SpaceConversationsActions({
   const suggestions = [
     {
       id: "onboarding-tasks",
-      label: "Get your project off the ground",
+      label: "Get your pod off the ground",
       icon: CheckIcon,
       description:
         "Add context, connect your knowledge, and bring the right people in. Flying solo? It still keeps everything in one place.",
@@ -27,7 +27,7 @@ export function SpaceConversationsActions({
   return (
     <div className="flex flex-col gap-3">
       <h3 className="heading-lg text-foreground dark:text-foreground-night">
-        New Project? Let us help you setup.
+        New Pod? Let us help you setup.
       </h3>
       <CardGrid>
         {suggestions.map((suggestion) => (

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -103,7 +103,7 @@ export function SpaceConversationsTab({
       case "all":
         return "No conversations found.";
       case "group":
-        return "No group conversations yet in this project.";
+        return "No group conversations yet in this pod.";
       case "with_me":
         return "You are not a participant in any conversation yet.";
     }
@@ -184,7 +184,7 @@ export function SpaceConversationsTab({
             {spaceInfo.archivedAt ? (
               <div className="mx-auto flex flex-col w-full py-4 sm:max-w-conversation">
                 <EmptyCTA
-                  message="This project is archived and no longer appears in your sidebar. You can still search for it and view past conversations, but you cannot start new ones."
+                  message="This pod is archived and no longer appears in your sidebar. You can still search for it and view past conversations, but you cannot start new ones."
                   action={null}
                 />
               </div>
@@ -290,7 +290,7 @@ export function SpaceConversationsTab({
                       <ButtonsSwitch
                         value="all"
                         label="All"
-                        tooltip="Every conversation in this project."
+                        tooltip="Every conversation in this pod."
                         onClick={() => onConversationFilterChange("all")}
                       />
                     </ButtonsSwitchList>

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -103,7 +103,7 @@ export function SpaceConversationsTab({
       case "all":
         return "No conversations found.";
       case "group":
-        return "No group conversations yet in this pod.";
+        return "No group conversations yet in this Pod.";
       case "with_me":
         return "You are not a participant in any conversation yet.";
     }
@@ -184,7 +184,7 @@ export function SpaceConversationsTab({
             {spaceInfo.archivedAt ? (
               <div className="mx-auto flex flex-col w-full py-4 sm:max-w-conversation">
                 <EmptyCTA
-                  message="This pod is archived and no longer appears in your sidebar. You can still search for it and view past conversations, but you cannot start new ones."
+                  message="This Pod is archived and no longer appears in your sidebar. You can still search for it and view past conversations, but you cannot start new ones."
                   action={null}
                 />
               </div>
@@ -290,7 +290,7 @@ export function SpaceConversationsTab({
                       <ButtonsSwitch
                         value="all"
                         label="All"
-                        tooltip="Every conversation in this pod."
+                        tooltip="Every conversation in this Pod."
                         onClick={() => onConversationFilterChange("all")}
                       />
                     </ButtonsSwitchList>

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskCreateBar.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskCreateBar.tsx
@@ -27,7 +27,7 @@ export function ProjectTaskCreateBar() {
   if (projectMembers.length === 0 || !defaultNewAssigneeId) {
     return (
       <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        No project members available to assign.
+        No pod members available to assign.
       </p>
     );
   }

--- a/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskCreateBar.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskCreateBar.tsx
@@ -27,7 +27,7 @@ export function ProjectTaskCreateBar() {
   if (projectMembers.length === 0 || !defaultNewAssigneeId) {
     return (
       <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        No pod members available to assign.
+        No Pod members available to assign.
       </p>
     );
   }

--- a/front/components/assistant/conversation/space/conversations/project_tasks/SuggestedTaskItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/SuggestedTaskItem.tsx
@@ -42,7 +42,7 @@ export const SuggestedTaskItem = memo(function SuggestedTaskItem({
 
   const canAct = viewerUserId !== null && !isReadOnly;
   const rationaleText =
-    task.actorRationale?.trim() || "Suggested from your pod takeaways.";
+    task.actorRationale?.trim() || "Suggested from your Pod takeaways.";
 
   return (
     <div className="group/suggestion-item flex items-start gap-3 py-1 pl-6">

--- a/front/components/assistant/conversation/space/conversations/project_tasks/SuggestedTaskItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/SuggestedTaskItem.tsx
@@ -42,7 +42,7 @@ export const SuggestedTaskItem = memo(function SuggestedTaskItem({
 
   const canAct = viewerUserId !== null && !isReadOnly;
   const rationaleText =
-    task.actorRationale?.trim() || "Suggested from your project takeaways.";
+    task.actorRationale?.trim() || "Suggested from your pod takeaways.";
 
   return (
     <div className="group/suggestion-item flex items-start gap-3 py-1 pl-6">

--- a/front/components/assistant/conversation/space/conversations/project_tasks/SuggestedTasksGenerationTile.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/SuggestedTasksGenerationTile.tsx
@@ -17,12 +17,12 @@ import {
 import { useCallback, useContext, useRef, useState } from "react";
 
 const SUGGEST_TO_DOS_TOOLTIP =
-  "When this is on, Dust periodically reviews this pod's conversations and connected sources and adds suggested tasks. Turn it off if you only want tasks you create yourself.";
+  "When this is on, Dust periodically reviews this Pod's conversations and connected sources and adds suggested tasks. Turn it off if you only want tasks you create yourself.";
 
-const SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR = `${SUGGEST_TO_DOS_TOOLTIP} Only pod editors can change this.`;
+const SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR = `${SUGGEST_TO_DOS_TOOLTIP} Only Pod editors can change this.`;
 
 const LAST_SCAN_NEVER_TOOLTIP =
-  "Dust has not run an automatic scan for task suggestions for this pod yet.";
+  "Dust has not run an automatic scan for task suggestions for this Pod yet.";
 
 function lastScanTooltip(lastTodoAnalysisAt: number | null): string {
   if (lastTodoAnalysisAt == null) {
@@ -63,7 +63,7 @@ export function SuggestedTasksGenerationTile({
   const sliderDisabled = structurallyDisabled || isUpdatingTodoGeneration;
 
   const toggleTooltip = isProjectArchived
-    ? "This pod is archived; suggestion settings cannot be changed."
+    ? "This Pod is archived; suggestion settings cannot be changed."
     : !space.isEditor && space.isMember
       ? SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR
       : SUGGEST_TO_DOS_TOOLTIP;
@@ -138,7 +138,7 @@ export function SuggestedTasksGenerationTile({
       <ProjectSettingsOptionLabel
         icon={SparklesIcon}
         title="Suggest tasks"
-        description="Automatic task suggestions from pod activity"
+        description="Automatic task suggestions from Pod activity"
         trailingInTitle={
           <Chip color="golden" label="Experimental" size="mini" />
         }

--- a/front/components/assistant/conversation/space/conversations/project_tasks/SuggestedTasksGenerationTile.tsx
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/SuggestedTasksGenerationTile.tsx
@@ -17,12 +17,12 @@ import {
 import { useCallback, useContext, useRef, useState } from "react";
 
 const SUGGEST_TO_DOS_TOOLTIP =
-  "When this is on, Dust periodically reviews this project’s conversations and connected sources and adds suggested tasks. Turn it off if you only want tasks you create yourself.";
+  "When this is on, Dust periodically reviews this pod's conversations and connected sources and adds suggested tasks. Turn it off if you only want tasks you create yourself.";
 
-const SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR = `${SUGGEST_TO_DOS_TOOLTIP} Only project editors can change this.`;
+const SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR = `${SUGGEST_TO_DOS_TOOLTIP} Only pod editors can change this.`;
 
 const LAST_SCAN_NEVER_TOOLTIP =
-  "Dust has not run an automatic scan for task suggestions for this project yet.";
+  "Dust has not run an automatic scan for task suggestions for this pod yet.";
 
 function lastScanTooltip(lastTodoAnalysisAt: number | null): string {
   if (lastTodoAnalysisAt == null) {
@@ -63,7 +63,7 @@ export function SuggestedTasksGenerationTile({
   const sliderDisabled = structurallyDisabled || isUpdatingTodoGeneration;
 
   const toggleTooltip = isProjectArchived
-    ? "This project is archived; suggestion settings cannot be changed."
+    ? "This pod is archived; suggestion settings cannot be changed."
     : !space.isEditor && space.isMember
       ? SUGGEST_TO_DOS_TOOLTIP_NON_EDITOR
       : SUGGEST_TO_DOS_TOOLTIP;
@@ -138,7 +138,7 @@ export function SuggestedTasksGenerationTile({
       <ProjectSettingsOptionLabel
         icon={SparklesIcon}
         title="Suggest tasks"
-        description="Automatic task suggestions from project activity"
+        description="Automatic task suggestions from pod activity"
         trailingInTitle={
           <Chip color="golden" label="Experimental" size="mini" />
         }

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -61,7 +61,7 @@ const NOTIFICATION_CONDITION_DESCRIPTIONS: Record<
   NotificationCondition,
   string
 > = {
-  all_messages: "New messages in projects and conversations",
+  all_messages: "New messages in pods and conversations",
   only_mentions: "New messages when directly mentioned",
   never: "No notifications",
 };

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -61,7 +61,7 @@ const NOTIFICATION_CONDITION_DESCRIPTIONS: Record<
   NotificationCondition,
   string
 > = {
-  all_messages: "New messages in pods and conversations",
+  all_messages: "New messages in Pods and conversations",
   only_mentions: "New messages when directly mentioned",
   never: "No notifications",
 };

--- a/front/components/poke/pages/ProjectPage.tsx
+++ b/front/components/poke/pages/ProjectPage.tsx
@@ -16,14 +16,14 @@ interface ProjectPageProps {
 
 export function ProjectPage({ details }: ProjectPageProps) {
   const owner = useWorkspace();
-  useDocumentTitle(`Poke - ${owner.name} - Project`);
+  useDocumentTitle(`Poke - ${owner.name} - Pod`);
 
   const { members, metadata, space } = details;
 
   return (
     <>
       <h3 className="text-xl font-bold">
-        Project {space.name} within workspace{" "}
+        Pod {space.name} within workspace{" "}
         <LinkWrapper href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
         </LinkWrapper>

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -265,7 +265,7 @@ export function WorkspacePage() {
               <TabsTrigger value="featureflags" label="Feature Flags" />
               <TabsTrigger value="groups" label="Groups" />
               <TabsTrigger value="mcpviews" label="MCP Server Views" />
-              <TabsTrigger value="projects" label="Projects" />
+              <TabsTrigger value="pods" label="Pods" />
               <TabsTrigger value="skills" label="Skills" />
               <TabsTrigger value="spaces" label="Spaces" />
 
@@ -284,7 +284,7 @@ export function WorkspacePage() {
             <TabsContent value="mcpviews">
               <MCPServerViewsDataTable owner={owner} loadOnInit />
             </TabsContent>
-            <TabsContent value="projects">
+            <TabsContent value="pods">
               <ProjectsDataTable owner={owner} loadOnInit />
             </TabsContent>
             <TabsContent value="spaces">

--- a/front/components/poke/projects/table.tsx
+++ b/front/components/poke/projects/table.tsx
@@ -15,7 +15,7 @@ export function ProjectsDataTable({
 }: ProjectsDataTableProps) {
   return (
     <PokeDataTableConditionalFetch
-      header="Projects"
+      header="Pods"
       owner={owner}
       loadOnInit={loadOnInit}
       useSWRHook={usePokeProjects}

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -101,12 +101,12 @@ export function useRemoveSpaceConfirm({
     const hasKnowledge = knowledgeInInstructions.length > 0;
 
     return confirm({
-      title: `Remove ${getSpaceName(space)} ${space.kind === "project" ? "pod" : "space"}`,
+      title: `Remove ${getSpaceName(space)} ${space.kind === "project" ? "Pod" : "space"}`,
       message: (
         <div className="space-y-3">
           <p className="text-sm">
             {hasKnowledge
-              ? `The following elements from this ${space.kind === "project" ? "pod" : "space"} are used in the ${entityName}:`
+              ? `The following elements from this ${space.kind === "project" ? "Pod" : "space"} are used in the ${entityName}:`
               : `This will remove the following elements from the ${entityName}:`}
           </p>
           <span className="flex flex-wrap items-center gap-1">
@@ -126,7 +126,7 @@ export function useRemoveSpaceConfirm({
           </span>
           {hasKnowledge && (
             <p className="dark:text-warning-night text-sm">
-              To remove this {space.kind === "project" ? "pod" : "space"}, first
+              To remove this {space.kind === "project" ? "Pod" : "space"}, first
               update your instructions to remove the knowledge references.
             </p>
           )}

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -101,12 +101,12 @@ export function useRemoveSpaceConfirm({
     const hasKnowledge = knowledgeInInstructions.length > 0;
 
     return confirm({
-      title: `Remove ${getSpaceName(space)} ${space.kind === "project" ? "project" : "space"}`,
+      title: `Remove ${getSpaceName(space)} ${space.kind === "project" ? "pod" : "space"}`,
       message: (
         <div className="space-y-3">
           <p className="text-sm">
             {hasKnowledge
-              ? `The following elements from this ${space.kind === "project" ? "project" : "space"} are used in the ${entityName}:`
+              ? `The following elements from this ${space.kind === "project" ? "pod" : "space"} are used in the ${entityName}:`
               : `This will remove the following elements from the ${entityName}:`}
           </p>
           <span className="flex flex-wrap items-center gap-1">
@@ -126,8 +126,8 @@ export function useRemoveSpaceConfirm({
           </span>
           {hasKnowledge && (
             <p className="dark:text-warning-night text-sm">
-              To remove this {space.kind === "project" ? "project" : "space"},
-              first update your instructions to remove the knowledge references.
+              To remove this {space.kind === "project" ? "pod" : "space"}, first
+              update your instructions to remove the knowledge references.
             </p>
           )}
         </div>

--- a/front/components/spaces/ProjectJoinCTA.tsx
+++ b/front/components/spaces/ProjectJoinCTA.tsx
@@ -30,12 +30,12 @@ export function ProjectJoinCTA({
   };
 
   const message = isRestricted
-    ? "You need to be invited to participate in this project."
-    : "Join this project to participate in conversations.";
+    ? "You need to be invited to participate in this pod."
+    : "Join this pod to participate in conversations.";
 
   const action = isRestricted ? null : (
     <Button
-      label={isJoining ? "Joining..." : `Join the ${spaceName} project`}
+      label={isJoining ? "Joining..." : `Join the ${spaceName} pod`}
       variant="highlight"
       onClick={handleJoin}
       disabled={isJoining}

--- a/front/components/spaces/ProjectJoinCTA.tsx
+++ b/front/components/spaces/ProjectJoinCTA.tsx
@@ -30,12 +30,12 @@ export function ProjectJoinCTA({
   };
 
   const message = isRestricted
-    ? "You need to be invited to participate in this pod."
-    : "Join this pod to participate in conversations.";
+    ? "You need to be invited to participate in this Pod."
+    : "Join this Pod to participate in conversations.";
 
   const action = isRestricted ? null : (
     <Button
-      label={isJoining ? "Joining..." : `Join the ${spaceName} pod`}
+      label={isJoining ? "Joining..." : `Join the ${spaceName} Pod`}
       variant="highlight"
       onClick={handleJoin}
       disabled={isJoining}

--- a/front/components/workspace/settings/OpenProjectsPolicy.tsx
+++ b/front/components/workspace/settings/OpenProjectsPolicy.tsx
@@ -16,15 +16,15 @@ import {
 const OPEN_PROJECTS_POLICIES = [
   {
     value: "private_and_open",
-    label: "Private and open pods",
-    description: "Members can create either private or open pods.",
+    label: "Private and open Pods",
+    description: "Members can create either private or open Pods.",
     icon: SpaceOpenIcon,
     allowOpenProjects: true,
   },
   {
     value: "private_only",
-    label: "Private pods only",
-    description: "Members can only create private pods.",
+    label: "Private Pods only",
+    description: "Members can only create private Pods.",
     icon: SpaceClosedIcon,
     allowOpenProjects: false,
   },
@@ -46,7 +46,7 @@ export function OpenProjectsPolicy({ owner }: { owner: WorkspaceType }) {
   return (
     <ContextItem
       title="Pod visibility policy"
-      subElement="Control whether pods can be private only or private and open."
+      subElement="Control whether Pods can be private only or private and open."
       visual={<SpaceClosedIcon className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/components/workspace/settings/OpenProjectsPolicy.tsx
+++ b/front/components/workspace/settings/OpenProjectsPolicy.tsx
@@ -16,15 +16,15 @@ import {
 const OPEN_PROJECTS_POLICIES = [
   {
     value: "private_and_open",
-    label: "Private and open projects",
-    description: "Members can create either private or open projects.",
+    label: "Private and open pods",
+    description: "Members can create either private or open pods.",
     icon: SpaceOpenIcon,
     allowOpenProjects: true,
   },
   {
     value: "private_only",
-    label: "Private projects only",
-    description: "Members can only create private projects.",
+    label: "Private pods only",
+    description: "Members can only create private pods.",
     icon: SpaceClosedIcon,
     allowOpenProjects: false,
   },
@@ -45,8 +45,8 @@ export function OpenProjectsPolicy({ owner }: { owner: WorkspaceType }) {
 
   return (
     <ContextItem
-      title="Project visibility policy"
-      subElement="Control whether projects can be private only or private and open."
+      title="Pod visibility policy"
+      subElement="Control whether pods can be private only or private and open."
       visual={<SpaceClosedIcon className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/components/workspace/settings/ProjectKnowledgePolicy.tsx
+++ b/front/components/workspace/settings/ProjectKnowledgePolicy.tsx
@@ -17,14 +17,14 @@ const PROJECT_KNOWLEDGE_POLICIES = [
   {
     value: "enabled",
     label: "Manual updates allowed",
-    description: "Members can manually add files to project.",
+    description: "Members can manually add files to pod.",
     icon: BookOpenIcon,
     allowManualProjectKnowledgeManagement: true,
   },
   {
     value: "disabled",
     label: "Manual updates disabled",
-    description: "Members cannot manually add files to project.",
+    description: "Members cannot manually add files to pod.",
     icon: LockIcon,
     allowManualProjectKnowledgeManagement: false,
   },
@@ -50,8 +50,8 @@ export function ProjectKnowledgePolicy({ owner }: { owner: WorkspaceType }) {
 
   return (
     <ContextItem
-      title="Project files policy"
-      subElement="Control whether members can manually add files to project."
+      title="Pod files policy"
+      subElement="Control whether members can manually add files to pods."
       visual={<BookOpenIcon className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/components/workspace/settings/ProjectKnowledgePolicy.tsx
+++ b/front/components/workspace/settings/ProjectKnowledgePolicy.tsx
@@ -17,14 +17,14 @@ const PROJECT_KNOWLEDGE_POLICIES = [
   {
     value: "enabled",
     label: "Manual updates allowed",
-    description: "Members can manually add files to pod.",
+    description: "Members can manually add files to Pod.",
     icon: BookOpenIcon,
     allowManualProjectKnowledgeManagement: true,
   },
   {
     value: "disabled",
     label: "Manual updates disabled",
-    description: "Members cannot manually add files to pod.",
+    description: "Members cannot manually add files to Pod.",
     icon: LockIcon,
     allowManualProjectKnowledgeManagement: false,
   },
@@ -51,7 +51,7 @@ export function ProjectKnowledgePolicy({ owner }: { owner: WorkspaceType }) {
   return (
     <ContextItem
       title="Pod files policy"
-      subElement="Control whether members can manually add files to pods."
+      subElement="Control whether members can manually add files to Pods."
       visual={<BookOpenIcon className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={

--- a/front/hooks/useArchiveProject.tsx
+++ b/front/hooks/useArchiveProject.tsx
@@ -19,9 +19,9 @@ export function useArchiveProject({
 
   const archiveProject = useCallback(async () => {
     const confirmed = await confirm({
-      title: "Archive project?",
+      title: "Archive pod?",
       message:
-        "You'll no longer be able to create new conversations in this project and it will be hidden from the sidebar. However, existing content can still be used by agents. Unarchive it to get back access to it.",
+        "You'll no longer be able to create new conversations in this pod and it will be hidden from the sidebar. However, existing content can still be used by agents. Unarchive it to get back access to it.",
       validateVariant: "warning",
     });
 

--- a/front/hooks/useArchiveProject.tsx
+++ b/front/hooks/useArchiveProject.tsx
@@ -19,9 +19,9 @@ export function useArchiveProject({
 
   const archiveProject = useCallback(async () => {
     const confirmed = await confirm({
-      title: "Archive pod?",
+      title: "Archive Pod?",
       message:
-        "You'll no longer be able to create new conversations in this pod and it will be hidden from the sidebar. However, existing content can still be used by agents. Unarchive it to get back access to it.",
+        "You'll no longer be able to create new conversations in this Pod and it will be hidden from the sidebar. However, existing content can still be used by agents. Unarchive it to get back access to it.",
       validateVariant: "warning",
     });
 

--- a/front/hooks/useMoveConversationOutOfProject.tsx
+++ b/front/hooks/useMoveConversationOutOfProject.tsx
@@ -40,11 +40,11 @@ export function useMoveConversationOutOfProject(
   return useCallback(
     async (conversation: ConversationListItemType): Promise<boolean> => {
       const confirmed = await confirm({
-        title: "Remove from pod?",
+        title: "Remove from Pod?",
         message: (
           <div>
             <strong>{getConversationDisplayTitle(conversation)}</strong> will be
-            removed from the pod. Participants who no longer have access to the
+            removed from the Pod. Participants who no longer have access to the
             required spaces will be removed from the conversation.
           </div>
         ),
@@ -70,7 +70,7 @@ export function useMoveConversationOutOfProject(
         const errorData = await getErrorFromResponse(res);
 
         sendNotification({
-          title: "Error removing conversation from pod.",
+          title: "Error removing conversation from Pod.",
           description: errorData.message,
           type: "error",
         });
@@ -82,7 +82,7 @@ export function useMoveConversationOutOfProject(
       void mutateConversation();
       void sendNotification({
         title: "Conversation removed.",
-        description: "The conversation has been removed from the pod.",
+        description: "The conversation has been removed from the Pod.",
         type: "success",
       });
 

--- a/front/hooks/useMoveConversationOutOfProject.tsx
+++ b/front/hooks/useMoveConversationOutOfProject.tsx
@@ -40,12 +40,12 @@ export function useMoveConversationOutOfProject(
   return useCallback(
     async (conversation: ConversationListItemType): Promise<boolean> => {
       const confirmed = await confirm({
-        title: "Remove from project?",
+        title: "Remove from pod?",
         message: (
           <div>
             <strong>{getConversationDisplayTitle(conversation)}</strong> will be
-            removed from the project. Participants who no longer have access to
-            the required spaces will be removed from the conversation.
+            removed from the pod. Participants who no longer have access to the
+            required spaces will be removed from the conversation.
           </div>
         ),
         validateLabel: "Remove",
@@ -70,7 +70,7 @@ export function useMoveConversationOutOfProject(
         const errorData = await getErrorFromResponse(res);
 
         sendNotification({
-          title: "Error removing conversation from project.",
+          title: "Error removing conversation from pod.",
           description: errorData.message,
           type: "error",
         });
@@ -82,7 +82,7 @@ export function useMoveConversationOutOfProject(
       void mutateConversation();
       void sendNotification({
         title: "Conversation removed.",
-        description: "The conversation has been removed from the project.",
+        description: "The conversation has been removed from the pod.",
         type: "success",
       });
 

--- a/front/hooks/useMoveConversationToProject.tsx
+++ b/front/hooks/useMoveConversationToProject.tsx
@@ -34,12 +34,12 @@ export function useMoveConversationToProject(owner: LightWorkspaceType) {
       space: SpaceType
     ): Promise<boolean> => {
       const confirmed = await confirm({
-        title: "Move conversation to pod",
+        title: "Move conversation to Pod",
         message: (
           <div>
             The content of the conversation{" "}
             <strong>{getConversationDisplayTitle(conversation)}</strong> will be
-            available to all members of the pod <strong>{space.name}</strong>.
+            available to all members of the Pod <strong>{space.name}</strong>.
           </div>
         ),
         validateLabel: "Move",
@@ -78,7 +78,7 @@ export function useMoveConversationToProject(owner: LightWorkspaceType) {
       void mutateSpaceSummary();
       void sendNotification({
         title: "Conversation moved.",
-        description: "The conversation has been moved to the pod.",
+        description: "The conversation has been moved to the Pod.",
         type: "success",
       });
 

--- a/front/hooks/useMoveConversationToProject.tsx
+++ b/front/hooks/useMoveConversationToProject.tsx
@@ -34,13 +34,12 @@ export function useMoveConversationToProject(owner: LightWorkspaceType) {
       space: SpaceType
     ): Promise<boolean> => {
       const confirmed = await confirm({
-        title: "Move conversation to project",
+        title: "Move conversation to pod",
         message: (
           <div>
             The content of the conversation{" "}
             <strong>{getConversationDisplayTitle(conversation)}</strong> will be
-            available to all members of the project{" "}
-            <strong>{space.name}</strong>.
+            available to all members of the pod <strong>{space.name}</strong>.
           </div>
         ),
         validateLabel: "Move",
@@ -79,7 +78,7 @@ export function useMoveConversationToProject(owner: LightWorkspaceType) {
       void mutateSpaceSummary();
       void sendNotification({
         title: "Conversation moved.",
-        description: "The conversation has been moved to the project.",
+        description: "The conversation has been moved to the pod.",
         type: "success",
       });
 

--- a/front/hooks/useOpenProjectsPolicy.ts
+++ b/front/hooks/useOpenProjectsPolicy.ts
@@ -29,14 +29,14 @@ export function useOpenProjectsPolicy({ owner }: UseOpenProjectsPolicyProps) {
       });
 
       if (!res.ok) {
-        throw new Error("Failed to update pod visibility policy.");
+        throw new Error("Failed to update Pod visibility policy.");
       }
 
       setAllowOpenProjects(nextValue);
     } catch (error) {
       sendNotification({
         type: "error",
-        title: "Failed to update pod visibility policy",
+        title: "Failed to update Pod visibility policy",
         description: normalizeError(error).message,
       });
       return false;

--- a/front/hooks/useOpenProjectsPolicy.ts
+++ b/front/hooks/useOpenProjectsPolicy.ts
@@ -29,14 +29,14 @@ export function useOpenProjectsPolicy({ owner }: UseOpenProjectsPolicyProps) {
       });
 
       if (!res.ok) {
-        throw new Error("Failed to update project visibility policy.");
+        throw new Error("Failed to update pod visibility policy.");
       }
 
       setAllowOpenProjects(nextValue);
     } catch (error) {
       sendNotification({
         type: "error",
-        title: "Failed to update project visibility policy",
+        title: "Failed to update pod visibility policy",
         description: normalizeError(error).message,
       });
       return false;

--- a/front/hooks/useProjectKnowledgePolicy.ts
+++ b/front/hooks/useProjectKnowledgePolicy.ts
@@ -32,14 +32,14 @@ export function useProjectKnowledgePolicy({
       });
 
       if (!res.ok) {
-        throw new Error("Failed to update project knowledge policy.");
+        throw new Error("Failed to update pod knowledge policy.");
       }
 
       setAllowManualProjectKnowledgeManagement(nextValue);
     } catch (error) {
       sendNotification({
         type: "error",
-        title: "Failed to update project knowledge policy",
+        title: "Failed to update pod knowledge policy",
         description: normalizeError(error).message,
       });
       return false;

--- a/front/hooks/useProjectKnowledgePolicy.ts
+++ b/front/hooks/useProjectKnowledgePolicy.ts
@@ -32,14 +32,14 @@ export function useProjectKnowledgePolicy({
       });
 
       if (!res.ok) {
-        throw new Error("Failed to update pod knowledge policy.");
+        throw new Error("Failed to update Pod knowledge policy.");
       }
 
       setAllowManualProjectKnowledgeManagement(nextValue);
     } catch (error) {
       sendNotification({
         type: "error",
-        title: "Failed to update pod knowledge policy",
+        title: "Failed to update Pod knowledge policy",
         description: normalizeError(error).message,
       });
       return false;

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -574,9 +574,7 @@ export function parseProjectConfigurationURI(
 ): Result<ProjectConfigInfo, Error> {
   const match = uri.match(PROJECT_CONFIGURATION_URI_PATTERN);
   if (!match) {
-    return new Err(
-      new Error(`Invalid URI for a project configuration: ${uri}`)
-    );
+    return new Err(new Error(`Invalid URI for a pod configuration: ${uri}`));
   }
 
   const [, workspaceId, projectId] = match;

--- a/front/lib/actions/tool_approval_labels.ts
+++ b/front/lib/actions/tool_approval_labels.ts
@@ -34,7 +34,7 @@ export async function getApprovalArgsLabel({
       if (parsedProject.isOk()) {
         const { workspaceId, projectId } = parsedProject.value;
         if (workspaceId !== auth.getNonNullableWorkspace().sId) {
-          return `Always allow @${agentName} to ${asDisplayName(toolName)} in pod ${parsed.data.uri}`;
+          return `Always allow @${agentName} to ${asDisplayName(toolName)} in Pod ${parsed.data.uri}`;
         }
 
         const space = await SpaceResource.fetchById(auth, projectId);

--- a/front/lib/actions/tool_approval_labels.ts
+++ b/front/lib/actions/tool_approval_labels.ts
@@ -34,7 +34,7 @@ export async function getApprovalArgsLabel({
       if (parsedProject.isOk()) {
         const { workspaceId, projectId } = parsedProject.value;
         if (workspaceId !== auth.getNonNullableWorkspace().sId) {
-          return `Always allow @${agentName} to ${asDisplayName(toolName)} in project ${parsed.data.uri}`;
+          return `Always allow @${agentName} to ${asDisplayName(toolName)} in pod ${parsed.data.uri}`;
         }
 
         const space = await SpaceResource.fetchById(auth, projectId);

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -108,8 +108,8 @@ function getDynamicToolDisplayLabels({
       if (toolName === "semantic_search" && isSearchInputTypeWithTags(inputs)) {
         const q = truncateQuery(inputs.query);
         return {
-          running: `Searching “${q}” in project`,
-          done: `Search “${q}” in project`,
+          running: `Searching “${q}” in pod`,
+          done: `Search “${q}” in pod`,
         };
       }
       return null;

--- a/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
@@ -62,7 +62,7 @@ describe("contentFromAttachments", () => {
     const out = contentFromAttachments(attachments);
 
     expect(out).toContain(
-      "The following files are currently attached to the conversation via the project context:"
+      "The following files are currently attached to the conversation via the pod context:"
     );
     expect(out).toContain('id="file-proj"');
     expect(out).toContain('isInProjectContext="true"');
@@ -93,7 +93,7 @@ describe("contentFromAttachments", () => {
     const out = contentFromAttachments(attachments);
 
     const idxDirectHeader = out.indexOf("conversation directly:");
-    const idxProjectHeader = out.indexOf("via the project context:");
+    const idxProjectHeader = out.indexOf("via the pod context:");
     const idxDirectFile = out.indexOf('id="direct-mid"');
     const idxProjFirst = out.indexOf('id="proj-first"');
     const idxProjLast = out.indexOf('id="proj-last"');

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -71,7 +71,7 @@ export const contentFromAttachments = (
     .forEach((attachment, i) => {
       if (i === 0) {
         content +=
-          "The following files are currently attached to the conversation via the project context:\n";
+          "The following files are currently attached to the conversation via the pod context:\n";
       } else {
         content += "\n";
       }

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -527,7 +527,7 @@ export async function createSpaceAndGroup(
         if (spaceKind === "project") {
           assert(
             params.memberIds.length === 0,
-            "Cannot add members to pods on creation."
+            "Cannot add members to Pods on creation."
           );
           break;
         }
@@ -625,7 +625,7 @@ export async function createSpaceAndGroup(
             spaceId: space.sId,
             workspaceId: owner.sId,
           },
-          "Failed to create dust_project connector for pod, but space was created"
+          "Failed to create dust_project connector for Pod, but space was created"
         );
         // Don't fail space creation if connector creation fails
         // The connector can be created later if needed

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -527,7 +527,7 @@ export async function createSpaceAndGroup(
         if (spaceKind === "project") {
           assert(
             params.memberIds.length === 0,
-            "Cannot add members to projects on creation."
+            "Cannot add members to pods on creation."
           );
           break;
         }
@@ -625,7 +625,7 @@ export async function createSpaceAndGroup(
             spaceId: space.sId,
             workspaceId: owner.sId,
           },
-          "Failed to create dust_project connector for project, but space was created"
+          "Failed to create dust_project connector for pod, but space was created"
         );
         // Don't fail space creation if connector creation fails
         // The connector can be created later if needed

--- a/front/lib/connector_providers_ui.ts
+++ b/front/lib/connector_providers_ui.ts
@@ -440,9 +440,9 @@ export const CONNECTOR_UI_CONFIGURATIONS: Record<
   },
   dust_project: {
     hide: true,
-    description: "Use Dust pod as a data source.",
+    description: "Use Dust Pod as a data source.",
     limitations: null,
-    mismatchError: `You cannot change the Dust pod. Please add a new Dust pod connection instead.`,
+    mismatchError: `You cannot change the Dust Pod. Please add a new Dust Pod connection instead.`,
     guideLink: null,
     getLogoComponent: () => {
       return DustLogoSquare;

--- a/front/lib/connector_providers_ui.ts
+++ b/front/lib/connector_providers_ui.ts
@@ -440,9 +440,9 @@ export const CONNECTOR_UI_CONFIGURATIONS: Record<
   },
   dust_project: {
     hide: true,
-    description: "Use Dust project as a data source.",
+    description: "Use Dust pod as a data source.",
     limitations: null,
-    mismatchError: `You cannot change the Dust project. Please add a new Dust project connection instead.`,
+    mismatchError: `You cannot change the Dust pod. Please add a new Dust pod connection instead.`,
     guideLink: null,
     getLogoComponent: () => {
       return DustLogoSquare;

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -41,7 +41,7 @@ export function getDisplayNameForDataSource(
 ) {
   if (ds.connectorProvider) {
     if (ds.connectorProvider === "dust_project") {
-      return aggregate ? "Projects" : ds.name;
+      return aggregate ? "Pods" : ds.name;
     }
     if (ds.connectorProvider === "webcrawler") {
       return aggregate ? "Websites" : ds.name;

--- a/front/lib/project_task/analyze_document/prompts.ts
+++ b/front/lib/project_task/analyze_document/prompts.ts
@@ -7,7 +7,7 @@ export function buildPromptForSourceType(
   switch (sourceType) {
     case "project_conversation":
       return (
-        "IMPORTANT CONTEXT: This is a conversation that was created within the project itself.\n" +
+        "IMPORTANT CONTEXT: This is a conversation that was created within the pod itself.\n" +
         "Messages from the agents are AI-generated responses, NOT from a human participant.\n" +
         "- Do NOT treat user questions that the agents already answered as open action items.\n" +
         "- Only extract action items that represent real commitments between human participants, " +
@@ -18,8 +18,8 @@ export function buildPromptForSourceType(
       );
     case "project_knowledge":
       return (
-        "IMPORTANT CONTEXT: This is a project knowledge document.\n" +
-        "It has been added to the project knowledge base explicitly\n\n"
+        "IMPORTANT CONTEXT: This is a pod knowledge document.\n" +
+        "It has been added to the pod knowledge base explicitly\n\n"
       );
     case "slack":
       return (
@@ -35,27 +35,27 @@ export function buildPromptForSourceType(
     case "notion":
       return (
         "IMPORTANT CONTEXT: This is a notion document.\n" +
-        "It has been added to the project knowledge base explicitly\n\n"
+        "It has been added to the pod knowledge base explicitly\n\n"
       );
     case "gdrive":
       return (
         "IMPORTANT CONTEXT: This is a gdrive document.\n" +
-        "It has been added to the project knowledge base explicitly\n\n"
+        "It has been added to the pod knowledge base explicitly\n\n"
       );
     case "confluence":
       return (
         "IMPORTANT CONTEXT: This is a confluence document.\n" +
-        "It has been added to the project knowledge base explicitly\n\n"
+        "It has been added to the pod knowledge base explicitly\n\n"
       );
     case "github":
       return (
         "IMPORTANT CONTEXT: This is a github document (issue, pull request, discussion, or code file).\n" +
-        "It has been added to the project knowledge base explicitly\n\n"
+        "It has been added to the pod knowledge base explicitly\n\n"
       );
     case "microsoft":
       return (
         "IMPORTANT CONTEXT: This is a Microsoft document (SharePoint, OneDrive, or Teams file).\n" +
-        "It has been added to the project knowledge base explicitly\n\n"
+        "It has been added to the pod knowledge base explicitly\n\n"
       );
     default:
       assertNever(sourceType);

--- a/front/lib/project_task/analyze_document/prompts.ts
+++ b/front/lib/project_task/analyze_document/prompts.ts
@@ -7,7 +7,7 @@ export function buildPromptForSourceType(
   switch (sourceType) {
     case "project_conversation":
       return (
-        "IMPORTANT CONTEXT: This is a conversation that was created within the pod itself.\n" +
+        "IMPORTANT CONTEXT: This is a conversation that was created within the Pod itself.\n" +
         "Messages from the agents are AI-generated responses, NOT from a human participant.\n" +
         "- Do NOT treat user questions that the agents already answered as open action items.\n" +
         "- Only extract action items that represent real commitments between human participants, " +
@@ -18,8 +18,8 @@ export function buildPromptForSourceType(
       );
     case "project_knowledge":
       return (
-        "IMPORTANT CONTEXT: This is a pod knowledge document.\n" +
-        "It has been added to the pod knowledge base explicitly\n\n"
+        "IMPORTANT CONTEXT: This is a Pod knowledge document.\n" +
+        "It has been added to the Pod knowledge base explicitly\n\n"
       );
     case "slack":
       return (
@@ -35,27 +35,27 @@ export function buildPromptForSourceType(
     case "notion":
       return (
         "IMPORTANT CONTEXT: This is a notion document.\n" +
-        "It has been added to the pod knowledge base explicitly\n\n"
+        "It has been added to the Pod knowledge base explicitly\n\n"
       );
     case "gdrive":
       return (
         "IMPORTANT CONTEXT: This is a gdrive document.\n" +
-        "It has been added to the pod knowledge base explicitly\n\n"
+        "It has been added to the Pod knowledge base explicitly\n\n"
       );
     case "confluence":
       return (
         "IMPORTANT CONTEXT: This is a confluence document.\n" +
-        "It has been added to the pod knowledge base explicitly\n\n"
+        "It has been added to the Pod knowledge base explicitly\n\n"
       );
     case "github":
       return (
         "IMPORTANT CONTEXT: This is a github document (issue, pull request, discussion, or code file).\n" +
-        "It has been added to the pod knowledge base explicitly\n\n"
+        "It has been added to the Pod knowledge base explicitly\n\n"
       );
     case "microsoft":
       return (
         "IMPORTANT CONTEXT: This is a Microsoft document (SharePoint, OneDrive, or Teams file).\n" +
-        "It has been added to the pod knowledge base explicitly\n\n"
+        "It has been added to the Pod knowledge base explicitly\n\n"
       );
     default:
       assertNever(sourceType);

--- a/front/lib/project_task/initial_project_tasks.ts
+++ b/front/lib/project_task/initial_project_tasks.ts
@@ -9,27 +9,27 @@ export const INITIAL_PROJECT_TASKS: {
   agentInstructions: string;
 }[] = [
   {
-    text: "Set up the project description and goals",
+    text: "Set up the pod description and goals",
     agentInstructions:
-      "Help the user refine a short project description and clear goals. Use project tools to read or update project metadata if available. Propose concrete edits; keep the tone practical and brief.\n\n" +
+      "Help the user refine a short pod description and clear goals. Use pod tools to read or update pod metadata if available. Propose concrete edits; keep the tone practical and brief.\n\n" +
       NEXT_TASK_PROMPT,
   },
   {
     text: "Bring in knowledge from company data",
     agentInstructions:
-      "When it matches the project's purpose, do a substantive pass over company data (search / retrieval across workspace sources and connected systems—not just a single quick lookup). Synthesize what matters, cite where it came from, then help store it in project knowledge using project tools (files, uploads, or structured notes). Skip deep dives when context isn't needed yet.\n\n" +
+      "When it matches the pod's purpose, do a substantive pass over company data (search / retrieval across workspace sources and connected systems—not just a single quick lookup). Synthesize what matters, cite where it came from, then help store it in pod knowledge using pod tools (files, uploads, or structured notes). Skip deep dives when context isn't needed yet.\n\n" +
       NEXT_TASK_PROMPT,
   },
   {
-    text: "Search for and add project members",
+    text: "Search for and add pod members",
     agentInstructions:
-      "Help the user identify the right collaborators for this project. Use people search or directory tools to find candidates by name, role, team, or expertise. Once you have good candidates, mention them by name in the conversation using @mention — this will show the user a dialog to add them to the project directly from the conversation. If the user needs an alternative, link them to the project settings page by appending `#settings` to the project URL.\n\n" +
+      "Help the user identify the right collaborators for this pod. Use people search or directory tools to find candidates by name, role, team, or expertise. Once you have good candidates, mention them by name in the conversation using @mention — this will show the user a dialog to add them to the pod directly from the conversation. If the user needs an alternative, link them to the pod settings page by appending `#settings` to the pod URL.\n\n" +
       NEXT_TASK_PROMPT,
   },
   {
     text: "Build a list of initial tasks",
     agentInstructions:
-      "Partner with the user to produce a practical starter backlog for this project: concrete next steps, early milestones, dependencies, and risks to watch. Keep items actionable; offer wording they can turn into tasks. This list shapes follow-on work—don't recycle these seeded items verbatim.\n\n" +
+      "Partner with the user to produce a practical starter backlog for this pod: concrete next steps, early milestones, dependencies, and risks to watch. Keep items actionable; offer wording they can turn into tasks. This list shapes follow-on work—don't recycle these seeded items verbatim.\n\n" +
       NEXT_TASK_PROMPT,
   },
 ];

--- a/front/lib/project_task/initial_project_tasks.ts
+++ b/front/lib/project_task/initial_project_tasks.ts
@@ -9,27 +9,27 @@ export const INITIAL_PROJECT_TASKS: {
   agentInstructions: string;
 }[] = [
   {
-    text: "Set up the pod description and goals",
+    text: "Set up the Pod description and goals",
     agentInstructions:
-      "Help the user refine a short pod description and clear goals. Use pod tools to read or update pod metadata if available. Propose concrete edits; keep the tone practical and brief.\n\n" +
+      "Help the user refine a short Pod description and clear goals. Use Pod tools to read or update Pod metadata if available. Propose concrete edits; keep the tone practical and brief.\n\n" +
       NEXT_TASK_PROMPT,
   },
   {
     text: "Bring in knowledge from company data",
     agentInstructions:
-      "When it matches the pod's purpose, do a substantive pass over company data (search / retrieval across workspace sources and connected systems—not just a single quick lookup). Synthesize what matters, cite where it came from, then help store it in pod knowledge using pod tools (files, uploads, or structured notes). Skip deep dives when context isn't needed yet.\n\n" +
+      "When it matches the Pod's purpose, do a substantive pass over company data (search / retrieval across workspace sources and connected systems—not just a single quick lookup). Synthesize what matters, cite where it came from, then help store it in Pod knowledge using Pod tools (files, uploads, or structured notes). Skip deep dives when context isn't needed yet.\n\n" +
       NEXT_TASK_PROMPT,
   },
   {
-    text: "Search for and add pod members",
+    text: "Search for and add Pod members",
     agentInstructions:
-      "Help the user identify the right collaborators for this pod. Use people search or directory tools to find candidates by name, role, team, or expertise. Once you have good candidates, mention them by name in the conversation using @mention — this will show the user a dialog to add them to the pod directly from the conversation. If the user needs an alternative, link them to the pod settings page by appending `#settings` to the pod URL.\n\n" +
+      "Help the user identify the right collaborators for this Pod. Use people search or directory tools to find candidates by name, role, team, or expertise. Once you have good candidates, mention them by name in the conversation using @mention — this will show the user a dialog to add them to the Pod directly from the conversation. If the user needs an alternative, link them to the Pod settings page by appending `#settings` to the Pod URL.\n\n" +
       NEXT_TASK_PROMPT,
   },
   {
     text: "Build a list of initial tasks",
     agentInstructions:
-      "Partner with the user to produce a practical starter backlog for this pod: concrete next steps, early milestones, dependencies, and risks to watch. Keep items actionable; offer wording they can turn into tasks. This list shapes follow-on work—don't recycle these seeded items verbatim.\n\n" +
+      "Partner with the user to produce a practical starter backlog for this Pod: concrete next steps, early milestones, dependencies, and risks to watch. Keep items actionable; offer wording they can turn into tasks. This list shapes follow-on work—don't recycle these seeded items verbatim.\n\n" +
       NEXT_TASK_PROMPT,
   },
 ];

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -197,7 +197,7 @@ export function useMentionValidation({
             type: "success",
             title: "Success",
             description: isProjectConversation
-              ? `${mention.label} has been added to the pod, and added to the conversation`
+              ? `${mention.label} has been added to the Pod, and added to the conversation`
               : `${mention.label} has been invited to the conversation.`,
           });
         }

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -197,7 +197,7 @@ export function useMentionValidation({
             type: "success",
             title: "Success",
             description: isProjectConversation
-              ? `${mention.label} has been added to the project, and added to the conversation`
+              ? `${mention.label} has been added to the pod, and added to the conversation`
               : `${mention.label} has been invited to the conversation.`,
           });
         }

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -138,7 +138,7 @@ export function useAddProjectContextContentNodes({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to add references to pod",
+          title: "Failed to add references to Pod",
           description: errorData.message,
         });
         return new Err(new Error(errorData.message));
@@ -153,8 +153,8 @@ export function useAddProjectContextContentNodes({
           type: "success",
           title:
             addedCount === 1
-              ? "Added to pod context"
-              : `Added ${addedCount} items to pod context`,
+              ? "Added to Pod context"
+              : `Added ${addedCount} items to Pod context`,
         });
       } else {
         sendNotification({
@@ -169,7 +169,7 @@ export function useAddProjectContextContentNodes({
       const errorMessage = normalizeError(e).message;
       sendNotification({
         type: "error",
-        title: "Failed to add references to pod",
+        title: "Failed to add references to Pod",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));
@@ -199,7 +199,7 @@ export function useRemoveProjectContextFile({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to remove file from pod",
+          title: "Failed to remove file from Pod",
           description: errorData.message,
         });
         return new Err(new Error(errorData.message));
@@ -207,7 +207,7 @@ export function useRemoveProjectContextFile({
 
       sendNotification({
         type: "success",
-        title: "Removed from pod knowledge",
+        title: "Removed from Pod knowledge",
       });
 
       return new Ok(undefined);
@@ -215,7 +215,7 @@ export function useRemoveProjectContextFile({
       const errorMessage = normalizeError(e).message;
       sendNotification({
         type: "error",
-        title: "Failed to remove file from pod",
+        title: "Failed to remove file from Pod",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));
@@ -252,7 +252,7 @@ export function useRemoveProjectContextContentNodes({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to remove content nodes from pod",
+          title: "Failed to remove content nodes from Pod",
           description: errorData.message,
         });
         return new Err(new Error(errorData.message));
@@ -262,8 +262,8 @@ export function useRemoveProjectContextContentNodes({
         type: "success",
         title:
           items.length === 1
-            ? "Removed from pod knowledge"
-            : `Removed ${items.length} items from pod knowledge`,
+            ? "Removed from Pod knowledge"
+            : `Removed ${items.length} items from Pod knowledge`,
       });
 
       return new Ok(undefined);
@@ -271,7 +271,7 @@ export function useRemoveProjectContextContentNodes({
       const errorMessage = normalizeError(e).message;
       sendNotification({
         type: "error",
-        title: "Failed to remove content nodes from pod",
+        title: "Failed to remove content nodes from Pod",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -138,7 +138,7 @@ export function useAddProjectContextContentNodes({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to add references to project",
+          title: "Failed to add references to pod",
           description: errorData.message,
         });
         return new Err(new Error(errorData.message));
@@ -153,8 +153,8 @@ export function useAddProjectContextContentNodes({
           type: "success",
           title:
             addedCount === 1
-              ? "Added to project context"
-              : `Added ${addedCount} items to project context`,
+              ? "Added to pod context"
+              : `Added ${addedCount} items to pod context`,
         });
       } else {
         sendNotification({
@@ -169,7 +169,7 @@ export function useAddProjectContextContentNodes({
       const errorMessage = normalizeError(e).message;
       sendNotification({
         type: "error",
-        title: "Failed to add references to project",
+        title: "Failed to add references to pod",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));
@@ -199,7 +199,7 @@ export function useRemoveProjectContextFile({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to remove file from project",
+          title: "Failed to remove file from pod",
           description: errorData.message,
         });
         return new Err(new Error(errorData.message));
@@ -207,7 +207,7 @@ export function useRemoveProjectContextFile({
 
       sendNotification({
         type: "success",
-        title: "Removed from project knowledge",
+        title: "Removed from pod knowledge",
       });
 
       return new Ok(undefined);
@@ -215,7 +215,7 @@ export function useRemoveProjectContextFile({
       const errorMessage = normalizeError(e).message;
       sendNotification({
         type: "error",
-        title: "Failed to remove file from project",
+        title: "Failed to remove file from pod",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));
@@ -252,7 +252,7 @@ export function useRemoveProjectContextContentNodes({
         const errorData = await getErrorFromResponse(res);
         sendNotification({
           type: "error",
-          title: "Failed to remove content nodes from project",
+          title: "Failed to remove content nodes from pod",
           description: errorData.message,
         });
         return new Err(new Error(errorData.message));
@@ -262,8 +262,8 @@ export function useRemoveProjectContextContentNodes({
         type: "success",
         title:
           items.length === 1
-            ? "Removed from project knowledge"
-            : `Removed ${items.length} items from project knowledge`,
+            ? "Removed from pod knowledge"
+            : `Removed ${items.length} items from pod knowledge`,
       });
 
       return new Ok(undefined);
@@ -271,7 +271,7 @@ export function useRemoveProjectContextContentNodes({
       const errorMessage = normalizeError(e).message;
       sendNotification({
         type: "error",
-        title: "Failed to remove content nodes from project",
+        title: "Failed to remove content nodes from pod",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -1020,7 +1020,7 @@ export function useUpdateProjectMetadata({
       const errorData = await getErrorFromResponse(res);
       sendNotification({
         type: "error",
-        title: "Error updating pod metadata",
+        title: "Error updating Pod metadata",
         description: `Error: ${errorData.message}`,
       });
       return null;
@@ -1113,7 +1113,7 @@ export function useUpdateProjectNotificationPreference({
       const errorData = await getErrorFromResponse(res);
       sendNotification({
         type: "error",
-        title: "Error updating pod notification preference",
+        title: "Error updating Pod notification preference",
         description: `Error: ${errorData.message}`,
       });
       return null;
@@ -1165,15 +1165,15 @@ export function useLeaveProject({
       void mutateSpaceSummary();
       sendNotification({
         type: "success",
-        title: `${userName} left pod ${spaceName}`,
-        description: "You have successfully left the pod.",
+        title: `${userName} left Pod ${spaceName}`,
+        description: "You have successfully left the Pod.",
       });
       return true;
     } else {
       const errorData = await getErrorFromResponse(res);
       sendNotification({
         type: "error",
-        title: "Could not leave pod",
+        title: "Could not leave Pod",
         description: `Error: ${errorData.message}`,
       });
       return false;
@@ -1216,7 +1216,7 @@ export function useJoinProject({
       void mutateSpaceSummary();
       sendNotification({
         type: "success",
-        title: `${userName} joined pod ${spaceName}`,
+        title: `${userName} joined Pod ${spaceName}`,
         description: "You can now participate in conversations.",
       });
       return true;
@@ -1224,7 +1224,7 @@ export function useJoinProject({
       const errorData = await getErrorFromResponse(res);
       sendNotification({
         type: "error",
-        title: "Could not join pod",
+        title: "Could not join Pod",
         description: `Error: ${errorData.message}`,
       });
       return false;

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -1020,7 +1020,7 @@ export function useUpdateProjectMetadata({
       const errorData = await getErrorFromResponse(res);
       sendNotification({
         type: "error",
-        title: "Error updating project metadata",
+        title: "Error updating pod metadata",
         description: `Error: ${errorData.message}`,
       });
       return null;
@@ -1033,13 +1033,13 @@ export function useUpdateProjectMetadata({
     const title =
       updates.archive !== undefined
         ? updates.archive
-          ? "Project archived"
-          : "Project unarchived"
+          ? "Pod archived"
+          : "Pod unarchived"
         : updates.todoGenerationEnabled !== undefined
           ? updates.todoGenerationEnabled
             ? "Automatic task suggestions turned on"
             : "Automatic task suggestions turned off"
-          : "Project updated";
+          : "Pod updated";
 
     sendNotification({
       type: "success",
@@ -1113,7 +1113,7 @@ export function useUpdateProjectNotificationPreference({
       const errorData = await getErrorFromResponse(res);
       sendNotification({
         type: "error",
-        title: "Error updating project notification preference",
+        title: "Error updating pod notification preference",
         description: `Error: ${errorData.message}`,
       });
       return null;
@@ -1123,7 +1123,7 @@ export function useUpdateProjectNotificationPreference({
 
     sendNotification({
       type: "success",
-      title: "Project notification preference updated",
+      title: "Pod notification preference updated",
     });
 
     const response: PatchUserProjectNotificationPreferenceResponseBody =
@@ -1165,15 +1165,15 @@ export function useLeaveProject({
       void mutateSpaceSummary();
       sendNotification({
         type: "success",
-        title: `${userName} left project ${spaceName}`,
-        description: "You have successfully left the project.",
+        title: `${userName} left pod ${spaceName}`,
+        description: "You have successfully left the pod.",
       });
       return true;
     } else {
       const errorData = await getErrorFromResponse(res);
       sendNotification({
         type: "error",
-        title: "Could not leave project",
+        title: "Could not leave pod",
         description: `Error: ${errorData.message}`,
       });
       return false;
@@ -1216,7 +1216,7 @@ export function useJoinProject({
       void mutateSpaceSummary();
       sendNotification({
         type: "success",
-        title: `${userName} joined project ${spaceName}`,
+        title: `${userName} joined pod ${spaceName}`,
         description: "You can now participate in conversations.",
       });
       return true;
@@ -1224,7 +1224,7 @@ export function useJoinProject({
       const errorData = await getErrorFromResponse(res);
       sendNotification({
         type: "error",
-        title: "Could not join project",
+        title: "Could not join pod",
         description: `Error: ${errorData.message}`,
       });
       return false;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -121,7 +121,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
     expect(res._getJSONData()).toEqual({
       error: {
         type: "invalid_request_error",
-        message: "Project metadata is only available for project spaces.",
+        message: "Pod metadata is only available for pod spaces.",
       },
     });
   });

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -121,7 +121,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
     expect(res._getJSONData()).toEqual({
       error: {
         type: "invalid_request_error",
-        message: "Pod metadata is only available for pod spaces.",
+        message: "Pod metadata is only available for Pod spaces.",
       },
     });
   });

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -73,7 +73,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Pod metadata is only available for pod spaces.",
+            message: "Pod metadata is only available for Pod spaces.",
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -73,7 +73,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "Project metadata is only available for project spaces.",
+            message: "Pod metadata is only available for pod spaces.",
           },
         });
       }
@@ -86,7 +86,7 @@ async function handler(
           status_code: 404,
           api_error: {
             type: "project_metadata_not_found",
-            message: "Project metadata not found for this space.",
+            message: "Pod metadata not found for this space.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -64,7 +64,7 @@ async function handler(
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
-        message: "You are not a member of the pod.",
+        message: "You are not a member of the Pod.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -64,7 +64,7 @@ async function handler(
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
-        message: "You are not a member of the project.",
+        message: "You are not a member of the pod.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.test.ts
@@ -112,12 +112,12 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
     expect(res._getJSONData()).toEqual({
       error: {
         type: "invalid_request_error",
-        message: "Only Frame files can be saved to a project.",
+        message: "Only Frame files can be saved to a pod.",
       },
     });
   });
 
-  it("should return 400 when file is already in a project", async () => {
+  it("should return 400 when file is already in a pod", async () => {
     const {
       auth: auth,
       req,
@@ -155,7 +155,7 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
       error: {
         type: "invalid_request_error",
         message:
-          "Only conversation frame files can be saved to a project. This file is already in a project or has another use case.",
+          "Only conversation frame files can be saved to a pod. This file is already in a pod or has another use case.",
       },
     });
   });

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
@@ -66,7 +66,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Only Frame files can be saved to a project.",
+        message: "Only Frame files can be saved to a pod.",
       },
     });
   }
@@ -78,7 +78,7 @@ async function handler(
       api_error: {
         type: "invalid_request_error",
         message:
-          "Only conversation frame files can be saved to a project. This file is already in a project or has another use case.",
+          "Only conversation frame files can be saved to a pod. This file is already in a pod or has another use case.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/join.ts
@@ -32,7 +32,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "You can only join pods, not regular spaces.",
+            message: "You can only join Pods, not regular spaces.",
           },
         });
       }
@@ -42,7 +42,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message: "This pod is restricted. You need to be invited to join.",
+            message: "This Pod is restricted. You need to be invited to join.",
           },
         });
       }
@@ -53,7 +53,7 @@ async function handler(
           api_error: {
             type: "invalid_request_error",
             message:
-              "You cannot join this pod, its members are not managed manually.",
+              "You cannot join this Pod, its members are not managed manually.",
           },
         });
       }
@@ -63,7 +63,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "You are already a member of this pod.",
+            message: "You are already a member of this Pod.",
           },
         });
       }
@@ -78,7 +78,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: "There should be exactly one member group for the pod.",
+            message: "There should be exactly one member group for the Pod.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/join.ts
@@ -32,7 +32,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "You can only join projects, not regular spaces.",
+            message: "You can only join pods, not regular spaces.",
           },
         });
       }
@@ -42,8 +42,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message:
-              "This project is restricted. You need to be invited to join.",
+            message: "This pod is restricted. You need to be invited to join.",
           },
         });
       }
@@ -54,7 +53,7 @@ async function handler(
           api_error: {
             type: "invalid_request_error",
             message:
-              "You cannot join this project, its members are not managed manually.",
+              "You cannot join this pod, its members are not managed manually.",
           },
         });
       }
@@ -64,7 +63,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "You are already a member of this project.",
+            message: "You are already a member of this pod.",
           },
         });
       }
@@ -79,8 +78,7 @@ async function handler(
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message:
-              "There should be exactly one member group for the project.",
+            message: "There should be exactly one member group for the pod.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/leave.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/leave.test.ts
@@ -76,7 +76,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/leave", () => {
 
       expect(res._getStatusCode()).toBe(400);
       expect(res._getJSONData().error.type).toBe("invalid_request_error");
-      expect(res._getJSONData().error.message).toContain("only leave projects");
+      expect(res._getJSONData().error.message).toContain("only leave Pods");
     });
 
     it("should return 403 when user is not a member of the project", async () => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/leave.ts
@@ -31,7 +31,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "You can only leave pods, not regular spaces.",
+            message: "You can only leave Pods, not regular spaces.",
           },
         });
       }
@@ -42,7 +42,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message: "You are not a member of this pod.",
+            message: "You are not a member of this Pod.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/leave.ts
@@ -31,7 +31,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "You can only leave projects, not regular spaces.",
+            message: "You can only leave pods, not regular spaces.",
           },
         });
       }
@@ -42,7 +42,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message: "You are not a member of this project.",
+            message: "You are not a member of this pod.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -39,7 +39,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Pod metadata is only available for pod spaces.",
+        message: "Pod metadata is only available for Pod spaces.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -39,7 +39,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Project metadata is only available for project spaces.",
+        message: "Pod metadata is only available for pod spaces.",
       },
     });
   }
@@ -58,7 +58,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message: "Only project editors can update project metadata.",
+            message: "Only pod editors can update pod metadata.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
@@ -150,7 +150,7 @@ async function handler(
       api_error: {
         type: "invalid_request_error",
         message:
-          "Project notification preferences are only available for project spaces.",
+          "Pod notification preferences are only available for pod spaces.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
@@ -35,7 +35,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Project star is only available for project spaces.",
+        message: "Pod star is only available for pod spaces.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
@@ -35,7 +35,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Pod star is only available for pod spaces.",
+        message: "Pod star is only available for Pod spaces.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
@@ -35,7 +35,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "You can only star Pods."
+        message: "You can only star Pods.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
@@ -35,7 +35,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Pod star is only available for Pod spaces.",
+        message: "You can only star Pods."
       },
     });
   }

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -126,6 +126,6 @@ export function getHeaderFromRole(role: RoleType | undefined) {
 export const AGENT_GROUP_PREFIX = "Group for Agent";
 export const SKILL_GROUP_PREFIX = "Group for Skill";
 export const SPACE_GROUP_PREFIX = "Group for space";
-export const PROJECT_GROUP_PREFIX = "Group for pod";
-export const PROJECT_EDITOR_GROUP_PREFIX = "Editors for pod";
+export const PROJECT_GROUP_PREFIX = "Group for Pod";
+export const PROJECT_EDITOR_GROUP_PREFIX = "Editors for Pod";
 export const GLOBAL_SPACE_NAME = "Company Data";

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -126,6 +126,6 @@ export function getHeaderFromRole(role: RoleType | undefined) {
 export const AGENT_GROUP_PREFIX = "Group for Agent";
 export const SKILL_GROUP_PREFIX = "Group for Skill";
 export const SPACE_GROUP_PREFIX = "Group for space";
-export const PROJECT_GROUP_PREFIX = "Group for project";
-export const PROJECT_EDITOR_GROUP_PREFIX = "Editors for project";
+export const PROJECT_GROUP_PREFIX = "Group for pod";
+export const PROJECT_EDITOR_GROUP_PREFIX = "Editors for pod";
 export const GLOBAL_SPACE_NAME = "Company Data";


### PR DESCRIPTION
## Description

This PR renames "projects" to "pods" throughout the UI to align with updated terminology.

The project skill and mcp servers will be updated in followup PRs.

## Tests

Manually

## Risks
Low

## Deploy Plan
Standard deployment.
