### PR TITLE
[DB] Drop redundant workspace FK indexes

### DIFF
--- a/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
+++ b/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
@@ -66,20 +66,9 @@ AgentStepContentToolExecutionModel.init(
       // N:1 from action's side: each action has at most one stepContent.
       {
         unique: true,
-        fields: ["workspaceId", "agentMCPActionId"],
-        concurrently: true,
-        name: "agent_sc_te_workspace_action",
-      },
-      {
-        unique: true,
         fields: ["agentMCPActionId"],
         concurrently: true,
         name: "agent_step_content_tool_executions_agent_mcp_action_id",
-      },
-      {
-        fields: ["workspaceId", "stepContentId"],
-        concurrently: true,
-        name: "agent_sc_te_workspace_step_content",
       },
       {
         fields: ["stepContentId"],

--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -399,7 +399,6 @@ AgentMCPActionOutputItemModel.init(
         concurrently: true,
       },
       { fields: ["workspaceId", "id"], concurrently: true },
-      // TODO(2025-11-24 fabien) Remove this useless index when the one on ("workspaceId", "agentMCPActionId") is created.
       {
         fields: ["agentMCPActionId"],
         concurrently: true,
@@ -407,11 +406,6 @@ AgentMCPActionOutputItemModel.init(
       {
         fields: ["fileId"],
         concurrently: true,
-      },
-      {
-        fields: ["workspaceId", "agentMCPActionId"],
-        concurrently: true,
-        name: "agent_mcp_action_output_items_workspace_id_agent_mcp_action_id",
       },
       {
         fields: ["workspaceId", "agentMCPActionId", "contentGcsPath"],

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -92,10 +92,6 @@ AgentSuggestionModel.init(
         concurrently: true,
       },
       {
-        fields: ["workspaceId", "conversationId"],
-        concurrently: true,
-      },
-      {
         fields: ["conversationId"],
         concurrently: true,
         name: "agent_suggestions_conversation_id",

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -191,9 +191,6 @@ ConversationParticipantModel.init(
         unique: true,
       },
       {
-        fields: ["workspaceId", "conversationId"],
-      },
-      {
         fields: ["workspaceId", "userId", "action"],
       },
       {
@@ -242,9 +239,6 @@ UserConversationReadsModel.init(
       {
         fields: ["workspaceId", "userId", "conversationId"],
         unique: true,
-      },
-      {
-        fields: ["workspaceId", "conversationId"],
       },
       {
         fields: ["conversationId"],
@@ -644,7 +638,6 @@ AgentMessageFeedbackModel.init(
         name: "agent_message_feedbacks_conversation_id",
         concurrently: true,
       },
-      { fields: ["workspaceId", "conversationId"], concurrently: true },
     ],
   }
 );

--- a/front/lib/resources/storage/models/wakeup.ts
+++ b/front/lib/resources/storage/models/wakeup.ts
@@ -97,11 +97,6 @@ WakeUpModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
-        fields: ["workspaceId", "conversationId", "status"],
-        name: "wake_ups_workspace_id_conversation_id_status_idx",
-        concurrently: true,
-      },
-      {
         fields: ["conversationId"],
         name: "wake_ups_conversation_id",
         concurrently: true,

--- a/front/migrations/db/migration_644.sql
+++ b/front/migrations/db/migration_644.sql
@@ -1,0 +1,10 @@
+-- Migration created on May 19, 2026
+
+DROP INDEX CONCURRENTLY IF EXISTS "agent_message_feedbacks_workspace_id_conversation_id";
+DROP INDEX CONCURRENTLY IF EXISTS "agent_mcp_action_output_items_workspace_id_agent_mcp_action_id";
+DROP INDEX CONCURRENTLY IF EXISTS "agent_sc_te_workspace_action";
+DROP INDEX CONCURRENTLY IF EXISTS "agent_sc_te_workspace_step_content";
+DROP INDEX CONCURRENTLY IF EXISTS "agent_suggestions_workspace_id_conversation_id";
+DROP INDEX CONCURRENTLY IF EXISTS "conversation_participants_workspace_id_conversation_id";
+DROP INDEX CONCURRENTLY IF EXISTS "user_conversation_reads_workspace_id_conversation_id";
+DROP INDEX CONCURRENTLY IF EXISTS "wake_ups_workspace_id_conversation_id_status_idx";


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/8102.
Follows https://github.com/dust-tt/dust/pull/25725 and https://github.com/dust-tt/dust/pull/25748.

Several old indexes start with `workspaceId` before a globally unique FK id. Once the FK-leading indexes exist, these composites do not help PostgreSQL RI checks and add write/delete maintenance cost. This drops the redundant workspace-prefixed indexes while keeping composites that encode extra uniqueness, ordering, or lookup semantics.

## Risks
Blast radius: front DB query plans and index maintenance for conversation, wake-up, feedback, suggestion, and MCP tool execution tables.
Risk: standard

## Deploy Plan
- after migration_643.sql has completed, run migration_644.sql
- deploy front