### PR TITLE
Migrate seats, credits, and analytics GET routes to Hono

### DIFF
--- a/front-api/routes/w/[wId]/analytics/active-users-export.ts
+++ b/front-api/routes/w/[wId]/analytics/active-users-export.ts
@@ -1,0 +1,68 @@
+import { stringify } from "csv-stringify/sync";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
+import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+// Mounted at /api/w/:wId/analytics/active-users-export.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const { startDate, endDate } = daysToDateRange(days);
+  const result = await fetchActiveUsersMetrics(owner, startDate, endDate);
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve active users metrics: ${result.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const headers = ["date", "dau", "wau", "mau"];
+  const csvData = result.value.map((point) => [
+    point.date,
+    point.dau,
+    point.wau,
+    point.mau,
+  ]);
+  const csv = stringify([headers, ...csvData], { header: false });
+
+  c.header("Content-Type", "text/csv");
+  c.header(
+    "Content-Disposition",
+    `attachment; filename="dust_active_users_last_${days}_days.csv"`
+  );
+  return c.body(csv);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/active-users-export.ts
+++ b/front-api/routes/w/[wId]/analytics/active-users-export.ts
@@ -2,11 +2,12 @@ import { stringify } from "csv-stringify/sync";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -19,15 +20,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days } = c.req.valid("query");
@@ -37,15 +36,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const result = await fetchActiveUsersMetrics(owner, startDate, endDate);
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve active users metrics: ${result.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve active users metrics: ${result.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const headers = ["date", "dau", "wau", "mau"];

--- a/front-api/routes/w/[wId]/analytics/active-users.ts
+++ b/front-api/routes/w/[wId]/analytics/active-users.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
@@ -8,8 +11,6 @@ import {
   daysToDateRange,
   timezoneSchema,
 } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -27,15 +28,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days, timezone } = c.req.valid("query");
@@ -50,15 +49,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   );
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve active users metrics: ${result.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve active users metrics: ${result.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const body: GetWorkspaceActiveUsersResponse = {

--- a/front-api/routes/w/[wId]/analytics/active-users.ts
+++ b/front-api/routes/w/[wId]/analytics/active-users.ts
@@ -1,0 +1,70 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";
+import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
+import {
+  daysToDateRange,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  timezone: timezoneSchema,
+});
+
+export type GetWorkspaceActiveUsersResponse = {
+  points: ActiveUsersMetricsPoint[];
+};
+
+// Mounted at /api/w/:wId/analytics/active-users.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days, timezone } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const { startDate, endDate } = daysToDateRange(days, timezone);
+  const result = await fetchActiveUsersMetrics(
+    owner,
+    startDate,
+    endDate,
+    timezone
+  );
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve active users metrics: ${result.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const body: GetWorkspaceActiveUsersResponse = {
+    points: result.value,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/agents-export.ts
+++ b/front-api/routes/w/[wId]/analytics/agents-export.ts
@@ -1,0 +1,73 @@
+import { stringify } from "csv-stringify/sync";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import {
+  AGENT_EXPORT_HEADERS,
+  fetchAgentExportRows,
+} from "@app/lib/api/analytics/agents_export";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+// Mounted at /api/w/:wId/analytics/agents-export.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const result = await fetchAgentExportRows(baseQuery, auth, true);
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve agent analytics: ${result.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const csvData = result.value.map((row) =>
+    AGENT_EXPORT_HEADERS.map((h) => row[h])
+  );
+  const csv = stringify([AGENT_EXPORT_HEADERS, ...csvData], {
+    header: false,
+  });
+
+  c.header("Content-Type", "text/csv");
+  c.header(
+    "Content-Disposition",
+    `attachment; filename="dust_agents_last_${days}_days.csv"`
+  );
+  return c.body(csv);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/agents-export.ts
+++ b/front-api/routes/w/[wId]/analytics/agents-export.ts
@@ -2,14 +2,15 @@ import { stringify } from "csv-stringify/sync";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {
   AGENT_EXPORT_HEADERS,
   fetchAgentExportRows,
 } from "@app/lib/api/analytics/agents_export";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -22,15 +23,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days } = c.req.valid("query");
@@ -44,15 +43,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const result = await fetchAgentExportRows(baseQuery, auth, true);
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve agent analytics: ${result.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve agent analytics: ${result.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const csvData = result.value.map((row) =>

--- a/front-api/routes/w/[wId]/analytics/index.ts
+++ b/front-api/routes/w/[wId]/analytics/index.ts
@@ -1,0 +1,31 @@
+import { Hono } from "hono";
+
+import activeUsers from "./active-users";
+import metronomeUsage from "./metronome-usage";
+import overview from "./overview";
+import programmaticCost from "./programmatic-cost";
+import skillUsage from "./skill-usage";
+import skills from "./skills";
+import source from "./source";
+import tools from "./tools";
+import topAgents from "./top-agents";
+import topUsers from "./top-users";
+import usageMetrics from "./usage-metrics";
+
+// Mounted at /api/w/:wId/analytics. workspaceAuth is applied by the parent
+// workspace sub-app.
+const app = new Hono();
+
+app.route("/active-users", activeUsers);
+app.route("/metronome-usage", metronomeUsage);
+app.route("/overview", overview);
+app.route("/programmatic-cost", programmaticCost);
+app.route("/skill-usage", skillUsage);
+app.route("/skills", skills);
+app.route("/source", source);
+app.route("/tools", tools);
+app.route("/top-agents", topAgents);
+app.route("/top-users", topUsers);
+app.route("/usage-metrics", usageMetrics);
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/index.ts
+++ b/front-api/routes/w/[wId]/analytics/index.ts
@@ -1,31 +1,49 @@
 import { Hono } from "hono";
 
+import activeUsersExport from "./active-users-export";
 import activeUsers from "./active-users";
+import agentsExport from "./agents-export";
 import metronomeUsage from "./metronome-usage";
 import overview from "./overview";
+import programmaticCostExport from "./programmatic-cost-export";
 import programmaticCost from "./programmatic-cost";
+import skillUsageExport from "./skill-usage-export";
 import skillUsage from "./skill-usage";
 import skills from "./skills";
+import sourceExport from "./source-export";
 import source from "./source";
+import toolUsageExport from "./tool-usage-export";
+import toolUsage from "./tool-usage";
 import tools from "./tools";
 import topAgents from "./top-agents";
 import topUsers from "./top-users";
+import usageMetricsExport from "./usage-metrics-export";
 import usageMetrics from "./usage-metrics";
+import usersExport from "./users-export";
 
 // Mounted at /api/w/:wId/analytics. workspaceAuth is applied by the parent
 // workspace sub-app.
 const app = new Hono();
 
+app.route("/active-users-export", activeUsersExport);
 app.route("/active-users", activeUsers);
+app.route("/agents-export", agentsExport);
 app.route("/metronome-usage", metronomeUsage);
 app.route("/overview", overview);
+app.route("/programmatic-cost-export", programmaticCostExport);
 app.route("/programmatic-cost", programmaticCost);
+app.route("/skill-usage-export", skillUsageExport);
 app.route("/skill-usage", skillUsage);
 app.route("/skills", skills);
+app.route("/source-export", sourceExport);
 app.route("/source", source);
+app.route("/tool-usage-export", toolUsageExport);
+app.route("/tool-usage", toolUsage);
 app.route("/tools", tools);
 app.route("/top-agents", topAgents);
 app.route("/top-users", topUsers);
+app.route("/usage-metrics-export", usageMetricsExport);
 app.route("/usage-metrics", usageMetrics);
+app.route("/users-export", usersExport);
 
 export default app;

--- a/front-api/routes/w/[wId]/analytics/metronome-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/metronome-usage.ts
@@ -1,12 +1,16 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
-import type { WindowSize } from "@app/lib/api/analytics/time_utils";
 import {
   DAY_MS,
-  FOUR_HOURS_MS,
   getTimestampsForWindow,
 } from "@app/lib/api/analytics/time_utils";
+import {
+  aggregateToFourHourBuckets,
+  calculateCreditTotalsFromBalances,
+  getMetronomeWindowSize,
+  resolveGroupLabels,
+} from "@app/lib/api/analytics/metronome_usage";
 import { MARKUP_MULTIPLIER } from "@app/lib/api/programmatic_usage/common";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import {
@@ -20,13 +24,8 @@ import {
   getCreditTypeProgrammaticUsdId,
   getMetricLlmProviderCostProgrammaticId,
 } from "@app/lib/metronome/constants";
-import type { MetronomeBalance } from "@app/lib/metronome/types";
-import {
-  isMetronomeExcessCredit,
-  METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD,
-} from "@app/lib/metronome/types";
+import { isMetronomeExcessCredit } from "@app/lib/metronome/types";
 import logger from "@app/logger/logger";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import { validate } from "@front-api/middleware/validator";
 
@@ -72,128 +71,6 @@ const GROUP_BY_TO_EVENT_PROPERTY: Record<MetronomeUsageGroupByType, string> = {
   model: "model_id",
   origin: "origin",
 };
-
-type MetronomeWindowSize = "HOUR" | "DAY";
-
-function getMetronomeWindowSize(windowSize: WindowSize): MetronomeWindowSize {
-  switch (windowSize) {
-    case "FOUR_HOURS":
-    case "HOUR":
-      return "HOUR";
-    case "DAY":
-      return "DAY";
-    default:
-      assertNever(windowSize);
-  }
-}
-
-function aggregateToFourHourBuckets(
-  hourlyMap: Map<number, number>
-): Map<number, number> {
-  const aggregated = new Map<number, number>();
-  for (const [ts, value] of hourlyMap) {
-    const bucket = ts - (ts % FOUR_HOURS_MS);
-    aggregated.set(bucket, (aggregated.get(bucket) ?? 0) + value);
-  }
-  return aggregated;
-}
-
-interface ParsedBalance {
-  initialAmountCredits: number;
-  balanceCredits: number;
-  intervals: { start: number; end: number }[];
-}
-
-function calculateCreditTotalsFromBalances(
-  balances: MetronomeBalance[],
-  timestamps: number[]
-): Map<
-  number,
-  {
-    totalInitialCreditsMicroUsd: number;
-    totalConsumedCreditsMicroUsd: number;
-    totalRemainingCreditsMicroUsd: number;
-  }
-> {
-  const parsed: ParsedBalance[] = balances.map((entry) => {
-    const items = entry.access_schedule?.schedule_items ?? [];
-    let initialAmountCredits = 0;
-    const intervals: { start: number; end: number }[] = [];
-
-    for (const item of items) {
-      initialAmountCredits += item.amount;
-      intervals.push({
-        start: new Date(item.starting_at).getTime(),
-        end: new Date(item.ending_before).getTime(),
-      });
-    }
-
-    return {
-      initialAmountCredits,
-      balanceCredits: entry.balance ?? 0,
-      intervals,
-    };
-  });
-
-  const result = new Map<
-    number,
-    {
-      totalInitialCreditsMicroUsd: number;
-      totalConsumedCreditsMicroUsd: number;
-      totalRemainingCreditsMicroUsd: number;
-    }
-  >();
-
-  for (const timestamp of timestamps) {
-    let totalInitialCredits = 0;
-    let totalBalanceCredits = 0;
-
-    for (const b of parsed) {
-      const isActive = b.intervals.some(
-        (iv) => timestamp >= iv.start && timestamp < iv.end
-      );
-      if (isActive) {
-        totalInitialCredits += b.initialAmountCredits;
-        totalBalanceCredits += b.balanceCredits;
-      }
-    }
-
-    const totalInitialMicroUsd =
-      totalInitialCredits * METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD;
-    const totalRemainingMicroUsd =
-      totalBalanceCredits * METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD;
-
-    result.set(timestamp, {
-      totalInitialCreditsMicroUsd: totalInitialMicroUsd,
-      totalConsumedCreditsMicroUsd:
-        totalInitialMicroUsd - totalRemainingMicroUsd,
-      totalRemainingCreditsMicroUsd: totalRemainingMicroUsd,
-    });
-  }
-
-  return result;
-}
-
-async function resolveGroupLabels(
-  groupBy: MetronomeUsageGroupByType,
-  groupKeys: string[]
-): Promise<Map<string, string>> {
-  const labelMap = new Map<string, string>();
-
-  switch (groupBy) {
-    case "api_key":
-    case "model":
-    case "origin":
-      for (const key of groupKeys) {
-        labelMap.set(key, key);
-      }
-      break;
-    default:
-      assertNever(groupBy);
-  }
-
-  return labelMap;
-}
 
 // Mounted at /api/w/:wId/analytics/metronome-usage.
 const app = new Hono();

--- a/front-api/routes/w/[wId]/analytics/metronome-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/metronome-usage.ts
@@ -2,15 +2,15 @@ import { Hono } from "hono";
 import { z } from "zod";
 
 import {
-  DAY_MS,
-  getTimestampsForWindow,
-} from "@app/lib/api/analytics/time_utils";
-import {
   aggregateToFourHourBuckets,
   calculateCreditTotalsFromBalances,
   getMetronomeWindowSize,
   resolveGroupLabels,
 } from "@app/lib/api/analytics/metronome_usage";
+import {
+  DAY_MS,
+  getTimestampsForWindow,
+} from "@app/lib/api/analytics/time_utils";
 import { MARKUP_MULTIPLIER } from "@app/lib/api/programmatic_usage/common";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import {

--- a/front-api/routes/w/[wId]/analytics/metronome-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/metronome-usage.ts
@@ -1,0 +1,459 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import type { WindowSize } from "@app/lib/api/analytics/time_utils";
+import {
+  DAY_MS,
+  FOUR_HOURS_MS,
+  getTimestampsForWindow,
+} from "@app/lib/api/analytics/time_utils";
+import { MARKUP_MULTIPLIER } from "@app/lib/api/programmatic_usage/common";
+import { getBillingCycleFromDay } from "@app/lib/client/subscription";
+import {
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
+  listMetronomeBalances,
+  listMetronomeUsage,
+  listMetronomeUsageWithGroups,
+} from "@app/lib/metronome/client";
+import {
+  getCreditTypeProgrammaticUsdId,
+  getMetricLlmProviderCostProgrammaticId,
+} from "@app/lib/metronome/constants";
+import type { MetronomeBalance } from "@app/lib/metronome/types";
+import {
+  isMetronomeExcessCredit,
+  METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD,
+} from "@app/lib/metronome/types";
+import logger from "@app/logger/logger";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+import { validate } from "@front-api/middleware/validator";
+
+const METRONOME_USAGE_GROUP_BY_KEYS = ["api_key", "model", "origin"] as const;
+
+export type MetronomeUsageGroupByType =
+  (typeof METRONOME_USAGE_GROUP_BY_KEYS)[number];
+
+const QuerySchema = z.object({
+  groupBy: z.enum(METRONOME_USAGE_GROUP_BY_KEYS).optional(),
+  groupByCount: z.coerce.number().optional().default(5),
+  selectedPeriod: z.string().optional(),
+  billingCycleStartDay: z.coerce.number().min(1).max(31),
+  windowSize: z.enum(["HOUR", "FOUR_HOURS", "DAY"]).optional().default("DAY"),
+});
+
+export interface MetronomeUsagePointGroup {
+  groupKey: string;
+  valueMicroUsd: number;
+  cumulatedValueMicroUsd?: number;
+}
+
+export interface MetronomeUsagePoint {
+  timestamp: number;
+  groups: MetronomeUsagePointGroup[];
+  totalInitialCreditsMicroUsd: number;
+  totalConsumedCreditsMicroUsd: number;
+  totalRemainingCreditsMicroUsd: number;
+}
+
+export interface MetronomeUsageAvailableGroup {
+  groupKey: string;
+  groupLabel: string;
+}
+
+export interface GetMetronomeUsageResponse {
+  points: MetronomeUsagePoint[];
+  availableGroups: MetronomeUsageAvailableGroup[];
+}
+
+const GROUP_BY_TO_EVENT_PROPERTY: Record<MetronomeUsageGroupByType, string> = {
+  api_key: "api_key_name",
+  model: "model_id",
+  origin: "origin",
+};
+
+type MetronomeWindowSize = "HOUR" | "DAY";
+
+function getMetronomeWindowSize(windowSize: WindowSize): MetronomeWindowSize {
+  switch (windowSize) {
+    case "FOUR_HOURS":
+    case "HOUR":
+      return "HOUR";
+    case "DAY":
+      return "DAY";
+    default:
+      assertNever(windowSize);
+  }
+}
+
+function aggregateToFourHourBuckets(
+  hourlyMap: Map<number, number>
+): Map<number, number> {
+  const aggregated = new Map<number, number>();
+  for (const [ts, value] of hourlyMap) {
+    const bucket = ts - (ts % FOUR_HOURS_MS);
+    aggregated.set(bucket, (aggregated.get(bucket) ?? 0) + value);
+  }
+  return aggregated;
+}
+
+interface ParsedBalance {
+  initialAmountCredits: number;
+  balanceCredits: number;
+  intervals: { start: number; end: number }[];
+}
+
+function calculateCreditTotalsFromBalances(
+  balances: MetronomeBalance[],
+  timestamps: number[]
+): Map<
+  number,
+  {
+    totalInitialCreditsMicroUsd: number;
+    totalConsumedCreditsMicroUsd: number;
+    totalRemainingCreditsMicroUsd: number;
+  }
+> {
+  const parsed: ParsedBalance[] = balances.map((entry) => {
+    const items = entry.access_schedule?.schedule_items ?? [];
+    let initialAmountCredits = 0;
+    const intervals: { start: number; end: number }[] = [];
+
+    for (const item of items) {
+      initialAmountCredits += item.amount;
+      intervals.push({
+        start: new Date(item.starting_at).getTime(),
+        end: new Date(item.ending_before).getTime(),
+      });
+    }
+
+    return {
+      initialAmountCredits,
+      balanceCredits: entry.balance ?? 0,
+      intervals,
+    };
+  });
+
+  const result = new Map<
+    number,
+    {
+      totalInitialCreditsMicroUsd: number;
+      totalConsumedCreditsMicroUsd: number;
+      totalRemainingCreditsMicroUsd: number;
+    }
+  >();
+
+  for (const timestamp of timestamps) {
+    let totalInitialCredits = 0;
+    let totalBalanceCredits = 0;
+
+    for (const b of parsed) {
+      const isActive = b.intervals.some(
+        (iv) => timestamp >= iv.start && timestamp < iv.end
+      );
+      if (isActive) {
+        totalInitialCredits += b.initialAmountCredits;
+        totalBalanceCredits += b.balanceCredits;
+      }
+    }
+
+    const totalInitialMicroUsd =
+      totalInitialCredits * METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD;
+    const totalRemainingMicroUsd =
+      totalBalanceCredits * METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD;
+
+    result.set(timestamp, {
+      totalInitialCreditsMicroUsd: totalInitialMicroUsd,
+      totalConsumedCreditsMicroUsd:
+        totalInitialMicroUsd - totalRemainingMicroUsd,
+      totalRemainingCreditsMicroUsd: totalRemainingMicroUsd,
+    });
+  }
+
+  return result;
+}
+
+async function resolveGroupLabels(
+  groupBy: MetronomeUsageGroupByType,
+  groupKeys: string[]
+): Promise<Map<string, string>> {
+  const labelMap = new Map<string, string>();
+
+  switch (groupBy) {
+    case "api_key":
+    case "model":
+    case "origin":
+      for (const key of groupKeys) {
+        labelMap.set(key, key);
+      }
+      break;
+    default:
+      assertNever(groupBy);
+  }
+
+  return labelMap;
+}
+
+// Mounted at /api/w/:wId/analytics/metronome-usage.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+  const workspace = auth.getNonNullableWorkspace();
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return c.json(
+      {
+        error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      },
+      400
+    );
+  }
+
+  const llmMetricId = getMetricLlmProviderCostProgrammaticId();
+
+  const {
+    groupBy,
+    groupByCount,
+    selectedPeriod,
+    billingCycleStartDay,
+    windowSize,
+  } = c.req.valid("query");
+
+  const referenceDate = selectedPeriod ? new Date(selectedPeriod) : new Date();
+  if (selectedPeriod) {
+    referenceDate.setUTCDate(billingCycleStartDay);
+  }
+  const { cycleStart: periodStart, cycleEnd: periodEnd } =
+    getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
+
+  const TEN_DAYS_MS = 10 * DAY_MS;
+  const cappedEnd = new Date(
+    Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_MS)
+  );
+
+  const rangeStart = floorToMidnightUTC(periodStart);
+  const rangeEnd = ceilToMidnightUTC(cappedEnd);
+  const startingOn = rangeStart.toISOString();
+  const endingBefore = rangeEnd.toISOString();
+
+  const timestamps = getTimestampsForWindow(rangeStart, rangeEnd, windowSize);
+
+  const balancesPromise = listMetronomeBalances(metronomeCustomerId);
+
+  const groupValues: Record<string, Map<number, number>> = {};
+  const availableGroups: MetronomeUsageAvailableGroup[] = [];
+
+  const metronomeApiWindowSize = getMetronomeWindowSize(windowSize);
+  const needsFourHourAggregation = windowSize === "FOUR_HOURS";
+
+  if (!groupBy) {
+    const result = await listMetronomeUsage({
+      customerIds: [metronomeCustomerId],
+      billableMetricIds: [llmMetricId],
+      startingOn,
+      endingBefore,
+      windowSize: metronomeApiWindowSize,
+    });
+
+    if (result.isErr()) {
+      return c.json(
+        {
+          error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve Metronome usage: ${result.error.message}`,
+          },
+        },
+        500
+      );
+    }
+
+    let totalMap = new Map<number, number>();
+    for (const entry of result.value) {
+      const ts = new Date(entry.startTimestamp).getTime();
+      totalMap.set(
+        ts,
+        (totalMap.get(ts) ?? 0) + (entry.value ?? 0) * MARKUP_MULTIPLIER
+      );
+    }
+    if (needsFourHourAggregation) {
+      totalMap = aggregateToFourHourBuckets(totalMap);
+    }
+    groupValues["total"] = totalMap;
+
+    availableGroups.push({
+      groupKey: "total",
+      groupLabel: "Total usage",
+    });
+  } else {
+    const eventProperty = GROUP_BY_TO_EVENT_PROPERTY[groupBy];
+
+    const groupedQueryBase = {
+      customerId: metronomeCustomerId,
+      startingOn,
+      endingBefore,
+      windowSize: metronomeApiWindowSize,
+      groupKey: [eventProperty],
+    };
+
+    const llmGroupedResult = await listMetronomeUsageWithGroups({
+      ...groupedQueryBase,
+      billableMetricId: llmMetricId,
+    });
+
+    const mergedGroupMap = new Map<string, Map<number, number>>();
+
+    if (llmGroupedResult.isErr()) {
+      const msg = llmGroupedResult.error.message;
+      const isGroupKeyError =
+        msg.includes("group") || msg.includes("not found");
+      return c.json(
+        {
+          error: {
+            type: isGroupKeyError
+              ? "invalid_request_error"
+              : "internal_server_error",
+            message: isGroupKeyError
+              ? `Grouping by "${groupBy}" is not available. The billable metric ` +
+                `must have "${eventProperty}" configured as a group key in Metronome.`
+              : `Failed to retrieve Metronome grouped usage: ${msg}`,
+          },
+        },
+        isGroupKeyError ? 400 : 500
+      );
+    }
+
+    for (const entry of llmGroupedResult.value) {
+      const key = entry.group?.[eventProperty] ?? "unknown";
+      const ts = new Date(entry.startingOn).getTime();
+      let keyMap = mergedGroupMap.get(key);
+      if (!keyMap) {
+        keyMap = new Map();
+        mergedGroupMap.set(key, keyMap);
+      }
+      keyMap.set(
+        ts,
+        (keyMap.get(ts) ?? 0) + (entry.value ?? 0) * MARKUP_MULTIPLIER
+      );
+    }
+
+    if (needsFourHourAggregation) {
+      for (const key of [...mergedGroupMap.keys()]) {
+        const tsMap = mergedGroupMap.get(key)!;
+        mergedGroupMap.set(key, aggregateToFourHourBuckets(tsMap));
+      }
+    }
+
+    const totalMap = new Map<number, number>();
+    for (const tsMap of mergedGroupMap.values()) {
+      for (const [ts, value] of tsMap) {
+        totalMap.set(ts, (totalMap.get(ts) ?? 0) + value);
+      }
+    }
+    groupValues["total"] = totalMap;
+
+    const groupTotals = [...mergedGroupMap.entries()]
+      .map(([key, tsMap]) => ({
+        key,
+        total: [...tsMap.values()].reduce((a, b) => a + b, 0),
+        tsMap,
+      }))
+      .sort((a, b) => b.total - a.total);
+
+    const topGroups = groupTotals.slice(0, groupByCount);
+    for (const { key, tsMap } of topGroups) {
+      groupValues[key] = tsMap;
+    }
+
+    const groupKeys = topGroups.map((g) => g.key);
+    const labelMap = await resolveGroupLabels(groupBy, groupKeys);
+
+    for (const key of groupKeys) {
+      availableGroups.push({
+        groupKey: key,
+        groupLabel: labelMap.get(key) ?? key,
+      });
+    }
+  }
+
+  const balancesResult = await balancesPromise;
+  if (balancesResult.isErr()) {
+    logger.error(
+      { error: balancesResult.error, metronomeCustomerId },
+      "[Metronome] Failed to fetch balances for credit overlay"
+    );
+  }
+  const programmaticUsdCreditTypeId = getCreditTypeProgrammaticUsdId();
+  const balances = balancesResult.isOk()
+    ? balancesResult.value.filter(
+        (entry) =>
+          entry.access_schedule?.credit_type?.id ===
+            programmaticUsdCreditTypeId && !isMetronomeExcessCredit(entry)
+      )
+    : [];
+  const creditTotalsMap = calculateCreditTotalsFromBalances(
+    balances,
+    timestamps
+  );
+
+  const cumulatedValues: Record<string, number> = {};
+  for (const key of Object.keys(groupValues)) {
+    cumulatedValues[key] = 0;
+  }
+
+  const now = Date.now();
+
+  const points: MetronomeUsagePoint[] = timestamps.map((timestamp) => {
+    const groups = Object.entries(groupValues)
+      .filter(([key]) => !groupBy || key !== "total")
+      .map(([key, tsMap]) => {
+        const value = tsMap.get(timestamp) ?? 0;
+        const cumulated = (cumulatedValues[key] ?? 0) + value;
+        cumulatedValues[key] = cumulated;
+        return {
+          groupKey: key,
+          valueMicroUsd: value,
+          cumulatedValueMicroUsd: timestamp <= now ? cumulated : undefined,
+        };
+      });
+
+    if (groupBy) {
+      const topSum = groups.reduce((acc, g) => acc + g.valueMicroUsd, 0);
+      const totalValue = groupValues["total"]?.get(timestamp) ?? 0;
+      const othersValue = totalValue - topSum;
+      const cumulatedOthers = (cumulatedValues["others"] ?? 0) + othersValue;
+      cumulatedValues["others"] = cumulatedOthers;
+
+      groups.push({
+        groupKey: "others",
+        valueMicroUsd: othersValue,
+        cumulatedValueMicroUsd: timestamp <= now ? cumulatedOthers : undefined,
+      });
+    }
+
+    const credit = creditTotalsMap.get(timestamp);
+    return {
+      timestamp,
+      groups,
+      totalInitialCreditsMicroUsd: credit?.totalInitialCreditsMicroUsd ?? 0,
+      totalConsumedCreditsMicroUsd: credit?.totalConsumedCreditsMicroUsd ?? 0,
+      totalRemainingCreditsMicroUsd: credit?.totalRemainingCreditsMicroUsd ?? 0,
+    };
+  });
+
+  if ((cumulatedValues["others"] ?? 0) > 0) {
+    availableGroups.push({
+      groupKey: "others",
+      groupLabel: "Others",
+    });
+  }
+
+  const body: GetMetronomeUsageResponse = { points, availableGroups };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/metronome-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/metronome-usage.ts
@@ -27,6 +27,7 @@ import {
 import { isMetronomeExcessCredit } from "@app/lib/metronome/types";
 import logger from "@app/logger/logger";
 
+import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 
 const METRONOME_USAGE_GROUP_BY_KEYS = ["api_key", "model", "origin"] as const;
@@ -80,15 +81,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const workspace = auth.getNonNullableWorkspace();
   const { metronomeCustomerId } = workspace;
   if (!metronomeCustomerId) {
-    return c.json(
-      {
-        error: {
-          type: "invalid_request_error",
-          message: "Workspace is not configured for Metronome billing.",
-        },
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Workspace is not configured for Metronome billing.",
       },
-      400
-    );
+    });
   }
 
   const llmMetricId = getMetricLlmProviderCostProgrammaticId();
@@ -138,15 +137,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
     });
 
     if (result.isErr()) {
-      return c.json(
-        {
-          error: {
-            type: "internal_server_error",
-            message: `Failed to retrieve Metronome usage: ${result.error.message}`,
-          },
+      return apiError(c, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome usage: ${result.error.message}`,
         },
-        500
-      );
+      });
     }
 
     let totalMap = new Map<number, number>();
@@ -188,20 +185,18 @@ app.get("/", validate("query", QuerySchema), async (c) => {
       const msg = llmGroupedResult.error.message;
       const isGroupKeyError =
         msg.includes("group") || msg.includes("not found");
-      return c.json(
-        {
-          error: {
-            type: isGroupKeyError
-              ? "invalid_request_error"
-              : "internal_server_error",
-            message: isGroupKeyError
-              ? `Grouping by "${groupBy}" is not available. The billable metric ` +
-                `must have "${eventProperty}" configured as a group key in Metronome.`
-              : `Failed to retrieve Metronome grouped usage: ${msg}`,
-          },
+      return apiError(c, {
+        status_code: isGroupKeyError ? 400 : 500,
+        api_error: {
+          type: isGroupKeyError
+            ? "invalid_request_error"
+            : "internal_server_error",
+          message: isGroupKeyError
+            ? `Grouping by "${groupBy}" is not available. The billable metric ` +
+              `must have "${eventProperty}" configured as a group key in Metronome.`
+            : `Failed to retrieve Metronome grouped usage: ${msg}`,
         },
-        isGroupKeyError ? 400 : 500
-      );
+      });
     }
 
     for (const entry of llmGroupedResult.value) {

--- a/front-api/routes/w/[wId]/analytics/overview.ts
+++ b/front-api/routes/w/[wId]/analytics/overview.ts
@@ -3,12 +3,13 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -30,15 +31,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days } = c.req.valid("query");
@@ -72,15 +71,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   );
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve analytics overview: ${fromError(result.error).toString()}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve analytics overview: ${fromError(result.error).toString()}`,
       },
-      500
-    );
+    });
   }
 
   const activeUsers = Math.round(

--- a/front-api/routes/w/[wId]/analytics/overview.ts
+++ b/front-api/routes/w/[wId]/analytics/overview.ts
@@ -1,0 +1,97 @@
+import type { estypes } from "@elastic/elasticsearch";
+import { Hono } from "hono";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+export type GetWorkspaceAnalyticsOverviewResponse = {
+  totalMembers: number;
+  activeUsers: number;
+};
+
+type OverviewAggs = {
+  unique_users?: estypes.AggregationsCardinalityAggregate;
+};
+
+// Mounted at /api/w/:wId/analytics/overview.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const totalMembers = await MembershipResource.countActiveMembersForWorkspace({
+    workspace: owner,
+  });
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const result = await searchAnalytics<never, OverviewAggs>(
+    {
+      bool: {
+        filter: [baseQuery, { exists: { field: "user_id" } }],
+      },
+    },
+    {
+      aggregations: {
+        unique_users: {
+          cardinality: {
+            field: "user_id",
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve analytics overview: ${fromError(result.error).toString()}`,
+        },
+      },
+      500
+    );
+  }
+
+  const activeUsers = Math.round(
+    result.value.aggregations?.unique_users?.value ?? 0
+  );
+
+  const body: GetWorkspaceAnalyticsOverviewResponse = {
+    totalMembers,
+    activeUsers,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/programmatic-cost-export.ts
+++ b/front-api/routes/w/[wId]/analytics/programmatic-cost-export.ts
@@ -1,12 +1,12 @@
 import { Hono } from "hono";
-import type { ContentfulStatusCode } from "hono/utils/http-status";
+
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
 
 import {
   ExportQuerySchema,
   getProgrammaticCostExport,
 } from "@app/lib/api/analytics/programmatic_cost_export";
-
-import { validate } from "@front-api/middleware/validator";
 
 // Mounted at /api/w/:wId/analytics/programmatic-cost-export.
 const app = new Hono();
@@ -18,10 +18,10 @@ app.get("/", validate("query", ExportQuerySchema), async (c) => {
   const result = await getProgrammaticCostExport(auth, query);
 
   if (result.isErr()) {
-    return c.json(
-      { error: result.error.error },
-      result.error.status as ContentfulStatusCode
-    );
+    return apiError(c, {
+      status_code: result.error.status,
+      api_error: result.error.error,
+    });
   }
 
   const { csv, filename } = result.value;

--- a/front-api/routes/w/[wId]/analytics/programmatic-cost-export.ts
+++ b/front-api/routes/w/[wId]/analytics/programmatic-cost-export.ts
@@ -1,0 +1,33 @@
+import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+
+import {
+  ExportQuerySchema,
+  getProgrammaticCostExport,
+} from "@app/lib/api/analytics/programmatic_cost_export";
+
+import { validate } from "@front-api/middleware/validator";
+
+// Mounted at /api/w/:wId/analytics/programmatic-cost-export.
+const app = new Hono();
+
+app.get("/", validate("query", ExportQuerySchema), async (c) => {
+  const auth = c.get("auth");
+  const query = c.req.valid("query");
+
+  const result = await getProgrammaticCostExport(auth, query);
+
+  if (result.isErr()) {
+    return c.json(
+      { error: result.error.error },
+      result.error.status as ContentfulStatusCode
+    );
+  }
+
+  const { csv, filename } = result.value;
+  c.header("Content-Type", "text/csv");
+  c.header("Content-Disposition", `attachment; filename=${filename}`);
+  return c.body(csv);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
+++ b/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
@@ -27,6 +27,7 @@ import { getShouldTrackTokenUsageCostsESFilter } from "@app/lib/api/programmatic
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 
+import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 
 const GROUP_BY_KEYS = ["agent", "origin", "apiKey"] as const;
@@ -171,15 +172,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   });
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve grouped programmatic cost: ${result.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve grouped programmatic cost: ${result.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const totalBuckets = bucketsToArray<MetricsBucket>(
@@ -244,15 +243,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
       );
 
       if (availableGroupsResult.isErr()) {
-        return c.json(
-          {
-            error: {
-              type: "internal_server_error",
-              message: `Failed to retrieve grouped programmatic cost: ${availableGroupsResult.error.message}`,
-            },
+        return apiError(c, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve grouped programmatic cost: ${availableGroupsResult.error.message}`,
           },
-          500
-        );
+        });
       }
 
       availableGroupBuckets = bucketsToArray(

--- a/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
+++ b/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
@@ -1,0 +1,523 @@
+import type { estypes } from "@elastic/elasticsearch";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import {
+  DAY_MS,
+  getTimestampsForWindow,
+} from "@app/lib/api/analytics/time_utils";
+import type { MetricsBucket } from "@app/lib/api/assistant/observability/messages_metrics";
+import {
+  buildMetricAggregates,
+  parseMetricsFromBucket,
+} from "@app/lib/api/assistant/observability/messages_metrics";
+import { DUST_MARKUP_PERCENT } from "@app/lib/api/assistant/token_pricing";
+import {
+  bucketsToArray,
+  ensureAtMostNGroups,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import { getShouldTrackTokenUsageCostsESFilter } from "@app/lib/api/programmatic_usage/common";
+import { getBillingCycleFromDay } from "@app/lib/client/subscription";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { CreditResource } from "@app/lib/resources/credit_resource";
+
+import { validate } from "@front-api/middleware/validator";
+
+const GROUP_BY_KEYS = ["agent", "origin", "apiKey"] as const;
+
+export type GroupByType = (typeof GROUP_BY_KEYS)[number];
+
+const GROUP_BY_KEY_TO_ES_FIELD: Record<GroupByType, string> = {
+  agent: "agent_id",
+  origin: "context_origin",
+  apiKey: "api_key_name",
+};
+
+const FilterSchema = z.record(z.enum(GROUP_BY_KEYS), z.string().array());
+
+const QuerySchema = z.object({
+  groupBy: z.enum(GROUP_BY_KEYS).optional(),
+  groupByCount: z.coerce.number().optional().default(5),
+  filter: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (!val) {
+        return undefined;
+      }
+      try {
+        return JSON.parse(val);
+      } catch {
+        return val;
+      }
+    })
+    .pipe(FilterSchema.optional()),
+  selectedPeriod: z.string().optional(),
+  billingCycleStartDay: z.coerce.number().min(1).max(31),
+});
+
+export type WorkspaceProgrammaticCostPoint = {
+  timestamp: number;
+  groups: {
+    groupKey: string;
+    costMicroUsd: number;
+    cumulatedCostMicroUsd?: number;
+  }[];
+  totalInitialCreditsMicroUsd: number;
+  totalConsumedCreditsMicroUsd: number;
+  totalRemainingCreditsMicroUsd: number;
+};
+
+export type AvailableGroup = {
+  groupKey: string;
+  groupLabel: string;
+};
+
+export type GetWorkspaceProgrammaticCostResponse = {
+  points: WorkspaceProgrammaticCostPoint[];
+  availableGroups: AvailableGroup[];
+};
+
+type DailyBucket = MetricsBucket;
+
+type GroupBucket = {
+  key: string;
+  doc_count: number;
+  total_cost?: estypes.AggregationsSumAggregate;
+  by_hour?: estypes.AggregationsMultiBucketAggregateBase<DailyBucket>;
+};
+
+type GroupedAggs = {
+  by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
+  by_hour?: estypes.AggregationsMultiBucketAggregateBase<DailyBucket>;
+};
+
+function calculateCreditTotalsPerTimestamp(
+  credits: CreditResource[],
+  timestamps: number[]
+): Map<
+  number,
+  {
+    totalInitialCreditsMicroUsd: number;
+    totalConsumedCreditsMicroUsd: number;
+    totalRemainingCreditsMicroUsd: number;
+  }
+> {
+  const creditTotalsMap = new Map<
+    number,
+    {
+      totalInitialCreditsMicroUsd: number;
+      totalConsumedCreditsMicroUsd: number;
+      totalRemainingCreditsMicroUsd: number;
+    }
+  >();
+
+  const now = Date.now();
+
+  for (const timestamp of timestamps) {
+    const dayStart = new Date(timestamp);
+    dayStart.setUTCHours(0, 0, 0, 0);
+    const cutoffTime =
+      dayStart.getTime() === new Date().setUTCHours(0, 0, 0, 0)
+        ? now
+        : dayStart.getTime();
+
+    const activeCredits = credits.filter((credit) => {
+      if (!credit.startDate || credit.startDate.getTime() > cutoffTime) {
+        return false;
+      }
+
+      if (
+        credit.expirationDate &&
+        credit.expirationDate.getTime() <= cutoffTime
+      ) {
+        return false;
+      }
+
+      return true;
+    });
+
+    const {
+      totalInitialCreditsMicroUsd,
+      totalConsumedCreditsMicroUsd,
+      totalRemainingCreditsMicroUsd,
+    } = activeCredits.reduce(
+      (acc, credit) => {
+        acc.totalInitialCreditsMicroUsd += credit.initialAmountMicroUsd;
+        acc.totalConsumedCreditsMicroUsd += credit.consumedAmountMicroUsd;
+        acc.totalRemainingCreditsMicroUsd +=
+          credit.initialAmountMicroUsd - credit.consumedAmountMicroUsd;
+        return acc;
+      },
+      {
+        totalInitialCreditsMicroUsd: 0,
+        totalConsumedCreditsMicroUsd: 0,
+        totalRemainingCreditsMicroUsd: 0,
+      }
+    );
+
+    creditTotalsMap.set(timestamp, {
+      totalInitialCreditsMicroUsd,
+      totalConsumedCreditsMicroUsd,
+      totalRemainingCreditsMicroUsd,
+    });
+  }
+
+  return creditTotalsMap;
+}
+
+function getSelectedFilterClauses(
+  filterParams: Partial<Record<GroupByType, string[]>> | undefined,
+  excluded?: GroupByType
+): estypes.QueryDslQueryContainer[] {
+  if (!filterParams) {
+    return [];
+  }
+
+  return GROUP_BY_KEYS.filter(
+    (key) => key !== excluded && filterParams[key]
+  ).flatMap((filterKey) => {
+    const filterValues = filterParams[filterKey] as string[];
+    const esField = GROUP_BY_KEY_TO_ES_FIELD[filterKey];
+
+    const hasNonApiProgrammatic = filterValues.includes("non_api_programmatic");
+    const otherValues = filterValues.filter(
+      (v) => v !== "non_api_programmatic"
+    );
+
+    const clauses: estypes.QueryDslQueryContainer[] = [];
+
+    if (hasNonApiProgrammatic && otherValues.length > 0) {
+      clauses.push({
+        bool: {
+          should: [
+            { bool: { must_not: { exists: { field: esField } } } },
+            { terms: { [esField]: otherValues } },
+          ],
+          minimum_should_match: 1,
+        },
+      });
+    } else if (hasNonApiProgrammatic) {
+      clauses.push({
+        bool: { must_not: { exists: { field: esField } } },
+      });
+    } else {
+      clauses.push({ terms: { [esField]: filterValues } });
+    }
+
+    return clauses;
+  });
+}
+
+function buildAggregation(
+  groupBy: GroupByType,
+  groupByCount: number,
+  includeDailyBreakdown: boolean
+): Record<string, estypes.AggregationsAggregationContainer> {
+  const groupField = GROUP_BY_KEY_TO_ES_FIELD[groupBy];
+  const missingValue =
+    groupBy === "apiKey" ? "non_api_programmatic" : "unknown";
+  return {
+    by_group: {
+      terms: {
+        field: groupField,
+        size: groupByCount,
+        missing: missingValue,
+        order: { total_cost: "desc" },
+      },
+      aggs: {
+        total_cost: {
+          sum: { field: "tokens.cost_micro_usd" },
+        },
+        ...(includeDailyBreakdown
+          ? {
+              by_hour: {
+                date_histogram: {
+                  field: "timestamp",
+                  fixed_interval: "4h",
+                  time_zone: "UTC",
+                },
+                aggs: buildMetricAggregates(["costMicroUsd"]),
+              },
+            }
+          : {}),
+      },
+    },
+  };
+}
+
+// Mounted at /api/w/:wId/analytics/programmatic-cost.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  const {
+    groupBy,
+    groupByCount,
+    selectedPeriod,
+    billingCycleStartDay,
+    filter: filterParams,
+  } = c.req.valid("query");
+
+  const referenceDate = selectedPeriod ? new Date(selectedPeriod) : new Date();
+  if (selectedPeriod) {
+    referenceDate.setUTCDate(billingCycleStartDay);
+  }
+  const { cycleStart: periodStart, cycleEnd: periodEnd } =
+    getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
+
+  const TEN_DAYS_MS = 10 * DAY_MS;
+  const cappedPeriodEnd = new Date(
+    Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_MS)
+  );
+
+  const timestamps = getTimestampsForWindow(
+    periodStart,
+    cappedPeriodEnd,
+    "FOUR_HOURS"
+  );
+
+  const credits = await CreditResource.listAll(auth);
+
+  const creditTotalsMap = calculateCreditTotalsPerTimestamp(
+    credits,
+    timestamps
+  );
+
+  const baseFilterClauses: estypes.QueryDslQueryContainer[] = [
+    getShouldTrackTokenUsageCostsESFilter(auth),
+    {
+      range: {
+        timestamp: {
+          gte: periodStart.toISOString(),
+          lt: periodEnd.toISOString(),
+        },
+      },
+    },
+  ];
+
+  const baseQuery = {
+    bool: {
+      filter: [...baseFilterClauses, ...getSelectedFilterClauses(filterParams)],
+    },
+  };
+
+  const availableGroups: AvailableGroup[] = [];
+  const groupValues: Record<string, Map<number, number>> = {};
+
+  const result = await searchAnalytics<never, GroupedAggs>(baseQuery, {
+    aggregations: {
+      total_cost: {
+        sum: { field: "tokens.cost_micro_usd" },
+      },
+      by_hour: {
+        date_histogram: {
+          field: "timestamp",
+          fixed_interval: "4h",
+          time_zone: "UTC",
+        },
+        aggs: buildMetricAggregates(["costMicroUsd"]),
+      },
+      ...(groupBy ? buildAggregation(groupBy, groupByCount, true) : {}),
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve grouped programmatic cost: ${result.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const totalBuckets = bucketsToArray<MetricsBucket>(
+    result.value.aggregations?.by_hour?.buckets
+  );
+
+  const markupMultiplier = 1 + DUST_MARKUP_PERCENT / 100;
+
+  groupValues["total"] = new Map<number, number>();
+  totalBuckets.forEach((bucket) => {
+    const point = parseMetricsFromBucket(bucket, ["costMicroUsd"]);
+    groupValues["total"]?.set(
+      point.timestamp,
+      point.costMicroUsd * markupMultiplier
+    );
+  });
+
+  if (result.value.aggregations?.by_group) {
+    const groupBuckets = bucketsToArray(
+      result.value.aggregations?.by_group?.buckets
+    );
+
+    const groupsWithParsedPoints = groupBuckets.map((groupBucket) => {
+      return {
+        groupKey: groupBucket.key,
+        points: bucketsToArray(groupBucket.by_hour?.buckets).map((bucket) =>
+          parseMetricsFromBucket(bucket, ["costMicroUsd"])
+        ),
+      };
+    });
+
+    const allGroupsToProcess = ensureAtMostNGroups(
+      groupsWithParsedPoints,
+      groupByCount,
+      "costMicroUsd"
+    );
+
+    for (const { groupKey, points } of allGroupsToProcess) {
+      groupValues[groupKey] = new Map(
+        points.map((point) => [
+          point.timestamp,
+          point.costMicroUsd * markupMultiplier,
+        ])
+      );
+    }
+
+    let availableGroupBuckets = groupBuckets;
+    if (filterParams && groupBy) {
+      const availableGroupsResult = await searchAnalytics<never, GroupedAggs>(
+        {
+          bool: {
+            filter: [
+              ...baseFilterClauses,
+              ...getSelectedFilterClauses(filterParams, groupBy),
+            ],
+          },
+        },
+        {
+          aggregations: buildAggregation(groupBy, groupByCount, false),
+          size: 0,
+        }
+      );
+
+      if (availableGroupsResult.isErr()) {
+        return c.json(
+          {
+            error: {
+              type: "internal_server_error",
+              message: `Failed to retrieve grouped programmatic cost: ${availableGroupsResult.error.message}`,
+            },
+          },
+          500
+        );
+      }
+
+      availableGroupBuckets = bucketsToArray(
+        availableGroupsResult.value.aggregations?.by_group?.buckets
+      );
+    }
+
+    const agentNames: Record<string, string> = {};
+    if (groupBy === "agent") {
+      const agentIds = availableGroupBuckets.map((b) => b.key);
+      const agents = await AgentConfigurationModel.findAll({
+        where: {
+          sId: agentIds,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        attributes: ["sId", "name"],
+      });
+      agents.forEach((agent) => {
+        agentNames[agent.sId] = agent.name;
+      });
+    }
+
+    availableGroupBuckets.forEach((bucket) => {
+      let groupLabel = bucket.key;
+      if (bucket.key === "non_api_programmatic") {
+        groupLabel = "Non-API programmatic usage";
+      } else if (bucket.key === "unknown") {
+        groupLabel = "Unknown";
+      } else if (groupBy === "agent" && agentNames[bucket.key]) {
+        groupLabel = agentNames[bucket.key];
+      }
+      availableGroups.push({
+        groupKey: bucket.key,
+        groupLabel,
+      });
+    });
+  }
+
+  const cumulatedCostMicroUsd: Record<string, number> = {};
+  Object.keys(groupValues).forEach((group) => {
+    cumulatedCostMicroUsd[group] = 0;
+  });
+
+  const now = new Date();
+
+  const points = timestamps.map((timestamp) => {
+    const groups = Object.entries(groupValues)
+      .filter(([groupKey]) => !groupBy || groupKey !== "total")
+      .map(([groupKey, costMap]) => {
+        const cost = costMap?.get(timestamp);
+        const cumulatedCost =
+          (cumulatedCostMicroUsd[groupKey] ?? 0) + (cost ?? 0);
+        cumulatedCostMicroUsd[groupKey] = cumulatedCost;
+        return {
+          groupKey,
+          costMicroUsd: cost ?? 0,
+          cumulatedCostMicroUsd:
+            timestamp <= now.getTime() ? cumulatedCost : undefined,
+        };
+      });
+
+    if (groupBy) {
+      const costForAll = groups.reduce(
+        (acc, group) => acc + group.costMicroUsd,
+        0
+      );
+
+      const totalCost = groupValues.total?.get(timestamp) ?? 0;
+      const otherCost = totalCost - costForAll;
+      const cumulatedOtherCost =
+        (cumulatedCostMicroUsd["others"] ?? 0) + (otherCost ?? 0);
+      cumulatedCostMicroUsd["others"] = cumulatedOtherCost;
+
+      groups.push({
+        groupKey: "others",
+        costMicroUsd: otherCost,
+        cumulatedCostMicroUsd:
+          timestamp <= now.getTime() ? cumulatedOtherCost : undefined,
+      });
+    }
+
+    const credit = creditTotalsMap.get(timestamp);
+    return {
+      timestamp,
+      groups,
+      totalInitialCreditsMicroUsd: credit?.totalInitialCreditsMicroUsd ?? 0,
+      totalConsumedCreditsMicroUsd: credit?.totalConsumedCreditsMicroUsd ?? 0,
+      totalRemainingCreditsMicroUsd: credit?.totalRemainingCreditsMicroUsd ?? 0,
+    };
+  });
+
+  if (cumulatedCostMicroUsd["others"] > 0) {
+    availableGroups.push({
+      groupKey: "others",
+      groupLabel: "Others",
+    });
+  }
+
+  if (!groupBy) {
+    availableGroups.push({
+      groupKey: "total",
+      groupLabel: "Total cost consumed",
+    });
+  }
+
+  const body: GetWorkspaceProgrammaticCostResponse = {
+    points,
+    availableGroups,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
+++ b/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
@@ -11,6 +11,7 @@ import {
   DAY_MS,
   getTimestampsForWindow,
 } from "@app/lib/api/analytics/time_utils";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { MetricsBucket } from "@app/lib/api/assistant/observability/messages_metrics";
 import {
   buildMetricAggregates,
@@ -24,7 +25,6 @@ import {
 } from "@app/lib/api/elasticsearch";
 import { getShouldTrackTokenUsageCostsESFilter } from "@app/lib/api/programmatic_usage/common";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 
 import { validate } from "@front-api/middleware/validator";
@@ -263,12 +263,9 @@ app.get("/", validate("query", QuerySchema), async (c) => {
     const agentNames: Record<string, string> = {};
     if (groupBy === "agent") {
       const agentIds = availableGroupBuckets.map((b) => b.key);
-      const agents = await AgentConfigurationModel.findAll({
-        where: {
-          sId: agentIds,
-          workspaceId: auth.getNonNullableWorkspace().id,
-        },
-        attributes: ["sId", "name"],
+      const agents = await getAgentConfigurations(auth, {
+        agentIds,
+        variant: "extra_light",
       });
       agents.forEach((agent) => {
         agentNames[agent.sId] = agent.name;

--- a/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
+++ b/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
@@ -3,14 +3,14 @@ import { Hono } from "hono";
 import { z } from "zod";
 
 import {
-  DAY_MS,
-  getTimestampsForWindow,
-} from "@app/lib/api/analytics/time_utils";
-import {
   buildAggregation,
   calculateCreditTotalsPerTimestamp,
   getSelectedFilterClauses,
 } from "@app/lib/api/analytics/programmatic_cost";
+import {
+  DAY_MS,
+  getTimestampsForWindow,
+} from "@app/lib/api/analytics/time_utils";
 import type { MetricsBucket } from "@app/lib/api/assistant/observability/messages_metrics";
 import {
   buildMetricAggregates,

--- a/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
+++ b/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
@@ -6,6 +6,11 @@ import {
   DAY_MS,
   getTimestampsForWindow,
 } from "@app/lib/api/analytics/time_utils";
+import {
+  buildAggregation,
+  calculateCreditTotalsPerTimestamp,
+  getSelectedFilterClauses,
+} from "@app/lib/api/analytics/programmatic_cost";
 import type { MetricsBucket } from "@app/lib/api/assistant/observability/messages_metrics";
 import {
   buildMetricAggregates,
@@ -27,12 +32,6 @@ import { validate } from "@front-api/middleware/validator";
 const GROUP_BY_KEYS = ["agent", "origin", "apiKey"] as const;
 
 export type GroupByType = (typeof GROUP_BY_KEYS)[number];
-
-const GROUP_BY_KEY_TO_ES_FIELD: Record<GroupByType, string> = {
-  agent: "agent_id",
-  origin: "context_origin",
-  apiKey: "api_key_name",
-};
 
 const FilterSchema = z.record(z.enum(GROUP_BY_KEYS), z.string().array());
 
@@ -92,160 +91,6 @@ type GroupedAggs = {
   by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
   by_hour?: estypes.AggregationsMultiBucketAggregateBase<DailyBucket>;
 };
-
-function calculateCreditTotalsPerTimestamp(
-  credits: CreditResource[],
-  timestamps: number[]
-): Map<
-  number,
-  {
-    totalInitialCreditsMicroUsd: number;
-    totalConsumedCreditsMicroUsd: number;
-    totalRemainingCreditsMicroUsd: number;
-  }
-> {
-  const creditTotalsMap = new Map<
-    number,
-    {
-      totalInitialCreditsMicroUsd: number;
-      totalConsumedCreditsMicroUsd: number;
-      totalRemainingCreditsMicroUsd: number;
-    }
-  >();
-
-  const now = Date.now();
-
-  for (const timestamp of timestamps) {
-    const dayStart = new Date(timestamp);
-    dayStart.setUTCHours(0, 0, 0, 0);
-    const cutoffTime =
-      dayStart.getTime() === new Date().setUTCHours(0, 0, 0, 0)
-        ? now
-        : dayStart.getTime();
-
-    const activeCredits = credits.filter((credit) => {
-      if (!credit.startDate || credit.startDate.getTime() > cutoffTime) {
-        return false;
-      }
-
-      if (
-        credit.expirationDate &&
-        credit.expirationDate.getTime() <= cutoffTime
-      ) {
-        return false;
-      }
-
-      return true;
-    });
-
-    const {
-      totalInitialCreditsMicroUsd,
-      totalConsumedCreditsMicroUsd,
-      totalRemainingCreditsMicroUsd,
-    } = activeCredits.reduce(
-      (acc, credit) => {
-        acc.totalInitialCreditsMicroUsd += credit.initialAmountMicroUsd;
-        acc.totalConsumedCreditsMicroUsd += credit.consumedAmountMicroUsd;
-        acc.totalRemainingCreditsMicroUsd +=
-          credit.initialAmountMicroUsd - credit.consumedAmountMicroUsd;
-        return acc;
-      },
-      {
-        totalInitialCreditsMicroUsd: 0,
-        totalConsumedCreditsMicroUsd: 0,
-        totalRemainingCreditsMicroUsd: 0,
-      }
-    );
-
-    creditTotalsMap.set(timestamp, {
-      totalInitialCreditsMicroUsd,
-      totalConsumedCreditsMicroUsd,
-      totalRemainingCreditsMicroUsd,
-    });
-  }
-
-  return creditTotalsMap;
-}
-
-function getSelectedFilterClauses(
-  filterParams: Partial<Record<GroupByType, string[]>> | undefined,
-  excluded?: GroupByType
-): estypes.QueryDslQueryContainer[] {
-  if (!filterParams) {
-    return [];
-  }
-
-  return GROUP_BY_KEYS.filter(
-    (key) => key !== excluded && filterParams[key]
-  ).flatMap((filterKey) => {
-    const filterValues = filterParams[filterKey] as string[];
-    const esField = GROUP_BY_KEY_TO_ES_FIELD[filterKey];
-
-    const hasNonApiProgrammatic = filterValues.includes("non_api_programmatic");
-    const otherValues = filterValues.filter(
-      (v) => v !== "non_api_programmatic"
-    );
-
-    const clauses: estypes.QueryDslQueryContainer[] = [];
-
-    if (hasNonApiProgrammatic && otherValues.length > 0) {
-      clauses.push({
-        bool: {
-          should: [
-            { bool: { must_not: { exists: { field: esField } } } },
-            { terms: { [esField]: otherValues } },
-          ],
-          minimum_should_match: 1,
-        },
-      });
-    } else if (hasNonApiProgrammatic) {
-      clauses.push({
-        bool: { must_not: { exists: { field: esField } } },
-      });
-    } else {
-      clauses.push({ terms: { [esField]: filterValues } });
-    }
-
-    return clauses;
-  });
-}
-
-function buildAggregation(
-  groupBy: GroupByType,
-  groupByCount: number,
-  includeDailyBreakdown: boolean
-): Record<string, estypes.AggregationsAggregationContainer> {
-  const groupField = GROUP_BY_KEY_TO_ES_FIELD[groupBy];
-  const missingValue =
-    groupBy === "apiKey" ? "non_api_programmatic" : "unknown";
-  return {
-    by_group: {
-      terms: {
-        field: groupField,
-        size: groupByCount,
-        missing: missingValue,
-        order: { total_cost: "desc" },
-      },
-      aggs: {
-        total_cost: {
-          sum: { field: "tokens.cost_micro_usd" },
-        },
-        ...(includeDailyBreakdown
-          ? {
-              by_hour: {
-                date_histogram: {
-                  field: "timestamp",
-                  fixed_interval: "4h",
-                  time_zone: "UTC",
-                },
-                aggs: buildMetricAggregates(["costMicroUsd"]),
-              },
-            }
-          : {}),
-      },
-    },
-  };
-}
 
 // Mounted at /api/w/:wId/analytics/programmatic-cost.
 const app = new Hono();

--- a/front-api/routes/w/[wId]/analytics/skill-usage-export.ts
+++ b/front-api/routes/w/[wId]/analytics/skill-usage-export.ts
@@ -1,0 +1,118 @@
+import { stringify } from "csv-stringify/sync";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import {
+  fetchAvailableSkills,
+  fetchSkillUsageMetrics,
+} from "@app/lib/api/assistant/observability/skill_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+interface SkillUsageExportRow {
+  date: string;
+  skillName: string;
+  executions: number;
+  uniqueUsers: number;
+}
+
+// Mounted at /api/w/:wId/analytics/skill-usage-export.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const skillsResult = await fetchAvailableSkills(baseQuery);
+  if (skillsResult.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve available skills: ${skillsResult.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const skills = skillsResult.value;
+  const rows: SkillUsageExportRow[] = [];
+
+  for (const skill of skills) {
+    const usageResult = await fetchSkillUsageMetrics(
+      baseQuery,
+      skill.skillName
+    );
+    if (usageResult.isErr()) {
+      return c.json(
+        {
+          error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve skill usage for ${skill.skillName}: ${usageResult.error.message}`,
+          },
+        },
+        500
+      );
+    }
+
+    for (const point of usageResult.value) {
+      rows.push({
+        date: point.date,
+        skillName: skill.skillName,
+        executions: point.executionCount,
+        uniqueUsers: point.uniqueUsers,
+      });
+    }
+  }
+
+  rows.sort((a, b) => {
+    const dateCompare = a.date.localeCompare(b.date);
+    if (dateCompare !== 0) {
+      return dateCompare;
+    }
+    return a.skillName.localeCompare(b.skillName);
+  });
+
+  const headers: (keyof SkillUsageExportRow)[] = [
+    "date",
+    "skillName",
+    "executions",
+    "uniqueUsers",
+  ];
+  const csvData = rows.map((row) => headers.map((h) => row[h]));
+  const csv = stringify([headers, ...csvData], { header: false });
+
+  c.header("Content-Type", "text/csv");
+  c.header(
+    "Content-Disposition",
+    `attachment; filename="dust_skill_usage_last_${days}_days.csv"`
+  );
+  return c.body(csv);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/skill-usage-export.ts
+++ b/front-api/routes/w/[wId]/analytics/skill-usage-export.ts
@@ -2,14 +2,15 @@ import { stringify } from "csv-stringify/sync";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {
   fetchAvailableSkills,
   fetchSkillUsageMetrics,
 } from "@app/lib/api/assistant/observability/skill_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -29,15 +30,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days } = c.req.valid("query");
@@ -49,15 +48,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
 
   const skillsResult = await fetchAvailableSkills(baseQuery);
   if (skillsResult.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve available skills: ${skillsResult.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve available skills: ${skillsResult.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const skills = skillsResult.value;
@@ -69,15 +66,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
       skill.skillName
     );
     if (usageResult.isErr()) {
-      return c.json(
-        {
-          error: {
-            type: "internal_server_error",
-            message: `Failed to retrieve skill usage for ${skill.skillName}: ${usageResult.error.message}`,
-          },
+      return apiError(c, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve skill usage for ${skill.skillName}: ${usageResult.error.message}`,
         },
-        500
-      );
+      });
     }
 
     for (const point of usageResult.value) {

--- a/front-api/routes/w/[wId]/analytics/skill-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/skill-usage.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { SkillUsagePoint } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
@@ -8,8 +11,6 @@ import {
   buildAgentAnalyticsBaseQuery,
   timezoneSchema,
 } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -28,15 +29,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days, skillName, timezone } = c.req.valid("query");
@@ -54,15 +53,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   );
 
   if (usageResult.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve skill usage metrics: ${usageResult.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve skill usage metrics: ${usageResult.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const body: GetWorkspaceSkillUsageResponse = { points: usageResult.value };

--- a/front-api/routes/w/[wId]/analytics/skill-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/skill-usage.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { SkillUsagePoint } from "@app/lib/api/assistant/observability/skill_usage";
+import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
+import {
+  buildAgentAnalyticsBaseQuery,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  skillName: z.string().optional(),
+  timezone: timezoneSchema,
+});
+
+export type GetWorkspaceSkillUsageResponse = {
+  points: SkillUsagePoint[];
+};
+
+// Mounted at /api/w/:wId/analytics/skill-usage.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days, skillName, timezone } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const usageResult = await fetchSkillUsageMetrics(
+    baseQuery,
+    skillName ?? null,
+    timezone
+  );
+
+  if (usageResult.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve skill usage metrics: ${usageResult.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const body: GetWorkspaceSkillUsageResponse = { points: usageResult.value };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/skills.ts
+++ b/front-api/routes/w/[wId]/analytics/skills.ts
@@ -1,0 +1,63 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { AvailableSkill } from "@app/lib/api/assistant/observability/skill_usage";
+import { fetchAvailableSkills } from "@app/lib/api/assistant/observability/skill_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+export type GetWorkspaceSkillsResponse = {
+  skills: AvailableSkill[];
+};
+
+// Mounted at /api/w/:wId/analytics/skills.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const skillsResult = await fetchAvailableSkills(baseQuery);
+
+  if (skillsResult.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve skills: ${skillsResult.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const body: GetWorkspaceSkillsResponse = { skills: skillsResult.value };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/skills.ts
+++ b/front-api/routes/w/[wId]/analytics/skills.ts
@@ -1,12 +1,13 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { AvailableSkill } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchAvailableSkills } from "@app/lib/api/assistant/observability/skill_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -23,15 +24,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days } = c.req.valid("query");
@@ -45,15 +44,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const skillsResult = await fetchAvailableSkills(baseQuery);
 
   if (skillsResult.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve skills: ${skillsResult.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve skills: ${skillsResult.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const body: GetWorkspaceSkillsResponse = { skills: skillsResult.value };

--- a/front-api/routes/w/[wId]/analytics/source-export.ts
+++ b/front-api/routes/w/[wId]/analytics/source-export.ts
@@ -1,0 +1,74 @@
+import { stringify } from "csv-stringify/sync";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { fetchContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+// Mounted at /api/w/:wId/analytics/source-export.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const result = await fetchContextOriginDailyBreakdown(baseQuery);
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve source breakdown: ${result.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const rows = [...result.value].sort((a, b) => {
+    const dateCompare = a.date.localeCompare(b.date);
+    if (dateCompare !== 0) {
+      return dateCompare;
+    }
+    return a.origin.localeCompare(b.origin);
+  });
+
+  const headers = ["date", "source", "messageCount"];
+  const csvData = rows.map((row) => [row.date, row.origin, row.messageCount]);
+  const csv = stringify([headers, ...csvData], { header: false });
+
+  c.header("Content-Type", "text/csv");
+  c.header(
+    "Content-Disposition",
+    `attachment; filename="dust_sources_last_${days}_days.csv"`
+  );
+  return c.body(csv);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/source-export.ts
+++ b/front-api/routes/w/[wId]/analytics/source-export.ts
@@ -2,11 +2,12 @@ import { stringify } from "csv-stringify/sync";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -19,15 +20,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days } = c.req.valid("query");
@@ -40,15 +39,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const result = await fetchContextOriginDailyBreakdown(baseQuery);
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve source breakdown: ${result.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve source breakdown: ${result.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const rows = [...result.value].sort((a, b) => {

--- a/front-api/routes/w/[wId]/analytics/source.ts
+++ b/front-api/routes/w/[wId]/analytics/source.ts
@@ -1,0 +1,70 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { fetchContextOriginBreakdown } from "@app/lib/api/assistant/observability/context_origin";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+export type GetWorkspaceContextOriginResponse = {
+  total: number;
+  buckets: {
+    origin: string;
+    count: number;
+  }[];
+};
+
+// Mounted at /api/w/:wId/analytics/source.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const result = await fetchContextOriginBreakdown(baseQuery);
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve source breakdown: ${fromError(result.error).toString()}`,
+        },
+      },
+      500
+    );
+  }
+
+  const buckets = result.value;
+  const total = buckets.reduce((acc, b) => acc + b.count, 0);
+
+  const body: GetWorkspaceContextOriginResponse = { total, buckets };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/source.ts
+++ b/front-api/routes/w/[wId]/analytics/source.ts
@@ -2,11 +2,12 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchContextOriginBreakdown } from "@app/lib/api/assistant/observability/context_origin";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -27,15 +28,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days } = c.req.valid("query");
@@ -49,15 +48,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const result = await fetchContextOriginBreakdown(baseQuery);
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve source breakdown: ${fromError(result.error).toString()}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve source breakdown: ${fromError(result.error).toString()}`,
       },
-      500
-    );
+    });
   }
 
   const buckets = result.value;

--- a/front-api/routes/w/[wId]/analytics/tool-usage-export.ts
+++ b/front-api/routes/w/[wId]/analytics/tool-usage-export.ts
@@ -1,0 +1,116 @@
+import { stringify } from "csv-stringify/sync";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import {
+  fetchAvailableTools,
+  fetchToolUsageMetrics,
+  resolveToolDisplayNames,
+} from "@app/lib/api/assistant/observability/tool_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+interface ToolUsageExportRow {
+  date: string;
+  toolName: string;
+  executions: number;
+  uniqueUsers: number;
+}
+
+// Mounted at /api/w/:wId/analytics/tool-usage-export.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const toolsResult = await fetchAvailableTools(baseQuery);
+  if (toolsResult.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve available tools: ${toolsResult.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const tools = await resolveToolDisplayNames(auth, toolsResult.value);
+  const rows: ToolUsageExportRow[] = [];
+
+  for (const tool of tools) {
+    const usageResult = await fetchToolUsageMetrics(baseQuery, tool.serverName);
+    if (usageResult.isErr()) {
+      return c.json(
+        {
+          error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve tool usage for ${tool.serverName}: ${usageResult.error.message}`,
+          },
+        },
+        500
+      );
+    }
+
+    for (const point of usageResult.value) {
+      rows.push({
+        date: point.date,
+        toolName: tool.displayName,
+        executions: point.executionCount,
+        uniqueUsers: point.uniqueUsers,
+      });
+    }
+  }
+
+  rows.sort((a, b) => {
+    const dateCompare = a.date.localeCompare(b.date);
+    if (dateCompare !== 0) {
+      return dateCompare;
+    }
+    return a.toolName.localeCompare(b.toolName);
+  });
+
+  const headers: (keyof ToolUsageExportRow)[] = [
+    "date",
+    "toolName",
+    "executions",
+    "uniqueUsers",
+  ];
+  const csvData = rows.map((row) => headers.map((h) => row[h]));
+  const csv = stringify([headers, ...csvData], { header: false });
+
+  c.header("Content-Type", "text/csv");
+  c.header(
+    "Content-Disposition",
+    `attachment; filename="dust_tool_usage_last_${days}_days.csv"`
+  );
+  return c.body(csv);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/tool-usage-export.ts
+++ b/front-api/routes/w/[wId]/analytics/tool-usage-export.ts
@@ -2,6 +2,9 @@ import { stringify } from "csv-stringify/sync";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {
   fetchAvailableTools,
@@ -9,8 +12,6 @@ import {
   resolveToolDisplayNames,
 } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -30,15 +31,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days } = c.req.valid("query");
@@ -50,15 +49,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
 
   const toolsResult = await fetchAvailableTools(baseQuery);
   if (toolsResult.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve available tools: ${toolsResult.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve available tools: ${toolsResult.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const tools = await resolveToolDisplayNames(auth, toolsResult.value);
@@ -67,15 +64,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   for (const tool of tools) {
     const usageResult = await fetchToolUsageMetrics(baseQuery, tool.serverName);
     if (usageResult.isErr()) {
-      return c.json(
-        {
-          error: {
-            type: "internal_server_error",
-            message: `Failed to retrieve tool usage for ${tool.serverName}: ${usageResult.error.message}`,
-          },
+      return apiError(c, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve tool usage for ${tool.serverName}: ${usageResult.error.message}`,
         },
-        500
-      );
+      });
     }
 
     for (const point of usageResult.value) {

--- a/front-api/routes/w/[wId]/analytics/tool-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/tool-usage.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { ToolUsagePoint } from "@app/lib/api/assistant/observability/tool_usage";
+import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
+import {
+  buildAgentAnalyticsBaseQuery,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  serverName: z.string().optional(),
+  timezone: timezoneSchema,
+});
+
+export type GetWorkspaceToolUsageResponse = {
+  points: ToolUsagePoint[];
+};
+
+// Mounted at /api/w/:wId/analytics/tool-usage.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days, serverName, timezone } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const usageResult = await fetchToolUsageMetrics(
+    baseQuery,
+    serverName ?? null,
+    timezone
+  );
+
+  if (usageResult.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve tool usage metrics: ${usageResult.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const body: GetWorkspaceToolUsageResponse = { points: usageResult.value };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/tool-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/tool-usage.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ToolUsagePoint } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
@@ -8,8 +11,6 @@ import {
   buildAgentAnalyticsBaseQuery,
   timezoneSchema,
 } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -28,15 +29,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days, serverName, timezone } = c.req.valid("query");
@@ -54,15 +53,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   );
 
   if (usageResult.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve tool usage metrics: ${usageResult.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve tool usage metrics: ${usageResult.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const body: GetWorkspaceToolUsageResponse = { points: usageResult.value };

--- a/front-api/routes/w/[wId]/analytics/tools.ts
+++ b/front-api/routes/w/[wId]/analytics/tools.ts
@@ -1,0 +1,68 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";
+import {
+  fetchAvailableTools,
+  resolveToolDisplayNames,
+} from "@app/lib/api/assistant/observability/tool_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+export type GetWorkspaceToolsResponse = {
+  tools: AvailableTool[];
+};
+
+// Mounted at /api/w/:wId/analytics/tools.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const toolsResult = await fetchAvailableTools(baseQuery);
+
+  if (toolsResult.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve tools: ${toolsResult.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const tools = await resolveToolDisplayNames(auth, toolsResult.value);
+
+  const body: GetWorkspaceToolsResponse = { tools };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/tools.ts
+++ b/front-api/routes/w/[wId]/analytics/tools.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";
 import {
@@ -8,8 +11,6 @@ import {
   resolveToolDisplayNames,
 } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -26,15 +27,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days } = c.req.valid("query");
@@ -48,15 +47,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const toolsResult = await fetchAvailableTools(baseQuery);
 
   if (toolsResult.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve tools: ${toolsResult.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve tools: ${toolsResult.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const tools = await resolveToolDisplayNames(auth, toolsResult.value);

--- a/front-api/routes/w/[wId]/analytics/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/top-agents.ts
@@ -1,0 +1,138 @@
+import type { estypes } from "@elastic/elasticsearch";
+import { Hono } from "hono";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  limit: z.coerce.number().positive().max(100).optional().default(25),
+});
+
+export type WorkspaceTopAgentRow = {
+  agentId: string;
+  name: string;
+  pictureUrl: string | null;
+  messageCount: number;
+  userCount: number;
+};
+
+export type GetWorkspaceTopAgentsResponse = {
+  agents: WorkspaceTopAgentRow[];
+};
+
+type TopAgentsAggs = {
+  by_agent?: estypes.AggregationsMultiBucketAggregateBase<{
+    key: string;
+    doc_count: number;
+    unique_users?: estypes.AggregationsCardinalityAggregate;
+  }>;
+};
+
+type TopAgentBucket = {
+  key: string;
+  doc_count: number;
+  unique_users?: estypes.AggregationsCardinalityAggregate;
+};
+
+// Mounted at /api/w/:wId/analytics/top-agents.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days, limit } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const result = await searchAnalytics<never, TopAgentsAggs>(
+    {
+      bool: {
+        filter: [baseQuery, { exists: { field: "agent_id" } }],
+      },
+    },
+    {
+      aggregations: {
+        by_agent: {
+          terms: {
+            field: "agent_id",
+            size: limit,
+          },
+          aggs: {
+            unique_users: {
+              cardinality: {
+                field: "user_id",
+              },
+            },
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve top agents: ${fromError(result.error).toString()}`,
+        },
+      },
+      500
+    );
+  }
+
+  const buckets = bucketsToArray<TopAgentBucket>(
+    result.value.aggregations?.by_agent?.buckets
+  );
+
+  const agentIds = buckets.map((bucket) => String(bucket.key));
+  const agents =
+    agentIds.length > 0
+      ? await getAgentConfigurations(auth, {
+          agentIds,
+          variant: "extra_light",
+        })
+      : [];
+  const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
+
+  const rows = buckets.map((bucket) => {
+    const agentId = String(bucket.key);
+    const agent = agentsById.get(agentId);
+    return {
+      agentId,
+      name: agent?.name ?? "Unknown agent",
+      pictureUrl: agent?.pictureUrl ?? null,
+      messageCount: bucket.doc_count ?? 0,
+      userCount: Math.round(bucket.unique_users?.value ?? 0),
+    };
+  });
+
+  const body: GetWorkspaceTopAgentsResponse = { agents: rows };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/top-agents.ts
@@ -3,12 +3,13 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -48,15 +49,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days, limit } = c.req.valid("query");
@@ -94,15 +93,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   );
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve top agents: ${fromError(result.error).toString()}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve top agents: ${fromError(result.error).toString()}`,
       },
-      500
-    );
+    });
   }
 
   const buckets = bucketsToArray<TopAgentBucket>(

--- a/front-api/routes/w/[wId]/analytics/top-users.ts
+++ b/front-api/routes/w/[wId]/analytics/top-users.ts
@@ -3,12 +3,13 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import { UserResource } from "@app/lib/resources/user_resource";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -62,15 +63,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days, limit } = c.req.valid("query");
@@ -108,15 +107,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   );
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve top users: ${fromError(result.error).toString()}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve top users: ${fromError(result.error).toString()}`,
       },
-      500
-    );
+    });
   }
 
   const buckets = bucketsToArray<TopUserBucket>(

--- a/front-api/routes/w/[wId]/analytics/top-users.ts
+++ b/front-api/routes/w/[wId]/analytics/top-users.ts
@@ -1,0 +1,147 @@
+import type { estypes } from "@elastic/elasticsearch";
+import { Hono } from "hono";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import { UserResource } from "@app/lib/resources/user_resource";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  limit: z.coerce.number().positive().max(100).optional().default(25),
+});
+
+export type WorkspaceTopUserRow = {
+  userId: string;
+  name: string;
+  imageUrl: string | null;
+  messageCount: number;
+  agentCount: number;
+};
+
+export type GetWorkspaceTopUsersResponse = {
+  users: WorkspaceTopUserRow[];
+};
+
+type TopUsersAggs = {
+  by_user?: estypes.AggregationsMultiBucketAggregateBase<{
+    key: string;
+    doc_count: number;
+    unique_agents?: estypes.AggregationsCardinalityAggregate;
+  }>;
+};
+
+type TopUserBucket = {
+  key: string;
+  doc_count: number;
+  unique_agents?: estypes.AggregationsCardinalityAggregate;
+};
+
+function getUserDisplayName(user: UserResource | undefined): string {
+  if (!user) {
+    return "Programmatic usage";
+  }
+  const fullName = user.fullName();
+  if (fullName) {
+    return fullName;
+  }
+  if (user.username) {
+    return user.username;
+  }
+  return user.email || "Programmatic usage";
+}
+
+// Mounted at /api/w/:wId/analytics/top-users.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days, limit } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const result = await searchAnalytics<never, TopUsersAggs>(
+    {
+      bool: {
+        filter: [baseQuery, { exists: { field: "user_id" } }],
+      },
+    },
+    {
+      aggregations: {
+        by_user: {
+          terms: {
+            field: "user_id",
+            size: limit,
+          },
+          aggs: {
+            unique_agents: {
+              cardinality: {
+                field: "agent_id",
+              },
+            },
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve top users: ${fromError(result.error).toString()}`,
+        },
+      },
+      500
+    );
+  }
+
+  const buckets = bucketsToArray<TopUserBucket>(
+    result.value.aggregations?.by_user?.buckets
+  );
+
+  const userIds = buckets.map((bucket) => String(bucket.key));
+  const users =
+    userIds.length > 0 ? await UserResource.fetchByIds(userIds) : [];
+  const usersById = new Map(users.map((user) => [user.sId, user]));
+
+  const rows = buckets.map((bucket) => {
+    const userId = String(bucket.key);
+    const user = usersById.get(userId);
+    return {
+      userId,
+      name: getUserDisplayName(user),
+      imageUrl: user?.imageUrl ?? null,
+      messageCount: bucket.doc_count ?? 0,
+      agentCount: Math.round(bucket.unique_agents?.value ?? 0),
+    };
+  });
+
+  const body: GetWorkspaceTopUsersResponse = { users: rows };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/usage-metrics-export.ts
+++ b/front-api/routes/w/[wId]/analytics/usage-metrics-export.ts
@@ -1,0 +1,75 @@
+import { stringify } from "csv-stringify/sync";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { formatUTCDateFromMillis } from "@app/lib/api/elasticsearch";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+// Mounted at /api/w/:wId/analytics/usage-metrics-export.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const result = await fetchMessageMetrics(baseQuery, "day", [
+    "conversations",
+    "activeUsers",
+  ] as const);
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve usage metrics: ${result.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const headers = ["date", "messages", "conversations", "activeUsers"];
+  const csvData = result.value.map((point) => [
+    formatUTCDateFromMillis(point.timestamp),
+    point.count,
+    point.conversations,
+    point.activeUsers,
+  ]);
+  const csv = stringify([headers, ...csvData], { header: false });
+
+  c.header("Content-Type", "text/csv");
+  c.header(
+    "Content-Disposition",
+    `attachment; filename="dust_activity_last_${days}_days.csv"`
+  );
+  return c.body(csv);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/usage-metrics-export.ts
+++ b/front-api/routes/w/[wId]/analytics/usage-metrics-export.ts
@@ -2,12 +2,13 @@ import { stringify } from "csv-stringify/sync";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { formatUTCDateFromMillis } from "@app/lib/api/elasticsearch";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -20,15 +21,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days } = c.req.valid("query");
@@ -44,15 +43,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   ] as const);
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve usage metrics: ${result.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve usage metrics: ${result.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const headers = ["date", "messages", "conversations", "activeUsers"];

--- a/front-api/routes/w/[wId]/analytics/usage-metrics.ts
+++ b/front-api/routes/w/[wId]/analytics/usage-metrics.ts
@@ -1,0 +1,84 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type {
+  MessageMetricsPoint,
+  UsageMetricsInterval,
+} from "@app/lib/api/assistant/observability/messages_metrics";
+import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
+import {
+  buildAgentAnalyticsBaseQuery,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  interval: z.enum(["day", "week"]).optional().default("day"),
+  timezone: timezoneSchema,
+});
+
+export type GetWorkspaceUsageMetricsResponse = {
+  interval: UsageMetricsInterval;
+  points: Pick<
+    MessageMetricsPoint,
+    "timestamp" | "count" | "conversations" | "activeUsers"
+  >[];
+};
+
+// Mounted at /api/w/:wId/analytics/usage-metrics.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days, interval, timezone } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const usageMetricsResult = await fetchMessageMetrics(
+    baseQuery,
+    interval,
+    ["conversations", "activeUsers"] as const,
+    timezone
+  );
+
+  if (usageMetricsResult.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve usage metrics: ${fromError(usageMetricsResult.error).toString()}`,
+        },
+      },
+      500
+    );
+  }
+
+  const body: GetWorkspaceUsageMetricsResponse = {
+    interval,
+    points: usageMetricsResult.value,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/usage-metrics.ts
+++ b/front-api/routes/w/[wId]/analytics/usage-metrics.ts
@@ -2,6 +2,9 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type {
   MessageMetricsPoint,
@@ -12,8 +15,6 @@ import {
   buildAgentAnalyticsBaseQuery,
   timezoneSchema,
 } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -36,15 +37,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days, interval, timezone } = c.req.valid("query");
@@ -63,15 +62,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   );
 
   if (usageMetricsResult.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve usage metrics: ${fromError(usageMetricsResult.error).toString()}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve usage metrics: ${fromError(usageMetricsResult.error).toString()}`,
       },
-      500
-    );
+    });
   }
 
   const body: GetWorkspaceUsageMetricsResponse = {

--- a/front-api/routes/w/[wId]/analytics/users-export.ts
+++ b/front-api/routes/w/[wId]/analytics/users-export.ts
@@ -2,6 +2,9 @@ import { stringify } from "csv-stringify/sync";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {
   fetchUserExportRows,
@@ -12,8 +15,6 @@ import {
   daysToDateRange,
   timezoneSchema,
 } from "@app/lib/api/assistant/observability/utils";
-
-import { validate } from "@front-api/middleware/validator";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
@@ -27,15 +28,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access workspace analytics.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
       },
-      403
-    );
+    });
   }
 
   const { days, timezone } = c.req.valid("query");
@@ -57,15 +56,13 @@ app.get("/", validate("query", QuerySchema), async (c) => {
   });
 
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve user analytics: ${result.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve user analytics: ${result.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const csvData = result.value.map((row) =>

--- a/front-api/routes/w/[wId]/analytics/users-export.ts
+++ b/front-api/routes/w/[wId]/analytics/users-export.ts
@@ -1,0 +1,86 @@
+import { stringify } from "csv-stringify/sync";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import {
+  fetchUserExportRows,
+  USER_EXPORT_HEADERS,
+} from "@app/lib/api/analytics/users_export";
+import {
+  buildAgentAnalyticsBaseQuery,
+  daysToDateRange,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
+
+import { validate } from "@front-api/middleware/validator";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  timezone: timezoneSchema,
+});
+
+// Mounted at /api/w/:wId/analytics/users-export.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access workspace analytics.",
+        },
+      },
+      403
+    );
+  }
+
+  const { days, timezone } = c.req.valid("query");
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const { startDate, endDate } = daysToDateRange(days, timezone);
+
+  const result = await fetchUserExportRows({
+    baseQuery,
+    owner,
+    startDate: new Date(startDate),
+    endDate: new Date(endDate),
+    timezone,
+  });
+
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve user analytics: ${result.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const csvData = result.value.map((row) =>
+    USER_EXPORT_HEADERS.map((h) => row[h])
+  );
+  const csv = stringify([USER_EXPORT_HEADERS, ...csvData], {
+    header: false,
+  });
+
+  c.header("Content-Type", "text/csv");
+  c.header(
+    "Content-Disposition",
+    `attachment; filename="dust_users_last_${days}_days.csv"`
+  );
+  return c.body(csv);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 
+import { apiError } from "@front-api/middleware/utils";
+
 import {
   ceilToMidnightUTC,
   floorToMidnightUTC,
@@ -28,31 +30,27 @@ app.get("/", async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message:
-            "Only users that are `admins` for the current workspace can view credits.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can view credits.",
       },
-      403
-    );
+    });
   }
 
   const workspace = auth.getNonNullableWorkspace();
   const subscription = auth.subscription();
   const { metronomeCustomerId } = workspace;
   if (!metronomeCustomerId || !subscription?.metronomeContractId) {
-    return c.json(
-      {
-        error: {
-          type: "invalid_request_error",
-          message: "Workspace is not configured for Metronome billing.",
-        },
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Workspace is not configured for Metronome billing.",
       },
-      400
-    );
+    });
   }
   const { metronomeContractId } = subscription;
 
@@ -62,26 +60,22 @@ app.get("/", async (c) => {
   ]);
 
   if (balancesResult.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome balances: ${balancesResult.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve Metronome balances: ${balancesResult.error.message}`,
       },
