### PR TITLE
Fix infinite reconnect loop in useAgentMessageStream + useEventSource.

### DIFF
--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -313,6 +313,17 @@ export function useAgentMessageStream({
   // and same-millisecond re-processing produces duplicate React keys.
   const seenEventIds = useRef<Set<string>>(new Set());
 
+  // Once a terminal event (agent_message_success, agent_error, etc.) is
+  // received, we must stop reconnecting entirely. Without this, a race between
+  // Virtuoso's deferred item re-render (which updates `agentMessage.status` and
+  // flips `shouldStream` to false) and the immediate React re-render triggered
+  // by the SSE `done` frame causes the effect to fire with `shouldStream` still
+  // true, reconnecting to the server. The server then replays history including
+  // `end-of-stream`, after which every subsequent reconnect gets an empty
+  // history and another immediate `done`, producing an infinite loop.
+  // Returning null from buildEventSourceURL breaks the loop at the source.
+  const isStreamTerminated = useRef(false);
+
   useEffect(() => {
     return () => {
       updateMessageThrottled.cancel();
@@ -341,6 +352,9 @@ export function useAgentMessageStream({
 
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {
+      if (isStreamTerminated.current) {
+        return null;
+      }
       const esURL = `/api/sse/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${sId}/events`;
       let lastEventId = "";
       if (lastEvent) {
@@ -374,6 +388,7 @@ export function useAgentMessageStream({
         case "end-of-stream":
           // This event is emitted in front/lib/api/assistant/pubsub.ts. Its purpose is to signal the
           // end of the stream to the client. So we just return.
+          isStreamTerminated.current = true;
           return;
 
         case "tool_ask_user_question":
@@ -587,6 +602,7 @@ export function useAgentMessageStream({
 
         case "tool_error":
         case "agent_error":
+          isStreamTerminated.current = true;
           updateMessageThrottled.cancel();
           const error = eventPayload.data.error;
           methods.data.map((m) => {
@@ -627,6 +643,7 @@ export function useAgentMessageStream({
           break;
 
         case "agent_generation_cancelled": {
+          isStreamTerminated.current = true;
           updateMessageThrottled.cancel();
           const cancelData = eventPayload.data;
           if (cancelData.type !== "agent_generation_cancelled") {
@@ -660,6 +677,7 @@ export function useAgentMessageStream({
 
         case "agent_message_gracefully_stopped":
         case "agent_message_success": {
+          isStreamTerminated.current = true;
           updateMessageThrottled.cancel();
           const messageSuccess = eventPayload.data;
           // Flush any remaining CoT (but not content — the final text segment


### PR DESCRIPTION
## Description

The Infinite Streaming Loop Bug

**Root Cause**

A race between Virtuoso's deferred item re-render and an immediate React state update causes the SSE connection to reconnect after the stream is already done, entering an infinite loop.

**Exact Sequence**

1. Agent finishes → agent_message_success is processed → methods.data.map() is called to update the message in Virtuoso's internal store. Virtuoso defers the item re-render to the next animation frame.
2. The SSE done frame arrives immediately after → setReconnectCounter(c => c + 1) triggers a React re-render right now, before Virtuoso's animation frame fires → agentMessage.status is still "created" → shouldStream is still true.
3. First reconnect: The effect runs with shouldStream: true, creates a new SSE connection. The server replays history from lastEventId = agent_message_success.eventId. That history includes end-of-stream — the server breaks on it during live streaming but yields it during history replay (the two code paths in pubsub.ts are asymmetric). Client processes end-of-stream (does nothing useful), updates lastEvent.current to it, then receives done.
4. Second reconnect with lastEventId = end-of-stream.eventId → empty history → server closes immediately → done.
5. agent_message_success is now blocked by seenEventIds → methods.data.map() is never called again → Virtuoso state never updates in the reconnect loop → shouldStream stays true → infinite loop.
6. If the rapid reconnects block the main thread (each React re-render is slow when inlineActivitySteps is large), Virtuoso's animation frame never fires, making it truly infinite. Datadog captured a 46-second main thread freeze from exactly this.

**The Fix**

Add an isStreamTerminated ref. Set it to true in every terminal event handler (agent_message_success, agent_message_gracefully_stopped, agent_error, tool_error, agent_generation_cancelled, end-of-stream). Check it at the top of buildEventSourceURL and return null if set.

Returning null from buildEventSourceURL tells useEventSource to clean up and never create a new connection — breaking the loop before the first reconnect even happens, regardless of Virtuoso's re-render timing.

**Why a Ref (not state)**

- Refs don't trigger re-renders, so setting isStreamTerminated.current = true inside onEventCallback has no side effects.
- The ref value is read synchronously when buildEventSourceURL is called inside the connect closure, always reflecting the latest value even if the closure itself is stale.
- The ref is scoped to the component mount (one per agent message), so a retry that creates a new message automatically gets a fresh false.


## Tests

Hard to reproduce, I only tested that it was not breaking everything. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25726">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->