### PR TITLE
[front] checkout: enable coupons

### DIFF
--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -53,8 +53,6 @@ function getStripePromise() {
   return stripePromise;
 }
 
-const COUPONS_ENABLED = false;
-
 const couponFormSchema = z.object({
   couponCode: z.string().min(1, "Please enter a promotion code"),
 });
@@ -73,6 +71,7 @@ type PhaseError =
   | { kind: "payment_failed" }
   | { kind: "metronome_error" }
   | { kind: "internal_error" }
+  | { kind: "invalid_coupon" }
   | { kind: "generic" };
 
 function useBillingPeriodParam(): BillingPeriod {
@@ -249,6 +248,9 @@ export function CheckoutPage() {
         case "internal_error":
           setPhaseError({ kind: "internal_error" });
           break;
+        case "invalid_coupon":
+          setPhaseError({ kind: "invalid_coupon" });
+          break;
         default:
           assertNeverAndIgnore(result.error);
           setPhaseError({ kind: "generic" });
@@ -393,8 +395,8 @@ export function CheckoutPage() {
               </span>
             </div>
 
-            {COUPONS_ENABLED &&
-              !appliedCoupon &&
+            {!appliedCoupon &&
+              phase === "card_capture" &&
               (showCouponInput ? (
                 <div className="mt-4 flex flex-col gap-2">
                   <div className="flex gap-2">
@@ -430,19 +432,21 @@ export function CheckoutPage() {
                 </div>
               ))}
 
-            {COUPONS_ENABLED && appliedCoupon && (
+            {appliedCoupon && (
               <div className="mt-4 flex flex-col gap-1">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 text-sm text-muted-foreground">
                     <Icon visual={TagIcon} size="xs" />
                     <span className="font-medium">{appliedCoupon.code}</span>
-                    <button
-                      type="button"
-                      onClick={handleRemoveCoupon}
-                      className="ml-0.5 hover:text-foreground"
-                    >
-                      <Icon visual={XMarkIcon} size="xs" />
-                    </button>
+                    {phase === "card_capture" && (
+                      <button
+                        type="button"
+                        onClick={handleRemoveCoupon}
+                        className="ml-0.5 hover:text-foreground"
+                      >
+                        <Icon visual={XMarkIcon} size="xs" />
+                      </button>
+                    )}
                   </div>
                   <span className="text-sm text-success-500">
                     −
@@ -688,6 +692,27 @@ function RightPane({
                 and we&apos;ll get this sorted out right away.
               </p>
             </div>
+          </div>
+        );
+      }
+      if (phaseError?.kind === "invalid_coupon") {
+        return (
+          <div className="flex flex-col items-center gap-6 text-center">
+            <Icon
+              visual={ActionXCircleIcon}
+              size="2xl"
+              className="text-warning-500"
+            />
+            <div className="flex flex-col gap-3">
+              <h2 className="text-2xl font-semibold text-foreground">
+                Coupon no longer valid
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                This coupon is no longer valid. You have not been charged.
+                Please try again with a different code.
+              </p>
+            </div>
+            <Button label="Try again" onClick={onRestart} />
           </div>
         );
       }

--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -225,7 +225,18 @@ export async function provisionMetronomeFirstPeriodSubscription({
     workspace.sId
   );
   await restoreWorkspaceAfterSubscription(authAdmin);
-  await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({ workspaceId });
+  const workosWorkflowResult =
+    await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({ workspaceId });
+  if (workosWorkflowResult.isErr()) {
+    logger.error(
+      {
+        panic: true,
+        workspaceId,
+        error: normalizeError(workosWorkflowResult.error).message,
+      },
+      "[Checkout] Failed to launch WorkOS workspace subscription created workflow"
+    );
+  }
 
   logger.info(
     { workspaceId, metronomeContractId, uniquenessKey },

--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -6,10 +6,15 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
+import {
+  createCouponCredit,
+  getCreditTypeFromPackage,
+} from "@app/lib/metronome/coupons";
 import { loadFirstPeriodCredit } from "@app/lib/metronome/credits";
 import { PlanModel } from "@app/lib/models/plan";
 import { resolvePackageAliasForCurrency } from "@app/lib/plans/billing_currency";
-import { getStripeClient } from "@app/lib/plans/stripe";
+import type { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import type { CouponResource } from "@app/lib/resources/coupon_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -20,6 +25,7 @@ import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/
 import { isSupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 /**
  * Provisions a Metronome subscription after the first-period payment has been collected.
@@ -29,26 +35,28 @@ import { Err, Ok } from "@app/types/shared/result";
  */
 export async function provisionMetronomeFirstPeriodSubscription({
   stripeCustomerId,
-  paymentMethodId,
-  subtotalCents,
   currency,
   workspaceId,
   userId,
   planCode,
   metronomePackageAlias,
+  coupon,
+  pendingRedemption,
   firstPeriodPaymentEnforced,
+  firstPeriodPaymentCents,
   uniquenessKey,
   now,
 }: {
   stripeCustomerId: string;
-  paymentMethodId: string;
-  subtotalCents: number;
   currency: string;
   workspaceId: string;
   userId: string;
   planCode: string;
   metronomePackageAlias: string;
+  coupon?: CouponResource;
+  pendingRedemption?: CouponRedemptionResource;
   firstPeriodPaymentEnforced: boolean;
+  firstPeriodPaymentCents: number;
   uniquenessKey: string;
   now: Date;
 }): Promise<Result<void, DustError>> {
@@ -73,14 +81,6 @@ export async function provisionMetronomeFirstPeriodSubscription({
     },
     "[Metronome] Handle metronome checkout"
   );
-
-  // Set the payment method as the customer's default for future Metronome-generated
-  // invoices (month 2+). Must be done before provisioning so the PM is in place
-  // before any invoice is attempted.
-  const stripe = getStripeClient();
-  await stripe.customers.update(stripeCustomerId, {
-    invoice_settings: { default_payment_method: paymentMethodId },
-  });
 
   const validCurrency = isSupportedCurrency(currency) ? currency : "usd";
   const resolvedPackageAlias = resolvePackageAliasForCurrency(
@@ -108,17 +108,58 @@ export async function provisionMetronomeFirstPeriodSubscription({
   }
   const { metronomeCustomerId } = customerResult.value;
 
-  const authAdmin = await Authenticator.internalAdminForWorkspace(
-    workspace.sId
-  );
+  if (coupon && pendingRedemption) {
+    const creditTypeResult =
+      await getCreditTypeFromPackage(resolvedPackageAlias);
+    if (creditTypeResult.isErr()) {
+      logger.error(
+        {
+          panic: true,
+          workspaceId,
+          couponCode: coupon.code,
+          redemptionId: pendingRedemption.sId,
+          error: normalizeError(creditTypeResult.error).message,
+        },
+        "[Checkout] Failed to get credit type for coupon in Metronome checkout"
+      );
+      return new Err(
+        new DustError("metronome_error", creditTypeResult.error.message)
+      );
+    }
+    const { creditTypeId, currency: couponCurrency } = creditTypeResult.value;
+    const creditResult = await createCouponCredit({
+      metronomeCustomerId,
+      coupon,
+      redemptionId: pendingRedemption.sId,
+      redeemedAt: pendingRedemption.redeemedAt,
+      creditTypeId,
+      currency: couponCurrency,
+    });
+    if (creditResult.isErr()) {
+      logger.error(
+        {
+          panic: true,
+          workspaceId,
+          couponCode: coupon.code,
+          redemptionId: pendingRedemption.sId,
+          error: normalizeError(creditResult.error).message,
+        },
+        "[Checkout] Failed to create coupon credit in Metronome checkout"
+      );
+      return new Err(
+        new DustError("metronome_error", creditResult.error.message)
+      );
+    }
+    await pendingRedemption.markActive(creditResult.value);
+  }
 
   if (firstPeriodPaymentEnforced) {
     // Zero out the first Metronome-generated invoice. The customer already paid
-    // via the Stripe invoice. subtotalCents is pre-tax — exactly the amount that
+    // via the Stripe invoice. firstPeriodPaymentCents is pre-tax — exactly the amount that
     // Metronome will generate for the first period.
     const creditResult = await loadFirstPeriodCredit({
       metronomeCustomerId,
-      amountCents: subtotalCents,
+      amountCents: firstPeriodPaymentCents,
       currency: validCurrency,
       uniquenessKey,
       now,
@@ -166,6 +207,9 @@ export async function provisionMetronomeFirstPeriodSubscription({
     subscriptionStartAt: now,
   });
 
+  const authAdmin = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
   await restoreWorkspaceAfterSubscription(authAdmin);
   await launchWorkOSWorkspaceSubscriptionCreatedWorkflow({ workspaceId });
 

--- a/front/lib/metronome/checkout.ts
+++ b/front/lib/metronome/checkout.ts
@@ -114,7 +114,6 @@ export async function provisionMetronomeFirstPeriodSubscription({
     if (creditTypeResult.isErr()) {
       logger.error(
         {
-          panic: true,
           workspaceId,
           couponCode: coupon.code,
           redemptionId: pendingRedemption.sId,
@@ -138,7 +137,6 @@ export async function provisionMetronomeFirstPeriodSubscription({
     if (creditResult.isErr()) {
       logger.error(
         {
-          panic: true,
           workspaceId,
           couponCode: coupon.code,
           redemptionId: pendingRedemption.sId,
@@ -150,7 +148,23 @@ export async function provisionMetronomeFirstPeriodSubscription({
         new DustError("metronome_error", creditResult.error.message)
       );
     }
-    await pendingRedemption.markActive(creditResult.value);
+    const markActiveResult = await pendingRedemption.markActive(
+      creditResult.value
+    );
+    if (markActiveResult.isErr()) {
+      logger.error(
+        {
+          workspaceId,
+          couponCode: coupon.code,
+          redemptionId: pendingRedemption.sId,
+          error: normalizeError(markActiveResult.error).message,
+        },
+        "[Checkout] Failed to mark coupon redemption as active"
+      );
+      return new Err(
+        new DustError("metronome_error", markActiveResult.error.message)
+      );
+    }
   }
 
   if (firstPeriodPaymentEnforced) {

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -241,15 +241,25 @@ export async function redeemCoupon(
   });
 
   if (creditResult.isErr()) {
-    await redemption.rollback(coupon);
     logger.error(
       {
         err: creditResult.error,
         couponId: coupon.sId,
         workspaceId: workspace.sId,
       },
-      "[Metronome] Failed to create coupon credit — redemption marked failed"
+      "[Metronome] Failed to create coupon credit — rolling back redemption"
     );
+    const rollbackResult = await redemption.rollback(coupon);
+    if (rollbackResult.isErr()) {
+      logger.error(
+        {
+          err: rollbackResult.error,
+          couponId: coupon.sId,
+          workspaceId: workspace.sId,
+        },
+        "[Metronome] Failed to create coupon credit - failed to rollback coupon redemption"
+      );
+    }
     return new Err(creditResult.error);
   }
 

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -24,7 +24,6 @@ import type {
   CouponResource,
   CouponValidationError,
 } from "@app/lib/resources/coupon_resource";
-import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { CouponDiscountType } from "@app/types/coupon";
 import type { SupportedCurrency } from "@app/types/currency";
@@ -32,7 +31,6 @@ import { isSupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { addMonths } from "date-fns";
 
 async function getCreditTypeFromRateCardId(
@@ -225,20 +223,13 @@ export async function redeemCoupon(
   }
   const { creditTypeId, currency } = creditTypeIdResult.value;
 
-  let redemption: CouponRedemptionResource;
-  try {
-    redemption = await withTransaction(async (transaction) => {
-      const r = await CouponRedemptionResource.makeNew(
-        auth,
-        { coupon },
-        { transaction }
-      );
-      await coupon.incrementRedemptionCount({ transaction });
-      return r;
-    });
-  } catch (err) {
-    return new Err(normalizeError(err));
+  const pendingResult = await CouponRedemptionResource.createPending(auth, {
+    coupon,
+  });
+  if (pendingResult.isErr()) {
+    return new Err(pendingResult.error);
   }
+  const redemption = pendingResult.value;
 
   const creditResult = await createCouponCredit({
     metronomeCustomerId,
@@ -250,8 +241,7 @@ export async function redeemCoupon(
   });
 
   if (creditResult.isErr()) {
-    await coupon.decrementRedemptionCount();
-    await redemption.markFailed();
+    await redemption.rollback(coupon);
     logger.error(
       {
         err: creditResult.error,

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -389,18 +389,22 @@ async function makeFirstPeriodInvoiceForCustomer({
   stripeCustomerId,
   paymentMethodId,
   subtotalCents,
+  couponAmountCents,
   seatCount,
   setupSessionId,
   workspaceId,
   currency,
+  couponCode,
 }: {
   stripeCustomerId: string;
   paymentMethodId: string;
   subtotalCents: number;
+  couponAmountCents?: number;
   seatCount: number;
   setupSessionId: string;
   workspaceId: string;
   currency: SupportedCurrency;
+  couponCode?: string;
 }): Promise<Result<Stripe.Invoice, { error_message: string }>> {
   const stripe = getStripeClient();
   try {
@@ -416,6 +420,7 @@ async function makeFirstPeriodInvoiceForCustomer({
           metronome_first_period: "true",
           setup_session_id: setupSessionId,
           workspace_id: workspaceId,
+          ...(couponCode ? { coupon_code: couponCode } : {}),
         },
       },
       { idempotencyKey: `first-period-invoice-${setupSessionId}` }
@@ -428,6 +433,16 @@ async function makeFirstPeriodInvoiceForCustomer({
       description: `Workspace seat — ${seatCount} seat${seatCount > 1 ? "s" : ""}`,
       invoice: invoice.id,
     });
+
+    if (couponCode && couponAmountCents && couponAmountCents > 0) {
+      await stripe.invoiceItems.create({
+        customer: stripeCustomerId,
+        amount: -couponAmountCents,
+        currency,
+        description: `Coupon: ${couponCode}`,
+        invoice: invoice.id,
+      });
+    }
 
     return new Ok(invoice);
   } catch (error) {
@@ -449,27 +464,33 @@ export async function chargeFirstPeriodInvoice({
   stripeCustomerId,
   paymentMethodId,
   subtotalCents,
+  couponAmountCents,
   seatCount,
   setupSessionId,
   workspaceId,
   currency,
+  couponCode,
 }: {
   stripeCustomerId: string;
   paymentMethodId: string;
   subtotalCents: number;
+  couponAmountCents?: number;
   seatCount: number;
   setupSessionId: string;
   workspaceId: string;
   currency: SupportedCurrency;
+  couponCode?: string;
 }): Promise<Result<void, { error_message: string }>> {
   const invoiceResult = await makeFirstPeriodInvoiceForCustomer({
     stripeCustomerId,
     paymentMethodId,
     subtotalCents,
+    couponAmountCents,
     seatCount,
     setupSessionId,
     workspaceId,
     currency,
+    couponCode,
   });
   if (invoiceResult.isErr()) {
     logger.error(

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -460,6 +460,37 @@ async function makeFirstPeriodInvoiceForCustomer({
   }
 }
 
+export async function setStripeCustomerDefaultPaymentMethod({
+  stripeCustomerId,
+  paymentMethodId,
+  workspaceId,
+}: {
+  stripeCustomerId: string;
+  paymentMethodId: string;
+  workspaceId: string;
+}): Promise<Result<void, { error_message: string }>> {
+  const stripe = getStripeClient();
+  try {
+    await stripe.customers.update(stripeCustomerId, {
+      invoice_settings: { default_payment_method: paymentMethodId },
+    });
+    return new Ok(undefined);
+  } catch (error) {
+    logger.error(
+      {
+        workspaceId,
+        stripeCustomerId,
+        stripeError: true,
+        error: normalizeError(error).message,
+      },
+      "[Stripe] Failed to set default payment method on Stripe customer"
+    );
+    return new Err({
+      error_message: normalizeError(error).message,
+    });
+  }
+}
+
 export async function chargeFirstPeriodInvoice({
   stripeCustomerId,
   paymentMethodId,

--- a/front/lib/resources/coupon_redemption_resource.test.ts
+++ b/front/lib/resources/coupon_redemption_resource.test.ts
@@ -203,7 +203,8 @@ describe("CouponRedemptionResource.rollback", () => {
     }
     const redemption = pendingResult.value;
 
-    await redemption.rollback(coupon);
+    const rollbackResult = await redemption.rollback(coupon);
+    expect(rollbackResult.isOk()).toBe(true);
 
     expect(redemption.status).toBe("failed");
     const updated = await CouponResource.fetchByCouponId(coupon.sId);

--- a/front/lib/resources/coupon_redemption_resource.test.ts
+++ b/front/lib/resources/coupon_redemption_resource.test.ts
@@ -160,6 +160,57 @@ describe("CouponResource.incrementRedemptionCount / decrementRedemptionCount", (
   });
 });
 
+describe("CouponRedemptionResource.createPending", () => {
+  it("creates a pending redemption and increments the coupon count atomically", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create();
+
+    const result = await CouponRedemptionResource.createPending(auth, {
+      coupon,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const redemption = result.isOk() ? result.value : null;
+    expect(redemption?.status).toBe("pending");
+
+    const updated = await CouponResource.fetchByCouponId(coupon.sId);
+    expect(updated?.redemptionCount).toBe(1);
+  });
+
+  it("returns Err when the unique constraint is violated", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create();
+    await CouponRedemptionResource.makeNew(auth, { coupon });
+
+    const result = await CouponRedemptionResource.createPending(auth, {
+      coupon,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("CouponRedemptionResource.rollback", () => {
+  it("marks redemption failed and decrements the coupon count", async () => {
+    const { auth } = await makeWorkspaceWithUserAuth();
+    const coupon = await CouponFactory.create();
+    const pendingResult = await CouponRedemptionResource.createPending(auth, {
+      coupon,
+    });
+    expect(pendingResult.isOk()).toBe(true);
+    if (!pendingResult.isOk()) {
+      throw new Error("createPending failed");
+    }
+    const redemption = pendingResult.value;
+
+    await redemption.rollback(coupon);
+
+    expect(redemption.status).toBe("failed");
+    const updated = await CouponResource.fetchByCouponId(coupon.sId);
+    expect(updated?.redemptionCount).toBe(0);
+  });
+});
+
 describe("CouponRedemptionResource.delete", () => {
   it("removes the redemption", async () => {
     const { auth } = await makeWorkspaceWithUserAuth();

--- a/front/lib/resources/coupon_redemption_resource.ts
+++ b/front/lib/resources/coupon_redemption_resource.ts
@@ -8,6 +8,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   CouponRedemptionStatus,
   CouponRedemptionType,
@@ -89,6 +90,27 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
       couponSId: coupon.sId,
       redeemedByUserSId: user ? user.sId : null,
     });
+  }
+
+  static async createPending(
+    auth: Authenticator,
+    { coupon }: { coupon: CouponResource }
+  ): Promise<Result<CouponRedemptionResource, Error>> {
+    try {
+      const redemption = await withTransaction(async (transaction) => {
+        const r = await this.makeNew(auth, { coupon }, { transaction });
+        await coupon.incrementRedemptionCount({ transaction });
+        return r;
+      });
+      return new Ok(redemption);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  async rollback(coupon: CouponResource): Promise<void> {
+    await this.markFailed();
+    await coupon.decrementRedemptionCount();
   }
 
   static async findActiveOrPendingByCouponAndWorkspace(

--- a/front/lib/resources/coupon_redemption_resource.ts
+++ b/front/lib/resources/coupon_redemption_resource.ts
@@ -108,11 +108,19 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
     }
   }
 
-  async rollback(coupon: CouponResource): Promise<void> {
-    await withTransaction(async (transaction) => {
-      await this.markFailed({ transaction });
-      await coupon.decrementRedemptionCount({ transaction });
-    });
+  async rollback(coupon: CouponResource): Promise<Result<void, Error>> {
+    try {
+      await withTransaction(async (transaction) => {
+        const r = await this.markFailed({ transaction });
+        if (r.isErr()) {
+          throw r.error;
+        }
+        await coupon.decrementRedemptionCount({ transaction });
+      });
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
   }
 
   static async findActiveOrPendingByCouponAndWorkspace(

--- a/front/lib/resources/coupon_redemption_resource.ts
+++ b/front/lib/resources/coupon_redemption_resource.ts
@@ -109,8 +109,10 @@ export class CouponRedemptionResource extends BaseResource<CouponRedemptionModel
   }
 
   async rollback(coupon: CouponResource): Promise<void> {
-    await this.markFailed();
-    await coupon.decrementRedemptionCount();
+    await withTransaction(async (transaction) => {
+      await this.markFailed({ transaction });
+      await coupon.decrementRedemptionCount({ transaction });
+    });
   }
 
   static async findActiveOrPendingByCouponAndWorkspace(

--- a/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
@@ -8,6 +8,10 @@ import {
   chargeFirstPeriodInvoice,
   getStripeClient,
 } from "@app/lib/plans/stripe";
+import type { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { CouponRedemptionResource as CouponRedemptionResourceClass } from "@app/lib/resources/coupon_redemption_resource";
+import type { CouponResource } from "@app/lib/resources/coupon_resource";
+import { CouponResource as CouponResourceClass } from "@app/lib/resources/coupon_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { wakeLock } from "@app/lib/wake_lock";
@@ -31,7 +35,8 @@ export type PostCheckoutPaymentResponseBody =
         | "setup_failed"
         | "payment_failed"
         | "metronome_error"
-        | "internal_error";
+        | "internal_error"
+        | "invalid_coupon";
     };
 
 async function handler(
@@ -193,36 +198,95 @@ async function handler(
       const country = customer.address?.country ?? "US";
       const currency = getBillingCurrencyForCountry(country, true);
 
-      if (shouldEnforceFirstPeriodPayment) {
-        const chargeResult = await chargeFirstPeriodInvoice({
-          stripeCustomerId,
-          paymentMethodId,
-          subtotalCents,
-          seatCount,
-          setupSessionId,
-          workspaceId: owner.sId,
-          currency,
-        });
-        if (chargeResult.isErr()) {
-          return res.status(200).json({ error: "payment_failed" });
+      // Coupon: validate + create pending redemption before charging.
+      const couponCode = setupSession.metadata?.couponCode;
+      let coupon: CouponResource | undefined;
+      let pendingRedemption: CouponRedemptionResource | undefined;
+
+      if (couponCode) {
+        const found = await CouponResourceClass.findByCode(couponCode);
+        if (!found) {
+          return res.status(200).json({ error: "invalid_coupon" });
         }
+        const validation = found.validateRedemption();
+        if (validation.isErr()) {
+          return res.status(200).json({ error: "invalid_coupon" });
+        }
+        const existing =
+          await CouponRedemptionResourceClass.findActiveOrPendingByCouponAndWorkspace(
+            auth,
+            { coupon: found }
+          );
+        if (existing) {
+          return res.status(200).json({ error: "invalid_coupon" });
+        }
+        const pendingResult = await CouponRedemptionResourceClass.createPending(
+          auth,
+          { coupon: found }
+        );
+        if (pendingResult.isErr()) {
+          logger.error(
+            {
+              workspaceId: owner.sId,
+              couponCode,
+              error: pendingResult.error.message,
+            },
+            "[Checkout] Failed to create pending coupon redemption"
+          );
+          return res.status(200).json({ error: "invalid_coupon" });
+        }
+        pendingRedemption = pendingResult.value;
+        coupon = found;
       }
+
+      const couponAmountCents = coupon ? coupon.amount * 100 : 0;
+      const effectiveSubtotalCents = Math.max(
+        0,
+        subtotalCents - couponAmountCents
+      );
 
       const user = auth.getNonNullableUser();
       const planCode = setupSession.metadata?.planCode ?? "";
       const metronomePackageAlias =
         setupSession.metadata?.metronomePackageAlias ?? "";
 
+      // Set the payment method as the customer's Stripe default
+      // for future Metronome-generated invoices (month 2+).
+      await stripe.customers.update(stripeCustomerId, {
+        invoice_settings: { default_payment_method: paymentMethodId },
+      });
+
+      if (shouldEnforceFirstPeriodPayment) {
+        const chargeResult = await chargeFirstPeriodInvoice({
+          stripeCustomerId,
+          paymentMethodId,
+          subtotalCents,
+          couponAmountCents,
+          seatCount,
+          setupSessionId,
+          workspaceId: owner.sId,
+          currency,
+          couponCode,
+        });
+        if (chargeResult.isErr()) {
+          if (pendingRedemption && coupon) {
+            await pendingRedemption.rollback(coupon);
+          }
+          return res.status(200).json({ error: "payment_failed" });
+        }
+      }
+
       const provisionResult = await provisionMetronomeFirstPeriodSubscription({
         stripeCustomerId,
-        paymentMethodId,
-        subtotalCents,
         currency,
         workspaceId: owner.sId,
         userId: user.sId,
         planCode,
         metronomePackageAlias,
+        coupon,
+        pendingRedemption,
         firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
+        firstPeriodPaymentCents: effectiveSubtotalCents,
         uniquenessKey: setupSessionId,
         now: new Date(),
       });
@@ -233,6 +297,11 @@ async function handler(
             panic: true,
             workspaceId: owner.sId,
             error: normalizeError(provisionResult.error).message,
+            userId: user.sId,
+            planCode,
+            metronomePackageAlias,
+            firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
+            uniquenessKey: setupSessionId,
           },
           "[Checkout] Payment succeeded but Metronome provisioning failed"
         );

--- a/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
@@ -9,10 +9,8 @@ import {
   getStripeClient,
   setStripeCustomerDefaultPaymentMethod,
 } from "@app/lib/plans/stripe";
-import type { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
-import { CouponRedemptionResource as CouponRedemptionResourceClass } from "@app/lib/resources/coupon_redemption_resource";
-import type { CouponResource } from "@app/lib/resources/coupon_resource";
-import { CouponResource as CouponResourceClass } from "@app/lib/resources/coupon_resource";
+import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { wakeLock } from "@app/lib/wake_lock";
@@ -205,7 +203,7 @@ async function handler(
       let pendingRedemption: CouponRedemptionResource | undefined;
 
       if (couponCode) {
-        const found = await CouponResourceClass.findByCode(couponCode);
+        const found = await CouponResource.findByCode(couponCode);
         if (!found) {
           return res.status(200).json({ error: "invalid_coupon" });
         }
@@ -214,14 +212,14 @@ async function handler(
           return res.status(200).json({ error: "invalid_coupon" });
         }
         const existing =
-          await CouponRedemptionResourceClass.findActiveOrPendingByCouponAndWorkspace(
+          await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
             auth,
             { coupon: found }
           );
         if (existing) {
           return res.status(200).json({ error: "invalid_coupon" });
         }
-        const pendingResult = await CouponRedemptionResourceClass.createPending(
+        const pendingResult = await CouponRedemptionResource.createPending(
           auth,
           { coupon: found }
         );
@@ -261,7 +259,16 @@ async function handler(
         });
       if (setDefaultPaymentMethodResult.isErr()) {
         if (pendingRedemption && coupon) {
-          await pendingRedemption.rollback(coupon);
+          const rollbackResult = await pendingRedemption.rollback(coupon);
+          if (rollbackResult.isErr()) {
+            logger.error(
+              {
+                err: rollbackResult.error,
+                workspaceId: owner.sId,
+              },
+              "[Checkout] Failed to rollback coupon redemption after setDefaultPaymentMethod failure"
+            );
+          }
         }
         return res.status(200).json({ error: "payment_failed" });
       }
@@ -280,7 +287,13 @@ async function handler(
         });
         if (chargeResult.isErr()) {
           if (pendingRedemption && coupon) {
-            await pendingRedemption.rollback(coupon);
+            const rollbackResult = await pendingRedemption.rollback(coupon);
+            if (rollbackResult.isErr()) {
+              logger.error(
+                { err: rollbackResult.error, workspaceId: owner.sId },
+                "[Checkout] Failed to rollback coupon redemption after chargeFirstPeriodInvoice failure"
+              );
+            }
           }
           return res.status(200).json({ error: "payment_failed" });
         }

--- a/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
@@ -7,6 +7,7 @@ import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
 import {
   chargeFirstPeriodInvoice,
   getStripeClient,
+  setStripeCustomerDefaultPaymentMethod,
 } from "@app/lib/plans/stripe";
 import type { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
 import { CouponRedemptionResource as CouponRedemptionResourceClass } from "@app/lib/resources/coupon_redemption_resource";
@@ -252,9 +253,18 @@ async function handler(
 
       // Set the payment method as the customer's Stripe default
       // for future Metronome-generated invoices (month 2+).
-      await stripe.customers.update(stripeCustomerId, {
-        invoice_settings: { default_payment_method: paymentMethodId },
-      });
+      const setDefaultPaymentMethodResult =
+        await setStripeCustomerDefaultPaymentMethod({
+          stripeCustomerId,
+          paymentMethodId,
+          workspaceId: owner.sId,
+        });
+      if (setDefaultPaymentMethodResult.isErr()) {
+        if (pendingRedemption && coupon) {
+          await pendingRedemption.rollback(coupon);
+        }
+        return res.status(200).json({ error: "payment_failed" });
+      }
 
       if (shouldEnforceFirstPeriodPayment) {
         const chargeResult = await chargeFirstPeriodInvoice({

--- a/front/pages/api/w/[wId]/subscriptions/checkout/prepare-payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/prepare-payment.ts
@@ -4,6 +4,7 @@ import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
 import { calculateTax, getStripeClient } from "@app/lib/plans/stripe";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { apiError } from "@app/logger/withlogging";
 import { getStripeCheckoutSessionStatus } from "@app/pages/api/stripe/webhook";
 import type { SupportedCurrency } from "@app/types/currency";
@@ -176,9 +177,23 @@ async function handler(
   const country = customer.address?.country ?? "US";
   const currency = getBillingCurrencyForCountry(country, true);
 
+  // Apply coupon discount to the tax base if a coupon was stored in session metadata.
+  // No validation here — enforcement happens in POST /payment.
+  const couponCode = setupSession.metadata?.couponCode;
+  let discountedSubtotalCents = subtotalCents;
+  if (couponCode) {
+    const coupon = await CouponResource.findByCode(couponCode);
+    if (coupon) {
+      discountedSubtotalCents = Math.max(
+        0,
+        subtotalCents - coupon.amount * 100
+      );
+    }
+  }
+
   const taxResult = await calculateTax({
     stripeCustomerId,
-    amountCents: subtotalCents,
+    amountCents: discountedSubtotalCents,
     currency,
   });
   if (taxResult.isErr()) {


### PR DESCRIPTION
## Description

PR3 of https://github.com/dust-tt/tasks/issues/8100
Check it for global specs for checkout flow

This PR wires end-to-end coupon support into the new Metronome checkout flow (built on PR1 + PR2). Coupon codes travel via Stripe session metadata — no additional body params needed across the payment pipeline.

**CouponRedemptionResource**
* New static createPending(auth, { coupon }): atomically wraps makeNew + incrementRedemptionCount in a transaction, returning a Result
* New rollback(coupon): undoes a pending redemption (markFailed + decrementRedemptionCount) in one call
redeemCoupon in coupons.ts updated to use these new helpers, removing the duplicated transaction pattern
* Unit tests added for both createPending and rollback

**GET /prepare-payment**
* Reads couponCode from setup session metadata; looks up the coupon without validation (enforcement is in POST /payment)
* Computes discountedSubtotalCents and passes it to Stripe Tax; returns the original subtotalCents alongside tax/total so the left pane can display the full breakdown

**POST /payment**
* Validates the coupon (existence, redemption eligibility, no active/pending redemption for the workspace) and returns { error: "invalid_coupon" } on any failure
* Atomically creates a pending redemption + increments the coupon count before charging, then rolls it back (markFailed + decrementRedemptionCount) if the charge fails
* Passes coupon discount as a negative line item on the Stripe invoice ("Coupon: {code}") and forwards coupon + pendingRedemption to provisioning

**provisionMetronomeFirstPeriodSubscription**
* Accepts optional coupon + pendingRedemption params; when both are present, calls createCouponCredit in Metronome then markActive on the redemption
* Together with loadFirstPeriodCredit, the two credits fully zero out the first Metronome invoice: couponAmountCents + effectiveSubtotalCents = subtotalCents
* On credit failure: logs panic: true and returns Err without voiding the pending redemption, so a Poke operator can safely replay provisioning

**CheckoutPage.tsx**
* Removes the COUPONS_ENABLED = false flag — coupon UI is now always active
* Gates the coupon input to phase === "card_capture" only; the applied coupon badge remains visible (read-only) in later phases
* Adds "invalid_coupon" error kind with dedicated right-pane copy: "Coupon no longer valid — you have not been charged, try again with a different code"

## Tests

Tested locally with Coupons:
* for Pro with CB => initial stripe payment (invoice with coupon) + 0$ invoice in Metronome (first payment + coupon)
* for business with SEPA => no initial stripe payment => invoice in Metronome with coupon applied

## Risk

Medium, could invoice the wrong amounts if discounts are not properly calculated in stripe invoice and Metronome

## Deploy Plan

Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25763">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->