### PR TITLE
feat(temporal): add sandbox child tool workflow

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,3 +1,4 @@
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { isLightClientSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
   buildAuditLogTarget,
@@ -198,6 +199,16 @@ async function executeToolStreaming(
     getShutdownSignal(),
   ]);
 
+  // Sandbox-child actions are observed by the CLI through polling; they must
+  // not surface in the conversation timeline, so progress events are dropped.
+  const isSandboxChildAction = isSandboxChildActionInfo(
+    action.stepContext.sandboxChildActionInfo
+  );
+
+  const handleNonDeferredEvents = !isSandboxChildAction
+    ? updateResourceAndPublishEvent
+    : () => {};
+
   const eventStream = runToolWithStreaming(
     auth,
     {
@@ -224,7 +235,7 @@ async function executeToolStreaming(
         );
 
         // For tool errors, send immediately.
-        await updateResourceAndPublishEvent(auth, {
+        await handleNonDeferredEvents(auth, {
           event: {
             type: "tool_error",
             created: event.created,
@@ -256,7 +267,12 @@ async function executeToolStreaming(
         );
 
         let updatedAgentMessage = agentMessage;
-        if (!event.isError && event.text && !agentMessage.content) {
+        if (
+          !event.isError &&
+          event.text &&
+          !agentMessage.content &&
+          !isSandboxChildAction
+        ) {
           // Save and post the tool's text content only if the execution stopped
           // before any text was generated.
           await AgentStepContentResource.createNewVersion({
@@ -287,7 +303,7 @@ async function executeToolStreaming(
           };
         }
 
-        await updateResourceAndPublishEvent(auth, {
+        await handleNonDeferredEvents(auth, {
           event: event.isError
             ? {
                 type: "tool_error",
@@ -398,7 +414,7 @@ async function executeToolStreaming(
           },
         });
 
-        await updateResourceAndPublishEvent(auth, {
+        await handleNonDeferredEvents(auth, {
           event: {
             type: "agent_action_success",
             created: event.created,
@@ -413,7 +429,7 @@ async function executeToolStreaming(
         break;
       case "tool_params":
       case "tool_notification":
-        await updateResourceAndPublishEvent(auth, {
+        await handleNonDeferredEvents(auth, {
           event,
           agentMessage,
           conversation,

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -7,16 +7,24 @@ import { logAgentLoopStart } from "@app/temporal/agent_loop/activities/instrumen
 import {
   makeAgentLoopWorkflowId,
   makeCompactionWorkflowId,
+  makeSandboxChildToolWorkflowId,
 } from "@app/temporal/agent_loop/lib/workflow_ids";
-import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import type { AgentMCPActionType } from "@app/types/actions";
+import type {
+  AgentLoopArgs,
+  AgentLoopArgsWithTiming,
+} from "@app/types/assistant/agent_run";
 import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
-
 import { QUEUE_NAME } from "./config";
-import { agentLoopWorkflow, compactionWorkflow } from "./workflows";
+import {
+  agentLoopWorkflow,
+  compactionWorkflow,
+  runSandboxChildToolWorkflow,
+} from "./workflows";
 
 export async function launchAgentLoopWorkflow({
   auth,
@@ -178,6 +186,67 @@ export async function launchCompactionWorkflow({
         "Compaction workflow already running for this conversation."
       )
     );
+  }
+
+  return new Ok(undefined);
+}
+
+export async function launchSandboxChildToolWorkflow({
+  auth,
+  agentLoopArgs,
+  action,
+  step,
+  waitForCompletion,
+}: {
+  auth: Authenticator;
+  agentLoopArgs: AgentLoopArgsWithTiming;
+  action: AgentMCPActionType;
+  step: number;
+  // On resume paths, wait for any prior run for this action to finalize first
+  // — same mechanism as launchAgentLoopWorkflow.
+  waitForCompletion?: boolean;
+}): Promise<Result<undefined, Error>> {
+  const authType = auth.toJSON();
+  const { workspaceId } = authType;
+  const client = await getTemporalClientForAgentNamespace();
+
+  const workflowId = makeSandboxChildToolWorkflowId({
+    workspaceId,
+    actionModelId: action.id,
+  });
+
+  if (waitForCompletion) {
+    try {
+      const handle = client.workflow.getHandle(workflowId);
+      await handle.result();
+    } catch (error) {
+      logger.info(
+        { workflowId, error },
+        "Non-fatal while waiting for prior sandbox child workflow completion"
+      );
+    }
+  }
+
+  try {
+    await client.workflow.start(runSandboxChildToolWorkflow, {
+      args: [{ authType, agentLoopArgs, actionModelId: action.id, step }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      searchAttributes: {
+        conversationId: [agentLoopArgs.conversationId],
+        workspaceId: [workspaceId],
+      },
+      memo: {
+        conversationId: agentLoopArgs.conversationId,
+        workspaceId,
+      },
+    });
+  } catch (error) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      // Idempotent: another caller already kicked it off for this action.
+      return new Ok(undefined);
+    }
+    throw error;
   }
 
   return new Ok(undefined);

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
@@ -9,7 +10,6 @@ import {
   makeCompactionWorkflowId,
   makeSandboxChildToolWorkflowId,
 } from "@app/temporal/agent_loop/lib/workflow_ids";
-import type { AgentMCPActionType } from "@app/types/actions";
 import type {
   AgentLoopArgs,
   AgentLoopArgsWithTiming,
@@ -191,21 +191,22 @@ export async function launchCompactionWorkflow({
   return new Ok(undefined);
 }
 
-export async function launchSandboxChildToolWorkflow({
-  auth,
-  agentLoopArgs,
-  action,
-  step,
-  waitForCompletion,
-}: {
-  auth: Authenticator;
-  agentLoopArgs: AgentLoopArgsWithTiming;
-  action: AgentMCPActionType;
-  step: number;
-  // On resume paths, wait for any prior run for this action to finalize first
-  // — same mechanism as launchAgentLoopWorkflow.
-  waitForCompletion?: boolean;
-}): Promise<Result<undefined, Error>> {
+export async function launchSandboxChildToolWorkflow(
+  auth: Authenticator,
+  {
+    agentLoopArgs,
+    action,
+    step,
+    waitForCompletion,
+  }: {
+    agentLoopArgs: AgentLoopArgsWithTiming;
+    action: AgentMCPActionResource;
+    step: number;
+    // On resume paths, wait for any prior run for this action to finalize first
+    // — same mechanism as launchAgentLoopWorkflow.
+    waitForCompletion?: boolean;
+  }
+): Promise<Result<undefined, Error>> {
   const authType = auth.toJSON();
   const { workspaceId } = authType;
   const client = await getTemporalClientForAgentNamespace();

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -32,3 +32,13 @@ export function makeAgentLoopConversationTitleWorkflowId(
 
   return `agent-loop-conversation-title-workflow-${workspaceId}-${conversationId}`;
 }
+
+export function makeSandboxChildToolWorkflowId({
+  workspaceId,
+  actionModelId,
+}: {
+  workspaceId: string;
+  actionModelId: number;
+}) {
+  return `sandbox-child-tool-workflow-${workspaceId}-${actionModelId}`;
+}

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -113,7 +113,7 @@ const { ensureConversationTitleActivity } = proxyActivities<
 const { compactionActivity } = proxyActivities<typeof compactionActivities>({
   startToCloseTimeout: "20 minutes",
   retry: {
-    // Do not retry compaction, the message is marked as failed, not idempotent.
+    // Do not retry compaction, the message is marked as failed, not idempotent
     maximumAttempts: 1,
   },
 });
@@ -457,4 +457,26 @@ async function executeStepIteration({
     runId,
     shouldContinue: !toolResults.some((result) => result.shouldPauseAgentLoop),
   };
+}
+
+export async function runSandboxChildToolWorkflow({
+  authType,
+  agentLoopArgs,
+  actionModelId,
+  step,
+}: {
+  authType: AuthenticatorType;
+  agentLoopArgs: AgentLoopArgsWithTiming;
+  actionModelId: number;
+  step: number;
+}) {
+  const { deferredEvents } = await runToolActivity(authType, {
+    actionId: actionModelId,
+    runAgentArgs: agentLoopArgs,
+    step,
+  });
+
+  if (deferredEvents.length > 0) {
+    await publishDeferredEventsActivity(deferredEvents);
+  }
 }


### PR DESCRIPTION
## Description

Adds the Temporal plumbing to run an MCP tool execution spawned by a sandbox parent tool, isolated from the agent loop:

- `makeSandboxChildToolWorkflowId({ workspaceId, actionModelId })` in `lib/workflow_ids.ts`.
- `runSandboxChildToolWorkflow`: runs the tool activity and publishes any deferred events at the end.
- `launchSandboxChildToolWorkflow` in `client.ts` with optional `waitForCompletion` for resume paths (mirrors `launchAgentLoopWorkflow`).
- `run_tool` activity: when an action's `stepContext.sandboxChildActionInfo` is set, drop the in-flight progress events (`tool_error`, `tool_success`, `agent_action_success`, `tool_params`, `tool_notification`) so the conversation timeline is not polluted. Status of the child action is still persisted on the `AgentMCPAction` row; only event publication is suppressed.

The sandbox CLI consumes these child actions through polling instead of the event stream (endpoint added in a follow-up PR).

## Tests

Manual end-to-end test once the public API PR is stacked. No unit tests added (workflow is exercised through the integration path).

## Risk

Medium-low. New code paths are gated on `sandboxChildActionInfo` being set, so existing tool executions are unaffected. The event-suppression logic is the main thing to eyeball: a regression here would silently swallow events for normal actions.

## Deploy Plan

Depends on the shared-types PR (#25774). Safe to deploy ahead of the public-API endpoints — nothing calls `launchSandboxChildToolWorkflow` yet.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25775">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->