-      500
-    );
+    });
   }
   if (invoicesResult.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome invoices: ${invoicesResult.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve Metronome invoices: ${invoicesResult.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const now = Date.now();
@@ -157,15 +151,13 @@ app.get("/", async (c) => {
   ]);
 
   if (usageResult.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome usage: ${usageResult.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve Metronome usage: ${usageResult.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const perUserCredits = new Map<string, number>();

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -1,0 +1,202 @@
+import { Hono } from "hono";
+
+import {
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
+  listMetronomeBalances,
+  listMetronomeDraftInvoices,
+  listMetronomeUsageWithGroups,
+} from "@app/lib/metronome/client";
+import {
+  getCreditTypeAwuId,
+  getMetricLlmProviderCostAwuId,
+  getSeatProductIds,
+} from "@app/lib/metronome/constants";
+import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
+
+export type AwuPoolSummaryResponseBody = {
+  totalCredits: number;
+  consumedByUsersCredits: number;
+  consumedByProgrammaticCredits: number;
+  resetDate: string;
+};
+
+// Mounted at /api/w/:wId/credits/awu-pool-summary.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can view credits.",
+        },
+      },
+      403
+    );
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId || !subscription?.metronomeContractId) {
+    return c.json(
+      {
+        error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      },
+      400
+    );
+  }
+  const { metronomeContractId } = subscription;
+
+  const [balancesResult, invoicesResult] = await Promise.all([
+    listMetronomeBalances(metronomeCustomerId),
+    listMetronomeDraftInvoices(metronomeCustomerId),
+  ]);
+
+  if (balancesResult.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${balancesResult.error.message}`,
+        },
+      },
+      500
+    );
+  }
+  if (invoicesResult.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${invoicesResult.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const now = Date.now();
+
+  const currentInvoice = invoicesResult.value.find((inv) => {
+    if (inv.contract_id !== metronomeContractId) {
+      return false;
+    }
+    if (!inv.start_timestamp || !inv.end_timestamp) {
+      return false;
+    }
+    const startMs = new Date(inv.start_timestamp).getTime();
+    const endMs = new Date(inv.end_timestamp).getTime();
+    return startMs <= now && now < endMs;
+  });
+
+  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+    const emptyBody: AwuPoolSummaryResponseBody = {
+      totalCredits: 0,
+      consumedByUsersCredits: 0,
+      consumedByProgrammaticCredits: 0,
+      resetDate: "",
+    };
+    return c.json(emptyBody);
+  }
+
+  const resetDate = ceilToMidnightUTC(
+    new Date(currentInvoice.end_timestamp)
+  ).toISOString();
+
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const seatProductIds = getSeatProductIds();
+  const awuBalances = balancesResult.value.filter(
+    (entry) =>
+      entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
+      !seatProductIds.has(entry.product.id)
+  );
+
+  let totalCredits = 0;
+  for (const entry of awuBalances) {
+    const isActive = (entry.access_schedule?.schedule_items ?? []).some(
+      (item) => {
+        const itemStartMs = new Date(item.starting_at).getTime();
+        const itemEndMs = new Date(item.ending_before).getTime();
+        return itemStartMs <= now && now < itemEndMs;
+      }
+    );
+    if (isActive) {
+      totalCredits += entry.balance ?? 0;
+    }
+  }
+
+  const startingOn = floorToMidnightUTC(
+    new Date(currentInvoice.start_timestamp)
+  ).toISOString();
+  const endingBefore = ceilToMidnightUTC(
+    new Date(currentInvoice.end_timestamp)
+  ).toISOString();
+
+  const [usageResult, seatDataByUserId] = await Promise.all([
+    listMetronomeUsageWithGroups({
+      customerId: metronomeCustomerId,
+      billableMetricId: getMetricLlmProviderCostAwuId(),
+      startingOn,
+      endingBefore,
+      windowSize: "NONE",
+      groupKey: ["user_id", "usage_type"],
+    }),
+    buildSeatDataByUserId({
+      metronomeCustomerId,
+      contractId: metronomeContractId,
+    }),
+  ]);
+
+  if (usageResult.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome usage: ${usageResult.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const perUserCredits = new Map<string, number>();
+  let consumedByProgrammaticCredits = 0;
+
+  for (const row of usageResult.value) {
+    const credits = row.value ?? 0;
+    const usageType = row.group?.["usage_type"];
+    if (usageType === "programmatic") {
+      consumedByProgrammaticCredits += credits;
+    } else {
+      const userId = row.group?.["user_id"];
+      if (userId) {
+        perUserCredits.set(userId, (perUserCredits.get(userId) ?? 0) + credits);
+      }
+    }
+  }
+
+  let consumedByUsersCredits = 0;
+  for (const [userId, userCredits] of perUserCredits) {
+    const seatAllocation = seatDataByUserId.get(userId)?.awuAllocation ?? 0;
+    consumedByUsersCredits += Math.max(0, userCredits - seatAllocation);
+  }
+
+  const body: AwuPoolSummaryResponseBody = {
+    totalCredits,
+    consumedByUsersCredits,
+    consumedByProgrammaticCredits,
+    resetDate,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 
+import { apiError } from "@front-api/middleware/utils";
+
 import { getInvoicePaymentUrl } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -25,16 +27,14 @@ app.get("/", async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message:
-            "Only users that are `admins` for the current workspace can view credits.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can view credits.",
       },
-      403
-    );
+    });
   }
 
   const credits = await CreditResource.listAll(auth, {

--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -1,0 +1,80 @@
+import { Hono } from "hono";
+
+import { getInvoicePaymentUrl } from "@app/lib/plans/stripe";
+import { CreditResource } from "@app/lib/resources/credit_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type {
+  CreditDisplayData,
+  GetCreditsResponseBody,
+  PendingCreditData,
+} from "@app/types/credits";
+
+import awuPoolSummary from "./awu-pool-summary";
+import membersUsage from "./members-usage";
+import metronomeBalances from "./metronome-balances";
+
+// Mounted at /api/w/:wId/credits. workspaceAuth is applied by the parent
+// workspace sub-app.
+const app = new Hono();
+
+app.route("/awu-pool-summary", awuPoolSummary);
+app.route("/members-usage", membersUsage);
+app.route("/metronome-balances", metronomeBalances);
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can view credits.",
+        },
+      },
+      403
+    );
+  }
+
+  const credits = await CreditResource.listAll(auth, {
+    includeBuyer: true,
+  });
+
+  const creditsData: CreditDisplayData[] = credits
+    .filter((credit) => credit.startDate !== null && credit.type !== "excess")
+    .map((credit) => credit.toJSON());
+
+  const pendingCommittedCredits = credits.filter(
+    (credit) =>
+      credit.startDate === null &&
+      credit.type === "committed" &&
+      credit.invoiceOrLineItemId !== null
+  );
+
+  const pendingCreditsData: PendingCreditData[] = await concurrentExecutor(
+    pendingCommittedCredits,
+    async (credit) => {
+      const paymentUrl = credit.invoiceOrLineItemId
+        ? await getInvoicePaymentUrl(credit.invoiceOrLineItemId)
+        : null;
+      return {
+        sId: credit.sId,
+        type: credit.type,
+        initialAmountMicroUsd: credit.initialAmountMicroUsd,
+        paymentUrl,
+        createdAt: credit.createdAt.getTime(),
+      };
+    },
+    { concurrency: 8 }
+  );
+
+  const body: GetCreditsResponseBody = {
+    credits: creditsData,
+    pendingCredits:
+      pendingCreditsData.length > 0 ? pendingCreditsData : undefined,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
 import {
   ceilToMidnightUTC,
   floorToMidnightUTC,
@@ -15,8 +18,6 @@ import {
   type MembershipsPaginationParams,
 } from "@app/lib/resources/membership_resource";
 import type { MembershipSeatType } from "@app/types/memberships";
-
-import { validate } from "@front-api/middleware/validator";
 
 export type MemberUsageType = {
   sId: string;
@@ -141,15 +142,13 @@ app.get("/", validate("query", MembersUsagePaginationSchema), async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message: "Only workspace admins can access the members usage list.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access the members usage list.",
       },
-      403
-    );
+    });
   }
 
   const paginationParams = c.req.valid("query");

--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -1,0 +1,221 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import {
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
+  listMetronomeDraftInvoices,
+  listMetronomeUsageWithGroups,
+} from "@app/lib/metronome/client";
+import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
+import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
+import type { BillingFrequency } from "@app/lib/metronome/types";
+import {
+  MembershipResource,
+  type MembershipsPaginationParams,
+} from "@app/lib/resources/membership_resource";
+import type { MembershipSeatType } from "@app/types/memberships";
+
+import { validate } from "@front-api/middleware/validator";
+
+export type MemberUsageType = {
+  sId: string;
+  name: string;
+  email: string | null;
+  image: string | null;
+  seatType: MembershipSeatType | null;
+  seatUsagePercent: number | null;
+  consumedWorkplacePoolCredits: number;
+  billingFrequency: BillingFrequency | null;
+};
+
+export type GetMembersUsageResponseBody = {
+  members: MemberUsageType[];
+  total: number;
+  nextPageUrl?: string;
+};
+
+export const DEFAULT_MEMBERS_USAGE_PAGE_LIMIT = 50;
+export const MAX_MEMBERS_USAGE_PAGE_LIMIT = 150;
+
+const MembersUsagePaginationSchema = z.object({
+  limit: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(MAX_MEMBERS_USAGE_PAGE_LIMIT)
+    .catch(DEFAULT_MEMBERS_USAGE_PAGE_LIMIT),
+  orderColumn: z.literal("createdAt").catch("createdAt"),
+  orderDirection: z.enum(["asc", "desc"]).catch("desc"),
+  lastValue: z.coerce.number().optional().catch(undefined),
+});
+
+function buildUrlWithParams(
+  currentUrl: string,
+  newParams: MembershipsPaginationParams | undefined
+) {
+  if (!newParams) {
+    return undefined;
+  }
+  const url = new URL(currentUrl);
+  Object.entries(newParams).forEach(([key, value]) => {
+    if (value === null || value === undefined) {
+      url.searchParams.delete(key);
+    } else {
+      url.searchParams.set(key, value.toString());
+    }
+  });
+  return url.pathname + url.search;
+}
+
+async function fetchPerUserUsageCredits({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string | null;
+  metronomeContractId: string | null;
+}): Promise<Map<string, number>> {
+  if (!metronomeCustomerId || !metronomeContractId) {
+    return new Map();
+  }
+
+  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
+  if (invoicesResult.isErr()) {
+    return new Map();
+  }
+
+  const now = Date.now();
+  const currentInvoice = invoicesResult.value.find((inv) => {
+    if (inv.contract_id !== metronomeContractId) {
+      return false;
+    }
+    if (!inv.start_timestamp || !inv.end_timestamp) {
+      return false;
+    }
+    const startMs = new Date(inv.start_timestamp).getTime();
+    const endMs = new Date(inv.end_timestamp).getTime();
+    return startMs <= now && now < endMs;
+  });
+
+  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+    return new Map();
+  }
+
+  const startingOn = floorToMidnightUTC(
+    new Date(currentInvoice.start_timestamp)
+  ).toISOString();
+  const endingBefore = ceilToMidnightUTC(
+    new Date(currentInvoice.end_timestamp)
+  ).toISOString();
+
+  const usageResult = await listMetronomeUsageWithGroups({
+    customerId: metronomeCustomerId,
+    billableMetricId: getMetricLlmProviderCostAwuId(),
+    startingOn,
+    endingBefore,
+    windowSize: "NONE",
+    groupKey: ["user_id", "usage_type"],
+  });
+
+  if (usageResult.isErr()) {
+    return new Map();
+  }
+
+  const perUser = new Map<string, number>();
+  for (const entry of usageResult.value) {
+    const userId = entry.group?.["user_id"];
+    const usageType = entry.group?.["usage_type"];
+    if (!userId || usageType !== "user" || entry.value === null) {
+      continue;
+    }
+    const existing = perUser.get(userId) ?? 0;
+    perUser.set(userId, existing + entry.value);
+  }
+  return perUser;
+}
+
+// Mounted at /api/w/:wId/credits/members-usage.
+const app = new Hono();
+
+app.get("/", validate("query", MembersUsagePaginationSchema), async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access the members usage list.",
+        },
+      },
+      403
+    );
+  }
+
+  const paginationParams = c.req.valid("query");
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+  const { metronomeCustomerId } = workspace;
+  const metronomeContractId = subscription?.metronomeContractId ?? null;
+
+  const [membershipsResult, perUserTotalCredits, seatDataByUserId] =
+    await Promise.all([
+      MembershipResource.getActiveMemberships({
+        workspace,
+        paginationParams,
+      }),
+      fetchPerUserUsageCredits({
+        metronomeCustomerId: metronomeCustomerId ?? null,
+        metronomeContractId,
+      }),
+      metronomeCustomerId && metronomeContractId
+        ? buildSeatDataByUserId({
+            metronomeCustomerId,
+            contractId: metronomeContractId,
+          })
+        : Promise.resolve(new Map()),
+    ]);
+
+  const { memberships, total, nextPageParams } = membershipsResult;
+
+  const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
+    if (!m.user) {
+      return [];
+    }
+    const userId = m.user.sId;
+    const totalCredits = perUserTotalCredits.get(userId) ?? 0;
+    const seatData = seatDataByUserId.get(userId);
+    const awuAllocation = seatData?.awuAllocation ?? 0;
+
+    let seatUsagePercent: number | null = null;
+    let poolConsumedCredits = totalCredits;
+
+    if (awuAllocation > 0) {
+      const seatConsumed = Math.min(totalCredits, awuAllocation);
+      seatUsagePercent = (seatConsumed / awuAllocation) * 100;
+      poolConsumedCredits = Math.max(0, totalCredits - awuAllocation);
+    }
+
+    return [
+      {
+        sId: userId,
+        name: m.user.name,
+        email: m.user.email ?? null,
+        image: m.user.imageUrl ?? null,
+        seatType: m.seatType ?? null,
+        seatUsagePercent,
+        consumedWorkplacePoolCredits: poolConsumedCredits,
+        billingFrequency: seatData?.billingFrequency ?? null,
+      },
+    ];
+  });
+
+  const body: GetMembersUsageResponseBody = {
+    members: membersUsage,
+    total,
+    nextPageUrl: buildUrlWithParams(c.req.url, nextPageParams),
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/metronome-balances.ts
+++ b/front-api/routes/w/[wId]/credits/metronome-balances.ts
@@ -1,0 +1,71 @@
+import { Hono } from "hono";
+
+import { metronomeBalanceToDisplayData } from "@app/lib/api/credits/metronome_balances";
+import { listMetronomeBalances } from "@app/lib/metronome/client";
+import { getCreditTypeProgrammaticUsdId } from "@app/lib/metronome/constants";
+import { isMetronomeExcessCredit } from "@app/lib/metronome/types";
+import type {
+  CreditDisplayData,
+  GetCreditsResponseBody,
+} from "@app/types/credits";
+
+// Mounted at /api/w/:wId/credits/metronome-balances.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can view credits.",
+        },
+      },
+      403
+    );
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return c.json(
+      {
+        error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      },
+      400
+    );
+  }
+
+  const result = await listMetronomeBalances(metronomeCustomerId);
+  if (result.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${result.error.message}`,
+        },
+      },
+      500
+    );
+  }
+
+  const programmaticUsdCreditTypeId = getCreditTypeProgrammaticUsdId();
+  const credits: CreditDisplayData[] = result.value
+    .filter(
+      (entry) =>
+        entry.access_schedule?.credit_type?.id ===
+          programmaticUsdCreditTypeId && !isMetronomeExcessCredit(entry)
+    )
+    .map(metronomeBalanceToDisplayData);
+
+  const body: GetCreditsResponseBody = { credits };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/credits/metronome-balances.ts
+++ b/front-api/routes/w/[wId]/credits/metronome-balances.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 
+import { apiError } from "@front-api/middleware/utils";
+
 import { metronomeBalanceToDisplayData } from "@app/lib/api/credits/metronome_balances";
 import { listMetronomeBalances } from "@app/lib/metronome/client";
 import { getCreditTypeProgrammaticUsdId } from "@app/lib/metronome/constants";
