### PR TITLE
[Data Retention] Fix cleanup for MCP actions missing step content

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -41,22 +41,30 @@ async function destroyActionsRelatedResources(
   auth: Authenticator,
   agentMessageIds: Array<ModelId>
 ) {
-  // First, retrieve the MCP actions.
-  const mcpActions = await AgentMCPActionResource.listByAgentMessageIds(
-    auth,
-    agentMessageIds
-  );
+  if (agentMessageIds.length === 0) {
+    return;
+  }
+
+  const actionModelIds =
+    await AgentMCPActionResource.listModelIdsByAgentMessageIds(
+      auth,
+      agentMessageIds
+    );
 
   // Destroy MCP action output items (including GCS cleanup).
   await AgentMCPActionResource.destroyOutputItemsByActionIds(
     auth,
-    mcpActions.map((a) => a.id)
+    actionModelIds
   );
 
   // Destroy the actions.
-  await AgentMCPActionResource.deleteByAgentMessageId(auth, {
-    agentMessageIds,
-  });
+  const deleteActionsResult =
+    await AgentMCPActionResource.deleteByAgentMessageId(auth, {
+      agentMessageIds,
+    });
+  if (deleteActionsResult.isErr()) {
+    throw deleteActionsResult.error;
+  }
 }
 
 async function destroyMessageRelatedResources(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -669,6 +669,25 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
   }
 
+  static async listModelIdsByAgentMessageIds(
+    auth: Authenticator,
+    agentMessageIds: ModelId[]
+  ): Promise<ModelId[]> {
+    if (agentMessageIds.length === 0) {
+      return [];
+    }
+
+    const actions = await AgentMCPActionModel.findAll({
+      attributes: ["id"],
+      where: {
+        agentMessageId: { [Op.in]: agentMessageIds },
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    return actions.map((action) => action.id);
+  }
+
   static async listBlockedActionsForAgentMessage(
     auth: Authenticator,
     { agentMessageId }: { agentMessageId: ModelId }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1,6 +1,8 @@
 // biome-ignore-all lint/plugin/noRawSql: test file uses raw SQL for setup and verification
 import { loadAllModels } from "@app/admin/db";
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import {
   AgentMessageModel,
   ConversationModel,
@@ -514,6 +516,86 @@ describe("destroyConversation", () => {
       agentMessageDestroyCounts.reduce((sum, count) => sum + count, 0)
     ).toBe(30);
     expect(Math.max(...agentMessageDestroyCounts)).toBeLessThan(30);
+  });
+
+  it("should delete MCP actions with a missing step content link", async () => {
+    const conversationType = await ConversationFactory.create(auth, {
+      agentConfigurationId,
+      messagesCreatedAt: [new Date()],
+    });
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationType.sId
+    );
+    if (!conversation) {
+      throw new Error("Conversation should exist");
+    }
+
+    const agentMessage = (
+      await MessageModel.findAll({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      })
+    ).find((message) => message.agentMessageId !== null);
+    if (!agentMessage?.agentMessageId) {
+      throw new Error("Agent message should exist");
+    }
+    const agentMessageId = agentMessage.agentMessageId;
+
+    const toolConfiguration: LightMCPToolConfigurationType = {
+      id: 1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: "test_tool",
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: "test-server-view",
+      dustAppConfiguration: null,
+      secretName: null,
+      dustProject: null,
+      internalMCPServerId: null,
+      availability: "auto",
+      permission: "low",
+      toolServerId: "test-server",
+      retryPolicy: "no_retry",
+      originalName: "test_tool",
+      mcpServerName: "test_server",
+    };
+
+    await AgentMCPActionModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      agentMessageId,
+      mcpServerConfigurationId: generateRandomModelSId(),
+      status: "succeeded",
+      citationsAllocated: 0,
+      augmentedInputs: {},
+      toolConfiguration,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        resumeState: null,
+        retrievalTopK: 10,
+        websearchResultCount: 5,
+      },
+    });
+
+    const result = await destroyConversation(auth, { conversation });
+
+    expect(result.isOk()).toBe(true);
+    await expect(
+      AgentMCPActionModel.count({
+        where: {
+          agentMessageId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      })
+    ).resolves.toBe(0);
   });
 });
 


### PR DESCRIPTION
## Description

Fixes the data retention workflow getting stuck on `Step content not found` while deleting conversations.

Root cause: conversation destruction fetched full `AgentMCPActionResource` objects before deleting action-related rows. That fetch asserts that every MCP action still has step content. Retention can encounter historical or partially-cleaned-up action rows where the action still exists but the step-content junction/content is missing, so the cleanup failed before it could delete the action. The same code also ignored the `Result` returned by MCP action deletion, allowing later cleanup to proceed after a failed action delete.

This PR makes cleanup fetch MCP action model IDs directly, deletes output items from those IDs, then checks the action deletion result before continuing.

## Risks

Blast radius: conversation deletion paths, including data retention and workspace scrubbing.
Risk: low

## Deploy Plan

- deploy front workers
- deploy front

## Tests
- [x] `TEST_FRONT_DATABASE_URI=postgres://test:test@localhost:5433/dust_front_test_retention_step_content TEST_REDIS_URI=redis://localhost:6479 NODE_ENV=test npm test -- lib/resources/conversation_resource.test.ts -t "destroyConversation"`
- [x] `TEST_FRONT_DATABASE_URI=postgres://test:test@localhost:5433/dust_front_test_retention_step_content TEST_REDIS_URI=redis://localhost:6479 NODE_ENV=test npm test -- temporal/data_retention/activities.test.ts`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25752">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->