### PR TITLE
[dsbx] scope MITM to allowlist union from secrets file

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,11 +313,12 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",
  "libc",
+ "lru",
  "rcgen",
  "reqwest",
  "rustls",
@@ -326,6 +333,12 @@ dependencies = [
  "tracing-subscriber",
  "x509-parser",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -348,6 +361,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -422,6 +441,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -718,6 +748,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "lru-slab"

--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -364,9 +364,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -751,9 +751,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown",
 ]

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 libc = "0.2"
-lru = "0.12"
+lru = "0.16"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [[bin]]
@@ -12,6 +12,7 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 libc = "0.2"
+lru = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -5,6 +5,7 @@ mod original_dst;
 mod sni;
 mod tls_mitm;
 
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -13,11 +14,13 @@ use anyhow::{ensure, Context, Result};
 use rustls::pki_types::ServerName;
 use rustls::ClientConfig;
 use rustls::RootCertStore;
+use tokio::io::AsyncRead;
 use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::{sleep, timeout, timeout_at, Instant};
-use tokio_rustls::TlsConnector;
+use tokio_rustls::{TlsAcceptor, TlsConnector};
 use tracing::{debug, info, warn};
 
 use crate::egress_secrets::SecretTable;
@@ -38,6 +41,7 @@ const MITM_CA_CERT_PATH: &str = "/run/dust/egress-ca.pem";
 const MITM_CA_KEY_PATH: &str = "/run/dust/egress-ca.key";
 // Must match `front/lib/api/sandbox/egress_secrets.ts:EGRESS_SECRETS_PATH`.
 const EGRESS_SECRETS_PATH: &str = "/run/dust/egress-secrets.json";
