### PR TITLE
[front] chore: remove max number of retries in document upserts

### DIFF
--- a/front/temporal/upsert_queue/workflows.ts
+++ b/front/temporal/upsert_queue/workflows.ts
@@ -1,8 +1,6 @@
 import type * as activities from "@app/temporal/upsert_queue/activities";
 import { proxyActivities } from "@temporalio/workflow";
 
-const MAX_UPSERT_TABLE_ATTEMPTS = 10;
-
 const { upsertDocumentActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });

--- a/front/temporal/upsert_queue/workflows.ts
+++ b/front/temporal/upsert_queue/workflows.ts
@@ -5,9 +5,6 @@ const MAX_UPSERT_TABLE_ATTEMPTS = 10;
 
 const { upsertDocumentActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
-  retry: {
-    maximumAttempts: MAX_UPSERT_TABLE_ATTEMPTS,
-  },
 });
 
 export async function upsertDocumentWorkflow(


### PR DESCRIPTION
## Description

- This PR removes the max number of retries for the upsert queue activity (documents only)
- It was added in https://github.com/dust-tt/dust/pull/14577, which incorrectly targeted documents instead of tables
- Not adding a limit on tables: we do not have it, which means we probably do not need it, and the initial issue the PR was adding a limit for was to prevent overloading the memory of our pods of core (see [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1753428833873279)). This issue predates the move of tables to GCS and should not present itself anymore
- Additional context: we lost some workflows due to hitting the max number of retries due to an ongoing Qdrant issue

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25753">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->