### PR TITLE
[front] fix(email): handle empty files in multipart request

### DIFF
--- a/front/pages/api/email/webhook.test.ts
+++ b/front/pages/api/email/webhook.test.ts
@@ -8,25 +8,31 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   rawBodyMock,
   formParseMock,
+  incomingFormMock,
   evaluateInboundAuthMock,
   parseSendgridDkimResultsMock,
-} = vi.hoisted(() => ({
-  rawBodyMock: vi.fn(),
-  formParseMock: vi.fn(),
-  evaluateInboundAuthMock: vi.fn(),
-  parseSendgridDkimResultsMock: vi.fn(),
-}));
+} = vi.hoisted(() => {
+  const formParseMock = vi.fn();
+
+  return {
+    rawBodyMock: vi.fn(),
+    formParseMock,
+    incomingFormMock: vi.fn(function IncomingForm() {
+      return {
+        parse: formParseMock,
+      };
+    }),
+    evaluateInboundAuthMock: vi.fn(),
+    parseSendgridDkimResultsMock: vi.fn(),
+  };
+});
 
 vi.mock("raw-body", () => ({
   default: rawBodyMock,
 }));
 
 vi.mock("formidable", () => ({
-  IncomingForm: function IncomingForm() {
-    return {
-      parse: formParseMock,
-    };
-  },
+  IncomingForm: incomingFormMock,
 }));
 
 vi.mock("@app/lib/api/assistant/email/inbound_auth", () => ({
@@ -255,6 +261,56 @@ describe("POST /api/email/webhook", () => {
     expect(formParseMock).toHaveBeenCalledTimes(1);
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toEqual({ success: true });
+  });
+
+  it("ignores zero-byte attachments after parsing", async () => {
+    process.env.IS_DEVELOPMENT = "true";
+    formParseMock.mockResolvedValue([
+      PARSED_EMAIL_FIELDS,
+      {
+        attachment1: [
+          {
+            filepath: "/tmp/empty.txt",
+            originalFilename: "empty.txt",
+            mimetype: "text/plain",
+            size: 0,
+          },
+          {
+            filepath: "/tmp/body.txt",
+            originalFilename: "body.txt",
+            mimetype: "text/plain",
+            size: 12,
+          },
+        ],
+      },
+    ]);
+
+    const { req, res } = createMocks<
+      NextApiRequestWithContext,
+      NextApiResponse<WithAPIErrorResponse<PostResponseBody>>
+    >({
+      method: "POST",
+      headers: {
+        authorization: basicAuthHeader(process.env.EMAIL_WEBHOOK_SECRET ?? ""),
+        "content-type": "multipart/form-data; boundary=boundary",
+      },
+    });
+
+    await handler(req, res);
+
+    expect(evaluateInboundAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          {
+            filepath: "/tmp/body.txt",
+            filename: "body.txt",
+            contentType: "text/plain",
+            size: 12,
+          },
+        ],
+      })
+    );
+    expect(res._getStatusCode()).toBe(200);
   });
 
   it("accepts relayed requests without SendGrid signatures", async () => {

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -207,7 +207,10 @@ const parseSendgridWebhookContent = async (
       new Error("Failed to recreate request body for multipart parsing")
     );
   }
-  const form = new IncomingForm();
+  const form = new IncomingForm({
+    allowEmptyFiles: true,
+    minFileSize: 0,
+  });
   const [fields, files] = await form.parse(req);
 
   try {
@@ -254,6 +257,9 @@ const parseSendgridWebhookContent = async (
         continue;
       }
       for (const file of fileArray) {
+        if (file.size === 0) {
+          continue;
+        }
         if (file.mimetype && isSupportedFileContentType(file.mimetype)) {
           attachments.push({
             filepath: file.filepath,


### PR DESCRIPTION
## Description

- We are getting some unhandled errors on empty files in the email webhook handler ([logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ5ACbg5WPsPewAAABhBWjVBQ2J3TUFBRHZIOVlpTHBUUW13QUsAAAAkMDE5ZTQwMTQtMjQ2MC00YjY4LWI5NjAtOWQ5ZmNjYjE3ZTk1AAUa9Q&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1779190774812&to_ts=1779190905143&live=false)).
- Prevent inbound email webhooks from hard failing when we receive a multipart payload containing a zero-byte attachment.
- Configure the email webhook parser to accept empty file parts, then drop zero-byte attachments before building the inbound email attachment list.
- Non-empty supported attachments continue through the existing processing path unchanged.

## Tests

- Added a test.

## Risk

- Low: scoped to email webhook parsing.

## Deploy Plan

- Deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25765">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->