### PR TITLE
Color banner

### DIFF
--- a/front/components/home/content/Product/HeroOfficeSection.tsx
+++ b/front/components/home/content/Product/HeroOfficeSection.tsx
@@ -133,10 +133,10 @@ export function HeroOfficeSection() {
             <Link
               href="/landing/ebook"
               onClick={withTracking(TRACKING_AREAS.HOME, "hero_ebook_pill")}
-              className="group inline-flex max-w-[calc(100%-1.5rem)] items-center gap-2 rounded-full border border-gray-100 bg-white py-1.5 pl-3 pr-3 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 lg:max-w-none"
+              className="group inline-flex items-center gap-2 rounded-full border border-gray-100 bg-white py-1.5 pl-3 pr-3 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
             >
               <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500" />
-              <span className="min-w-0 truncate lg:min-w-0 lg:overflow-visible lg:whitespace-nowrap">
+              <span className="whitespace-nowrap">
                 <span className="font-semibold">New</span> · The AI Enterprise
                 Playbook
               </span>

--- a/front/components/home/content/Product/HeroOfficeSection.tsx
+++ b/front/components/home/content/Product/HeroOfficeSection.tsx
@@ -133,13 +133,12 @@ export function HeroOfficeSection() {
             <Link
               href="/landing/ebook"
               onClick={withTracking(TRACKING_AREAS.HOME, "hero_ebook_pill")}
-              className="group inline-flex max-w-[calc(100%-1.5rem)] items-center gap-2 rounded-full border border-blue-200 bg-blue-50 py-1 pl-1 pr-3 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-100"
+              className="group inline-flex max-w-[calc(100%-1.5rem)] items-center gap-2 rounded-full border border-gray-100 bg-white py-1.5 pl-3 pr-3 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 lg:max-w-none"
             >
-              <span className="inline-flex h-5 flex-shrink-0 items-center whitespace-nowrap rounded-full bg-blue-500 px-2 text-[10px] font-semibold uppercase leading-none tracking-[0.06em] text-white">
-                New ebook
-              </span>
-              <span className="min-w-0 truncate">
-                The AI Enterprise Playbook - Download it now
+              <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500" />
+              <span className="min-w-0 truncate lg:min-w-0 lg:overflow-visible lg:whitespace-nowrap">
+                <span className="font-semibold">New</span> · The AI Enterprise
+                Playbook
               </span>
               <svg
                 width="12"


### PR DESCRIPTION
## Description

Replaces the bold blue ebook pill (introduced in #25719) with a softer neutral gray treatment. The new design uses a white background with a light gray border, a small blue dot indicator, and condensed copy ("New · The AI Enterprise Playbook"). The second commit removes the now-unnecessary mobile truncation/responsive overrides since the shortened label fits naturally on mobile without wrapping.

## Tests

Manually tested across desktop and mobile viewports — verified the pill displays correctly and the full label remains visible without truncation.

## Risk

None. Pure CSS changes with no functional impact.

## Deploy Plan

Deploy front