### PR TITLE
[metronome] feat: wire PAYG on the Metronome path

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -4,6 +4,7 @@ import {
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
 import { clientFetch } from "@app/lib/egress/client";
+import { isPaygEligibleTier } from "@app/lib/metronome/types";
 import {
   isEntreprisePlanPrefix,
   PRO_PLAN_SEAT_29_CODE,
@@ -27,6 +28,8 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  Label,
+  SliderToggle,
   Spinner,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -34,12 +37,29 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-const SwitchContractFormSchema = z.object({
-  metronomePackageId: z.string().min(1, "Required"),
-  planCode: z.string().min(1, "Required"),
-  startingAt: z.string().optional(),
-  stripeCustomerId: z.string().min(1, "Required"),
-});
+const MICRO_USD_PER_DOLLAR = 1_000_000;
+const MAX_PAYG_CAP_DOLLARS = 20_000;
+
+const SwitchContractFormSchema = z
+  .object({
+    metronomePackageId: z.string().min(1, "Required"),
+    planCode: z.string().min(1, "Required"),
+    startingAt: z.string().optional(),
+    stripeCustomerId: z.string().min(1, "Required"),
+    paygEnabled: z.boolean().default(false),
+    paygCapDollars: z
+      .number()
+      .min(1, "PAYG cap must be at least $1")
+      .max(
+        MAX_PAYG_CAP_DOLLARS,
+        `PAYG cap cannot exceed $${MAX_PAYG_CAP_DOLLARS.toLocaleString()}`
+      )
+      .optional(),
+  })
+  .refine((data) => !data.paygEnabled || data.paygCapDollars !== undefined, {
+    message: "PAYG cap is required when Pay-as-you-go is enabled.",
+    path: ["paygCapDollars"],
+  });
 type SwitchContractFormValues = z.infer<typeof SwitchContractFormSchema>;
 
 function snapDatetimeLocalToHour(value: string): string {
@@ -99,6 +119,8 @@ export default function SwitchContractDialog({
     );
   }, []);
 
+  const initialPaygCapMicroUsd =
+    programmaticUsageConfig?.paygCapMicroUsd ?? null;
   const form = useForm<SwitchContractFormValues>({
     resolver: zodResolver(SwitchContractFormSchema),
     defaultValues: {
@@ -106,6 +128,11 @@ export default function SwitchContractDialog({
       planCode: "",
       startingAt: "",
       stripeCustomerId: stripeCustomerId ?? "",
+      paygEnabled: initialPaygCapMicroUsd !== null,
+      paygCapDollars:
+        initialPaygCapMicroUsd !== null
+          ? initialPaygCapMicroUsd / MICRO_USD_PER_DOLLAR
+          : undefined,
     },
   });
 
@@ -164,7 +191,8 @@ export default function SwitchContractDialog({
 
   // When the operator picks a package, derive (Pro/Business) or reset
   // (Enterprise) the plan code. The full list of ENT_* plans is offered for
-  // enterprise; pro/business map to a single plan code.
+  // enterprise; pro/business map to a single plan code. PAYG is force-disabled
+  // for tiers that don't support it (currently: pro).
   useEffect(() => {
     if (selectedTier === "pro") {
       form.setValue("planCode", PRO_PLAN_SEAT_29_CODE);
@@ -175,6 +203,10 @@ export default function SwitchContractDialog({
     } else if (selectedTier === "enterprise") {
       form.setValue("planCode", "");
       form.setValue("startingAt", minStartingAtLocal);
+    }
+    if (selectedTier && !isPaygEligibleTier(selectedTier)) {
+      form.setValue("paygEnabled", false);
+      form.setValue("paygCapDollars", undefined);
     }
   }, [selectedTier, form, minStartingAtLocal]);
 
@@ -189,7 +221,9 @@ export default function SwitchContractDialog({
     [plans]
   );
 
-  const paygDisabled = !!programmaticUsageConfig?.paygCapMicroUsd;
+  const paygEnabled = form.watch("paygEnabled");
+  const paygEligible =
+    selectedTier !== null && isPaygEligibleTier(selectedTier);
 
   const onSubmit = useCallback(
     (values: SwitchContractFormValues) => {
@@ -197,7 +231,11 @@ export default function SwitchContractDialog({
         metronomePackageId: values.metronomePackageId.trim(),
         planCode: values.planCode.trim(),
         stripeCustomerId: values.stripeCustomerId.trim(),
+        paygEnabled: values.paygEnabled,
       };
+      if (values.paygEnabled && values.paygCapDollars !== undefined) {
+        cleaned.paygCapDollars = values.paygCapDollars;
+      }
       if (selectedTier === "enterprise" && values.startingAt) {
         // datetime-local strings have no timezone — convert to ISO so the
         // server's Date.parse is unambiguous.
@@ -239,11 +277,7 @@ export default function SwitchContractDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button
-          variant="outline"
-          label="🔁 Switch contract"
-          disabled={paygDisabled}
-        />
+        <Button variant="outline" label="🔁 Switch contract" />
       </DialogTrigger>
       <DialogContent className="bg-primary-50 dark:bg-primary-50-night sm:max-w-[600px]">
         <DialogHeader>
@@ -255,20 +289,13 @@ export default function SwitchContractDialog({
           </DialogDescription>
         </DialogHeader>
         <DialogContainer>
-          {paygDisabled && (
-            <div className="text-warning text-sm">
-              Cannot switch contract while Pay-as-you-go is enabled. Disable
-              PAYG via the "Manage Programmatic Usage Configuration" plugin
-              first.
-            </div>
-          )}
           {error && <div className="text-warning">{error}</div>}
           {isSubmitting && (
             <div className="flex justify-center">
               <Spinner size="lg" />
             </div>
           )}
-          {!isSubmitting && !paygDisabled && (
+          {!isSubmitting && (
             <PokeForm {...form}>
               <form
                 onSubmit={form.handleSubmit(onSubmit)}
@@ -342,6 +369,30 @@ export default function SwitchContractDialog({
                     <span className="font-mono">{form.watch("planCode")}</span>{" "}
                     — swap at the current hour, subscription flips
                     synchronously.
+                  </div>
+                )}
+                {paygEligible && (
+                  <div className="border-t pt-4">
+                    <div className="mb-4 flex items-center gap-2">
+                      <SliderToggle
+                        selected={paygEnabled}
+                        onClick={() =>
+                          form.setValue("paygEnabled", !paygEnabled)
+                        }
+                      />
+                      <Label className="text-sm">Pay-as-you-go</Label>
+                    </div>
+                    {paygEnabled && (
+                      <div className="ml-6">
+                        <InputField
+                          control={form.control}
+                          name="paygCapDollars"
+                          title="PAYG Spending Cap (USD)"
+                          type="number"
+                          placeholder="e.g., 1000"
+                        />
+                      </div>
+                    )}
                   </div>
                 )}
                 <DialogFooter>

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -1,3 +1,5 @@
+import { Authenticator } from "@app/lib/auth";
+import { isPAYGEnabled } from "@app/lib/credits/payg";
 import {
   clearUserCapBlocked,
   setUserCapBlocked,
@@ -11,11 +13,9 @@ import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 
-// TODO(remy): replace stub with real contract lookup once the PAYG
-// flag location on the Metronome contract is settled. Until then we treat
-// every workspace as non-PAYG: `pool_exhausted` always routes to `depleted`.
-async function isPaygEnabled(_workspace: WorkspaceResource): Promise<boolean> {
-  return false;
+async function isPaygEnabled(workspace: WorkspaceResource): Promise<boolean> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  return isPAYGEnabled(auth);
 }
 
 export async function dispatchPerUserCapReached({
@@ -127,6 +127,22 @@ export async function dispatchCreditsAdded({
   workspace: WorkspaceResource;
 }): Promise<void> {
   await transitionWorkspacePool(workspace, { type: "credits_added" });
+}
+
+export async function dispatchPaygDisabled({
+  workspace,
+}: {
+  workspace: WorkspaceResource;
+}): Promise<void> {
+  await transitionWorkspacePool(workspace, { type: "payg_disabled" });
+}
+
+export async function dispatchPaygEnabled({
+  workspace,
+}: {
+  workspace: WorkspaceResource;
+}): Promise<void> {
+  await transitionWorkspacePool(workspace, { type: "payg_enabled" });
 }
 
 async function transitionWorkspacePool(

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -1,4 +1,8 @@
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
+import {
+  dispatchPaygDisabled,
+  dispatchPaygEnabled,
+} from "@app/lib/api/metronome/credit_state_dispatcher";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { getDefaultDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/daily_cap";
 import type { Authenticator } from "@app/lib/auth";
@@ -11,10 +15,20 @@ import {
   stopEnterprisePAYG,
 } from "@app/lib/credits/payg";
 import {
+  clearMetronomePaygCapAlert,
+  syncMetronomePaygCapAlert,
+} from "@app/lib/metronome/payg_alerts";
+import { PAYG_ELIGIBLE_TIERS } from "@app/lib/metronome/types";
+import {
+  isEntreprisePlanPrefix,
+  PRO_PLAN_SEAT_39_CODE,
+} from "@app/lib/plans/plan_codes";
+import {
   getStripeSubscription,
   isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
@@ -174,7 +188,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
         variant: "toggle",
         label: "Pay-as-you-go",
         description:
-          "Enable pay-as-you-go billing (enterprise only). When enabled, programmatic usage will still be possible after free and committed credits are exhausted. Requires a spending cap.",
+          "Enable pay-as-you-go billing. When enabled, programmatic usage will still be possible after free and committed credits are exhausted. Requires a spending cap. Available for enterprise (Stripe or Metronome) and business (Metronome only).",
         async: true,
       },
       paygCapDollars: {
@@ -290,13 +304,28 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
     }
 
     if (paygEnabled) {
-      if (
-        !stripeSubscription ||
-        !isEnterpriseSubscription(stripeSubscription)
-      ) {
-        return new Err(
-          new Error("PAYG can only be enabled for enterprise subscriptions.")
-        );
+      if (stripeSubscription) {
+        if (!isEnterpriseSubscription(stripeSubscription)) {
+          return new Err(
+            new Error(
+              "PAYG can only be enabled for enterprise Stripe subscriptions."
+            )
+          );
+        }
+      } else {
+        const planCode = subscription?.plan.code ?? "";
+        const isEligible =
+          isEntreprisePlanPrefix(planCode) ||
+          planCode === PRO_PLAN_SEAT_39_CODE;
+        if (!isEligible) {
+          return new Err(
+            new Error(
+              `PAYG can only be enabled for ${PAYG_ELIGIBLE_TIERS.join(
+                " or "
+              )} plans.`
+            )
+          );
+        }
       }
     }
 
@@ -340,32 +369,84 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       }
     }
 
-    // Handle PAYG enable/disable
-    if (paygEnabled && stripeSubscription) {
+    const workspace = auth.getNonNullableWorkspace();
+    if (paygEnabled) {
       assert(
         paygCapDollars !== undefined,
         "[Unreachable] PaygEnabled but paygCapDollars undefined"
       );
       const paygCapMicroUsd = Math.round(paygCapDollars * 1_000_000);
-      const paygResult = await startOrResumeEnterprisePAYG({
-        auth,
-        stripeSubscription,
-        paygCapMicroUsd,
-      });
-      if (paygResult.isErr()) {
-        return paygResult;
-      }
-    } else {
-      // Check if PAYG was previously enabled and needs to be stopped
-      const refreshedConfig =
-        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-      if (refreshedConfig?.paygCapMicroUsd !== null && stripeSubscription) {
-        const stopResult = await stopEnterprisePAYG({
+      if (stripeSubscription) {
+        const paygResult = await startOrResumeEnterprisePAYG({
           auth,
           stripeSubscription,
+          paygCapMicroUsd,
         });
-        if (stopResult.isErr()) {
-          return stopResult;
+        if (paygResult.isErr()) {
+          return paygResult;
+        }
+      } else {
+        const refreshedConfig =
+          await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+        if (refreshedConfig) {
+          const updateResult = await refreshedConfig.updateConfiguration(auth, {
+            paygCapMicroUsd,
+          });
+          if (updateResult.isErr()) {
+            return updateResult;
+          }
+        }
+        if (workspace.metronomeCustomerId) {
+          const alertResult = await syncMetronomePaygCapAlert({
+            metronomeCustomerId: workspace.metronomeCustomerId,
+            paygCapDollars,
+            workspaceSId: workspace.sId,
+          });
+          if (alertResult.isErr()) {
+            return alertResult;
+          }
+        }
+        const workspaceResource = await WorkspaceResource.fetchById(
+          workspace.sId
+        );
+        if (workspaceResource) {
+          await dispatchPaygEnabled({ workspace: workspaceResource });
+        }
+      }
+    } else {
+      const refreshedConfig =
+        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+      if (refreshedConfig?.paygCapMicroUsd !== null) {
+        if (stripeSubscription) {
+          const stopResult = await stopEnterprisePAYG({
+            auth,
+            stripeSubscription,
+          });
+          if (stopResult.isErr()) {
+            return stopResult;
+          }
+        } else if (refreshedConfig) {
+          const clearResult = await refreshedConfig.updateConfiguration(auth, {
+            paygCapMicroUsd: null,
+          });
+          if (clearResult.isErr()) {
+            return clearResult;
+          }
+          if (workspace.metronomeCustomerId) {
+            const alertResult = await clearMetronomePaygCapAlert({
+              metronomeCustomerId: workspace.metronomeCustomerId,
+              workspaceSId: workspace.sId,
+            });
+            if (alertResult.isErr()) {
+              return alertResult;
+            }
+          }
+          const workspaceResource = await WorkspaceResource.fetchById(
+            workspace.sId
+          );
+          if (workspaceResource) {
+            await dispatchPaygDisabled({ workspace: workspaceResource });
+          }
         }
       }
     }

--- a/front/lib/credits/awu_purchase.test.ts
+++ b/front/lib/credits/awu_purchase.test.ts
@@ -9,7 +9,9 @@ import {
 } from "@app/lib/metronome/plan_type";
 import { getStripeClient } from "@app/lib/plans/stripe";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Ok } from "@app/types/shared/result";
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -82,7 +84,9 @@ describe("getAwuPurchaseInfo", () => {
   });
 
   it("tracks prior EUR purchases using the invoice credit metadata rather than amount_paid", async () => {
-    const { workspace, user } = await createResourceTest({ role: "admin" });
+    const workspace = await WorkspaceFactory.metronome();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
 
     const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
       workspace.id,

--- a/front/lib/metronome/payg_alerts.ts
+++ b/front/lib/metronome/payg_alerts.ts
@@ -1,0 +1,148 @@
+import { currencyToAwuCredits } from "@app/lib/metronome/amounts";
+import { getMetronomeClient } from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+function paygAlertUniquenessKey(workspaceSId: string): string {
+  return `payg-cap-${workspaceSId}`;
+}
+
+async function findExistingPaygAlert({
+  metronomeCustomerId,
+  workspaceSId,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+}): Promise<Result<{ id: string; threshold: number } | null, Error>> {
+  const target = paygAlertUniquenessKey(workspaceSId);
+  try {
+    const client = getMetronomeClient();
+    for await (const entry of client.v1.customers.alerts.list({
+      customer_id: metronomeCustomerId,
+      alert_statuses: ["ENABLED", "DISABLED"],
+    })) {
+      if (entry.alert.uniqueness_key === target) {
+        return new Ok({
+          id: entry.alert.id,
+          threshold: entry.alert.threshold,
+        });
+      }
+    }
+    return new Ok(null);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Idempotently ensure a Metronome `spend_threshold_reached` alert exists on
+ * the customer matching the workspace's PAYG cap. If an alert with a
+ * different threshold already exists, it's archived (with key release) and
+ * recreated.
+ */
+export async function syncMetronomePaygCapAlert({
+  metronomeCustomerId,
+  paygCapDollars,
+  workspaceSId,
+}: {
+  metronomeCustomerId: string;
+  paygCapDollars: number;
+  workspaceSId: string;
+}): Promise<Result<{ alertId: string }, Error>> {
+  const paygCapAwu = Math.round(currencyToAwuCredits(paygCapDollars, "usd"));
+
+  const findResult = await findExistingPaygAlert({
+    metronomeCustomerId,
+    workspaceSId,
+  });
+  if (findResult.isErr()) {
+    return new Err(findResult.error);
+  }
+  const existing = findResult.value;
+
+  if (existing && existing.threshold === paygCapAwu) {
+    return new Ok({ alertId: existing.id });
+  }
+
+  const client = getMetronomeClient();
+  if (existing) {
+    try {
+      await client.v1.alerts.archive({
+        id: existing.id,
+        release_uniqueness_key: true,
+      });
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  try {
+    const created = await client.v1.alerts.create({
+      alert_type: "spend_threshold_reached",
+      name: `PAYG cap`,
+      threshold: paygCapAwu,
+      credit_type_id: getCreditTypeAwuId(),
+      customer_id: metronomeCustomerId,
+      uniqueness_key: paygAlertUniquenessKey(workspaceSId),
+    });
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        metronomeCustomerId,
+        alertId: created.data.id,
+        paygCapDollars,
+        paygCapAwu,
+      },
+      "[Metronome PAYG] Synced PAYG cap alert"
+    );
+    return new Ok({ alertId: created.data.id });
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Archive the workspace's PAYG cap alert, if any. Idempotent — no-op when
+ * no matching alert exists.
+ */
+export async function clearMetronomePaygCapAlert({
+  metronomeCustomerId,
+  workspaceSId,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+}): Promise<Result<void, Error>> {
+  const findResult = await findExistingPaygAlert({
+    metronomeCustomerId,
+    workspaceSId,
+  });
+  if (findResult.isErr()) {
+    return new Err(findResult.error);
+  }
+  const existing = findResult.value;
+  if (!existing) {
+    return new Ok(undefined);
+  }
+
+  try {
+    const client = getMetronomeClient();
+    await client.v1.alerts.archive({
+      id: existing.id,
+      release_uniqueness_key: true,
+    });
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        metronomeCustomerId,
+        alertId: existing.id,
+      },
+      "[Metronome PAYG] Cleared PAYG cap alert"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -29,6 +29,15 @@ export const LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS = "legacy-enterprise-eur";
 
 export type MetronomePackageTier = "pro" | "business" | "enterprise";
 
+export const PAYG_ELIGIBLE_TIERS: readonly MetronomePackageTier[] = [
+  "enterprise",
+  "business",
+];
+
+export function isPaygEligibleTier(tier: MetronomePackageTier): boolean {
+  return PAYG_ELIGIBLE_TIERS.includes(tier);
+}
+
 export type BillingFrequency = "MONTHLY" | "ANNUAL";
 
 /**

--- a/front/lib/metronome/workspace_credit_state_machine.test.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.test.ts
@@ -185,6 +185,78 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
     expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
     expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
+
+  it("overage + payg_disabled → depleted (marks pool depleted)", async () => {
+    const workspace = makeWorkspace("overage");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "payg_disabled" },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("depleted");
+    }
+    expect(workspace.updatePoolCreditState).toHaveBeenCalledWith(
+      "depleted",
+      undefined
+    );
+    expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
+  });
+
+  it("depleted + payg_enabled → overage (clears depleted cache)", async () => {
+    const workspace = makeWorkspace("depleted");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "payg_enabled" },
+      baseCtxPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("overage");
+    }
+    expect(workspace.updatePoolCreditState).toHaveBeenCalledWith(
+      "overage",
+      undefined
+    );
+    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
+    expect(mockSetWorkspacePoolDepleted).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "active + payg_enabled → active (no-op)",
+      from: "active" as const,
+      event: { type: "payg_enabled" } as WorkspaceCreditEvent,
+    },
+    {
+      label: "active + payg_disabled → active (no-op)",
+      from: "active" as const,
+      event: { type: "payg_disabled" } as WorkspaceCreditEvent,
+    },
+    {
+      label: "overage + payg_enabled → overage (no-op)",
+      from: "overage" as const,
+      event: { type: "payg_enabled" } as WorkspaceCreditEvent,
+    },
+    {
+      label: "depleted + payg_disabled → depleted (no-op)",
+      from: "depleted" as const,
+      event: { type: "payg_disabled" } as WorkspaceCreditEvent,
+    },
+  ])("$label", async ({ from, event }) => {
+    const workspace = makeWorkspace(from);
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      event,
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(from);
+    }
+    expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/front/lib/metronome/workspace_credit_state_machine.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.ts
@@ -27,7 +27,21 @@ export type WorkspaceCreditEvent =
    * machine's point of view these are indistinguishable and both bring the
    * pool back online.
    */
-  | { type: "credits_added" };
+  | { type: "credits_added" }
+  /**
+   * PAYG was turned off by an operator. Workspaces in `overage` were
+   * surviving on PAYG: with PAYG gone they have nothing left to spend, so
+   * they must move to `depleted`. `active` workspaces are unaffected — the
+   * pool will route correctly on the next `pool_exhausted`.
+   */
+  | { type: "payg_disabled" }
+  /**
+   * PAYG was turned on (or its cap raised) by an operator. Workspaces in
+   * `depleted` that were blocked for lack of PAYG can now spend against it,
+   * so they move to `overage`. `active` and `overage` workspaces are
+   * unaffected.
+   */
+  | { type: "payg_enabled" };
 
 type WorkspaceCreditTransition = {
   from: WorkspacePoolCreditState | WorkspacePoolCreditState[];
@@ -79,6 +93,16 @@ const TRANSITIONS: WorkspaceCreditTransition[] = [
     event: "credits_added",
     to: "active",
   },
+  {
+    from: "active",
+    event: "payg_enabled",
+    to: "active",
+  },
+  {
+    from: "active",
+    event: "payg_disabled",
+    to: "active",
+  },
 
   // overage -> ...
   {
@@ -100,6 +124,16 @@ const TRANSITIONS: WorkspaceCreditTransition[] = [
     event: "credits_added",
     to: "active",
   },
+  {
+    from: "overage",
+    event: "payg_disabled",
+    to: "depleted",
+  },
+  {
+    from: "overage",
+    event: "payg_enabled",
+    to: "overage",
+  },
 
   // depleted -> ...
   {
@@ -117,6 +151,16 @@ const TRANSITIONS: WorkspaceCreditTransition[] = [
     from: "depleted",
     event: "credits_added",
     to: "active",
+  },
+  {
+    from: "depleted",
+    event: "payg_enabled",
+    to: "overage",
+  },
+  {
+    from: "depleted",
+    event: "payg_disabled",
+    to: "depleted",
   },
 ];
 

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -4,12 +4,17 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
+import {
+  clearMetronomePaygCapAlert,
+  syncMetronomePaygCapAlert,
+} from "@app/lib/metronome/payg_alerts";
 import { PlanModel } from "@app/lib/models/plan";
 import {
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
 import { getStripeCustomer } from "@app/lib/plans/stripe";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -41,6 +46,17 @@ vi.mock("@app/lib/metronome/contracts", async () => {
     ...actual,
     ensureMetronomeCustomerForWorkspace: vi.fn(),
     provisionMetronomeContract: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/payg_alerts", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/payg_alerts")
+  >("@app/lib/metronome/payg_alerts");
+  return {
+    ...actual,
+    syncMetronomePaygCapAlert: vi.fn(),
+    clearMetronomePaygCapAlert: vi.fn(),
   };
 });
 
@@ -203,6 +219,10 @@ beforeEach(() => {
   vi.mocked(provisionMetronomeContract).mockResolvedValue(
     new Ok({ metronomeContractId: NEW_CONTRACT_ID })
   );
+  vi.mocked(syncMetronomePaygCapAlert).mockResolvedValue(
+    new Ok({ alertId: "alert_test" })
+  );
+  vi.mocked(clearMetronomePaygCapAlert).mockResolvedValue(new Ok(undefined));
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () => {
@@ -520,5 +540,138 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
 
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.message).toContain("Metronome-billed");
+  });
+});
+
+describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
+  it("persists paygCapMicroUsd and syncs the Metronome alert when switching to enterprise with PAYG enabled", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = enterpriseBody({ paygEnabled: true, paygCapDollars: 500 });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const config =
+      await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(
+        adminAuth
+      );
+    expect(config?.paygCapMicroUsd).toBe(500 * 1_000_000);
+
+    expect(syncMetronomePaygCapAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: METRONOME_CUSTOMER_ID,
+        paygCapDollars: 500,
+        workspaceSId: workspace.sId,
+      })
+    );
+  });
+
+  it("persists paygCapMicroUsd when switching to business with PAYG enabled", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = businessBody({ paygEnabled: true, paygCapDollars: 250 });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const config =
+      await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(
+        adminAuth
+      );
+    expect(config?.paygCapMicroUsd).toBe(250 * 1_000_000);
+  });
+
+  it("rejects PAYG on a pro contract", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = proBody({ paygEnabled: true, paygCapDollars: 100 });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "Pay-as-you-go can only be enabled"
+    );
+    expect(provisionMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("rejects when paygEnabled is true but paygCapDollars is missing", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = enterpriseBody({ paygEnabled: true });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain("PAYG cap");
+  });
+
+  it("clears paygCapMicroUsd and archives the Metronome alert when paygEnabled is false", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await ProgrammaticUsageConfigurationResource.makeNew(adminAuth, {
+      freeCreditMicroUsd: null,
+      defaultDiscountPercent: 0,
+      paygCapMicroUsd: 1_000 * 1_000_000,
+      dailyCapMicroUsd: null,
+    });
+
+    req.body = proBody();
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const config =
+      await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(
+        adminAuth
+      );
+    expect(config?.paygCapMicroUsd).toBeNull();
+
+    expect(clearMetronomePaygCapAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: METRONOME_CUSTOMER_ID,
+        workspaceSId: workspace.sId,
+      })
+    );
   });
 });

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -1,6 +1,11 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import {
+  dispatchPaygDisabled,
+  dispatchPaygEnabled,
+} from "@app/lib/api/metronome/credit_state_dispatcher";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import { MAX_PAYG_CAP_DOLLARS } from "@app/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -13,7 +18,15 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
-import type { MetronomePackageTier } from "@app/lib/metronome/types";
+import {
+  clearMetronomePaygCapAlert,
+  syncMetronomePaygCapAlert,
+} from "@app/lib/metronome/payg_alerts";
+import {
+  isPaygEligibleTier,
+  type MetronomePackageTier,
+  PAYG_ELIGIBLE_TIERS,
+} from "@app/lib/metronome/types";
 import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
 import {
   isEntreprisePlanPrefix,
@@ -24,6 +37,7 @@ import { getStripeCustomer } from "@app/lib/plans/stripe";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -37,15 +51,29 @@ export interface SwitchContractSuccessResponseBody {
   success: boolean;
 }
 
-const SwitchContractBodySchema = z.object({
-  planCode: z.string().min(1),
-  metronomePackageId: z.string().min(1),
-  // ISO timestamp. Required and validated to be ≥1h in the future when the
-  // selected package is enterprise-tier; forbidden otherwise (Pro/Business
-  // swap at the current hour).
-  startingAt: z.string().optional(),
-  stripeCustomerId: z.string().min(1),
-});
+const SwitchContractBodySchema = z
+  .object({
+    planCode: z.string().min(1),
+    metronomePackageId: z.string().min(1),
+    // ISO timestamp. Required and validated to be ≥1h in the future when the
+    // selected package is enterprise-tier; forbidden otherwise (Pro/Business
+    // swap at the current hour).
+    startingAt: z.string().optional(),
+    stripeCustomerId: z.string().min(1),
+    paygEnabled: z.boolean().default(false),
+    paygCapDollars: z
+      .number()
+      .min(1, "PAYG cap must be at least $1")
+      .max(
+        MAX_PAYG_CAP_DOLLARS,
+        `PAYG cap cannot exceed $${MAX_PAYG_CAP_DOLLARS.toLocaleString()}`
+      )
+      .optional(),
+  })
+  .refine((data) => !data.paygEnabled || data.paygCapDollars !== undefined, {
+    message: "PAYG cap is required when Pay-as-you-go is enabled.",
+    path: ["paygCapDollars"],
+  });
 
 type PlanTier = MetronomePackageTier | "free";
 
@@ -166,20 +194,8 @@ async function handler(
     });
   }
 
-  // PAYG on the Metronome path is not yet wired up — reject before touching
-  // any state.
   const programmaticConfig =
     await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-  if (programmaticConfig?.paygCapMicroUsd != null) {
-    const errorMessage =
-      "Pay-as-you-go is not yet supported for Metronome-billed subscriptions. " +
-      "Disable PAYG via the 'Manage Programmatic Usage Configuration' plugin first.";
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
-    });
-  }
 
   // Validate the Stripe customer exists before we touch Metronome.
   const stripeCustomer = await getStripeCustomer(body.stripeCustomerId);
@@ -253,6 +269,17 @@ async function handler(
         type: "invalid_request_error",
         message: compatResult.error.message,
       },
+    });
+  }
+
+  if (body.paygEnabled && !isPaygEligibleTier(pkg.tier)) {
+    const errorMessage = `Pay-as-you-go can only be enabled for ${PAYG_ELIGIBLE_TIERS.join(
+      " or "
+    )} contracts.`;
+    await pluginRun.recordError(errorMessage);
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: { type: "invalid_request_error", message: errorMessage },
     });
   }
 
@@ -359,12 +386,82 @@ async function handler(
     });
   }
 
+  const paygCapMicroUsd =
+    body.paygEnabled && body.paygCapDollars !== undefined
+      ? Math.round(body.paygCapDollars * 1_000_000)
+      : null;
+  if (programmaticConfig) {
+    const updateResult = await programmaticConfig.updateConfiguration(auth, {
+      paygCapMicroUsd,
+    });
+    if (updateResult.isErr()) {
+      const errorMessage = `Failed to update PAYG configuration: ${updateResult.error.message}`;
+      await pluginRun.recordError(errorMessage);
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: { type: "internal_server_error", message: errorMessage },
+      });
+    }
+  } else if (paygCapMicroUsd !== null) {
+    const createResult = await ProgrammaticUsageConfigurationResource.makeNew(
+      auth,
+      {
+        freeCreditMicroUsd: null,
+        defaultDiscountPercent: 0,
+        paygCapMicroUsd,
+        dailyCapMicroUsd: null,
+      }
+    );
+    if (createResult.isErr()) {
+      const errorMessage = `Failed to create PAYG configuration: ${createResult.error.message}`;
+      await pluginRun.recordError(errorMessage);
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: { type: "internal_server_error", message: errorMessage },
+      });
+    }
+  }
+
+  if (owner.metronomeCustomerId) {
+    const alertResult =
+      body.paygEnabled && body.paygCapDollars !== undefined
+        ? await syncMetronomePaygCapAlert({
+            metronomeCustomerId: owner.metronomeCustomerId,
+            paygCapDollars: body.paygCapDollars,
+            workspaceSId: owner.sId,
+          })
+        : await clearMetronomePaygCapAlert({
+            metronomeCustomerId: owner.metronomeCustomerId,
+            workspaceSId: owner.sId,
+          });
+    if (alertResult.isErr()) {
+      const errorMessage = `Failed to sync Metronome PAYG cap alert: ${alertResult.error.message}`;
+      await pluginRun.recordError(errorMessage);
+      return apiError(req, res, {
+        status_code: 502,
+        api_error: { type: "internal_server_error", message: errorMessage },
+      });
+    }
+  }
+
+  const workspaceResource = await WorkspaceResource.fetchById(owner.sId);
+  if (workspaceResource) {
+    if (body.paygEnabled) {
+      await dispatchPaygEnabled({ workspace: workspaceResource });
+    } else {
+      await dispatchPaygDisabled({ workspace: workspaceResource });
+    }
+  }
+
+  const paygStatus = body.paygEnabled
+    ? ` PAYG enabled with $${body.paygCapDollars} cap.`
+    : "";
   await pluginRun.recordResult({
     display: "text",
     value:
       `Workspace ${owner.name} scheduled to switch to plan ${body.planCode} ` +
       `(Metronome contract ${metronomeContractId}). Subscription will flip ` +
-      "when the contract.start webhook fires.",
+      `when the contract.start webhook fires.${paygStatus}`,
   });
   res.status(200).json({ success: true });
 }


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/8156

- Add PAYG (paygEnabled + paygCapDollars) to the poke switch-contract form and API; restrict to PAYG_ELIGIBLE_TIERS (enterprise + business).
- Extend `manage-programmatic-usage-configuration` plugin to support Metronome-only billed workspaces (no Stripe sub): persist paygCapMicroUsd directly instead of going through `startOrResumeEnterprisePAYG`.
- Mirror the cap as a Metronome `spend_threshold_reached` alert (AWU credit type) so the credit state machine receives `payg_cap_reached` when overage crosses the cap. New `payg_alerts.ts` syncs/clears the alert.
  **I don't think this properly works, but I'll fix it in a later PR**
- Add `payg_enabled` / `payg_disabled` events to the workspace credit state machine: depleted -> overage and overage -> depleted, with identity transitions for the other states. Dispatchers stay dumb; the state machine owns transition decisions.
- Replace the stubbed `isPaygEnabled` in the dispatcher with a real lookup via `ProgrammaticUsageConfigurationResource`.

## Tests

Local + unit

## Risk

Low, Metronome-billed only

## Deploy Plan

front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25745">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->