### PR TITLE
[Slack] Handle pending message promotion timeout

### DIFF
--- a/connectors/src/connectors/slack/bot.test.ts
+++ b/connectors/src/connectors/slack/bot.test.ts
@@ -162,4 +162,69 @@ describe("resolveSlackPendingUserMessage", () => {
     expect(streamHandler.stop).not.toHaveBeenCalled();
     expect(slackClient.chat.postMessage).not.toHaveBeenCalled();
   });
+
+  it("posts the controlled fallback when promotion has no agent message", async () => {
+    async function* promotedEventStream() {
+      yield {
+        type: "user_message_promoted",
+        created: Date.now(),
+        messageId: "user_msg_1",
+      } as const;
+    }
+
+    const pendingUserMessage = makeUserMessage("pending");
+    const dustAPI = {
+      streamConversationEvents: vi.fn(async () => {
+        return new Ok({ eventStream: promotedEventStream() });
+      }),
+      getConversation: vi.fn(async () => {
+        return new Ok(
+          makeConversation([
+            [
+              {
+                ...pendingUserMessage,
+                visibility: "visible",
+              } as UserMessageType,
+            ],
+          ])
+        );
+      }),
+    };
+    const slackClient = {
+      chat: {
+        postMessage: vi.fn(async () => ({ ts: "fallback_ts" })),
+      },
+    } as unknown as WebClient;
+    const streamHandler = {
+      stop: vi.fn(async () => undefined),
+    } as Pick<SlackStreamHandler, "stop">;
+
+    const res = await resolveSlackPendingUserMessage({
+      connector,
+      conversation: makeConversation([[pendingUserMessage]]),
+      dustAPI,
+      slack: {
+        slackChannelId: "C123",
+        slackClient,
+        slackMessageTs: "1700000000.000001",
+      },
+      streamHandler,
+      timeoutMs: 100,
+      userMessage: pendingUserMessage,
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      throw res.error;
+    }
+    expect(res.value).toBeNull();
+    expect(streamHandler.stop).toHaveBeenCalledTimes(1);
+    expect(slackClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        thread_ts: "1700000000.000001",
+        text: expect.stringContaining("Continue on Dust"),
+      })
+    );
+  });
 });

