### PR TITLE
Add Hono tests for members/search and v1 feature_flags

### DIFF
--- a/front-api/routes/v1/w/[wId]/feature_flags.test.ts
+++ b/front-api/routes/v1/w/[wId]/feature_flags.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+import { honoApp } from "@front-api/app";
+
+function getFeatureFlags(workspace: { sId: string }, key: { secret: string }) {
+  return honoApp.request(`/api/v1/w/${workspace.sId}/feature_flags`, {
+    headers: { authorization: `Bearer ${key.secret}` },
+  });
+}
+
+describe("GET /api/v1/w/:wId/feature_flags", () => {
+  it("returns 404 if not a system key", async () => {
+    const { workspace, key } = await createPublicApiMockRequest();
+
+    const response = await getFeatureFlags(workspace, key);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  });
+
+  it("returns 200 and the workspace feature flags", async () => {
+    const { workspace, key, auth } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    await FeatureFlagFactory.basic(auth, "deepseek_feature");
+    await FeatureFlagFactory.basic(auth, "xai_feature");
+
+    const response = await getFeatureFlags(workspace, key);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      feature_flags: expect.arrayContaining([
+        "deepseek_feature",
+        "xai_feature",
+      ]),
+    });
+  });
+
+  it("returns 200 and an empty array when no feature flags exist", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const response = await getFeatureFlags(workspace, key);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ feature_flags: [] });
+  });
+
+  it("returns feature flags only for the requested workspace", async () => {
+    const { workspace, key, auth } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const otherWorkspace = await WorkspaceFactory.basic();
+    await FeatureFlagFactory.basic(auth, "xai_feature");
+    await FeatureFlagFactory.basic(
+      await Authenticator.internalAdminForWorkspace(otherWorkspace.sId),
+      "labs_transcripts"
+    );
+
+    const response = await getFeatureFlags(workspace, key);
+
+    expect(response.status).toBe(200);
+    const { feature_flags } = await response.json();
+    expect(feature_flags).toEqual(expect.arrayContaining(["xai_feature"]));
+    expect(feature_flags).not.toContain("labs_transcripts");
+  });
+});

