### PR TITLE
Truncate large pasted content snippet to 256 chars when bigger than 128K chars

### DIFF
--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -321,11 +321,22 @@ export function makeFileAttachment({
 export function renderLargePasteXml({
   largePaste,
   content,
+  truncated = false,
+  path,
 }: {
   largePaste: LargePasteType;
   content: string;
+  truncated?: boolean;
+  path?: string;
 }): string {
-  return `<pastedContent name="${largePaste.title}">${content}</pastedContent>`;
+  const attrs = [`name="${largePaste.title}"`];
+  if (truncated) {
+    attrs.push('truncated="true"');
+  }
+  if (path) {
+    attrs.push(`path="${path}"`);
+  }
+  return `<pastedContent ${attrs.join(" ")}>${content}</pastedContent>`;
 }
 
 export function renderAttachmentXml({

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -369,7 +369,7 @@ function constructAttachmentsSectionNewFileExplorer({
     "Some attachments remain visible in the conversation history as metadata tags:\n\n" +
     tabularFilesLine +
     "- Connected data references (content nodes with a `nodeId` and `sourceUrl`) appear as `<attachment>` tags; use the available search and retrieval tools to access their full content.\n\n" +
-    "Pasted content appears inline in `<pastedContent>` tags and already contains the full text, no tool call needed.\n"
+    'Pasted content appears inline in `<pastedContent>` tags and already contains the full text, no tool call needed unless it has `truncated="true"`.\n'
   );
 }
 
@@ -377,7 +377,7 @@ function constructPastedContentSection(): string {
   return (
     "# PASTED CONTENT\n" +
     "The conversation history may contain large pasted contents, indicated by <pastedContent> tags. " +
-    "These tags contain the full content of the pasted content, so don't try to retrieve it with tools.\n"
+    'These tags contain the full content of the pasted content, so don\'t try to retrieve it with tools unless it has `truncated="true"`.\n'
   );
 }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -22,6 +22,10 @@ import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/global_agents";
 import type { EnabledSkill } from "@app/lib/api/assistant/skills_rendering";
+import {
+  PASTED_CONTENT_MAX_CHARACTERS,
+  TRUNCATED_SNIPPET_SIZE,
+} from "@app/lib/api/files/snippet";
 import type {
   StructuredSystemPrompt,
   SystemPromptContext,
@@ -368,8 +372,7 @@ function constructAttachmentsSectionNewFileExplorer({
     `Files attached to the conversation are accessible via the \`${FILES_SERVER_NAME}\` server.\n\n` +
     "Some attachments remain visible in the conversation history as metadata tags:\n\n" +
     tabularFilesLine +
-    "- Connected data references (content nodes with a `nodeId` and `sourceUrl`) appear as `<attachment>` tags; use the available search and retrieval tools to access their full content.\n\n" +
-    'Pasted content appears inline in `<pastedContent>` tags and already contains the full text, no tool call needed unless it has `truncated="true"`.\n'
+    "- Connected data references (content nodes with a `nodeId` and `sourceUrl`) appear as `<attachment>` tags; use the available search and retrieval tools to access their full content.\n"
   );
 }
 
@@ -377,7 +380,8 @@ function constructPastedContentSection(): string {
   return (
     "# PASTED CONTENT\n" +
     "The conversation history may contain large pasted contents, indicated by <pastedContent> tags. " +
-    'These tags contain the full content of the pasted content, so don\'t try to retrieve it with tools unless it has `truncated="true"`.\n'
+    `Pasted content below ${PASTED_CONTENT_MAX_CHARACTERS} chars contains the full text (no tool call needed). ` +
+    `Above ${PASTED_CONTENT_MAX_CHARACTERS} chars, the attribute \`truncated="true"\` is set, only a ${TRUNCATED_SNIPPET_SIZE}-char snippet is shown, and the full pasted content can be accessed through file utilities on the associated file.\n`
   );
 }
 

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -16,6 +16,10 @@ import { Err, Ok } from "@app/types/shared/result";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { isSupportedPlainTextContentType } from "@dust-tt/client";
 
+export const PASTED_CONTENT_MAX_CHARACTERS = 128 * 1024;
+export const TRUNCATED_SUFFIX = "... (truncated)";
+const TRUNCATED_TEXT_SIZE = 256 - TRUNCATED_SUFFIX.length;
+
 export async function generateSnippet(
   auth: Authenticator,
   {
@@ -51,7 +55,7 @@ export async function generateSnippet(
 
     let snippet = `${file.contentType} file with headers: ${schemaRes.value.schema.map((c) => c.name).join(",")}`;
     if (snippet.length > 256) {
-      snippet = snippet.slice(0, 242) + "... (truncated)";
+      snippet = snippet.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX;
     }
 
     return new Ok(snippet);
@@ -64,13 +68,19 @@ export async function generateSnippet(
     }
 
     if (isPastedFile(file.contentType)) {
-      // Include all the text content, as if they were pasted directly in the conversation.
+      // Include the full pasted text up to 128K characters. Beyond that, truncate to 256
+      // characters like a regular text file to avoid blowing up the conversation context.
+      // We really want to avoid having a snippet which is both large and truncated,
+      // otherwise the model will pay the cost of the large snippet + read the file.
+      if (content.length > PASTED_CONTENT_MAX_CHARACTERS) {
+        return new Ok(content.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX);
+      }
       return new Ok(content);
     }
 
     // Take the first 256 characters
     if (content.length > 256) {
-      return new Ok(content.slice(0, 242) + "... (truncated)");
+      return new Ok(content.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX);
     } else {
       return new Ok(content);
     }
@@ -84,7 +94,7 @@ export async function generateSnippet(
 
     let snippet = `Audio file: ${content}`;
     if (snippet.length > 256) {
-      snippet = snippet.slice(0, 242) + "... (truncated)";
+      snippet = snippet.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX;
     }
 
     return new Ok(snippet);

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -18,7 +18,9 @@ import { isSupportedPlainTextContentType } from "@dust-tt/client";
 
 export const PASTED_CONTENT_MAX_CHARACTERS = 128 * 1024;
 export const TRUNCATED_SUFFIX = "... (truncated)";
-const TRUNCATED_TEXT_SIZE = 256 - TRUNCATED_SUFFIX.length;
+export const TRUNCATED_SNIPPET_SIZE = 256;
+export const TRUNCATED_TEXT_SIZE =
+  TRUNCATED_SNIPPET_SIZE - TRUNCATED_SUFFIX.length;
 
 export async function generateSnippet(
   auth: Authenticator,
@@ -54,7 +56,7 @@ export async function generateSnippet(
     }
 
     let snippet = `${file.contentType} file with headers: ${schemaRes.value.schema.map((c) => c.name).join(",")}`;
-    if (snippet.length > 256) {
+    if (snippet.length > TRUNCATED_SNIPPET_SIZE) {
       snippet = snippet.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX;
     }
 
@@ -79,7 +81,7 @@ export async function generateSnippet(
     }
 
     // Take the first 256 characters
-    if (content.length > 256) {
+    if (content.length > TRUNCATED_SNIPPET_SIZE) {
       return new Ok(content.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX);
     } else {
       return new Ok(content);
@@ -93,7 +95,7 @@ export async function generateSnippet(
     }
 
     let snippet = `Audio file: ${content}`;
-    if (snippet.length > 256) {
+    if (snippet.length > TRUNCATED_SNIPPET_SIZE) {
       snippet = snippet.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX;
     }
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -1,19 +1,20 @@
 import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
-import type {
-  ConversationAttachmentType,
-  LargePasteType,
-} from "@app/lib/api/assistant/conversation/attachments";
+import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   conversationAttachmentId,
   getAttachmentFromContentFragment,
   isContentNodeAttachmentType,
+  isFileAttachmentType,
   renderAttachmentXml,
   renderLargePasteXml,
 } from "@app/lib/api/assistant/conversation/attachments";
 import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
-
 import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import {
+  PASTED_CONTENT_MAX_CHARACTERS,
+  TRUNCATED_SUFFIX,
+} from "@app/lib/api/files/snippet";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -1160,9 +1161,10 @@ export async function getContentFragmentFromAttachmentFile(
 
     // Check if this is a pasted content (large paste) - use simplified XML format
     if (isPastedFile(attachment.contentType)) {
-      const largePaste: LargePasteType = {
-        title: attachment.title,
-      };
+      const truncated = content.length > PASTED_CONTENT_MAX_CHARACTERS;
+      const truncatedContent = truncated
+        ? content.slice(0, 256 - TRUNCATED_SUFFIX.length) + TRUNCATED_SUFFIX
+        : content;
 
       return new Ok({
         role: "content_fragment",
@@ -1171,8 +1173,15 @@ export async function getContentFragmentFromAttachmentFile(
           {
             type: "text",
             text: renderLargePasteXml({
-              largePaste,
-              content,
+              largePaste: { title: attachment.title },
+              content: truncatedContent,
+              truncated,
+              // Show path only when truncated so the model can read the full file.
+              path: truncated
+                ? ((isFileAttachmentType(attachment)
+                    ? attachment.path
+                    : null) ?? `conversation/${attachment.title}`)
+                : undefined,
             }),
           },
         ],
@@ -1271,6 +1280,9 @@ export async function renderLightContentFragmentForModel(
 
   // Pasted content is always inlined regardless of feature flags.
   if (fileStringId && isPastedFile(contentType)) {
+    const snippet = attachment.snippet ?? "";
+    const truncated =
+      snippet.length === 256 && snippet.endsWith(TRUNCATED_SUFFIX);
     return {
       role: "content_fragment",
       name: `attach_pasted_content`,
@@ -1279,7 +1291,13 @@ export async function renderLightContentFragmentForModel(
           type: "text",
           text: renderLargePasteXml({
             largePaste: { title: attachment.title },
-            content: attachment.snippet ?? "",
+            content: snippet,
+            truncated,
+            // Show path only when truncated so the model can read the full file.
+            path: truncated
+              ? ((isFileAttachmentType(attachment) ? attachment.path : null) ??
+                `conversation/${attachment.title}`)
+              : undefined,
           }),
         },
       ],

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -13,7 +13,9 @@ import config from "@app/lib/api/config";
 import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import {
   PASTED_CONTENT_MAX_CHARACTERS,
+  TRUNCATED_SNIPPET_SIZE,
   TRUNCATED_SUFFIX,
+  TRUNCATED_TEXT_SIZE,
 } from "@app/lib/api/files/snippet";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -1163,7 +1165,7 @@ export async function getContentFragmentFromAttachmentFile(
     if (isPastedFile(attachment.contentType)) {
       const truncated = content.length > PASTED_CONTENT_MAX_CHARACTERS;
       const truncatedContent = truncated
-        ? content.slice(0, 256 - TRUNCATED_SUFFIX.length) + TRUNCATED_SUFFIX
+        ? content.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX
         : content;
 
       return new Ok({
@@ -1282,7 +1284,8 @@ export async function renderLightContentFragmentForModel(
   if (fileStringId && isPastedFile(contentType)) {
     const snippet = attachment.snippet ?? "";
     const truncated =
-      snippet.length === 256 && snippet.endsWith(TRUNCATED_SUFFIX);
+      snippet.length === TRUNCATED_SNIPPET_SIZE &&
+      snippet.endsWith(TRUNCATED_SUFFIX);
     return {
       role: "content_fragment",
       name: `attach_pasted_content`,


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/7732

New behavior for pasted content is the following:
 - `<16K` characters: included directly in the message
 - `16K-128K`: put in a text file + the full snippet is included to avoid a call to read the file
 - `>128K`: Put in a text file but snippet truncated to 256 characters so the model must read the file.

## Tests
Tested locally:
 - the model does not call tool to read the file when less than 128K characters
 - it correctly uses the tool to read the file after 128K characters

## Risk



## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25741">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->