### PR TITLE
Polish Pod File Explorer

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -410,6 +410,11 @@ export function AgentMessage({
             }
             if (action.internalMCPServerName === "sandbox") {
               void mutateSandboxStatus();
+            }
+            if (
+              action.internalMCPServerName === "sandbox" ||
+              action.generatedFiles.length > 0
+            ) {
               void mutateSandboxFiles();
             }
             if (action.internalMCPServerName === "wakeups") {

--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -574,9 +574,11 @@ function ProjectFileExplorerContent({
       <FileExplorer
         contentClassName="max-w-4xl mx-auto w-full"
         contentNodes={contentNodeEntries}
+        defaultViewMode="list"
         emptyState={hasFiles ? undefined : emptyState}
         files={projectGCSFiles}
         getFileUrl={getFileUrl}
+        hideTitleBorder
         onFileDownload={onFileDownload}
         onDelete={!isArchived ? onDelete : undefined}
         onRename={!isArchived ? onRename : undefined}

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -51,7 +51,9 @@ function FileExplorerBreadcrumb({
 interface FileExplorerProps {
   contentClassName?: string;
   contentNodes?: ContentNodeEntry[];
+  defaultViewMode?: ViewMode;
   emptyState?: React.ReactNode;
+  hideTitleBorder?: boolean;
   files: GCSMountEntry[];
   getFileUrl: (path: string) => string;
   headerActions?: React.ReactNode;
@@ -66,10 +68,12 @@ interface FileExplorerProps {
 export function FileExplorer({
   contentClassName,
   contentNodes = [],
+  defaultViewMode = "grid",
   emptyState,
   files,
   getFileUrl,
   headerActions,
+  hideTitleBorder = false,
   isLoading,
   onClose,
   onDelete,
@@ -78,7 +82,7 @@ export function FileExplorer({
   onRename,
 }: FileExplorerProps) {
   const [folderStack, setFolderStack] = useState<SandboxTreeNode[]>([]);
-  const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  const [viewMode, setViewMode] = useState<ViewMode>(defaultViewMode);
   const [searchQuery, setSearchQuery] = useState("");
   const [activeFilter, setActiveFilter] = useState<FileExplorerFilter>("all");
   const [sortMode, setSortMode] =
@@ -181,7 +185,7 @@ export function FileExplorer({
   return (
     <>
       <div className="flex h-full w-full min-h-0 flex-1 flex-col">
-        <AppLayoutTitle>
+        <AppLayoutTitle className={hideTitleBorder ? "border-b-0" : undefined}>
           <div
             className={cn(
               "flex h-full items-center justify-between gap-2 px-4",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/25744. Three small quality-of-life improvements on the project file explorer.

The file explorer in conversations wasn't refreshing when an agent created or edited a file using the file editing tools. Only sandbox command execution was triggering a refresh. It now refreshes whenever an action produces generated files, which covers the missing cases.

The project file explorer now opens in list view by default, which fits better with the document-heavy nature of project knowledge.

Finally, opening the Files tab in a project was showing two stacked separators. One from the tab bar and one from the breadcrumb header.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25759">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->