### PR TITLE
Ensure MCP server views on feature flag enable

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.test.ts
@@ -1,0 +1,76 @@
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { toggleFeatureFlagPlugin } from "@app/lib/api/poke/plugins/workspaces/toggle_feature_flag";
+import { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+describe("toggleFeatureFlagPlugin.execute", () => {
+  it("ensures sandbox MCP server views when enabling sandbox_tools", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+    const sandboxMCPServerId = autoInternalMCPServerNameToSId({
+      name: "sandbox",
+      workspaceId: workspace.id,
+    });
+
+    await expect(
+      MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        sandboxMCPServerId
+      )
+    ).resolves.toBeNull();
+    await expect(
+      MCPServerViewResource.getMCPServerViewForGlobalSpace(
+        auth,
+        sandboxMCPServerId
+      )
+    ).resolves.toBeNull();
+
+    const enableResult = await toggleFeatureFlagPlugin.execute(auth, null, {
+      features: ["sandbox_tools"],
+    });
+
+    expect(enableResult.isOk()).toBe(true);
+    if (!enableResult.isOk()) {
+      throw enableResult.error;
+    }
+    expect(enableResult.value.value).toContain("created 2 views");
+
+    await expect(
+      MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        sandboxMCPServerId
+      )
+    ).resolves.not.toBeNull();
+    await expect(
+      MCPServerViewResource.getMCPServerViewForGlobalSpace(
+        auth,
+        sandboxMCPServerId
+      )
+    ).resolves.not.toBeNull();
+
+    const disableResult = await toggleFeatureFlagPlugin.execute(auth, null, {
+      features: [],
+    });
+    expect(disableResult.isOk()).toBe(true);
+    if (!disableResult.isOk()) {
+      throw disableResult.error;
+    }
+
+    const reenableResult = await toggleFeatureFlagPlugin.execute(auth, null, {
+      features: ["sandbox_tools"],
+    });
+
+    expect(reenableResult.isOk()).toBe(true);
+    if (!reenableResult.isOk()) {
+      throw reenableResult.error;
+    }
+    expect(reenableResult.value.value).toContain("created 0 views");
+  });
+});

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.test.ts
@@ -40,20 +40,19 @@ describe("toggleFeatureFlagPlugin.execute", () => {
     if (!enableResult.isOk()) {
       throw enableResult.error;
     }
-    expect(enableResult.value.value).toContain("created 2 views");
 
-    await expect(
-      MCPServerViewResource.getMCPServerViewForSystemSpace(
+    const systemViewAfterEnable =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
         auth,
         sandboxMCPServerId
-      )
-    ).resolves.not.toBeNull();
-    await expect(
-      MCPServerViewResource.getMCPServerViewForGlobalSpace(
+      );
+    const globalViewAfterEnable =
+      await MCPServerViewResource.getMCPServerViewForGlobalSpace(
         auth,
         sandboxMCPServerId
-      )
-    ).resolves.not.toBeNull();
+      );
+    expect(systemViewAfterEnable).not.toBeNull();
+    expect(globalViewAfterEnable).not.toBeNull();
 
     const disableResult = await toggleFeatureFlagPlugin.execute(auth, null, {
       features: [],
@@ -66,11 +65,24 @@ describe("toggleFeatureFlagPlugin.execute", () => {
     const reenableResult = await toggleFeatureFlagPlugin.execute(auth, null, {
       features: ["sandbox_tools"],
     });
-
     expect(reenableResult.isOk()).toBe(true);
     if (!reenableResult.isOk()) {
       throw reenableResult.error;
     }
-    expect(reenableResult.value.value).toContain("created 0 views");
+
+    // Re-enabling must not create new views: the system/global view sIds
+    // should match the ones returned right after the first enable.
+    const systemViewAfterReenable =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        sandboxMCPServerId
+      );
+    const globalViewAfterReenable =
+      await MCPServerViewResource.getMCPServerViewForGlobalSpace(
+        auth,
+        sandboxMCPServerId
+      );
+    expect(systemViewAfterReenable?.sId).toBe(systemViewAfterEnable?.sId);
+    expect(globalViewAfterReenable?.sId).toBe(globalViewAfterEnable?.sId);
   });
 });

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
@@ -96,23 +96,6 @@ export const toggleFeatureFlagPlugin = createPlugin({
       invalidateFeatureFlagsCache(auth);
     }
 
-    let createdMCPServerViewsCount: number | null = null;
-
-    if (toAdd.length > 0) {
-      const { createdViewsCount } =
-        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-      createdMCPServerViewsCount = createdViewsCount;
-
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          enabledFlags: toAdd,
-          createdViewsCount,
-        },
-        "Ensured MCP server views after enabling feature flags."
-      );
-    }
-
     const actions: string[] = [];
 
     for (const feature of toAdd) {
@@ -128,10 +111,23 @@ export const toggleFeatureFlagPlugin = createPlugin({
         );
       }
     }
