### PR TITLE
[front] coupons: improve display of redemptions in poke

### DIFF
--- a/front/components/poke/pages/CouponsPage.tsx
+++ b/front/components/poke/pages/CouponsPage.tsx
@@ -21,6 +21,7 @@ import {
   ChevronRightIcon,
   Chip,
   DataTable,
+  LinkWrapper,
   PlusIcon,
   Spinner,
 } from "@dust-tt/sparkle";
@@ -178,7 +179,14 @@ const redemptionColumns: ColumnDef<CouponRedemptionRowData>[] = [
     accessorKey: "workspaceId",
     header: "Workspace",
     cell: ({ row }) => (
-      <DataTable.BasicCellContent label={row.original.workspaceId} />
+      <DataTable.CellContent>
+        <LinkWrapper
+          href={`/poke/${row.original.workspaceId}`}
+          className="text-highlight-500"
+        >
+          {row.original.workspaceId}
+        </LinkWrapper>
+      </DataTable.CellContent>
     ),
   },
   {
@@ -197,7 +205,7 @@ const redemptionColumns: ColumnDef<CouponRedemptionRowData>[] = [
       <DataTable.BasicCellContent
         label={formatTimestampToFriendlyDate(
           new Date(row.original.redeemedAt).getTime(),
-          "compactWithDay"
+          "long"
         )}
       />
     ),


### PR DESCRIPTION
## Description

Small UX improvement in poke for coupon redemptions display
* add link to workpace
* display full date and time for "redeemed At"

## Tests

Tested locally

## Risk

Low, only UI in poke

## Deploy Plan

Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->