### PR TITLE
[Wake-ups] Avoid failures for stale wake-ups

### DIFF
--- a/front/temporal/triggers/activities.test.ts
+++ b/front/temporal/triggers/activities.test.ts
@@ -1,6 +1,6 @@
 import { createConversation } from "@app/lib/api/assistant/conversation";
-import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import {
   expireWakeUpActivity,
   runWakeUpActivity,
@@ -40,7 +40,7 @@ describe("wake-up activities", () => {
     });
 
     await expect(
-      runWakeUpActivity({ workspaceId: workspace.sId, wakeUpId }),
+      runWakeUpActivity({ workspaceId: workspace.sId, wakeUpId })
     ).resolves.toBeUndefined();
   });
 
@@ -52,10 +52,10 @@ describe("wake-up activities", () => {
     });
 
     await expect(
-      runWakeUpActivity({ workspaceId: workspace.sId, wakeUpId }),
+      runWakeUpActivity({ workspaceId: workspace.sId, wakeUpId })
     ).resolves.toBeUndefined();
     await expect(
-      expireWakeUpActivity({ workspaceId: workspace.sId, wakeUpId }),
+      expireWakeUpActivity({ workspaceId: workspace.sId, wakeUpId })
     ).resolves.toBeUndefined();
   });
 });

