### PR TITLE
Use metronome payment-gated commits

### DIFF
--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -19,7 +19,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  ExternalLinkIcon,
   Icon,
   Input,
   Spinner,
@@ -31,7 +30,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useCallback, useMemo, useState } from "react";
 
-type PurchaseState = "idle" | "processing" | "success" | "redirect" | "error";
+type PurchaseState = "idle" | "processing" | "success" | "error";
 type TopUpTab = "one-time" | "automatic";
 
 const QUICK_SELECT_AMOUNTS = [10, 50, 100] as const;
@@ -110,7 +109,6 @@ export function BuyAwuCreditsDialog({
   const [selectedTab, setSelectedTab] = useState<TopUpTab>("one-time");
   const [purchaseState, setPurchaseState] = useState<PurchaseState>("idle");
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const [paymentUrl, setPaymentUrl] = useState<string | null>(null);
   const { purchaseAwuCredits } = useAwuPurchase({ workspaceId });
 
   const resetModalStateAndClose = useCallback(() => {
@@ -118,7 +116,6 @@ export function BuyAwuCreditsDialog({
     setSelectedTab("one-time");
     setPurchaseState("idle");
     setErrorMessage("");
-    setPaymentUrl(null);
     onClose();
   }, [onClose]);
 
@@ -170,10 +167,6 @@ export function BuyAwuCreditsDialog({
         setPurchaseState("success");
         onPurchaseSuccess?.();
         break;
-      case "redirect":
-        setPaymentUrl(result.paymentUrl);
-        setPurchaseState("redirect");
-        break;
       case "error":
         setErrorMessage(result.message);
         setPurchaseState("error");
@@ -214,26 +207,6 @@ export function BuyAwuCreditsDialog({
                 <span className="font-semibold">
                   Invoice has been sent by email.
                 </span>
-              </p>
-            </div>
-          </div>
-        );
-
-      case "redirect":
-        return (
-          <div className="flex flex-col items-center justify-center gap-4 py-8">
-            <Icon
-              visual={ExternalLinkIcon}
-              size="lg"
-              className="text-primary dark:text-primary-night"
-            />
-            <div className="text-center">
-              <p className="text-lg font-medium text-foreground dark:text-foreground-night">
-                Payment confirmation required
-              </p>
-              <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
-                Please complete the payment to finalize your credit purchase or
-                contact support to cancel pending invoices.
               </p>
             </div>
           </div>
@@ -413,25 +386,6 @@ export function BuyAwuCreditsDialog({
             }}
           />
         );
-      case "redirect":
-        return (
-          <DialogFooter
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-              onClick: resetModalStateAndClose,
-            }}
-            rightButtonProps={{
-              label: "Go to Payment",
-              variant: "primary",
-              onClick: () => {
-                if (paymentUrl) {
-                  window.open(paymentUrl, "_blank")?.focus();
-                }
-              },
-            }}
-          />
-        );
       case "error":
         return (
           <DialogFooter
@@ -485,11 +439,10 @@ export function BuyAwuCreditsDialog({
     );
   }
 
-  // Once a purchase is in flight (processing / redirect / success / error),
-  // drive the dialog from local state and ignore the refreshed
-  // awuPurchaseInfo — the just-created invoice would otherwise flip it to
-  // `pending_purchase` and bump the user off the "Payment confirmation
-  // required" screen before they can click through.
+  // Once a purchase is in flight (processing / success / error), drive the
+  // dialog from local state and ignore the refreshed awuPurchaseInfo — the
+  // just-created Metronome commit would otherwise flip it to
+  // `pending_purchase` and bump the user off the success screen.
   const isPurchaseInFlight = purchaseState !== "idle";
 
   // Cannot purchase: legacy plan.

--- a/front/hooks/useAwuPurchase.ts
+++ b/front/hooks/useAwuPurchase.ts
@@ -27,7 +27,6 @@ function subscribeToAwuPurchaseLoading(callback: () => void) {
 
 export type AwuPurchaseOutcome =
   | { status: "success" }
-  | { status: "redirect"; paymentUrl: string }
   | { status: "error"; message: string };
 
 export function useAwuPurchase({ workspaceId }: { workspaceId: string }) {
@@ -72,14 +71,9 @@ export function useAwuPurchase({ workspaceId }: { workspaceId: string }) {
           return { status: "error", message };
         }
 
-        const data = await response.json();
+        await response.json();
 
         void mutateAwuPurchaseInfo();
-
-        if (data.paymentUrl) {
-          return { status: "redirect", paymentUrl: data.paymentUrl };
-        }
-
         resetAwuPostPurchaseRefreshCount(workspaceId);
         void mutateAwuPoolSummary();
 

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -1,22 +1,19 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycle } from "@app/lib/client/subscription";
 import {
-  createMetronomeCredit,
+  addPaymentGatedCommitToContract,
   getMetronomeCustomerStripeCustomerId,
 } from "@app/lib/metronome/client";
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
+  CURRENCY_TO_CREDIT_TYPE_ID,
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
 } from "@app/lib/metronome/constants";
 import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
 import { getActiveContract, isLegacyPlan } from "@app/lib/metronome/plan_type";
-import {
-  finalizeInvoice,
-  getStripeClient,
-  makeAwuPurchaseInvoiceForCustomer,
-  payInvoice,
-} from "@app/lib/plans/stripe";
+import { AWU_PRICE_PER_CREDIT } from "@app/lib/metronome/types";
+import { getStripeClient } from "@app/lib/plans/stripe";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
@@ -43,10 +40,7 @@ export type AwuPurchaseInfo =
     };
 
 export type AwuPurchaseResult = {
-  invoiceId: string;
   amountCredits: number;
-  amountCents: number;
-  paymentUrl: string | null;
 };
 
 export type AwuPurchaseError =
@@ -191,9 +185,11 @@ export async function purchaseAwuCredits(
     return new Err({ code: eligibility.error.code });
   }
 
-  const { stripeCustomerId, stripe } = eligibility.value;
+  const { metronomeCustomerId, stripeCustomerId, stripe } = eligibility.value;
   const workspace = auth.getNonNullableWorkspace();
+  // checkAwuPurchaseEligibility already verified both are set.
   const subscription = auth.subscription()!;
+  const metronomeContractId = subscription.metronomeContractId!;
 
   if (amountCredits < MIN_AWU_PURCHASE_CREDITS) {
     return new Err({
@@ -241,143 +237,71 @@ export async function purchaseAwuCredits(
       message: currencyResult.error.message,
     });
   }
+  const currency = currencyResult.value;
 
-  const invoiceResult = await makeAwuPurchaseInvoiceForCustomer({
-    stripeCustomerId,
-    workspaceId: workspace.sId,
-    currency: currencyResult.value,
-    amountCredits,
-  });
-  if (invoiceResult.isErr()) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        amountCredits,
-        error: invoiceResult.error.error_message,
-      },
-      "[AWU Purchase] Failed to create Stripe invoice"
-    );
-    return new Err({
-      code: "purchase_failed",
-      message: invoiceResult.error.error_message,
-    });
-  }
-  const invoice = invoiceResult.value;
-
-  const finalizeResult = await finalizeInvoice(invoice);
-  if (finalizeResult.isErr()) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        invoiceId: invoice.id,
-        error: finalizeResult.error.error_message,
-      },
-      "[AWU Purchase] Failed to finalize Stripe invoice"
-    );
-    return new Err({
-      code: "purchase_failed",
-      message: finalizeResult.error.error_message,
-    });
-  }
-
-  const payResult = await payInvoice(finalizeResult.value);
-  if (payResult.isErr()) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        invoiceId: invoice.id,
-        error: payResult.error.error_message,
-      },
-      "[AWU Purchase] Failed to pay Stripe invoice"
-    );
-    return new Err({
-      code: "purchase_failed",
-      message: payResult.error.error_message,
-    });
-  }
-
-  const { paymentUrl } = payResult.value;
-
-  logger.info(
-    {
-      workspaceId: workspace.sId,
-      invoiceId: invoice.id,
-      amountCredits,
-      requiresAction: paymentUrl !== null,
-    },
-    "[AWU Purchase] Invoice created and paid, credits will be granted via webhook"
-  );
-
-  return new Ok({
-    invoiceId: invoice.id,
-    amountCredits,
-    amountCents: amountCredits,
-    paymentUrl,
-  });
-}
-
-/**
- * Called by the Stripe webhook (invoice.paid) to grant AWU credits in Metronome
- * once payment is confirmed.
- */
-export async function grantAwuCreditsFromPaidInvoice({
-  invoice,
-  auth,
-}: {
-  invoice: Stripe.Invoice;
-  auth: Authenticator;
-}): Promise<void> {
-  const workspace = auth.getNonNullableWorkspace();
-
-  const amountCreditsStr = invoice.metadata?.awu_amount_credits;
-  if (!amountCreditsStr) {
-    logger.error(
-      { invoiceId: invoice.id, workspaceId: workspace.sId },
-      "[AWU Purchase] Paid invoice missing awu_amount_credits metadata"
-    );
-    return;
-  }
-  const amountCredits = parseInt(amountCreditsStr, 10);
-  if (isNaN(amountCredits) || amountCredits <= 0) {
-    logger.error(
-      { invoiceId: invoice.id, workspaceId: workspace.sId, amountCreditsStr },
-      "[AWU Purchase] Invalid awu_amount_credits in invoice metadata"
-    );
-    return;
-  }
-
-  if (!workspace.metronomeCustomerId) {
-    logger.error(
-      { invoiceId: invoice.id, workspaceId: workspace.sId },
-      "[AWU Purchase] Workspace has no Metronome customer ID"
-    );
-    return;
-  }
+  // Metronome wants invoice unit prices in the credit type's units: cents
+  // for USD, whole units for EUR (matches the rate-card convention; see
+  // `metronomeAmount`). AWU_PRICE_PER_CREDIT is per-credit in the
+  // currency's natural unit ($0.01 / €0.0087):
+  //   USD: 0.01 USD * 100 = 1 cent per credit
+  //   EUR: 0.0087 EUR per credit (Metronome allows decimal unit prices)
+  const invoiceUnitPrice =
+    currency === "usd"
+      ? AWU_PRICE_PER_CREDIT.usd * 100
+      : AWU_PRICE_PER_CREDIT.eur;
 
   const now = new Date();
   const oneYearFromNow = new Date(now);
   oneYearFromNow.setUTCFullYear(oneYearFromNow.getUTCFullYear() + 1);
 
-  const grantResult = await createMetronomeCredit({
-    metronomeCustomerId: workspace.metronomeCustomerId,
+  const editResult = await addPaymentGatedCommitToContract({
+    metronomeCustomerId,
+    metronomeContractId,
     productId: getProductPrepaidCommitId(),
-    creditTypeId: getCreditTypeAwuId(),
-    amount: amountCredits,
-    startingAt: now.toISOString(),
-    endingBefore: oneYearFromNow.toISOString(),
-    name: `AWU credit top-up: ${amountCredits.toLocaleString()} credits`,
-    idempotencyKey: `awuPurchase-${workspace.sId}-${invoice.id}`,
+    accessAmount: amountCredits,
+    accessCreditTypeId: getCreditTypeAwuId(),
+    accessStartingAt: now,
+    accessEndingBefore: oneYearFromNow,
+    invoiceUnitPrice,
+    invoiceQuantity: amountCredits,
+    invoiceCreditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[currency],
+    invoiceTimestamp: now,
     priority: AWU_PRIORITY_PURCHASED_COMMIT,
+    name: `Credit top-up: ${amountCredits.toLocaleString()} credits`,
+    uniquenessKey: `awuPurchase-${workspace.sId}-${now.getTime()}`,
+    // Stamped on the Stripe invoice Metronome pushes downstream so the
+    // existing eligibility check (`isAwuPurchaseInvoice`) still recognises
+    // pending AWU purchases.
+    stripeInvoiceMetadata: {
+      awu_purchase: "true",
+      awu_amount_credits: String(amountCredits),
+      workspace_id: workspace.sId,
+    },
   });
 
-  if (grantResult.isErr()) {
-    throw new Error(
-      `[AWU Purchase] Failed to grant Metronome credits: ${grantResult.error.message} (invoiceId=${invoice.id}, workspaceId=${workspace.sId}, amountCredits=${amountCredits})`
+  if (editResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        amountCredits,
+        error: editResult.error.message,
+      },
+      "[AWU Purchase] Failed to add payment-gated commit"
     );
+    return new Err({
+      code: "purchase_failed",
+      message: editResult.error.message,
+    });
   }
 
   logger.info(
-    { invoiceId: invoice.id, workspaceId: workspace.sId, amountCredits },
-    "[AWU Purchase] Successfully granted AWU credits from webhook"
+    {
+      workspaceId: workspace.sId,
+      editId: editResult.value.editId,
+      amountCredits,
+    },
+    "[AWU Purchase] Payment-gated commit created — Metronome will invoice and unlock on payment"
   );
+
+  return new Ok({ amountCredits });
 }

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1168,6 +1168,140 @@ export async function createMetronomeCommit({
 }
 
 /**
+ * Add a Stripe payment-gated PREPAID commit to an existing contract via
+ * `v2.contracts.edit`. Metronome will create the commit, generate the
+ * invoice, push it to Stripe, and unlock the commit once payment is
+ * collected (no manual grant needed on our side).
+ *
+ * `invoiceUnitPrice` is the per-credit fiat price in the invoice credit
+ * type's units — cents for USD, whole units for other fiat currencies
+ * (matches Metronome's fiat unit convention; see `metronomeAmount`).
+ * `invoiceQuantity` is the number of credits being invoiced. Passing
+ * unit_price + quantity (instead of a flat `amount`) lets Metronome
+ * construct Stripe `price_data` on push and auto-provision the Stripe
+ * Product for FIXED Metronome products that have never been invoiced
+ * via Stripe before.
+ *
+ * `tax_type` is intentionally omitted: each Metronome product carries a
+ * default tax category that Stripe uses, and overriding it from here
+ * would force Metronome to resolve a per-line Stripe Product mapping it
+ * doesn't have.
+ */
+export async function addPaymentGatedCommitToContract({
+  metronomeCustomerId,
+  metronomeContractId,
+  productId,
+  accessAmount,
+  accessCreditTypeId,
+  accessStartingAt,
+  accessEndingBefore,
+  invoiceUnitPrice,
+  invoiceQuantity,
+  invoiceCreditTypeId,
+  invoiceTimestamp,
+  priority,
+  name,
+  uniquenessKey,
+  stripeInvoiceMetadata,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  productId: string;
+  accessAmount: number;
+  accessCreditTypeId: string;
+  accessStartingAt: Date;
+  accessEndingBefore: Date;
+  invoiceUnitPrice: number;
+  invoiceQuantity: number;
+  invoiceCreditTypeId: string;
+  invoiceTimestamp: Date;
+  priority: number;
+  name: string;
+  uniquenessKey: string;
+  stripeInvoiceMetadata: Record<string, string>;
+}): Promise<Result<{ editId: string }, Error>> {
+  try {
+    const response = await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+      uniqueness_key: uniquenessKey,
+      add_commits: [
+        {
+          product_id: productId,
+          type: "PREPAID",
+          name,
+          priority,
+          applicable_product_tags: ["usage"],
+          access_schedule: {
+            credit_type_id: accessCreditTypeId,
+            schedule_items: [
+              {
+                amount: accessAmount,
+                starting_at: floorToHourISO(accessStartingAt),
+                ending_before: floorToHourISO(accessEndingBefore),
+              },
+            ],
+          },
+          invoice_schedule: {
+            credit_type_id: invoiceCreditTypeId,
+            schedule_items: [
+              {
+                unit_price: invoiceUnitPrice,
+                quantity: invoiceQuantity,
+                timestamp: floorToHourISO(invoiceTimestamp),
+              },
+            ],
+          },
+          payment_gate_config: {
+            payment_gate_type: "STRIPE",
+            stripe_config: {
+              payment_type: "INVOICE",
+              invoice_metadata: stripeInvoiceMetadata,
+            },
+          },
+        },
+      ],
+    });
+
+    logger.info(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        editId: response.data.id,
+        accessAmount,
+        invoiceUnitPrice,
+        invoiceQuantity,
+      },
+      "[Metronome] Payment-gated commit added to contract"
+    );
+
+    return new Ok({ editId: response.data.id });
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      logger.info(
+        { metronomeCustomerId, metronomeContractId, uniquenessKey },
+        "[Metronome] Payment-gated commit edit already exists (idempotent)"
+      );
+      return new Ok({ editId: "" });
+    }
+
+    const error = normalizeError(err);
+    logger.error(
+      {
+        error,
+        metronomeCustomerId,
+        metronomeContractId,
+        accessAmount,
+        invoiceUnitPrice,
+        invoiceQuantity,
+      },
+      "[Metronome] Failed to add payment-gated commit to contract"
+    );
+    return new Err(error);
+  }
+}
+
+/**
  * Find a customer-level commit by its uniqueness_key.
  * Used to recover the id after a 409 conflict on creation.
  * Scoped via covering_date so we don't paginate through expired commits.

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,6 +1,5 @@
 import config from "@app/lib/api/config";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
-import { AWU_PRICE_PER_CREDIT } from "@app/lib/metronome/types";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { PHONE_TRIAL_ENABLED } from "@app/lib/plans/trial/constants";
@@ -13,7 +12,7 @@ import {
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
-import { CURRENCY_SYMBOLS, SUPPORTED_CURRENCIES } from "@app/types/currency";
+import { SUPPORTED_CURRENCIES } from "@app/types/currency";
 import type { BillingPeriod, SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
@@ -1422,40 +1421,6 @@ export async function getInvoicePaymentUrl(
   const stripe = getStripeClient();
   const invoice = await stripe.invoices.retrieve(invoiceId);
   return invoice.hosted_invoice_url ?? null;
-}
-
-/**
- * Creates a one-off AWU credit purchase invoice on a Stripe customer
- */
-export async function makeAwuPurchaseInvoiceForCustomer({
-  stripeCustomerId,
-  workspaceId,
-  currency,
-  amountCredits,
-}: {
-  stripeCustomerId: string;
-  workspaceId: string;
-  currency: SupportedCurrency;
-  amountCredits: number;
-}): Promise<Result<Stripe.Invoice, { error_message: string }>> {
-  const amountInCurrency = amountCredits * AWU_PRICE_PER_CREDIT[currency];
-  const currencySymbol = CURRENCY_SYMBOLS[currency];
-
-  return makeInvoice({
-    target: { kind: "customer", stripeCustomerId, currency },
-    metadata: {
-      awu_purchase: "true",
-      awu_amount_credits: String(amountCredits),
-      workspace_id: workspaceId,
-    },
-    lineItem: {
-      priceId: getCreditPurchasePriceId(),
-      quantity: amountCredits,
-      description: `${amountCredits.toLocaleString()} credits for (${currencySymbol}${amountInCurrency.toFixed(2)})`,
-    },
-    collectionMethod: "charge_automatically",
-    requestThreeDSecure: "challenge",
-  });
 }
 
 export function getAnnualizedSubscriptionValueMicroUsd(

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -299,6 +299,44 @@ async function handler(
         case "invoice.finalized":
           break;
 
+        // Payment-gated commit lifecycle. Metronome activates the commit
+        // itself on success, so we don't grant credits here — just log the
+        // outcome for observability (and surface failures with their
+        // Stripe error message). AWU credit top-ups go through this flow
+        // via `addPaymentGatedCommitToContract`.
+        case "payment_gate.payment_status": {
+          const {
+            customer_id: customerId,
+            contract_id: contractId,
+            invoice_id: invoiceId,
+            payment_status: paymentStatus,
+            error_message: errorMessage,
+          } = event.properties;
+          if (paymentStatus === "succeeded") {
+            logger.info(
+              { customerId, contractId, invoiceId, paymentStatus },
+              "[Metronome Webhook] Payment-gated commit paid"
+            );
+          } else {
+            logger.warn(
+              {
+                customerId,
+                contractId,
+                invoiceId,
+                paymentStatus,
+                errorMessage,
+              },
+              "[Metronome Webhook] Payment-gated commit payment failed"
+            );
+          }
+          break;
+        }
+
+        case "payment_gate.payment_pending_action_required":
+        case "payment_gate.threshold_reached":
+        case "payment_gate.external_initiate":
+          break;
+
         case "credit.segment.start": {
           const {
             customer_id: customerId,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -9,7 +9,6 @@ import { getRedisCacheClient } from "@app/lib/api/redis";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import { grantAwuCreditsFromPaidInvoice } from "@app/lib/credits/awu_purchase";
 import {
   deleteCreditFromVoidedInvoice,
   startCreditFromEnterpriseOneOffInvoice,
@@ -850,10 +849,11 @@ async function handler(
               isEnterprise: ctx.isEnterprise,
             });
           } else if (isAwuPurchaseInvoice(invoice)) {
-            await grantAwuCreditsFromPaidInvoice({
-              invoice,
-              auth: ctx.auth,
-            });
+            // AWU credit purchases are now provisioned as Metronome
+            // payment-gated commits — Metronome itself unlocks the commit
+            // on `invoice.paid`, no external grant needed here. Kept for
+            // observability; the metadata still flags the invoice so the
+            // pending-purchase eligibility check works.
           } else {
             await ctx.subscription.clearPaymentFailingStatus();
           }

--- a/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
@@ -22,10 +22,7 @@ const PostAwuPurchaseBody = z.object({
 });
 
 export type PostAwuPurchaseResponseBody = {
-  invoiceId: string;
   amountCredits: number;
-  amountCents: number;
-  paymentUrl: string | null;
 };
 
 async function handler(


### PR DESCRIPTION
## Description

Built on top of #25670, which introduced the AWU top-off API issuing Stripe invoices directly. This PR replaces that flow with [Metronome manual payment-gated commits](https://docs.metronome.com/guides/pricing-packaging/apply-credits-and-commits/manual-payment-gated-commits) so Metronome owns the full lifecycle (invoice → Stripe push → payment → commit activation).

**What changes:**
- `purchaseAwuCredits` no longer creates/finalizes/pays a Stripe invoice by hand. It calls `v2.contracts.edit` with `add_commits[]` carrying `payment_gate_config: { payment_gate_type: "STRIPE", stripe_config: { payment_type: "INVOICE", invoice_metadata } }`. Metronome creates the commit, generates the invoice, pushes it to Stripe via the contract's billing config, and unlocks the commit on payment.
- The Stripe `invoice.paid` webhook branch that called `grantAwuCreditsFromPaidInvoice` is gone — Metronome activates the commit itself. `grantAwuCreditsFromPaidInvoice` and `makeAwuPurchaseInvoiceForCustomer` are removed.
- The Metronome webhook handler now explicitly logs `payment_gate.payment_status` (success → info, failure → warn with Metronome `error_message`) and acks the other `payment_gate.*` events instead of falling through to "Unhandled".
- Currency comes from the active Metronome contract's rate card (source of truth), not from the Stripe customer.
- `invoice_schedule.schedule_items` uses `unit_price` × `quantity` rather than a flat `amount` — required so Metronome can construct Stripe `price_data` and auto-provision the Stripe Product for the FIXED "Prepaid Commit" Metronome product the first time it's invoiced. `tax_type` is omitted on `payment_gate_config` so each product's default Stripe tax category is used.
- The `pending_purchase` eligibility check still scans Stripe open invoices: the commit's `stripe_config.invoice_metadata` stamps `awu_purchase: "true"` / `workspace_id` / `awu_amount_credits` on the downstream Stripe invoice, so `isAwuPurchaseInvoice` continues to work.
- UI: the dialog drops the `redirect` state — the new flow has no immediate Stripe-hosted URL to redirect to. Once a purchase is in flight, the dialog is driven by local state so the just-created commit can't flip `awuPurchaseInfo` to `pending_purchase` and bump the user off the success screen.

## Tests

Manual: triggered a purchase end-to-end on a Metronome-billed dev workspace.
- Initial attempt failed with `payment_gate.payment_status: failed` ("Failed to get Stripe product ID for Metronome Product") because the Prepaid Commit product had no Stripe mapping.
- Fix: switched `invoice_schedule` to `unit_price`/`quantity` and dropped explicit `tax_type` — Metronome auto-created the Stripe Product on push.
- Subsequent purchase: invoice generated, Stripe charged, `payment_gate.payment_status: succeeded` webhook received, commit unlocked, AWU balance updated.

## Risk

- Low on the customer side (not yet GA — same surface as #25670, still admin-only).
- Behavioural change: there is no longer a synchronous Stripe-hosted invoice URL after purchase. 3DS / payment-pending-action cases now flow through Metronome → Stripe automation and arrive by email instead of an in-dialog redirect. UI shows a "Processing" state and the pool summary polls.
- The pending-purchase eligibility check still depends on Metronome stamping our metadata on the Stripe invoice it pushes. Verified manually; if Metronome ever stops propagating `invoice_metadata`, the check would silently let duplicate purchases through.

## Deploy Plan

- Deploy front.
- Merges after #25670.