### PR TITLE
Compaction: non-truncated rendered conversation as text for file creation

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -171,7 +171,7 @@ export async function renderConversationForModel(
     tokensMargin: TOKENS_MARGIN,
     messageCount: messages.length,
     interactionCount: interactions.length,
-    pokeUrl: `https://https://poke.dust.tt/${conversation.owner.sId}/conversation/${conversation.sId}`,
+    pokeUrl: `https://poke.dust.tt/${conversation.owner.sId}/conversation/${conversation.sId}`,
   };
 
   if (currentInteractionTokens > availableTokens) {

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -254,8 +254,17 @@ export async function runCompaction(
       summaryRes.value.summary,
       sourceConversation?.attachmentIdReplacements
     );
-    const renderedMessages = replaceStandaloneAttachmentIds(
-      summaryRes.value.renderedMessages,
+
+    // We generate the conversattion as text without `truncateTotalChars` to store as file.
+    let renderedMessages = renderConversationAsText(conversationToSummarize, {
+      includeTimestamps: true,
+      includeActions: true,
+      includeActionDetails: true,
+      skipRunningAgentMessages: true,
+    });
+
+    renderedMessages = replaceStandaloneAttachmentIds(
+      renderedMessages,
       sourceConversation?.attachmentIdReplacements
     );
 
@@ -351,7 +360,7 @@ async function generateCompactionSummary(
     compactionMessage: CompactionMessageType;
     model: SupportedModel;
   }
-): Promise<Result<{ summary: string; renderedMessages: string }, Error>> {
+): Promise<Result<{ summary: string }, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
   const conversationToSummarize =
@@ -444,5 +453,5 @@ async function generateCompactionSummary(
     return new Err(new Error("Compaction LLM returned empty summary"));
   }
 
-  return new Ok({ summary, renderedMessages });
+  return new Ok({ summary });
 }


### PR DESCRIPTION
## Description

We started using `truncateTotalChars` in the summary generation to avoid context exhaustion in ill-formed cases. But we want to have the full conversation stored in file for future reference without `truncateTotalChars`.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25722">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->