### PR TITLE
Add rename and delete for project files, with GCS and agent tooling

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -183,8 +183,7 @@ function buildMountFilePreviewHref({
   filePath: string;
 }): string | undefined {
   if (filePath.startsWith("conversation/")) {
-    const rel = filePath.slice("conversation/".length);
-    return `${apiBaseUrl}/api/w/${ownerId}/assistant/conversations/${conversationId}/files/${rel}`;
+    return `${apiBaseUrl}/api/w/${ownerId}/assistant/conversations/${conversationId}/files/${filePath}`;
   }
 
   if (filePath.startsWith("project/")) {
@@ -192,8 +191,7 @@ function buildMountFilePreviewHref({
       return undefined;
     }
 
-    const rel = filePath.slice("project/".length);
-    return `${apiBaseUrl}/api/w/${ownerId}/spaces/${spaceId}/files/${rel}`;
+    return `${apiBaseUrl}/api/w/${ownerId}/spaces/${spaceId}/files/${filePath}`;
   }
 
   return undefined;

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -285,15 +285,12 @@ export const VisualizationActionIframe = forwardRef<
       let url: string;
 
       if (fileId.startsWith("conversation/")) {
-        const slashIdx = fileId.indexOf("/");
-        const rel = fileId.slice(slashIdx + 1);
-
         if (!conversationId) {
           return null;
         }
 
-        url = `/api/w/${workspaceId}/assistant/conversations/${conversationId}/files/${rel}`;
         // TODO(20260428 FILE_SYSTEM): implement space files content endpoint when project-scoped files are added.
+        url = `/api/w/${workspaceId}/assistant/conversations/${conversationId}/files/${fileId}`;
       } else {
         url = `/api/w/${workspaceId}/files/${fileId}?action=view`;
       }

--- a/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewDialog.tsx
@@ -1,7 +1,6 @@
 import { getFilePreviewConfig } from "@app/components/spaces/FilePreviewSheet";
 import { useConversationFileContent } from "@app/hooks/conversations/useConversationFileContent";
 import config from "@app/lib/api/config";
-import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import type { ProcessedContent } from "@app/lib/file_content_utils";
 import { processFileContent } from "@app/lib/file_content_utils";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
@@ -43,15 +42,7 @@ function getConversationFileUrl(
     filePath: string;
   }
 ): string {
-  // TODO(20260504 FILE SYSTEM): Align endpoint so it accepts the scoped version.
-  // entry.path is scoped (e.g. "conversation/notes.txt") but [...rel].ts
-  // expects the path relative to the conversation's /files/ base, so strip the scope prefix.
-  // Use an absolute URL so iframe/audio src attributes resolve against the API origin, not the
-  // browser's current origin.
-  const scoped = parseScopedFilePath(filePath);
-  const rel = scoped ? scoped.rel : filePath;
-
-  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${rel}`;
+  return `${config.getApiBaseUrl()}/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${filePath}`;
 }
 
 const EXTENSION_TO_LANGUAGE: Record<string, string> = {

--- a/front/components/assistant/conversation/space/RenameFileDialog.tsx
+++ b/front/components/assistant/conversation/space/RenameFileDialog.tsx
@@ -37,7 +37,8 @@ interface RenameFileDialogProps {
   onClose: () => void;
   onRenamed: () => void;
   owner: LightWorkspaceType;
-  file: { sId: string; fileName: string } | null;
+  spaceId: string;
+  file: { path: string; fileName: string } | null;
 }
 
 export function RenameFileDialog({
@@ -45,12 +46,13 @@ export function RenameFileDialog({
   onClose,
   onRenamed,
   owner,
+  spaceId,
   file,
 }: RenameFileDialogProps) {
   const [baseName, setBaseName] = useState<string>("");
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const renameFile = useRenameProjectFile({ owner });
+  const renameFile = useRenameProjectFile({ owner, spaceId });
 
   const extension = useMemo(() => {
     if (!file) {
@@ -75,7 +77,7 @@ export function RenameFileDialog({
       return;
     }
     const newFileName = baseName.trim() + extension;
-    const result = await renameFile(file.sId, newFileName);
+    const result = await renameFile(file.path, newFileName);
     if (result.isOk()) {
       onRenamed();
       onClose();

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -22,10 +22,10 @@ import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { useAppRouter } from "@app/lib/platform";
 import {
   useAddProjectContextContentNodes,
+  useDeleteProjectFile,
   useProjectContextAttachments,
   useProjectFiles,
   useRemoveProjectContextContentNodes,
-  useRemoveProjectContextFile,
 } from "@app/lib/swr/projects";
 import { useSpaceDataSourceViews, useSpaces } from "@app/lib/swr/spaces";
 import { isManualProjectKnowledgeManagementAllowed } from "@app/lib/workspace_policies";
@@ -333,7 +333,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [fileToRename, setFileToRename] = useState<{
-    sId: string;
+    path: string;
     fileName: string;
   } | null>(null);
   const [selectedFile, setSelectedFile] = useState<{
@@ -415,7 +415,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     [contentNodeAttachments, fileAttachments]
   );
 
-  const removeProjectContextFile = useRemoveProjectContextFile({
+  const deleteProjectFile = useDeleteProjectFile({
     owner,
     spaceId: space.sId,
   });
@@ -469,7 +469,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
   }, [droppedFiles, setDroppedFiles, handleDroppedFiles]);
 
   const handleDeleteFile = async (item: ContextAttachmentItem) => {
-    if (!isFileAttachmentType(item)) {
+    if (!isFileAttachmentType(item) || !item.path) {
       return;
     }
     const confirmed = await confirm({
@@ -480,7 +480,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     });
 
     if (confirmed) {
-      const result = await removeProjectContextFile(item.fileId);
+      const result = await deleteProjectFile(item.path);
       if (result.isOk()) {
         void mutateProjectFiles();
       }
@@ -515,9 +515,8 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
     (item: ContextAttachmentItem) => {
       if (isFileAttachmentType(item)) {
         if (isAgentFileId(item.fileId) && item.path) {
-          const rel = item.path.replace(/^project\//, "");
           window.open(
-            `${config.getApiBaseUrl()}/api/w/${owner.sId}/spaces/${space.sId}/files/${rel}`,
+            `${config.getApiBaseUrl()}/api/w/${owner.sId}/spaces/${space.sId}/files/${item.path}`,
             "_blank",
             "noopener,noreferrer"
           );
@@ -674,10 +673,10 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
   );
 
   const handleRenameClick = (item: ContextAttachmentItem) => {
-    if (!isFileAttachmentType(item)) {
+    if (!isFileAttachmentType(item) || !item.path) {
       return;
     }
-    setFileToRename({ sId: item.fileId, fileName: item.title });
+    setFileToRename({ path: item.path, fileName: item.title });
     setShowRenameDialog(true);
   };
 
@@ -687,29 +686,27 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
       ...attachment,
       onClick: () => openAttachment(attachment),
       menuItems: isFileAttachmentType(attachment)
-        ? isAgentFileId(attachment.fileId)
-          ? []
-          : [
-              {
-                kind: "item" as const,
-                label: "Rename",
-                icon: PencilSquareIcon,
-                onClick: (e: React.MouseEvent) => {
-                  e.stopPropagation();
-                  handleRenameClick(attachment);
-                },
+        ? [
+            {
+              kind: "item" as const,
+              label: "Rename",
+              icon: PencilSquareIcon,
+              onClick: (e: React.MouseEvent) => {
+                e.stopPropagation();
+                handleRenameClick(attachment);
               },
-              {
-                kind: "item" as const,
-                label: "Delete",
-                icon: TrashIcon,
-                variant: "warning" as const,
-                onClick: (e: React.MouseEvent) => {
-                  e.stopPropagation();
-                  void handleDeleteFile(attachment);
-                },
+            },
+            {
+              kind: "item" as const,
+              label: "Delete",
+              icon: TrashIcon,
+              variant: "warning" as const,
+              onClick: (e: React.MouseEvent) => {
+                e.stopPropagation();
+                void handleDeleteFile(attachment);
               },
-            ]
+            },
+          ]
         : isContentNodeAttachmentType(attachment)
           ? [
               {
@@ -842,6 +839,7 @@ function SpaceKnowledgeTabContent({ owner, space }: SpaceKnowledgeTabProps) {
         onClose={() => setShowRenameDialog(false)}
         onRenamed={() => void mutateProjectFiles()}
         owner={owner}
+        spaceId={space.sId}
         file={fileToRename}
       />
 

--- a/front/hooks/conversations/useConversationFileContent.ts
+++ b/front/hooks/conversations/useConversationFileContent.ts
@@ -1,4 +1,3 @@
-import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import { clientFetch } from "@app/lib/egress/client";
 import { useSWRWithDefaults } from "@app/lib/swr/swr";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -16,10 +15,8 @@ export function useConversationFileContent({
   disabled?: boolean;
 }) {
   const isDisabled = disabled || !filePath;
-  const scoped = filePath ? parseScopedFilePath(filePath) : null;
-  const rel = scoped ? scoped.rel : filePath;
-  const url = rel
-    ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${rel}`
+  const url = filePath
+    ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/files/${filePath}`
     : null;
 
   const { data, error } = useSWRWithDefaults<string | null, string>(

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -2,19 +2,22 @@ import {
   copyConversationGCSMount,
   copyMountFile,
   createGCSMountFile,
+  deleteGCSMountFile,
   type GCSMountFileEntry,
   getConversationFileMountSignedUrl,
   listGCSMountFiles,
+  renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import assert from "assert";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/config", () => ({
   default: {
@@ -527,6 +530,143 @@ describe("copyMountFile", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.message).toContain("GCS copy unavailable");
+    }
+  });
+});
+
+describe("renameGCSMountFile", () => {
+  let auth: Authenticator;
+  let workspaceId: string;
+  let copyFileMock: ReturnType<typeof vi.fn>;
+  let deleteMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    copyFileMock = vi.fn().mockResolvedValue(undefined);
+    deleteMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      copyFile: copyFileMock,
+      delete: deleteMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator } = await createResourceTest({});
+    auth = authenticator;
+    workspaceId = auth.getNonNullableWorkspace().sId;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("copies to the new path and deletes the old path", async () => {
+    const result = await renameGCSMountFile(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeFilePath: "report.pdf", newFileName: "final.pdf" }
+    );
+
+    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    expect(result.isOk()).toBe(true);
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `${prefix}report.pdf`,
+      `${prefix}final.pdf`
+    );
+    expect(deleteMock).toHaveBeenCalledWith(`${prefix}report.pdf`);
+  });
+
+  it("preserves directory structure when renaming a nested file", async () => {
+    await renameGCSMountFile(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeFilePath: "reports/q1.csv", newFileName: "q1-final.csv" }
+    );
+
+    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `${prefix}reports/q1.csv`,
+      `${prefix}reports/q1-final.csv`
+    );
+    expect(deleteMock).toHaveBeenCalledWith(`${prefix}reports/q1.csv`);
+  });
+
+  it("returns Err when the GCS copy fails without deleting", async () => {
+    copyFileMock.mockRejectedValue(new Error("copy failed"));
+
+    const result = await renameGCSMountFile(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeFilePath: "report.pdf", newFileName: "final.pdf" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("copy failed");
+    }
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("calls renameMountFile on the FileResource when one is linked to the old path", async () => {
+    const renameMountFileMock = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(FileResource, "fetchByMountFilePaths").mockResolvedValue([
+      { renameMountFile: renameMountFileMock } as unknown as FileResource,
+    ]);
+
+    const result = await renameGCSMountFile(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeFilePath: "old.pdf", newFileName: "new.pdf" }
+    );
+
+    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    expect(result.isOk()).toBe(true);
+    expect(renameMountFileMock).toHaveBeenCalledWith(
+      "new.pdf",
+      `${prefix}new.pdf`
+    );
+  });
+});
+
+describe("deleteGCSMountFile", () => {
+  let auth: Authenticator;
+  let workspaceId: string;
+  let deleteMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    deleteMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      delete: deleteMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator } = await createResourceTest({});
+    auth = authenticator;
+    workspaceId = auth.getNonNullableWorkspace().sId;
+  });
+
+  it("calls bucket.delete with the correct GCS path and ignoreNotFound", async () => {
+    const result = await deleteGCSMountFile(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeFilePath: "archive/old.pdf" }
+    );
+
+    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    expect(result.isOk()).toBe(true);
+    expect(deleteMock).toHaveBeenCalledWith(`${prefix}archive/old.pdf`, {
+      ignoreNotFound: true,
+    });
+  });
+
+  it("returns Err when bucket.delete throws", async () => {
+    deleteMock.mockRejectedValue(new Error("delete failed"));
+
+    const result = await deleteGCSMountFile(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeFilePath: "file.pdf" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("delete failed");
     }
   });
 });

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -11,7 +11,6 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -557,7 +556,7 @@ describe("renameGCSMountFile", () => {
     vi.restoreAllMocks();
   });
 
-  it("copies to the new path and deletes the old path", async () => {
+  it("copies to the new path, deletes the old path, and returns the new GCS path", async () => {
     const result = await renameGCSMountFile(
       auth,
       { useCase: "project", projectId: "proj123" },
@@ -571,6 +570,9 @@ describe("renameGCSMountFile", () => {
       `${prefix}final.pdf`
     );
     expect(deleteMock).toHaveBeenCalledWith(`${prefix}report.pdf`);
+    if (result.isOk()) {
+      expect(result.value.newGcsPath).toBe(`${prefix}final.pdf`);
+    }
   });
 
   it("preserves directory structure when renaming a nested file", async () => {
@@ -602,26 +604,6 @@ describe("renameGCSMountFile", () => {
       expect(result.error.message).toContain("copy failed");
     }
     expect(deleteMock).not.toHaveBeenCalled();
-  });
-
-  it("calls renameMountFile on the FileResource when one is linked to the old path", async () => {
-    const renameMountFileMock = vi.fn().mockResolvedValue(undefined);
-    vi.spyOn(FileResource, "fetchByMountFilePaths").mockResolvedValue([
-      { renameMountFile: renameMountFileMock } as unknown as FileResource,
-    ]);
-
-    const result = await renameGCSMountFile(
-      auth,
-      { useCase: "project", projectId: "proj123" },
-      { relativeFilePath: "old.pdf", newFileName: "new.pdf" }
-    );
-
-    const prefix = `w/${workspaceId}/projects/proj123/files/`;
-    expect(result.isOk()).toBe(true);
-    expect(renameMountFileMock).toHaveBeenCalledWith(
-      "new.pdf",
-      `${prefix}new.pdf`
-    );
   });
 });
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -25,6 +25,7 @@ const GCS_MOUNT_COPY_MAX_FILES = 5000;
 
 type GCSMountEntryBase = {
   fileName: string;
+  /** Scoped path, e.g. `project/report.pdf` or `conversation/.tool_outputs/chart.png`. */
   path: string;
   sizeBytes: number;
   lastModifiedMs: number;
@@ -301,6 +302,46 @@ export async function listGCSMountFiles(
 }
 
 /**
+ * Rename (move) a file within a GCS mount point.
+ * If a FileResource is linked to the old path via mountFilePath, its fileName
+ * and mountFilePath are updated to stay in sync.
+ */
+export async function renameGCSMountFile(
+  auth: Authenticator,
+  scope: GCSMountPoint,
+  {
+    relativeFilePath,
+    newFileName,
+  }: { relativeFilePath: string; newFileName: string }
+): Promise<Result<void, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const prefix = resolvePrefix(owner, scope);
+
+  const oldGcsPath = `${prefix}${relativeFilePath}`;
+  const lastSlash = relativeFilePath.lastIndexOf("/");
+  const dir = lastSlash >= 0 ? relativeFilePath.slice(0, lastSlash + 1) : "";
+  const newGcsPath = `${prefix}${dir}${newFileName}`;
+
+  const bucket = getPrivateUploadBucket();
+
+  try {
+    await bucket.copyFile(oldGcsPath, newGcsPath);
+    await bucket.delete(oldGcsPath);
+
+    const fileResources = await FileResource.fetchByMountFilePaths(auth, [
+      oldGcsPath,
+    ]);
+    if (fileResources.length > 0) {
+      await fileResources[0].renameMountFile(newFileName, newGcsPath);
+    }
+
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
  * Generate a short-lived signed URL for a GCS mount file.
  * Validates that the path belongs to the expected scope before signing.
  */
@@ -367,6 +408,30 @@ export async function createGCSMountFile(
       owner.sId
     )
   );
+}
+
+/**
+ * Delete a file from a GCS mount point.
+ * If a FileResource is linked via mountFilePath, it is deleted through FileResource.delete()
+ * so the DB record is cleaned up. For path-only files (no FileResource), the GCS object is
+ * removed directly.
+ */
+export async function deleteGCSMountFile(
+  auth: Authenticator,
+  scope: GCSMountPoint,
+  { relativeFilePath }: { relativeFilePath: string }
+): Promise<Result<void, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const prefix = resolvePrefix(owner, scope);
+  const gcsPath = `${prefix}${relativeFilePath}`;
+
+  const bucket = getPrivateUploadBucket();
+  try {
+    await bucket.delete(gcsPath, { ignoreNotFound: true });
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
 }
 
 /**

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -302,9 +302,9 @@ export async function listGCSMountFiles(
 }
 
 /**
- * Rename (move) a file within a GCS mount point.
- * If a FileResource is linked to the old path via mountFilePath, its fileName
- * and mountFilePath are updated to stay in sync.
+ * Rename (move) a file within a GCS mount point — pure GCS primitive.
+ * Does not touch FileResource records; callers are responsible for any DB sync.
+ * Returns the new GCS path on success so callers can update linked records.
  */
 export async function renameGCSMountFile(
   auth: Authenticator,
@@ -313,7 +313,7 @@ export async function renameGCSMountFile(
     relativeFilePath,
     newFileName,
   }: { relativeFilePath: string; newFileName: string }
-): Promise<Result<void, Error>> {
+): Promise<Result<{ newGcsPath: string }, Error>> {
   const owner = auth.getNonNullableWorkspace();
   const prefix = resolvePrefix(owner, scope);
 
@@ -327,15 +327,7 @@ export async function renameGCSMountFile(
   try {
     await bucket.copyFile(oldGcsPath, newGcsPath);
     await bucket.delete(oldGcsPath);
-
-    const fileResources = await FileResource.fetchByMountFilePaths(auth, [
-      oldGcsPath,
-    ]);
-    if (fileResources.length > 0) {
-      await fileResources[0].renameMountFile(newFileName, newGcsPath);
-    }
-
-    return new Ok(undefined);
+    return new Ok({ newGcsPath });
   } catch (err) {
     return new Err(normalizeError(err));
   }
@@ -411,10 +403,8 @@ export async function createGCSMountFile(
 }
 
 /**
- * Delete a file from a GCS mount point.
- * If a FileResource is linked via mountFilePath, it is deleted through FileResource.delete()
- * so the DB record is cleaned up. For path-only files (no FileResource), the GCS object is
- * removed directly.
+ * Delete a file from a GCS mount point — pure GCS primitive.
+ * Does not touch FileResource records; callers are responsible for any DB cleanup.
  */
 export async function deleteGCSMountFile(
   auth: Authenticator,

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -5,6 +5,8 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
+import { deleteGCSMountFile } from "@app/lib/api/files/gcs_mount/files";
+import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { MessageModel } from "@app/lib/models/agent/conversation";
@@ -420,6 +422,43 @@ export async function removeFileFromProject(
   }
 
   return new Ok(undefined);
+}
+
+/**
+ * Delete a project file by its relative path.
+ *
+ * When a FileResource is linked to the path (user-uploaded files), delegates to
+ * removeFileFromProject which handles ContentFragment cleanup and Core artifact removal.
+ * For path-only files (agent-created, no FileResource), delegates to the GCS primitive.
+ */
+export async function deleteProjectFile(
+  auth: Authenticator,
+  {
+    space,
+    relativeFilePath,
+  }: {
+    space: SpaceResource;
+    relativeFilePath: string;
+  }
+): Promise<Result<void, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const gcsPath = `${getProjectFilesBasePath({ workspaceId: owner.sId, projectId: space.sId })}${relativeFilePath}`;
+
+  const fileResources = await FileResource.fetchByMountFilePaths(auth, [
+    gcsPath,
+  ]);
+  if (fileResources.length > 0) {
+    return removeFileFromProject(auth, {
+      space,
+      fileId: fileResources[0].sId,
+    });
+  }
+
+  return deleteGCSMountFile(
+    auth,
+    { useCase: "project", projectId: space.sId },
+    { relativeFilePath }
+  );
 }
 
 /**

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -5,7 +5,10 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
-import { deleteGCSMountFile } from "@app/lib/api/files/gcs_mount/files";
+import {
+  deleteGCSMountFile,
+  renameGCSMountFile,
+} from "@app/lib/api/files/gcs_mount/files";
 import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
@@ -419,6 +422,50 @@ export async function removeFileFromProject(
   const deleteRes = await file.delete(auth);
   if (deleteRes.isErr()) {
     return new Err(deleteRes.error);
+  }
+
+  return new Ok(undefined);
+}
+
+/**
+ * Rename a project file by its relative path.
+ *
+ * Renames the GCS object and, if a FileResource is linked to the path, updates
+ * its fileName and mountFilePath to stay in sync.
+ */
+export async function renameProjectFile(
+  auth: Authenticator,
+  {
+    space,
+    relativeFilePath,
+    newFileName,
+  }: {
+    space: SpaceResource;
+    relativeFilePath: string;
+    newFileName: string;
+  }
+): Promise<Result<void, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const oldGcsPath = `${getProjectFilesBasePath({ workspaceId: owner.sId, projectId: space.sId })}${relativeFilePath}`;
+
+  const fileResources = await FileResource.fetchByMountFilePaths(auth, [
+    oldGcsPath,
+  ]);
+
+  const renameResult = await renameGCSMountFile(
+    auth,
+    { useCase: "project", projectId: space.sId },
+    { relativeFilePath, newFileName }
+  );
+  if (renameResult.isErr()) {
+    return renameResult;
+  }
+
+  if (fileResources.length > 0) {
+    await fileResources[0].renameMountFile(
+      newFileName,
+      renameResult.value.newGcsPath
+    );
   }
 
   return new Ok(undefined);

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1171,6 +1171,13 @@ export class FileResource extends BaseResource<FileModel> {
     return this.update({ fileName: newFileName.normalize("NFC") });
   }
 
+  renameMountFile(newFileName: string, newMountFilePath: string) {
+    return this.update({
+      fileName: newFileName.normalize("NFC"),
+      mountFilePath: newMountFilePath,
+    });
+  }
+
   // Sharing logic.
 
   private getShareUrlForShareableFile({

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -279,22 +279,26 @@ export function useRemoveProjectContextContentNodes({
   };
 }
 
-export function useRenameProjectFile({ owner }: { owner: LightWorkspaceType }) {
+export function useRenameProjectFile({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
   const sendNotification = useSendNotification();
 
   return async (
-    fileId: string,
-    fileName: string
+    relPath: string,
+    newFileName: string
   ): Promise<Result<void, Error>> => {
     try {
       const res = await clientFetch(
-        `/api/w/${owner.sId}/files/${fileId}/rename`,
+        `/api/w/${owner.sId}/spaces/${spaceId}/files/${relPath}`,
         {
           method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ fileName }),
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ fileName: newFileName }),
         }
       );
 
@@ -310,7 +314,7 @@ export function useRenameProjectFile({ owner }: { owner: LightWorkspaceType }) {
 
       sendNotification({
         type: "success",
-        title: `File renamed to "${fileName}"`,
+        title: `File renamed to "${newFileName}"`,
       });
 
       return new Ok(undefined);
@@ -319,6 +323,50 @@ export function useRenameProjectFile({ owner }: { owner: LightWorkspaceType }) {
       sendNotification({
         type: "error",
         title: "Failed to rename file",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
+export function useDeleteProjectFile({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  return async (relPath: string): Promise<Result<void, Error>> => {
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/files/${relPath}`,
+        { method: "DELETE" }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to delete file",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      sendNotification({
+        type: "success",
+        title: "File deleted",
+      });
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to delete file",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -1,6 +1,9 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import {
+  getConversationFilesBasePath,
+  parseScopedFilePath,
+} from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -50,17 +53,14 @@ async function handler(
 
   const owner = auth.getNonNullableWorkspace();
 
-  // filePath is relative to the conversation's files base. Reject any traversal attempt.
-  const normalizedRelative = path.posix.normalize(rel.join("/"));
-  if (
-    normalizedRelative.startsWith("..") ||
-    normalizedRelative.startsWith("/")
-  ) {
+  const scopedPath = parseScopedFilePath(rel.join("/"));
+  if (!scopedPath || scopedPath.prefix !== "conversation") {
     return apiError(req, res, {
-      status_code: 403,
+      status_code: 400,
       api_error: {
-        type: "workspace_auth_error",
-        message: "Access denied: path is outside conversation scope.",
+        type: "invalid_request_error",
+        message:
+          "Path must start with the scope prefix `conversation/`.",
       },
     });
   }
@@ -69,7 +69,19 @@ async function handler(
     workspaceId: owner.sId,
     conversationId: cId,
   });
-  const gcsPath = `${basePath}${normalizedRelative}`;
+  const normalizedGcsPath = path.posix.normalize(
+    `${basePath}${scopedPath.rel}`
+  );
+  if (!normalizedGcsPath.startsWith(basePath)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Access denied: path is outside conversation scope.",
+      },
+    });
+  }
+  const gcsPath = normalizedGcsPath;
 
   const bucket = getPrivateUploadBucket();
   const contentTypeResult = await bucket.getFileContentType(gcsPath);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -59,8 +59,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message:
