### PR TITLE
[front] checkout stripe invoice: small naming change

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -425,7 +425,7 @@ async function makeFirstPeriodInvoiceForCustomer({
       customer: stripeCustomerId,
       amount: subtotalCents,
       currency,
-      description: `Subscription first period — ${seatCount} seat${seatCount > 1 ? "s" : ""}`,
+      description: `Workspace seat — ${seatCount} seat${seatCount > 1 ? "s" : ""}`,
       invoice: invoice.id,
     });
 


### PR DESCRIPTION
## Description

Use same product name "Workspace seat" in stripe invoice for first payment (in checkout flow)

## Tests

Not needed, small text change

## Risk

None, small text change

## Deploy Plan

Deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25773">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->