### PR TITLE
Gmail: add send_reply and get_thread to Gmail MCP

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -194,7 +194,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "gmail": {
     "create_draft": "medium",
-    "create_reply_draft": "medium",
     "delete_draft": "high",
     "get_attachment": "never_ask",
     "get_drafts": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -200,6 +200,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_drafts": "never_ask",
     "get_labels": "never_ask",
     "get_messages": "never_ask",
+    "get_thread": "never_ask",
     "send_mail": "high",
     "set_message_labels": "medium",
   },

--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -86,6 +86,10 @@ export function decodeMessageBody(
     const base64 = payload.body.data.replace(/-/g, "+").replace(/_/g, "/");
     return Buffer.from(base64, "base64").toString("utf-8");
   }
+  if (payload.mimeType == "text/html" && payload.body?.data) {
+    const base64 = payload.body.data.replace(/-/g, "+").replace(/_/g, "/");
+    return Buffer.from(base64, "base64").toString("utf-8");
+  }
 
   if (payload.parts) {
     for (const part of payload.parts) {

--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -238,7 +238,7 @@ export function createThreadingHeaders(
     headers.push(`In-Reply-To: ${originalMessageId}`);
 
     if (originalReferences) {
-      headers.push(`References: ${originalReferences}`);
+      headers.push(`References: ${originalReferences} ${originalMessageId}`);
     } else {
       headers.push(`References: ${originalMessageId}`);
     }

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -37,13 +37,13 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe(
-          "The email addresses of the recipients. Optional if replyToMessageId is provided then Dust will automatically use the recipients from the original message."
+          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
         ),
-      cc: z.array(z.string()).optional().describe("The email addresses to CC"),
+      cc: z.array(z.string()).optional().describe("The CC email addresses (optional if replyToMessageId is set, acts as override)"),
       bcc: z
         .array(z.string())
         .optional()
-        .describe("The email addresses to BCC"),
+        .describe("The BCC email addresses (optional if replyToMessageId is set, acts as override)."),
       subject: z.string().describe("The subject line of the email"),
       contentType: z
         .enum(["text/plain", "text/html"])
@@ -182,13 +182,13 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe(
-          "The email addresses of the recipients. Optional if replyToMessageId is provided then Dust will automatically use the recipients from the original message."
+          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
         ),
-      cc: z.array(z.string()).optional().describe("The email addresses to CC"),
+      cc: z.array(z.string()).optional().describe("The CC email addresses (optional if replyToMessageId is set, acts as override)."),
       bcc: z
         .array(z.string())
         .optional()
-        .describe("The email addresses to BCC"),
+        .describe("The BCC email addresses (optional if replyToMessageId is set, acts as override)."),
       from: z
         .string()
         .email()

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -33,7 +33,12 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
 - If replyToMessageId is provided, the draft will be created as a reply in the existing thread, with the original message quoted.
 - The draft will include proper email headers and formatting.`,
     schema: {
-      to: z.array(z.string()).optional().describe("The email addresses of the recipients. Optional if replyToMessageId is provided then Dust will automatically use the recipients from the original message."),
+      to: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "The email addresses of the recipients. Optional if replyToMessageId is provided then Dust will automatically use the recipients from the original message."
+        ),
       cc: z.array(z.string()).optional().describe("The email addresses to CC"),
       bcc: z
         .array(z.string())
@@ -174,8 +179,11 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
 - The email will include proper headers and formatting.`,
     schema: {
       to: z
-        .array(z.string()).optional()
-        .describe("The email addresses of the recipients. Optional if replyToMessageId is provided then Dust will automatically use the recipients from the original message."),
+        .array(z.string())
+        .optional()
+        .describe(
+          "The email addresses of the recipients. Optional if replyToMessageId is provided then Dust will automatically use the recipients from the original message."
+        ),
       cc: z.array(z.string()).optional().describe("The email addresses to CC"),
       bcc: z
         .array(z.string())

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -30,14 +30,13 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
   create_draft: {
     description: `Create a new email draft in Gmail, or a reply draft to an existing message.
 - The draft will be saved in the user's Gmail account and can be reviewed and sent later.
-- If replyToMessageId is provided, the draft will be created as a reply in the existing thread, with the original message quoted.
 - The draft will include proper email headers and formatting.`,
     schema: {
       to: z
         .array(z.string())
         .optional()
         .describe(
-          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
+          "The email addresses of the recipients (optional if replyToMessageId is set, defaults to the original sender, acts as override)."
         ),
       cc: z
         .array(z.string())
@@ -55,11 +54,13 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "The subject line of the email (required if replyToMessageId is not set, should be omitted if replyToMessageId is set)."
+          "The subject line of the email (required if replyToMessageId is not set, must be omitted if replyToMessageId is set)."
         ),
       contentType: z
         .enum(["text/plain", "text/html"])
-        .describe("The content type of the email (text/plain or text/html)."),
+        .describe(
+          "The content type of the email body. Use text/plain for plain text or text/html for HTML. Must be text/html when replyToMessageId is set."
+        ),
       body: z.string().describe("The body of the email"),
       replyToMessageId: z
         .string()
@@ -187,14 +188,13 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     description: `Send an email directly via Gmail.
 - The email will be sent immediately without creating a draft.
 - Use this to send emails when you have all the required information.
-- If replyToMessageId is provided, the email will be sent as a reply in the existing thread, with the original message quoted.
 - The email will include proper headers and formatting.`,
     schema: {
       to: z
         .array(z.string())
         .optional()
         .describe(
-          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
+          "The email addresses of the recipients (optional if replyToMessageId is set, defaults to the original sender, acts as override)."
         ),
       cc: z
         .array(z.string())
@@ -219,11 +219,13 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "The subject line of the email (required if replyToMessageId is not set, should be omitted if replyToMessageId is set)."
+          "The subject line of the email (required if replyToMessageId is not set, must be omitted if replyToMessageId is set)."
         ),
       contentType: z
         .enum(["text/plain", "text/html"])
-        .describe("The content type of the email (text/plain or text/html)."),
+        .describe(
+          "The content type of the email body. Use text/plain for plain text or text/html for HTML. Must be text/html when replyToMessageId is set."
+        ),
       body: z.string().describe("The body of the email"),
       replyToMessageId: z
         .string()

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -39,11 +39,18 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
         ),
-      cc: z.array(z.string()).optional().describe("The CC email addresses (optional if replyToMessageId is set, acts as override)"),
+      cc: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "The CC email addresses (optional if replyToMessageId is set, acts as override)"
+        ),
       bcc: z
         .array(z.string())
         .optional()
-        .describe("The BCC email addresses (optional if replyToMessageId is set, acts as override)."),
+        .describe(
+          "The BCC email addresses (optional if replyToMessageId is set, acts as override)."
+        ),
       subject: z.string().describe("The subject line of the email"),
       contentType: z
         .enum(["text/plain", "text/html"])
@@ -184,11 +191,18 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
         ),
-      cc: z.array(z.string()).optional().describe("The CC email addresses (optional if replyToMessageId is set, acts as override)."),
+      cc: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "The CC email addresses (optional if replyToMessageId is set, acts as override)."
+        ),
       bcc: z
         .array(z.string())
         .optional()
-        .describe("The BCC email addresses (optional if replyToMessageId is set, acts as override)."),
+        .describe(
+          "The BCC email addresses (optional if replyToMessageId is set, acts as override)."
+        ),
       from: z
         .string()
         .email()

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -28,12 +28,12 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_draft: {
-    description: `Create a new email draft in Gmail, or a reply draft to an existing thread.
+    description: `Create a new email draft in Gmail, or a reply draft to an existing message.
 - The draft will be saved in the user's Gmail account and can be reviewed and sent later.
 - If replyToMessageId is provided, the draft will be created as a reply in the existing thread, with the original message quoted.
 - The draft will include proper email headers and formatting.`,
     schema: {
-      to: z.array(z.string()).describe("The email addresses of the recipients"),
+      to: z.array(z.string()).optional().describe("The email addresses of the recipients. Optional if replyToMessageId is provided then Dust will automatically use the recipients from the original message."),
       cc: z.array(z.string()).optional().describe("The email addresses to CC"),
       bcc: z
         .array(z.string())
@@ -170,12 +170,12 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     description: `Send an email directly via Gmail.
 - The email will be sent immediately without creating a draft.
 - Use this to send emails when you have all the required information.
+- If replyToMessageId is provided, the email will be sent as a reply in the existing thread, with the original message quoted.
 - The email will include proper headers and formatting.`,
     schema: {
       to: z
-        .array(z.string())
-        .min(1)
-        .describe("The email addresses of the recipients"),
+        .array(z.string()).optional()
+        .describe("The email addresses of the recipients. Optional if replyToMessageId is provided then Dust will automatically use the recipients from the original message."),
       cc: z.array(z.string()).optional().describe("The email addresses to CC"),
       bcc: z
         .array(z.string())
@@ -197,7 +197,7 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread."
+          "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread, with proper threading headers and the original message quoted."
         ),
     },
     stake: "high",
@@ -217,8 +217,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "getting Gmail thread",
-      done: "Get Gmail messages",
+      running: "Getting Gmail thread",
+      done: "Get Gmail thread",
     },
   },
 });

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -36,19 +36,26 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe(
-          "The email addresses of the recipients. Required if replyToMessageId is not set. If replyToMessageId is set and to is not provided, will fall back to the From field of the original message. If you are the sender of the original message, you must provide to explicitly."
+          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
         ),
       cc: z
         .array(z.string())
         .optional()
         .describe(
-          "The CC email addresses (optional if replyToMessageId is set, acts as override)."
+          "The CC email addresses (optional, acts as override if replyToMessageId is set)."
         ),
       bcc: z
         .array(z.string())
         .optional()
         .describe(
-          "The BCC email addresses (optional if replyToMessageId is set, acts as override)."
+          "The BCC email addresses (optional, acts as override if replyToMessageId is set)."
+        ),
+      from: z
+        .string()
+        .email()
+        .optional()
+        .describe(
+          "Optional. The email address to send from. Must be configured as a send-as alias in the user's Gmail settings (e.g. a shared Google Group address like team@company.com). If omitted, Gmail will use the authenticated user's primary address."
         ),
       subject: z
         .string()
@@ -58,8 +65,9 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         ),
       contentType: z
         .enum(["text/plain", "text/html"])
+        .optional()
         .describe(
-          "The content type of the email body. Use text/plain for plain text or text/html for HTML. Must be text/html when replyToMessageId is set."
+          "The content type of the email body, use text/plain for plain text or text/html for HTML (required if replyToMessageId is not set, must be omitted if replyToMessageId is set (forced to text/html))."
         ),
       body: z.string().describe("The body of the email"),
       replyToMessageId: z
@@ -194,19 +202,19 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe(
-          "The email addresses of the recipients. Required if replyToMessageId is not set. If replyToMessageId is set and to is not provided, will fall back to the From field of the original message. If you are the sender of the original message, you must provide to explicitly."
+          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
         ),
       cc: z
         .array(z.string())
         .optional()
         .describe(
-          "The CC email addresses (optional if replyToMessageId is set, acts as override)."
+          "The CC email addresses (optional, acts as override if replyToMessageId is set)."
         ),
       bcc: z
         .array(z.string())
         .optional()
         .describe(
-          "The BCC email addresses (optional if replyToMessageId is set, acts as override)."
+          "The BCC email addresses (optional, acts as override if replyToMessageId is set)."
         ),
       from: z
         .string()
@@ -223,8 +231,9 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         ),
       contentType: z
         .enum(["text/plain", "text/html"])
+        .optional()
         .describe(
-          "The content type of the email body. Use text/plain for plain text or text/html for HTML. Must be text/html when replyToMessageId is set."
+          "The content type of the email body, use text/plain for plain text or text/html for HTML (required if replyToMessageId is not set, must be omitted if replyToMessageId is set (forced to text/html))."
         ),
       body: z.string().describe("The body of the email"),
       replyToMessageId: z

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -36,7 +36,7 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe(
-          "The email addresses of the recipients (optional if replyToMessageId is set, defaults to the original sender, acts as override)."
+          "The email addresses of the recipients. Required if replyToMessageId is not set. If replyToMessageId is set and to is not provided, will fall back to the From field of the original message. If you are the sender of the original message, you must provide to explicitly."
         ),
       cc: z
         .array(z.string())
@@ -194,7 +194,7 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe(
-          "The email addresses of the recipients (optional if replyToMessageId is set, defaults to the original sender, acts as override)."
+          "The email addresses of the recipients. Required if replyToMessageId is not set. If replyToMessageId is set and to is not provided, will fall back to the From field of the original message. If you are the sender of the original message, you must provide to explicitly."
         ),
       cc: z
         .array(z.string())

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -220,11 +220,53 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .enum(["text/plain", "text/html"])
         .describe("The content type of the email (text/plain or text/html)."),
       body: z.string().describe("The body of the email"),
+      replyToMessageId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread."
+        ),
     },
     stake: "high",
     displayLabels: {
       running: "Sending Gmail email",
       done: "Send Gmail email",
+    },
+  },
+
+  // create_label: {
+  //   description: "Create a new Gmail label.",
+  //   schema: {
+  //     name: z
+  //     .string()
+  //     .describe("the name of the label"),
+  //     color: z.object({
+  //       textColor: z.string(),
+  //       backgroundColor: z.string()
+  //     })
+  //     .optional()
+  //     .describe("Optional. The color of the label. Must use Gmail's predefined hex color codes. Example green: backgroundColor: '#16a766', textColor: '#ffffff'")
+  //   },
+  //   stake: "medium",
+  //   displayLabels: {
+  //     running: "creating the label",
+  //     done: "label created"
+  //   },
+  // },
+
+  get_thread: {
+    description: "Get all messages in a Gmail thread/conversation.",
+    schema: {
+      threadId: z
+        .string()
+        .describe(
+          "The ID of the thread to retrieve. Can be found in the threadId field of any message."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "getting Gmail thread",
+      done: "Get Gmail messages",
     },
   },
 });

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -233,27 +233,6 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       done: "Send Gmail email",
     },
   },
-
-  // create_label: {
-  //   description: "Create a new Gmail label.",
-  //   schema: {
-  //     name: z
-  //     .string()
-  //     .describe("the name of the label"),
-  //     color: z.object({
-  //       textColor: z.string(),
-  //       backgroundColor: z.string()
-  //     })
-  //     .optional()
-  //     .describe("Optional. The color of the label. Must use Gmail's predefined hex color codes. Example green: backgroundColor: '#16a766', textColor: '#ffffff'")
-  //   },
-  //   stake: "medium",
-  //   displayLabels: {
-  //     running: "creating the label",
-  //     done: "label created"
-  //   },
-  // },
-
   get_thread: {
     description: "Get all messages in a Gmail thread/conversation.",
     schema: {

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -28,10 +28,10 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_draft: {
-    description: `Create a new email draft in Gmail.
+    description: `Create a new email draft in Gmail, or a reply draft to an existing thread.
 - The draft will be saved in the user's Gmail account and can be reviewed and sent later.
-- The user can review and send the draft later
-- The draft will include proper email headers and formatting`,
+- If replyToMessageId is provided, the draft will be created as a reply in the existing thread, with the original message quoted.
+- The draft will include proper email headers and formatting.`,
     schema: {
       to: z.array(z.string()).describe("The email addresses of the recipients"),
       cc: z.array(z.string()).optional().describe("The email addresses to CC"),
@@ -44,6 +44,12 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .enum(["text/plain", "text/html"])
         .describe("The content type of the email (text/plain or text/html)."),
       body: z.string().describe("The body of the email"),
+      replyToMessageId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. The ID of the message to reply to. If provided, the draft will be created as a reply in the existing thread, with proper threading headers and the original message quoted."
+        ),
     },
     stake: "medium",
     displayLabels: {
@@ -132,39 +138,6 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Getting Gmail attachment",
       done: "Get Gmail attachment",
-    },
-  },
-  create_reply_draft: {
-    description: `Create a reply draft to an existing email thread in Gmail.
-- The draft will be saved in the user's Gmail account and can be reviewed and sent later.
-- The reply will be properly formatted with the original message quoted.
-- The draft will include proper email headers and threading information.`,
-    schema: {
-      messageId: z.string().describe("The ID of the message to reply to"),
-      body: z.string().describe("The body of the reply email"),
-      contentType: z
-        .enum(["text/plain", "text/html"])
-        .optional()
-        .describe(
-          "The content type of the email (text/plain or text/html). Defaults to text/plain."
-        ),
-      to: z
-        .array(z.string())
-        .optional()
-        .describe("Override the To recipients for the reply."),
-      cc: z
-        .array(z.string())
-        .optional()
-        .describe("Override the CC recipients for the reply."),
-      bcc: z
-        .array(z.string())
-        .optional()
-        .describe("Override the BCC recipients for the reply."),
-    },
-    stake: "medium",
-    displayLabels: {
-      running: "Creating Gmail reply draft",
-      done: "Create Gmail reply draft",
     },
   },
   get_labels: {

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -43,7 +43,7 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe(
-          "The CC email addresses (optional if replyToMessageId is set, acts as override)"
+          "The CC email addresses (optional if replyToMessageId is set, acts as override)."
         ),
       bcc: z
         .array(z.string())
@@ -51,7 +51,12 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "The BCC email addresses (optional if replyToMessageId is set, acts as override)."
         ),
-      subject: z.string().describe("The subject line of the email"),
+      subject: z
+        .string()
+        .optional()
+        .describe(
+          "The subject line of the email (required if replyToMessageId is not set, should be omitted if replyToMessageId is set)."
+        ),
       contentType: z
         .enum(["text/plain", "text/html"])
         .describe("The content type of the email (text/plain or text/html)."),
@@ -210,7 +215,12 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional. The email address to send from. Must be configured as a send-as alias in the user's Gmail settings (e.g. a shared Google Group address like team@company.com). If omitted, Gmail will use the authenticated user's primary address."
         ),
-      subject: z.string().describe("The subject line of the email"),
+      subject: z
+        .string()
+        .optional()
+        .describe(
+          "The subject line of the email (required if replyToMessageId is not set, should be omitted if replyToMessageId is set)."
+        ),
       contentType: z
         .enum(["text/plain", "text/html"])
         .describe("The content type of the email (text/plain or text/html)."),

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -35,8 +35,8 @@ import { unescape } from "html-escaper";
 // Validates email addresses to prevent header injection attacks.
 function validateEmailAddresses(
   to: string[],
-  cc?: string[] | null,
-  bcc?: string[] | null,
+  cc: string[] | null,
+  bcc: string[] | null,
   from?: string
 ): Err<MCPError> | null {
   const allAddresses = [...to, ...(cc ?? []), ...(bcc ?? [])];
@@ -55,8 +55,8 @@ function validateEmailAddresses(
 // Used by both create_draft and send_mail to avoid code duplication.
 function buildAndEncodeEmail(params: {
   to: string[];
-  cc?: string[] | null;
-  bcc?: string[] | null;
+  cc: string[] | null;
+  bcc: string[] | null;
   from?: string;
   subject: string;
   contentType: string;
@@ -99,11 +99,10 @@ function buildAndEncodeEmail(params: {
 async function buildReplyContext(params: {
   replyToMessageId: string;
   accessToken: string;
-  to?: string[];
-  cc?: string[] | null;
-  bcc?: string[] | null;
+  to: string[] | null;
+  cc: string[] | null;
+  bcc: string[] | null;
   body: string;
-  contentType: "text/plain" | "text/html";
   subject?: string;
 }): Promise<
   | Err<MCPError>
@@ -120,12 +119,6 @@ async function buildReplyContext(params: {
   if (params.subject) {
     return new Err(
       new MCPError("Subject should not be provided when replying to a message.")
-    );
-  }
-
-  if (params.contentType === "text/plain") {
-    return new Err(
-      new MCPError("Content type must be text/html when replying to a message.")
     );
   }
 
@@ -179,7 +172,7 @@ async function buildReplyContext(params: {
 
   const fullBody = buildReplyBody(
     params.body,
-    params.contentType,
+    "text/html",
     originalBody,
     originalDate,
     originalFrom
@@ -273,7 +266,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   create_draft: async (
-    { to, cc, bcc, subject, contentType, body, replyToMessageId },
+    { to, cc, bcc, from, subject, contentType, body, replyToMessageId },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
@@ -281,18 +274,50 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       return new Err(new MCPError("Authentication required"));
     }
 
+    // If a from alias was requested, verify it's a configured send-as address
+    // before sending. Gmail silently falls back to the primary address if the
+    // alias isn't set up, so we fail early to surface the issue.
+    if (from) {
+      const sendAsResponse = await fetchFromGmail(
+        "/gmail/v1/users/me/settings/sendAs",
+        accessToken,
+        { method: "GET" }
+      );
+      if (sendAsResponse.ok) {
+        const sendAsResult = await sendAsResponse.json();
+        const aliases: { sendAsEmail: string }[] = sendAsResult.sendAs ?? [];
+        const aliasConfigured = aliases.some(
+          (a) => a.sendAsEmail.toLowerCase() === from.toLowerCase()
+        );
+        if (!aliasConfigured) {
+          return new Err(
+            new MCPError(
+              `"${from}" is not configured as a send-as alias in Gmail settings. The email was not sent.`
+            )
+          );
+        }
+      }
+    }
+
     let encodedMessage: string | undefined = undefined;
     let threadId: string | undefined = undefined;
 
     if (replyToMessageId) {
+      if (contentType) {
+        return new Err(
+          new MCPError(
+            "contentType must be omitted when replying to a message."
+          )
+        );
+      }
+
       const replyContext = await buildReplyContext({
         replyToMessageId,
         accessToken,
-        to,
-        cc,
-        bcc,
+        to: to ?? null,
+        cc: cc ?? null,
+        bcc: bcc ?? null,
         body,
-        contentType,
         subject,
       });
       if (replyContext.isErr()) {
@@ -313,6 +338,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         to: replyTo,
         cc: replyCc,
         bcc: replyBcc,
+        from,
         subject: originalSubject?.startsWith("Re: ")
           ? originalSubject
           : `Re: ${originalSubject ?? "No Subject"}`,
@@ -325,6 +351,13 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
       encodedMessage = encodedMessageResult.value;
     } else {
+      if (!contentType) {
+        return new Err(
+          new MCPError(
+            "contentType is required when not replying to a message."
+          )
+        );
+      }
       if (!subject?.trim()) {
         return new Err(
           new MCPError("Subject is required when not replying to a message.")
@@ -341,12 +374,11 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
 
       const encodedMessageResult = buildAndEncodeEmail({
         to,
-        cc,
-        bcc,
+        cc: cc ?? null,
+        bcc: bcc ?? null,
         subject,
         contentType,
         body,
-        threadingHeaders: [],
       });
 
       if (encodedMessageResult.isErr()) {
@@ -828,14 +860,21 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     let threadId: string | undefined = undefined;
 
     if (replyToMessageId) {
+      if (contentType) {
+        return new Err(
+          new MCPError(
+            "contentType must be omitted when replying to a message."
+          )
+        );
+      }
+
       const replyContext = await buildReplyContext({
         replyToMessageId,
         accessToken,
-        to,
-        cc,
-        bcc,
+        to: to ?? null,
+        cc: cc ?? null,
+        bcc: bcc ?? null,
         body,
-        contentType,
         subject,
       });
       if (replyContext.isErr()) {
@@ -871,12 +910,18 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
       encodedMessage = encodedMessageResult.value;
     } else {
+      if (!contentType) {
+        return new Err(
+          new MCPError(
+            "contentType is required when not replying to a message."
+          )
+        );
+      }
       if (!subject?.trim()) {
         return new Err(
           new MCPError("Subject is required when not replying to a message.")
         );
       }
-
       if (!to?.length) {
         return new Err(
           new MCPError(
@@ -887,13 +932,12 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
 
       const encodedMessageResult = buildAndEncodeEmail({
         to,
-        cc,
-        bcc,
+        cc: cc ?? null,
+        bcc: bcc ?? null,
         from,
         subject,
         contentType,
         body,
-        threadingHeaders: [],
       });
 
       if (encodedMessageResult.isErr()) {

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -30,12 +30,13 @@ import { GMAIL_TOOLS_METADATA } from "@app/lib/api/actions/servers/gmail/metadat
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
+import { unescape } from "html-escaper";
 
 // Validates email addresses to prevent header injection attacks.
 function validateEmailAddresses(
   to: string[],
-  cc?: string[],
-  bcc?: string[],
+  cc?: string[] | null,
+  bcc?: string[] | null,
   from?: string
 ): Err<MCPError> | null {
   const allAddresses = [...to, ...(cc ?? []), ...(bcc ?? [])];
@@ -54,8 +55,8 @@ function validateEmailAddresses(
 // Used by both create_draft and send_mail to avoid code duplication.
 function buildAndEncodeEmail(params: {
   to: string[];
-  cc?: string[];
-  bcc?: string[];
+  cc?: string[] | null;
+  bcc?: string[] | null;
   from?: string;
   subject: string;
   contentType: string;
@@ -99,8 +100,8 @@ async function buildReplyContext(params: {
   replyToMessageId: string;
   accessToken: string;
   to?: string[];
-  cc?: string[];
-  bcc?: string[];
+  cc?: string[] | null;
+  bcc?: string[] | null;
   body: string;
   contentType: "text/plain" | "text/html";
   subject?: string;
@@ -109,9 +110,9 @@ async function buildReplyContext(params: {
   | Ok<{
       threadId: string;
       replyTo: string[];
-      replyCc: string[] | undefined;
-      replyBcc: string[] | undefined;
-      originalSubject: string | undefined;
+      replyCc: string[] | null;
+      replyBcc: string[] | null;
+      originalSubject: string | null;
       fullBody: string;
       threadingHeaders: string[];
     }>
@@ -166,11 +167,15 @@ async function buildReplyContext(params: {
   const originalBody = decodeMessageBody(originalMessage.payload);
   const originalCc = getHeaderValue(headers, "Cc");
   const originalBcc = getHeaderValue(headers, "Bcc");
-  const originalSubject = getHeaderValue(headers, "Subject");
+  const originalSubject = getHeaderValue(headers, "Subject") ?? null;
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const replyTo = params.to?.length ? params.to : originalFrom?.split(", ");
-  const replyCc = params.cc?.length ? params.cc : originalCc?.split(", ");
-  const replyBcc = params.bcc?.length ? params.bcc : originalBcc?.split(", ");
+  const replyCc = params.cc?.length
+    ? params.cc
+    : (originalCc?.split(", ") ?? null);
+  const replyBcc = params.bcc?.length
+    ? params.bcc
+    : (originalBcc?.split(", ") ?? null);
 
   const fullBody = buildReplyBody(
     params.body,
@@ -465,12 +470,28 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       return new Err(new MCPError(`Failed to get thread: ${errorText}`));
     }
     const result = await response.json();
+    const cleanedMessages = (result.messages ?? []).map(
+      (message: GmailMessage) => {
+        const headers = message.payload?.headers ?? [];
+        const from = getHeaderValue(headers, "From");
+        const to = getHeaderValue(headers, "To");
+        const date = getHeaderValue(headers, "Date");
+        const subject = getHeaderValue(headers, "Subject");
+        const body = unescape(
+          decodeMessageBody(message.payload)
+            .replace(/<[^>]*>/g, " ")
+            .replace(/\s+/g, " ")
+            .trim()
+        );
+        return { id: message.id, from, to, date, subject, body };
+      }
+    );
 
     return new Ok([
       { type: "text" as const, text: "Thread fetched successfully" },
       {
         type: "text" as const,
-        text: JSON.stringify({ thread: result ?? {} }, null, 2),
+        text: JSON.stringify({ messages: cleanedMessages }, null, 2),
       },
     ]);
   },

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -60,6 +60,7 @@ function buildAndEncodeEmail(params: {
   subject: string;
   contentType: string;
   body: string;
+  threadingHeaders?: string[];
 }): Err<MCPError> | Ok<string> {
   const encodedSubject = encodeSubject(params.subject);
 
@@ -83,6 +84,7 @@ function buildAndEncodeEmail(params: {
     `Subject: ${encodedSubject}`,
     `Content-Type: ${params.contentType}; charset=UTF-8`,
     "MIME-Version: 1.0",
+    ...(params.threadingHeaders ?? []),
     "",
     params.body,
   ].filter((line): line is string => line !== null);
@@ -270,6 +272,74 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       {
         type: "text" as const,
         text: JSON.stringify({ labels: result.labels ?? [] }, null, 2),
+      },
+    ]);
+  },
+
+  // create_label: async (
+  //   {name},
+  //   {authInfo}
+  // ) => {
+  //   const accessToken = authInfo?.token;
+  //   if (!accessToken) {
+  //     return new Err(new MCPError("Authentication required"));
+  //   }
+  //   const response = await fetchFromGmail(
+  //     '/gmail/v1/users/me/labels',
+  //     accessToken,
+  //     {
+  //       method: "POST",
+  //       headers: { "Content-Type": "application/json" },
+  //       body: JSON.stringify({
+  //         name: name,
+  //       }),
+  //     }
+  //     );
+  //     if (!response.ok) {
+  //     const errorText = await getErrorText(response);
+  //     return new Err(
+  //       new MCPError(`Failed to create label: ${errorText}`)
+  //     );
+  //   }
+  //   const result = await response.json();
+
+  //   return new Ok([
+  //     { type: "text" as const, text: "label created successfully" },
+  //     {
+  //       type: "text" as const,
+  //       text: JSON.stringify(
+  //         {
+  //           name: result.name,
+  //           id: result.id,
+  //           color: result.color
+  //         }
+  //       ),
+  //     },
+  //   ]);
+  //   },
+
+  get_thread: async ({ threadId }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Authentication required"));
+    }
+    const response = await fetchFromGmail(
+      `/gmail/v1/users/me/threads/${threadId}`,
+      accessToken,
+      { method: "GET" }
+    );
+
+    if (!response.ok) {
+      const errorText = await getErrorText(response);
+      return new Err(new MCPError(`Failed to get thread: ${errorText}`));
+    }
+    const result = await response.json();
+
+    return new Ok([
+      { type: "text" as const, text: "thread fetched successfully" },
+      {
+        type: "text" as const,
+        text: JSON.stringify({ thread: result ?? [] }, null, 2),
       },
     ]);
   },
@@ -722,7 +792,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   send_mail: async (
-    { to, cc, bcc, from, subject, contentType, body },
+    { to, cc, bcc, from, subject, contentType, body, replyToMessageId },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
@@ -755,6 +825,47 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
     }
 
+    let threadingHeaders: string[] = [];
+    let threadId: string | undefined = undefined;
+
+    if (replyToMessageId) {
+      const messageResponse = await fetchFromGmail(
+        `/gmail/v1/users/me/messages/${replyToMessageId}?format=full`,
+        accessToken,
+        { method: "GET" }
+      );
+
+      if (!messageResponse.ok) {
+        const errorText = await getErrorText(messageResponse);
+        if (messageResponse.status === 404) {
+          return new Err(
+            new MCPError(`Message not found: ${replyToMessageId}`, {
+              tracked: false,
+            })
+          );
+        }
+        return new Err(
+          new MCPError(
+            `Failed to get original message: ${messageResponse.status} ${messageResponse.statusText} - ${errorText}`
+          )
+        );
+      }
+      const originalMessage: GmailMessage = await messageResponse.json();
+
+      threadId = originalMessage.threadId;
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      const headers = originalMessage.payload?.headers || [];
+
+      // Extract header values
+      const originalMessageIdHeader = getHeaderValue(headers, "Message-ID");
+      const originalReferences = getHeaderValue(headers, "References");
+
+      // Create subject and headers
+      threadingHeaders = createThreadingHeaders(
+        originalMessageIdHeader,
+        originalReferences
+      );
+    }
     // Build and encode the email message
     const encodedMessageResult = buildAndEncodeEmail({
       to,
@@ -764,6 +875,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       subject,
       contentType,
       body,
+      threadingHeaders,
     });
 
     if (encodedMessageResult.isErr()) {
@@ -782,6 +894,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         },
         body: JSON.stringify({
           raw: encodedMessage,
+          ...(threadId ? { threadId: threadId } : {}),
         }),
       }
     );

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -276,48 +276,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     ]);
   },
 
-  // create_label: async (
-  //   {name},
-  //   {authInfo}
-  // ) => {
-  //   const accessToken = authInfo?.token;
-  //   if (!accessToken) {
-  //     return new Err(new MCPError("Authentication required"));
-  //   }
-  //   const response = await fetchFromGmail(
-  //     '/gmail/v1/users/me/labels',
-  //     accessToken,
-  //     {
-  //       method: "POST",
-  //       headers: { "Content-Type": "application/json" },
-  //       body: JSON.stringify({
-  //         name: name,
-  //       }),
-  //     }
-  //     );
-  //     if (!response.ok) {
-  //     const errorText = await getErrorText(response);
-  //     return new Err(
-  //       new MCPError(`Failed to create label: ${errorText}`)
-  //     );
-  //   }
-  //   const result = await response.json();
-
-  //   return new Ok([
-  //     { type: "text" as const, text: "label created successfully" },
-  //     {
-  //       type: "text" as const,
-  //       text: JSON.stringify(
-  //         {
-  //           name: result.name,
-  //           id: result.id,
-  //           color: result.color
-  //         }
-  //       ),
-  //     },
-  //   ]);
-  //   },
-
   get_thread: async ({ threadId }, { authInfo }) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -98,19 +98,19 @@ function buildAndEncodeEmail(params: {
 async function buildReplyContext(params: {
   replyToMessageId: string;
   accessToken: string;
-  to: string[] | undefined;
-  cc: string[] | undefined;
-  bcc: string[] | undefined;
+  to?: string[];
+  cc?: string[];
+  bcc?: string[];
   body: string;
   contentType: "text/plain" | "text/html";
-  subject: string | undefined;
+  subject?: string;
 }): Promise<
   | Err<MCPError>
   | Ok<{
-      threadId: string | undefined;
-      replyTo: string;
-      replyCc: string | undefined;
-      replyBcc: string | undefined;
+      threadId: string;
+      replyTo: string[];
+      replyCc: string[] | undefined;
+      replyBcc: string[] | undefined;
       originalSubject: string | undefined;
       fullBody: string;
       threadingHeaders: string[];
@@ -122,90 +122,86 @@ async function buildReplyContext(params: {
     );
   }
 
-  let threadingHeaders: string[] = [];
-  let threadId: string | undefined = undefined;
-  let fullBody: string | undefined = undefined;
-  let replyTo: string | undefined = undefined;
-  let replyCc: string | undefined = undefined;
-  let originalSubject: string | undefined = undefined;
-  let replyBcc: string | undefined = undefined;
-
-  if (params.replyToMessageId) {
-    const messageResponse = await fetchFromGmail(
-      `/gmail/v1/users/me/messages/${params.replyToMessageId}?format=full`,
-      params.accessToken,
-      { method: "GET" }
-    );
-
-    if (!messageResponse.ok) {
-      const errorText = await getErrorText(messageResponse);
-      if (messageResponse.status === 404) {
-        return new Err(
-          new MCPError(`Message not found: ${params.replyToMessageId}`, {
-            tracked: false,
-          })
-        );
-      }
-      return new Err(
-        new MCPError(
-          `Failed to get original message: ${messageResponse.status} ${messageResponse.statusText} - ${errorText}`
-        )
-      );
-    }
-    const originalMessage: GmailMessage = await messageResponse.json();
-    threadId = originalMessage.threadId;
-
-    // Determine recipients
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const headers = originalMessage.payload?.headers || [];
-    const originalFrom = getHeaderValue(headers, "From");
-    const originalDate = getHeaderValue(headers, "Date");
-    const originalBody = decodeMessageBody(originalMessage.payload);
-    const originalTo = getHeaderValue(headers, "To");
-    const originalCc = getHeaderValue(headers, "Cc");
-    const originalBcc = getHeaderValue(headers, "Bcc");
-    originalSubject = getHeaderValue(headers, "Subject");
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    replyTo = params.to?.length
-      ? params.to.join(", ")
-      : originalTo || originalFrom;
-    replyCc = params.cc?.length ? params.cc.join(", ") : originalCc;
-    replyBcc = params.bcc?.length ? params.bcc.join(", ") : originalBcc;
-
-    if (!replyTo?.trim()) {
-      return new Err(
-        new MCPError("Cannot determine reply-to address from original message")
-      );
-    }
-
-    fullBody = buildReplyBody(
-      params.body,
-      params.contentType,
-      originalBody,
-      originalDate,
-      originalFrom
-    );
-
-    // Extract header values
-    const originalMessageIdHeader = getHeaderValue(headers, "Message-ID");
-    const originalReferences = getHeaderValue(headers, "References");
-
-    // Create subject and headers
-    threadingHeaders = createThreadingHeaders(
-      originalMessageIdHeader,
-      originalReferences
+  if (params.contentType === "text/plain") {
+    return new Err(
+      new MCPError("Content type must be text/html when replying to a message.")
     );
   }
-  if (!params.replyToMessageId && !params.to?.length) {
-    return new Err(new MCPError("At least one recipient is required"));
+
+  const messageResponse = await fetchFromGmail(
+    `/gmail/v1/users/me/messages/${params.replyToMessageId}?format=full`,
+    params.accessToken,
+    { method: "GET" }
+  );
+
+  if (!messageResponse.ok) {
+    const errorText = await getErrorText(messageResponse);
+    if (messageResponse.status === 404) {
+      return new Err(
+        new MCPError(`Message not found: ${params.replyToMessageId}`, {
+          tracked: false,
+        })
+      );
+    }
+    return new Err(
+      new MCPError(
+        `Failed to get original message: ${messageResponse.status} ${messageResponse.statusText} - ${errorText}`
+      )
+    );
+  }
+  const originalMessage: GmailMessage = await messageResponse.json();
+  const threadId = originalMessage.threadId ?? "";
+
+  if (!threadId) {
+    return new Err(
+      new MCPError("Could not determine thread ID from original message")
+    );
+  }
+
+  // Determine recipients
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const headers = originalMessage.payload?.headers || [];
+  const originalFrom = getHeaderValue(headers, "From");
+  const originalDate = getHeaderValue(headers, "Date");
+  const originalBody = decodeMessageBody(originalMessage.payload);
+  const originalCc = getHeaderValue(headers, "Cc");
+  const originalBcc = getHeaderValue(headers, "Bcc");
+  const originalSubject = getHeaderValue(headers, "Subject");
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const replyTo = params.to?.length ? params.to : originalFrom?.split(", ");
+  const replyCc = params.cc?.length ? params.cc : originalCc?.split(", ");
+  const replyBcc = params.bcc?.length ? params.bcc : originalBcc?.split(", ");
+
+  const fullBody = buildReplyBody(
+    params.body,
+    params.contentType,
+    originalBody,
+    originalDate,
+    originalFrom
+  );
+
+  // Extract header values
+  const originalMessageIdHeader = getHeaderValue(headers, "Message-ID");
+  const originalReferences = getHeaderValue(headers, "References");
+
+  // Create subject and headers
+  const threadingHeaders = createThreadingHeaders(
+    originalMessageIdHeader,
+    originalReferences
+  );
+
+  if (!replyTo || !replyTo.length) {
+    return new Err(
+      new MCPError("Cannot determine reply-to address from original message")
+    );
   }
   return new Ok({
     threadId,
-    replyTo: replyTo as string,
+    replyTo,
     replyCc,
     replyBcc,
     originalSubject,
-    fullBody: fullBody ?? params.body,
+    fullBody,
     threadingHeaders,
   });
 }
@@ -309,14 +305,14 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
 
       // Build and encode the email message
       const encodedMessageResult = buildAndEncodeEmail({
-        to: [replyTo],
-        cc: replyCc ? [replyCc] : cc,
-        bcc: replyBcc ? [replyBcc] : bcc,
+        to: replyTo,
+        cc: replyCc,
+        bcc: replyBcc,
         subject: originalSubject?.startsWith("Re: ")
           ? originalSubject
           : `Re: ${originalSubject ?? "No Subject"}`,
-        contentType: replyToMessageId ? "text/html" : contentType,
-        body: fullBody ?? body,
+        contentType: "text/html",
+        body: fullBody,
         threadingHeaders,
       });
       if (encodedMessageResult.isErr()) {
@@ -331,7 +327,11 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
 
       if (!to?.length) {
-        return new Err(new MCPError("At least one recipient is required"));
+        return new Err(
+          new MCPError(
+            "At least one recipient is required when replyToMessageId is not set. Please provide a 'to' address."
+          )
+        );
       }
 
       const encodedMessageResult = buildAndEncodeEmail({
@@ -340,7 +340,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         bcc,
         subject,
         contentType,
-        body: body,
+        body,
         threadingHeaders: [],
       });
 
@@ -833,15 +833,15 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
 
       // Build and encode the email message
       const encodedMessageResult = buildAndEncodeEmail({
-        to: [replyTo],
-        cc: replyCc ? [replyCc] : cc,
-        bcc: replyBcc ? [replyBcc] : bcc,
+        to: replyTo,
+        cc: replyCc,
+        bcc: replyBcc,
         from,
         subject: originalSubject?.startsWith("Re: ")
           ? originalSubject
           : `Re: ${originalSubject ?? "No Subject"}`,
-        contentType: replyToMessageId ? "text/html" : contentType,
-        body: fullBody ?? body,
+        contentType: "text/html",
+        body: fullBody,
         threadingHeaders,
       });
 
@@ -857,7 +857,11 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
 
       if (!to?.length) {
-        return new Err(new MCPError("At least one recipient is required"));
+        return new Err(
+          new MCPError(
+            "At least one recipient is required when replyToMessageId is not set. Please provide a 'to' address."
+          )
+        );
       }
 
       const encodedMessageResult = buildAndEncodeEmail({
@@ -867,7 +871,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         from,
         subject,
         contentType,
-        body: body,
+        body,
         threadingHeaders: [],
       });
 

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -82,7 +82,7 @@ function buildAndEncodeEmail(params: {
     params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
     params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
     `Subject: ${encodedSubject}`,
-    `Content-Type: text/html; charset=UTF-8`,
+    `Content-Type: ${params.contentType}; charset=UTF-8`,
     "MIME-Version: 1.0",
     ...(params.threadingHeaders ?? []),
     "",
@@ -167,6 +167,10 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     let threadingHeaders: string[] = [];
     let threadId: string | undefined = undefined;
     let fullBody: string | undefined = undefined;
+    let replyTo : string | undefined = undefined;
+    let replyCc : string | undefined = undefined;
+    let originalSubject : string | undefined = undefined;
+    let replyBcc : string | undefined = undefined;
 
     if (replyToMessageId) {
       const messageResponse = await fetchFromGmail(
@@ -189,15 +193,29 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
           )
         );
       }
-
       const originalMessage: GmailMessage = await messageResponse.json();
       threadId = originalMessage.threadId;
-
+      
+      // Determine recipients
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const headers = originalMessage.payload?.headers || [];
       const originalFrom = getHeaderValue(headers, "From");
       const originalDate = getHeaderValue(headers, "Date");
       const originalBody = decodeMessageBody(originalMessage.payload);
+      const originalTo = getHeaderValue(headers, "To");
+      const originalCc = getHeaderValue(headers, "Cc");
+      const originalBcc = getHeaderValue(headers, "Bcc");
+      originalSubject = getHeaderValue(headers, "Subject")
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      replyTo = to?.length ? to.join(", ") : originalTo || originalFrom;
+      replyCc = cc?.length ? cc.join(", ") : originalCc;
+      replyBcc = bcc?.length ? bcc.join(", ") : originalBcc;
+
+      if (!replyTo?.trim()) {
+        return new Err(
+          new MCPError("Cannot determine reply-to address from original message")
+        );
+      }
 
       fullBody = buildReplyBody(
         body,
@@ -217,13 +235,21 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         originalReferences
       );
     }
+    if (!replyToMessageId && !to?.length) {
+      return new Err(new MCPError("At least one recipient is required"));
+    }
 
     // Build and encode the email message
     const encodedMessageResult = buildAndEncodeEmail({
-      to,
-      cc,
-      bcc,
-      subject,
+      to: replyToMessageId && replyTo ? [replyTo] : (to ?? []),
+      cc: replyToMessageId && replyCc ? [replyCc] : cc,
+      bcc: replyToMessageId && replyBcc ? [replyBcc] : bcc,
+      subject: replyToMessageId
+      ? subject
+      ?? (originalSubject?.startsWith("Re: ")
+      ? originalSubject : `Re: ${originalSubject ?? "No Subject"}`
+    )
+    : subject,
       contentType: replyToMessageId ? "text/html" : contentType,
       body: fullBody ?? body,
       threadingHeaders,
@@ -349,10 +375,10 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     const result = await response.json();
 
     return new Ok([
-      { type: "text" as const, text: "thread fetched successfully" },
+      { type: "text" as const, text: "Thread fetched successfully" },
       {
         type: "text" as const,
-        text: JSON.stringify({ thread: result ?? [] }, null, 2),
+        text: JSON.stringify({ thread: result ?? {} }, null, 2),
       },
     ]);
   },
@@ -689,6 +715,10 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     let threadingHeaders: string[] = [];
     let threadId: string | undefined = undefined;
     let fullBody: string | undefined = undefined;
+    let replyTo : string | undefined = undefined;
+    let replyCc : string | undefined = undefined;
+    let originalSubject : string | undefined = undefined;
+    let replyBcc : string | undefined = undefined;
 
     if (replyToMessageId) {
       const messageResponse = await fetchFromGmail(
@@ -696,7 +726,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         accessToken,
         { method: "GET" }
       );
-
       if (!messageResponse.ok) {
         const errorText = await getErrorText(messageResponse);
         if (messageResponse.status === 404) {
@@ -713,13 +742,28 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         );
       }
       const originalMessage: GmailMessage = await messageResponse.json();
-
       threadId = originalMessage.threadId;
+    
+      // Determine recipients
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const headers = originalMessage.payload?.headers || [];
       const originalFrom = getHeaderValue(headers, "From");
       const originalDate = getHeaderValue(headers, "Date");
       const originalBody = decodeMessageBody(originalMessage.payload);
+      const originalTo = getHeaderValue(headers, "To");
+      const originalCc = getHeaderValue(headers, "Cc");
+      const originalBcc = getHeaderValue(headers, "Bcc");
+      originalSubject = getHeaderValue(headers, "Subject");
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      replyTo = to?.length ? to.join(", ") : originalTo || originalFrom;
+      replyCc = cc?.length ? cc.join(", ") : originalCc;
+      replyBcc = bcc?.length ? bcc.join(", ") : originalBcc;
+
+      if (!replyTo?.trim()) {
+        return new Err(
+          new MCPError("Cannot determine reply-to address from original message")
+        );
+      }
 
       fullBody = buildReplyBody(
         body,
@@ -728,6 +772,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         originalDate,
         originalFrom
       );
+
       // Extract header values
       const originalMessageIdHeader = getHeaderValue(headers, "Message-ID");
       const originalReferences = getHeaderValue(headers, "References");
@@ -738,13 +783,24 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         originalReferences
       );
     }
+
+    if (!replyToMessageId && !to?.length) {
+      return new Err(new MCPError("At least one recipient is required"));
+    }
+
     // Build and encode the email message
     const encodedMessageResult = buildAndEncodeEmail({
-      to,
-      cc,
-      bcc,
+      to: replyToMessageId && replyTo ? [replyTo] : (to ?? []),
+      cc: replyToMessageId && replyCc ? [replyCc] : cc,
+      bcc: replyToMessageId && replyBcc ? [replyBcc] : bcc,
       from,
-      subject,
+      subject: replyToMessageId
+      ? subject 
+      ?? (
+        originalSubject?.startsWith("Re:") ? originalSubject
+        : `Re: ${originalSubject ?? "No Subject"}`
+      )
+      : subject,
       contentType: replyToMessageId ? "text/html" : contentType,
       body: fullBody ?? body,
       threadingHeaders,
@@ -756,6 +812,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
 
     const encodedMessage = encodedMessageResult.value;
 
+    // Make the API call to send email in Gmail.
     const response = await fetchFromGmail(
       "/gmail/v1/users/me/messages/send",
       accessToken,

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -167,10 +167,10 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     let threadingHeaders: string[] = [];
     let threadId: string | undefined = undefined;
     let fullBody: string | undefined = undefined;
-    let replyTo : string | undefined = undefined;
-    let replyCc : string | undefined = undefined;
-    let originalSubject : string | undefined = undefined;
-    let replyBcc : string | undefined = undefined;
+    let replyTo: string | undefined = undefined;
+    let replyCc: string | undefined = undefined;
+    let originalSubject: string | undefined = undefined;
+    let replyBcc: string | undefined = undefined;
 
     if (replyToMessageId) {
       const messageResponse = await fetchFromGmail(
@@ -195,7 +195,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
       const originalMessage: GmailMessage = await messageResponse.json();
       threadId = originalMessage.threadId;
-      
+
       // Determine recipients
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const headers = originalMessage.payload?.headers || [];
@@ -205,7 +205,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       const originalTo = getHeaderValue(headers, "To");
       const originalCc = getHeaderValue(headers, "Cc");
       const originalBcc = getHeaderValue(headers, "Bcc");
-      originalSubject = getHeaderValue(headers, "Subject")
+      originalSubject = getHeaderValue(headers, "Subject");
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       replyTo = to?.length ? to.join(", ") : originalTo || originalFrom;
       replyCc = cc?.length ? cc.join(", ") : originalCc;
@@ -213,7 +213,9 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
 
       if (!replyTo?.trim()) {
         return new Err(
-          new MCPError("Cannot determine reply-to address from original message")
+          new MCPError(
+            "Cannot determine reply-to address from original message"
+          )
         );
       }
 
@@ -245,11 +247,11 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       cc: replyToMessageId && replyCc ? [replyCc] : cc,
       bcc: replyToMessageId && replyBcc ? [replyBcc] : bcc,
       subject: replyToMessageId
-      ? subject
-      ?? (originalSubject?.startsWith("Re: ")
-      ? originalSubject : `Re: ${originalSubject ?? "No Subject"}`
-    )
-    : subject,
+        ? (subject ??
+          (originalSubject?.startsWith("Re: ")
+            ? originalSubject
+            : `Re: ${originalSubject ?? "No Subject"}`))
+        : subject,
       contentType: replyToMessageId ? "text/html" : contentType,
       body: fullBody ?? body,
       threadingHeaders,
@@ -715,10 +717,10 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     let threadingHeaders: string[] = [];
     let threadId: string | undefined = undefined;
     let fullBody: string | undefined = undefined;
-    let replyTo : string | undefined = undefined;
-    let replyCc : string | undefined = undefined;
-    let originalSubject : string | undefined = undefined;
-    let replyBcc : string | undefined = undefined;
+    let replyTo: string | undefined = undefined;
+    let replyCc: string | undefined = undefined;
+    let originalSubject: string | undefined = undefined;
+    let replyBcc: string | undefined = undefined;
 
     if (replyToMessageId) {
       const messageResponse = await fetchFromGmail(
@@ -743,7 +745,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
       const originalMessage: GmailMessage = await messageResponse.json();
       threadId = originalMessage.threadId;
-    
+
       // Determine recipients
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const headers = originalMessage.payload?.headers || [];
@@ -761,7 +763,9 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
 
       if (!replyTo?.trim()) {
         return new Err(
-          new MCPError("Cannot determine reply-to address from original message")
+          new MCPError(
+            "Cannot determine reply-to address from original message"
+          )
         );
       }
 
@@ -795,12 +799,11 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       bcc: replyToMessageId && replyBcc ? [replyBcc] : bcc,
       from,
       subject: replyToMessageId
-      ? subject 
-      ?? (
-        originalSubject?.startsWith("Re:") ? originalSubject
-        : `Re: ${originalSubject ?? "No Subject"}`
-      )
-      : subject,
+        ? (subject ??
+          (originalSubject?.startsWith("Re:")
+            ? originalSubject
+            : `Re: ${originalSubject ?? "No Subject"}`))
+        : subject,
       contentType: replyToMessageId ? "text/html" : contentType,
       body: fullBody ?? body,
       threadingHeaders,

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -82,7 +82,7 @@ function buildAndEncodeEmail(params: {
     params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
     params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
     `Subject: ${encodedSubject}`,
-    `Content-Type: ${params.contentType}; charset=UTF-8`,
+    `Content-Type: text/html; charset=UTF-8`,
     "MIME-Version: 1.0",
     ...(params.threadingHeaders ?? []),
     "",
@@ -157,12 +157,65 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   create_draft: async (
-    { to, cc, bcc, subject, contentType, body },
+    { to, cc, bcc, subject, contentType, body, replyToMessageId },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
+    }
+    let threadingHeaders: string[] = [];
+    let threadId: string | undefined = undefined;
+    let fullBody: string | undefined = undefined;
+
+    if (replyToMessageId) {
+      const messageResponse = await fetchFromGmail(
+        `/gmail/v1/users/me/messages/${replyToMessageId}?format=full`,
+        accessToken,
+        { method: "GET" }
+      );
+      if (!messageResponse.ok) {
+        const errorText = await getErrorText(messageResponse);
+        if (messageResponse.status === 404) {
+          return new Err(
+            new MCPError(`Message not found: ${replyToMessageId}`, {
+              tracked: false,
+            })
+          );
+        }
+        return new Err(
+          new MCPError(
+            `Failed to get original message: ${messageResponse.status} ${messageResponse.statusText} - ${errorText}`
+          )
+        );
+      }
+
+      const originalMessage: GmailMessage = await messageResponse.json();
+      threadId = originalMessage.threadId;
+
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      const headers = originalMessage.payload?.headers || [];
+      const originalFrom = getHeaderValue(headers, "From");
+      const originalDate = getHeaderValue(headers, "Date");
+      const originalBody = decodeMessageBody(originalMessage.payload);
+
+      fullBody = buildReplyBody(
+        body,
+        contentType,
+        originalBody,
+        originalDate,
+        originalFrom
+      );
+
+      // Extract header values
+      const originalMessageIdHeader = getHeaderValue(headers, "Message-ID");
+      const originalReferences = getHeaderValue(headers, "References");
+
+      // Create subject and headers
+      threadingHeaders = createThreadingHeaders(
+        originalMessageIdHeader,
+        originalReferences
+      );
     }
 
     // Build and encode the email message
@@ -171,8 +224,9 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       cc,
       bcc,
       subject,
-      contentType,
-      body,
+      contentType: replyToMessageId ? "text/html" : contentType,
+      body: fullBody ?? body,
+      threadingHeaders,
     });
 
     if (encodedMessageResult.isErr()) {
@@ -193,6 +247,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         body: JSON.stringify({
           message: {
             raw: encodedMessage,
+            ...(threadId ? { threadId: threadId } : {}),
           },
         }),
       }
@@ -597,158 +652,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     return result;
   },
 
-  create_reply_draft: async (
-    { messageId, body, contentType = "text/plain" as const, to, cc, bcc },
-    { authInfo }
-  ) => {
-    const accessToken = authInfo?.token;
-    if (!accessToken) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    // Fetch the original message
-    const messageResponse = await fetchFromGmail(
-      `/gmail/v1/users/me/messages/${messageId}?format=full`,
-      accessToken,
-      { method: "GET" }
-    );
-
-    if (!messageResponse.ok) {
-      const errorText = await getErrorText(messageResponse);
-      if (messageResponse.status === 404) {
-        return new Err(
-          new MCPError(`Message not found: ${messageId}`, {
-            tracked: false,
-          })
-        );
-      }
-      return new Err(
-        new MCPError(
-          `Failed to get original message: ${messageResponse.status} ${messageResponse.statusText} - ${errorText}`
-        )
-      );
-    }
-
-    const originalMessage: GmailMessage = await messageResponse.json();
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const headers = originalMessage.payload?.headers || [];
-
-    // Extract header values
-    const originalFrom = getHeaderValue(headers, "From");
-    const originalTo = getHeaderValue(headers, "To");
-    const originalCc = getHeaderValue(headers, "Cc");
-    const originalBcc = getHeaderValue(headers, "Bcc");
-    const originalSubject = getHeaderValue(headers, "Subject");
-    const originalMessageIdHeader = getHeaderValue(headers, "Message-ID");
-    const originalReferences = getHeaderValue(headers, "References");
-    const originalDate = getHeaderValue(headers, "Date");
-
-    // Validate user-provided email addresses to prevent header injection
-    if (to?.length || cc?.length || bcc?.length) {
-      const validationError = validateEmailAddresses(to ?? [], cc, bcc);
-      if (validationError) {
-        return validationError;
-      }
-    }
-
-    // Determine recipients
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const replyTo = to?.length ? to.join(", ") : originalTo || originalFrom;
-    const replyCc = cc?.length ? cc.join(", ") : originalCc;
-    const replyBcc = bcc?.length ? bcc.join(", ") : originalBcc;
-
-    if (!replyTo?.trim()) {
-      return new Err(
-        new MCPError("Cannot determine reply-to address from original message")
-      );
-    }
-
-    // Create subject and headers
-    const replySubject = originalSubject?.startsWith("Re:")
-      ? originalSubject
-      : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        `Re: ${originalSubject || "No Subject"}`;
-    const encodedSubject = encodeSubject(replySubject);
-    const threadingHeaders = createThreadingHeaders(
-      originalMessageIdHeader,
-      originalReferences
-    );
-
-    // Build reply body
-    const originalBody = decodeMessageBody(originalMessage.payload);
-    const fullBody = buildReplyBody(
-      body,
-      contentType,
-      originalBody,
-      originalDate,
-      originalFrom
-    );
-
-    // Construct the reply message
-    const messageLines = [
-      `To: ${replyTo}`,
-      replyCc ? `Cc: ${replyCc}` : null,
-      replyBcc ? `Bcc: ${replyBcc}` : null,
-      `Subject: ${encodedSubject}`,
-      "Content-Type: text/html; charset=UTF-8",
-      "MIME-Version: 1.0",
-      ...threadingHeaders,
-      "",
-      fullBody,
-    ].filter((line): line is string => line !== null);
-
-    const message = messageLines.join("\r\n");
-
-    // Encode the message in base64 as required by the Gmail API
-    const encodedMessage = encodeMessageForGmail(message);
-
-    const response = await fetchFromGmail(
-      "/gmail/v1/users/me/drafts",
-      accessToken,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          message: {
-            raw: encodedMessage,
-            threadId: originalMessage.threadId,
-          },
-        }),
-      }
-    );
-
-    if (!response.ok) {
-      const errorText = await getErrorText(response);
-      return new Err(
-        new MCPError(
-          `Failed to create reply draft: ${response.status} ${response.statusText} - ${errorText}`
-        )
-      );
-    }
-
-    const result = await response.json();
-
-    return new Ok([
-      { type: "text" as const, text: "Reply draft created successfully" },
-      {
-        type: "text" as const,
-        text: JSON.stringify(
-          {
-            draftId: result.id,
-            messageId: result.message.id,
-            originalMessageId: messageId,
-            replyTo,
-            subject: replySubject,
-          },
-          null,
-          2
-        ),
-      },
-    ]);
-  },
-
   send_mail: async (
     { to, cc, bcc, from, subject, contentType, body, replyToMessageId },
     { authInfo }
@@ -785,6 +688,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
 
     let threadingHeaders: string[] = [];
     let threadId: string | undefined = undefined;
+    let fullBody: string | undefined = undefined;
 
     if (replyToMessageId) {
       const messageResponse = await fetchFromGmail(
@@ -813,7 +717,17 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       threadId = originalMessage.threadId;
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const headers = originalMessage.payload?.headers || [];
+      const originalFrom = getHeaderValue(headers, "From");
+      const originalDate = getHeaderValue(headers, "Date");
+      const originalBody = decodeMessageBody(originalMessage.payload);
 
+      fullBody = buildReplyBody(
+        body,
+        contentType,
+        originalBody,
+        originalDate,
+        originalFrom
+      );
       // Extract header values
       const originalMessageIdHeader = getHeaderValue(headers, "Message-ID");
       const originalReferences = getHeaderValue(headers, "References");
@@ -831,8 +745,8 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       bcc,
       from,
       subject,
-      contentType,
-      body,
+      contentType: replyToMessageId ? "text/html" : contentType,
+      body: fullBody ?? body,
       threadingHeaders,
     });
 

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -95,6 +95,121 @@ function buildAndEncodeEmail(params: {
   return new Ok(encodedMessage);
 }
 
+async function buildReplyContext(params: {
+  replyToMessageId: string;
+  accessToken: string;
+  to: string[] | undefined;
+  cc: string[] | undefined;
+  bcc: string[] | undefined;
+  body: string;
+  contentType: "text/plain" | "text/html";
+  subject: string | undefined;
+}): Promise<
+  | Err<MCPError>
+  | Ok<{
+      threadId: string | undefined;
+      replyTo: string;
+      replyCc: string | undefined;
+      replyBcc: string | undefined;
+      originalSubject: string | undefined;
+      fullBody: string;
+      threadingHeaders: string[];
+    }>
+> {
+  if (params.subject) {
+    return new Err(
+      new MCPError("Subject should not be provided when replying to a message.")
+    );
+  }
+
+  let threadingHeaders: string[] = [];
+  let threadId: string | undefined = undefined;
+  let fullBody: string | undefined = undefined;
+  let replyTo: string | undefined = undefined;
+  let replyCc: string | undefined = undefined;
+  let originalSubject: string | undefined = undefined;
+  let replyBcc: string | undefined = undefined;
+
+  if (params.replyToMessageId) {
+    const messageResponse = await fetchFromGmail(
+      `/gmail/v1/users/me/messages/${params.replyToMessageId}?format=full`,
+      params.accessToken,
+      { method: "GET" }
+    );
+
+    if (!messageResponse.ok) {
+      const errorText = await getErrorText(messageResponse);
+      if (messageResponse.status === 404) {
+        return new Err(
+          new MCPError(`Message not found: ${params.replyToMessageId}`, {
+            tracked: false,
+          })
+        );
+      }
+      return new Err(
+        new MCPError(
+          `Failed to get original message: ${messageResponse.status} ${messageResponse.statusText} - ${errorText}`
+        )
+      );
+    }
+    const originalMessage: GmailMessage = await messageResponse.json();
+    threadId = originalMessage.threadId;
+
+    // Determine recipients
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const headers = originalMessage.payload?.headers || [];
+    const originalFrom = getHeaderValue(headers, "From");
+    const originalDate = getHeaderValue(headers, "Date");
+    const originalBody = decodeMessageBody(originalMessage.payload);
+    const originalTo = getHeaderValue(headers, "To");
+    const originalCc = getHeaderValue(headers, "Cc");
+    const originalBcc = getHeaderValue(headers, "Bcc");
+    originalSubject = getHeaderValue(headers, "Subject");
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    replyTo = params.to?.length
+      ? params.to.join(", ")
+      : originalTo || originalFrom;
+    replyCc = params.cc?.length ? params.cc.join(", ") : originalCc;
+    replyBcc = params.bcc?.length ? params.bcc.join(", ") : originalBcc;
+
+    if (!replyTo?.trim()) {
+      return new Err(
+        new MCPError("Cannot determine reply-to address from original message")
+      );
+    }
+
+    fullBody = buildReplyBody(
+      params.body,
+      params.contentType,
+      originalBody,
+      originalDate,
+      originalFrom
+    );
+
+    // Extract header values
+    const originalMessageIdHeader = getHeaderValue(headers, "Message-ID");
+    const originalReferences = getHeaderValue(headers, "References");
+
+    // Create subject and headers
+    threadingHeaders = createThreadingHeaders(
+      originalMessageIdHeader,
+      originalReferences
+    );
+  }
+  if (!params.replyToMessageId && !params.to?.length) {
+    return new Err(new MCPError("At least one recipient is required"));
+  }
+  return new Ok({
+    threadId,
+    replyTo: replyTo as string,
+    replyCc,
+    replyBcc,
+    originalSubject,
+    fullBody: fullBody ?? params.body,
+    threadingHeaders,
+  });
+}
+
 const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   get_drafts: async ({ q, pageToken }, { authInfo }) => {
     const accessToken = authInfo?.token;
@@ -164,104 +279,79 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
-    let threadingHeaders: string[] = [];
+
+    let encodedMessage: string | undefined = undefined;
     let threadId: string | undefined = undefined;
-    let fullBody: string | undefined = undefined;
-    let replyTo: string | undefined = undefined;
-    let replyCc: string | undefined = undefined;
-    let originalSubject: string | undefined = undefined;
-    let replyBcc: string | undefined = undefined;
 
     if (replyToMessageId) {
-      const messageResponse = await fetchFromGmail(
-        `/gmail/v1/users/me/messages/${replyToMessageId}?format=full`,
+      const replyContext = await buildReplyContext({
+        replyToMessageId,
         accessToken,
-        { method: "GET" }
-      );
-      if (!messageResponse.ok) {
-        const errorText = await getErrorText(messageResponse);
-        if (messageResponse.status === 404) {
-          return new Err(
-            new MCPError(`Message not found: ${replyToMessageId}`, {
-              tracked: false,
-            })
-          );
-        }
-        return new Err(
-          new MCPError(
-            `Failed to get original message: ${messageResponse.status} ${messageResponse.statusText} - ${errorText}`
-          )
-        );
-      }
-      const originalMessage: GmailMessage = await messageResponse.json();
-      threadId = originalMessage.threadId;
-
-      // Determine recipients
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      const headers = originalMessage.payload?.headers || [];
-      const originalFrom = getHeaderValue(headers, "From");
-      const originalDate = getHeaderValue(headers, "Date");
-      const originalBody = decodeMessageBody(originalMessage.payload);
-      const originalTo = getHeaderValue(headers, "To");
-      const originalCc = getHeaderValue(headers, "Cc");
-      const originalBcc = getHeaderValue(headers, "Bcc");
-      originalSubject = getHeaderValue(headers, "Subject");
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      replyTo = to?.length ? to.join(", ") : originalTo || originalFrom;
-      replyCc = cc?.length ? cc.join(", ") : originalCc;
-      replyBcc = bcc?.length ? bcc.join(", ") : originalBcc;
-
-      if (!replyTo?.trim()) {
-        return new Err(
-          new MCPError(
-            "Cannot determine reply-to address from original message"
-          )
-        );
-      }
-
-      fullBody = buildReplyBody(
+        to,
+        cc,
+        bcc,
         body,
         contentType,
-        originalBody,
-        originalDate,
-        originalFrom
-      );
+        subject,
+      });
+      if (replyContext.isErr()) {
+        return replyContext;
+      }
+      const {
+        replyTo,
+        replyCc,
+        replyBcc,
+        originalSubject,
+        fullBody,
+        threadingHeaders,
+      } = replyContext.value;
+      threadId = replyContext.value.threadId;
 
-      // Extract header values
-      const originalMessageIdHeader = getHeaderValue(headers, "Message-ID");
-      const originalReferences = getHeaderValue(headers, "References");
+      // Build and encode the email message
+      const encodedMessageResult = buildAndEncodeEmail({
+        to: [replyTo],
+        cc: replyCc ? [replyCc] : cc,
+        bcc: replyBcc ? [replyBcc] : bcc,
+        subject: originalSubject?.startsWith("Re: ")
+          ? originalSubject
+          : `Re: ${originalSubject ?? "No Subject"}`,
+        contentType: replyToMessageId ? "text/html" : contentType,
+        body: fullBody ?? body,
+        threadingHeaders,
+      });
+      if (encodedMessageResult.isErr()) {
+        return encodedMessageResult;
+      }
+      encodedMessage = encodedMessageResult.value;
+    } else {
+      if (!subject) {
+        return new Err(
+          new MCPError("Subject is required when not replying to a message.")
+        );
+      }
 
-      // Create subject and headers
-      threadingHeaders = createThreadingHeaders(
-        originalMessageIdHeader,
-        originalReferences
-      );
+      if (!to?.length) {
+        return new Err(new MCPError("At least one recipient is required"));
+      }
+
+      const encodedMessageResult = buildAndEncodeEmail({
+        to,
+        cc,
+        bcc,
+        subject,
+        contentType,
+        body: body,
+        threadingHeaders: [],
+      });
+
+      if (encodedMessageResult.isErr()) {
+        return encodedMessageResult;
+      }
+      encodedMessage = encodedMessageResult.value;
     }
-    if (!replyToMessageId && !to?.length) {
-      return new Err(new MCPError("At least one recipient is required"));
+    if (!encodedMessage) {
+      return new Err(new MCPError("Failed to encode email"));
     }
-
-    // Build and encode the email message
-    const encodedMessageResult = buildAndEncodeEmail({
-      to: replyToMessageId && replyTo ? [replyTo] : (to ?? []),
-      cc: replyToMessageId && replyCc ? [replyCc] : cc,
-      bcc: replyToMessageId && replyBcc ? [replyBcc] : bcc,
-      subject: replyToMessageId
-        ? (subject ??
-          (originalSubject?.startsWith("Re: ")
-            ? originalSubject
-            : `Re: ${originalSubject ?? "No Subject"}`))
-        : subject,
-      contentType: replyToMessageId ? "text/html" : contentType,
-      body: fullBody ?? body,
-      threadingHeaders,
-    });
-
-    if (encodedMessageResult.isErr()) {
-      return encodedMessageResult;
-    }
-
-    const encodedMessage = encodedMessageResult.value;
 
     // Make the API call to create the draft in Gmail.
     const response = await fetchFromGmail(
@@ -688,7 +778,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
-
     // If a from alias was requested, verify it's a configured send-as address
     // before sending. Gmail silently falls back to the primary address if the
     // alias isn't set up, so we fail early to surface the issue.
@@ -714,106 +803,83 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
     }
 
-    let threadingHeaders: string[] = [];
+    let encodedMessage: string | undefined = undefined;
     let threadId: string | undefined = undefined;
-    let fullBody: string | undefined = undefined;
-    let replyTo: string | undefined = undefined;
-    let replyCc: string | undefined = undefined;
-    let originalSubject: string | undefined = undefined;
-    let replyBcc: string | undefined = undefined;
 
     if (replyToMessageId) {
-      const messageResponse = await fetchFromGmail(
-        `/gmail/v1/users/me/messages/${replyToMessageId}?format=full`,
+      const replyContext = await buildReplyContext({
+        replyToMessageId,
         accessToken,
-        { method: "GET" }
-      );
-      if (!messageResponse.ok) {
-        const errorText = await getErrorText(messageResponse);
-        if (messageResponse.status === 404) {
-          return new Err(
-            new MCPError(`Message not found: ${replyToMessageId}`, {
-              tracked: false,
-            })
-          );
-        }
-        return new Err(
-          new MCPError(
-            `Failed to get original message: ${messageResponse.status} ${messageResponse.statusText} - ${errorText}`
-          )
-        );
-      }
-      const originalMessage: GmailMessage = await messageResponse.json();
-      threadId = originalMessage.threadId;
-
-      // Determine recipients
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      const headers = originalMessage.payload?.headers || [];
-      const originalFrom = getHeaderValue(headers, "From");
-      const originalDate = getHeaderValue(headers, "Date");
-      const originalBody = decodeMessageBody(originalMessage.payload);
-      const originalTo = getHeaderValue(headers, "To");
-      const originalCc = getHeaderValue(headers, "Cc");
-      const originalBcc = getHeaderValue(headers, "Bcc");
-      originalSubject = getHeaderValue(headers, "Subject");
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      replyTo = to?.length ? to.join(", ") : originalTo || originalFrom;
-      replyCc = cc?.length ? cc.join(", ") : originalCc;
-      replyBcc = bcc?.length ? bcc.join(", ") : originalBcc;
-
-      if (!replyTo?.trim()) {
-        return new Err(
-          new MCPError(
-            "Cannot determine reply-to address from original message"
-          )
-        );
-      }
-
-      fullBody = buildReplyBody(
+        to,
+        cc,
+        bcc,
         body,
         contentType,
-        originalBody,
-        originalDate,
-        originalFrom
-      );
+        subject,
+      });
+      if (replyContext.isErr()) {
+        return replyContext;
+      }
 
-      // Extract header values
-      const originalMessageIdHeader = getHeaderValue(headers, "Message-ID");
-      const originalReferences = getHeaderValue(headers, "References");
+      const {
+        replyTo,
+        replyCc,
+        replyBcc,
+        originalSubject,
+        fullBody,
+        threadingHeaders,
+      } = replyContext.value;
+      threadId = replyContext.value.threadId;
 
-      // Create subject and headers
-      threadingHeaders = createThreadingHeaders(
-        originalMessageIdHeader,
-        originalReferences
-      );
+      // Build and encode the email message
+      const encodedMessageResult = buildAndEncodeEmail({
+        to: [replyTo],
+        cc: replyCc ? [replyCc] : cc,
+        bcc: replyBcc ? [replyBcc] : bcc,
+        from,
+        subject: originalSubject?.startsWith("Re: ")
+          ? originalSubject
+          : `Re: ${originalSubject ?? "No Subject"}`,
+        contentType: replyToMessageId ? "text/html" : contentType,
+        body: fullBody ?? body,
+        threadingHeaders,
+      });
+
+      if (encodedMessageResult.isErr()) {
+        return encodedMessageResult;
+      }
+      encodedMessage = encodedMessageResult.value;
+    } else {
+      if (!subject) {
+        return new Err(
+          new MCPError("Subject is required when not replying to a message.")
+        );
+      }
+
+      if (!to?.length) {
+        return new Err(new MCPError("At least one recipient is required"));
+      }
+
+      const encodedMessageResult = buildAndEncodeEmail({
+        to,
+        cc,
+        bcc,
+        from,
+        subject,
+        contentType,
+        body: body,
+        threadingHeaders: [],
+      });
+
+      if (encodedMessageResult.isErr()) {
+        return encodedMessageResult;
+      }
+      encodedMessage = encodedMessageResult.value;
     }
 
-    if (!replyToMessageId && !to?.length) {
-      return new Err(new MCPError("At least one recipient is required"));
+    if (!encodedMessage) {
+      return new Err(new MCPError("Failed to encode email"));
     }
-
-    // Build and encode the email message
-    const encodedMessageResult = buildAndEncodeEmail({
-      to: replyToMessageId && replyTo ? [replyTo] : (to ?? []),
-      cc: replyToMessageId && replyCc ? [replyCc] : cc,
-      bcc: replyToMessageId && replyBcc ? [replyBcc] : bcc,
-      from,
-      subject: replyToMessageId
-        ? (subject ??
-          (originalSubject?.startsWith("Re:")
-            ? originalSubject
-            : `Re: ${originalSubject ?? "No Subject"}`))
-        : subject,
-      contentType: replyToMessageId ? "text/html" : contentType,
-      body: fullBody ?? body,
-      threadingHeaders,
-    });
-
-    if (encodedMessageResult.isErr()) {
-      return encodedMessageResult;
-    }
-
-    const encodedMessage = encodedMessageResult.value;
 
     // Make the API call to send email in Gmail.
     const response = await fetchFromGmail(
@@ -835,7 +901,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       const errorText = await getErrorText(response);
       return new Err(new MCPError(`Failed to send email: ${errorText}`));
     }
-
     const result = await response.json();
 
     return new Ok([

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -157,7 +157,11 @@ async function buildReplyContext(params: {
   const headers = originalMessage.payload?.headers || [];
   const originalFrom = getHeaderValue(headers, "From");
   const originalDate = getHeaderValue(headers, "Date");
-  const originalBody = decodeMessageBody(originalMessage.payload);
+  const rawBody = decodeMessageBody(originalMessage.payload);
+  const originalBody = unescape(rawBody)
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
   const originalCc = getHeaderValue(headers, "Cc");
   const originalBcc = getHeaderValue(headers, "Bcc");
   const originalSubject = getHeaderValue(headers, "Subject") ?? null;

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -325,7 +325,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
       encodedMessage = encodedMessageResult.value;
     } else {
-      if (!subject) {
+      if (!subject?.trim()) {
         return new Err(
           new MCPError("Subject is required when not replying to a message.")
         );
@@ -871,7 +871,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
       encodedMessage = encodedMessageResult.value;
     } else {
-      if (!subject) {
+      if (!subject?.trim()) {
         return new Err(
           new MCPError("Subject is required when not replying to a message.")
         );


### PR DESCRIPTION
## Description
Two new capabilities added to the Gmail MCP tool:

- `send_mail` now accepts an optional `replyToMessageId` parameter. When provided, the email is sent as a reply in the existing thread, with proper threading headers (`In-Reply-To`, `References`) and `threadId` to ensure compatibility with all email clients.

- `get_thread` retrieves all messages of a Gmail thread in a single API call, enabling agents to get full conversation context.

## Tests
Tested manually locally:

Non-regression tests (existing tools):
- get_messages: verified working
- get_drafts: verified working
- create_draft: verified working (also uses buildAndEncodeEmail — no regression)
- delete_draft: verified working
- create_reply_draft: verified working
- get_labels: verified working
- set_message_labels: verified working
- send_mail (without replyToMessageId): verified working — no regression after buildAndEncodeEmail modification
- get_attachment: verified working

New features:
- send_mail with replyToMessageId: successfully sent a reply that appeared in the correct thread in Gmail
- get_thread: successfully retrieved all messages of a thread

Edge cases:
- send_mail with invalid replyToMessageId: returns a clear 400 error from Gmail API, no silent failure
- get_thread with invalid threadId: returns a clear error, no silent failure

Updated MCP snapshot to reflect new tool definitions.

## Risk
Low. replyToMessageId is optional — existing send_mail behavior is unchanged when not provided. get_thread is a read-only operation. buildAndEncodeEmail was modified to accept an optional threadingHeaders parameter with a default empty value, so existing callers are unaffected.

## Deploy Plan
No specific deployment steps required. Changes are backward compatible.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->