### PR TITLE
Wake-up: Improve InputBar disabled experience

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -24,7 +24,6 @@ import { CONTEXT_USAGE_PERCENT_THRESHOLDS } from "@app/hooks/conversations/useCo
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
-import { describeWakeUpSchedule } from "@app/lib/utils/wakeup_description";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   isRichAgentMention,

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -143,7 +143,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
   const isActiveWakeUpOwner = activeWakeUp?.user.sId === context.user.sId;
   const wakeUpBlockMessage =
     activeWakeUp && !isActiveWakeUpOwner
-      ? `Conversation paused - a wake-up is scheduled ${describeWakeUpSchedule(activeWakeUp)}`
+      ? `You cannot send a message to an agent awaiting a wake-up set by another user`
       : null;
 
   const autoMentions = useMemo(() => {
@@ -577,7 +577,6 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
         actions={agentBuilderContext?.actionsToShow}
         isSubmitting={agentBuilderContext?.isSubmitting === true}
         isAgentBuilder={!!agentBuilderContext}
-        disableInput={wakeUpBlockMessage !== null}
         submitBlockMessage={wakeUpBlockMessage ?? compactionBlockMessage}
       />
     </div>


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/8078
Regression introduced by https://github.com/dust-tt/dust/pull/25394 I believe


Full disablement of the input bar is quite misleading for users as only by hovering the send button can they understand why it's disabled. Without full disablement but just `submitBlockMessage` the user can write in the input bar and when they hit enter the tooltip is shown and the input bar jiggles (existing behavior) which makes them fall in the pit of not success put understanding.

I also improved the message to be more descriptive as to why it's blocked.

Can type:

<img width="759" height="214" alt="Screenshot 2026-05-19 at 15 56 02" src="https://github.com/user-attachments/assets/7491f122-2d6a-4821-97e5-187eb7862b72" />

When hitting Enter or hovering the send button:

<img width="758" height="198" alt="Screenshot 2026-05-19 at 15 56 09" src="https://github.com/user-attachments/assets/425c53fe-1c25-41ed-b74d-f59d3926139c" />

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25780">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->