### PR TITLE
Add files__resolve MCP tool to translate file IDs to file system paths

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -117,6 +117,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "delete": "medium",
     "grep": "never_ask",
     "list": "never_ask",
+    "resolve": "never_ask",
   },
   "freshservice": {
     "add_ticket_note": "low",

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -12,6 +12,7 @@ export const FILES_GREP_ACTION_NAME = "grep" as const;
 export const FILES_CREATE_ACTION_NAME = "create" as const;
 export const FILES_DELETE_ACTION_NAME = "delete" as const;
 export const FILES_COPY_ACTION_NAME = "copy" as const;
+export const FILES_RESOLVE_ACTION_NAME = "resolve" as const;
 
 export const CAT_LINES_DEFAULT = 200;
 export const CAT_LINES_MAX = 500;
@@ -123,6 +124,29 @@ const COPY_PROJECT_AWARE_TOOL = {
 // Stake levels in this record are typed via `as const` so the object can be spread into
 // `createToolsRecord`, which expects the narrowed `MCPToolStakeLevelType` literal.
 const FILES_TOOLS_COMMON_METADATA = {
+  [FILES_RESOLVE_ACTION_NAME]: {
+    description:
+      "Resolve a file ID (e.g. `fil_abc123`) to its scoped file system path " +
+      "(e.g. `conversation/report.pdf` or `project/data.csv`). " +
+      "Use this when you have a raw file identifier but need the path accepted by other tools " +
+      "such as `" +
+      getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME) +
+      "` or `" +
+      getPrefixedToolName(FILES_SERVER_NAME, FILES_GREP_ACTION_NAME) +
+      "`.",
+    schema: {
+      file_id: z
+        .string()
+        .describe(
+          "File identifier starting with `fil_` (e.g. `fil_abc123def456`)"
+        ),
+    },
+    stake: "never_ask" as const,
+    displayLabels: {
+      running: "Resolving file ID",
+      done: "Resolved file ID",
+    },
+  },
   [FILES_CAT_ACTION_NAME]: {
     description:
       "Read the content of a file. " +

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -6,6 +6,7 @@ import {
   FILES_DELETE_ACTION_NAME,
   FILES_GREP_ACTION_NAME,
   FILES_LIST_ACTION_NAME,
+  FILES_RESOLVE_ACTION_NAME,
   FILES_TOOLS_METADATA,
   FILES_TOOLS_METADATA_WITH_PROJECT,
 } from "@app/lib/api/actions/servers/files/metadata";
@@ -15,6 +16,7 @@ import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
 import { grepHandler } from "@app/lib/api/actions/servers/files/tools/grep";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
+import { resolveHandler } from "@app/lib/api/actions/servers/files/tools/resolve";
 
 const HANDLERS = {
   [FILES_CAT_ACTION_NAME]: catHandler,
@@ -23,6 +25,7 @@ const HANDLERS = {
   [FILES_DELETE_ACTION_NAME]: deleteHandler,
   [FILES_GREP_ACTION_NAME]: grepHandler,
   [FILES_LIST_ACTION_NAME]: listHandler,
+  [FILES_RESOLVE_ACTION_NAME]: resolveHandler,
 };
 
 export const TOOLS = buildTools(FILES_TOOLS_METADATA, HANDLERS);

--- a/front/lib/api/actions/servers/files/tools/resolve.ts
+++ b/front/lib/api/actions/servers/files/tools/resolve.ts
@@ -1,0 +1,110 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  getConversationFilesBasePath,
+  getProjectFilesBasePath,
+} from "@app/lib/api/files/mount_path";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { isProjectConversation } from "@app/types/assistant/conversation";
+import { isConversationFileUseCase } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function resolveHandler(
+  { file_id }: { file_id: string },
+  extra: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const conversation = extra.agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(
+      new MCPError("No conversation context available.", { tracked: false })
+    );
+  }
+
+  const file = await FileResource.fetchById(extra.auth, file_id);
+  if (!file) {
+    return new Err(
+      new MCPError(`File not found: \`${file_id}\`.`, { tracked: false })
+    );
+  }
+
+  if (!file.mountFilePath) {
+    return new Err(
+      new MCPError(
+        `File \`${file_id}\` is not accessible through the file system.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const owner = extra.auth.getNonNullableWorkspace();
+  const { useCase, useCaseMetadata } = file;
+
+  if (isConversationFileUseCase(useCase)) {
+    if (useCaseMetadata?.conversationId !== conversation.sId) {
+      return new Err(
+        new MCPError(
+          `File \`${file_id}\` does not belong to this conversation.`,
+          { tracked: false }
+        )
+      );
+    }
+
+    const prefix = getConversationFilesBasePath({
+      workspaceId: owner.sId,
+      conversationId: conversation.sId,
+    });
+    const relPath = file.mountFilePath.slice(prefix.length);
+
+    return new Ok([{ type: "text", text: `conversation/${relPath}` }]);
+  }
+
+  if (useCase === "project_context") {
+    if (!isProjectConversation(conversation)) {
+      return new Err(
+        new MCPError(
+          `File \`${file_id}\` is a project file but this is not a project conversation.`,
+          { tracked: false }
+        )
+      );
+    }
+
+    const spaceId = useCaseMetadata?.spaceId;
+    if (!spaceId || spaceId !== conversation.spaceId) {
+      return new Err(
+        new MCPError(
+          `File \`${file_id}\` does not belong to the project of this conversation.`,
+          { tracked: false }
+        )
+      );
+    }
+
+    const space = await SpaceResource.fetchById(extra.auth, spaceId);
+    if (!space || !space.canRead(extra.auth)) {
+      return new Err(
+        new MCPError(
+          "You do not have read access to the project containing this file.",
+          { tracked: false }
+        )
+      );
+    }
+
+    const prefix = getProjectFilesBasePath({
+      workspaceId: owner.sId,
+      projectId: spaceId,
+    });
+    const relPath = file.mountFilePath.slice(prefix.length);
+
+    return new Ok([{ type: "text", text: `project/${relPath}` }]);
+  }
+
+  return new Err(
+    new MCPError(
+      `File \`${file_id}\` is not accessible through the file system (use case: ${useCase}).`,
+      { tracked: false }
+    )
+  );
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Mainly because that was the only reference available at authoring time. Those opaque IDs cause confusing behavior now that models primarily interact with the file system through scoped paths like `conversation/report.pdf`. The model has no way to bridge the gap on its own since a `fil_xxx` string carries no path information.

This PR adds a `files__resolve` tool to the files MCP server. Given a file ID, it looks up the corresponding `FileResource`, verifies it belongs to the current conversation or project scope, and returns the canonical scoped path. The model can then pass that path to other files tools, or any other tool that expects a scoped path. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25711">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->