### PR TITLE
[front] payment: protect endpoint with wakeLock

### DIFF
--- a/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
@@ -10,6 +10,7 @@ import {
 } from "@app/lib/plans/stripe";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { wakeLock } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -38,197 +39,210 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostCheckoutPaymentResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  if (req.method !== "POST") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message: "The method passed is not supported, POST is expected.",
-      },
-    });
-  }
+  return wakeLock(
+    async () => {
+      if (req.method !== "POST") {
+        return apiError(req, res, {
+          status_code: 405,
+          api_error: {
+            type: "method_not_supported_error",
+            message: "The method passed is not supported, POST is expected.",
+          },
+        });
+      }
 
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can access this endpoint.",
-      },
-    });
-  }
+      if (!auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "Only users that are `admins` for the current workspace can access this endpoint.",
+          },
+        });
+      }
 
-  const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
-  if (!useMetronomeBilling) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Metronome billing is not enabled for this workspace.",
-      },
-    });
-  }
+      const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
+      if (!useMetronomeBilling) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Metronome billing is not enabled for this workspace.",
+          },
+        });
+      }
 
-  const bodyValidation = BodySchema.safeParse(req.body);
-  if (!bodyValidation.success) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: fromError(bodyValidation.error).toString(),
-      },
-    });
-  }
+      const bodyValidation = BodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: fromError(bodyValidation.error).toString(),
+          },
+        });
+      }
 
-  const { setupSessionId } = bodyValidation.data;
-  const owner = auth.getNonNullableWorkspace();
+      const { setupSessionId } = bodyValidation.data;
+      const owner = auth.getNonNullableWorkspace();
 
-  // Idempotency guard: provisioning already completed.
-  const workspace = await WorkspaceResource.fetchById(owner.sId);
-  if (workspace) {
-    const activeSubscription =
-      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
-    if (activeSubscription?.metronomeContractId) {
-      return res.status(200).json({ success: true });
-    }
-  }
+      // Idempotency guard: provisioning already completed.
+      const workspace = await WorkspaceResource.fetchById(owner.sId);
+      if (workspace) {
+        const activeSubscription =
+          await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            workspace.id
+          );
+        if (activeSubscription?.metronomeContractId) {
+          return res.status(200).json({ success: true });
+        }
+      }
 
-  const stripe = getStripeClient();
-  const setupSession = await stripe.checkout.sessions.retrieve(setupSessionId, {
-    expand: ["setup_intent", "setup_intent.payment_method"],
-  });
+      const stripe = getStripeClient();
+      const setupSession = await stripe.checkout.sessions.retrieve(
+        setupSessionId,
+        {
+          expand: ["setup_intent", "setup_intent.payment_method"],
+        }
+      );
 
-  const setupIntent = setupSession.setup_intent;
-  if (
-    !setupIntent ||
-    isString(setupIntent) ||
-    setupIntent.status !== "succeeded"
-  ) {
-    return res.status(200).json({ error: "setup_failed" });
-  }
-  if (setupSession.client_reference_id !== owner.sId) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Setup intent does not correspond to the current workspace.",
-      },
-    });
-  }
+      const setupIntent = setupSession.setup_intent;
+      if (
+        !setupIntent ||
+        isString(setupIntent) ||
+        setupIntent.status !== "succeeded"
+      ) {
+        return res.status(200).json({ error: "setup_failed" });
+      }
+      if (setupSession.client_reference_id !== owner.sId) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "Setup intent does not correspond to the current workspace.",
+          },
+        });
+      }
 
-  const { seatCount: seatCountStr, pricePerSeatCents: pricePerSeatCentsStr } =
-    setupSession.metadata ?? {};
+      const {
+        seatCount: seatCountStr,
+        pricePerSeatCents: pricePerSeatCentsStr,
+      } = setupSession.metadata ?? {};
 
-  if (!isString(seatCountStr) || !isString(pricePerSeatCentsStr)) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message:
-          "Setup session metadata is missing seatCount or pricePerSeatCents.",
-      },
-    });
-  }
+      if (!isString(seatCountStr) || !isString(pricePerSeatCentsStr)) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message:
+              "Setup session metadata is missing seatCount or pricePerSeatCents.",
+          },
+        });
+      }
 
-  const seatCount = Number(seatCountStr);
-  const pricePerSeatCents = Number(pricePerSeatCentsStr);
-  const subtotalCents = seatCount * pricePerSeatCents;
-  const stripeCustomerId = setupSession.customer;
+      const seatCount = Number(seatCountStr);
+      const pricePerSeatCents = Number(pricePerSeatCentsStr);
+      const subtotalCents = seatCount * pricePerSeatCents;
+      const stripeCustomerId = setupSession.customer;
 
-  if (!isString(stripeCustomerId)) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Setup session is missing a customer ID.",
-      },
-    });
-  }
+      if (!isString(stripeCustomerId)) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Setup session is missing a customer ID.",
+          },
+        });
+      }
 