-    if (createdMCPServerViewsCount !== null) {
-      const viewLabel = createdMCPServerViewsCount === 1 ? "view" : "views";
+
+    if (toAdd.length > 0) {
+      const { createdViewsCount } =
+        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          enabledFlags: toAdd,
+          createdViewsCount,
+        },
+        "Ensured MCP server views after enabling feature flags."
+      );
+
+      const viewLabel = createdViewsCount === 1 ? "view" : "views";
       actions.push(
-        `MCP server views ensured for all enabled auto tools (created ${createdMCPServerViewsCount} ${viewLabel}).`
+        `MCP server views ensured for all enabled auto tools (created ${createdViewsCount} ${viewLabel}).`
       );
     }
 

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
@@ -2,6 +2,8 @@ import { createPlugin } from "@app/lib/api/poke/types";
 import { invalidateFeatureFlagsCache } from "@app/lib/auth";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import logger from "@app/logger/logger";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import {
   FEATURE_FLAG_STAGE_LABELS,
@@ -94,6 +96,23 @@ export const toggleFeatureFlagPlugin = createPlugin({
       invalidateFeatureFlagsCache(auth);
     }
 
+    let createdMCPServerViewsCount: number | null = null;
+
+    if (toAdd.length > 0) {
+      const { createdViewsCount } =
+        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+      createdMCPServerViewsCount = createdViewsCount;
+
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          enabledFlags: toAdd,
+          createdViewsCount,
+        },
+        "Ensured MCP server views after enabling feature flags."
+      );
+    }
+
     const actions: string[] = [];
 
     for (const feature of toAdd) {
@@ -108,6 +127,12 @@ export const toggleFeatureFlagPlugin = createPlugin({
           `❌ Feature "${feature}" has been DISABLED for workspace "${workspace.name}"`
         );
       }
+    }
+    if (createdMCPServerViewsCount !== null) {
+      const viewLabel = createdMCPServerViewsCount === 1 ? "view" : "views";
+      actions.push(
+        `MCP server views ensured for all enabled auto tools (created ${createdMCPServerViewsCount} ${viewLabel}).`
+      );
     }
 
     return new Ok({


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#8161.

When a feature flag gating a sandbox MCP server is toggled ON for a workspace via Poke, the matching `MCPServerView` rows in the system and global spaces were not created. The skill became available but agents looped trying to find tools (e.g. `bash`). The fix calls `MCPServerViewResource.ensureAllAutoToolsAreCreated(auth)` after `FeatureFlagResource.enableMany` in the per-workspace Poke toggle, so views are materialized automatically. The Poke action message now also reports how many views were created.

> [!NOTE]
> Out of scope: global rollout via `toggleGlobalFeatureFlagPlugin`. Raising the percentage enables workspaces transparently with no per-workspace row written, so `scripts/ensure_all_mcp_server_views_created.ts` remains the supported path there until we wrap it in a Temporal workflow.

## Tests

Added a functional test for the plugin that, on a fresh workspace, asserts the sandbox MCP server views are absent before, exist after enabling `sandbox_tools`, and that re-enabling produces the same view sIds (idempotency).

## Risk

Low. `ensureAllAutoToolsAreCreated` is idempotent, admin-gated, scoped to the current workspace, and already called from workspace creation, seeds, and ~15 migrations. The only new behavior is calling it from the Poke toggle path on enable.

## Deploy Plan

Standard deploy.