### PR TITLE
[DB] Add FK indexes for conversation deletes

### DIFF
--- a/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
+++ b/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
@@ -76,9 +76,19 @@ AgentStepContentToolExecutionModel.init(
         name: "agent_sc_te_workspace_step_content",
       },
       {
+        fields: ["stepContentId"],
+        concurrently: true,
+        name: "agent_step_content_tool_executions_step_content_id",
+      },
+      {
         fields: ["workspaceId", "conversationId", "agentMessageId"],
         concurrently: true,
         name: "agent_sc_te_workspace_conversation_message",
+      },
+      {
+        fields: ["conversationId"],
+        concurrently: true,
+        name: "agent_step_content_tool_executions_conversation_id",
       },
     ],
   }

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -95,6 +95,11 @@ AgentSuggestionModel.init(
         fields: ["workspaceId", "conversationId"],
         concurrently: true,
       },
+      {
+        fields: ["conversationId"],
+        concurrently: true,
+        name: "agent_suggestions_conversation_id",
+      },
     ],
   }
 );

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -247,6 +247,11 @@ UserConversationReadsModel.init(
         fields: ["workspaceId", "conversationId"],
       },
       {
+        fields: ["conversationId"],
+        name: "user_conversation_reads_conversation_id",
+        concurrently: true,
+      },
+      {
         fields: ["workspaceId", "userId"],
       },
     ],
@@ -634,6 +639,11 @@ AgentMessageFeedbackModel.init(
         name: "agent_message_feedbacks_agent_configuration_id_agent_message_id",
       },
       { fields: ["workspaceId"], concurrently: true },
+      {
+        fields: ["conversationId"],
+        name: "agent_message_feedbacks_conversation_id",
+        concurrently: true,
+      },
       { fields: ["workspaceId", "conversationId"], concurrently: true },
     ],
   }
@@ -835,6 +845,11 @@ MessageModel.init(
       },
       {
         fields: ["branchId"],
+        concurrently: true,
+      },
+      {
+        fields: ["conversationId"],
+        name: "messages_conversation_id",
         concurrently: true,
       },
       {

--- a/front/lib/models/agent/conversation_branch.ts
+++ b/front/lib/models/agent/conversation_branch.ts
@@ -52,6 +52,11 @@ ConversationBranchModel.init(
         fields: ["workspaceId", "conversationId", "userId"],
       },
       {
+        fields: ["conversationId"],
+        name: "conversation_branches_conversation_id",
+        concurrently: true,
+      },
+      {
         fields: ["previousMessageId"],
       },
     ],

--- a/front/lib/resources/storage/models/wakeup.ts
+++ b/front/lib/resources/storage/models/wakeup.ts
@@ -102,6 +102,11 @@ WakeUpModel.init(
         concurrently: true,
       },
       {
+        fields: ["conversationId"],
+        name: "wake_ups_conversation_id",
+        concurrently: true,
+      },
+      {
         fields: ["workspaceId", "userId"],
         name: "wake_ups_workspace_id_user_id_idx",
         concurrently: true,

--- a/front/migrations/db/migration_641.sql
+++ b/front/migrations/db/migration_641.sql
@@ -1,0 +1,19 @@
+-- Migration created on May 18, 2026
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "agent_message_feedbacks_conversation_id"
+  ON "public"."agent_message_feedbacks" ("conversationId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "agent_step_content_tool_executions_conversation_id"
+  ON "public"."agent_step_content_tool_executions" ("conversationId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "agent_step_content_tool_executions_step_content_id"
+  ON "public"."agent_step_content_tool_executions" ("stepContentId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "agent_suggestions_conversation_id"
+  ON "public"."agent_suggestions" ("conversationId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_branches_conversation_id"
+  ON "public"."conversation_branches" ("conversationId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "conversation_participants_conversation_id"
+  ON "public"."conversation_participants" ("conversationId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "messages_conversation_id"
+  ON "public"."messages" ("conversationId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "user_conversation_reads_conversation_id"
+  ON "public"."user_conversation_reads" ("conversationId");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "wake_ups_conversation_id"
+  ON "public"."wake_ups" ("conversationId");


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8102.

Query Insights showed slow Front DB time on `DELETE FROM "conversations" WHERE "workspaceId" = $1 AND "id" = $2`. That generates frequent high CPU monitor for front db.

The parent row lookup is indexed; the expensive part can be PostgreSQL enforcing FKs from large child tables whose indexes start with `workspaceId`. This adds FK-leading indexes so RI checks during conversation and step-content deletes can use targeted lookups.

## Risks
Blast radius: Front DB additive indexes on conversation-related child tables.
Risk: low

## Deploy Plan
- Run additive migration `front/migrations/db/migration_641.sql` before deploying services.
- Deploy `front` and `front-sse` so Sequelize model metadata matches the new schema.