-  const rawPaymentMethod = setupIntent.payment_method;
-  const paymentMethodId =
-    rawPaymentMethod === null
-      ? null
-      : isString(rawPaymentMethod)
-        ? rawPaymentMethod
-        : rawPaymentMethod.id;
+      const rawPaymentMethod = setupIntent.payment_method;
+      const paymentMethodId =
+        rawPaymentMethod === null
+          ? null
+          : isString(rawPaymentMethod)
+            ? rawPaymentMethod
+            : rawPaymentMethod.id;
 
-  if (!paymentMethodId) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Setup intent is missing a payment method.",
-      },
-    });
-  }
+      if (!paymentMethodId) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Setup intent is missing a payment method.",
+          },
+        });
+      }
 
-  const shouldEnforceFirstPeriodPayment =
-    rawPaymentMethod !== null &&
-    !isString(rawPaymentMethod) &&
-    rawPaymentMethod.type === "card";
+      const shouldEnforceFirstPeriodPayment =
+        rawPaymentMethod !== null &&
+        !isString(rawPaymentMethod) &&
+        rawPaymentMethod.type === "card";
 
-  const customer = await stripe.customers.retrieve(stripeCustomerId);
-  if (customer.deleted) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Stripe customer has been deleted.",
-      },
-    });
-  }
-  const country = customer.address?.country ?? "US";
-  const currency = getBillingCurrencyForCountry(country, true);
+      const customer = await stripe.customers.retrieve(stripeCustomerId);
+      if (customer.deleted) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Stripe customer has been deleted.",
+          },
+        });
+      }
+      const country = customer.address?.country ?? "US";
+      const currency = getBillingCurrencyForCountry(country, true);
 
-  if (shouldEnforceFirstPeriodPayment) {
-    const chargeResult = await chargeFirstPeriodInvoice({
-      stripeCustomerId,
-      paymentMethodId,
-      subtotalCents,
-      seatCount,
-      setupSessionId,
-      workspaceId: owner.sId,
-      currency,
-    });
-    if (chargeResult.isErr()) {
-      return res.status(200).json({ error: "payment_failed" });
-    }
-  }
+      if (shouldEnforceFirstPeriodPayment) {
+        const chargeResult = await chargeFirstPeriodInvoice({
+          stripeCustomerId,
+          paymentMethodId,
+          subtotalCents,
+          seatCount,
+          setupSessionId,
+          workspaceId: owner.sId,
+          currency,
+        });
+        if (chargeResult.isErr()) {
+          return res.status(200).json({ error: "payment_failed" });
+        }
+      }
 
-  const user = auth.getNonNullableUser();
-  const planCode = setupSession.metadata?.planCode ?? "";
-  const metronomePackageAlias =
-    setupSession.metadata?.metronomePackageAlias ?? "";
+      const user = auth.getNonNullableUser();
+      const planCode = setupSession.metadata?.planCode ?? "";
+      const metronomePackageAlias =
+        setupSession.metadata?.metronomePackageAlias ?? "";
 
-  const provisionResult = await provisionMetronomeFirstPeriodSubscription({
-    stripeCustomerId,
-    paymentMethodId,
-    subtotalCents,
-    currency,
-    workspaceId: owner.sId,
-    userId: user.sId,
-    planCode,
-    metronomePackageAlias,
-    firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
-    uniquenessKey: setupSessionId,
-    now: new Date(),
-  });
-
-  if (provisionResult.isErr()) {
-    logger.error(
-      {
-        panic: true,
+      const provisionResult = await provisionMetronomeFirstPeriodSubscription({
+        stripeCustomerId,
+        paymentMethodId,
+        subtotalCents,
+        currency,
         workspaceId: owner.sId,
-        error: normalizeError(provisionResult.error).message,
-      },
-      "[Checkout] Payment succeeded but Metronome provisioning failed"
-    );
-    return res.status(500).json({ error: "metronome_error" });
-  }
+        userId: user.sId,
+        planCode,
+        metronomePackageAlias,
+        firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
+        uniquenessKey: setupSessionId,
+        now: new Date(),
+      });
 
-  return res.status(200).json({ success: true });
+      if (provisionResult.isErr()) {
+        logger.error(
+          {
+            panic: true,
+            workspaceId: owner.sId,
+            error: normalizeError(provisionResult.error).message,
+          },
+          "[Checkout] Payment succeeded but Metronome provisioning failed"
+        );
+        return res.status(500).json({ error: "metronome_error" });
+      }
+
+      return res.status(200).json({ success: true });
+    },
+    { endpoint: req.url ?? null }
+  );
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {


### PR DESCRIPTION
## Description

payment endpoint can last around 10 seconds as it calls Stripe API and Metronome API
=> we wrap the call in a wakeLock to prevent the pod from shutting down during the operations

## Tests

Tested locally

## Risk

Low

## Deploy Plan

Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25716">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->