### PR TITLE
feat(api): add sandbox public API to spawn child MCP actions

### DIFF
--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -1,0 +1,247 @@
+import {
+  FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL,
+  FALLBACK_MCP_TOOL_STAKE_LEVEL,
+} from "@app/lib/actions/constants";
+import { makeServerSideMCPToolConfigurations } from "@app/lib/actions/mcp_actions";
+import {
+  getAvailabilityOfInternalMCPServerById,
+  getInternalMCPServerDisplayedAs,
+  getInternalMCPServerNameFromSId,
+  getInternalMCPServerToolStakes,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
+import { validateToolInputs } from "@app/lib/actions/mcp_utils";
+import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
+import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
+import { getJITServers } from "@app/lib/api/assistant/jit_actions";
+import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
+import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
+import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
+import type { AgentMessageType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export type CreateSandboxChildActionResult = {
+  actionId: string;
+  needsApproval: boolean;
+};
+
+/**
+ * Creates a sandbox child MCP action — the result of an LLM running inside a
+ * `sandbox` MCP tool invoking another MCP tool through the public sandbox API.
+ */
+export async function createSandboxChildAction(
+  auth: Authenticator,
+  {
+    parentActionId,
+    agentId,
+    conversationId,
+    agentMessageId,
+    serverViewId,
+    toolName,
+    rawInputs,
+  }: {
+    parentActionId: string;
+    agentId: string;
+    conversationId: string;
+    agentMessageId: string;
+    serverViewId: string;
+    toolName: string;
+    rawInputs: Record<string, unknown>;
+  }
+): Promise<Result<CreateSandboxChildActionResult, Error>> {
+  const view = await MCPServerViewResource.fetchById(auth, serverViewId);
+  if (!view) {
+    return new Err(normalizeError("MCP server view not found."));
+  }
+
+  const [agentConfiguration, conversationResult, parentAction] =
+    await Promise.all([
+      getAgentConfiguration(auth, { agentId, variant: "full" }),
+      getConversation(auth, conversationId),
+      AgentMCPActionResource.fetchById(auth, parentActionId),
+    ]);
+
+  if (!agentConfiguration) {
+    return new Err(normalizeError("Agent configuration not found."));
+  }
+  if (conversationResult.isErr()) {
+    return new Err(normalizeError("Conversation not found."));
+  }
+  if (!parentAction) {
+    return new Err(normalizeError("Parent action not found."));
+  }
+
+  const conversation = conversationResult.value;
+
+  const agentMessage = conversation.content
+    .flat()
+    .find(
+      (m): m is AgentMessageType =>
+        m.type === "agent_message" && m.sId === agentMessageId
+    );
+  if (!agentMessage) {
+    return new Err(normalizeError("Agent message not found."));
+  }
+
+  // JIT servers cover tools added via the conversation input bar.
+  let serverSideConfig = agentConfiguration.actions
+    .filter(isServerSideMCPServerConfiguration)
+    .find((a) => a.mcpServerViewId === view.sId);
+
+  if (!serverSideConfig) {
+    const { servers: jitServers } = await getJITServers(auth, {
+      agentConfiguration,
+      conversation,
+      attachments: [],
+    });
+    serverSideConfig = jitServers.find((s) => s.mcpServerViewId === view.sId);
+  }
+
+  if (!serverSideConfig) {
+    return new Err(
+      normalizeError("Tool is not available to this agent or conversation.")
+    );
+  }
+
+  const availability = getAvailabilityOfInternalMCPServerById(view.mcpServerId);
+  const internalServerName = getInternalMCPServerNameFromSId(view.mcpServerId);
+  const serverDefaultStake = internalServerName
+    ? getInternalMCPServerToolStakes(internalServerName)[toolName]
+    : undefined;
+
+  const stakeLevel =
+    view.getToolPermission(toolName) ??
+    serverDefaultStake ??
+    (availability === "manual"
+      ? FALLBACK_MCP_TOOL_STAKE_LEVEL
+      : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL);
+
+  const [fullToolConfiguration] = makeServerSideMCPToolConfigurations(
+    serverSideConfig,
+    [
+      {
+        name: toolName,
+        description: "",
+        availability,
+        stakeLevel,
+        toolServerId: view.mcpServerId,
+        retryPolicy: DEFAULT_MCP_TOOL_RETRY_POLICY,
+      },
+    ]
+  );
+
+  if (!fullToolConfiguration) {
+    return new Err(
+      normalizeError("Tool is not available to this agent or conversation.")
+    );
+  }
+
+  const validateInputsResult = validateToolInputs(rawInputs);
+  if (validateInputsResult.isErr()) {
+    return new Err(normalizeError(validateInputsResult.error));
+  }
+
+  const { status } = await getExecutionStatusFromConfig(auth, {
+    actionConfiguration: fullToolConfiguration,
+    agentMessage,
+    context: {
+      agentId: agentConfiguration.sId,
+      toolInputs: rawInputs,
+    },
+  });
+
+  const action = await createMCPAction(auth, {
+    actionConfiguration: fullToolConfiguration,
+    agentMessage,
+    augmentedInputs: rawInputs,
+    conversation,
+    status,
+    stepContent: parentAction.stepContent,
+    stepContext: {
+      ...parentAction.stepContext,
+      resumeState: null,
+      sandboxChildActionInfo: { parentActionId: parentAction.sId },
+    },
+  });
+
+  if (status === "blocked_validation_required") {
+    const argumentsRequiringApproval =
+      fullToolConfiguration.argumentsRequiringApproval ?? [];
+    const internalMCPServerName = getInternalMCPServerNameFromSId(
+      fullToolConfiguration.toolServerId
+    );
+    const approvalEvent: MCPApproveExecutionEvent = {
+      type: "tool_approve_execution",
+      actionId: action.sId,
+      configurationId: fullToolConfiguration.sId,
+      conversationId: conversation.sId,
+      created: Date.now(),
+      inputs: rawInputs,
+      messageId: agentMessage.sId,
+      stake: fullToolConfiguration.permission,
+      userId: auth.user()?.sId,
+      isLastBlockingEventForStep: true,
+      metadata: {
+        toolName: fullToolConfiguration.originalName,
+        mcpServerName: fullToolConfiguration.mcpServerName,
+        agentName: agentConfiguration.name,
+        icon: fullToolConfiguration.icon,
+        displayedAs: getInternalMCPServerDisplayedAs(
+          fullToolConfiguration.toolServerId
+        ),
+      },
+      argumentsRequiringApproval,
+      approvalArgsLabel: await getApprovalArgsLabel({
+        auth,
+        internalMCPServerName,
+        toolName: fullToolConfiguration.originalName,
+        agentName: agentConfiguration.name,
+        inputs: rawInputs,
+        argumentsRequiringApproval,
+      }),
+    };
+
+    await updateResourceAndPublishEvent(auth, {
+      event: approvalEvent,
+      agentMessage,
+      conversation,
+      step: parentAction.stepContent.step,
+    });
+  } else {
+    const userMessageInfo = await getUserMessageIdFromMessageId(auth, {
+      messageId: agentMessage.sId,
+    });
+
+    await launchSandboxChildToolWorkflow({
+      auth,
+      agentLoopArgs: {
+        agentMessageId: agentMessage.sId,
+        agentMessageVersion: agentMessage.version,
+        conversationId: conversation.sId,
+        conversationTitle: conversation.title,
+        conversationBranchId: agentMessage.branchId,
+        userMessageId: userMessageInfo.userMessageId,
+        userMessageVersion: userMessageInfo.userMessageVersion,
+        userMessageOrigin: userMessageInfo.userMessageOrigin,
+        initialStartTime: Date.now(),
+      },
+      action: action.toJSON(),
+      step: parentAction.stepContent.step,
+    });
+  }
+
+  return new Ok({
+    actionId: action.sId,
+    needsApproval: status === "blocked_validation_required",
+  });
+}

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -28,7 +28,6 @@ import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client"
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export type CreateSandboxChildActionResult = {
   actionId: string;
@@ -61,24 +60,28 @@ export async function createSandboxChildAction(
 ): Promise<Result<CreateSandboxChildActionResult, Error>> {
   const view = await MCPServerViewResource.fetchById(auth, serverViewId);
   if (!view) {
-    return new Err(normalizeError("MCP server view not found."));
+    return new Err(new Error("MCP server view not found."));
   }
 
-  const [agentConfiguration, conversationResult, parentAction] =
-    await Promise.all([
-      getAgentConfiguration(auth, { agentId, variant: "full" }),
-      getConversation(auth, conversationId),
-      AgentMCPActionResource.fetchById(auth, parentActionId),
-    ]);
-
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId,
+    variant: "full",
+  });
   if (!agentConfiguration) {
-    return new Err(normalizeError("Agent configuration not found."));
+    return new Err(new Error("Agent configuration not found."));
   }
+
+  const conversationResult = await getConversation(auth, conversationId);
   if (conversationResult.isErr()) {
-    return new Err(normalizeError("Conversation not found."));
+    return new Err(new Error("Conversation not found."));
   }
+
+  const parentAction = await AgentMCPActionResource.fetchById(
+    auth,
+    parentActionId
+  );
   if (!parentAction) {
-    return new Err(normalizeError("Parent action not found."));
+    return new Err(new Error("Parent action not found."));
   }
 
   const conversation = conversationResult.value;
@@ -90,7 +93,7 @@ export async function createSandboxChildAction(
         m.type === "agent_message" && m.sId === agentMessageId
     );
   if (!agentMessage) {
-    return new Err(normalizeError("Agent message not found."));
+    return new Err(new Error("Agent message not found."));
   }
 
   // JIT servers cover tools added via the conversation input bar.
@@ -109,7 +112,7 @@ export async function createSandboxChildAction(
 
   if (!serverSideConfig) {
     return new Err(
-      normalizeError("Tool is not available to this agent or conversation.")
+      new Error("Tool is not available to this agent or conversation.")
     );
   }
 
@@ -142,13 +145,13 @@ export async function createSandboxChildAction(
 
   if (!fullToolConfiguration) {
     return new Err(
-      normalizeError("Tool is not available to this agent or conversation.")
+      new Error("Tool is not available to this agent or conversation.")
     );
   }
 
   const validateInputsResult = validateToolInputs(rawInputs);
   if (validateInputsResult.isErr()) {
-    return new Err(normalizeError(validateInputsResult.error));
+    return validateInputsResult;
   }
 
   const { status } = await getExecutionStatusFromConfig(auth, {
@@ -180,7 +183,7 @@ export async function createSandboxChildAction(
     const internalMCPServerName = getInternalMCPServerNameFromSId(
       fullToolConfiguration.toolServerId
     );
-    const approvalEvent: MCPApproveExecutionEvent = {
+    const approvalRequirementEvent: MCPApproveExecutionEvent = {
       type: "tool_approve_execution",
       actionId: action.sId,
       configurationId: fullToolConfiguration.sId,
@@ -212,7 +215,7 @@ export async function createSandboxChildAction(
     };
 
     await updateResourceAndPublishEvent(auth, {
-      event: approvalEvent,
+      event: approvalRequirementEvent,
       agentMessage,
       conversation,
       step: parentAction.stepContent.step,
@@ -222,8 +225,7 @@ export async function createSandboxChildAction(
       messageId: agentMessage.sId,
     });
 
-    await launchSandboxChildToolWorkflow({
-      auth,
+    await launchSandboxChildToolWorkflow(auth, {
       agentLoopArgs: {
         agentMessageId: agentMessage.sId,
         agentMessageVersion: agentMessage.version,
@@ -235,7 +237,7 @@ export async function createSandboxChildAction(
         userMessageOrigin: userMessageInfo.userMessageOrigin,
         initialStartTime: Date.now(),
       },
-      action: action.toJSON(),
+      action,
       step: parentAction.stepContent.step,
     });
   }

--- a/front/pages/api/v1/w/[wId]/sandbox/actions/[aId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/actions/[aId]/index.ts
@@ -30,6 +30,10 @@ export type FetchConversationMessageActionResponse =
   | CallToolPendingResponse
   | CallToolRejectedResponse;
 
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<

--- a/front/pages/api/v1/w/[wId]/sandbox/actions/[aId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/actions/[aId]/index.ts
@@ -1,0 +1,120 @@
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { verifySandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type CallToolPendingResponse = {
+  status: "pending";
+  actionId: string;
+};
+
+type CallToolRejectedResponse = {
+  status: "rejected";
+};
+
+type CallToolSuccessResponse = {
+  status: "success";
+  action: AgentMCPActionWithOutputType;
+};
+
+export type FetchConversationMessageActionResponse =
+  | CallToolSuccessResponse
+  | CallToolPendingResponse
+  | CallToolRejectedResponse;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<FetchConversationMessageActionResponse>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const claims = await verifySandboxExecToken(req.headers.authorization ?? "");
+  if (!claims) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "not_authenticated",
+        message: "The authentication token is invalid.",
+      },
+    });
+  }
+
+  const { aId } = req.query;
+  if (!isString(aId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `aId` is required.",
+      },
+    });
+  }
+
+  const action = await AgentMCPActionResource.fetchById(auth, aId);
+  if (!action) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "action_not_found",
+        message: "Action not found.",
+      },
+    });
+  }
+
+  // Scope the action lookup to the token's agent message — prevents a token
+  // leaking access to actions on other messages of the same workspace.
+  if (
+    !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo) ||
+    action.stepContext.sandboxChildActionInfo?.parentActionId !==
+      claims.actionId
+  ) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "action_not_found",
+        message: "Action not found.",
+      },
+    });
+  }
+
+  if (!isToolExecutionStatusFinal(action.status)) {
+    return res.status(202).json({ status: "pending", actionId: action.sId });
+  }
+
+  switch (action.status) {
+    case "succeeded":
+    case "errored": {
+      const [enriched] =
+        await AgentMCPActionResource.enrichActionsWithOutputItems(auth, {
+          actions: [action],
+          ignoreContent: false,
+        });
+      return res.status(200).json({ status: "success", action: enriched });
+    }
+    case "denied":
+      return res.status(403).json({ status: "rejected" });
+    default:
+      assertNever(action.status);
+  }
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/actions/call.ts
@@ -1,0 +1,95 @@
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { verifySandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
+import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type CallSandboxToolResponse = {
+  status: "pending";
+  actionId: string;
+};
+
+/**
+ * @ignoreswagger
+ * internal endpoint
+ */
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<CallSandboxToolResponse>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const claims = await verifySandboxExecToken(req.headers.authorization ?? "");
+  if (!claims) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "not_authenticated",
+        message: "The authentication token is invalid.",
+      },
+    });
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("sandbox_dsbx_tools")) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Sandbox dsbx tools are not enabled for this workspace.",
+      },
+    });
+  }
+
+  const bodyRes = CallMCPToolRequestBodySchema.safeParse(req.body);
+  if (!bodyRes.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${bodyRes.error.message}`,
+      },
+    });
+  }
+
+  const { serverViewId, toolName, arguments: toolArgs } = bodyRes.data;
+
+  const result = await createSandboxChildAction(auth, {
+    parentActionId: claims.actionId,
+    agentId: claims.aId,
+    conversationId: claims.cId,
+    agentMessageId: claims.mId,
+    serverViewId,
+    toolName,
+    rawInputs: toolArgs ?? {},
+  });
+
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: result.error.message,
+      },
+    });
+  }
+
+  return res
+    .status(202)
+    .json({ status: "pending", actionId: result.value.actionId });
+}
+
+export default withPublicAPIAuthentication(handler);


### PR DESCRIPTION
## Description

User-facing surface for sandbox MCP tools to call other MCP tools through the public API, gated on the `sandbox_dsbx_tools` feature flag.

It's not called yet by the sandbox CLI. 
Next PRs will implement the polling logic in dsbx.

- **`lib/api/sandbox/create_child_action.ts`** — business logic for creating a child MCP action under a sandbox parent. Resolves the MCP server view, derives the tool's stake level, validates inputs, persists the action with the parent's `stepContent` and a `sandboxChildActionInfo` marker, and either emits a `tool_approve_execution` event when validation is required or launches the sandbox child workflow.
- **`POST /api/v1/w/[wId]/sandbox/actions/call`** — thin handler that verifies the sandbox token, validates the body via `CallMCPToolRequestBodySchema`, delegates to `createSandboxChildAction`, returns `202` + `actionId`.
- **`GET /api/v1/w/[wId]/sandbox/actions/[aId]`** — polling endpoint that returns `pending` / `success` / `rejected` depending on the child action's terminal status. Scopes the lookup to the parent action id carried in the token to prevent cross-message access.

## Tests

Manual end-to-end:
1. Enable `sandbox_dsbx_tools` for a workspace.
2. Start a conversation with a sandbox parent tool that calls a child via the public API.
3. Verify the parent receives an `actionId`, polling returns `pending` → terminal, and the child execution does not appear in the conversation timeline.

Functional tests for the two endpoints will follow in a separate PR.

## Risk

Medium-low. New public-API surface area:
- Gated on `sandbox_dsbx_tools` so blast radius is limited to workspaces opted in.

Still not used. The sandbox does not call those endpoints yet.

## Deploy Plan

Depends on:
- #25774 (shared types — `SandboxChildActionInfo`, `serverViewId`)
- #25775 (temporal child workflow)
- #25776 (resource filter to hide child actions)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25777">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->