-          "Path must start with the scope prefix `conversation/`.",
+        message: "Path must start with the scope prefix `conversation/`.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
@@ -67,14 +67,18 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/[...rel]", () => 
   });
 
   it("should stream a file for a valid path", async () => {
-    const { req, res } = await setupTest(["chart.png"]);
+    const { req, res } = await setupTest(["conversation", "chart.png"]);
     await handler(req, res);
     expect(res._getStatusCode()).toBe(200);
     expect(res.getHeader("Content-Type")).toBe("image/png");
   });
 
   it("should stream a nested file path", async () => {
-    const { req, res } = await setupTest(["results", "report.csv"]);
+    const { req, res } = await setupTest([
+      "conversation",
+      "results",
+      "report.csv",
+    ]);
     await handler(req, res);
     expect(res._getStatusCode()).toBe(200);
     expect(mockGetFileContentType).toHaveBeenCalledWith(
@@ -84,7 +88,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/[...rel]", () => 
 
   it("should return 404 when GCS file does not exist", async () => {
     mockGetFileContentType.mockResolvedValue(new Err(new Error("not found")));
-    const { req, res } = await setupTest(["missing.png"]);
+    const { req, res } = await setupTest(["conversation", "missing.png"]);
     await handler(req, res);
     expect(res._getStatusCode()).toBe(404);
     expect(res._getJSONData()).toEqual({
@@ -93,7 +97,13 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/[...rel]", () => 
   });
 
   it("should reject path traversal attempts", async () => {
-    const { req, res } = await setupTest(["..", "..", "etc", "passwd"]);
+    const { req, res } = await setupTest([
+      "conversation",
+      "..",
+      "..",
+      "etc",
+      "passwd",
+    ]);
     await handler(req, res);
     expect(res._getStatusCode()).toBe(403);
     expect(res._getJSONData()).toEqual({
@@ -134,7 +144,7 @@ describe("GET /api/w/[wId]/assistant/conversations/[cId]/files/[...rel]", () => 
   });
 
   it("should use conversation-scoped GCS path", async () => {
-    const { req, res } = await setupTest(["chart.png"]);
+    const { req, res } = await setupTest(["conversation", "chart.png"]);
     await handler(req, res);
     expect(mockGetFileContentType).toHaveBeenCalledWith(
       `w/${WORKSPACE_SID}/conversations/${CONVERSATION_SID}/files/chart.png`

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -1,11 +1,13 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { renameGCSMountFile } from "@app/lib/api/files/gcs_mount/files";
 import {
   getProjectFilesBasePath,
   parseScopedFilePath,
 } from "@app/lib/api/files/mount_path";
-import { deleteProjectFile } from "@app/lib/api/projects/context";
+import {
+  deleteProjectFile,
+  renameProjectFile,
+} from "@app/lib/api/projects/context";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -132,11 +134,11 @@ async function handler(
         });
       }
 
-      const renameResult = await renameGCSMountFile(
-        auth,
-        { useCase: "project", projectId: space.sId },
-        { relativeFilePath: normalizedRelative, newFileName: fileName.trim() }
-      );
+      const renameResult = await renameProjectFile(auth, {
+        space,
+        relativeFilePath: normalizedRelative,
+        newFileName: fileName.trim(),
+      });
       if (renameResult.isErr()) {
         return apiError(req, res, {
           status_code: 500,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -92,8 +92,7 @@ async function handler(
         });
       }
 
-      const contentType =
-        contentTypeResult.value ?? "application/octet-stream";
+      const contentType = contentTypeResult.value ?? "application/octet-stream";
       res.setHeader("Content-Type", contentType);
       const readStream = bucket.file(gcsPath).createReadStream();
       readStream.on("error", (err) => {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -1,6 +1,11 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
+import { renameGCSMountFile } from "@app/lib/api/files/gcs_mount/files";
+import {
+  getProjectFilesBasePath,
+  parseScopedFilePath,
+} from "@app/lib/api/files/mount_path";
+import { deleteProjectFile } from "@app/lib/api/projects/context";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -8,25 +13,18 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import path from "path";
 
+export type ProjectFileRelResponseBody = Record<string, never>;
+
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<never>>,
+  res: NextApiResponse<WithAPIErrorResponse<ProjectFileRelResponseBody>>,
   auth: Authenticator,
   { space }: { space: SpaceResource }
 ): Promise<void> {
-  if (req.method !== "GET") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message: "Only GET method is supported.",
-      },
-    });
-  }
-
   if (!space.isProject()) {
     return apiError(req, res, {
       status_code: 400,
@@ -48,17 +46,13 @@ async function handler(
     });
   }
 
-  // filePath is relative to the project's files base. Reject any traversal attempt.
-  const normalizedRelative = path.posix.normalize(rel.join("/"));
-  if (
-    normalizedRelative.startsWith("..") ||
-    normalizedRelative.startsWith("/")
-  ) {
+  const scopedPath = parseScopedFilePath(rel.join("/"));
+  if (!scopedPath || scopedPath.prefix !== "project") {
     return apiError(req, res, {
-      status_code: 403,
+      status_code: 400,
       api_error: {
-        type: "workspace_auth_error",
-        message: "Access denied: path is outside project scope.",
+        type: "invalid_request_error",
+        message: "Path must start with the scope prefix `project/`.",
       },
     });
   }
@@ -68,29 +62,132 @@ async function handler(
     workspaceId: owner.sId,
     projectId: space.sId,
   });
-  const gcsPath = `${basePath}${normalizedRelative}`;
-
-  const bucket = getPrivateUploadBucket();
-  const contentTypeResult = await bucket.getFileContentType(gcsPath);
-  if (contentTypeResult.isErr()) {
+  const normalizedGcsPath = path.posix.normalize(
+    `${basePath}${scopedPath.rel}`
+  );
+  if (!normalizedGcsPath.startsWith(basePath)) {
     return apiError(req, res, {
-      status_code: 404,
+      status_code: 403,
       api_error: {
-        type: "file_not_found",
-        message: "File not found.",
+        type: "workspace_auth_error",
+        message: "Access denied: path is outside project scope.",
       },
     });
   }
+  const normalizedRelative = scopedPath.rel;
 
-  const contentType = contentTypeResult.value ?? "application/octet-stream";
-  res.setHeader("Content-Type", contentType);
-  const readStream = bucket.file(gcsPath).createReadStream();
-  readStream.on("error", (err) => {
-    logger.error({ err, gcsPath }, "Error streaming project file (GCS)");
-    readStream.destroy();
-    res.end();
-  });
-  readStream.pipe(res);
+  switch (req.method) {
+    case "GET": {
+      const gcsPath = normalizedGcsPath;
+
+      const bucket = getPrivateUploadBucket();
+      const contentTypeResult = await bucket.getFileContentType(gcsPath);
+      if (contentTypeResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "file_not_found",
+            message: "File not found.",
+          },
+        });
+      }
+
+      const contentType =
+        contentTypeResult.value ?? "application/octet-stream";
+      res.setHeader("Content-Type", contentType);
+      const readStream = bucket.file(gcsPath).createReadStream();
+      readStream.on("error", (err) => {
+        logger.error({ err, gcsPath }, "Error streaming project file (GCS)");
+        readStream.destroy();
+        res.end();
+      });
+      readStream.pipe(res);
+      return;
+    }
+
+    case "PATCH": {
+      if (!space.canWrite(auth)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "You do not have write access to this project.",
+          },
+        });
+      }
+
+      const { fileName } = req.body;
+      if (
+        !isString(fileName) ||
+        fileName.trim() === "" ||
+        fileName.includes("/") ||
+        fileName.includes("\\")
+      ) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "fileName is required and must be a non-empty string without path separators.",
+          },
+        });
+      }
+
+      const renameResult = await renameGCSMountFile(
+        auth,
+        { useCase: "project", projectId: space.sId },
+        { relativeFilePath: normalizedRelative, newFileName: fileName.trim() }
+      );
+      if (renameResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: renameResult.error.message,
+          },
+        });
+      }
+
+      return res.status(200).json({});
+    }
+
+    case "DELETE": {
+      if (!space.canWrite(auth)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "You do not have write access to this project.",
+          },
+        });
+      }
+
+      const deleteResult = await deleteProjectFile(auth, {
+        space,
+        relativeFilePath: normalizedRelative,
+      });
+      if (deleteResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: deleteResult.error.message,
+          },
+        });
+      }
+
+      return res.status(200).json({});
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "Only GET, PATCH and DELETE methods are supported.",
+        },
+      });
+  }
 }
 
 export default withSessionAuthenticationForWorkspace(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -1,0 +1,273 @@
+import * as gcsFiles from "@app/lib/api/files/gcs_mount/files";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import * as projectsContext from "@app/lib/api/projects/context";
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import type { RequestMethod } from "node-mocks-http";
+import { PassThrough } from "stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./[...rel]";
+
+vi.mock("@app/lib/api/auth_wrappers", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/api/auth_wrappers")
+  >("@app/lib/api/auth_wrappers");
+  return {
+    ...actual,
+    withSessionAuthenticationForWorkspace:
+      (fn: (...args: unknown[]) => unknown) =>
+      async (req: any, res: any) =>
+        fn(req, res, req._auth),
+  };
+});
+
+async function makeProjectRequest(
+  method: RequestMethod,
+  rel: string[],
+  options: { body?: Record<string, unknown> } = {}
+) {
+  const { req, res, workspace, user } = await createPrivateApiMockRequest({
+    method,
+  });
+  const project = await SpaceFactory.project(workspace, user.id);
+  // Re-create auth after project creation so the editor group is included.
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  req.query.spaceId = project.sId;
+  req.query.rel = rel;
+  (req as any)._auth = auth;
+  if (options.body) {
+    req.body = options.body;
+  }
+  return { req, res, auth, project };
+}
+
+describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("GET", () => {
+    beforeEach(() => {
+      vi.mocked(getPrivateUploadBucket).mockReturnValue({
+        getFileContentType: vi.fn().mockResolvedValue(new Ok("text/plain")),
+        file: vi.fn(() => ({
+          createReadStream: vi.fn().mockReturnValue(
+            Object.assign(new PassThrough(), { pipe: vi.fn() })
+          ),
+        })),
+      } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+    });
+
+    it("returns 200 and streams a file for a valid scoped path", async () => {
+      const { req, res } = await makeProjectRequest("GET", [
+        "project",
+        "report.pdf",
+      ]);
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      expect(res.getHeader("Content-Type")).toBe("text/plain");
+    });
+
+    it("returns 400 when path lacks the project/ prefix", async () => {
+      const { req, res } = await makeProjectRequest("GET", ["report.pdf"]);
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.message).toMatch(/project\//);
+    });
+
+    it("returns 403 for path traversal attempts", async () => {
+      const { req, res } = await makeProjectRequest("GET", [
+        "project",
+        "..",
+        "..",
+        "etc",
+        "passwd",
+      ]);
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(403);
+    });
+
+    it("returns 404 when the file does not exist in GCS", async () => {
+      vi.mocked(getPrivateUploadBucket).mockReturnValue({
+        getFileContentType: vi
+          .fn()
+          .mockResolvedValue(new Err(new Error("not found"))),
+      } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+      const { req, res } = await makeProjectRequest("GET", [
+        "project",
+        "missing.txt",
+      ]);
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData().error.type).toBe("file_not_found");
+    });
+  });
+
+  describe("PATCH", () => {
+    beforeEach(() => {
+      vi.spyOn(gcsFiles, "renameGCSMountFile").mockResolvedValue(
+        new Ok(undefined)
+      );
+    });
+
+    it("returns 200 and calls renameGCSMountFile with the right args", async () => {
+      const { req, res, project } = await makeProjectRequest(
+        "PATCH",
+        ["project", "old.txt"],
+        { body: { fileName: "new.txt" } }
+      );
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      expect(gcsFiles.renameGCSMountFile).toHaveBeenCalledWith(
+        expect.anything(),
+        { useCase: "project", projectId: project.sId },
+        { relativeFilePath: "old.txt", newFileName: "new.txt" }
+      );
+    });
+
+    it("returns 400 when fileName is missing", async () => {
+      const { req, res } = await makeProjectRequest(
+        "PATCH",
+        ["project", "file.txt"],
+        { body: {} }
+      );
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(400);
+    });
+
+    it("returns 400 when fileName contains a slash", async () => {
+      const { req, res } = await makeProjectRequest(
+        "PATCH",
+        ["project", "file.txt"],
+        { body: { fileName: "sub/name.txt" } }
+      );
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(400);
+    });
+
+    it("returns 400 when path lacks the project/ prefix", async () => {
+      const { req, res } = await makeProjectRequest("PATCH", ["file.txt"], {
+        body: { fileName: "new.txt" },
+      });
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(400);
+    });
+
+    it("returns 403 for path traversal attempts", async () => {
+      const { req, res } = await makeProjectRequest(
+        "PATCH",
+        ["project", "..", "evil.txt"],
+        { body: { fileName: "new.txt" } }
+      );
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(403);
+    });
+
+    it("returns 403 when the user lacks write permission", async () => {
+      vi.spyOn(SpaceResource.prototype, "canWrite").mockReturnValue(false);
+      const { req, res } = await makeProjectRequest(
+        "PATCH",
+        ["project", "file.txt"],
+        { body: { fileName: "new.txt" } }
+      );
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(403);
+    });
+
+    it("returns 500 when renameGCSMountFile fails", async () => {
+      vi.spyOn(gcsFiles, "renameGCSMountFile").mockResolvedValue(
+        new Err(new Error("GCS error"))
+      );
+      const { req, res } = await makeProjectRequest(
+        "PATCH",
+        ["project", "file.txt"],
+        { body: { fileName: "new.txt" } }
+      );
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(500);
+    });
+  });
+
+  describe("DELETE", () => {
+    beforeEach(() => {
+      vi.spyOn(projectsContext, "deleteProjectFile").mockResolvedValue(
+        new Ok(undefined)
+      );
+    });
+
+    it("returns 200 and calls deleteProjectFile with the right args", async () => {
+      const { req, res, project } = await makeProjectRequest("DELETE", [
+        "project",
+        "file.txt",
+      ]);
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      expect(projectsContext.deleteProjectFile).toHaveBeenCalledWith(
+        expect.anything(),
+        {
+          space: expect.objectContaining({ sId: project.sId }),
+          relativeFilePath: "file.txt",
+        }
+      );
+    });
+
+    it("returns 400 when path lacks the project/ prefix", async () => {
+      const { req, res } = await makeProjectRequest("DELETE", ["file.txt"]);
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(400);
+    });
+
+    it("returns 403 for path traversal attempts", async () => {
+      const { req, res } = await makeProjectRequest("DELETE", [
+        "project",
+        "..",
+        "evil.txt",
+      ]);
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(403);
+    });
+
+    it("returns 403 when the user lacks write permission", async () => {
+      vi.spyOn(SpaceResource.prototype, "canWrite").mockReturnValue(false);
+      const { req, res } = await makeProjectRequest("DELETE", [
+        "project",
+        "file.txt",
+      ]);
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(403);
+    });
+
+    it("returns 500 when deleteProjectFile fails", async () => {
+      vi.spyOn(projectsContext, "deleteProjectFile").mockResolvedValue(
+        new Err(new Error("GCS error"))
+      );
+      const { req, res } = await makeProjectRequest("DELETE", [
+        "project",
+        "file.txt",
+      ]);
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(500);
+    });
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    const { req, res } = await makeProjectRequest("POST", [
+      "project",
+      "file.txt",
+    ]);
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(405);
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -1,7 +1,7 @@
 import * as gcsFiles from "@app/lib/api/files/gcs_mount/files";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import * as projectsContext from "@app/lib/api/projects/context";
 import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -19,8 +19,7 @@ vi.mock("@app/lib/api/auth_wrappers", async () => {
   return {
     ...actual,
     withSessionAuthenticationForWorkspace:
-      (fn: (...args: unknown[]) => unknown) =>
-      async (req: any, res: any) =>
+      (fn: (...args: unknown[]) => unknown) => async (req: any, res: any) =>
         fn(req, res, req._auth),
   };
 });
@@ -62,9 +61,11 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
       vi.mocked(getPrivateUploadBucket).mockReturnValue({
         getFileContentType: vi.fn().mockResolvedValue(new Ok("text/plain")),
         file: vi.fn(() => ({
-          createReadStream: vi.fn().mockReturnValue(
-            Object.assign(new PassThrough(), { pipe: vi.fn() })
-          ),
+          createReadStream: vi
+            .fn()
+            .mockReturnValue(
+              Object.assign(new PassThrough(), { pipe: vi.fn() })
+            ),
         })),
       } as unknown as ReturnType<typeof getPrivateUploadBucket>);
     });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -1,4 +1,3 @@
-import * as gcsFiles from "@app/lib/api/files/gcs_mount/files";
 import * as projectsContext from "@app/lib/api/projects/context";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -118,12 +117,12 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
 
   describe("PATCH", () => {
     beforeEach(() => {
-      vi.spyOn(gcsFiles, "renameGCSMountFile").mockResolvedValue(
+      vi.spyOn(projectsContext, "renameProjectFile").mockResolvedValue(
         new Ok(undefined)
       );
     });
 
-    it("returns 200 and calls renameGCSMountFile with the right args", async () => {
+    it("returns 200 and calls renameProjectFile with the right args", async () => {
       const { req, res, project } = await makeProjectRequest(
         "PATCH",
         ["project", "old.txt"],
@@ -131,10 +130,13 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
       );
       await handler(req, res);
       expect(res._getStatusCode()).toBe(200);
-      expect(gcsFiles.renameGCSMountFile).toHaveBeenCalledWith(
+      expect(projectsContext.renameProjectFile).toHaveBeenCalledWith(
         expect.anything(),
-        { useCase: "project", projectId: project.sId },
-        { relativeFilePath: "old.txt", newFileName: "new.txt" }
+        {
+          space: expect.objectContaining({ sId: project.sId }),
+          relativeFilePath: "old.txt",
+          newFileName: "new.txt",
+        }
       );
     });
 
@@ -187,8 +189,8 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
       expect(res._getStatusCode()).toBe(403);
     });
 
-    it("returns 500 when renameGCSMountFile fails", async () => {
-      vi.spyOn(gcsFiles, "renameGCSMountFile").mockResolvedValue(
+    it("returns 500 when renameProjectFile fails", async () => {
+      vi.spyOn(projectsContext, "renameProjectFile").mockResolvedValue(
         new Err(new Error("GCS error"))
       );
       const { req, res } = await makeProjectRequest(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Project spaces now support renaming and deleting files directly. Users can rename a file from the knowledge tab without
leaving the conversation, and agents can trigger file deletions as part of their tool use.

Under the hood, the file system layer was reorganized so that the low-level GCS operations are kept separate from the higher-level project logic. Deleting a project file now correctly handles the two cases: files uploaded by users (which need database cleanup) and files created directly by agents (which only exist in GCS). This split makes the behavior easier to reason about and test independently.

The conversation file streaming endpoint was updated to require a scope prefix in the path, which closes a gap where unscoped paths could be requested. Existing tests were updated to match.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25709">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->