### PR TITLE
[DB] Add MCP action FK index for tool executions

### DIFF
--- a/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
+++ b/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
@@ -71,6 +71,12 @@ AgentStepContentToolExecutionModel.init(
         name: "agent_sc_te_workspace_action",
       },
       {
+        unique: true,
+        fields: ["agentMCPActionId"],
+        concurrently: true,
+        name: "agent_step_content_tool_executions_agent_mcp_action_id",
+      },
+      {
         fields: ["workspaceId", "stepContentId"],
         concurrently: true,
         name: "agent_sc_te_workspace_step_content",

--- a/front/migrations/db/migration_643.sql
+++ b/front/migrations/db/migration_643.sql
@@ -1,0 +1,4 @@
+-- Migration created on May 19, 2026
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "agent_step_content_tool_executions_agent_mcp_action_id"
+ON "public"."agent_step_content_tool_executions" ("agentMCPActionId");


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/8102.
Follows https://github.com/dust-tt/dust/pull/25725.

Deletes of `agent_mcp_actions` must check child rows in `agent_step_content_tool_executions` by `agentMCPActionId`. The existing index starts with `workspaceId`, so PostgreSQL FK checks cannot use it efficiently. This adds the missing FK-leading unique index. The other id13 paths are already covered by `agent_mcp_actions_step_content_id` and `agent_mcp_action_output_items_agent_m_c_p_action_id`.

## Risks
Blast radius: front DB index maintenance for tool execution rows and deletes of MCP actions.
Risk: low

## Deploy Plan
- run migration_643.sql
- deploy front