### PR TITLE
[LLM] declare regional availability on every model configuration

### DIFF
--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -46,6 +46,10 @@ export const CLAUDE_4_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
   availableIfOneOf: {
     featureFlag: "claude_4_opus_feature",
   },
@@ -72,6 +76,10 @@ export const CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -96,6 +104,10 @@ export const CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   supportsPromptCaching: true,
   supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -118,6 +130,10 @@ export const CLAUDE_3_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -139,6 +155,10 @@ export const CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -161,6 +181,10 @@ export const CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -188,6 +212,10 @@ export const CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "claude_4_5_opus_feature",
   },
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -219,6 +247,10 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   },
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],
   disablePrefill: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const CLAUDE_OPUS_4_7_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -252,6 +284,10 @@ export const CLAUDE_OPUS_4_7_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   },
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],
   disablePrefill: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -282,6 +318,10 @@ export const CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   customThinkingType: "auto",
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],
   disablePrefill: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 
 /**
@@ -307,6 +347,10 @@ export const CLAUDE_3_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const CLAUDE_3_5_SONNET_20240620_DEPRECATED_MODEL_CONFIG: ModelConfigurationType =
   {
@@ -328,6 +372,10 @@ export const CLAUDE_3_5_SONNET_20240620_DEPRECATED_MODEL_CONFIG: ModelConfigurat
     defaultReasoningEffort: "light",
     tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
     tokenizer: { type: "tiktoken", base: "anthropic_base" },
+    regionalAvailability: {
+      "us-central1": true,
+      "europe-west1": false,
+    },
   };
 export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -348,6 +396,10 @@ export const CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const CLAUDE_3_7_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
@@ -368,4 +420,8 @@ export const CLAUDE_3_7_SONNET_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "light",
   tokenCountAdjustment: ANTHROPIC_TOKEN_COUNT_ADJUSTMENT,
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };

--- a/front/types/assistant/models/deepseek.ts
+++ b/front/types/assistant/models/deepseek.ts
@@ -23,6 +23,10 @@ export const DEEPSEEK_CHAT_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "deepseek_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const DEEPSEEK_REASONER_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "deepseek",
@@ -45,4 +49,8 @@ export const DEEPSEEK_REASONER_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "deepseek_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };

--- a/front/types/assistant/models/fireworks.ts
+++ b/front/types/assistant/models/fireworks.ts
@@ -33,6 +33,10 @@ export const FIREWORKS_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const FIREWORKS_DEEPSEEK_V3P2_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
@@ -59,6 +63,10 @@ export const FIREWORKS_DEEPSEEK_V3P2_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "fireworks_new_model_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
@@ -80,6 +88,10 @@ export const FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   supportsResponseFormat: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const FIREWORKS_KIMI_K2_INSTRUCT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
@@ -99,6 +111,10 @@ export const FIREWORKS_KIMI_K2_INSTRUCT_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "light",
   defaultReasoningEffort: "light",
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const FIREWORKS_KIMI_K2P5_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
@@ -122,6 +138,10 @@ export const FIREWORKS_KIMI_K2P5_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   availableIfOneOf: {
     featureFlag: "fireworks_new_model_feature",
+  },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
   },
 };
 export const FIREWORKS_MINIMAX_M2P5_MODEL_CONFIG: ModelConfigurationType = {
@@ -147,6 +167,10 @@ export const FIREWORKS_MINIMAX_M2P5_MODEL_CONFIG: ModelConfigurationType = {
   availableIfOneOf: {
     featureFlag: "fireworks_new_model_feature",
   },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const FIREWORKS_GLM_5_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
@@ -170,5 +194,9 @@ export const FIREWORKS_GLM_5_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   availableIfOneOf: {
     featureFlag: "fireworks_new_model_feature",
+  },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
   },
 };

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -34,6 +34,10 @@ export const GEMINI_2_5_FLASH_LITE_MODEL_CONFIG: ModelConfigurationType = {
   useNativeLightReasoning: true,
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GEMINI_3_1_FLASH_LITE_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -56,6 +60,10 @@ export const GEMINI_3_1_FLASH_LITE_MODEL_CONFIG: ModelConfigurationType = {
   useNativeLightReasoning: true,
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GEMINI_2_5_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -78,6 +86,10 @@ export const GEMINI_2_5_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   useNativeLightReasoning: true,
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -100,6 +112,10 @@ export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   useNativeLightReasoning: true,
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GEMINI_3_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -123,6 +139,10 @@ export const GEMINI_3_PRO_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   useNativeLightReasoning: true,
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GEMINI_3_1_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -146,6 +166,10 @@ export const GEMINI_3_1_PRO_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   useNativeLightReasoning: true,
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GEMINI_3_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "google_ai_studio",
@@ -168,4 +192,8 @@ export const GEMINI_3_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
   useNativeLightReasoning: true,
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };

--- a/front/types/assistant/models/mistral.ts
+++ b/front/types/assistant/models/mistral.ts
@@ -29,6 +29,10 @@ export const MISTRAL_LARGE_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   tokenizer: { type: "sentence_piece", base: "model_v2" },
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -49,6 +53,10 @@ export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   tokenizer: { type: "sentence_piece", base: "model_v2" },
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -69,6 +77,10 @@ export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   tokenizer: { type: "sentence_piece", base: "model_v2" },
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const MISTRAL_CODESTRAL_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "mistral",
@@ -90,4 +102,8 @@ export const MISTRAL_CODESTRAL_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   tokenizer: { type: "sentence_piece", base: "model_v2" },
   supportsBatchProcessing: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };

--- a/front/types/assistant/models/noop.ts
+++ b/front/types/assistant/models/noop.ts
@@ -23,4 +23,8 @@ export const NOOP_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "noop_model_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -45,6 +45,10 @@ export const GPT_3_5_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -66,6 +70,10 @@ export const GPT_4_TURBO_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
   tokenizer: { type: "tiktoken", base: "cl100k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_4O_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -87,6 +95,10 @@ export const GPT_4O_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_4_1_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -108,6 +120,10 @@ export const GPT_4_1_MINI_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_4_1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -129,6 +145,10 @@ export const GPT_4_1_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_4O_20240806_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -150,6 +170,10 @@ export const GPT_4O_20240806_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: true,
   supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_4O_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -172,6 +196,10 @@ export const GPT_4O_MINI_MODEL_CONFIG: ModelConfigurationType = {
   supportsResponseFormat: false,
   supportsBatchProcessing: true,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const OPENAI_FORMATTING_META_PROMPT = `# Response Formats
 SYSTEM STYLE: Rich Markdown by default
@@ -229,6 +257,10 @@ export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "r50k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_5_1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -253,6 +285,10 @@ export const GPT_5_1_MODEL_CONFIG: ModelConfigurationType = {
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "r50k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_5_2_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -278,6 +314,10 @@ export const GPT_5_2_MODEL_CONFIG: ModelConfigurationType = {
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "r50k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_5_4_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -303,6 +343,10 @@ export const GPT_5_4_MODEL_CONFIG: ModelConfigurationType = {
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "r50k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_5_5_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -328,6 +372,10 @@ export const GPT_5_5_MODEL_CONFIG: ModelConfigurationType = {
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "r50k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_5_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -353,6 +401,10 @@ export const GPT_5_MINI_MODEL_CONFIG: ModelConfigurationType = {
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "r50k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const GPT_5_NANO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -377,6 +429,10 @@ export const GPT_5_NANO_MODEL_CONFIG: ModelConfigurationType = {
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "r50k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const O1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -404,6 +460,10 @@ export const O1_MODEL_CONFIG: ModelConfigurationType = {
   },
   supportsResponseFormat: false,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const O1_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -428,6 +488,10 @@ export const O1_MINI_MODEL_CONFIG: ModelConfigurationType = {
   },
   supportsResponseFormat: false,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const O3_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -452,6 +516,10 @@ export const O3_MODEL_CONFIG: ModelConfigurationType = {
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const O3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -476,6 +544,10 @@ export const O3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };
 export const O4_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -499,4 +571,8 @@ export const O4_MINI_MODEL_CONFIG: ModelConfigurationType = {
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
 };

--- a/front/types/assistant/models/togetherai.ts
+++ b/front/types/assistant/models/togetherai.ts
@@ -32,6 +32,10 @@ export const TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_CONFIG: ModelConfigur
     maximumReasoningEffort: "none",
     defaultReasoningEffort: "none",
     tokenizer: { type: "tiktoken", base: "o200k_base" },
+    regionalAvailability: {
+      "us-central1": true,
+      "europe-west1": false,
+    },
   };
 export const TOGETHERAI_QWEN_2_5_CODER_32B_INSTRUCT_MODEL_CONFIG: ModelConfigurationType =
   {
@@ -52,6 +56,10 @@ export const TOGETHERAI_QWEN_2_5_CODER_32B_INSTRUCT_MODEL_CONFIG: ModelConfigura
     maximumReasoningEffort: "none",
     defaultReasoningEffort: "none",
     tokenizer: { type: "tiktoken", base: "o200k_base" },
+    regionalAvailability: {
+      "us-central1": true,
+      "europe-west1": false,
+    },
   };
 export const TOGETHERAI_QWEN_QWQ_32B_PREVIEW_MODEL_CONFIG: ModelConfigurationType =
   {
@@ -72,6 +80,10 @@ export const TOGETHERAI_QWEN_QWQ_32B_PREVIEW_MODEL_CONFIG: ModelConfigurationTyp
     maximumReasoningEffort: "none",
     defaultReasoningEffort: "none",
     tokenizer: { type: "tiktoken", base: "o200k_base" },
+    regionalAvailability: {
+      "us-central1": true,
+      "europe-west1": false,
+    },
   };
 export const TOGETHERAI_QWEN_72B_INSTRUCT_MODEL_CONFIG: ModelConfigurationType =
   {
@@ -92,6 +104,10 @@ export const TOGETHERAI_QWEN_72B_INSTRUCT_MODEL_CONFIG: ModelConfigurationType =
     maximumReasoningEffort: "none",
     defaultReasoningEffort: "none",
     tokenizer: { type: "tiktoken", base: "o200k_base" },
+    regionalAvailability: {
+      "us-central1": true,
+      "europe-west1": false,
+    },
   };
 export const TOGETHERAI_DEEPSEEK_V3_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "togetherai",
@@ -111,6 +127,10 @@ export const TOGETHERAI_DEEPSEEK_V3_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const TOGETHERAI_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "togetherai",
@@ -130,4 +150,8 @@ export const TOGETHERAI_DEEPSEEK_R1_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "none",
   defaultReasoningEffort: "none",
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -1,5 +1,5 @@
+import type { RegionType } from "@app/lib/api/regions/config";
 import { z } from "zod";
-
 import type { WhitelistableFeature } from "../../shared/feature_flags";
 import type { ExtractSpecificKeys } from "../../shared/typescipt_utils";
 import type { TokenizerConfig } from "../../tokenizer";
@@ -74,6 +74,8 @@ export type ModelConfigurationType = Omit<
   minimumReasoningEffort: AgentReasoningEffort;
   maximumReasoningEffort: AgentReasoningEffort;
   defaultReasoningEffort: AgentReasoningEffort;
+  // Specify if the model is available in specific regions.
+  regionalAvailability: Record<RegionType, boolean>;
   // If undefined, model is available.
   // If object is empty, model is not available.
   // If defined, model must satisfy one of the conditions to be available.

--- a/front/types/assistant/models/xai.ts
+++ b/front/types/assistant/models/xai.ts
@@ -34,6 +34,10 @@ export const GROK_3_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GROK_3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "xai",
@@ -57,6 +61,10 @@ export const GROK_3_MINI_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 
 export const GROK_4_MODEL_CONFIG: ModelConfigurationType = {
@@ -81,6 +89,10 @@ export const GROK_4_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GROK_4_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "xai",
@@ -104,6 +116,10 @@ export const GROK_4_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GROK_4_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "xai",
@@ -127,6 +143,10 @@ export const GROK_4_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GROK_4_1_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "xai",
@@ -150,6 +170,10 @@ export const GROK_4_1_FAST_REASONING_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "xai_feature",
   },
   tokenizer: { type: "tiktoken", base: "o200k_base" },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": false,
+  },
 };
 export const GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType =
   {
@@ -175,4 +199,8 @@ export const GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG: ModelConfigurationType =
       featureFlag: "xai_feature",
     },
     tokenizer: { type: "tiktoken", base: "o200k_base" },
+    regionalAvailability: {
+      "us-central1": true,
+      "europe-west1": false,
+    },
   };


### PR DESCRIPTION
## Description

Adds a required `regionalAvailability: Record<RegionType, boolean>` field (`us-central1`, `europe-west1`) on `ModelConfigurationType` and populates it across all 67 model configs. `europe-west1: true` is set for OpenAI (EU endpoint), Mistral (EU inference), and the 5 Vertex-whitelisted Anthropic models (Claude 4.5 Sonnet, 4.5 Haiku, 4.5 Opus, Opus 4.6, Sonnet 4.6). Everything else stays US-only for now.

## Tests

Not yet — declaration-only change, no consumer wired up. Type-checked with `tsgo --noEmit`.

## Risk

Low. The field is declared but not yet read anywhere, so there is no runtime behaviour change. Safe to roll back by reverting.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25712">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->