--- a/connectors/src/connectors/slack/bot.test.ts
+++ b/connectors/src/connectors/slack/bot.test.ts
@@ -1,0 +1,165 @@
+import type { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type {
+  ConversationPublicType,
+  UserMessageType,
+} from "@dust-tt/client";
+import { Ok } from "@dust-tt/client";
+import type { WebClient } from "@slack/web-api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockMakeConversationUrl = vi.hoisted(() =>
+  vi.fn(
+    (workspaceId: string, conversationId: string | null | undefined) =>
+      conversationId
+        ? `https://dust.test/w/${workspaceId}/conversation/${conversationId}`
+        : null
+  )
+);
+
+vi.mock("@connectors/lib/bot/conversation_utils", () => ({
+  makeConversationUrl: mockMakeConversationUrl,
+}));
+
+import { resolveSlackPendingUserMessage } from "./bot";
+
+function makeConversation(
+  content: ConversationPublicType["content"] = []
+): ConversationPublicType {
+  return {
+    sId: "conv_1",
+    content,
+  } as ConversationPublicType;
+}
+
+function makeUserMessage(visibility: UserMessageType["visibility"]) {
+  return {
+    sId: "user_msg_1",
+    type: "user_message",
+    visibility,
+  } as UserMessageType;
+}
+
+describe("resolveSlackPendingUserMessage", () => {
+  const connector = {
+    id: 123,
+    workspaceId: "w_test",
+  } as ConnectorResource;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("posts a controlled fallback when a pending message is not promoted", async () => {
+    async function* emptyEventStream() {}
+
+    const pendingUserMessage = makeUserMessage("pending");
+    const dustAPI = {
+      streamConversationEvents: vi.fn(async () => {
+        return new Ok({ eventStream: emptyEventStream() });
+      }),
+      getConversation: vi.fn(async () => {
+        return new Ok(makeConversation([[pendingUserMessage]]));
+      }),
+    };
+    const slackClient = {
+      chat: {
+        postMessage: vi.fn(async () => ({ ts: "fallback_ts" })),
+      },
+    } as unknown as WebClient;
+    const streamHandler = {
+      stop: vi.fn(async () => undefined),
+    } as Pick<SlackStreamHandler, "stop">;
+
+    const res = await resolveSlackPendingUserMessage({
+      connector,
+      conversation: makeConversation([[pendingUserMessage]]),
+      dustAPI,
+      slack: {
+        slackChannelId: "C123",
+        slackClient,
+        slackMessageTs: "1700000000.000001",
+      },
+      streamHandler,
+      timeoutMs: 1,
+      userMessage: pendingUserMessage,
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      throw res.error;
+    }
+    expect(res.value).toBeNull();
+    expect(streamHandler.stop).toHaveBeenCalledTimes(1);
+    expect(slackClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        thread_ts: "1700000000.000001",
+        text: expect.stringContaining("Continue on Dust"),
+      })
+    );
+  });
+
+  it("refetches the conversation and streams normally after promotion", async () => {
+    async function* promotedEventStream() {
+      yield {
+        type: "user_message_promoted",
+        created: Date.now(),
+        messageId: "user_msg_1",
+      } as const;
+    }
+
+    const pendingUserMessage = makeUserMessage("pending");
+    const promotedContent = [
+      [{ ...pendingUserMessage, visibility: "visible" } as UserMessageType],
+      [
+        {
+          type: "agent_message",
+          parentMessageId: "user_msg_1",
+        },
+      ],
+    ] as unknown as ConversationPublicType["content"];
+    const promotedConversation = makeConversation(promotedContent);
+    const dustAPI = {
+      streamConversationEvents: vi.fn(async () => {
+        return new Ok({ eventStream: promotedEventStream() });
+      }),
+      getConversation: vi.fn(async () => {
+        return new Ok(promotedConversation);
+      }),
+    };
+    const slackClient = {
+      chat: {
+        postMessage: vi.fn(async () => ({ ts: "fallback_ts" })),
+      },
+    } as unknown as WebClient;
+    const streamHandler = {
+      stop: vi.fn(async () => undefined),
+    } as Pick<SlackStreamHandler, "stop">;
+
+    const res = await resolveSlackPendingUserMessage({
+      connector,
+      conversation: makeConversation([[pendingUserMessage]]),
+      dustAPI,
+      slack: {
+        slackChannelId: "C123",
+        slackClient,
+        slackMessageTs: "1700000000.000001",
+      },
+      streamHandler,
+      timeoutMs: 100,
+      userMessage: pendingUserMessage,
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      throw res.error;
+    }
+    expect(res.value).toBe(promotedConversation);
+    expect(dustAPI.getConversation).toHaveBeenCalledWith({
+      conversationId: "conv_1",
+    });
+    expect(streamHandler.stop).not.toHaveBeenCalled();
+    expect(slackClient.chat.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -135,7 +135,7 @@ function getSlackPendingUserMessageFallbackText(
   return `:hourglass_flowing_sand: _Dust is still finishing the previous request, so this Slack reply could not start in time.${urlPart}_`;
 }
 
-function isUserMessageReadyToStream(
+function hasAgentMessageForUserMessage(
   conversation: ConversationPublicType,
   userMessageId: string
 ): boolean {
@@ -143,14 +143,6 @@ function isUserMessageReadyToStream(
     const message = messageVersions[messageVersions.length - 1];
     if (!message) {
       continue;
-    }
-
-    if (
-      message.type === "user_message" &&
-      message.sId === userMessageId &&
-      message.visibility === "visible"
-    ) {
-      return true;
     }
 
     if (
@@ -322,17 +314,9 @@ export async function resolveSlackPendingUserMessage({
     conversationId: conversation.sId,
   });
 
-  if (waitRes.value === "promoted") {
-    if (conversationRes.isErr()) {
-      return conversationRes;
-    }
-
-    return new Ok(conversationRes.value);
-  }
-
   if (
     conversationRes.isOk() &&
-    isUserMessageReadyToStream(conversationRes.value, userMessage.sId)
+    hasAgentMessageForUserMessage(conversationRes.value, userMessage.sId)
   ) {
     return new Ok(conversationRes.value);
   }

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -5,7 +5,10 @@ import {
 } from "@connectors/connectors/slack/chat/blocks";
 import { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
 // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
-import { streamConversationToSlack } from "@connectors/connectors/slack/chat/stream_conversation_handler";
+import {
+  SLACK_USER_ACTION_IDLE_TIMEOUT_MS,
+  streamConversationToSlack,
+} from "@connectors/connectors/slack/chat/stream_conversation_handler";
 import {
   getBotUserIdResponse,
   getUserInfo,
@@ -70,6 +73,7 @@ import {
   isSupportedAudioContentType,
   isSupportedFileContentType,
   isSupportedImageContentType,
+  normalizeError,
   Ok,
   removeNulls,
 } from "@dust-tt/client";
@@ -88,6 +92,7 @@ const MAX_IMAGE_FILE_SIZE_TO_UPLOAD = 20 * 1024 * 1024; // 20 MB
 const MAX_AUDIO_FILE_SIZE_TO_UPLOAD = 100 * 1024 * 1024; // 100 MB
 
 const DEFAULT_AGENTS = ["dust", "claude-4-sonnet", "gpt-5"];
+const SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS = 1_000;
 
 function getMaxFileSizeToUpload(contentType: SupportedFileContentType): number {
   if (isSupportedImageContentType(contentType)) {
@@ -112,6 +117,283 @@ type BotAnswerParams = {
   slackMessageTs: string;
   slackThreadTs?: string;
 };
+
+type SlackPendingUserMessageDustAPI = Pick<
+  DustAPI,
+  "getConversation" | "streamConversationEvents"
+>;
+
+type SlackPendingUserMessageResult = "promoted" | "timed_out";
+
+function getSlackPendingUserMessageFallbackText(
+  conversationUrl: string | null
+): string {
+  const urlPart = conversationUrl
+    ? ` <${conversationUrl}|Continue on Dust>.`
+    : "";
+
+  return `:hourglass_flowing_sand: _Dust is still finishing the previous request, so this Slack reply could not start in time.${urlPart}_`;
+}
+
+function isUserMessageReadyToStream(
+  conversation: ConversationPublicType,
+  userMessageId: string
+): boolean {
+  for (const messageVersions of conversation.content) {
+    const message = messageVersions[messageVersions.length - 1];
+    if (!message) {
+      continue;
+    }
+
+    if (
+      message.type === "user_message" &&
+      message.sId === userMessageId &&
+      message.visibility === "visible"
+    ) {
+      return true;
+    }
+
+    if (
+      message.type === "agent_message" &&
+      message.parentMessageId === userMessageId
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function sleepUntilNextPendingPromotionReconnect({
+  remainingMs,
+  signal,
+}: {
+  remainingMs: number;
+  signal: AbortSignal;
+}): Promise<void> {
+  const sleepMs = Math.min(
+    remainingMs,
+    SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS
+  );
+  if (sleepMs <= 0) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let timeout: ReturnType<typeof setTimeout>;
+    const onAbort = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, sleepMs);
+    timeout.unref?.();
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function waitForSlackUserMessagePromotion({
+  dustAPI,
+  conversationId,
+  timeoutMs,
+  userMessageId,
+}: {
+  dustAPI: SlackPendingUserMessageDustAPI;
+  conversationId: string;
+  timeoutMs: number;
+  userMessageId: string;
+}): Promise<Result<SlackPendingUserMessageResult, Error | APIError>> {
+  const abortController = new AbortController();
+  const deadline = Date.now() + timeoutMs;
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    abortController.abort();
+  }, timeoutMs);
+  timeout.unref?.();
+
+  try {
+    while (!timedOut) {
+      const streamRes = await dustAPI.streamConversationEvents({
+        conversationId,
+        signal: abortController.signal,
+        options: {
+          autoReconnect: false,
+          maxReconnectAttempts: 1,
+          reconnectDelay: SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS,
+        },
+      });
+      if (streamRes.isErr()) {
+        if (timedOut || abortController.signal.aborted) {
+          return new Ok("timed_out");
+        }
+        return new Err(normalizeError(streamRes.error));
+      }
+
+      try {
+        for await (const event of streamRes.value.eventStream) {
+          if (
+            event.type === "user_message_promoted" &&
+            event.messageId === userMessageId
+          ) {
+            return new Ok("promoted");
+          }
+
+          if (
+            event.type === "user_message_new" &&
+            event.messageId === userMessageId &&
+            event.message.visibility === "visible"
+          ) {
+            return new Ok("promoted");
+          }
+        }
+      } catch (error) {
+        if (timedOut || abortController.signal.aborted) {
+          return new Ok("timed_out");
+        }
+        return new Err(normalizeError(error));
+      }
+
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        return new Ok("timed_out");
+      }
+
+      await sleepUntilNextPendingPromotionReconnect({
+        remainingMs,
+        signal: abortController.signal,
+      });
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  return new Ok("timed_out");
+}
+
+export async function resolveSlackPendingUserMessage({
+  connector,
+  conversation,
+  dustAPI,
+  slack,
+  streamHandler,
+  timeoutMs,
+  userMessage,
+}: {
+  connector: ConnectorResource;
+  conversation: ConversationPublicType;
+  dustAPI: SlackPendingUserMessageDustAPI;
+  slack: {
+    slackChannelId: string;
+    slackClient: WebClient;
+    slackMessageTs: string;
+  };
+  streamHandler: Pick<SlackStreamHandler, "stop">;
+  timeoutMs: number;
+  userMessage: UserMessageType;
+}): Promise<Result<ConversationPublicType | null, Error | APIError>> {
+  if (userMessage.visibility !== "pending") {
+    return new Ok(conversation);
+  }
+
+  logger.info(
+    {
+      connectorId: connector.id,
+      conversationId: conversation.sId,
+      userMessageId: userMessage.sId,
+    },
+    "Slack user message is pending, waiting for promotion before streaming."
+  );
+
+  const waitRes = await waitForSlackUserMessagePromotion({
+    dustAPI,
+    conversationId: conversation.sId,
+    timeoutMs,
+    userMessageId: userMessage.sId,
+  });
+  if (waitRes.isErr()) {
+    return waitRes;
+  }
+
+  const conversationRes = await dustAPI.getConversation({
+    conversationId: conversation.sId,
+  });
+
+  if (waitRes.value === "promoted") {
+    if (conversationRes.isErr()) {
+      return conversationRes;
+    }
+
+    return new Ok(conversationRes.value);
+  }
+
+  if (
+    conversationRes.isOk() &&
+    isUserMessageReadyToStream(conversationRes.value, userMessage.sId)
+  ) {
+    return new Ok(conversationRes.value);
+  }
+
+  if (conversationRes.isErr()) {
+    logger.warn(
+      {
+        error: conversationRes.error,
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        userMessageId: userMessage.sId,
+      },
+      "Failed to refetch Slack conversation after pending user message timeout."
+    );
+  }
+
+  await streamHandler.stop();
+
+  const conversationUrl = makeConversationUrl(
+    connector.workspaceId,
+    conversation.sId
+  );
+  const fallbackText = getSlackPendingUserMessageFallbackText(conversationUrl);
+
+  try {
+    reportSlackUsage({
+      connectorId: connector.id,
+      method: "chat.postMessage",
+      channelId: slack.slackChannelId,
+      useCase: "bot",
+    });
+    await slack.slackClient.chat.postMessage({
+      channel: slack.slackChannelId,
+      text: fallbackText,
+      blocks: makeMarkdownBlock(fallbackText),
+      thread_ts: slack.slackMessageTs,
+      unfurl_links: false,
+    });
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        userMessageId: userMessage.sId,
+      },
+      "Failed to post Slack pending user message fallback."
+    );
+  }
+
+  logger.info(
+    {
+      connectorId: connector.id,
+      conversationId: conversation.sId,
+      userMessageId: userMessage.sId,
+    },
+    "Posted Slack pending user message fallback after promotion timeout."
+  );
+
+  return new Ok(null);
+}
 
 export async function getSlackConnector(params: BotAnswerParams) {
   const { slackTeamId } = params;
@@ -1164,6 +1446,7 @@ async function answerMessage(
       | "getConversation"
       | "createConversation"
       | "postUserMessage"
+      | "waitForUserMessagePromotion"
       | "streamConversationToSlack"
   ) => {
     logger.error(
@@ -1287,6 +1570,30 @@ async function answerMessage(
     slackChatBotMessage.conversationId = conversation.sId;
     await slackChatBotMessage.save();
   }
+
+  const pendingUserMessageRes = await resolveSlackPendingUserMessage({
+    connector,
+    conversation,
+    dustAPI,
+    slack: {
+      slackChannelId: slackChannel,
+      slackClient,
+      slackMessageTs,
+    },
+    streamHandler,
+    timeoutMs: SLACK_USER_ACTION_IDLE_TIMEOUT_MS,
+    userMessage,
+  });
+  if (pendingUserMessageRes.isErr()) {
+    return buildSlackMessageError(
+      pendingUserMessageRes,
+      "waitForUserMessagePromotion"
+    );
+  }
+  if (pendingUserMessageRes.value === null) {
+    return new Ok(undefined);
+  }
+  conversation = pendingUserMessageRes.value;
 
   const streamRes = await streamConversationToSlack(dustAPI, {
     assistantName: mention.agentName,

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.test.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.test.ts
@@ -1,0 +1,138 @@
+import type { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
+import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
+import type { SlackChatBotMessageModel } from "@connectors/lib/models/slack";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type {
+  AgentEvent,
+  ConversationPublicType,
+  DustAPI,
+  UserMessageType,
+} from "@dust-tt/client";
+import { Ok } from "@dust-tt/client";
+import type { WebClient } from "@slack/web-api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockMakeConversationUrl = vi.hoisted(() =>
+  vi.fn(
+    (workspaceId: string, conversationId: string | null | undefined) =>
+      conversationId
+        ? `https://dust.test/w/${workspaceId}/conversation/${conversationId}`
+        : null
+  )
+);
+
+vi.mock("@connectors/lib/bot/conversation_utils", () => ({
+  makeConversationUrl: mockMakeConversationUrl,
+}));
+
+import { streamConversationToSlack } from "./stream_conversation_handler";
+
+describe("streamConversationToSlack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("cancels the blocked agent message when Slack user-action controls fail", async () => {
+    const invalidBlocksError = Object.assign(new Error("invalid_blocks"), {
+      data: { error: "invalid_blocks" },
+    });
+    const toolAskUserQuestionEvent = {
+      type: "tool_ask_user_question",
+      actionId: "action_1",
+      configurationId: "agent_1",
+      conversationId: "conv_1",
+      created: Date.now(),
+      inputs: {},
+      messageId: "agent_msg_1",
+      metadata: {
+        agentName: "Support",
+        mcpServerName: "server",
+        mcpServerDisplayName: "Server",
+        toolName: "ask",
+      },
+      question: {
+        question: "Which option?",
+        options: [{ label: "One" }],
+        multiSelect: false,
+      },
+      stake: "low",
+    } as AgentEvent;
+
+    async function* eventStream() {
+      yield toolAskUserQuestionEvent;
+    }
+
+    const dustAPI = {
+      streamAgentAnswerEvents: vi.fn(async () => {
+        return new Ok({ eventStream: eventStream() });
+      }),
+      cancelMessageGeneration: vi.fn(async () => {
+        return new Ok({ success: true });
+      }),
+    };
+    const slackClient = {
+      chat: {
+        postEphemeral: vi.fn(async () => {
+          throw invalidBlocksError;
+        }),
+        postMessage: vi.fn(async () => ({ ts: "fallback_ts" })),
+        delete: vi.fn(async () => ({ ok: true })),
+      },
+    } as unknown as WebClient;
+    const streamHandler = {
+      messageTs: "stream_ts",
+      stop: vi.fn(async () => undefined),
+      setThinking: vi.fn(async () => undefined),
+      appendText: vi.fn(async () => undefined),
+      isStopped: false,
+    } as unknown as SlackStreamHandler;
+
+    const res = await streamConversationToSlack(dustAPI as unknown as DustAPI, {
+      assistantName: "Support",
+      agentConfigurations: [],
+      connector: {
+        id: 123,
+        workspaceId: "w_test",
+      } as ConnectorResource,
+      conversation: {
+        sId: "conv_1",
+        content: [],
+      } as unknown as ConversationPublicType,
+      feedbackVisibleToAuthorOnly: true,
+      slack: {
+        slackChannelId: "C123",
+        slackClient,
+        slackMessageTs: "1700000000.000001",
+        slackTeamId: "T123",
+        slackUserId: "U123",
+        slackUserInfo: {
+          is_bot: false,
+        } as unknown as SlackUserInfo,
+      },
+      slackChatBotMessage: {
+        id: 42,
+      } as SlackChatBotMessageModel,
+      streamHandler,
+      userMessage: {
+        sId: "user_msg_1",
+      } as UserMessageType,
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      throw res.error;
+    }
+    expect(dustAPI.cancelMessageGeneration).toHaveBeenCalledWith({
+      conversationId: "conv_1",
+      messageIds: ["agent_msg_1"],
+    });
+    expect(streamHandler.stop).toHaveBeenCalled();
+    expect(slackClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        text: expect.stringContaining("could not display"),
+        thread_ts: "1700000000.000001",
+      })
+    );
+  });
+});

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -200,35 +200,45 @@ type SlackUserActionType = Extract<
   | "tool_ask_user_question"
 >;
 
-const SLACK_USER_ACTION_IDLE_TIMEOUT_MS = 4 * 60 * 1000 + 30 * 1000; // 4.5 minutes
+export const SLACK_USER_ACTION_IDLE_TIMEOUT_MS = 4 * 60 * 1000 + 30 * 1000; // 4.5 minutes
+
+type SlackUserActionEvent = Extract<AgentEvent, { type: SlackUserActionType }>;
+
+function getUserActionLabel(actionType: SlackUserActionType): string {
+  switch (actionType) {
+    case "tool_approve_execution":
+      return "tool execution approval";
+    case "tool_file_auth_required":
+      return "file access authorization";
+    case "tool_personal_auth_required":
+      return "tool authentication";
+    case "tool_ask_user_question":
+      return "response to a question";
+    default:
+      assertNever(actionType);
+  }
+}
 
 function getUserActionFallbackMessage(
   actionType: SlackUserActionType,
   conversationUrl: string | null
 ): string {
-  let actionLabel: string;
-  switch (actionType) {
-    case "tool_approve_execution":
-      actionLabel = "tool execution approval";
-      break;
-    case "tool_file_auth_required":
-      actionLabel = "file access authorization";
-      break;
-    case "tool_personal_auth_required":
-      actionLabel = "tool authentication";
-      break;
-    case "tool_ask_user_question":
-      actionLabel = "response to a question";
-      break;
-    default:
-      assertNever(actionType);
-  }
-
   const urlPart = conversationUrl
     ? ` <${conversationUrl}|Continue on Dust>.`
     : "";
 
-  return `:hourglass_flowing_sand: _Streaming was interrupted after 5 mins waiting on a ${actionLabel}.${urlPart}_`;
+  return `:hourglass_flowing_sand: _Streaming was interrupted after 5 mins waiting on a ${getUserActionLabel(actionType)}.${urlPart}_`;
+}
+
+function getUserActionPostFailureFallbackMessage(
+  actionType: SlackUserActionType,
+  conversationUrl: string | null
+): string {
+  const urlPart = conversationUrl
+    ? ` <${conversationUrl}|Continue on Dust>.`
+    : "";
+
+  return `:warning: _Dust could not display the Slack controls for a ${getUserActionLabel(actionType)}.${urlPart}_`;
 }
 
 async function streamAgentAnswerToSlack(
@@ -343,6 +353,78 @@ async function streamAgentAnswerToSlack(
     );
   };
 
+  const handleUserActionPostFailure = async (
+    event: SlackUserActionEvent,
+    error: unknown
+  ): Promise<Result<undefined, Error>> => {
+    clearUserActionTimeout();
+    abortController.abort();
+    planHandler.abortAllChildStreams();
+    await planHandler.deletePlanMessage();
+    await streamHandler.stop();
+
+    logger.error(
+      {
+        error,
+        connectorId: connector.id,
+        conversationId: event.conversationId,
+        messageId: event.messageId,
+        actionType: event.type,
+      },
+      "Failed to post Slack user-action controls, cancelling the blocked agent message."
+    );
+
+    const cancelRes = await dustAPI.cancelMessageGeneration({
+      conversationId: event.conversationId,
+      messageIds: [event.messageId],
+    });
+    if (cancelRes.isErr()) {
+      logger.error(
+        {
+          error: cancelRes.error,
+          connectorId: connector.id,
+          conversationId: event.conversationId,
+          messageId: event.messageId,
+          actionType: event.type,
+        },
+        "Failed to cancel the agent message after Slack user-action controls failed to post."
+      );
+      return new Err(new Error(cancelRes.error.message));
+    }
+
+    const conversationUrl = makeConversationUrl(
+      connector.workspaceId,
+      event.conversationId
+    );
+    const fallbackText = getUserActionPostFailureFallbackMessage(
+      event.type,
+      conversationUrl
+    );
+
+    try {
+      await slackClient.chat.postMessage({
+        channel: slackChannelId,
+        text: fallbackText,
+        blocks: makeMarkdownBlock(fallbackText),
+        thread_ts: slackMessageTs,
+        unfurl_links: false,
+      });
+    } catch (postError) {
+      logger.error(
+        {
+          error: postError,
+          connectorId: connector.id,
+          conversationId: event.conversationId,
+          messageId: event.messageId,
+          actionType: event.type,
+        },
+        "Failed to post Slack fallback after user-action controls failed."
+      );
+    }
+
+    return new Ok(undefined);
+  };
+
   async function* eventStreamWithTimeoutCleanup() {
     try {
       yield* eventStream;
@@ -409,17 +491,21 @@ async function streamAgentAnswerToSlack(
         await streamHandler.setThinking(AWAITING_TOOL_APPROVAL_LABEL);
 
         if (slackUserId && !slackUserInfo.is_bot) {
-          await slackClient.chat.postEphemeral({
-            channel: slackChannelId,
-            user: slackUserId,
-            text: "Approve tool execution",
-            blocks: makeToolValidationBlock({
-              agentName: event.metadata.agentName,
-              toolName: event.metadata.toolName,
-              id: JSON.stringify(blockId),
-            }),
-            thread_ts: slackMessageTs,
-          });
+          try {
+            await slackClient.chat.postEphemeral({
+              channel: slackChannelId,
+              user: slackUserId,
+              text: "Approve tool execution",
+              blocks: makeToolValidationBlock({
+                agentName: event.metadata.agentName,
+                toolName: event.metadata.toolName,
+                id: JSON.stringify(blockId),
+              }),
+              thread_ts: slackMessageTs,
+            });
+          } catch (error) {
+            return await handleUserActionPostFailure(event, error);
+          }
         }
         break;
       }
@@ -433,21 +519,25 @@ async function streamAgentAnswerToSlack(
         );
 
         if (slackUserId && !slackUserInfo.is_bot && conversationUrl) {
-          await slackClient.chat.postEphemeral({
-            channel: slackChannelId,
-            user: slackUserId,
-            text: "Personal authentication required",
-            blocks: makeToolAuthenticationBlock({
-              agentName: event.metadata.agentName,
-              serverName: event.metadata.mcpServerDisplayName,
-              conversationUrl,
-              value: JSON.stringify({
-                workspaceId: connector.workspaceId,
-                messageId: event.messageId,
+          try {
+            await slackClient.chat.postEphemeral({
+              channel: slackChannelId,
+              user: slackUserId,
+              text: "Personal authentication required",
+              blocks: makeToolAuthenticationBlock({
+                agentName: event.metadata.agentName,
+                serverName: event.metadata.mcpServerDisplayName,
+                conversationUrl,
+                value: JSON.stringify({
+                  workspaceId: connector.workspaceId,
+                  messageId: event.messageId,
+                }),
               }),
-            }),
-            thread_ts: slackMessageTs,
-          });
+              thread_ts: slackMessageTs,
+            });
+          } catch (error) {
+            return await handleUserActionPostFailure(event, error);
+          }
 
           pendingPersonalAuth = {
             redisKey: getAuthResponseUrlRedisKey(
@@ -472,21 +562,25 @@ async function streamAgentAnswerToSlack(
         );
 
         if (slackUserId && !slackUserInfo.is_bot && conversationUrl) {
-          await slackClient.chat.postEphemeral({
-            channel: slackChannelId,
-            user: slackUserId,
-            text: "File authorization required",
-            blocks: makeToolFileAuthorizationBlock({
-              agentName: event.metadata.agentName,
-              fileName: event.fileAuthError.fileName,
-              conversationUrl,
-              value: JSON.stringify({
-                workspaceId: connector.workspaceId,
-                messageId: event.messageId,
+          try {
+            await slackClient.chat.postEphemeral({
+              channel: slackChannelId,
+              user: slackUserId,
+              text: "File authorization required",
+              blocks: makeToolFileAuthorizationBlock({
+                agentName: event.metadata.agentName,
+                fileName: event.fileAuthError.fileName,
+                conversationUrl,
+                value: JSON.stringify({
+                  workspaceId: connector.workspaceId,
+                  messageId: event.messageId,
+                }),
               }),
-            }),
-            thread_ts: slackMessageTs,
-          });
+              thread_ts: slackMessageTs,
+            });
+          } catch (error) {
+            return await handleUserActionPostFailure(event, error);
+          }
         }
 
         await streamHandler.setThinking("Waiting for file authorization...");
@@ -811,16 +905,20 @@ async function streamAgentAnswerToSlack(
         });
 
         if (slackUserId && !slackUserInfo.is_bot) {
-          await slackClient.chat.postEphemeral({
-            channel: slackChannelId,
-            user: slackUserId,
-            text: event.question.question,
-            blocks: makeUserQuestionBlock({
-              question: event.question,
-              value: questionValue,
-            }),
-            thread_ts: slackMessageTs,
-          });
+          try {
+            await slackClient.chat.postEphemeral({
+              channel: slackChannelId,
+              user: slackUserId,
+              text: event.question.question,
+              blocks: makeUserQuestionBlock({
+                question: event.question,
+                value: questionValue,
+              }),
+              thread_ts: slackMessageTs,
+            });
+          } catch (error) {
+            return await handleUserActionPostFailure(event, error);
+          }
         }
         break;
       }


### PR DESCRIPTION
## Description
Slack messages posted while the previous agent run is still active can come back as `visibility: "pending"`. The Slack bot now waits for the matching `user_message_promoted` conversation event before starting answer streaming; if it does not arrive within the existing Slack user-action timeout, it stops the Slack stream and posts a fallback with the Dust conversation link.

Also cancels the blocked Dust message when Slack cannot post required user-action controls, so later Slack messages are not stranded behind a stuck pending message.

## Risks
Blast radius: Slack bot replies for steering/pending messages and Slack tool/user-action prompts.
Risk: standard

## Deploy Plan
- deploy connectors

## Tests
- [x] `NODE_ENV=test CONNECTORS_DATABASE_URI=postgres://dev:dev@localhost:5432/dust_connectors_test npx vitest run src/connectors/slack/bot.test.ts src/connectors/slack/chat/stream_conversation_handler.test.ts --config vite.config.mjs`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25787">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->