### PR TITLE
feat(actions): hide sandbox child actions from conversation timeline

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -19,6 +19,7 @@ import {
 import type { StepContext } from "@app/lib/actions/types";
 import {
   isFileAuthorizationInfo,
+  isSandboxChildActionInfo,
   isUserQuestionResumeState,
 } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
@@ -621,7 +622,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    let agentStepContentToolExecutions =
+    const agentStepContentToolExecutions =
       await AgentStepContentToolExecutionModel.findAll({
         where: {
           workspaceId,
@@ -638,7 +639,16 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
     const stepContentsMap = new Map(stepContents.map((s) => [s.id, s]));
 
-    return agentStepContentToolExecutions.map((row) => {
+    // Sandbox-child actions share their parent's stepContent and must not
+    // surface as separate executions in the conversation timeline.
+    const visibleExecutions = agentStepContentToolExecutions.filter(
+      (row) =>
+        !isSandboxChildActionInfo(
+          row.agentMCPAction.stepContext.sandboxChildActionInfo
+        )
+    );
+
+    return visibleExecutions.map((row) => {
       const a = row.agentMCPAction;
       const stepContent = stepContentsMap.get(row.stepContentId);
 
@@ -660,15 +670,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
   }
 
-  static async listByAgentMessageIds(
-    auth: Authenticator,
-    agentMessageIds: ModelId[]
-  ): Promise<AgentMCPActionResource[]> {
-    return this.baseFetch(auth, {
-      where: { agentMessageId: { [Op.in]: agentMessageIds } },
-    });
-  }
-
   static async listModelIdsByAgentMessageIds(
     auth: Authenticator,
     agentMessageIds: ModelId[]
@@ -686,6 +687,15 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
 
     return actions.map((action) => action.id);
+  }
+
+  static async listByAgentMessageIds(
+    auth: Authenticator,
+    agentMessageIds: ModelId[]
+  ): Promise<AgentMCPActionResource[]> {
+    return this.baseFetch(auth, {
+      where: { agentMessageId: { [Op.in]: agentMessageIds } },
+    });
   }
 
   static async listBlockedActionsForAgentMessage(


### PR DESCRIPTION
## Description

Sandbox child actions share their parent's `stepContent` — they are internal plumbing for the sandbox CLI's polling flow and must not surface as separate executions in the conversation UI.

Filters out rows whose `stepContext` carries a `SandboxChildActionInfo` marker when reconstructing tool executions in `AgentMCPActionResource`.

## Tests

Manual end-to-end test once the public API PR is stacked: invoke a sandbox tool that calls a child, confirm only the parent execution shows in the conversation.

## Risk

Low. The filter is a no-op for any action without `sandboxChildActionInfo` set on its step context, so existing conversations are unaffected.

## Deploy Plan

Depends on the shared-types PR (#25774) for the guard. Safe to deploy independently of the temporal and public-API PRs.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25776">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->