### PR TITLE
Add pod name in conversation page in poke

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -8,6 +8,7 @@ import { usePokeConversation } from "@app/poke/swr";
 import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
 import { usePokeConversationConfig } from "@app/poke/swr/conversation_config";
 import { useCopyReinforcementTestCase } from "@app/poke/swr/reinforcement_test_case";
+import { usePokeSpaceDetails } from "@app/poke/swr/space_details";
 import type {
   AgentMessageStatus,
   CompactionMessageStatus,
@@ -414,6 +415,15 @@ export function ConversationPage() {
     workspaceId: owner.sId,
     conversationId,
   });
+
+  const { data: spaceDetails } = usePokeSpaceDetails({
+    owner,
+    spaceId: conversation?.spaceId ?? "",
+    disabled: !conversation?.spaceId,
+  });
+  const pod =
+    spaceDetails?.space.kind === "project" ? spaceDetails.space : null;
+
   const [useMarkdown, setUseMarkdown] = useState(false);
   const { data: agents } = usePokeAgentConfigurations({
     owner,
@@ -535,6 +545,18 @@ export function ConversationPage() {
           >
             {owner.name}
           </LinkWrapper>
+          {pod && (
+            <>
+              {" "}
+              in pod{" "}
+              <LinkWrapper
+                href={`/poke/${owner.sId}/spaces/${pod.sId}`}
+                className="text-highlight-500"
+              >
+                {pod.name}
+              </LinkWrapper>
+            </>
+          )}
         </h3>
         <Page.Vertical align="stretch">
           <PluginList


### PR DESCRIPTION
## Description

Useful when looking for the pod info of the conversation

<img width="2016" height="1196" alt="image" src="https://github.com/user-attachments/assets/321949d6-6842-4e57-8c0f-6e602d832c06" />

## Tests

tested locally

## Risk

low, it's poke

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25779">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->