### PR TITLE
[homepage] fix sign up page navigation

### DIFF
--- a/front/pages/sign-up.tsx
+++ b/front/pages/sign-up.tsx
@@ -5,8 +5,10 @@ const DEFAULT_RETURN_TO = "/api/login";
 
 export default function SignUpNextJS() {
   useEffect(() => {
-    window.location.href = appendUTMParams(
-      `/api/workos/login?returnTo=${encodeURIComponent(DEFAULT_RETURN_TO)}&screenHint=sign-up`
+    window.location.replace(
+      appendUTMParams(
+        `/api/workos/login?returnTo=${encodeURIComponent(DEFAULT_RETURN_TO)}&screenHint=sign-up`
+      )
     );
   }, []);
 


### PR DESCRIPTION
## Description
This PR is to fix [this issue](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1779109395554679). When you go to sign up page via Try For Free button on the homepage, and then go back to the page navigation, you have to click twice to go back to the homepage due to this: 

```
Problem: The /sign-up page used window.location.href = ... to redirect to WorkOS login.
  This pushes a new entry onto the browser history stack. So clicking "Try for free" creates
   two history entries: one for /sign-up and one for the WorkOS login URL. The back button
  hits the intermediate /sign-up page first, which immediately redirects forward again —
  making it feel like you need two back clicks.
```

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25704">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->