+const HTTP_1_1_ALPN: &[u8] = b"http/1.1";
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct ForwardArgs {
@@ -69,9 +73,10 @@ struct ForwardRuntime {
     deny_log: Arc<PathBuf>,
     // Plumbed in Slice 4; consumed by SNI-scoped MITM in Slice 5 and the
     // request rewriter in Slice 6.
-    #[allow(dead_code)]
     secret_table: Arc<SecretTable>,
     tls_connector: TlsConnector,
+    mitm_tls_connector: TlsConnector,
+    mitm_ca: Arc<MitmCa>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -90,19 +95,22 @@ struct DomainExtraction {
 pub async fn cmd_forward(args: ForwardArgs) -> Result<()> {
     let token = load_token(&args.token_file).await?;
     let tls_connector = build_tls_connector()?;
+    let mitm_tls_connector = build_http1_tls_connector()?;
 
     // The CA must be loaded/generated BEFORE we bind the listener. Front uses
     // "port 9990 is LISTEN" as the readiness signal and, the moment that's
     // true, reads /run/dust/egress-ca.pem to build the sandbox trust bundle.
     // Bind-then-write would race: front could see a missing or stale CA file.
-    // Keep this ordering intact on restarts too. The slice that wires up TLS
-    // termination will reintroduce the CA into ForwardRuntime; today only its
-    // on-disk side effect matters, so we drop the in-memory handle.
-    let _ = MitmCa::load_or_generate(
-        std::path::Path::new(MITM_CA_CERT_PATH),
-        std::path::Path::new(MITM_CA_KEY_PATH),
-    )
-    .context("failed to load or generate persistent MITM CA")?;
+    // Keep this ordering intact on restarts too. The in-memory handle backs
+    // the SNI-scoped TLS termination path; the on-disk cert is what front
+    // installs into the sandbox trust bundle.
+    let mitm_ca = Arc::new(
+        MitmCa::load_or_generate(
+            std::path::Path::new(MITM_CA_CERT_PATH),
+            std::path::Path::new(MITM_CA_KEY_PATH),
+        )
+        .context("failed to load or generate persistent MITM CA")?,
+    );
 
     // The secrets file is intentionally loaded once at dsbx startup. Front
     // propagates changes in Phase 1 by rewriting the file and restarting dsbx
@@ -132,6 +140,8 @@ pub async fn cmd_forward(args: ForwardArgs) -> Result<()> {
         deny_log: Arc::new(args.deny_log),
         secret_table: Arc::new(secret_table),
         tls_connector,
+        mitm_tls_connector,
+        mitm_ca,
     };
 
     loop {
@@ -165,6 +175,14 @@ async fn load_token(token_file: &PathBuf) -> Result<String> {
 }
 
 fn build_tls_connector() -> Result<TlsConnector> {
+    build_tls_connector_with_alpn(Vec::new())
+}
+
+fn build_http1_tls_connector() -> Result<TlsConnector> {
+    build_tls_connector_with_alpn(vec![HTTP_1_1_ALPN.to_vec()])
+}
+
+fn build_tls_connector_with_alpn(alpn_protocols: Vec<Vec<u8>>) -> Result<TlsConnector> {
     // rustls 0.23 requires an explicit process-level CryptoProvider.
     // install_default returns Err if one is already installed — we just want to
     // guarantee some provider is present before ClientConfig::builder().
@@ -186,12 +204,13 @@ fn build_tls_connector() -> Result<TlsConnector> {
     }
     ensure!(
         loaded != 0,
-        "failed to load any native root certificates for proxy TLS validation"
+        "failed to load any native root certificates for TLS validation"
     );
 
-    let config = ClientConfig::builder()
+    let mut config = ClientConfig::builder()
         .with_root_certificates(roots)
         .with_no_client_auth();
+    config.alpn_protocols = alpn_protocols;
 
     Ok(TlsConnector::from(Arc::new(config)))
 }
@@ -205,6 +224,11 @@ async fn handle_connection(
         resolve_original_dst(&client_stream).context("failed to resolve original destination")?;
     let original_port = original_dst.port();
     let domain_extraction = extract_domain(&client_stream, original_port).await;
+    let mitm_target = mitm_target_for(
+        original_port,
+        &domain_extraction.domain,
+        &runtime.secret_table,
+    );
 
     let server_name = ServerName::try_from(runtime.proxy_tls_name.to_string())
         .context("invalid proxy TLS server name")?;
@@ -231,12 +255,19 @@ async fn handle_connection(
                 peer_addr = %peer_addr,
                 original_port,
                 domain = display_domain(&domain_extraction.domain),
+                mitm = mitm_target.is_some(),
                 "proxy allowed forwarded connection"
             );
 
-            tokio::io::copy_bidirectional(&mut client_stream, &mut proxy_stream)
-                .await
-                .context("bidirectional copy failed")?;
+            if let Some(sni) = mitm_target {
+                run_mitm_session(&runtime, &sni, client_stream, proxy_stream)
+                    .await
+                    .context("MITM session failed")?;
+            } else {
+                tokio::io::copy_bidirectional(&mut client_stream, &mut proxy_stream)
+                    .await
+                    .context("bidirectional copy failed")?;
+            }
         }
         ProxyDecision::Deny => {
             let reason = if domain_extraction.failed {
@@ -276,6 +307,63 @@ async fn handle_connection(
                 "proxy returned an invalid response"
             );
         }
+    }
+
+    Ok(())
+}
+
+fn mitm_target_for(original_port: u16, domain: &str, secret_table: &SecretTable) -> Option<String> {
+    if original_port != 443 || !secret_table.sni_match_set.matches(domain) {
+        return None;
+    }
+
+    Some(domain.to_string())
+}
+
+async fn run_mitm_session<C, S>(
+    runtime: &ForwardRuntime,
+    sni: &str,
+    client_stream: C,
+    proxy_stream: S,
+) -> Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let upstream_server_name =
+        ServerName::try_from(sni.to_string()).context("invalid upstream SNI for MITM TLS")?;
+    let mut upstream_tls = runtime
+        .mitm_tls_connector
+        .connect(upstream_server_name, proxy_stream)
+        .await
+        .context("failed to establish MITM TLS to upstream via proxy tunnel")?;
+
+    let server_config = runtime
+        .mitm_ca
+        .server_config_for(sni)
+        .await
+        .context("failed to build MITM server config for SNI")?;
+    let acceptor = TlsAcceptor::from(server_config);
+    let mut agent_tls = acceptor
+        .accept(client_stream)
+        .await
+        .context("failed to accept agent TLS for MITM")?;
+
+    match tokio::io::copy_bidirectional(&mut agent_tls, &mut upstream_tls).await {
+        Ok(_) => {}
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::BrokenPipe | ErrorKind::ConnectionReset
+            ) =>
+        {
+            debug!(
+                sni,
+                error = %error,
+                "MITM bidirectional copy ended after peer closed the connection"
+            );
+        }
+        Err(error) => return Err(error).context("MITM bidirectional copy failed"),
     }
 
     Ok(())
@@ -376,5 +464,220 @@ where
             _ => ProxyDecision::ProtocolError,
         },
         Ok(Err(_)) | Err(_) => ProxyDecision::ProtocolError,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use anyhow::{ensure, Context, Result};
+    use rcgen::{
+        BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair,
+        KeyUsagePurpose, SanType,
+    };
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    use crate::egress_secrets::DomainSet;
+
+    use super::*;
+
+    #[test]
+    fn mitm_target_matches_exact_and_wildcard_secret_domains() -> Result<()> {
+        let table = secret_table(&["api.openai.com", "*.googleapis.com"])?;
+
+        assert_eq!(
+            mitm_target_for(443, "api.openai.com", &table),
+            Some("api.openai.com".to_string())
+        );
+        assert_eq!(
+            mitm_target_for(443, "storage.googleapis.com", &table),
+            Some("storage.googleapis.com".to_string())
+        );
+        assert_eq!(mitm_target_for(443, "googleapis.com", &table), None);
+        assert_eq!(mitm_target_for(80, "api.openai.com", &table), None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn mitm_target_is_empty_without_loaded_secrets() {
+        assert_eq!(
+            mitm_target_for(443, "api.openai.com", &SecretTable::default()),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn mitm_session_copies_decrypted_bytes_unchanged() -> Result<()> {
+        let sni = "api.openai.com";
+        let mitm_ca = Arc::new(MitmCa::generate()?);
+        let (upstream_server_config, upstream_ca_der) = test_upstream_server_config(sni)?;
+        let runtime = test_runtime(Arc::clone(&mitm_ca), upstream_ca_der)?;
+
+        let (agent_client_io, agent_dsbx_io) = tokio::io::duplex(4096);
+        let (dsbx_proxy_io, upstream_server_io) = tokio::io::duplex(4096);
+
+        let upstream_task = tokio::spawn(async move {
+            let acceptor = TlsAcceptor::from(upstream_server_config);
+            let mut tls = acceptor
+                .accept(upstream_server_io)
+                .await
+                .context("test upstream failed to accept TLS")?;
+            ensure!(
+                tls.get_ref().1.alpn_protocol() == Some(HTTP_1_1_ALPN),
+                "test upstream did not negotiate http/1.1"
+            );
+
+            let mut request = [0_u8; 4];
+            tls.read_exact(&mut request)
+                .await
+                .context("test upstream failed to read request bytes")?;
+            assert_eq!(&request, b"ping");
+            tls.write_all(b"pong")
+                .await
+                .context("test upstream failed to write response bytes")?;
+            let mut tail = Vec::new();
+            tls.read_to_end(&mut tail)
+                .await
+                .context("test upstream failed to read client close")?;
+            tls.shutdown()
+                .await
+                .context("test upstream failed to shut down TLS")?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        let agent_connector = test_tls_connector(
+            mitm_ca.ca_cert_der(),
+            vec![b"h2".to_vec(), HTTP_1_1_ALPN.to_vec()],
+        )?;
+        let agent_task = tokio::spawn(async move {
+            let server_name =
+                ServerName::try_from(sni.to_string()).context("invalid test agent SNI")?;
+            let mut tls = agent_connector
+                .connect(server_name, agent_client_io)
+                .await
+                .context("test agent failed to connect to dsbx MITM")?;
+            ensure!(
+                tls.get_ref().1.alpn_protocol() == Some(HTTP_1_1_ALPN),
+                "test agent did not negotiate http/1.1"
+            );
+
+            tls.write_all(b"ping")
+                .await
+                .context("test agent failed to write request bytes")?;
+            let mut response = [0_u8; 4];
+            tls.read_exact(&mut response)
+                .await
+                .context("test agent failed to read response bytes")?;
+            assert_eq!(&response, b"pong");
+            tls.shutdown()
+                .await
+                .context("test agent failed to shut down TLS")?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        run_mitm_session(&runtime, sni, agent_dsbx_io, dsbx_proxy_io).await?;
+        agent_task.await.context("test agent task panicked")??;
+        upstream_task
+            .await
+            .context("test upstream task panicked")??;
+
+        Ok(())
+    }
+
+    fn secret_table(patterns: &[&str]) -> Result<SecretTable> {
+        let allowed_domains = patterns
+            .iter()
+            .map(|pattern| (*pattern).to_string())
+            .collect::<Vec<_>>();
+        Ok(SecretTable {
+            by_placeholder: HashMap::new(),
+            sni_match_set: DomainSet::from_patterns(&allowed_domains)?,
+        })
+    }
+
+    fn test_runtime(
+        mitm_ca: Arc<MitmCa>,
+        upstream_ca_der: CertificateDer<'static>,
+    ) -> Result<ForwardRuntime> {
+        let tls_connector = test_tls_connector(upstream_ca_der.clone(), Vec::new())?;
+        let mitm_tls_connector = test_tls_connector(upstream_ca_der, vec![HTTP_1_1_ALPN.to_vec()])?;
+
+        Ok(ForwardRuntime {
+            token: Arc::<str>::from("token"),
+            proxy_addr: "127.0.0.1:1".parse()?,
+            proxy_tls_name: Arc::<str>::from("proxy.test"),
+            deny_log: Arc::new(PathBuf::from("/tmp/dust-egress-denied-test.log")),
+            secret_table: Arc::new(SecretTable::default()),
+            tls_connector,
+            mitm_tls_connector,
+            mitm_ca,
+        })
+    }
+
+    fn test_tls_connector(
+        root: CertificateDer<'static>,
+        alpn_protocols: Vec<Vec<u8>>,
+    ) -> Result<TlsConnector> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let mut roots = RootCertStore::empty();
+        roots.add(root).context("failed to add test root cert")?;
+        let mut config = ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        config.alpn_protocols = alpn_protocols;
+        Ok(TlsConnector::from(Arc::new(config)))
+    }
+
+    fn test_upstream_server_config(
+        sni: &str,
+    ) -> Result<(Arc<rustls::ServerConfig>, CertificateDer<'static>)> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let mut ca_params =
+            CertificateParams::new(Vec::<String>::new()).context("invalid test CA params")?;
+        let mut ca_dn = DistinguishedName::new();
+        ca_dn.push(DnType::CommonName, "Dust test upstream CA");
+        ca_params.distinguished_name = ca_dn;
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::CrlSign,
+            KeyUsagePurpose::DigitalSignature,
+        ];
+        let ca_key = KeyPair::generate().context("failed to generate test CA key")?;
+        let ca_cert = ca_params
+            .self_signed(&ca_key)
+            .context("failed to self-sign test CA")?;
+
+        let mut leaf_params =
+            CertificateParams::new(Vec::<String>::new()).context("invalid test leaf params")?;
+        let mut leaf_dn = DistinguishedName::new();
+        leaf_dn.push(DnType::CommonName, sni);
+        leaf_params.distinguished_name = leaf_dn;
+        leaf_params.subject_alt_names = vec![SanType::DnsName(
+            sni.to_string().try_into().context("invalid test SNI")?,
+        )];
+        let leaf_key = KeyPair::generate().context("failed to generate test leaf key")?;
+        let leaf_cert = leaf_params
+            .signed_by(&leaf_key, &ca_cert, &ca_key)
+            .context("failed to sign test leaf")?;
+
+        let leaf_der = CertificateDer::from(leaf_cert.der().to_vec());
+        let key_der = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(leaf_key.serialize_der()));
+        let mut server_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![leaf_der], key_der)
+            .context("failed to build test upstream server config")?;
+        server_config.alpn_protocols = vec![HTTP_1_1_ALPN.to_vec()];
+
+        Ok((
+            Arc::new(server_config),
+            CertificateDer::from(ca_cert.der().to_vec()),
+        ))
     }
 }

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -30,7 +30,7 @@ use self::handshake::{build_handshake_frame, ALLOW_RESPONSE, DENY_RESPONSE};
 use self::http_host::parse_http_host;
 use self::original_dst::resolve_original_dst;
 use self::sni::parse_client_hello_sni;
-use self::tls_mitm::MitmCa;
+use self::tls_mitm::{MitmCa, HTTP_1_1_ALPN};
 
 const DOMAIN_PEEK_TIMEOUT: Duration = Duration::from_secs(2);
 const DOMAIN_PEEK_RETRY_DELAY: Duration = Duration::from_millis(25);
@@ -41,7 +41,6 @@ const MITM_CA_CERT_PATH: &str = "/run/dust/egress-ca.pem";
 const MITM_CA_KEY_PATH: &str = "/run/dust/egress-ca.key";
 // Must match `front/lib/api/sandbox/egress_secrets.ts:EGRESS_SECRETS_PATH`.
 const EGRESS_SECRETS_PATH: &str = "/run/dust/egress-secrets.json";
-const HTTP_1_1_ALPN: &[u8] = b"http/1.1";
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct ForwardArgs {
@@ -260,7 +259,7 @@ async fn handle_connection(
             );
 
             if let Some(sni) = mitm_target {
-                run_mitm_session(&runtime, &sni, client_stream, proxy_stream)
+                run_mitm_session(&runtime, sni, client_stream, proxy_stream)
                     .await
                     .context("MITM session failed")?;
             } else {
@@ -312,12 +311,16 @@ async fn handle_connection(
     Ok(())
 }
 
-fn mitm_target_for(original_port: u16, domain: &str, secret_table: &SecretTable) -> Option<String> {
+fn mitm_target_for<'a>(
+    original_port: u16,
+    domain: &'a str,
+    secret_table: &SecretTable,
+) -> Option<&'a str> {
     if original_port != 443 || !secret_table.sni_match_set.matches(domain) {
         return None;
     }
 
-    Some(domain.to_string())
+    Some(domain)
 }
 
 async fn run_mitm_session<C, S>(
@@ -354,7 +357,7 @@ where
         Err(error)
             if matches!(
                 error.kind(),
-                ErrorKind::BrokenPipe | ErrorKind::ConnectionReset
+                ErrorKind::BrokenPipe | ErrorKind::ConnectionReset | ErrorKind::UnexpectedEof
             ) =>
         {
             debug!(
@@ -490,11 +493,11 @@ mod tests {
 
         assert_eq!(
             mitm_target_for(443, "api.openai.com", &table),
-            Some("api.openai.com".to_string())
+            Some("api.openai.com")
         );
         assert_eq!(
             mitm_target_for(443, "storage.googleapis.com", &table),
-            Some("storage.googleapis.com".to_string())
+            Some("storage.googleapis.com")
         );
         assert_eq!(mitm_target_for(443, "googleapis.com", &table), None);
         assert_eq!(mitm_target_for(80, "api.openai.com", &table), None);

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -183,10 +183,20 @@ fn build_http1_tls_connector() -> Result<TlsConnector> {
 
 fn build_tls_connector_with_alpn(alpn_protocols: Vec<Vec<u8>>) -> Result<TlsConnector> {
     // rustls 0.23 requires an explicit process-level CryptoProvider.
-    // install_default returns Err if one is already installed — we just want to
+    // install_default returns Err if one is already installed; we just want to
     // guarantee some provider is present before ClientConfig::builder().
     let _ = rustls::crypto::ring::default_provider().install_default();
 
+    // Outbound trust set comes from the OS root store via rustls_native_certs.
+    // On a wake/restart the trust-bundle installer has already added dsbx's
+    // own CA at /etc/ssl/certs/dust-egress.pem, so the restarted dsbx will
+    // load its own CA into this outbound trust set. The "dsbx must not trust
+    // its own CA on outbound" invariant therefore depends on the threat
+    // model: forging a cert signed by that CA requires the private key at
+    // /run/dust/egress-ca.key (mode 0600 root-owned). We assume an attacker
+    // does not get root in the sandbox, so this is accepted as-is rather
+    // than filtered out here. If that assumption ever weakens, switch dsbx
+    // outbound to webpki-roots (vendored Mozilla bundle) instead of native.
     let mut roots = RootCertStore::empty();
     let certs = rustls_native_certs::load_native_certs();
 

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -591,6 +591,94 @@ mod tests {
         Ok(())
     }
 
+    // SNI-miss path: dsbx does not terminate, just splices. The agent's TLS
+    // client must see the upstream's real cert chain (not the dsbx CA),
+    // which is the load-bearing property of the splice branch.
+    #[tokio::test]
+    async fn splice_session_preserves_upstream_chain() -> Result<()> {
+        let sni = "other.com";
+        let mitm_ca = Arc::new(MitmCa::generate()?);
+        let (upstream_server_config, upstream_ca_der) = test_upstream_server_config(sni)?;
+
+        // Empty allowlist union means the branch decision is splice for any SNI.
+        let secret_table = SecretTable::default();
+        assert_eq!(mitm_target_for(443, sni, &secret_table), None);
+
+        let (agent_client_io, mut agent_dsbx_io) = tokio::io::duplex(4096);
+        let (mut dsbx_proxy_io, upstream_server_io) = tokio::io::duplex(4096);
+
+        let upstream_task = tokio::spawn(async move {
+            let acceptor = TlsAcceptor::from(upstream_server_config);
+            let mut tls = acceptor
+                .accept(upstream_server_io)
+                .await
+                .context("test upstream failed to accept TLS")?;
+
+            let mut request = [0_u8; 4];
+            tls.read_exact(&mut request)
+                .await
+                .context("test upstream failed to read request bytes")?;
+            assert_eq!(&request, b"ping");
+            tls.write_all(b"pong")
+                .await
+                .context("test upstream failed to write response bytes")?;
+            let mut tail = Vec::new();
+            tls.read_to_end(&mut tail)
+                .await
+                .context("test upstream failed to read client close")?;
+            tls.shutdown()
+                .await
+                .context("test upstream failed to shut down TLS")?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        // Trust ONLY the upstream's real CA. If dsbx silently terminated and
+        // re-signed with its own CA, the agent connect would fail.
+        let agent_connector = test_tls_connector(upstream_ca_der, Vec::new())?;
+        let mitm_ca_subject = mitm_ca.ca_cert_der();
+        let agent_task = tokio::spawn(async move {
+            let server_name =
+                ServerName::try_from(sni.to_string()).context("invalid test agent SNI")?;
+            let mut tls = agent_connector
+                .connect(server_name, agent_client_io)
+                .await
+                .context("test agent failed to connect through dsbx splice")?;
+
+            let observed_chain = tls.get_ref().1.peer_certificates().unwrap_or(&[]);
+            let observed_leaf = observed_chain.first().expect("expected leaf cert").to_vec();
+            assert_ne!(
+                observed_leaf,
+                mitm_ca_subject.to_vec(),
+                "splice path leaked the dsbx MITM CA into the agent's TLS view"
+            );
+
+            tls.write_all(b"ping")
+                .await
+                .context("test agent failed to write request bytes")?;
+            let mut response = [0_u8; 4];
+            tls.read_exact(&mut response)
+                .await
+                .context("test agent failed to read response bytes")?;
+            assert_eq!(&response, b"pong");
+            tls.shutdown()
+                .await
+                .context("test agent failed to shut down TLS")?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        tokio::io::copy_bidirectional(&mut agent_dsbx_io, &mut dsbx_proxy_io)
+            .await
+            .ok();
+        agent_task.await.context("test agent task panicked")??;
+        upstream_task
+            .await
+            .context("test upstream task panicked")??;
+
+        // Silence the dead variable warning when MitmCa stays unused on this path.
+        let _ = mitm_ca;
+        Ok(())
+    }
+
     fn secret_table(patterns: &[&str]) -> Result<SecretTable> {
         let allowed_domains = patterns
             .iter()

--- a/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
+++ b/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
@@ -1,26 +1,32 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
+use std::num::NonZeroUsize;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context, Result};
+use lru::LruCache;
 use rcgen::{
     BasicConstraints, Certificate, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair,
-    KeyUsagePurpose,
+    KeyUsagePurpose, SanType,
 };
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use rustls::server::ResolvesServerCert;
+use rustls::sign::CertifiedKey;
+use rustls::ServerConfig;
+use tokio::sync::Mutex;
 
 const CA_COMMON_NAME: &str = "Dust Sandbox Egress MITM CA";
+const LEAF_CACHE_CAPACITY: usize = 256;
+const HTTP_1_1_ALPN: &[u8] = b"http/1.1";
 
-// Slice 3 only persists the CA on disk so front can install it in the sandbox
-// trust bundle. Per-host leaf signing + an LRU-bounded cache land in the slice
-// that wires up TLS termination, alongside the per-request placeholder swap.
 pub struct MitmCa {
-    #[allow(dead_code)]
     ca_cert: Certificate,
-    #[allow(dead_code)]
     ca_key_pair: KeyPair,
     ca_cert_pem: String,
+    leaf_cache: Mutex<LruCache<String, Arc<CertifiedKey>>>,
 }
 
 impl MitmCa {
@@ -64,6 +70,7 @@ impl MitmCa {
             ca_cert,
             ca_key_pair,
             ca_cert_pem,
+            leaf_cache: Mutex::new(Self::new_leaf_cache()),
         })
     }
 
@@ -101,7 +108,20 @@ impl MitmCa {
             ca_cert,
             ca_key_pair,
             ca_cert_pem,
+            leaf_cache: Mutex::new(Self::new_leaf_cache()),
         })
+    }
+
+    pub async fn server_config_for(self: &Arc<Self>, sni: &str) -> Result<Arc<ServerConfig>> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let certified = self.get_or_mint_leaf(sni).await?;
+        let resolver = SingleCertResolver { key: certified };
+        let mut config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_cert_resolver(Arc::new(resolver));
+        config.alpn_protocols = vec![HTTP_1_1_ALPN.to_vec()];
+        Ok(Arc::new(config))
     }
 
     fn new_ca_params() -> Result<CertificateParams> {
@@ -120,12 +140,71 @@ impl MitmCa {
         Ok(params)
     }
 
+    fn new_leaf_cache() -> LruCache<String, Arc<CertifiedKey>> {
+        let Some(capacity) = NonZeroUsize::new(LEAF_CACHE_CAPACITY) else {
+            unreachable!("leaf cache capacity must be non-zero");
+        };
+        LruCache::new(capacity)
+    }
+
     fn write_persistent(&self, cert_path: &Path, key_path: &Path) -> Result<()> {
         write_file_atomically(cert_path, self.ca_cert_pem.as_bytes(), 0o644)
             .with_context(|| format!("failed to write CA cert file {}", cert_path.display()))?;
         write_file_atomically(key_path, self.ca_key_pair.serialize_pem().as_bytes(), 0o600)
             .with_context(|| format!("failed to write CA key file {}", key_path.display()))?;
         Ok(())
+    }
+
+    async fn get_or_mint_leaf(&self, sni: &str) -> Result<Arc<CertifiedKey>> {
+        let mut cache = self.leaf_cache.lock().await;
+        if let Some(existing) = cache.get(sni).cloned() {
+            return Ok(existing);
+        }
+
+        let minted = self.mint_leaf(sni)?;
+        cache.put(sni.to_string(), Arc::clone(&minted));
+        Ok(minted)
+    }
+
+    fn mint_leaf(&self, sni: &str) -> Result<Arc<CertifiedKey>> {
+        let mut params =
+            CertificateParams::new(Vec::<String>::new()).context("invalid leaf params")?;
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, sni);
+        params.distinguished_name = dn;
+        params.subject_alt_names = vec![SanType::DnsName(
+            sni.to_string()
+                .try_into()
+                .context("invalid SNI for leaf cert")?,
+        )];
+
+        let leaf_key = KeyPair::generate().context("failed to generate leaf key pair")?;
+        let leaf = params
+            .signed_by(&leaf_key, &self.ca_cert, &self.ca_key_pair)
+            .context("failed to sign leaf certificate")?;
+
+        let leaf_der = CertificateDer::from(leaf.der().to_vec());
+        let key_der = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(leaf_key.serialize_der()));
+        let signing_key = rustls::crypto::ring::sign::any_supported_type(&key_der)
+            .context("failed to load leaf signing key")?;
+
+        Ok(Arc::new(CertifiedKey::new(vec![leaf_der], signing_key)))
+    }
+
+    #[cfg(test)]
+    pub(super) fn ca_cert_der(&self) -> CertificateDer<'static> {
+        CertificateDer::from(self.ca_cert.der().to_vec())
+    }
+}
+
+#[derive(Debug)]
+struct SingleCertResolver {
+    key: Arc<CertifiedKey>,
+}
+
+impl ResolvesServerCert for SingleCertResolver {
+    fn resolve(&self, _client_hello: rustls::server::ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        Some(Arc::clone(&self.key))
     }
 }
 
@@ -316,6 +395,29 @@ mod tests {
             }
         }
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn server_config_for_forces_http1_alpn() -> Result<()> {
+        let ca = Arc::new(MitmCa::generate()?);
+
+        let config = ca.server_config_for("api.openai.com").await?;
+
+        assert_eq!(config.alpn_protocols, vec![HTTP_1_1_ALPN.to_vec()]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn leaf_cache_is_lru_bounded() -> Result<()> {
+        let ca = Arc::new(MitmCa::generate()?);
+
+        for i in 0..(LEAF_CACHE_CAPACITY + 10) {
+            let sni = format!("host-{i}.example.com");
+            ca.server_config_for(&sni).await?;
+        }
+
+        assert_eq!(ca.leaf_cache.lock().await.len(), LEAF_CACHE_CAPACITY);
         Ok(())
     }
 }

--- a/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
+++ b/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
@@ -113,6 +113,10 @@ impl MitmCa {
     }
 
     pub async fn server_config_for(&self, sni: &str) -> Result<Arc<ServerConfig>> {
+        // Idempotent. Keeps focused tests (e.g. `cargo test server_config_for`)
+        // from panicking when no other test installed the provider first.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let certified = self.get_or_mint_leaf(sni).await?;
         let resolver = SingleCertResolver { key: certified };
         let mut config = ServerConfig::builder()

--- a/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
+++ b/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
@@ -20,7 +20,7 @@ use tokio::sync::Mutex;
 
 const CA_COMMON_NAME: &str = "Dust Sandbox Egress MITM CA";
 const LEAF_CACHE_CAPACITY: usize = 256;
-const HTTP_1_1_ALPN: &[u8] = b"http/1.1";
+pub(super) const HTTP_1_1_ALPN: &[u8] = b"http/1.1";
 
 pub struct MitmCa {
     ca_cert: Certificate,
@@ -112,9 +112,7 @@ impl MitmCa {
         })
     }
 
-    pub async fn server_config_for(self: &Arc<Self>, sni: &str) -> Result<Arc<ServerConfig>> {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-
+    pub async fn server_config_for(&self, sni: &str) -> Result<Arc<ServerConfig>> {
         let certified = self.get_or_mint_leaf(sni).await?;
         let resolver = SingleCertResolver { key: certified };
         let mut config = ServerConfig::builder()

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -49,10 +49,10 @@ function getCopiedContent(
 }
 
 describe("sandbox image registry", () => {
-  test("bumps the base image for the trust-matrix rollout", () => {
+  test("bumps the base image for the scoped MITM rollout", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.11",
+      tag: "0.8.12",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -14,8 +14,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.11";
-const DSBX_CLI_VERSION = "0.1.7";
+const DUST_BASE_IMAGE_VERSION = "0.8.12";
+const DSBX_CLI_VERSION = "0.1.8";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.


### PR DESCRIPTION
## Description

Reintroduces TLS termination inside dsbx, gated on SNI being in the allowlist union built from `/run/dust/egress-secrets.json`:

1. `mitm_target_for(port, sni, secrets)` decides whether to terminate. Port 443 + SNI in the union, else splice.
2. `run_mitm_session` terminates inbound TLS with a leaf signed by the persistent CA, dials outbound through the proxy tunnel, bidi-copies decrypted bytes.
3. ALPN forced to `http/1.1` on both sides so the upcoming HTTP/1.1 rewriter never has to deal with h2 frames mid-stream.
4. Leaf cert cache is `lru::LruCache` bounded at 256 from the start. No unbounded HashMap with a TODO.
5. `MitmCa` keeps its in-memory handle now (it was previously dropped after the on-disk write).

The CA load-or-generate still happens before binding the listener, so front's "port 9990 LISTEN" readiness still implies the on-disk cert is ready for the trust-bundle install. The deprecated `--mitm-experiment-*` flags are already gone, so no lockstep release hazard with front.

> [!NOTE]
> No workspace has any `https_secret` row in prod yet, so this PR has zero substitution traffic. Once a row is promoted, dsbx will start terminating real TLS on the allowlisted SNIs (no header substitution yet, that comes in the next PR, but TLS is MITM'd end-to-end).

Bumps:
- dsbx 0.1.7 to 0.1.8
- dust-base 0.8.11 to 0.8.12 (forces image rebuild)

## Tests

Cargo tests cover the new bits with two real TLS round trips through `tokio::io::duplex` pairs:

- MITM path (`mitm_session_copies_decrypted_bytes_unchanged`): agent trust store contains only dsbx's CA. Confirms substitution boundary terminates inbound, dials outbound, and round-trips plaintext bytes unchanged. Both sides negotiate `http/1.1`.
- Splice path (`splice_session_preserves_upstream_chain`): empty allowlist union, agent trust store contains only the upstream's real CA (not dsbx's). If the splice path ever silently re-signed, the agent connect would fail.

`mitm_target_for` is covered for exact + wildcard SNI matches, port-80 negation, and empty secret table. Leaf cache LRU bound is exercised by minting 266 leaves and asserting the cache holds at 256.

The full `handle_connection` end-to-end (including the central-proxy handshake and SO_ORIGINAL_DST) stays smoke-tested rather than unit-tested. The harness for that lands with the upcoming rewriter PR.

Smoke against a fresh sandbox post-image-rebuild: confirm SNI hit terminates with the dsbx CA leaf and SNI miss splices through transparently.

## Risk

Medium. Once `https_secret` rows exist for a workspace, dsbx terminates real prod TLS on the allowlisted SNIs. None exist in prod today, so this is preflight only. Worst case, a TLS handshake mismatch surfaces a clean TLS error to the agent, same failure mode as no MITM at all. Safe to rollback (revert + base image rebuild).

## Deploy Plan

- [ ] **First**: manually trigger the `Release dsbx CLI` workflow (`release-dsbx-cli.yml`, `workflow_dispatch`) for this branch to publish `dsbx-v0.1.8`. Verify both `dsbx-linux-x86_64` and `checksums-sha256.txt` are present on the GitHub release. The image build downloads these by URL, so without this step the next step 404s.
- [ ] Manual Deploy workflow with `component=front`. `ensure-sandbox-images` rebuilds `dust-base:0.8.12` in EU + US with `dsbx 0.1.8` baked in.
- [ ] Spawn a fresh sandbox, confirm SNI not in the (still-empty) allowlist union splices through as before.
- [ ] Confirm http/1.1 still works via curl + node + python on allowlisted hosts.
- [ ] No data migration, no GCP secret changes.