### PR TITLE
fix(sdk): default regionalModelsOnly to false to tolerate missing field

### DIFF
--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -778,6 +778,7 @@ const LightWorkspaceSchema = z.object({
   segmentation: WorkspaceSegmentationSchema,
   whiteListedProviders: ModelProviderIdSchema.array().nullable(),
   defaultEmbeddingProvider: EmbeddingProviderIdSchema.nullable(),
+  regionalModelsOnly: z.boolean().default(false),
 });
 
 export type LightWorkspaceType = z.infer<typeof LightWorkspaceSchema>;


### PR DESCRIPTION
## Description

fixes

```
Unexpected response format from DustAPI calling http://front-service/api/v1/w/7UegL3ttqi/assistant/conversations : [
  {
    "code": "invalid_type",
    "expected": "boolean",
    "received": "undefined",
    "path": [
      "conversation",
      "owner",
      "regionalModelsOnly"
    ],
    "message": "Required"
  }
]
```

## Tests

No

## Risk

Low - bug fix

## Deploy Plan

front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25782">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->