--- a/front/temporal/triggers/activities.test.ts
+++ b/front/temporal/triggers/activities.test.ts
@@ -1,0 +1,61 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
+import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
+import {
+  expireWakeUpActivity,
+  runWakeUpActivity,
+} from "@app/temporal/triggers/activities";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+const MISSING_WAKE_UP_MODEL_ID = 9_000_000_000;
+
+describe("wake-up activities", () => {
+  it("skips terminal wake-ups without failing the activity", async () => {
+    const { authenticator, user, workspace } = await createResourceTest({
+      role: "builder",
+    });
+    const conversation = await createConversation(authenticator, {
+      title: null,
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const wakeUp = await WakeUpModel.create({
+      workspaceId: workspace.id,
+      conversationId: conversation.id,
+      userId: user.id,
+      agentConfigurationId: "test-agent",
+      scheduleType: "one_shot",
+      fireAt: new Date(),
+      cronExpression: null,
+      cronTimezone: null,
+      reason: "Already cancelled wake-up",
+      status: "cancelled",
+      fireCount: 0,
+    });
+    const wakeUpId = WakeUpResource.modelIdToSId({
+      id: wakeUp.id,
+      workspaceId: workspace.id,
+    });
+
+    await expect(
+      runWakeUpActivity({ workspaceId: workspace.sId, wakeUpId }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips missing wake-ups without failing the activity", async () => {
+    const { workspace } = await createResourceTest({ role: "builder" });
+    const wakeUpId = WakeUpResource.modelIdToSId({
+      id: MISSING_WAKE_UP_MODEL_ID,
+      workspaceId: workspace.id,
+    });
+
+    await expect(
+      runWakeUpActivity({ workspaceId: workspace.sId, wakeUpId }),
+    ).resolves.toBeUndefined();
+    await expect(
+      expireWakeUpActivity({ workspaceId: workspace.sId, wakeUpId }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -31,7 +31,6 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 class TriggerNonRetryableError extends Error {}
-class WakeUpNonRetryableError extends Error {}
 
 async function createConversationForAgentConfiguration({
   auth,
@@ -367,7 +366,7 @@ export async function runWakeUpActivity({
       { wakeUpId, workspaceId, error: normalizeError(wakeUpAndAuthRes.error) },
       "Skipping wake-up: workspace or wake-up not found."
     );
-    throw new WakeUpNonRetryableError("Workspace or wake-up not found.");
+    return;
   }
 
   const { auth, wakeUp } = wakeUpAndAuthRes.value;
@@ -377,7 +376,7 @@ export async function runWakeUpActivity({
       { status: wakeUp.status, wakeUpId, workspaceId },
       "Skipping wake-up: wake-up is not scheduled."
     );
-    throw new WakeUpNonRetryableError("Wake-up is not scheduled.");
+    return;
   }
 
   const [c] = await ConversationResource.fetchByModelIds(auth, [
@@ -389,7 +388,7 @@ export async function runWakeUpActivity({
       "Cancelling wake-up: conversation not found."
     );
     await wakeUp.markCancelled(auth);
-    throw new WakeUpNonRetryableError("Conversation not found.");
+    return;
   }
 
   const conversationRes = await getConversation(auth, c.sId);
@@ -404,7 +403,7 @@ export async function runWakeUpActivity({
       "Cancelling wake-up: conversation not accessible."
     );
     await wakeUp.markCancelled(auth);
-    throw new WakeUpNonRetryableError("Conversation not accessible.");
+    return;
   }
 
   const conversation = conversationRes.value;
@@ -434,10 +433,16 @@ export async function runWakeUpActivity({
       type === "agent_inaccessible" ||
       type === "model_disabled"
     ) {
-      await wakeUp.markCancelled(auth);
-      throw new WakeUpNonRetryableError(
-        `Cancelling wake-up: ${type} (${message}).`
+      logger.info(
+        {
+          wakeUpId,
+          workspaceId,
+          error: postMessageResult.error,
+        },
+        "Cancelling wake-up: agent cannot be invoked."
       );
+      await wakeUp.markCancelled(auth);
+      return;
     }
 
     throw new Error(`Error posting wake-up message: [${type}] ${message}`);
@@ -476,7 +481,7 @@ export async function expireWakeUpActivity({
       { wakeUpId, workspaceId, error: normalizeError(wakeUpAndAuthRes.error) },
       "Expire wake-up: workspace or wake-up not found."
     );
-    throw new WakeUpNonRetryableError("Workspace or wake-up not found.");
+    return;
   }
   const { auth, wakeUp } = wakeUpAndAuthRes.value;
 

--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -19,7 +19,6 @@ const { expireWakeUpActivity, runWakeUpActivity } = proxyActivities<
     backoffCoefficient: 2,
     maximumAttempts: 3,
     maximumInterval: "5 minutes",
-    nonRetryableErrorTypes: ["WakeUpNonRetryableError"],
   },
 });
 
@@ -42,17 +41,15 @@ export async function agentTriggerWorkflow({
   });
 }
 
-function isWakeUpActivityRetryExhausted(
-  error: unknown
-): error is ActivityFailure {
+function isRunWakeUpActivityFailure(error: unknown): error is ActivityFailure {
   if (!(error instanceof ActivityFailure)) {
     return false;
   }
 
-  if (error.activityType !== "runWakeUpActivity") {
-    return false;
-  }
+  return error.activityType === "runWakeUpActivity";
+}
 
+function isWakeUpActivityRetryExhausted(error: ActivityFailure): boolean {
   return (
     error.retryState === RetryState.MAXIMUM_ATTEMPTS_REACHED ||
     error.retryState === RetryState.TIMEOUT
@@ -69,9 +66,16 @@ export async function wakeUpWorkflow({
   try {
     await runWakeUpActivity({ workspaceId, wakeUpId });
   } catch (error) {
-    if (isWakeUpActivityRetryExhausted(error)) {
-      await expireWakeUpActivity({ workspaceId, wakeUpId });
-      return;
+    if (isRunWakeUpActivityFailure(error)) {
+      // Older workers used WakeUpNonRetryableError for expected stale wake-up states.
+      if (error.retryState === RetryState.NON_RETRYABLE_FAILURE) {
+        return;
+      }
+
+      if (isWakeUpActivityRetryExhausted(error)) {
+        await expireWakeUpActivity({ workspaceId, wakeUpId });
+        return;
+      }
     }
 
     throw error;


### PR DESCRIPTION
## Description

Wake-up Temporal activities can observe expected stale states: already cancelled/fired/expired wake-ups, missing rows, inaccessible conversations, or agents that can no longer be invoked. These states mean there is no wake-up side effect left to perform, so the activity should complete as a logged no-op after any relevant cleanup.

This keeps Temporal failure signals for actionable issues: unexpected post-message failures still throw and retry, while expected stale/idempotency races no longer create workflow failures. Also handles `NON_RETRYABLE_FAILURE` from older workers so in-flight histories complete cleanly during rollout.

## Risks

Blast radius: Temporal wake-up execution and expiration handling.
Risk: low

## Deploy Plan

- deploy front workers
