### PR TITLE
Add files__move tool and block frame copy in the files MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -117,6 +117,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "delete": "medium",
     "grep": "never_ask",
     "list": "never_ask",
+    "move": "never_ask",
     "resolve": "never_ask",
   },
   "freshservice": {

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -12,6 +12,7 @@ export const FILES_GREP_ACTION_NAME = "grep" as const;
 export const FILES_CREATE_ACTION_NAME = "create" as const;
 export const FILES_DELETE_ACTION_NAME = "delete" as const;
 export const FILES_COPY_ACTION_NAME = "copy" as const;
+export const FILES_MOVE_ACTION_NAME = "move" as const;
 export const FILES_RESOLVE_ACTION_NAME = "resolve" as const;
 
 export const CAT_LINES_DEFAULT = 200;
@@ -70,10 +71,16 @@ const LIST_PROJECT_AWARE_TOOL = {
 // conversation use cases. The project-aware build is registered only in project conversations
 // and adds an example of the cross-scope promotion the agent can perform there.
 const COPY_DESCRIPTION_BASE =
-  "Copy a file between scoped paths, preserving its bytes and content type. " +
-  "Useful for duplicating a file without round-tripping the content through the agent, " +
-  "which keeps binary files (PDFs, images, audio) intact. " +
+  "Copy a file between scoped paths, keeping the source intact. " +
+  `Does not support frame files (\`application/vnd.dust.frame\`); use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_MOVE_ACTION_NAME)}\` for those. ` +
+  "Useful for duplicating a file without round-tripping content through the agent. " +
   "Overwrites `dest` if it already exists.";
+
+// `move` tool variants. Move atomically transfers a file (copy + delete source).
+// Frame files must be moved rather than copied: copying produces a raw GCS object
+const MOVE_DESCRIPTION_BASE =
+  "Move a file from one scoped path to another, removing the source after a successful transfer. " +
+  "Frame files (`application/vnd.dust.frame`) must be moved rather than copied.";
 
 const COPY_CONVERSATION_ONLY_TOOL = {
   description: COPY_DESCRIPTION_BASE,
@@ -118,6 +125,51 @@ const COPY_PROJECT_AWARE_TOOL = {
   displayLabels: {
     running: "Copying file",
     done: "Copied file",
+  },
+};
+
+const MOVE_SCHEMA = {
+  source: z
+    .string()
+    .describe(
+      "Scoped path of the file to move (e.g. `conversation/report.pdf`)."
+    ),
+  dest: z
+    .string()
+    .describe("Scoped path of the destination (e.g. `project/report.pdf`)."),
+};
+
+const MOVE_CONVERSATION_ONLY_TOOL = {
+  description: MOVE_DESCRIPTION_BASE,
+  schema: MOVE_SCHEMA,
+  stake: "never_ask" as const,
+  displayLabels: {
+    running: "Moving file",
+    done: "Moved file",
+  },
+};
+
+const MOVE_PROJECT_AWARE_TOOL = {
+  description:
+    `${MOVE_DESCRIPTION_BASE} ` +
+    "Since this conversation belongs to a Pod, you can also move between scopes, " +
+    "e.g. `conversation/frame.html` -> `project/frame.html` to promote a frame into the Pod.",
+  schema: {
+    source: z
+      .string()
+      .describe(
+        "Scoped path of the file to move (e.g. `conversation/frame.html` or `project/data.csv`)."
+      ),
+    dest: z
+      .string()
+      .describe(
+        "Scoped path of the destination (e.g. `project/frame.html` or `conversation/archive/data.csv`)."
+      ),
+  },
+  stake: "never_ask" as const,
+  displayLabels: {
+    running: "Moving file",
+    done: "Moved file",
   },
 };
 
@@ -188,7 +240,7 @@ const FILES_TOOLS_COMMON_METADATA = {
     description:
       "Search a text file for lines matching a regular expression. " +
       "Returns matching lines with their line numbers. " +
-      "Use the line numbers with `files__cat` to read surrounding context. " +
+      `Use the line numbers with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` to read surrounding context. ` +
       `Results are capped at ${GREP_MATCHES_MAX} matches.`,
     schema: {
       path: z
@@ -257,12 +309,14 @@ export const FILES_TOOLS_METADATA = createToolsRecord({
   [FILES_LIST_ACTION_NAME]: LIST_CONVERSATION_ONLY_TOOL,
   ...FILES_TOOLS_COMMON_METADATA,
   [FILES_COPY_ACTION_NAME]: COPY_CONVERSATION_ONLY_TOOL,
+  [FILES_MOVE_ACTION_NAME]: MOVE_CONVERSATION_ONLY_TOOL,
 });
 
 export const FILES_TOOLS_METADATA_WITH_PROJECT = createToolsRecord({
   [FILES_LIST_ACTION_NAME]: LIST_PROJECT_AWARE_TOOL,
   ...FILES_TOOLS_COMMON_METADATA,
   [FILES_COPY_ACTION_NAME]: COPY_PROJECT_AWARE_TOOL,
+  [FILES_MOVE_ACTION_NAME]: MOVE_PROJECT_AWARE_TOOL,
 });
 
 export const FILES_SERVER = {

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -78,6 +78,7 @@ const COPY_DESCRIPTION_BASE =
 
 // `move` tool variants. Move atomically transfers a file (copy + delete source).
 // Frame files must be moved rather than copied: copying produces a raw GCS object
+// with no FileResource record, breaking interactive rendering.
 const MOVE_DESCRIPTION_BASE =
   "Move a file from one scoped path to another, removing the source after a successful transfer. " +
   "Frame files (`application/vnd.dust.frame`) must be moved rather than copied.";

--- a/front/lib/api/actions/servers/files/tools/copy.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.ts
@@ -11,7 +11,10 @@ import {
 import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
 import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { isInteractiveContentType, stripMimeParameters } from "@app/types/files";
+import {
+  isInteractiveContentType,
+  stripMimeParameters,
+} from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";

--- a/front/lib/api/actions/servers/files/tools/copy.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.ts
@@ -3,11 +3,18 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  FILES_MOVE_ACTION_NAME,
+  FILES_SERVER_NAME,
+} from "@app/lib/api/actions/servers/files/metadata";
 import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
 import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { isInteractiveContentType, stripMimeParameters } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 
 export async function copyHandler(
   { source, dest }: { source: string; dest: string },
@@ -66,10 +73,26 @@ export async function copyHandler(
   const bucket = getPrivateUploadBucket();
   const sourceFile = bucket.file(sourceGcsPath);
 
-  const [exists] = await sourceFile.exists();
-  if (!exists) {
+  let mimeType: string;
+  try {
+    const [metadata] = await sourceFile.getMetadata();
+    mimeType = stripMimeParameters(
+      isString(metadata.contentType)
+        ? metadata.contentType
+        : "application/octet-stream"
+    );
+  } catch {
     return new Err(
       new MCPError(`Source file not found: \`${source}\`.`, { tracked: false })
+    );
+  }
+
+  if (isInteractiveContentType(mimeType)) {
+    return new Err(
+      new MCPError(
+        `Frame files cannot be copied. Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_MOVE_ACTION_NAME)}\` to move \`${source}\` instead.`,
+        { tracked: false }
+      )
     );
   }
 

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -6,6 +6,7 @@ import {
   FILES_DELETE_ACTION_NAME,
   FILES_GREP_ACTION_NAME,
   FILES_LIST_ACTION_NAME,
+  FILES_MOVE_ACTION_NAME,
   FILES_RESOLVE_ACTION_NAME,
   FILES_TOOLS_METADATA,
   FILES_TOOLS_METADATA_WITH_PROJECT,
@@ -16,6 +17,7 @@ import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
 import { grepHandler } from "@app/lib/api/actions/servers/files/tools/grep";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
+import { moveHandler } from "@app/lib/api/actions/servers/files/tools/move";
 import { resolveHandler } from "@app/lib/api/actions/servers/files/tools/resolve";
 
 const HANDLERS = {
@@ -25,6 +27,7 @@ const HANDLERS = {
   [FILES_DELETE_ACTION_NAME]: deleteHandler,
   [FILES_GREP_ACTION_NAME]: grepHandler,
   [FILES_LIST_ACTION_NAME]: listHandler,
+  [FILES_MOVE_ACTION_NAME]: moveHandler,
   [FILES_RESOLVE_ACTION_NAME]: resolveHandler,
 };
 

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -1,6 +1,6 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
+import { moveHandler } from "@app/lib/api/actions/servers/files/tools/move";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -50,11 +50,11 @@ async function setupProjectConversation(
   };
 }
 
-describe("copyHandler", () => {
-  it("copies a file from conversation to project mount", async () => {
+describe("moveHandler", () => {
+  it("moves a file from conversation to project mount", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
-    const result = await copyHandler(
+    const result = await moveHandler(
       { source: "conversation/report.pdf", dest: "project/report.pdf" },
       makeExtra(auth, conversation)
     );
@@ -63,18 +63,16 @@ describe("copyHandler", () => {
     if (!result.isOk()) {
       return;
     }
-    expect(result.value).toEqual([
-      {
-        type: "text",
-        text: "Copied `conversation/report.pdf` to `project/report.pdf`.",
-      },
-    ]);
+    expect(result.value[0]).toEqual({
+      type: "text",
+      text: "Moved `conversation/report.pdf` to `project/report.pdf`.",
+    });
   });
 
-  it("copies a file from project to conversation mount", async () => {
+  it("moves a file from project to conversation mount", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
-    const result = await copyHandler(
+    const result = await moveHandler(
       { source: "project/spec.md", dest: "conversation/spec.md" },
       makeExtra(auth, conversation)
     );
@@ -85,18 +83,18 @@ describe("copyHandler", () => {
   it("returns Err when the source file does not exist", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
-    // Override the bucket so getMetadata rejects (simulates a missing GCS object).
     const mockBucket = {
       file: vi.fn(() => ({
         getMetadata: vi.fn().mockRejectedValue(new Error("Not Found")),
         copy: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
       })),
     };
     vi.mocked(getPrivateUploadBucket).mockReturnValueOnce(
       mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
     );
 
-    const result = await copyHandler(
+    const result = await moveHandler(
       { source: "conversation/missing.pdf", dest: "project/missing.pdf" },
       makeExtra(auth, conversation)
     );
@@ -108,42 +106,10 @@ describe("copyHandler", () => {
     expect(result.error.message).toContain("Source file not found");
   });
 
-  it("returns Err when the source is a frame file", async () => {
-    const { auth, conversation } = await setupProjectConversation();
-
-    const mockBucket = {
-      file: vi.fn(() => ({
-        getMetadata: vi
-          .fn()
-          .mockResolvedValue([
-            { contentType: "application/vnd.dust.frame", size: "100" },
-          ]),
-        copy: vi.fn().mockResolvedValue(undefined),
-      })),
-    };
-    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce(
-      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
-    );
-
-    const result = await copyHandler(
-      {
-        source: "conversation/interactive.html",
-        dest: "project/interactive.html",
-      },
-      makeExtra(auth, conversation)
-    );
-
-    expect(result.isErr()).toBe(true);
-    if (!result.isErr()) {
-      return;
-    }
-    expect(result.error.message).toContain("files__move");
-  });
-
   it("returns Err when source and dest resolve to the same GCS path", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
-    const result = await copyHandler(
+    const result = await moveHandler(
       { source: "conversation/x.md", dest: "conversation/x.md" },
       makeExtra(auth, conversation)
     );
@@ -158,7 +124,7 @@ describe("copyHandler", () => {
   it("returns Err for an invalid source scope prefix", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
-    const result = await copyHandler(
+    const result = await moveHandler(
       { source: "other/foo.md", dest: "project/foo.md" },
       makeExtra(auth, conversation)
     );
@@ -175,7 +141,7 @@ describe("copyHandler", () => {
       spaceId: null,
     });
 
-    const result = await copyHandler(
+    const result = await moveHandler(
       { source: "conversation/x.md", dest: "project/x.md" },
       makeExtra(auth, conversation)
     );

--- a/front/lib/api/actions/servers/files/tools/move.ts
+++ b/front/lib/api/actions/servers/files/tools/move.ts
@@ -1,0 +1,152 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolGeneratedFilePathType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
+import {
+  getGCSPathFromScopedPath,
+  moveFile,
+} from "@app/lib/api/files/gcs_mount/files";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { FileResource } from "@app/lib/resources/file_resource";
+import {
+  isAllSupportedFileContentType,
+  stripMimeParameters,
+} from "@app/types/files";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+
+export async function moveHandler(
+  { source, dest }: { source: string; dest: string },
+  { auth, agentLoopContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const conversation = agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(
+      new MCPError("No conversation context available.", { tracked: false })
+    );
+  }
+
+  const sourceMountRes = await resolveMountPoint(auth, conversation, {
+    access: "write",
+    scopedPath: source,
+  });
+  if (sourceMountRes.isErr()) {
+    return sourceMountRes;
+  }
+
+  const destMountRes = await resolveMountPoint(auth, conversation, {
+    access: "write",
+    scopedPath: dest,
+  });
+  if (destMountRes.isErr()) {
+    return destMountRes;
+  }
+
+  const sourceGcsPath = getGCSPathFromScopedPath({
+    prefix: sourceMountRes.value.prefix,
+    scopedPath: source,
+    useCase: sourceMountRes.value.scope.useCase,
+  });
+  if (!sourceGcsPath) {
+    return new Err(
+      new MCPError(
+        "Invalid path: `source` does not match the resolved mount point.",
+        { tracked: false }
+      )
+    );
+  }
+
+  if (source === dest) {
+    return new Err(
+      new MCPError("`source` and `dest` resolve to the same path.", {
+        tracked: false,
+      })
+    );
+  }
+
+  const bucket = getPrivateUploadBucket();
+  let mimeType: string;
+  try {
+    const [metadata] = await bucket.file(sourceGcsPath).getMetadata();
+    mimeType = stripMimeParameters(
+      isString(metadata.contentType)
+        ? metadata.contentType
+        : "application/octet-stream"
+    );
+  } catch {
+    return new Err(
+      new MCPError(`Source file not found: \`${source}\`.`, { tracked: false })
+    );
+  }
+
+  const [linkedFileResource] = await FileResource.fetchByMountFilePaths(auth, [
+    sourceGcsPath,
+  ]);
+
+  const destFileName = dest.split("/").pop() ?? dest;
+  const destScope = destMountRes.value.scope;
+  let destUseCase: FileUseCase;
+  let destUseCaseMetadata: FileUseCaseMetadata | undefined;
+  switch (destScope.useCase) {
+    case "project":
+      destUseCase = "project_context";
+      destUseCaseMetadata = { spaceId: destScope.projectId };
+      break;
+    case "conversation":
+      destUseCase = "tool_output";
+      destUseCaseMetadata = { conversationId: conversation.sId };
+      break;
+    default:
+      assertNever(destScope);
+  }
+
+  const destRelativeFilePath = dest.slice(`${destScope.useCase}/`.length);
+  const moveRes = await moveFile(auth, {
+    file: linkedFileResource,
+    sourceGcsPath,
+    destScope,
+    destRelativeFilePath,
+    destFileName,
+    destUseCase,
+    destUseCaseMetadata,
+  });
+  if (moveRes.isErr()) {
+    return new Err(
+      new MCPError(
+        `Failed to move \`${source}\` to \`${dest}\`: ${moveRes.error.message}`
+      )
+    );
+  }
+
+  const items: Array<
+    | { type: "text"; text: string }
+    | { type: "resource"; resource: ToolGeneratedFilePathType }
+  > = [
+    {
+      type: "text",
+      text: `Moved \`${source}\` to \`${dest}\`.`,
+    },
+  ];
+
+  if (isAllSupportedFileContentType(mimeType)) {
+    items.push({
+      type: "resource",
+      resource: {
+        text: `Moved \`${source}\` to \`${dest}\``,
+        uri: dest,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
+        path: dest,
+        title: destFileName,
+        contentType: mimeType,
+      },
+    });
+  }
+
+  return new Ok(items);
+}

--- a/front/lib/api/actions/servers/files/tools/move.ts
+++ b/front/lib/api/actions/servers/files/tools/move.ts
@@ -11,11 +11,11 @@ import {
 } from "@app/lib/api/files/gcs_mount/files";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import {
   isAllSupportedFileContentType,
   stripMimeParameters,
 } from "@app/types/files";
-import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -8,6 +8,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import {
@@ -513,4 +514,71 @@ export async function copyConversationGCSMount(
   } catch (err) {
     return new Err(normalizeError(err));
   }
+}
+
+async function moveGCSMountFile({
+  sourceGcsPath,
+  destGcsPath,
+}: {
+  sourceGcsPath: string;
+  destGcsPath: string;
+}): Promise<Result<void, Error>> {
+  const bucket = getPrivateUploadBucket();
+  try {
+    await bucket.copyFile(sourceGcsPath, destGcsPath);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+  try {
+    await bucket.delete(sourceGcsPath);
+  } catch (err) {
+    logger.error(
+      { sourceGcsPath, destGcsPath, err: normalizeError(err) },
+      "moveGCSMountFile: source delete failed after successful copy"
+    );
+  }
+  return new Ok(undefined);
+}
+
+/**
+ * Move a file in GCS and, when a FileResource is provided, keep its DB record in sync.
+ * The DB update is skipped for plain GCS objects that have no FileResource record.
+ */
+export async function moveFile(
+  auth: Authenticator,
+  {
+    file,
+    sourceGcsPath,
+    destScope,
+    destRelativeFilePath,
+    destFileName,
+    destUseCase,
+    destUseCaseMetadata,
+  }: {
+    file?: FileResource;
+    sourceGcsPath: string;
+    destScope: GCSMountPoint;
+    destRelativeFilePath: string;
+    destFileName: string;
+    destUseCase: FileUseCase;
+    destUseCaseMetadata?: FileUseCaseMetadata;
+  }
+): Promise<Result<void, Error>> {
+  const destGcsPath = `${resolvePrefix(auth.getNonNullableWorkspace(), destScope)}${destRelativeFilePath}`;
+
+  const moveRes = await moveGCSMountFile({ sourceGcsPath, destGcsPath });
+  if (moveRes.isErr()) {
+    return moveRes;
+  }
+
+  if (file) {
+    await file.updateMount({
+      destFileName,
+      destMountFilePath: destGcsPath,
+      destUseCase,
+      destUseCaseMetadata,
+    });
+  }
+
+  return new Ok(undefined);
 }

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -8,9 +8,9 @@ import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
-import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import {
   isSupportedImageContentType,
   stripMimeParameters,
@@ -516,6 +516,9 @@ export async function copyConversationGCSMount(
   }
 }
 
+// GCS has no native rename/move, so we copy then delete. This is not atomic: if the delete
+// fails the source survives alongside the copy. The destination is already the authoritative
+// copy at that point, so we log and move on rather than surfacing an error.
 async function moveGCSMountFile({
   sourceGcsPath,
   destGcsPath,

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -7,9 +7,9 @@ import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/cont
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import {
   deleteGCSMountFile,
+  moveFile,
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
-import { moveFile } from "@app/lib/api/files/gcs_mount/files";
 import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -9,6 +9,7 @@ import {
   deleteGCSMountFile,
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
+import { moveFile } from "@app/lib/api/files/gcs_mount/files";
 import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
@@ -248,12 +249,31 @@ export async function addFileToProject(
     });
   }
 
-  // TODO(projects) this is not sufficient, the file mountpoint is not updated on GCS.
-  await file.updateUseCase(auth, "project_context", {
-    spaceId: space.sId,
-    conversationId: undefined,
-    sourceConversationId,
+  if (!file.mountFilePath) {
+    return new Err({
+      name: "dust_error",
+      code: "invalid_request_error",
+      message: "File has no mount path and cannot be moved to the project.",
+    });
+  }
+
+  const destFileName = file.fileName;
+  const moveRes = await moveFile(auth, {
+    file,
+    sourceGcsPath: file.mountFilePath,
+    destScope: { useCase: "project", projectId: space.sId },
+    destRelativeFilePath: destFileName,
+    destFileName,
+    destUseCase: "project_context",
+    destUseCaseMetadata: { spaceId: space.sId, sourceConversationId },
   });
+  if (moveRes.isErr()) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_error",
+      message: moveRes.error.message,
+    });
+  }
 
   // TODO(projects) once the source of truth for the project's files is GCS, we can remove this.
   const fragmentRes =

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1178,6 +1178,25 @@ export class FileResource extends BaseResource<FileModel> {
     });
   }
 
+  updateMount({
+    destFileName,
+    destMountFilePath,
+    destUseCase,
+    destUseCaseMetadata,
+  }: {
+    destFileName: string;
+    destMountFilePath: string;
+    destUseCase: FileUseCase;
+    destUseCaseMetadata?: FileUseCaseMetadata;
+  }) {
+    return this.update({
+      fileName: destFileName.normalize("NFC"),
+      mountFilePath: destMountFilePath,
+      useCase: destUseCase,
+      useCaseMetadata: destUseCaseMetadata ?? null,
+    });
+  }
+
   // Sharing logic.
 
   private getShareUrlForShareableFile({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Agents can now move files between scopes, conversation to project, within conversation, etc. With a single `files__move` tool that copies then deletes the source. When the file has a database record (frames, uploaded files), the record is kept in sync: `useCase`, `useCaseMetadata`, `mountFilePath`, and `fileName` are all updated to reflect the new location.

Frame files (`application/vnd.dust.frame`) are blocked from being copied since copying without updating the database record breaks interactive rendering. The copy tool now returns a clear error pointing the agent to `files__move` instead.

The underlying `moveFile` function is also wired into `addFileToProject`, which previously only updated the database and left the GCS object at the conversation path. Both the frame drawer's save-to-project button and the agent tool now go through the same code path.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25784">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->