### PR TITLE
[front] Use metronome amount helpers for AWU purchase and fix non-dollar case

### DIFF
--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -5,7 +5,10 @@ import {
   MAX_AWU_PURCHASE_CREDITS_PER_CYCLE,
   MIN_AWU_PURCHASE_CREDITS,
 } from "@app/lib/credits/awu_purchase_constants";
-import { AWU_PRICE_PER_CREDIT } from "@app/lib/metronome/types";
+import {
+  awuCreditsToCurrency,
+  currencyToAwuCredits,
+} from "@app/lib/metronome/amounts";
 import { CURRENCY_SYMBOLS } from "@app/types/currency";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
@@ -123,15 +126,15 @@ export function BuyAwuCreditsDialog({
     ? awuPurchaseInfo.currency
     : "usd";
   const currencySymbol = CURRENCY_SYMBOLS[currency];
-  const pricePerCredit = AWU_PRICE_PER_CREDIT[currency];
-  const creditsPerCurrencyUnit = 1 / pricePerCredit;
 
   const maxAmountInCurrency = useMemo(() => {
     if (!awuPurchaseInfo?.canPurchase) {
       return null;
     }
-    return Math.floor(awuPurchaseInfo.remainingCycleCredits * pricePerCredit);
-  }, [awuPurchaseInfo, pricePerCredit]);
+    return Math.floor(
+      awuCreditsToCurrency(awuPurchaseInfo.remainingCycleCredits, currency)
+    );
+  }, [awuPurchaseInfo, currency]);
 
   const maxAmountFormatted = useMemo(() => {
     if (maxAmountInCurrency === null) {
@@ -142,7 +145,9 @@ export function BuyAwuCreditsDialog({
 
   const effectiveMaxAmount =
     maxAmountInCurrency ??
-    Math.floor(MAX_AWU_PURCHASE_CREDITS_PER_CYCLE * pricePerCredit);
+    Math.floor(
+      awuCreditsToCurrency(MAX_AWU_PURCHASE_CREDITS_PER_CYCLE, currency)
+    );
 
   const setAmountWithClamp = useCallback(
     (amount: number) => {
@@ -154,7 +159,7 @@ export function BuyAwuCreditsDialog({
   const parsedAmount = parseFloat(amountInput) || 0;
   const isValidAmount = parsedAmount > 0;
   const amountExceedsMax = parsedAmount > effectiveMaxAmount;
-  const addedCredits = parsedAmount * creditsPerCurrencyUnit;
+  const addedCredits = currencyToAwuCredits(parsedAmount, currency);
 
   const canPurchase = isValidAmount && !amountExceedsMax;
 

--- a/front/lib/credits/awu_purchase.test.ts
+++ b/front/lib/credits/awu_purchase.test.ts
@@ -1,0 +1,135 @@
+import { Authenticator } from "@app/lib/auth";
+import { getAwuPurchaseInfo } from "@app/lib/credits/awu_purchase";
+import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
+import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
+import {
+  type CachedContract,
+  getActiveContract,
+  isLegacyPlan,
+} from "@app/lib/metronome/plan_type";
+import { getStripeClient } from "@app/lib/plans/stripe";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
+import type Stripe from "stripe";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual("@app/lib/metronome/client");
+  return {
+    ...actual,
+    getMetronomeCustomerStripeCustomerId: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/coupons", async () => {
+  const actual = await vi.importActual("@app/lib/metronome/coupons");
+  return {
+    ...actual,
+    getCreditTypeFromContract: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual("@app/lib/metronome/plan_type");
+  return {
+    ...actual,
+    getActiveContract: vi.fn(),
+    isLegacyPlan: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/plans/stripe", async () => {
+  const actual = await vi.importActual("@app/lib/plans/stripe");
+  return {
+    ...actual,
+    getStripeClient: vi.fn(),
+  };
+});
+
+function makeInvoiceList(
+  invoices: Stripe.Invoice[]
+): Stripe.ApiList<Stripe.Invoice> {
+  return {
+    object: "list",
+    url: "/v1/invoices",
+    has_more: false,
+    data: invoices,
+  } as Stripe.ApiList<Stripe.Invoice>;
+}
+
+function makeAwuPurchaseInvoice({
+  amountPaid,
+  amountCredits,
+}: {
+  amountPaid: number;
+  amountCredits: number;
+}): Stripe.Invoice {
+  return {
+    id: "in_awu_purchase",
+    status: "paid",
+    amount_paid: amountPaid,
+    metadata: {
+      awu_purchase: "true",
+      awu_amount_credits: String(amountCredits),
+    },
+  } as unknown as Stripe.Invoice;
+}
+
+describe("getAwuPurchaseInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tracks prior EUR purchases using the invoice credit metadata rather than amount_paid", async () => {
+    const { workspace, user } = await createResourceTest({ role: "admin" });
+
+    const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
+      workspace.id,
+      "m_customer"
+    );
+    expect(updateResult.isOk()).toBe(true);
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    vi.mocked(isLegacyPlan).mockResolvedValue(false);
+    vi.mocked(getMetronomeCustomerStripeCustomerId).mockResolvedValue(
+      new Ok("cus_123")
+    );
+    vi.mocked(getActiveContract).mockResolvedValue({
+      rate_card_id: "rc_123",
+    } as CachedContract);
+    vi.mocked(getCreditTypeFromContract).mockResolvedValue(
+      new Ok({ creditTypeId: "eur-credit-type", currency: "eur" })
+    );
+
+    const listInvoices = vi
+      .fn()
+      .mockResolvedValueOnce(makeInvoiceList([]))
+      .mockResolvedValueOnce(
+        makeInvoiceList([
+          makeAwuPurchaseInvoice({
+            amountPaid: 870_000,
+            amountCredits: 1_000_000,
+          }),
+        ])
+      );
+
+    vi.mocked(getStripeClient).mockReturnValue({
+      invoices: {
+        list: listInvoices,
+      },
+    } as unknown as Stripe);
+
+    const result = await getAwuPurchaseInfo(auth);
+
+    expect(result).toEqual({
+      canPurchase: true,
+      remainingCycleCredits: 0,
+      currency: "eur",
+    });
+  });
+});

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -66,6 +66,24 @@ type AwuEligibilityOk = {
   stripe: Stripe;
 };
 
+function getAwuPurchasedCreditsFromInvoice(invoice: Stripe.Invoice): number {
+  if (invoice.metadata?.awu_purchase !== "true") {
+    return 0;
+  }
+
+  const amountCreditsString = invoice.metadata?.awu_amount_credits;
+  if (!amountCreditsString) {
+    return 0;
+  }
+
+  const amountCredits = Number.parseInt(amountCreditsString, 10);
+  if (!Number.isFinite(amountCredits)) {
+    return 0;
+  }
+
+  return amountCredits;
+}
+
 /**
  * Resolves the billing currency from the active Metronome contract's rate
  * card — the source of truth for Metronome-billed workspaces. The Stripe
@@ -170,9 +188,10 @@ export async function getAwuPurchaseInfo(
     status: "paid",
     created: { gte: cycleStartSeconds },
   });
-  const alreadyPurchasedThisCycleCredits = paidInvoices.data
-    .filter((inv) => inv.metadata?.awu_purchase === "true")
-    .reduce((sum, inv) => sum + (inv.amount_paid ?? 0), 0);
+  const alreadyPurchasedThisCycleCredits = paidInvoices.data.reduce(
+    (sum, inv) => sum + getAwuPurchasedCreditsFromInvoice(inv),
+    0
+  );
 
   return {
     canPurchase: true,
@@ -221,9 +240,10 @@ export async function purchaseAwuCredits(
     status: "paid",
     created: { gte: cycleStartSeconds },
   });
-  const alreadyPurchasedThisCycleCredits = paidInvoices.data
-    .filter((inv) => inv.metadata?.awu_purchase === "true")
-    .reduce((sum, inv) => sum + (inv.amount_paid ?? 0), 0);
+  const alreadyPurchasedThisCycleCredits = paidInvoices.data.reduce(
+    (sum, inv) => sum + getAwuPurchasedCreditsFromInvoice(inv),
+    0
+  );
 
   const remaining =
     MAX_AWU_PURCHASE_CREDITS_PER_CYCLE - alreadyPurchasedThisCycleCredits;

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -1,6 +1,10 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycle } from "@app/lib/client/subscription";
 import {
+  AWU_PRICE_PER_CREDIT,
+  metronomeAmount,
+} from "@app/lib/metronome/amounts";
+import {
   addPaymentGatedCommitToContract,
   getMetronomeCustomerStripeCustomerId,
 } from "@app/lib/metronome/client";
@@ -12,7 +16,6 @@ import {
 } from "@app/lib/metronome/constants";
 import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
 import { getActiveContract, isLegacyPlan } from "@app/lib/metronome/plan_type";
-import { AWU_PRICE_PER_CREDIT } from "@app/lib/metronome/types";
 import { getStripeClient } from "@app/lib/plans/stripe";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
@@ -244,16 +247,13 @@ export async function purchaseAwuCredits(
   }
   const currency = currencyResult.value;
 
-  // Metronome wants invoice unit prices in the credit type's units: cents
-  // for USD, whole units for EUR (matches the rate-card convention; see
-  // `metronomeAmount`). AWU_PRICE_PER_CREDIT is per-credit in the
-  // currency's natural unit ($0.01 / €0.0087):
-  //   USD: 0.01 USD * 100 = 1 cent per credit
-  //   EUR: 0.0087 EUR per credit (Metronome allows decimal unit prices)
-  const invoiceUnitPrice =
-    currency === "usd"
-      ? AWU_PRICE_PER_CREDIT.usd * 100
-      : AWU_PRICE_PER_CREDIT.eur;
+  // Per-credit price expressed in Metronome's unit for this currency:
+  // cents for USD (1 cent), whole units for EUR (0.0087 EUR — Metronome
+  // accepts decimal unit prices for non-USD).
+  const invoiceUnitPrice = metronomeAmount(
+    AWU_PRICE_PER_CREDIT[currency] * 100,
+    currency
+  );
 
   const now = new Date();
   const oneYearFromNow = new Date(now);

--- a/front/lib/metronome/amounts.test.ts
+++ b/front/lib/metronome/amounts.test.ts
@@ -1,0 +1,77 @@
+import {
+  AWU_PRICE_PER_CREDIT,
+  amountCents,
+  awuCreditsToCurrency,
+  currencyToAwuCredits,
+  metronomeAmount,
+} from "@app/lib/metronome/amounts";
+import { describe, expect, it } from "vitest";
+
+describe("amountCents", () => {
+  it("passes USD through (already in cents) and rounds to an integer", () => {
+    expect(amountCents(1234, "usd")).toBe(1234);
+    expect(amountCents(1234.4, "usd")).toBe(1234);
+    expect(amountCents(1234.5, "usd")).toBe(1235);
+  });
+
+  it("converts EUR whole units to cents", () => {
+    expect(amountCents(10, "eur")).toBe(1000);
+    expect(amountCents(0.5, "eur")).toBe(50);
+  });
+
+  it("rounds EUR sub-cent fractions to the nearest cent", () => {
+    expect(amountCents(0.0087, "eur")).toBe(1);
+    expect(amountCents(0.004, "eur")).toBe(0);
+  });
+});
+
+describe("metronomeAmount", () => {
+  it("passes USD through (Metronome USD is already in cents)", () => {
+    expect(metronomeAmount(1234, "usd")).toBe(1234);
+    expect(metronomeAmount(0, "usd")).toBe(0);
+  });
+
+  it("converts EUR cents to whole units", () => {
+    expect(metronomeAmount(1000, "eur")).toBe(10);
+  });
+
+  it("preserves EUR decimals (Metronome accepts decimal unit prices for non-USD)", () => {
+    expect(metronomeAmount(50, "eur")).toBe(0.5);
+    expect(metronomeAmount(0.87, "eur")).toBeCloseTo(0.0087, 10);
+  });
+
+  it("is the inverse of amountCents for round-trippable values", () => {
+    expect(metronomeAmount(amountCents(12.34, "eur"), "eur")).toBeCloseTo(
+      12.34,
+      10
+    );
+    expect(metronomeAmount(amountCents(1234, "usd"), "usd")).toBe(1234);
+  });
+});
+
+describe("awuCreditsToCurrency / currencyToAwuCredits", () => {
+  it("uses the per-currency AWU rate", () => {
+    expect(awuCreditsToCurrency(100, "usd")).toBeCloseTo(
+      100 * AWU_PRICE_PER_CREDIT.usd,
+      10
+    );
+    expect(awuCreditsToCurrency(100, "eur")).toBeCloseTo(
+      100 * AWU_PRICE_PER_CREDIT.eur,
+      10
+    );
+  });
+
+  it("inverts cleanly between credits and currency units", () => {
+    expect(currencyToAwuCredits(awuCreditsToCurrency(250, "usd"), "usd")).toBe(
+      250
+    );
+    expect(
+      currencyToAwuCredits(awuCreditsToCurrency(250, "eur"), "eur")
+    ).toBeCloseTo(250, 10);
+  });
+
+  it("matches the AWU pricing constants (1 USD = 100 credits, 1 EUR ≈ 114.94 credits)", () => {
+    expect(currencyToAwuCredits(1, "usd")).toBe(100);
+    expect(currencyToAwuCredits(1, "eur")).toBeCloseTo(1 / 0.0087, 6);
+  });
+});

--- a/front/lib/metronome/amounts.ts
+++ b/front/lib/metronome/amounts.ts
@@ -22,7 +22,8 @@ export function amountCents(
  *
  * Metronome pricing depends on currency:
  * - USD: expressed in cents
- * - Other fiat currencies: expressed in whole currency units
+ * - Other fiat currencies: expressed in whole currency units (decimals
+ *   are accepted, e.g. 0.0087 EUR for sub-cent unit prices)
  */
 export function metronomeAmount(
   amountCents: number,
@@ -32,5 +33,26 @@ export function metronomeAmount(
     return amountCents;
   }
 
-  return Math.round(amountCents / 100);
+  return amountCents / 100;
+}
+
+// Price per AWU credit in each supported currency. Must stay in sync with
+// scripts/metronome_setup.ts (AWU_IN_USD_CENTS / AWU_IN_EUR).
+export const AWU_PRICE_PER_CREDIT: Record<SupportedCurrency, number> = {
+  usd: 0.01,
+  eur: 0.0087,
+};
+
+export function currencyToAwuCredits(
+  amountCurrencyUnits: number,
+  currency: SupportedCurrency
+): number {
+  return amountCurrencyUnits / AWU_PRICE_PER_CREDIT[currency];
+}
+
+export function awuCreditsToCurrency(
+  credits: number,
+  currency: SupportedCurrency
+): number {
+  return credits * AWU_PRICE_PER_CREDIT[currency];
 }

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -114,13 +114,6 @@ export const MICRO_USD_PER_DOLLAR = 1_000_000;
 export const MIN_CREDIT_PURCHASE_AMOUNT_MICRO_USD = MICRO_USD_PER_DOLLAR;
 // Hard cap used by purchase UIs
 export const MAX_CREDIT_PURCHASE_AMOUNT_MICRO_USD = 1_000_000_000;
-// Price per AWU credit in each supported currency. Must stay in sync with
-// scripts/metronome_setup.ts (AWU_IN_USD_CENTS / AWU_IN_EUR).
-export const AWU_PRICE_PER_CREDIT: Record<SupportedCurrency, number> = {
-  usd: 0.01,
-  eur: 0.0087,
-};
-
 export interface MetronomeUsageListResponse {
   billableMetricId: string;
   billableMetricName: string;


### PR DESCRIPTION
## Description

* Consolidates AWU credit ↔ currency conversion behind helpers next to `metronomeAmount`, lets `metronomeAmount` preserve sub-cent EUR decimals (needed for the 0.0087 EUR per-credit AWU unit price), and pins the new behavior with unit tests.
* Fix accounting on AWU purchase that were only correct in USD and allowed to purchase more than the max limit of credits when in EUR

## Tests

unit

## Risk

low

## Deploy Plan

front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25757">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->