### PR TITLE
fix(home): marquee case study links + copy refresh

### DIFF
--- a/front/components/home/TrustedBy.tsx
+++ b/front/components/home/TrustedBy.tsx
@@ -242,7 +242,7 @@ export default function TrustedBy({
     >
       {showTitle && (
         <H4 className="mb-6 w-full text-center text-foreground">
-          Trusted by <span className="text-blue-500">5,000+</span> organizations
+          Trusted by <span className="text-blue-500">3,000+</span> organizations
         </H4>
       )}
 

--- a/front/components/home/content/Product/HomeAIOperatorsCTASection.tsx
+++ b/front/components/home/content/Product/HomeAIOperatorsCTASection.tsx
@@ -20,7 +20,7 @@ const STATS: CTAStat[] = [
   },
   {
     label: "Teams running on Dust",
-    display: "5,000+",
+    display: "3,000+",
     accent: "golden",
   },
   {

--- a/front/components/home/content/Product/HomeTrustedSection.tsx
+++ b/front/components/home/content/Product/HomeTrustedSection.tsx
@@ -25,6 +25,8 @@ const CASE_STUDIES: Record<string, string> = {
   persona: "/customers/how-persona-hit-80-ai-agent-adoption-with-dust",
   profound: "/customers/profound-post-sales-team-reclaimed-1800-hours",
   qonto: "/customers/qonto-dust-ai-partnership",
+  spendesk:
+    "/customers/how-spendesk-achieved-90-ai-adoption-in-6-months-with-dust",
   wakam:
     "/customers/how-wakam-cut-legal-contract-analysis-time-by-50-with-dust",
   watershed:
@@ -184,9 +186,7 @@ export function HomeTrustedSection() {
             <div className="home-trusted-track flex w-max items-end gap-x-16 sm:gap-x-20 lg:gap-x-24">
               {marqueeLogos.map((logo, idx) => {
                 const caseStudyUrl =
-                  idx < logos.length
-                    ? CASE_STUDIES[logo.name.toLowerCase().replace(/\s+/g, "")]
-                    : undefined;
+                  CASE_STUDIES[logo.name.toLowerCase().replace(/\s+/g, "")];
                 const itemClassName =
                   "home-trusted-item flex flex-shrink-0 flex-col items-center gap-1";
                 const inner = (

--- a/front/components/home/content/Skip/config/skipConfig.tsx
+++ b/front/components/home/content/Skip/config/skipConfig.tsx
@@ -95,7 +95,7 @@ export const skipConfig: SkipConfig = {
         embedUrl: "https://www.youtube.com/embed/38vCIR2yHoA",
       },
     ],
-    usersCount: "5,000+ teams already using Dust",
+    usersCount: "3,000+ teams already using Dust",
   },
 
   trustedByTitle: "TRUSTED BY AMBITIOUS TEAMS AT:",

--- a/front/components/home/content/SqAgent/config/sqAgentConfig.tsx
+++ b/front/components/home/content/SqAgent/config/sqAgentConfig.tsx
@@ -106,7 +106,7 @@ export const sqAgentConfig: SqAgentConfig = {
         embedUrl: "https://www.youtube.com/embed/38vCIR2yHoA",
       },
     ],
-    usersCount: "5,000+ teams already using Dust",
+    usersCount: "3,000+ teams already using Dust",
   },
 
   trustedByTitle: "TRUSTED BY LEADING B2B SAAS COMPANIES",

--- a/front/pages/home/index.tsx
+++ b/front/pages/home/index.tsx
@@ -32,8 +32,8 @@ export function Landing({ news }: HomeProps) {
   return (
     <>
       <PageMetadata
-        title="Dust - Build Custom AI Agents for Your Organization"
-        description="Break down knowledge silos and amplify team performance with data-augmented, customizable and secure AI agents. Deploy in minutes, no coding required."
+        title="Dust - Multiplayer AI for human-agent collaboration"
+        description="Dust is where people and agents collaborate as co-contributors, so that work doesn't just get done – it gets rewired."
         pathname={router.asPath}
       />
       <IntroSection news={news} />


### PR DESCRIPTION
- Restore case study link on duplicated logos in the marquee second loop
- Add Spendesk case study entry
- Replace "5,000+" with "3,000+" across homepage, SqAgent, Skip
- Refresh home page metadata title and description

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25710">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->