### PR TITLE
[Regions] Derive client URLs from region

### DIFF
--- a/front/components/pages/email/ValidationPage.test.tsx
+++ b/front/components/pages/email/ValidationPage.test.tsx
@@ -90,22 +90,4 @@ describe("ValidationPage", () => {
     }
     expect(tokenInput.value).toBe("approval-token");
   });
-
-  it("ignores regionUrl when resolving the validation URL", async () => {
-    window.history.replaceState(
-      null,
-      "",
-      "/email/validation?token=approval-token&region=europe-west1&regionUrl=https%3A%2F%2Fattacker.example"
-    );
-
-    renderValidationPage();
-
-    const form = await getValidationForm();
-
-    expect(form.getAttribute("action")).toBe(
-      "https://eu.dust.tt/api/email/validate-action"
-    );
-    expect(submitSpy).toHaveBeenCalledOnce();
-    expect(window.location.search).toBe("?token=approval-token");
-  });
 });

--- a/front/components/pages/onboarding/InviteChoosePage.tsx
+++ b/front/components/pages/onboarding/InviteChoosePage.tsx
@@ -1,4 +1,6 @@
 import config from "@app/lib/api/config";
+import type { RegionType } from "@app/lib/api/regions/config";
+import { getRegionUrl } from "@app/lib/auth/RegionContext";
 import { useUser } from "@app/lib/swr/user";
 import { usePendingInvitations } from "@app/lib/swr/workspaces";
 import {
@@ -18,8 +20,8 @@ export function InviteChoosePage() {
     usePendingInvitations();
 
   const handleInvitationSelection = useCallback(
-    (token: string, regionUrl?: string) => {
-      const baseUrl = regionUrl ?? config.getApiBaseUrl();
+    (token: string, region?: RegionType) => {
+      const baseUrl = region ? getRegionUrl(region) : config.getApiBaseUrl();
       window.location.assign(
         `${baseUrl}/api/login?inviteToken=${encodeURIComponent(token)}`
       );
@@ -84,7 +86,7 @@ export function InviteChoosePage() {
                       onClick={() =>
                         handleInvitationSelection(
                           invitation.token,
-                          invitation.regionUrl
+                          invitation.region
                         )
                       }
                     />

--- a/front/components/pages/onboarding/InviteChoosePage.tsx
+++ b/front/components/pages/onboarding/InviteChoosePage.tsx
@@ -20,10 +20,8 @@ export function InviteChoosePage() {
     usePendingInvitations();
 
   const handleInvitationSelection = useCallback(
-    (token: string, region?: RegionType, regionUrl?: string) => {
-      const baseUrl = region
-        ? getRegionUrl(region)
-        : (regionUrl ?? config.getApiBaseUrl());
+    (token: string, region?: RegionType) => {
+      const baseUrl = region ? getRegionUrl(region) : config.getApiBaseUrl();
       window.location.assign(
         `${baseUrl}/api/login?inviteToken=${encodeURIComponent(token)}`
       );
@@ -88,8 +86,7 @@ export function InviteChoosePage() {
                       onClick={() =>
                         handleInvitationSelection(
                           invitation.token,
-                          invitation.region,
-                          invitation.regionUrl
+                          invitation.region
                         )
                       }
                     />

--- a/front/components/pages/onboarding/InviteChoosePage.tsx
+++ b/front/components/pages/onboarding/InviteChoosePage.tsx
@@ -20,8 +20,10 @@ export function InviteChoosePage() {
     usePendingInvitations();
 
   const handleInvitationSelection = useCallback(
-    (token: string, region?: RegionType) => {
-      const baseUrl = region ? getRegionUrl(region) : config.getApiBaseUrl();
+    (token: string, region?: RegionType, regionUrl?: string) => {
+      const baseUrl = region
+        ? getRegionUrl(region)
+        : (regionUrl ?? config.getApiBaseUrl());
       window.location.assign(
         `${baseUrl}/api/login?inviteToken=${encodeURIComponent(token)}`
       );
@@ -86,7 +88,8 @@ export function InviteChoosePage() {
                       onClick={() =>
                         handleInvitationSelection(
                           invitation.token,
-                          invitation.region
+                          invitation.region,
+                          invitation.regionUrl
                         )
                       }
                     />

--- a/front/lib/api/regions/lookup.ts
+++ b/front/lib/api/regions/lookup.ts
@@ -265,11 +265,9 @@ export async function fetchInvitationsFromOtherRegion(
       return new Err(new Error(data.error.message));
     }
 
-    // Keep regionUrl for existing clients; new clients derive the URL from region.
     const invitations = data.pendingInvitations.map((inv) => ({
       ...inv,
       region: name,
-      regionUrl: url,
     }));
 
     return new Ok(invitations);

--- a/front/lib/api/regions/lookup.ts
+++ b/front/lib/api/regions/lookup.ts
@@ -245,7 +245,7 @@ export async function handleLookupInvitations(
 export async function fetchInvitationsFromOtherRegion(
   email: string
 ): Promise<Result<PendingInvitationOption[], Error>> {
-  const { url } = config.getOtherRegionInfo();
+  const { name, url } = config.getOtherRegionInfo();
 
   const body: InvitationsLookupRequestBodyType = { email };
 
@@ -265,9 +265,10 @@ export async function fetchInvitationsFromOtherRegion(
       return new Err(new Error(data.error.message));
     }
 
-    // Tag each invitation with the other region's URL so the client can redirect there.
+    // Keep regionUrl for existing clients; new clients derive the URL from region.
     const invitations = data.pendingInvitations.map((inv) => ({
       ...inv,
+      region: name,
       regionUrl: url,
     }));
 

--- a/front/lib/auth/RegionContext.tsx
+++ b/front/lib/auth/RegionContext.tsx
@@ -20,7 +20,7 @@ const DEFAULT_URL = import.meta.env?.VITE_DUST_API_URL ?? "";
 const DEFAULT_REGION: RegionType =
   (import.meta.env?.VITE_DUST_REGION as RegionType) ?? "us-central1";
 
-function getRegionUrl(region: RegionType): string {
+export function getRegionUrl(region: RegionType): string {
   return (
     (region === "europe-west1"
       ? import.meta.env?.VITE_DUST_API_URL_EU

--- a/front/lib/auth/RegionContext.tsx
+++ b/front/lib/auth/RegionContext.tsx
@@ -95,7 +95,6 @@ export function RegionProvider({ children }: { children: React.ReactNode }) {
 
       // Clean region params from URL once consumed.
       params.delete("region");
-      params.delete("regionUrl");
       const qs = params.toString();
       const newUrl =
         window.location.pathname + (qs ? `?${qs}` : "") + window.location.hash;

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -26,7 +26,6 @@ export interface PendingInvitationOption {
   createdAt: number;
   isExpired: boolean;
   region?: RegionType;
-  regionUrl?: string;
 }
 
 // Types for the invite form in Poke.

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -1,3 +1,4 @@
+import type { RegionType } from "@app/lib/api/regions/config";
 import { z } from "zod";
 
 import type { ModelId } from "./shared/model_id";
@@ -24,6 +25,7 @@ export interface PendingInvitationOption {
   initialRole: ActiveRoleType;
   createdAt: number;
   isExpired: boolean;
+  region?: RegionType;
   regionUrl?: string;
 }
 

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -33,9 +33,9 @@ export async function setupOAuthConnection({
     if (extraConfig) {
       url += `&extraConfig=${encodeURIComponent(JSON.stringify(extraConfig))}`;
     }
-    // Pass region info so the OAuth popup's RegionContext initializes with the correct region.
+    // Pass region so the OAuth popup's RegionContext initializes with the correct API URL.
     if (regionInfo) {
-      url += `&region=${encodeURIComponent(regionInfo.name)}&regionUrl=${encodeURIComponent(regionInfo.url)}`;
+      url += `&region=${encodeURIComponent(regionInfo.name)}`;
     }
     const oauthPopup = window.open(url);
     let authComplete = false;


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/25645.

Remove the remaining `regionUrl` plumbing from client-owned flows. OAuth popups and cross-region invitation selection now pass only `region`; the SPA derives the corresponding API URL from region build config.

This intentionally removes the private `/api/invitations` `regionUrl` response field. The tradeoff is simpler code, with a short mixed-version deploy window where old front-spa code and new front API responses are not compatible for cross-region invitation selection.

## Risks
Blast radius: OAuth setup popups and cross-region invitation selection.
Risk: low

## Deploy Plan
- deploy front-spa and front close together

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25715">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->