### PR TITLE
feat: small pod ui renaming

### DIFF
--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -65,7 +65,7 @@ import {
 } from "react";
 
 const PROJECT_KNOWLEDGE_MANAGEMENT_DISABLED_TOOLTIP =
-  "Adding files to projects is disabled by your workspace admin.";
+  "Adding files to Pods is disabled by your workspace admin.";
 
 interface AttachKnowledgeDropdownProps {
   buttonLabel: string;
@@ -350,7 +350,7 @@ function ProjectFileExplorerContent({
       if (entry.kind === "node") {
         const confirmed = await confirm({
           title: "Remove content node?",
-          message: `Are you sure you want to remove "${entry.fileName}" from this project?`,
+          message: `Are you sure you want to remove "${entry.fileName}" from this Pod?`,
           validateLabel: "Remove",
           validateVariant: "warning",
         });
@@ -521,8 +521,8 @@ function ProjectFileExplorerContent({
     <EmptyCTA
       message={
         isArchived
-          ? "This project is archived. No files have been added."
-          : "No files have been added to this project yet."
+          ? "This Pod is archived. No files have been added."
+          : "No files have been added to this Pod yet."
       }
       action={addButton}
     />

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -153,8 +153,8 @@ export function useAddProjectContextContentNodes({
           type: "success",
           title:
             addedCount === 1
-              ? "Added to Pod context"
-              : `Added ${addedCount} items to Pod context`,
+              ? "Added to Pod files"
+              : `Added ${addedCount} items to Pod files`,
         });
       } else {
         sendNotification({
@@ -207,7 +207,7 @@ export function useRemoveProjectContextFile({
 
       sendNotification({
         type: "success",
-        title: "Removed from Pod knowledge",
+        title: "Removed from Pod files",
       });
 
       return new Ok(undefined);
@@ -262,8 +262,8 @@ export function useRemoveProjectContextContentNodes({
         type: "success",
         title:
           items.length === 1
-            ? "Removed from Pod knowledge"
-            : `Removed ${items.length} items from Pod knowledge`,
+            ? "Removed from Pod files"
+            : `Removed ${items.length} items from Pod files`,
       });
 
       return new Ok(undefined);


### PR DESCRIPTION
## Description

This PR updates some UI labels to refer to "Pods" and "files" instead of projects and knowledge/context.

## Tests
Manually

## Risks
Low

## Deploy Plan

Standard deployment
