### PR TITLE
[front] checkout: billingPeriod in Stripe session metadata + redirect_url

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -278,21 +278,23 @@ export const createStripeSubscriptionCheckoutSession = async ({
  */
 export const createEmbeddedMetronomeSetupCheckoutSession = async ({
   allowedPaymentMethods = ["card"],
-  couponCode,
   metronomePackageAlias,
   owner,
   planCode,
+  billingPeriod,
   seatCount,
   pricePerSeatCents,
+  couponCode,
   user,
 }: {
   allowedPaymentMethods?: SupportedPaymentMethod[];
-  couponCode?: string;
   metronomePackageAlias: string;
   owner: WorkspaceType;
   planCode: string;
+  billingPeriod: string;
   seatCount?: number;
   pricePerSeatCents?: number;
+  couponCode?: string;
   user: UserType;
 }): Promise<{ clientSecret: string; sessionId: string }> => {
   const stripe = getStripeClient();
@@ -301,15 +303,17 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
     planCode,
     userId: user.sId,
     metronomePackageAlias,
+    billingPeriod,
   };
-  if (couponCode) {
-    metadata.couponCode = couponCode;
-  }
+
   if (seatCount !== undefined) {
     metadata.seatCount = String(seatCount);
   }
   if (pricePerSeatCents !== undefined) {
     metadata.pricePerSeatCents = String(pricePerSeatCents);
+  }
+  if (couponCode) {
+    metadata.couponCode = couponCode;
   }
 
   const session = await stripe.checkout.sessions.create({
@@ -325,7 +329,7 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
       enabled: true,
     },
     redirect_on_completion: "if_required",
-    return_url: `${config.getAppUrl()}/w/${owner.sId}/subscription/checkout?setup_session_id={CHECKOUT_SESSION_ID}`,
+    return_url: `${config.getAppUrl()}/w/${owner.sId}/subscription/checkout?billingPeriod=${billingPeriod}&setup_session_id={CHECKOUT_SESSION_ID}`,
     consent_collection: {
       terms_of_service: "required",
     },

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1265,14 +1265,15 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
       const { clientSecret, sessionId } =
         await createEmbeddedMetronomeSetupCheckoutSession({
-          owner,
-          user,
-          planCode,
-          metronomePackageAlias,
           allowedPaymentMethods,
-          couponCode,
+          metronomePackageAlias,
+          owner,
+          planCode,
+          billingPeriod,
           seatCount,
           pricePerSeatCents,
+          couponCode,
+          user,
         });
       return {
         mode: "embedded",


### PR DESCRIPTION
## Description

* Add billingPeriod in Stripe session metadata so that it could be used in invoicing
* Make sure to have billingPeriod in redirect_url so that the url fits with the previous url in the flow
* Small cleaning in parameters order in createEmbeddedMetronomeSetupCheckoutSession

## Tests

Tested locally with forced (hardcoded) redirection to redirect_url in Stripe setup session

## Risk

Low

## Deploy Plan

Merge into https://github.com/dust-tt/dust/pull/25582 before merging it to have only one PR for Checkout

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25728">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->