### PR TITLE
Use convertToBase64 in tool call outputs too

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -133,7 +133,8 @@ function assistantContentToParam(
 }
 
 async function toolResultToParam(
-  message: FunctionMessageTypeModel
+  message: FunctionMessageTypeModel,
+  { convertToBase64 }: { convertToBase64: boolean }
 ): Promise<ToolResultBlockParam> {
   return {
     type: "tool_result",
@@ -142,18 +143,19 @@ async function toolResultToParam(
       ? message.content
       : await concurrentExecutor(
           message.content,
-          (c) => userContentToParam(c),
+          (c) => userContentToParam(c, { convertToBase64 }),
           { concurrency: 10 }
         ),
   };
 }
 
 async function functionMessage(
-  message: FunctionMessageTypeModel
+  message: FunctionMessageTypeModel,
+  { convertToBase64 }: { convertToBase64: boolean }
 ): Promise<MessageParam> {
   return {
     role: "user",
-    content: [await toolResultToParam(message)],
+    content: [await toolResultToParam(message, { convertToBase64 })],
   };
 }
 
@@ -219,7 +221,9 @@ export async function toMessage(
         convertToBase64: convertToBase64 ?? false,
       });
     case "function":
-      return functionMessage(message);
+      return functionMessage(message, {
+        convertToBase64: convertToBase64 ?? false,
+      });
     case "assistant":
       return assistantMessage(message, omittedThinking);
     case "compaction":


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/8098

 - When using Vertex AI (which requires base64-encoded images), images in tool results were sent as URLs instead of base64, causing "URL sources are not supported" errors
  - The convertToBase64 flag was correctly passed for user messages but missing from the toolResultToParam 

## Tests

Tested locally with Vertex: I managed to reproduce the issue by asking the model to use `files__cat` on picture, this PR fixed the issue 

## Risk

low

## Deploy Plan

deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25756">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->