--- a/front-api/routes/w/[wId]/members/search.test.ts
+++ b/front-api/routes/w/[wId]/members/search.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+
+// Stub Elasticsearch-backed search with a SQL implementation so tests don't
+// depend on a running ES cluster.
+vi.mock(import("@app/lib/user_search/search"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    searchUsers: vi.fn(
+      async ({
+        owner,
+        searchTerm,
+        offset,
+        limit,
+      }: {
+        owner: LightWorkspaceType;
+        searchTerm: string;
+        offset: number;
+        limit: number;
+      }) => {
+        const { memberships } =
+          await MembershipResource.getMembershipsForWorkspace({
+            workspace: owner,
+            includeUser: true,
+          });
+
+        const users = memberships
+          .map((m) => m.user)
+          .filter((u): u is NonNullable<typeof u> => u !== undefined);
+
+        const filteredUsers =
+          searchTerm && searchTerm.trim()
+            ? users.filter((user) => {
+                const lowerSearchTerm = searchTerm.toLowerCase();
+                const email = user.email?.toLowerCase() || "";
+                const fullName =
+                  `${user.firstName ?? ""} ${user.lastName ?? ""}`.toLowerCase();
+                return (
+                  email.includes(lowerSearchTerm) ||
+                  fullName.includes(lowerSearchTerm)
+                );
+              })
+            : users;
+
+        const paginatedUsers = filteredUsers.slice(offset, offset + limit);
+
+        const userDocs = paginatedUsers.map((user) => ({
+          workspace_id: owner.sId,
+          user_id: user.sId,
+          email: user.email,
+          full_name: `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim(),
+          updated_at: user.updatedAt,
+        }));
+
+        return new Ok({
+          users: userDocs,
+          total: filteredUsers.length,
+        });
+      }
+    ),
+  };
+});
+
+import { honoApp } from "@front-api/app";
+
+async function setup(role: "builder" | "user" | "admin" = "admin") {
+  const { workspace, user } = await createPrivateApiMockRequest({ role });
+  return { workspace, user };
+}
+
+function searchUrl(wId: string, params: Record<string, string> = {}) {
+  const qs = new URLSearchParams(params).toString();
+  const base = `/api/w/${wId}/members/search`;
+  return qs ? `${base}?${qs}` : base;
+}
+
+describe("GET /api/w/:wId/members/search", () => {
+  it("allows users to search members", async () => {
+    const { workspace, user } = await setup("user");
+
+    const response = await honoApp.request(searchUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.total).toBe(1);
+    expect(data.members).toHaveLength(1);
+    expect(data.members[0].id).toBe(user.id);
+    expect(data.members[0].workspace.role).toBe("user");
+  });
+
+  it("handles search by term", async () => {
+    const { workspace } = await setup();
+
+    const users = await Promise.all([
+      UserFactory.basic(),
+      UserFactory.basic(),
+      UserFactory.basic(),
+    ]);
+
+    await Promise.all(
+      users.map((u) =>
+        MembershipFactory.associate(workspace, u, { role: "user" })
+      )
+    );
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, { searchTerm: users[0].email })
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.total).toBe(1);
+    expect(data.members).toHaveLength(1);
+    expect(data.members[0].id).toBe(users[0].id);
+  });
+
+  it("handles search by emails", async () => {
+    const { workspace } = await setup();
+
+    const users = await Promise.all([
+      UserFactory.basic(),
+      UserFactory.basic(),
+      UserFactory.basic(),
+    ]);
+
+    await Promise.all(
+      users.map((u) =>
+        MembershipFactory.associate(workspace, u, { role: "user" })
+      )
+    );
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, {
+        searchEmails: `${users[0].email},${users[1].email}`,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.total).toBe(2);
+    expect(data.members).toHaveLength(2);
+    expect(data.members.map((m: { email: string }) => m.email)).toContain(
+      users[0].email
+    );
+    expect(data.members.map((m: { email: string }) => m.email)).toContain(
+      users[1].email
+    );
+  });
+
+  it("returns 400 when too many emails provided", async () => {
+    const { workspace } = await setup();
+
+    const tooManyEmails = Array(MAX_SEARCH_EMAILS + 1)
+      .fill(null)
+      .map((_, i) => `user${i}@example.com`)
+      .join(",");
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, { searchEmails: tooManyEmails })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("handles pagination with search results", async () => {
+    const { workspace } = await setup();
+
+    const users = await Promise.all(
+      Array(29)
+        .fill(null)
+        .map(() => UserFactory.basic())
+    );
+
+    await Promise.all(
+      users.map((u) =>
+        MembershipFactory.associate(workspace, u, { role: "user" })
+      )
+    );
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, { limit: "20", offset: "0" })
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.total).toBe(30);
+    expect(data.members).toHaveLength(20);
+  });
+
+  it("handles empty search results", async () => {
+    const { workspace } = await setup();
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, { searchTerm: "NonexistentUser" })
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.total).toBe(0);
+    expect(data.members).toHaveLength(0);
+  });
+
+  it("filters to only builders and admins when buildersOnly=true", async () => {
+    const { workspace } = await setup();
+
+    const users = await Promise.all([
+      UserFactory.basic(),
+      UserFactory.basic(),
+      UserFactory.basic(),
+      UserFactory.basic(),
+    ]);
+
+    await Promise.all([
+      MembershipFactory.associate(workspace, users[0], { role: "admin" }),
+      MembershipFactory.associate(workspace, users[1], { role: "builder" }),
+      MembershipFactory.associate(workspace, users[2], { role: "user" }),
+      MembershipFactory.associate(workspace, users[3], { role: "user" }),
+    ]);
+
+    const response = await honoApp.request(
+      searchUrl(workspace.sId, {
+        buildersOnly: "true",
+        offset: "0",
+        limit: "25",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.total).toBe(3);
+    expect(data.members).toHaveLength(3);
+    for (const member of data.members) {
+      expect(["admin", "builder"]).toContain(member.workspace.role);
+    }
+  });
+});


### PR DESCRIPTION
## Description
Ports the existing Next.js test suites for two routes migrated before we established a testing pattern. Skips the 405-on-wrong-method cases — Hono handles method routing at the framework level. Stubs the Elasticsearch-backed searchUsers in members/search via MembershipResource so tests don't need a running ES cluster.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
See these pass 
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
None
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25732">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->