### PR TITLE
Migrate various assistant conversation handlers to Hono

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/attachments.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/attachments.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono";
+
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+
+import { jsonApiError } from "@front-api/middleware/utils";
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/attachments.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const conversationId = c.req.param("cId") ?? "";
+
+  const conversationRes = await getConversation(auth, conversationId);
+  if (conversationRes.isErr()) {
+    return jsonApiError(c, getConversationApiError(conversationRes.error));
+  }
+
+  const attachments = await listAttachments(auth, {
+    conversation: conversationRes.value,
+  });
+
+  return c.json({ attachments });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
+import { terminateMessageGeneration } from "@app/lib/api/cancel";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+import { jsonApiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+const PostMessageEventBodySchema = z.object({
+  action: z.enum(["cancel", "gracefully_stop", "interrupt"]),
+  messageIds: z.array(z.string()),
+});
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/cancel.
+const app = new Hono();
+
+app.post("/", validate("json", PostMessageEventBodySchema), async (c) => {
+  const auth = c.get("auth");
+  const conversationId = c.req.param("cId") ?? "";
+
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+  if (conversationRes.isErr()) {
+    return jsonApiError(c, getConversationApiError(conversationRes.error));
+  }
+
+  const { action, messageIds } = c.req.valid("json");
+
+  switch (action) {
+    case "cancel":
+    case "interrupt":
+      await terminateMessageGeneration(auth, {
+        messageIds,
+        conversationId,
+        action,
+      });
+      break;
+    case "gracefully_stop":
+      await gracefullyStopAgentLoop(auth, {
+        messageIds,
+        conversationId,
+      });
+      break;
+    default:
+      assertNever(action);
+  }
+
+  return c.json({ success: true });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { compactConversation } from "@app/lib/api/assistant/conversation/compaction";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { isProviderWhitelisted } from "@app/lib/assistant";
+import { isSupportedModel } from "@app/types/assistant/assistant";
+
+import { jsonApiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+const PostConversationCompactionsBodySchema = z.object({
+  model: z.object({
+    providerId: z.string(),
+    modelId: z.string(),
+  }),
+});
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/compactions.
+const app = new Hono();
+
+app.post(
+  "/",
+  validate("json", PostConversationCompactionsBodySchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const conversationId = c.req.param("cId") ?? "";
+
+    const conversationRes = await getConversation(auth, conversationId);
+    if (conversationRes.isErr()) {
+      return jsonApiError(c, getConversationApiError(conversationRes.error));
+    }
+
+    const { model } = c.req.valid("json");
+    if (!isSupportedModel(model)) {
+      return c.json(
+        {
+          error: {
+            type: "invalid_request_error",
+            message: `Unsupported model: ${model.providerId}/${model.modelId}.`,
+          },
+        },
+        400
+      );
+    }
+
+    if (!isProviderWhitelisted(auth, model.providerId)) {
+      return c.json(
+        {
+          error: {
+            type: "model_disabled",
+            message: `The model provider ${model.providerId} has been disabled by your workspace admin.`,
+          },
+        },
+        400
+      );
+    }
+
+    const result = await compactConversation(auth, {
+      conversation: conversationRes.value,
+      model,
+    });
+    if (result.isErr()) {
+      return jsonApiError(c, result.error);
+    }
+
+    return c.json({ compactionMessage: result.value.compactionMessage });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/context-usage.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { SupportedModel } from "@app/types/assistant/models/types";
+
+import { honoApp } from "@front-api/app";
+
+const MODEL: SupportedModel = {
+  providerId: "anthropic",
+  modelId: "claude-haiku-4-5-20251001",
+};
+
+function makeRunUsage({
+  promptTokens,
+  completionTokens,
+}: {
+  promptTokens: number;
+  completionTokens: number;
+}): RunUsageType {
+  return {
+    providerId: MODEL.providerId,
+    modelId: MODEL.modelId,
+    promptTokens,
+    completionTokens,
+    cachedTokens: null,
+    cacheCreationTokens: null,
+    costMicroUsd: 1,
+    isBatch: false,
+  };
+}
+
+function makeRunWithUsages(usages: RunUsageType[]) {
+  return {
+    listRunUsages: vi.fn().mockResolvedValue(usages),
+  };
+}
+
+function makeConversationResource({
+  latestAgentMessageRun,
+  latestCompactionMessageRun,
+  previousAgentMessageRun = null,
+}: {
+  latestAgentMessageRun: {
+    rank: number;
+    run: ReturnType<typeof makeRunWithUsages>;
+  } | null;
+  latestCompactionMessageRun: {
+    rank: number;
+    run: ReturnType<typeof makeRunWithUsages>;
+  } | null;
+  previousAgentMessageRun?: {
+    rank: number;
+    run: ReturnType<typeof makeRunWithUsages>;
+  } | null;
+}) {
+  return {
+    getLatestAgentMessageRun: vi
+      .fn()
+      .mockResolvedValueOnce(latestAgentMessageRun)
+      .mockResolvedValueOnce(previousAgentMessageRun),
+    getLatestCompactionMessageRun: vi
+      .fn()
+      .mockResolvedValue(latestCompactionMessageRun),
+  } satisfies Pick<
+    ConversationResource,
+    "getLatestAgentMessageRun" | "getLatestCompactionMessageRun"
+  >;
+}
+
+function get(workspace: { sId: string }) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/conversation_sid/context-usage`
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/w/:wId/assistant/conversations/:cId/context-usage", () => {
+  it("uses the latest succeeded compaction run when it is newer than the latest agent run", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "GET",
+    });
+
+    const agentRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 111, completionTokens: 11 }),
+    ]);
+    const compactionRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 222, completionTokens: 123 }),
+    ]);
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: { rank: 10, run: agentRun },
+      latestCompactionMessageRun: { rank: 20, run: compactionRun },
+    });
+
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      model: MODEL,
+      contextUsage: 123,
+    });
+    expect(agentRun.listRunUsages).not.toHaveBeenCalled();
+    expect(compactionRun.listRunUsages).toHaveBeenCalledOnce();
+  });
+
+  it("uses the latest agent run when it is newer than the latest succeeded compaction run", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "GET",
+    });
+
+    const agentRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 222, completionTokens: 22 }),
+    ]);
+    const compactionRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 111, completionTokens: 77 }),
+    ]);
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: { rank: 20, run: agentRun },
+      latestCompactionMessageRun: { rank: 10, run: compactionRun },
+    });
+
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      model: MODEL,
+      contextUsage: 222,
+    });
+    expect(compactionRun.listRunUsages).not.toHaveBeenCalled();
+    expect(agentRun.listRunUsages).toHaveBeenCalledOnce();
+  });
+
+  it("returns pending usage when the latest compaction run has no usage rows yet", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "GET",
+    });
+
+    const agentRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 111, completionTokens: 11 }),
+    ]);
+    const compactionRun = makeRunWithUsages([]);
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: { rank: 10, run: agentRun },
+      latestCompactionMessageRun: { rank: 20, run: compactionRun },
+    });
+
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      model: null,
+      contextUsage: null,
+      contextSize: null,
+    });
+    expect(agentRun.listRunUsages).not.toHaveBeenCalled();
+    expect(compactionRun.listRunUsages).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the previous agent run when the latest has no usage rows yet", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "GET",
+    });
+
+    const latestRun = makeRunWithUsages([]);
+    const previousRun = makeRunWithUsages([
+      makeRunUsage({ promptTokens: 555, completionTokens: 55 }),
+    ]);
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: { rank: 20, run: latestRun },
+      latestCompactionMessageRun: null,
+      previousAgentMessageRun: { rank: 18, run: previousRun },
+    });
+
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      model: MODEL,
+      contextUsage: 555,
+    });
+    expect(latestRun.listRunUsages).toHaveBeenCalledOnce();
+    expect(previousRun.listRunUsages).toHaveBeenCalledOnce();
+    expect(conversation.getLatestAgentMessageRun).toHaveBeenCalledTimes(2);
+    expect(conversation.getLatestAgentMessageRun).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      { maxRank: 19 }
+    );
+  });
+
+  it("returns pending usage when the latest agent run has no usage rows and there is no previous run", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "GET",
+    });
+
+    const agentRun = makeRunWithUsages([]);
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: { rank: 20, run: agentRun },
+      latestCompactionMessageRun: null,
+    });
+
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      model: null,
+      contextUsage: null,
+      contextSize: null,
+    });
+    expect(agentRun.listRunUsages).toHaveBeenCalledOnce();
+    expect(conversation.getLatestAgentMessageRun).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns pending usage when the conversation has no run data yet", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "GET",
+    });
+
+    const conversation = makeConversationResource({
+      latestAgentMessageRun: null,
+      latestCompactionMessageRun: null,
+    });
+
+    vi.spyOn(ConversationResource, "fetchById").mockResolvedValue(
+      conversation as unknown as ConversationResource
+    );
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      model: null,
+      contextUsage: null,
+      contextSize: null,
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -1,0 +1,114 @@
+import { Hono } from "hono";
+
+import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { SupportedModel } from "@app/types/assistant/models/types";
+
+export type GetConversationContextUsageResponse = {
+  model: SupportedModel | null;
+  contextUsage: number | null;
+  contextSize: number | null;
+};
+
+const PENDING_CONTEXT_USAGE_RESPONSE: GetConversationContextUsageResponse = {
+  model: null,
+  contextUsage: null,
+  contextSize: null,
+};
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/context-usage.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const conversationId = c.req.param("cId") ?? "";
+
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return c.json(
+      {
+        error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      },
+      404
+    );
+  }
+
+  const [lastAgentRun, lastCompactionRun] = await Promise.all([
+    conversation.getLatestAgentMessageRun(auth),
+    conversation.getLatestCompactionMessageRun(auth),
+  ]);
+
+  if (
+    lastCompactionRun &&
+    lastCompactionRun.rank >= (lastAgentRun?.rank || 0)
+  ) {
+    // If the latest run is a compaction run we provide a best guess estimate of the context
+    // usage with the compaction generated tokens. This misses the system prompt context usage
+    // but this will recover at the next agent message and allow us in a somewhat hacky but
+    // minimal way to show reduction of context usage as soon as possible.
+    const usages = await lastCompactionRun.run.listRunUsages(auth);
+    if (usages.length === 0) {
+      return c.json(PENDING_CONTEXT_USAGE_RESPONSE);
+    }
+
+    const maxUsage = usages.reduce((max, u) =>
+      u.completionTokens > max.completionTokens ? u : max
+    );
+
+    const modelConfig = getModelConfigByModelId(maxUsage.modelId);
+
+    return c.json({
+      model: {
+        providerId: maxUsage.providerId,
+        modelId: maxUsage.modelId,
+      },
+      contextUsage: maxUsage.completionTokens,
+      contextSize: modelConfig?.contextSize ?? 0,
+    });
+  }
+
+  if (!lastAgentRun) {
+    return c.json(PENDING_CONTEXT_USAGE_RESPONSE);
+  }
+
+  let usages = await lastAgentRun.run.listRunUsages(auth);
+
+  if (usages.length === 0) {
+    // The latest run has no usage rows yet (still processing). Fall back to the previous
+    // completed run so the indicator stays stable instead of dropping to 0%.
+    const previousAgentRun = await conversation.getLatestAgentMessageRun(auth, {
+      maxRank: lastAgentRun.rank - 1,
+    });
+    if (previousAgentRun) {
+      usages = await previousAgentRun.run.listRunUsages(auth);
+    }
+  }
+
+  if (usages.length === 0) {
+    return c.json(PENDING_CONTEXT_USAGE_RESPONSE);
+  }
+
+  // Take the max promptTokens across usages of the run — this represents the peak
+  // context usage as seen by the model.
+  const maxUsage = usages.reduce((max, u) =>
+    u.promptTokens > max.promptTokens ? u : max
+  );
+  const modelConfig = getModelConfigByModelId(maxUsage.modelId);
+
+  return c.json({
+    model: {
+      providerId: maxUsage.providerId,
+      modelId: maxUsage.modelId,
+    },
+    contextUsage: maxUsage.promptTokens,
+    contextSize: modelConfig?.contextSize ?? 0,
+  });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/feedbacks.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/feedbacks.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import type { Authenticator } from "@app/lib/auth";
+import { MessageModel } from "@app/lib/models/agent/conversation";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { ModelId } from "@app/types/shared/model_id";
+
+import { honoApp } from "@front-api/app";
+
+async function getMessageByRank(
+  auth: Authenticator,
+  conversationId: ModelId,
+  rank: number
+): Promise<MessageModel> {
+  const message = await MessageModel.findOne({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId,
+      rank,
+    },
+  });
+  if (!message) {
+    throw new Error(`No message found at rank ${rank}`);
+  }
+  return message;
+}
+
+function getFeedbacks(workspace: { sId: string }, cId: string) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/${cId}/feedbacks`
+  );
+}
+
+describe("GET /api/w/:wId/assistant/conversations/:cId/feedbacks", () => {
+  it("returns empty feedbacks when none exist", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const response = await getFeedbacks(workspace, conversation.sId);
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).feedbacks).toEqual([]);
+  });
+
+  it("returns feedbacks for the current user only", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    const user = auth.getNonNullableUser();
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date(), new Date()],
+    });
+
+    // rank 1 = first agent message, rank 3 = second agent message.
+    const msg1 = await getMessageByRank(auth, conversation.id, 1);
+    const msg2 = await getMessageByRank(auth, conversation.id, 3);
+    const { agentMessage: am1 } = await ConversationFactory.getMessage(
+      auth,
+      msg1.id
+    );
+    const { agentMessage: am2 } = await ConversationFactory.getMessage(
+      auth,
+      msg2.id
+    );
+
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: 0,
+      conversationId: conversation.id,
+      agentMessageId: am1!.id,
+      userId: user.id,
+      thumbDirection: "up",
+      content: "good",
+      isConversationShared: false,
+      dismissed: false,
+    });
+
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: 0,
+      conversationId: conversation.id,
+      agentMessageId: am2!.id,
+      userId: user.id,
+      thumbDirection: "down",
+      content: "bad",
+      isConversationShared: false,
+      dismissed: false,
+    });
+
+    const response = await getFeedbacks(workspace, conversation.sId);
+
+    expect(response.status).toBe(200);
+
+    const feedbacks = (await response.json()).feedbacks;
+    expect(feedbacks).toHaveLength(2);
+
+    const directions = feedbacks.map(
+      (f: { thumbDirection: string }) => f.thumbDirection
+    );
+    expect(directions).toContain("up");
+    expect(directions).toContain("down");
+  });
+
+  it("does not return feedbacks from other conversations", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    const user = auth.getNonNullableUser();
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    const conversation1 = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const conversation2 = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const msg = await getMessageByRank(auth, conversation2.id, 1);
+    const { agentMessage } = await ConversationFactory.getMessage(auth, msg.id);
+
+    await AgentMessageFeedbackResource.makeNew({
+      workspaceId: workspace.id,
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: 0,
+      conversationId: conversation2.id,
+      agentMessageId: agentMessage!.id,
+      userId: user.id,
+      thumbDirection: "up",
+      content: null,
+      isConversationShared: false,
+      dismissed: false,
+    });
+
+    // Query feedbacks for conversation1: should be empty.
+    const response = await getFeedbacks(workspace, conversation1.sId);
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).feedbacks).toEqual([]);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
@@ -1,0 +1,36 @@
+import { Hono } from "hono";
+
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationFeedbacksForUser } from "@app/lib/api/assistant/feedback";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+
+import { jsonApiError } from "@front-api/middleware/utils";
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/feedbacks.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const conversationId = c.req.param("cId") ?? "";
+
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+  if (conversationRes.isErr()) {
+    return jsonApiError(c, getConversationApiError(conversationRes.error));
+  }
+
+  const feedbacksRes = await getConversationFeedbacksForUser(
+    auth,
+    conversationRes.value
+  );
+  if (feedbacksRes.isErr()) {
+    return jsonApiError(c, getConversationApiError(feedbacksRes.error));
+  }
+
+  return c.json({ feedbacks: feedbacksRes.value });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -1,0 +1,236 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { getConversationUrlAccessMode } from "@app/types/assistant/conversation";
+
+import { honoApp } from "@front-api/app";
+
+async function setupUserRequestWithConversation({
+  privateByDefaultEnabled,
+}: {
+  privateByDefaultEnabled: boolean;
+}) {
+  const { workspace, auth, user, globalSpace } =
+    await createPrivateApiMockRequest({
+      role: "user",
+      method: "GET",
+    });
+
+  const adminUser = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+  const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    adminUser.sId,
+    workspace.sId
+  );
+
+  const conversation = await ConversationFactory.create(adminAuth, {
+    agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    requestedSpaceIds: [globalSpace.id],
+    messagesCreatedAt: [new Date()],
+  });
+
+  const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+    privateConversationUrlsByDefault: privateByDefaultEnabled,
+  });
+  assert(
+    updateResult.isOk(),
+    "Failed to update private conversation URLs setting"
+  );
+
+  return { workspace, auth, user, conversation };
+}
+
+function getConversation(workspace: { sId: string }, cId: string) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/${cId}`
+  );
+}
+
+function patchConversation(
+  workspace: { sId: string },
+  cId: string,
+  body: unknown
+) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/${cId}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("GET /api/w/:wId/assistant/conversations/:cId", () => {
+  it("returns 200 for non-participants when private conversation URLs are disabled", async () => {
+    const { workspace, conversation } = await setupUserRequestWithConversation({
+      privateByDefaultEnabled: false,
+    });
+
+    const response = await getConversation(workspace, conversation.sId);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 404 conversation_not_found for non-participants when private conversation URLs are enabled", async () => {
+    const { workspace, conversation } = await setupUserRequestWithConversation({
+      privateByDefaultEnabled: true,
+    });
+
+    const response = await getConversation(workspace, conversation.sId);
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("conversation_not_found");
+  });
+
+  it("returns 200 for participants when private conversation URLs are enabled", async () => {
+    const { workspace, auth, user, conversation } =
+      await setupUserRequestWithConversation({
+        privateByDefaultEnabled: true,
+      });
+
+    await ConversationResource.upsertParticipation(auth, {
+      conversation,
+      action: "posted",
+      user: user.toJSON(),
+      lastReadAt: null,
+    });
+
+    const response = await getConversation(workspace, conversation.sId);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 200 for project conversations for non-participants when private conversation URLs are enabled", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      role: "user",
+      method: "GET",
+    });
+
+    const adminUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const projectSpace = await SpaceFactory.project(workspace, adminUser.id);
+    const addMemberResult = await projectSpace.addMembers(adminAuth, {
+      userIds: [adminUser.sId, user.sId],
+    });
+    assert(addMemberResult.isOk(), "Failed to add users to project space");
+    const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const conversation = await ConversationFactory.create(refreshedAdminAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [projectSpace.id],
+      spaceId: projectSpace.id,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(
+      updateResult.isOk(),
+      "Failed to enable private conversation URLs setting"
+    );
+
+    const response = await getConversation(workspace, conversation.sId);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 404 conversation_not_found for admins when private conversation URLs are enabled and they are not participants", async () => {
+    const { workspace, globalSpace } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "GET",
+    });
+
+    const regularUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, regularUser, { role: "user" });
+    const regularUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      regularUser.sId,
+      workspace.sId
+    );
+
+    const conversation = await ConversationFactory.create(regularUserAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [globalSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(
+      updateResult.isOk(),
+      "Failed to update private conversation URLs setting"
+    );
+
+    const response = await getConversation(workspace, conversation.sId);
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("conversation_not_found");
+  });
+});
+
+describe("PATCH /api/w/:wId/assistant/conversations/:cId", () => {
+  it("updates conversation URL access mode", async () => {
+    const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "PATCH",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [globalSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+
+    const response = await patchConversation(workspace, conversation.sId, {
+      accessMode: "workspace_members",
+    });
+
+    expect(response.status).toBe(200);
+
+    const updatedConversation = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    assert(updatedConversation, "Expected conversation to exist");
+    expect(getConversationUrlAccessMode(updatedConversation.metadata)).toBe(
+      "workspace_members"
+    );
+  });
+
+  it("returns 400 on unsupported URL access mode", async () => {
+    const { workspace, auth, globalSpace } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "PATCH",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      requestedSpaceIds: [globalSpace.id],
+      messagesCreatedAt: [new Date()],
+    });
+
+    const response = await patchConversation(workspace, conversation.sId, {
+      accessMode: "everyone",
+    });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,0 +1,276 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { deleteOrLeaveConversation } from "@app/lib/api/assistant/conversation";
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import {
+  moveConversationOutOfProject,
+  moveConversationToProject,
+} from "@app/lib/api/projects/conversations";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+import { jsonApiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+import attachments from "./attachments";
+import cancel from "./cancel";
+import compactions from "./compactions";
+import contextUsage from "./context-usage";
+import feedbacks from "./feedbacks";
+import onboardingFollowup from "./onboarding-followup";
+import participants from "./participants";
+import planMode from "./plan_mode";
+import skills from "./skills";
+import suggest from "./suggest";
+import tools from "./tools";
+
+const PatchConversationsRequestBodySchema = z.union([
+  z.object({ title: z.string() }),
+  z.object({ read: z.boolean() }),
+  z.object({ spaceId: z.string() }),
+  z.object({
+    accessMode: z.enum(["participants_only", "workspace_members"]),
+  }),
+  z.object({ removeFromProject: z.literal(true) }),
+]);
+
+// Mounted under /api/w/:wId/assistant/conversations/:cId. The bare `/`
+// handles GET, DELETE, and PATCH on the conversation resource itself.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const cId = c.req.param("cId") ?? "";
+
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(auth, cId, {
+      includeForkingData: true,
+    });
+
+  if (conversationRes.isErr()) {
+    // Distinguish between "not found" and "access restricted" for the UI.
+    const canAccess = await ConversationResource.canAccess(auth, cId);
+    const error =
+      canAccess === "conversation_access_restricted"
+        ? new ConversationError("conversation_access_restricted")
+        : conversationRes.error;
+    return jsonApiError(c, getConversationApiError(error));
+  }
+
+  const conversation = conversationRes.value;
+
+  void emitAuditLogEvent({
+    auth,
+    action: "conversation.accessed",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("conversation", {
+        sId: conversation.sId,
+        name: conversation.title ?? "",
+      }),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      conversation_id: conversation.sId,
+    },
+  });
+
+  return c.json({ conversation });
+});
+
+app.delete("/", async (c) => {
+  const auth = c.get("auth");
+  const cId = c.req.param("cId") ?? "";
+  const forceDelete = c.req.query("forceDelete") === "true";
+
+  const result = await deleteOrLeaveConversation(auth, {
+    conversationId: cId,
+    forceDelete,
+  });
+  if (result.isErr()) {
+    return jsonApiError(c, getConversationApiError(result.error));
+  }
+
+  return c.body(null, 200);
+});
+
+app.patch(
+  "/",
+  validate("json", PatchConversationsRequestBodySchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const cId = c.req.param("cId") ?? "";
+
+    const conversationRes =
+      await ConversationResource.fetchConversationWithoutContent(auth, cId);
+    if (conversationRes.isErr()) {
+      return jsonApiError(c, getConversationApiError(conversationRes.error));
+    }
+
+    const conversation = conversationRes.value;
+    const data = c.req.valid("json");
+
+    if ("title" in data) {
+      const result = await updateConversationTitle(auth, {
+        conversationId: conversation.sId,
+        title: data.title,
+      });
+      await ConversationResource.markAsReadForAuthUser(auth, { conversation });
+
+      if (result.isErr()) {
+        return jsonApiError(c, getConversationApiError(result.error));
+      }
+      return c.json({ success: true });
+    }
+
+    if ("read" in data) {
+      if (data.read) {
+        await ConversationResource.markAsReadForAuthUser(auth, {
+          conversation,
+        });
+      } else {
+        await ConversationResource.markAsUnreadForAuthUser(auth, {
+          conversation,
+        });
+      }
+      return c.json({ success: true });
+    }
+
+    if ("spaceId" in data) {
+      const r = await moveConversationToProject(auth, {
+        conversation,
+        spaceId: data.spaceId,
+      });
+      if (r.isOk()) {
+        return c.json({ success: true });
+      }
+      switch (r.error.code) {
+        case "unauthorized":
+          return c.json(
+            {
+              error: { type: "user_not_found", message: r.error.message },
+            },
+            404
+          );
+        case "space_not_found":
+          return c.json(
+            {
+              error: { type: "space_not_found", message: "Space not found" },
+            },
+            404
+          );
+        case "conversation_not_found":
+          return c.json(
+            {
+              error: {
+                type: "conversation_not_found",
+                message: "Conversation not found",
+              },
+            },
+            404
+          );
+        case "internal_error":
+          return c.json(
+            {
+              error: {
+                type: "internal_server_error",
+                message: "Internal server error",
+              },
+            },
+            500
+          );
+        default:
+          assertNever(r.error.code);
+      }
+    }
+
+    if ("accessMode" in data) {
+      const result = await ConversationResource.updateUrlAccessMode(
+        auth,
+        conversation.sId,
+        data.accessMode
+      );
+      if (result.isErr()) {
+        return jsonApiError(c, getConversationApiError(result.error));
+      }
+      return c.json({ success: true });
+    }
+
+    if ("removeFromProject" in data) {
+      const r = await moveConversationOutOfProject(auth, { conversation });
+      if (r.isOk()) {
+        return c.json({ success: true });
+      }
+      switch (r.error.code) {
+        case "unauthorized":
+          return c.json(
+            {
+              error: { type: "user_not_found", message: r.error.message },
+            },
+            404
+          );
+        case "space_not_found":
+          return c.json(
+            {
+              error: { type: "space_not_found", message: "Space not found" },
+            },
+            404
+          );
+        case "conversation_not_found":
+          return c.json(
+            {
+              error: {
+                type: "conversation_not_found",
+                message: "Conversation not found",
+              },
+            },
+            404
+          );
+        case "internal_error":
+          return c.json(
+            {
+              error: {
+                type: "internal_server_error",
+                message: "Internal server error",
+              },
+            },
+            500
+          );
+        default:
+          assertNever(r.error.code);
+      }
+    }
+
+    return c.json(
+      {
+        error: {
+          type: "invalid_request_error",
+          message: "Invalid request body",
+        },
+      },
+      400
+    );
+  }
+);
+
+app.route("/attachments", attachments);
+app.route("/cancel", cancel);
+app.route("/compactions", compactions);
+app.route("/context-usage", contextUsage);
+app.route("/feedbacks", feedbacks);
+app.route("/onboarding-followup", onboardingFollowup);
+app.route("/participants", participants);
+app.route("/plan_mode", planMode);
+app.route("/skills", skills);
+app.route("/suggest", suggest);
+app.route("/tools", tools);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -1,0 +1,76 @@
+import { Hono } from "hono";
+
+import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
+import { postUserMessage } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { buildOnboardingFollowUpPrompt } from "@app/lib/api/assistant/onboarding";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { isString } from "@app/types/shared/utils/general";
+
+import { jsonApiError } from "@front-api/middleware/utils";
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/onboarding-followup.
+const app = new Hono();
+
+app.post("/", async (c) => {
+  const auth = c.get("auth");
+  const user = auth.getNonNullableUser();
+  const conversationId = c.req.param("cId") ?? "";
+
+  const body = await c.req.json().catch(() => ({}));
+  const { toolId } = body;
+
+  if (!isString(toolId) || !isInternalMCPServerName(toolId)) {
+    return c.json(
+      {
+        error: {
+          type: "invalid_request_error",
+          message:
+            "Invalid request body, `toolId` (valid tool id) is required.",
+        },
+      },
+      400
+    );
+  }
+
+  const conversationRes = await getConversation(auth, conversationId);
+  if (conversationRes.isErr()) {
+    return jsonApiError(c, getConversationApiError(conversationRes.error));
+  }
+
+  const conversation = conversationRes.value;
+
+  // Extract user's preferred language from Accept-Language header.
+  const acceptLanguage = c.req.header("accept-language");
+  const language = acceptLanguage?.split(",")[0]?.split("-")[0] ?? null;
+
+  const followUpPrompt = buildOnboardingFollowUpPrompt(toolId, language);
+
+  const messageRes = await postUserMessage(auth, {
+    conversation,
+    content: followUpPrompt,
+    mentions: [
+      {
+        configurationId: GLOBAL_AGENTS_SID.DUST,
+      },
+    ],
+    context: {
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      username: user.username,
+      fullName: user.fullName(),
+      email: user.email,
+      profilePictureUrl: user.imageUrl,
+      origin: "onboarding_conversation",
+    },
+    skipToolsValidation: false,
+  });
+
+  if (messageRes.isErr()) {
+    return jsonApiError(c, messageRes.error);
+  }
+
+  return c.json({ agentMessages: messageRes.value.agentMessages });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -1,0 +1,97 @@
+import { Hono } from "hono";
+
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { fetchConversationParticipants } from "@app/lib/api/assistant/participants";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationError } from "@app/types/assistant/conversation";
+
+import { jsonApiError } from "@front-api/middleware/utils";
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/participants.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const conversationId = c.req.param("cId") ?? "";
+
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+  if (conversationRes.isErr()) {
+    return jsonApiError(c, getConversationApiError(conversationRes.error));
+  }
+
+  const participantsRes = await fetchConversationParticipants(
+    auth,
+    conversationRes.value
+  );
+  if (participantsRes.isErr()) {
+    return c.json(
+      {
+        error: {
+          type: "conversation_not_found",
+          message: "Conversation not found",
+        },
+      },
+      404
+    );
+  }
+
+  return c.json({ participants: participantsRes.value });
+});
+
+app.post("/", async (c) => {
+  const auth = c.get("auth");
+  const conversationId = c.req.param("cId") ?? "";
+
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+  if (conversationRes.isErr()) {
+    return jsonApiError(c, getConversationApiError(conversationRes.error));
+  }
+
+  const conversation = conversationRes.value;
+  const u = auth.user();
+  if (!u) {
+    return c.json(
+      {
+        error: {
+          type: "app_auth_error",
+          message: "User not authenticated",
+        },
+      },
+      401
+    );
+  }
+
+  const user = u.toJSON();
+
+  const isAlreadyParticipant =
+    await ConversationResource.isConversationParticipant(auth, {
+      conversation,
+      user,
+    });
+
+  if (isAlreadyParticipant) {
+    return jsonApiError(
+      c,
+      getConversationApiError(new ConversationError("user_already_participant"))
+    );
+  }
+
+  await ConversationResource.upsertParticipation(auth, {
+    conversation,
+    user,
+    action: "subscribed",
+    lastReadAt: new Date(),
+  });
+
+  return c.body(null, 201);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
@@ -1,73 +1,39 @@
-/** @ignoreswagger
- * Internal endpoint used by the UI to read the conversation's active plan file. Undocumented.
- */
-// @migration-status: MIGRATED_TO_HONO
+import { Hono } from "hono";
+
 import {
   PLAN_MODE_SERVER_NAME,
   REQUEST_PLAN_APPROVAL_TOOL_NAME,
 } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
 import { findActivePlanFile } from "@app/lib/api/assistant/plan_mode";
-import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getFileContent } from "@app/lib/api/files/utils";
-import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types/error";
-import type { FileType } from "@app/types/files";
-import { isString } from "@app/types/shared/utils/general";
-import type { NextApiRequest, NextApiResponse } from "next";
+
+import { jsonApiError } from "@front-api/middleware/utils";
 
 export type PlanApprovalState = "draft" | "pending" | "approved";
 
-export type GetConversationPlanModeResponseBody = {
-  planFile: FileType | null;
-  content: string | null;
-  approvalState: PlanApprovalState;
-};
+// Mounted at /api/w/:wId/assistant/conversations/:cId/plan_mode.
+const app = new Hono();
 
-async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<GetConversationPlanModeResponseBody>
-  >,
-  auth: Authenticator
-): Promise<void> {
-  if (req.method !== "GET") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message: "Only GET method is supported.",
-      },
-    });
-  }
-
-  const { cId } = req.query;
-  if (!isString(cId)) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid query parameters, `cId` (string) is required.",
-      },
-    });
-  }
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const cId = c.req.param("cId") ?? "";
 
   // Ensure the caller has access to the conversation.
   const conversationRes = await getLightConversation(auth, cId);
   if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
+    return jsonApiError(c, getConversationApiError(conversationRes.error));
   }
 
   const planFile = await findActivePlanFile(auth, cId);
   if (!planFile) {
-    return res.status(200).json({
+    return c.json({
       planFile: null,
       content: null,
-      approvalState: "draft",
+      approvalState: "draft" as PlanApprovalState,
     });
   }
 
@@ -93,11 +59,11 @@ async function handler(
       ? "approved"
       : "draft";
 
-  return res.status(200).json({
+  return c.json({
     planFile: planFile.toJSON(auth),
     content,
     approvalState,
   });
-}
+});
 
-export default withSessionAuthenticationForWorkspace(handler);
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -1,0 +1,113 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import logger from "@app/logger/logger";
+
+import { jsonApiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+const ConversationSkillActionRequestSchema = z.object({
+  action: z.enum(["add", "delete"]),
+  skillId: z.string(),
+});
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/skills.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const conversationId = c.req.param("cId") ?? "";
+
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+  if (conversationRes.isErr()) {
+    return jsonApiError(c, getConversationApiError(conversationRes.error));
+  }
+
+  const conversationSkills = await SkillResource.listEnabledByConversation(
+    auth,
+    { conversation: conversationRes.value }
+  );
+
+  return c.json({ skills: conversationSkills.map((s) => s.toJSON(auth)) });
+});
+
+app.post(
+  "/",
+  validate("json", ConversationSkillActionRequestSchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const conversationId = c.req.param("cId") ?? "";
+
+    const conversationRes =
+      await ConversationResource.fetchConversationWithoutContent(
+        auth,
+        conversationId
+      );
+    if (conversationRes.isErr()) {
+      return jsonApiError(c, getConversationApiError(conversationRes.error));
+    }
+
+    const conversationWithoutContent = conversationRes.value;
+    const { action, skillId } = c.req.valid("json");
+
+    const skillRes = await SkillResource.fetchById(auth, skillId);
+
+    if (!skillRes) {
+      logger.error(
+        {
+          skillId,
+          conversationId,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+        },
+        "Skill not found"
+      );
+      return c.json(
+        {
+          error: {
+            type: "skill_not_found",
+            message: "Skill not found",
+          },
+        },
+        404
+      );
+    }
+
+    const r = await SkillResource.upsertConversationSkills(auth, {
+      conversationId: conversationWithoutContent.id,
+      skills: [skillRes],
+      enabled: action === "add",
+    });
+    if (r.isErr()) {
+      logger.error(
+        {
+          error: r.error,
+          skillId,
+          conversationId,
+          action,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+        },
+        "Failed to upsert skill to conversation"
+      );
+      return c.json(
+        {
+          error: {
+            type: "internal_server_error",
+            message: "Failed to add skill to conversation",
+          },
+        },
+        500
+      );
+    }
+
+    return c.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/suggest.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/suggest.ts
@@ -1,0 +1,12 @@
+import { Hono } from "hono";
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/suggest.
+// Kept alive for backward compatibility with older clients while the
+// underlying suggestion feature has been removed.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  return c.json({ agentConfigurations: [] });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.test.ts
@@ -1,0 +1,400 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { MembershipRoleType } from "@app/types/memberships";
+
+import { honoApp } from "@front-api/app";
+
+async function setupTest(role: MembershipRoleType = "admin") {
+  const { workspace, auth, globalSpace, systemSpace } =
+    await createPrivateApiMockRequest({ role });
+
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    messagesCreatedAt: [new Date()],
+  });
+
+  return { auth, conversation, globalSpace, systemSpace, workspace };
+}
+
+function getTools(workspace: { sId: string }, cId: string) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/${cId}/tools`
+  );
+}
+
+function postTools(workspace: { sId: string }, cId: string, body: unknown) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/${cId}/tools`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("GET /api/w/:wId/assistant/conversations/:cId/tools", () => {
+  it("should return empty tools list when no tools are enabled", async () => {
+    const { workspace, conversation } = await setupTest("admin");
+
+    const response = await getTools(workspace, conversation.sId);
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).tools).toEqual([]);
+  });
+
+  it("should return enabled tools for a conversation", async () => {
+    const { workspace, globalSpace, conversation, auth } =
+      await setupTest("admin");
+
+    const remoteMCPServer1 = await RemoteMCPServerFactory.create(workspace);
+    const remoteMCPServer2 = await RemoteMCPServerFactory.create(workspace);
+
+    const systemView1 =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        remoteMCPServer1.sId
+      );
+    assert(systemView1, "MCP server view not found");
+    const { view: mcpServerView1 } = await MCPServerViewResource.create(auth, {
+      systemView: systemView1,
+      space: globalSpace,
+    });
+    const systemView2 =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        remoteMCPServer2.sId
+      );
+    assert(systemView2, "MCP server view not found");
+    const { view: mcpServerView2 } = await MCPServerViewResource.create(auth, {
+      systemView: systemView2,
+      space: globalSpace,
+    });
+
+    await ConversationResource.upsertMCPServerViews(auth, {
+      conversation,
+      mcpServerViews: [mcpServerView1],
+      enabled: true,
+      source: "conversation",
+      agentConfigurationId: null,
+    });
+    await ConversationResource.upsertMCPServerViews(auth, {
+      conversation,
+      mcpServerViews: [mcpServerView2],
+      enabled: false,
+      source: "conversation",
+      agentConfigurationId: null,
+    });
+
+    const response = await getTools(workspace, conversation.sId);
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.tools).toHaveLength(1);
+    expect(responseData.tools[0].sId).toBe(mcpServerView1.sId);
+  });
+
+  it("should return 404 when conversation doesn't exist", async () => {
+    const { workspace } = await setupTest("admin");
+
+    const response = await getTools(workspace, "non-existent-conversation");
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("POST /api/w/:wId/assistant/conversations/:cId/tools", () => {
+  describe("add action", () => {
+    it("should add a new tool to conversation", async () => {
+      const { workspace, conversation, auth, globalSpace } =
+        await setupTest("admin");
+
+      const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          auth,
+          remoteMCPServer.sId
+        );
+      assert(systemView, "MCP server view not found");
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
+        systemView,
+        space: globalSpace,
+      });
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "add",
+        mcp_server_view_id: mcpServerView.sId,
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).success).toBe(true);
+
+      const relationship = await ConversationResource.fetchMCPServerViews(
+        auth,
+        conversation
+      );
+      expect(relationship).toHaveLength(1);
+      expect(relationship[0].enabled).toBe(true);
+    });
+
+    it("should enable existing disabled tool", async () => {
+      const { workspace, conversation, auth, globalSpace } =
+        await setupTest("admin");
+
+      const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          auth,
+          remoteMCPServer.sId
+        );
+      assert(systemView, "MCP server view not found");
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
+        systemView,
+        space: globalSpace,
+      });
+
+      await ConversationResource.upsertMCPServerViews(auth, {
+        conversation,
+        mcpServerViews: [mcpServerView],
+        enabled: false,
+        source: "conversation",
+        agentConfigurationId: null,
+      });
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "add",
+        mcp_server_view_id: mcpServerView.sId,
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).success).toBe(true);
+
+      const relationship = await ConversationResource.fetchMCPServerViews(
+        auth,
+        conversation
+      );
+      expect(relationship).toHaveLength(1);
+      expect(relationship[0].enabled).toBe(true);
+    });
+
+    it("should handle already enabled tool gracefully", async () => {
+      const { workspace, conversation, auth, globalSpace } =
+        await setupTest("admin");
+
+      const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          auth,
+          remoteMCPServer.sId
+        );
+      assert(systemView, "MCP server view not found");
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
+        systemView,
+        space: globalSpace,
+      });
+
+      await ConversationResource.upsertMCPServerViews(auth, {
+        conversation,
+        mcpServerViews: [mcpServerView],
+        enabled: true,
+        source: "conversation",
+        agentConfigurationId: null,
+      });
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "add",
+        mcp_server_view_id: mcpServerView.sId,
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).success).toBe(true);
+    });
+
+    it("should return 404 when MCP server view doesn't exist", async () => {
+      const { workspace, conversation } = await setupTest("admin");
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "add",
+        mcp_server_view_id: "non-existent-view",
+      });
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.type).toBe(
+        "mcp_server_view_not_found"
+      );
+    });
+  });
+
+  describe("delete action", () => {
+    it("should disable existing tool", async () => {
+      const { workspace, conversation, auth, globalSpace } =
+        await setupTest("admin");
+
+      const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          auth,
+          remoteMCPServer.sId
+        );
+      assert(systemView, "MCP server view not found");
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
+        systemView,
+        space: globalSpace,
+      });
+
+      await ConversationResource.upsertMCPServerViews(auth, {
+        conversation,
+        mcpServerViews: [mcpServerView],
+        enabled: true,
+        source: "conversation",
+        agentConfigurationId: null,
+      });
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "delete",
+        mcp_server_view_id: mcpServerView.sId,
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).success).toBe(true);
+
+      const relationship = await ConversationResource.fetchMCPServerViews(
+        auth,
+        conversation
+      );
+      expect(relationship).toHaveLength(1);
+      expect(relationship[0].enabled).toBe(false);
+    });
+
+    it("should handle non-existent relationship gracefully", async () => {
+      const { workspace, conversation, auth, globalSpace } =
+        await setupTest("admin");
+
+      const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          auth,
+          remoteMCPServer.sId
+        );
+      assert(systemView, "MCP server view not found");
+      const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
+        systemView,
+        space: globalSpace,
+      });
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "delete",
+        mcp_server_view_id: mcpServerView.sId,
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).success).toBe(true);
+    });
+
+    it("should return 404 when MCP server view doesn't exist", async () => {
+      const { workspace, conversation } = await setupTest("admin");
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "delete",
+        mcp_server_view_id: "non-existent-view",
+      });
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.type).toBe(
+        "mcp_server_view_not_found"
+      );
+    });
+  });
+
+  describe("validation", () => {
+    it("should return 400 for invalid request body", async () => {
+      const { workspace, conversation } = await setupTest("admin");
+
+      const response = await honoApp.request(
+        `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}/tools`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "null",
+        }
+      );
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
+
+    it("should return 400 for invalid action", async () => {
+      const { workspace, conversation } = await setupTest("admin");
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "invalid",
+        mcp_server_view_id: "some-id",
+      });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
+
+    it("should return 400 for missing mcp_server_view_id", async () => {
+      const { workspace, conversation } = await setupTest("admin");
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "add",
+      });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
+
+    it("should return 400 for non-string mcp_server_view_id", async () => {
+      const { workspace, conversation } = await setupTest("admin");
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "add",
+        mcp_server_view_id: 123,
+      });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
+  });
+
+  describe("permissions", () => {
+    it("should work for users with access to conversation", async () => {
+      const { workspace, conversation, globalSpace } = await setupTest("user");
+
+      const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const systemView =
+        await MCPServerViewResource.getMCPServerViewForSystemSpace(
+          adminAuth,
+          remoteMCPServer.sId
+        );
+      assert(systemView, "MCP server view not found");
+      const { view: mcpServerView } = await MCPServerViewResource.create(
+        adminAuth,
+        {
+          systemView,
+          space: globalSpace,
+        }
+      );
+
+      const response = await postTools(workspace, conversation.sId, {
+        action: "add",
+        mcp_server_view_id: mcpServerView.sId,
+      });
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).success).toBe(true);
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -1,0 +1,118 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { isString } from "@app/types/shared/utils/general";
+
+import { jsonApiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+const ConversationToolActionRequestSchema = z.object({
+  action: z.enum(["add", "delete"]),
+  mcp_server_view_id: z.string(),
+});
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/tools.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const conversationId = c.req.param("cId") ?? "";
+
+  const conversationRes =
+    await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      conversationId
+    );
+  if (conversationRes.isErr()) {
+    return jsonApiError(c, getConversationApiError(conversationRes.error));
+  }
+
+  const conversationWithoutContent = conversationRes.value;
+  const agentConfigurationId = c.req.query("agent_configuration_id");
+
+  const conversationMCPServerViews =
+    await ConversationResource.fetchMCPServerViews(
+      auth,
+      conversationWithoutContent,
+      {
+        onlyEnabled: true,
+        ...(isString(agentConfigurationId) ? { agentConfigurationId } : {}),
+      }
+    );
+
+  const mcpServerViewIds = conversationMCPServerViews.map(
+    (v) => v.mcpServerViewId
+  );
+  const mcpServerViews = await MCPServerViewResource.fetchByModelIds(
+    auth,
+    mcpServerViewIds
+  );
+
+  const tools = mcpServerViews.map((v) => v.toJSON());
+
+  return c.json({ tools });
+});
+
+app.post(
+  "/",
+  validate("json", ConversationToolActionRequestSchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const conversationId = c.req.param("cId") ?? "";
+
+    const conversationRes =
+      await ConversationResource.fetchConversationWithoutContent(
+        auth,
+        conversationId
+      );
+    if (conversationRes.isErr()) {
+      return jsonApiError(c, getConversationApiError(conversationRes.error));
+    }
+
+    const conversationWithoutContent = conversationRes.value;
+    const { action, mcp_server_view_id } = c.req.valid("json");
+
+    const mcpServerView = await MCPServerViewResource.fetchById(
+      auth,
+      mcp_server_view_id
+    );
+
+    if (!mcpServerView) {
+      return c.json(
+        {
+          error: {
+            type: "mcp_server_view_not_found",
+            message: "MCP server view not found",
+          },
+        },
+        404
+      );
+    }
+
+    const upsertResult = await ConversationResource.upsertMCPServerViews(auth, {
+      conversation: conversationWithoutContent,
+      mcpServerViews: [mcpServerView],
+      enabled: action === "add",
+      source: "conversation",
+      agentConfigurationId: null,
+    });
+    if (upsertResult.isErr()) {
+      return c.json(
+        {
+          error: {
+            type: "internal_server_error",
+            message: "Failed to add MCP server view to conversation",
+          },
+        },
+        500
+      );
+    }
+
+    return c.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono";
+
+import conversation from "./[cId]";
+
+// Mounted under /api/w/:wId/assistant/conversations.
+const app = new Hono();
+
+app.route("/:cId", conversation);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/index.ts
+++ b/front-api/routes/w/[wId]/assistant/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import builder from "./builder";
+import conversations from "./conversations";
 import mentions from "./mentions";
 import skills from "./skills";
 
@@ -9,6 +10,7 @@ import skills from "./skills";
 const app = new Hono();
 
 app.route("/builder", builder);
+app.route("/conversations", conversations);
 app.route("/mentions", mentions);
 app.route("/skills", skills);
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/attachments.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/attachments.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /**
  * @swagger
  * /api/w/{wId}/assistant/conversations/{cId}/cancel:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /**
  * @swagger
  * /api/w/{wId}/assistant/conversations/{cId}/compactions:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /**
  * @swagger
  * /api/w/{wId}/assistant/conversations/{cId}/feedbacks:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /**
  * @swagger
  * /api/w/{wId}/assistant/conversations/{cId}:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /**
  * @swagger
  * /api/w/{wId}/assistant/conversations/{cId}/participants:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/suggest.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/suggest.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";


### PR DESCRIPTION
## Description

Migrated:
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/attachments.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/context-usage.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/suggest.ts
  - front/pages/api/w/[wId]/assistant/conversations/[cId]/tools.ts

  Not migrated: events.ts (skipped to preserve SSE pod isolation).

## Tests

Migrated

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25740">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->