### PR TITLE
[front] fix shared public logo imports for SPA builds

### DIFF
--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
@@ -1,4 +1,4 @@
-import { PublicWebsiteLogo } from "@app/components/home/LandingLayout";
+import { PublicWebsiteLogo } from "@app/components/home/PublicWebsiteLogo";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import config from "@app/lib/api/config";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -9,6 +9,7 @@ import { MainNavigation } from "@app/components/home/menu/MainNavigation";
 import { MobileNavigation } from "@app/components/home/menu/MobileNavigation";
 import { OpenDustButton } from "@app/components/home/OpenDustButton";
 import { PromoBanner } from "@app/components/home/PromoBanner";
+import { PublicWebsiteLogo } from "@app/components/home/PublicWebsiteLogo";
 import ScrollingHeader from "@app/components/home/ScrollingHeader";
 import UTMButton from "@app/components/UTMButton";
 import { useStripUtmParams } from "@app/hooks/useStripUtmParams";
@@ -25,8 +26,7 @@ import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames, getFaviconPath } from "@app/lib/utils";
 import { getOrCreateAnonymousId } from "@app/lib/utils/anonymous_id";
 import { appendUTMParams } from "@app/lib/utils/utm";
-import { Button, cn, DustLogo } from "@dust-tt/sparkle";
-import { cva } from "class-variance-authority";
+import { Button, cn } from "@dust-tt/sparkle";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -416,38 +416,5 @@ const Header = () => {
         href="/static/AppIcon_228.png"
       />
     </Head>
-  );
-};
-
-interface PublicWebsiteLogoProps {
-  size?: "default" | "small";
-  utmParam?: string;
-  baseUrl?: string;
-}
-
-const logoVariants = cva("", {
-  variants: {
-    size: {
-      default: "h-[24px] w-[96px]",
-      small: "h-[20px] w-[80px]",
-    },
-  },
-  defaultVariants: {
-    size: "default",
-  },
-});
-
-export const PublicWebsiteLogo = ({
-  size = "default",
-  utmParam,
-  baseUrl,
-}: PublicWebsiteLogoProps) => {
-  const className = logoVariants({ size });
-  const href = `${baseUrl ?? ""}/home${utmParam ? `?${utmParam}` : ""}`;
-
-  return (
-    <Link href={href}>
-      <DustLogo className={className} />
-    </Link>
   );
 };

--- a/front/components/home/PublicWebsiteLogo.tsx
+++ b/front/components/home/PublicWebsiteLogo.tsx
@@ -1,0 +1,27 @@
+import { LinkWrapper } from "@app/lib/platform";
+import { DustLogo } from "@dust-tt/sparkle";
+
+interface PublicWebsiteLogoProps {
+  size?: "default" | "small";
+  utmParam?: string;
+  baseUrl?: string;
+}
+
+const LOGO_CLASS_NAMES = {
+  default: "h-[24px] w-[96px]",
+  small: "h-[20px] w-[80px]",
+} as const;
+
+export const PublicWebsiteLogo = ({
+  size = "default",
+  utmParam,
+  baseUrl,
+}: PublicWebsiteLogoProps) => {
+  const href = `${baseUrl ?? ""}/home${utmParam ? `?${utmParam}` : ""}`;
+
+  return (
+    <LinkWrapper href={href}>
+      <DustLogo className={LOGO_CLASS_NAMES[size]} />
+    </LinkWrapper>
+  );
+};

--- a/front/components/pages/share/EmailVerificationFlow.tsx
+++ b/front/components/pages/share/EmailVerificationFlow.tsx
@@ -1,4 +1,4 @@
-import { PublicWebsiteLogo } from "@app/components/home/LandingLayout";
+import { PublicWebsiteLogo } from "@app/components/home/PublicWebsiteLogo";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import config from "@app/lib/api/config";
 import { useSendOtpVerification, useVerifyOtpCode } from "@app/lib/swr/share";


### PR DESCRIPTION
## Description

- Move the public website logo out of the Next-specific `LandingLayout` so shared public frame components can use it without pulling in `next/router`.
- The build was failing due to this: https://github.com/dust-tt/dust/actions/runs/26036594516/job/76536617336 When importing from Next in Vite (therefore without building with Next), some server side code may be imported (in this case gzip via a bloom filter imported alongside `next/router`)

## Tests

- Tested locally (`npm run build:app in front-spa` after removing `.vite-temp`).

## Risk

- Low.

## Deploy Plan

- Deploy front



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25707">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->