@@ -16,43 +18,37 @@ app.get("/", async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message:
-            "Only users that are `admins` for the current workspace can view credits.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can view credits.",
       },
-      403
-    );
+    });
   }
 
   const workspace = auth.getNonNullableWorkspace();
   const { metronomeCustomerId } = workspace;
   if (!metronomeCustomerId) {
-    return c.json(
-      {
-        error: {
-          type: "invalid_request_error",
-          message: "Workspace is not configured for Metronome billing.",
-        },
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Workspace is not configured for Metronome billing.",
       },
-      400
-    );
+    });
   }
 
   const result = await listMetronomeBalances(metronomeCustomerId);
   if (result.isErr()) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: `Failed to retrieve Metronome balances: ${result.error.message}`,
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve Metronome balances: ${result.error.message}`,
       },
-      500
-    );
+    });
   }
 
   const programmaticUsdCreditTypeId = getCreditTypeProgrammaticUsdId();

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -2,9 +2,11 @@ import { Hono } from "hono";
 
 import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
+import analytics from "./analytics";
 import assistant from "./assistant";
 import builder from "./builder";
 import coupon from "./coupon";
+import credits from "./credits";
 import dataSourceViews from "./data_source_views";
 import dataSources from "./data_sources";
 import extension from "./extension";
@@ -16,6 +18,7 @@ import members from "./members";
 import models from "./models";
 import providers from "./providers";
 import provisioningStatus from "./provisioning-status";
+import seats from "./seats";
 import skills from "./skills";
 import spaces from "./spaces";
 import subscriptions from "./subscriptions";
@@ -31,9 +34,11 @@ const app = new Hono();
 
 app.use("*", workspaceAuth);
 
+app.route("/analytics", analytics);
 app.route("/assistant", assistant);
 app.route("/builder", builder);
 app.route("/coupon", coupon);
+app.route("/credits", credits);
 app.route("/data_source_views", dataSourceViews);
 app.route("/data_sources", dataSources);
 app.route("/extension", extension);
@@ -45,6 +50,7 @@ app.route("/members", members);
 app.route("/models", models);
 app.route("/providers", providers);
 app.route("/provisioning-status", provisioningStatus);
+app.route("/seats", seats);
 app.route("/skills", skills);
 app.route("/spaces", spaces);
 app.route("/subscriptions", subscriptions);

--- a/front-api/routes/w/[wId]/seats/availability.ts
+++ b/front-api/routes/w/[wId]/seats/availability.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 
+import { apiError } from "@front-api/middleware/utils";
+
 import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";
 
 export type GetSeatAvailabilityResponseBody = {
@@ -13,16 +15,14 @@ app.get("/", async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message:
-            "Only users that are `admins` for the current workspace can access this endpoint.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
       },
-      403
-    );
+    });
   }
 
   const hasAvailableSeats = await checkWorkspaceSeatAvailabilityUsingAuth(auth);

--- a/front-api/routes/w/[wId]/seats/availability.ts
+++ b/front-api/routes/w/[wId]/seats/availability.ts
@@ -1,0 +1,33 @@
+import { Hono } from "hono";
+
+import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";
+
+export type GetSeatAvailabilityResponseBody = {
+  hasAvailableSeats: boolean;
+};
+
+// Mounted at /api/w/:wId/seats/availability.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can access this endpoint.",
+        },
+      },
+      403
+    );
+  }
+
+  const hasAvailableSeats = await checkWorkspaceSeatAvailabilityUsingAuth(auth);
+  const body: GetSeatAvailabilityResponseBody = { hasAvailableSeats };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/seats/count.ts
+++ b/front-api/routes/w/[wId]/seats/count.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 
+import { apiError } from "@front-api/middleware/utils";
+
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 
 export type GetWorkspaceSeatsCountResponseBody = {
@@ -13,16 +15,14 @@ app.get("/", async (c) => {
   const auth = c.get("auth");
 
   if (!auth.isAdmin()) {
-    return c.json(
-      {
-        error: {
-          type: "workspace_auth_error",
-          message:
-            "Only users that are `admins` for the current workspace can access this endpoint.",
-        },
+    return apiError(c, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
       },
-      403
-    );
+    });
   }
 
   const owner = auth.getNonNullableWorkspace();

--- a/front-api/routes/w/[wId]/seats/count.ts
+++ b/front-api/routes/w/[wId]/seats/count.ts
@@ -1,0 +1,37 @@
+import { Hono } from "hono";
+
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+
+export type GetWorkspaceSeatsCountResponseBody = {
+  seatsCount: number;
+};
+
+// Mounted at /api/w/:wId/seats/count.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+
+  if (!auth.isAdmin()) {
+    return c.json(
+      {
+        error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can access this endpoint.",
+        },
+      },
+      403
+    );
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+
+  const seatsCount = await MembershipResource.countActiveSeatsInWorkspace(
+    owner.sId
+  );
+  const body: GetWorkspaceSeatsCountResponseBody = { seatsCount };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/seats/index.ts
+++ b/front-api/routes/w/[wId]/seats/index.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+
+import availability from "./availability";
+import count from "./count";
+import plan from "./plan";
+
+// Mounted at /api/w/:wId/seats. workspaceAuth is applied by the parent
+// workspace sub-app.
+const app = new Hono();
+
+app.route("/availability", availability);
+app.route("/count", count);
+app.route("/plan", plan);
+
+export default app;

--- a/front-api/routes/w/[wId]/seats/plan.ts
+++ b/front-api/routes/w/[wId]/seats/plan.ts
@@ -1,0 +1,122 @@
+import { Hono } from "hono";
+
+import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
+import { getMetronomeClient } from "@app/lib/metronome/client";
+import {
+  MAX_SEAT_CREDIT_NAME,
+  MAX_SEAT_PRODUCT_NAME,
+  PRO_SEAT_CREDIT_NAME,
+  PRO_SEAT_PRODUCT_NAME,
+} from "@app/lib/metronome/constants";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+type PriceKey = "pro" | "max";
+
+interface SeatTypeInfo {
+  awuCredits: number;
+  priceCents: number;
+}
+
+// Mounted at /api/w/:wId/seats/plan.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+
+  const workspace = auth.getNonNullableWorkspace();
+  const contract = await getActiveContract(workspace.sId);
+
+  if (!contract || !contract.rate_card_id) {
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      },
+      400
+    );
+  }
+
+  const awuCreditsMap = new Map<PriceKey, number>();
+  for (const credit of contract.recurring_credits ?? []) {
+    if (credit.name === PRO_SEAT_CREDIT_NAME) {
+      awuCreditsMap.set("pro", credit.access_amount.unit_price);
+    } else if (credit.name === MAX_SEAT_CREDIT_NAME) {
+      awuCreditsMap.set("max", credit.access_amount.unit_price);
+    }
+  }
+
+  const monthlyPriceCentsMap = new Map<PriceKey, number>();
+
+  try {
+    const startingAt = new Date().toISOString();
+    let nextPage: string | null | undefined = undefined;
+    do {
+      const rateSchedule =
+        await getMetronomeClient().v1.contracts.rateCards.retrieveRateSchedule({
+          rate_card_id: contract.rate_card_id,
+          starting_at: startingAt,
+          ...(nextPage ? { next_page: nextPage } : {}),
+        });
+
+      for (const entry of rateSchedule.data ?? []) {
+        if (!entry.entitled || entry.rate.price === undefined) {
+          continue;
+        }
+        const key: PriceKey | undefined =
+          entry.product_name === PRO_SEAT_PRODUCT_NAME
+            ? "pro"
+            : entry.product_name === MAX_SEAT_PRODUCT_NAME
+              ? "max"
+              : undefined;
+        if (!key) {
+          continue;
+        }
+        // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
+        monthlyPriceCentsMap.set(key, entry.rate.price);
+      }
+
+      nextPage = rateSchedule.next_page;
+    } while (nextPage && monthlyPriceCentsMap.size < 2);
+  } catch (err) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        rateCardId: contract.rate_card_id,
+        err: normalizeError(err),
+      },
+      "[Metronome] Failed to fetch rate schedule for seat products"
+    );
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: "Failed to fetch rate schedule for seat products.",
+        },
+      },
+      500
+    );
+  }
+
+  const buildSeatInfo = (key: PriceKey): SeatTypeInfo | null => {
+    const monthlyPriceCents = monthlyPriceCentsMap.get(key);
+    if (monthlyPriceCents === undefined) {
+      return null;
+    }
+    return {
+      awuCredits: awuCreditsMap.get(key) ?? 0,
+      priceCents: monthlyPriceCents,
+    };
+  };
+
+  const body: SeatPlanResponseBody = {
+    pro: buildSeatInfo("pro"),
+    max: buildSeatInfo("max"),
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/seats/plan.ts
+++ b/front-api/routes/w/[wId]/seats/plan.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 
+import { apiError } from "@front-api/middleware/utils";
+
 import type {
   SeatPlanResponseBody,
   SeatTypeInfo,
@@ -29,15 +31,13 @@ app.get("/", async (c) => {
   const contract = await getActiveContract(workspace.sId);
 
   if (!contract || !contract.rate_card_id) {
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: "Workspace is not configured for Metronome billing.",
-        },
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "internal_server_error",
+        message: "Workspace is not configured for Metronome billing.",
       },
-      400
-    );
+    });
   }
 
   const creditTypeResult = await getCreditTypeFromContract(contract);
@@ -50,15 +50,13 @@ app.get("/", async (c) => {
       },
       "[Metronome] Failed to resolve contract currency for seat plan"
     );
-    return c.json(
-      {
-        error: {
-          type: "internal_server_error",
-          message: "Failed to resolve currency for seat plan.",
-        },
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to resolve currency for seat plan.",
       },
-      500
-    );
+    });
   }
   const { currency } = creditTypeResult.value;
 
@@ -106,22 +104,25 @@ app.get("/", async (c) => {
       nextPage = rateSchedule.next_page;
     } while (nextPage && monthlyPriceCentsMap.size < 2);
   } catch (err) {
+    const normalized = normalizeError(err);
     logger.warn(
       {
         workspaceId: workspace.sId,
         rateCardId: contract.rate_card_id,
-        err: normalizeError(err),
+        err: normalized,
       },
       "[Metronome] Failed to fetch rate schedule for seat products"
     );
-    return c.json(
+    return apiError(
+      c,
       {
-        error: {
+        status_code: 500,
+        api_error: {
           type: "internal_server_error",
           message: "Failed to fetch rate schedule for seat products.",
         },
       },
-      500
+      normalized
     );
   }
 

--- a/front-api/routes/w/[wId]/seats/plan.ts
+++ b/front-api/routes/w/[wId]/seats/plan.ts
@@ -1,6 +1,10 @@
 import { Hono } from "hono";
 
-import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
+import type {
+  SeatPlanResponseBody,
+  SeatTypeInfo,
+} from "@app/lib/api/credits/seat_plan";
+import { amountCents } from "@app/lib/metronome/amounts";
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import {
   MAX_SEAT_CREDIT_NAME,
@@ -8,16 +12,12 @@ import {
   PRO_SEAT_CREDIT_NAME,
   PRO_SEAT_PRODUCT_NAME,
 } from "@app/lib/metronome/constants";
+import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 type PriceKey = "pro" | "max";
-
-interface SeatTypeInfo {
-  awuCredits: number;
-  priceCents: number;
-}
 
 // Mounted at /api/w/:wId/seats/plan.
 const app = new Hono();
@@ -39,6 +39,28 @@ app.get("/", async (c) => {
       400
     );
   }
+
+  const creditTypeResult = await getCreditTypeFromContract(contract);
+  if (creditTypeResult.isErr()) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        rateCardId: contract.rate_card_id,
+        err: creditTypeResult.error,
+      },
+      "[Metronome] Failed to resolve contract currency for seat plan"
+    );
+    return c.json(
+      {
+        error: {
+          type: "internal_server_error",
+          message: "Failed to resolve currency for seat plan.",
+        },
+      },
+      500
+    );
+  }
+  const { currency } = creditTypeResult.value;
 
   const awuCreditsMap = new Map<PriceKey, number>();
   for (const credit of contract.recurring_credits ?? []) {
@@ -75,8 +97,10 @@ app.get("/", async (c) => {
         if (!key) {
           continue;
         }
+        // Metronome quotes prices in its per-currency native unit (USD in
+        // cents, others in whole units); normalize to actual cents here.
         // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
-        monthlyPriceCentsMap.set(key, entry.rate.price);
+        monthlyPriceCentsMap.set(key, amountCents(entry.rate.price, currency));
       }
 
       nextPage = rateSchedule.next_page;
@@ -109,6 +133,7 @@ app.get("/", async (c) => {
     return {
       awuCredits: awuCreditsMap.get(key) ?? 0,
       priceCents: monthlyPriceCents,
+      currency,
     };
   };
 

--- a/front/lib/api/analytics/metronome_usage.ts
+++ b/front/lib/api/analytics/metronome_usage.ts
@@ -75,7 +75,9 @@ const GROUP_BY_TO_EVENT_PROPERTY: Record<MetronomeUsageGroupByType, string> = {
 
 type MetronomeWindowSize = "HOUR" | "DAY";
 
-function getMetronomeWindowSize(windowSize: WindowSize): MetronomeWindowSize {
+export function getMetronomeWindowSize(
+  windowSize: WindowSize
+): MetronomeWindowSize {
   switch (windowSize) {
     case "FOUR_HOURS":
     case "HOUR":
@@ -87,7 +89,7 @@ function getMetronomeWindowSize(windowSize: WindowSize): MetronomeWindowSize {
   }
 }
 
-function aggregateToFourHourBuckets(
+export function aggregateToFourHourBuckets(
   hourlyMap: Map<number, number>
 ): Map<number, number> {
   const aggregated = new Map<number, number>();
@@ -104,7 +106,7 @@ interface ParsedBalance {
   intervals: { start: number; end: number }[];
 }
 
-function calculateCreditTotalsFromBalances(
+export function calculateCreditTotalsFromBalances(
   balances: MetronomeBalance[],
   timestamps: number[]
 ): Map<
@@ -463,7 +465,7 @@ export async function handleMetronomeUsageRequest(
   }
 }
 
-async function resolveGroupLabels(
+export async function resolveGroupLabels(
   groupBy: MetronomeUsageGroupByType,
   groupKeys: string[]
 ): Promise<Map<string, string>> {

--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -100,7 +100,7 @@ type GroupedAggs = {
  * - It has been started (startDate is not null and <= day start)
  * - It hasn't expired yet on that day (expirationDate is null or > day start)
  */
-function calculateCreditTotalsPerTimestamp(
+export function calculateCreditTotalsPerTimestamp(
   credits: CreditResource[],
   timestamps: number[]
 ): Map<
@@ -175,7 +175,7 @@ function calculateCreditTotalsPerTimestamp(
   return creditTotalsMap;
 }
 
-function getSelectedFilterClauses(
+export function getSelectedFilterClauses(
   filterParams: Partial<Record<GroupByType, string[]>> | undefined,
   excluded?: GroupByType
 ): estypes.QueryDslQueryContainer[] {
@@ -223,7 +223,7 @@ function getSelectedFilterClauses(
   });
 }
 
-function buildAggregation(
+export function buildAggregation(
   groupBy: GroupByType,
   groupByCount: number,
   includeDailyBreakdown: boolean

--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -2,6 +2,7 @@ import {
   DAY_MS,
   getTimestampsForWindow,
 } from "@app/lib/api/analytics/time_utils";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { MetricsBucket } from "@app/lib/api/assistant/observability/messages_metrics";
 import {
   buildMetricAggregates,
@@ -16,7 +17,6 @@ import {
 import { getShouldTrackTokenUsageCostsESFilter } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -474,12 +474,9 @@ export async function handleProgrammaticCostRequest(
         const agentNames: Record<string, string> = {};
         if (groupBy === "agent") {
           const agentIds = availableGroupBuckets.map((b) => b.key);
-          const agents = await AgentConfigurationModel.findAll({
-            where: {
-              sId: agentIds,
-              workspaceId: auth.getNonNullableWorkspace().id,
-            },
-            attributes: ["sId", "name"],
+          const agents = await getAgentConfigurations(auth, {
+            agentIds,
+            variant: "extra_light",
           });
           agents.forEach((agent) => {
             agentNames[agent.sId] = agent.name;

--- a/front/pages/api/w/[wId]/analytics/active-users-export.ts
+++ b/front/pages/api/w/[wId]/analytics/active-users-export.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";

--- a/front/pages/api/w/[wId]/analytics/active-users.ts
+++ b/front/pages/api/w/[wId]/analytics/active-users.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";

--- a/front/pages/api/w/[wId]/analytics/agents-export.ts
+++ b/front/pages/api/w/[wId]/analytics/agents-export.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {

--- a/front/pages/api/w/[wId]/analytics/metronome-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/metronome-usage.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import type { GetMetronomeUsageResponse } from "@app/lib/api/analytics/metronome_usage";
 import { handleMetronomeUsageRequest } from "@app/lib/api/analytics/metronome_usage";

--- a/front/pages/api/w/[wId]/analytics/overview.ts
+++ b/front/pages/api/w/[wId]/analytics/overview.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost-export.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost-export.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import {
   ExportQuerySchema,

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import type { GetWorkspaceProgrammaticCostResponse } from "@app/lib/api/analytics/programmatic_cost";
 import { handleProgrammaticCostRequest } from "@app/lib/api/analytics/programmatic_cost";

--- a/front/pages/api/w/[wId]/analytics/skill-usage-export.ts
+++ b/front/pages/api/w/[wId]/analytics/skill-usage-export.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {

--- a/front/pages/api/w/[wId]/analytics/skill-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/skill-usage.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { SkillUsagePoint } from "@app/lib/api/assistant/observability/skill_usage";

--- a/front/pages/api/w/[wId]/analytics/skills.ts
+++ b/front/pages/api/w/[wId]/analytics/skills.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { AvailableSkill } from "@app/lib/api/assistant/observability/skill_usage";

--- a/front/pages/api/w/[wId]/analytics/source-export.ts
+++ b/front/pages/api/w/[wId]/analytics/source-export.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";

--- a/front/pages/api/w/[wId]/analytics/source.ts
+++ b/front/pages/api/w/[wId]/analytics/source.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchContextOriginBreakdown } from "@app/lib/api/assistant/observability/context_origin";

--- a/front/pages/api/w/[wId]/analytics/tool-usage-export.ts
+++ b/front/pages/api/w/[wId]/analytics/tool-usage-export.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {

--- a/front/pages/api/w/[wId]/analytics/tool-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/tool-usage.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ToolUsagePoint } from "@app/lib/api/assistant/observability/tool_usage";

--- a/front/pages/api/w/[wId]/analytics/tools.ts
+++ b/front/pages/api/w/[wId]/analytics/tools.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";

--- a/front/pages/api/w/[wId]/analytics/top-agents.ts
+++ b/front/pages/api/w/[wId]/analytics/top-agents.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";

--- a/front/pages/api/w/[wId]/analytics/top-users.ts
+++ b/front/pages/api/w/[wId]/analytics/top-users.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";

--- a/front/pages/api/w/[wId]/analytics/usage-metrics-export.ts
+++ b/front/pages/api/w/[wId]/analytics/usage-metrics-export.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";

--- a/front/pages/api/w/[wId]/analytics/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/analytics/usage-metrics.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type {

--- a/front/pages/api/w/[wId]/analytics/users-export.ts
+++ b/front/pages/api/w/[wId]/analytics/users-export.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {

--- a/front/pages/api/w/[wId]/credits/awu-pool-summary.ts
+++ b/front/pages/api/w/[wId]/credits/awu-pool-summary.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/credits/index.ts
+++ b/front/pages/api/w/[wId]/credits/index.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/credits/members-usage.ts
+++ b/front/pages/api/w/[wId]/credits/members-usage.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";

--- a/front/pages/api/w/[wId]/credits/metronome-balances.ts
+++ b/front/pages/api/w/[wId]/credits/metronome-balances.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/seats/availability.ts
+++ b/front/pages/api/w/[wId]/seats/availability.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";

--- a/front/pages/api/w/[wId]/seats/count.ts
+++ b/front/pages/api/w/[wId]/seats/count.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/seats/plan.ts
+++ b/front/pages/api/w/[wId]/seats/plan.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";


### PR DESCRIPTION
## Description
Migrates 18 workspace-scoped GET endpoints from Next.js to Hono:
- /api/w/:wId/seats/{count,availability,plan}
- /api/w/:wId/credits/{index,awu-pool-summary,members-usage,metronome-balances}
- /api/w/:wId/analytics/{overview,active-users,top-agents,top-users,tools, skills,source,skill-usage,usage-metrics,metronome-usage,programmatic-cost}

Each Next handler is marked @migration-status: MIGRATED_TO_HONO. Adds seats/, credits/, and analytics/ sub-apps mounted from the workspace router. Routes delegating to (req,res)-shaped lib helpers inline the logic per the BACK18 pragmatic exception.

Some of these analytics ones have a ton of logic, could be good candidates for refactoring

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
None of these have 
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
None yet
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25731">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->