### PR TITLE
feat: pods path gsc double write

### DIFF
--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -126,6 +126,47 @@ describe("createGCSMountFile", () => {
     assert(entryRes.isOk());
     expect(entryRes.value.thumbnailUrl).toBeNull();
   });
+
+  it("dual-writes to the pods/ mirror for project use-case", async () => {
+    const content = Buffer.from("hello");
+
+    await createGCSMountFile(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeFilePath: "report.txt", content, contentType: "text/plain" }
+    );
+
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${workspaceId}/projects/proj123/files/report.txt`
+    );
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${workspaceId}/pods/proj123/files/report.txt`
+    );
+    expect(saveMock).toHaveBeenCalledTimes(2);
+    expect(saveMock).toHaveBeenNthCalledWith(1, content, {
+      contentType: "text/plain",
+    });
+    expect(saveMock).toHaveBeenNthCalledWith(2, content, {
+      contentType: "text/plain",
+    });
+  });
+
+  it("does not write to pods/ for conversation use-case", async () => {
+    await createGCSMountFile(
+      auth,
+      { useCase: "conversation", conversationId },
+      {
+        relativeFilePath: "report.txt",
+        content: Buffer.from("hello"),
+        contentType: "text/plain",
+      }
+    );
+
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+    expect(bucket.file).toHaveBeenCalledTimes(1);
+    expect(saveMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("createGCSMountDirectory", () => {
@@ -607,6 +648,32 @@ describe("copyMountFile", () => {
       expect(result.error.message).toContain("GCS copy unavailable");
     }
   });
+
+  it("mirrors the destination write on pods/ when dest is a project", async () => {
+    const result = await copyMountFile(auth, {
+      source: {
+        scope: { useCase: "conversation", conversationId: "src-conv" },
+        relativeFilePath: "report.pdf",
+      },
+      dest: {
+        scope: { useCase: "project", projectId: "proj123" },
+        relativeFilePath: "report.pdf",
+      },
+    });
+
+    assert(result.isOk());
+    const sourcePath = `w/${workspaceId}/conversations/src-conv/files/report.pdf`;
+    const destProjectPath = `w/${workspaceId}/projects/proj123/files/report.pdf`;
+    const destPodsPath = `w/${workspaceId}/pods/proj123/files/report.pdf`;
+
+    expect(copyFileMock).toHaveBeenCalledTimes(2);
+    expect(copyFileMock).toHaveBeenNthCalledWith(
+      1,
+      sourcePath,
+      destProjectPath
+    );
+    expect(copyFileMock).toHaveBeenNthCalledWith(2, sourcePath, destPodsPath);
+  });
 });
 
 describe("renameGCSMountFile", () => {
@@ -681,6 +748,49 @@ describe("renameGCSMountFile", () => {
     }
     expect(deleteMock).not.toHaveBeenCalled();
   });
+
+  it("mirrors rename on pods/ for project use-case using the new canonical as source", async () => {
+    await renameGCSMountFile(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeFilePath: "report.pdf", newFileName: "final.pdf" }
+    );
+
+    const projectPrefix = `w/${workspaceId}/projects/proj123/files/`;
+    const podsPrefix = `w/${workspaceId}/pods/proj123/files/`;
+
+    expect(copyFileMock).toHaveBeenCalledTimes(2);
+    expect(copyFileMock).toHaveBeenNthCalledWith(
+      1,
+      `${projectPrefix}report.pdf`,
+      `${projectPrefix}final.pdf`
+    );
+    // Pods mirror copies from the NEW canonical (not from an old pods/ source,
+    // which may not exist for files predating the dual-write).
+    expect(copyFileMock).toHaveBeenNthCalledWith(
+      2,
+      `${projectPrefix}final.pdf`,
+      `${podsPrefix}final.pdf`
+    );
+
+    expect(deleteMock).toHaveBeenCalledTimes(2);
+    expect(deleteMock).toHaveBeenNthCalledWith(1, `${projectPrefix}report.pdf`);
+    expect(deleteMock).toHaveBeenNthCalledWith(2, `${podsPrefix}report.pdf`, {
+      ignoreNotFound: true,
+    });
+  });
+
+  it("does not mirror rename on pods/ for conversation use-case", async () => {
+    const result = await renameGCSMountFile(
+      auth,
+      { useCase: "conversation", conversationId: "conv-rename" },
+      { relativeFilePath: "report.pdf", newFileName: "final.pdf" }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(copyFileMock).toHaveBeenCalledTimes(1);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("deleteGCSMountFile", () => {
@@ -726,6 +836,35 @@ describe("deleteGCSMountFile", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("delete failed");
     }
+  });
+
+  it("mirrors delete on pods/ for project use-case", async () => {
+    await deleteGCSMountFile(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeFilePath: "archive/old.pdf" }
+    );
+
+    const projectPath = `w/${workspaceId}/projects/proj123/files/archive/old.pdf`;
+    const podsPath = `w/${workspaceId}/pods/proj123/files/archive/old.pdf`;
+
+    expect(deleteMock).toHaveBeenCalledTimes(2);
+    expect(deleteMock).toHaveBeenNthCalledWith(1, projectPath, {
+      ignoreNotFound: true,
+    });
+    expect(deleteMock).toHaveBeenNthCalledWith(2, podsPath, {
+      ignoreNotFound: true,
+    });
+  });
+
+  it("does not mirror delete on pods/ for conversation use-case", async () => {
+    await deleteGCSMountFile(
+      auth,
+      { useCase: "conversation", conversationId: "conv-del" },
+      { relativeFilePath: "old.pdf" }
+    );
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -7,10 +7,10 @@ import config from "@app/lib/api/config";
 import { GCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
 import {
   getConversationFilesBasePath,
-  getPodsFilesBasePath,
+  getPodFilesBasePath,
   getProjectFilesBasePath,
   TOOL_OUTPUTS_FOLDER_NAME,
-  toPodsMountFilePath,
+  toPodMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -362,7 +362,7 @@ export async function renameGCSMountFile(
     // projects/ path (instead of an old pods/ path that may not exist for files predating the
     // dual-write) — this also opportunistically backfills the pods/ side as files get renamed.
     if (scope.useCase === "project") {
-      const podsPrefix = getPodsFilesBasePath({
+      const podsPrefix = getPodFilesBasePath({
         workspaceId: owner.sId,
         projectId: scope.projectId,
       });
@@ -429,7 +429,7 @@ export async function createGCSMountFile(
 
     // Mirror the write on the pods/ side for project files
     if (scope.useCase === "project") {
-      const podsPrefix = getPodsFilesBasePath({
+      const podsPrefix = getPodFilesBasePath({
         workspaceId: owner.sId,
         projectId: scope.projectId,
       });
@@ -522,7 +522,7 @@ export async function deleteGCSMountFile(
 
     // Mirror delete on the pods/ side for project files
     if (scope.useCase === "project") {
-      const podsPrefix = getPodsFilesBasePath({
+      const podsPrefix = getPodFilesBasePath({
         workspaceId: owner.sId,
         projectId: scope.projectId,
       });
@@ -560,7 +560,7 @@ export async function copyMountFile(
 
     // Mirror the destination write on the pods/ side for project files (double-write counterpart).
     if (dest.scope.useCase === "project") {
-      const podsPrefix = getPodsFilesBasePath({
+      const podsPrefix = getPodFilesBasePath({
         workspaceId: owner.sId,
         projectId: dest.scope.projectId,
       });
@@ -760,7 +760,7 @@ export async function moveFile(
   // source was a non-project file (no pre-existing pods/ source to copy from).
   const bucket = getPrivateUploadBucket();
   if (destScope.useCase === "project") {
-    const podsPrefix = getPodsFilesBasePath({
+    const podsPrefix = getPodFilesBasePath({
       workspaceId: auth.getNonNullableWorkspace().sId,
       projectId: destScope.projectId,
     });
@@ -773,7 +773,7 @@ export async function moveFile(
   }
 
   // Clean up the pods/ mirror of the source if the source was a project mount path.
-  const sourcePodsPath = toPodsMountFilePath(sourceGcsPath);
+  const sourcePodsPath = toPodMountFilePath(sourceGcsPath);
   if (sourcePodsPath) {
     try {
       await bucket.delete(sourcePodsPath, { ignoreNotFound: true });

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -7,6 +7,7 @@ import config from "@app/lib/api/config";
 import { GCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
 import {
   getConversationFilesBasePath,
+  getPodsFilesBasePath,
   getProjectFilesBasePath,
   TOOL_OUTPUTS_FOLDER_NAME,
 } from "@app/lib/api/files/mount_path";
@@ -355,6 +356,19 @@ export async function renameGCSMountFile(
   try {
     await bucket.copyFile(oldGcsPath, newGcsPath);
     await bucket.delete(oldGcsPath);
+
+    // Mirror the rename on the pods/ side for project files
+    if (scope.useCase === "project") {
+      const podsPrefix = getPodsFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: scope.projectId,
+      });
+      const oldPodsPath = `${podsPrefix}${relativeFilePath}`;
+      const newPodsPath = `${podsPrefix}${dir}${newFileName}`;
+      await bucket.copyFile(oldPodsPath, newPodsPath);
+      await bucket.delete(oldPodsPath);
+    }
+
     return new Ok({ newGcsPath });
   } catch (err) {
     return new Err(normalizeError(err));
@@ -409,6 +423,16 @@ export async function createGCSMountFile(
   const bucket = getPrivateUploadBucket();
   try {
     await bucket.file(gcsPath).save(content, { contentType });
+
+    // Mirror the write on the pods/ side for project files
+    if (scope.useCase === "project") {
+      const podsPrefix = getPodsFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: scope.projectId,
+      });
+      const podsGcsPath = `${podsPrefix}${relativeFilePath}`;
+      await bucket.file(podsGcsPath).save(content, { contentType });
+    }
   } catch (error) {
     return new Err(normalizeError(error));
   }
@@ -492,6 +516,17 @@ export async function deleteGCSMountFile(
   const bucket = getPrivateUploadBucket();
   try {
     await bucket.delete(gcsPath, { ignoreNotFound: true });
+
+    // Mirror delete on the pods/ side for project files
+    if (scope.useCase === "project") {
+      const podsPrefix = getPodsFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: scope.projectId,
+      });
+      const podsGcsPath = `${podsPrefix}${relativeFilePath}`;
+      await bucket.delete(podsGcsPath, { ignoreNotFound: true });
+    }
+
     return new Ok(undefined);
   } catch (err) {
     return new Err(normalizeError(err));
@@ -519,6 +554,17 @@ export async function copyMountFile(
 
   try {
     await bucket.copyFile(sourceGcsPath, destGcsPath);
+
+    // Mirror the destination write on the pods/ side for project files (double-write counterpart).
+    if (dest.scope.useCase === "project") {
+      const podsPrefix = getPodsFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: dest.scope.projectId,
+      });
+      const destPodsPath = `${podsPrefix}${dest.relativeFilePath}`;
+      await bucket.copyFile(sourceGcsPath, destPodsPath);
+    }
+
     return new Ok(undefined);
   } catch (err) {
     return new Err(normalizeError(err));

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -10,6 +10,7 @@ import {
   getPodsFilesBasePath,
   getProjectFilesBasePath,
   TOOL_OUTPUTS_FOLDER_NAME,
+  toPodsMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -753,6 +754,35 @@ export async function moveFile(
   const moveRes = await moveGCSMountFile({ sourceGcsPath, destGcsPath });
   if (moveRes.isErr()) {
     return moveRes;
+  }
+
+  // Dual-write to the pods/ side. Copy from the new canonical so this works even when the
+  // source was a non-project file (no pre-existing pods/ source to copy from).
+  const bucket = getPrivateUploadBucket();
+  if (destScope.useCase === "project") {
+    const podsPrefix = getPodsFilesBasePath({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      projectId: destScope.projectId,
+    });
+    const destPodsPath = `${podsPrefix}${destRelativeFilePath}`;
+    try {
+      await bucket.copyFile(destGcsPath, destPodsPath);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  // Clean up the pods/ mirror of the source if the source was a project mount path.
+  const sourcePodsPath = toPodsMountFilePath(sourceGcsPath);
+  if (sourcePodsPath) {
+    try {
+      await bucket.delete(sourcePodsPath, { ignoreNotFound: true });
+    } catch (err) {
+      logger.error(
+        { sourcePodsPath, err: normalizeError(err) },
+        "moveFile: source pods/ mirror delete failed after successful move"
+      );
+    }
   }
 
   if (file) {

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -357,7 +357,9 @@ export async function renameGCSMountFile(
     await bucket.copyFile(oldGcsPath, newGcsPath);
     await bucket.delete(oldGcsPath);
 
-    // Mirror the rename on the pods/ side for project files
+    // Mirror the rename on the pods/ side for project files. We copy from the new canonical
+    // projects/ path (instead of an old pods/ path that may not exist for files predating the
+    // dual-write) — this also opportunistically backfills the pods/ side as files get renamed.
     if (scope.useCase === "project") {
       const podsPrefix = getPodsFilesBasePath({
         workspaceId: owner.sId,
@@ -365,8 +367,8 @@ export async function renameGCSMountFile(
       });
       const oldPodsPath = `${podsPrefix}${relativeFilePath}`;
       const newPodsPath = `${podsPrefix}${dir}${newFileName}`;
-      await bucket.copyFile(oldPodsPath, newPodsPath);
-      await bucket.delete(oldPodsPath);
+      await bucket.copyFile(newGcsPath, newPodsPath);
+      await bucket.delete(oldPodsPath, { ignoreNotFound: true });
     }
 
     return new Ok({ newGcsPath });

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -3,6 +3,7 @@ import {
   getBaseMountPathForWorkspace,
   getConversationFilePath,
   getConversationFilesBasePath,
+  getPodFilesBasePath,
   getProjectFilesBasePath,
   makeProcessedMountFileName,
   normalizeAndValidateMountRelativeFilePath,
@@ -14,6 +15,7 @@ import {
   resolveMountFileSourcePath,
   resolveMoveSourcePath,
   resolveScopedMountFilePath,
+  toPodMountFilePath,
   validateMountFolderName,
 } from "@app/lib/api/files/mount_path";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -45,6 +47,46 @@ describe("mount_path helpers", () => {
       expect(
         getProjectFilesBasePath({ workspaceId: "ws1", projectId: "spc1" })
       ).toBe("w/ws1/projects/spc1/files/");
+    });
+  });
+
+  describe("getPodFilesBasePath", () => {
+    it("should return full pod files path", () => {
+      expect(
+        getPodFilesBasePath({ workspaceId: "ws1", projectId: "spc1" })
+      ).toBe("w/ws1/pods/spc1/files/");
+    });
+  });
+
+  describe("toPodMountFilePath", () => {
+    it("converts a project mount file path to its pods/ counterpart", () => {
+      expect(toPodMountFilePath("w/ws1/projects/p1/files/report.pdf")).toBe(
+        "w/ws1/pods/p1/files/report.pdf"
+      );
+    });
+
+    it("preserves nested directory structure", () => {
+      expect(
+        toPodMountFilePath("w/ws1/projects/p1/files/dir/sub/report.pdf")
+      ).toBe("w/ws1/pods/p1/files/dir/sub/report.pdf");
+    });
+
+    it("returns null for conversation paths", () => {
+      expect(
+        toPodMountFilePath("w/ws1/conversations/c1/files/report.pdf")
+      ).toBeNull();
+    });
+
+    it("returns null for already-pods paths (no double-rewrite)", () => {
+      expect(toPodMountFilePath("w/ws1/pods/p1/files/report.pdf")).toBeNull();
+    });
+
+    it("returns null when the w/ workspace prefix is missing", () => {
+      expect(toPodMountFilePath("projects/p1/files/report.pdf")).toBeNull();
+    });
+
+    it("returns null when nothing follows projects/", () => {
+      expect(toPodMountFilePath("w/ws1/projects/")).toBeNull();
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -65,6 +65,30 @@ export function getProjectFilesBasePath({
   return `${getBaseMountPathForWorkspace({ workspaceId })}projects/${projectId}/files/`;
 }
 
+export function getPodsFilesBasePath({
+  workspaceId,
+  projectId,
+}: {
+  workspaceId: string;
+  projectId: string;
+}): string {
+  return `${getBaseMountPathForWorkspace({ workspaceId })}pods/${projectId}/files/`;
+}
+
+/**
+ * Convert a project mount file path (`w/{wId}/projects/{pId}/files/...`) to its pods/ counterpart
+ * (`w/{wId}/pods/{pId}/files/...`). Returns `null` if the input is not a project mount path.
+ */
+export function toPodsMountFilePath(
+  projectMountFilePath: string
+): string | null {
+  const match = projectMountFilePath.match(/^(w\/[^/]+\/)projects\/(.+)$/);
+  if (!match) {
+    return null;
+  }
+  return `${match[1]}pods/${match[2]}`;
+}
+
 /**
  * Given a mount file path like "w/.../files/report.pdf",
  * returns "w/.../files/report.processed.pdf".

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -65,7 +65,7 @@ export function getProjectFilesBasePath({
   return `${getBaseMountPathForWorkspace({ workspaceId })}projects/${projectId}/files/`;
 }
 
-export function getPodsFilesBasePath({
+export function getPodFilesBasePath({
   workspaceId,
   projectId,
 }: {
@@ -79,7 +79,7 @@ export function getPodsFilesBasePath({
  * Convert a project mount file path (`w/{wId}/projects/{pId}/files/...`) to its pods/ counterpart
  * (`w/{wId}/pods/{pId}/files/...`). Returns `null` if the input is not a project mount path.
  */
-export function toPodsMountFilePath(
+export function toPodMountFilePath(
   projectMountFilePath: string
 ): string | null {
   const match = projectMountFilePath.match(/^(w\/[^/]+\/)projects\/(.+)$/);

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -7,7 +7,7 @@ import {
   getConversationFilePath,
   getProjectFilesBasePath,
   makeProcessedMountFileName,
-  toPodsMountFilePath,
+  toPodMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import {
   getProcessedContentType,
@@ -947,7 +947,7 @@ export class FileResource extends BaseResource<FileModel> {
       });
 
       // Double-write to the pods/ path for project mount paths.
-      const podsMountFilePath = toPodsMountFilePath(this.mountFilePath);
+      const podsMountFilePath = toPodMountFilePath(this.mountFilePath);
       if (podsMountFilePath) {
         await getPrivateUploadBucket().uploadRawContentToBucket({
           content,
@@ -1089,7 +1089,7 @@ export class FileResource extends BaseResource<FileModel> {
     await bucket.copyFile(srcOriginalPath, mountFilePath);
 
     // Double-write to the pods/ path for project mount paths.
-    const podsMountFilePath = toPodsMountFilePath(mountFilePath);
+    const podsMountFilePath = toPodMountFilePath(mountFilePath);
     if (podsMountFilePath) {
       await bucket.copyFile(srcOriginalPath, podsMountFilePath);
     }
@@ -1103,7 +1103,7 @@ export class FileResource extends BaseResource<FileModel> {
       });
       await bucket.copyFile(srcProcessedPath, processedMountPath);
 
-      const processedPodsMountPath = toPodsMountFilePath(processedMountPath);
+      const processedPodsMountPath = toPodMountFilePath(processedMountPath);
       if (processedPodsMountPath) {
         await bucket.copyFile(srcProcessedPath, processedPodsMountPath);
       }
@@ -1133,7 +1133,7 @@ export class FileResource extends BaseResource<FileModel> {
     await bucket.delete(this.mountFilePath, { ignoreNotFound: true });
 
     // Mirror delete on the pods/ side for project files (double-write counterpart).
-    const podsMountFilePath = toPodsMountFilePath(this.mountFilePath);
+    const podsMountFilePath = toPodMountFilePath(this.mountFilePath);
     if (podsMountFilePath) {
       await bucket.delete(podsMountFilePath, { ignoreNotFound: true });
     }
@@ -1152,7 +1152,7 @@ export class FileResource extends BaseResource<FileModel> {
     });
     await bucket.delete(processedMountPath, { ignoreNotFound: true });
 
-    const processedPodsMountPath = toPodsMountFilePath(processedMountPath);
+    const processedPodsMountPath = toPodMountFilePath(processedMountPath);
     if (processedPodsMountPath) {
       await bucket.delete(processedPodsMountPath, { ignoreNotFound: true });
     }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -7,6 +7,7 @@ import {
   getConversationFilePath,
   getProjectFilesBasePath,
   makeProcessedMountFileName,
+  toPodsMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import {
   getProcessedContentType,
@@ -944,6 +945,16 @@ export class FileResource extends BaseResource<FileModel> {
         contentType: this.contentType,
         filePath: this.mountFilePath,
       });
+
+      // Double-write to the pods/ path for project mount paths.
+      const podsMountFilePath = toPodsMountFilePath(this.mountFilePath);
+      if (podsMountFilePath) {
+        await getPrivateUploadBucket().uploadRawContentToBucket({
+          content,
+          contentType: this.contentType,
+          filePath: podsMountFilePath,
+        });
+      }
     }
 
     // Increment version after successful upload and mark as ready
@@ -1077,6 +1088,12 @@ export class FileResource extends BaseResource<FileModel> {
     const srcOriginalPath = this.getCloudStoragePath(auth, "original");
     await bucket.copyFile(srcOriginalPath, mountFilePath);
 
+    // Double-write to the pods/ path for project mount paths.
+    const podsMountFilePath = toPodsMountFilePath(mountFilePath);
+    if (podsMountFilePath) {
+      await bucket.copyFile(srcOriginalPath, podsMountFilePath);
+    }
+
     // Copy processed version only if this file type has real processing.
     if (this.getContentVersion() === "processed") {
       const srcProcessedPath = this.getCloudStoragePath(auth, "processed");
@@ -1085,6 +1102,11 @@ export class FileResource extends BaseResource<FileModel> {
         processedContentType: getProcessedContentType(this.contentType),
       });
       await bucket.copyFile(srcProcessedPath, processedMountPath);
+
+      const processedPodsMountPath = toPodsMountFilePath(processedMountPath);
+      if (processedPodsMountPath) {
+        await bucket.copyFile(srcProcessedPath, processedPodsMountPath);
+      }
     }
 
     await this.update({ mountFilePath });
@@ -1110,6 +1132,12 @@ export class FileResource extends BaseResource<FileModel> {
     const bucket = getPrivateUploadBucket();
     await bucket.delete(this.mountFilePath, { ignoreNotFound: true });
 
+    // Mirror delete on the pods/ side for project files (double-write counterpart).
+    const podsMountFilePath = toPodsMountFilePath(this.mountFilePath);
+    if (podsMountFilePath) {
+      await bucket.delete(podsMountFilePath, { ignoreNotFound: true });
+    }
+
     if (
       this.useCaseMetadata?.skipFileProcessing === true ||
       !hasProcessedVersion(this.contentType)
@@ -1123,6 +1151,11 @@ export class FileResource extends BaseResource<FileModel> {
       processedContentType: getProcessedContentType(this.contentType),
     });
     await bucket.delete(processedMountPath, { ignoreNotFound: true });
+
+    const processedPodsMountPath = toPodsMountFilePath(processedMountPath);
+    if (processedPodsMountPath) {
+      await bucket.delete(processedPodsMountPath, { ignoreNotFound: true });
+    }
   }
 
   static async bulkSetUseCaseMetadata(


### PR DESCRIPTION
## Description

This PR starts the migration of project context file storage from the current `projects/` GCS prefix to the new `pods/` GCS prefix.

Today, project context files are saved and read from paths like:

`w/{wId}/projects/{projectId}/files/...`

The target storage layout is:

`w/{wId}/pods/{projectId}/files/...`

As a first step toward that migration, this PR keeps the existing behavior unchanged while adding a double-write to the new location:

- DB `mountFilePath` values continue to point to `projects/...`.
- Reads continue to use `projects/...`.
- New or updated project context files are still written to `projects/...`.
- The same content is also mirrored to the equivalent `pods/...` path.
- Processed file siblings are mirrored as well

This lets us safely start populating the new `pods/` storage layout before switching reads or persisted paths in a later migration step.

## Tests

## Risk

Low. The current `projects/...` storage path remains the source of truth, and reads are not moved to `pods/...` in this PR.

## Deploy Plan

Standard deployment