### PR TITLE
timeout compaction LLM call after 15 minutes, make the activity last 20 minutes

### DIFF
--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -1,4 +1,4 @@
-import type { LLMConfig } from "@app/lib/api/assistant/call_llm";
+import type { LLMConfig, LLMOutput } from "@app/lib/api/assistant/call_llm";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { updateCompactionMessageWithContentAndFinalStatus } from "@app/lib/api/assistant/conversation/compaction";
 import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/conversation/compaction_attachment_id_replacements";
@@ -415,29 +415,49 @@ async function generateCompactionSummary(
     temperature: 0,
   };
 
-  const res = await runMultiActionsAgent(
-    auth,
-    config,
-    {
-      conversation: conv,
-      prompt: COMPACTION_PROMPT,
-      specifications: [],
-    },
-    {
-      context: {
-        operationType: "compaction",
-        conversationId: targetConversation.sId,
-        userId: auth.user()?.sId,
-        workspaceId: owner.sId,
+  const LLM_TIMEOUT_MS = 15 * 60 * 1000;
+  let timeoutHandle: NodeJS.Timeout | undefined;
+
+  const res = await Promise.race([
+    runMultiActionsAgent(
+      auth,
+      config,
+      {
+        conversation: conv,
+        prompt: COMPACTION_PROMPT,
+        specifications: [],
       },
-      onRunId: async (runId) => {
-        await ConversationResource.updateCompactionMessageRunIds(auth, {
-          compactionMessageModelId: compactionMessage.compactionMessageId,
-          runIds: [runId],
-        });
-      },
-    }
-  );
+      {
+        context: {
+          operationType: "compaction",
+          conversationId: targetConversation.sId,
+          userId: auth.user()?.sId,
+          workspaceId: owner.sId,
+        },
+        onRunId: async (runId) => {
+          await ConversationResource.updateCompactionMessageRunIds(auth, {
+            compactionMessageModelId: compactionMessage.compactionMessageId,
+            runIds: [runId],
+          });
+        },
+      }
+    ),
+    new Promise<Result<LLMOutput, Error>>((resolve) => {
+      timeoutHandle = setTimeout(() => {
+        logger.error(
+          {
+            workspaceId: owner.sId,
+            conversationId: conversationToSummarize.sId,
+            compactionMessageId: compactionMessage.sId,
+            timeoutMs: LLM_TIMEOUT_MS,
+          },
+          "Compaction LLM call timed out"
+        );
+        resolve(new Err(new Error("Compaction LLM call timed out after 15m")));
+      }, LLM_TIMEOUT_MS);
+    }),
+  ]);
+  clearTimeout(timeoutHandle);
 
   if (res.isErr()) {
     return res;

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -111,9 +111,9 @@ const { ensureConversationTitleActivity } = proxyActivities<
 });
 
 const { compactionActivity } = proxyActivities<typeof compactionActivities>({
-  startToCloseTimeout: "10 minutes",
+  startToCloseTimeout: "20 minutes",
   retry: {
-    // Do not retry compaction, the mesage is marked as failed, not idempotent
+    // Do not retry compaction, the message is marked as failed, not idempotent.
     maximumAttempts: 1,
   },
 });


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8159

 - Wrap LLM call with a tiemout to fail faster than the activity timeout and have time to clean state.
 - make the activity last 20 minutes

If the LLM call tiemout, the compaction will be marked as failed and the user will receive an event.
They will be able to re-run another comapction 

## Tests

not tested

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->