### PR TITLE
[front-api] Drop Next req/res shim from Hono auth middleware

### DIFF
--- a/front-api/CODING_RULES.md
+++ b/front-api/CODING_RULES.md
@@ -229,9 +229,14 @@ should use the alias.
 middleware reads what it needs from Hono's `Context` directly
 (`c.req.header(...)`, `c.req.param(...)`, `c.req.raw.headers`).
 
-Known exception: the bridge in `workspace_auth.ts`, which still constructs
-a Next-shaped `req`/`res` to call the legacy `getSession(req, res)`. That
-will go away when `getSession` is refactored to take an I/O abstraction.
+For cookie-based session resolution, call
+`getWorkOSSessionWithSetCookies(workOSSessionCookie)` from
+`@app/lib/api/workos/user`. It returns `{ session, setCookies }` — emit
+each `setCookies` value with
+`c.header("Set-Cookie", cookie, { append: true })`. The Next-flavored
+`getSession(req, res)` / `getWorkOSSession(req, res)` helpers remain the
+entry point for Next code paths and must not be called from Hono
+middleware.
 
 The strangler entry in `server.ts` keeps `import next from "next"` — that
 disappears when Next is fully retired.

--- a/front-api/middleware/poke_auth.ts
+++ b/front-api/middleware/poke_auth.ts
@@ -1,12 +1,9 @@
 import type { MiddlewareHandler } from "hono";
 
-import {
-  Authenticator,
-  getSession,
-  getSessionFromBearerToken,
-} from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 
-import { apiError, buildNextLikeReqRes } from "./utils";
+import { resolveSession } from "@front-api/middleware/session_resolution";
+import { apiError } from "@front-api/middleware/utils";
 
 /**
  * Authenticates a Poke (super-user) request and stores the resolved
@@ -17,38 +14,12 @@ import { apiError, buildNextLikeReqRes } from "./utils";
  * `/api/poke/...`.
  */
 export const pokeAuth: MiddlewareHandler = async (c, next) => {
-  const { req, res, setCookies } = buildNextLikeReqRes(c);
-
-  const bearerRes = await getSessionFromBearerToken(
-    c.req.header("authorization")
-  );
-  if (bearerRes.isErr()) {
-    return apiError(c, {
-      status_code: 401,
-      api_error: {
-        type: bearerRes.error,
-        message: "The request does not have valid authentication credentials.",
-      },
-    });
-  }
-  const session = bearerRes.value ?? (await getSession(req, res));
-
-  for (const cookie of setCookies) {
-    c.header("Set-Cookie", cookie, { append: true });
+  const sessionResult = await resolveSession(c);
+  if (sessionResult instanceof Response) {
+    return sessionResult;
   }
 
-  if (!session) {
-    return apiError(c, {
-      status_code: 401,
-      api_error: {
-        type: "not_authenticated",
-        message:
-          "The user does not have an active session or is not authenticated.",
-      },
-    });
-  }
-
-  const auth = await Authenticator.fromSuperUserSession(session, null);
+  const auth = await Authenticator.fromSuperUserSession(sessionResult, null);
 
   if (!auth.isDustSuperUser()) {
     return apiError(c, {

--- a/front-api/middleware/session_auth.ts
+++ b/front-api/middleware/session_auth.ts
@@ -1,10 +1,8 @@
-import { apiError } from "@front-api/middleware/utils";
 import type { MiddlewareHandler } from "hono";
 
-import { getSession, getSessionFromBearerToken } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 
-import { buildNextLikeReqRes } from "./utils";
+import { resolveSession } from "@front-api/middleware/session_resolution";
 
 declare module "hono" {
   interface ContextVariableMap {
@@ -20,37 +18,11 @@ declare module "hono" {
  * Apply to routes that need a logged-in user but no workspace scoping.
  */
 export const sessionAuth: MiddlewareHandler = async (c, next) => {
-  const bearerRes = await getSessionFromBearerToken(
-    c.req.header("authorization")
-  );
-  if (bearerRes.isErr()) {
-    return apiError(c, {
-      status_code: 401,
-      api_error: {
-        type: bearerRes.error,
-        message: "The request does not have valid authentication credentials.",
-      },
-    });
+  const result = await resolveSession(c);
+  if (result instanceof Response) {
+    return result;
   }
 
-  const { req, res, setCookies } = buildNextLikeReqRes(c);
-  const session = bearerRes.value ?? (await getSession(req, res));
-
-  for (const cookie of setCookies) {
-    c.header("Set-Cookie", cookie, { append: true });
-  }
-
-  if (!session) {
-    return apiError(c, {
-      status_code: 401,
-      api_error: {
-        type: "not_authenticated",
-        message:
-          "The user does not have an active session or is not authenticated.",
-      },
-    });
-  }
-
-  c.set("session", session);
+  c.set("session", result);
   await next();
 };

--- a/front-api/middleware/session_resolution.ts
+++ b/front-api/middleware/session_resolution.ts
@@ -1,0 +1,57 @@
+import type { Context } from "hono";
+
+import { getWorkOSSessionWithSetCookies } from "@app/lib/api/workos/user";
+import { getSessionFromBearerToken } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+
+import { apiError, parseCookieHeader } from "@front-api/middleware/utils";
+
+/**
+ * Resolves the session for a Hono request by trying the bearer token first,
+ * then falling back to the `workos_session` cookie. Returns the resolved
+ * session on success, or a `Response` (to be returned by the caller) when
+ * authentication fails.
+ *
+ * Mirrors the bearer-or-cookie chain in `front/logger/withlogging.ts`.
+ */
+export async function resolveSession(
+  c: Context
+): Promise<Response | SessionWithUser> {
+  const bearerRes = await getSessionFromBearerToken(
+    c.req.header("authorization")
+  );
+  if (bearerRes.isErr()) {
+    return apiError(c, {
+      status_code: 401,
+      api_error: {
+        type: bearerRes.error,
+        message: "The request does not have valid authentication credentials.",
+      },
+    });
+  }
+
+  let session: SessionWithUser | null | undefined = bearerRes.value;
+  if (!session) {
+    const cookies = parseCookieHeader(c.req.header("cookie"));
+    const result = await getWorkOSSessionWithSetCookies(
+      cookies["workos_session"]
+    );
+    for (const cookie of result.setCookies) {
+      c.header("Set-Cookie", cookie, { append: true });
+    }
+    session = result.session ?? null;
+  }
+
+  if (!session) {
+    return apiError(c, {
+      status_code: 401,
+      api_error: {
+        type: "not_authenticated",
+        message:
+          "The user does not have an active session or is not authenticated.",
+      },
+    });
+  }
+
+  return session;
+}

--- a/front-api/middleware/utils.ts
+++ b/front-api/middleware/utils.ts
@@ -81,4 +81,3 @@ export function parseCookieHeader(
   }
   return cookies;
 }
-

--- a/front-api/middleware/utils.ts
+++ b/front-api/middleware/utils.ts
@@ -1,6 +1,5 @@
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
@@ -83,45 +82,3 @@ export function parseCookieHeader(
   return cookies;
 }
 
-// Bridge a Hono Context to the minimal NextApiRequest/NextApiResponse shape
-// required by the existing auth helpers (which read req.cookies/req.headers
-// and call res.setHeader to refresh the workos_session cookie).
-export function buildNextLikeReqRes(c: Context): {
-  req: NextApiRequest;
-  res: NextApiResponse;
-  setCookies: string[];
-} {
-  const headers: Record<string, string> = {};
-  c.req.raw.headers.forEach((value, key) => {
-    headers[key] = value;
-  });
-  const cookies = parseCookieHeader(headers.cookie);
-  const setCookies: string[] = [];
-
-  const req = {
-    cookies,
-    headers,
-    query: {},
-    socket: { remoteAddress: undefined },
-    method: c.req.method,
-    url: c.req.url,
-  };
-
-  const res = {
-    setHeader: (name: string, value: string | string[]) => {
-      if (name.toLowerCase() === "set-cookie") {
-        if (Array.isArray(value)) {
-          setCookies.push(...value);
-        } else {
-          setCookies.push(value);
-        }
-      }
-    },
-  };
-
-  return {
-    req: req as unknown as NextApiRequest,
-    res: res as unknown as NextApiResponse,
-    setCookies,
-  };
-}

--- a/front-api/middleware/workspace_auth.ts
+++ b/front-api/middleware/workspace_auth.ts
@@ -1,14 +1,10 @@
-import { apiError } from "@front-api/middleware/utils";
 import type { MiddlewareHandler } from "hono";
 
-import {
-  Authenticator,
-  getSession,
-  getSessionFromBearerToken,
-} from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { getClientIp } from "@app/lib/utils/request";
 
-import { buildNextLikeReqRes } from "./utils";
+import { resolveSession } from "@front-api/middleware/session_resolution";
+import { apiError } from "@front-api/middleware/utils";
 
 declare module "hono" {
   interface ContextVariableMap {
@@ -36,42 +32,18 @@ export const workspaceAuth: MiddlewareHandler = async (c, next) => {
     });
   }
 
-  const { req, res, setCookies } = buildNextLikeReqRes(c);
-
-  // Try bearer token first, then fall back to cookie-based session.
-  // Mirrors withLogging in front/logger/withlogging.ts.
-  const bearerRes = await getSessionFromBearerToken(
-    c.req.header("authorization")
-  );
-  if (bearerRes.isErr()) {
-    return apiError(c, {
-      status_code: 401,
-      api_error: {
-        type: bearerRes.error,
-        message: "The request does not have valid authentication credentials.",
-      },
-    });
-  }
-  const session = bearerRes.value ?? (await getSession(req, res));
-
-  for (const cookie of setCookies) {
-    c.header("Set-Cookie", cookie, { append: true });
+  const sessionResult = await resolveSession(c);
+  if (sessionResult instanceof Response) {
+    return sessionResult;
   }
 
-  if (!session) {
-    return apiError(c, {
-      status_code: 401,
-      api_error: {
-        type: "not_authenticated",
-        message:
-          "The user does not have an active session or is not authenticated.",
-      },
-    });
-  }
+  const auth = await Authenticator.fromSession(sessionResult, wId);
 
-  const auth = await Authenticator.fromSession(session, wId);
-
-  const ip = getClientIp(req);
+  const headers: Record<string, string | string[] | undefined> = {};
+  c.req.raw.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  const ip = getClientIp({ headers });
   if (ip !== "internal") {
     auth.setClientIp(ip);
   }

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -43,41 +43,57 @@ export async function getWorkOSSession(
   req: NextApiRequest | GetServerSidePropsContext["req"],
   res: NextApiResponse | GetServerSidePropsContext["res"]
 ): Promise<SessionWithUser | undefined> {
-  const workOSSessionCookie = req.cookies["workos_session"];
-  if (workOSSessionCookie) {
-    const result = await getWorkOSSessionFromCookie(workOSSessionCookie);
-    const domain = config.getWorkOSSessionCookieDomain();
-    // In development (localhost), omit Secure flag as it requires HTTPS
-    // Safari strictly enforces this and will not set cookies with Secure flag on HTTP
-    const secureFlag = isDevelopment() ? "" : "; Secure";
-    if (result.cookie === "") {
-      if (domain) {
-        res.setHeader("Set-Cookie", [
-          `workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
-          `workos_session=; Domain=${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
-        ]);
-      } else {
-        res.setHeader("Set-Cookie", [
-          `workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
-        ]);
-      }
-    } else if (result.cookie) {
-      if (domain) {
-        res.setHeader("Set-Cookie", [
-          `workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
-          `workos_session=${result.cookie}; Domain=${domain}; Path=/; HttpOnly${secureFlag}; SameSite=Lax; Max-Age=2592000`,
-        ]);
-      } else {
-        res.setHeader("Set-Cookie", [
-          `workos_session=${result.cookie}; Path=/; HttpOnly${secureFlag}; SameSite=Lax; Max-Age=2592000`,
-        ]);
-      }
-    }
+  const { session, setCookies } = await getWorkOSSessionWithSetCookies(
+    req.cookies["workos_session"]
+  );
+  if (setCookies.length > 0) {
+    res.setHeader("Set-Cookie", setCookies);
+  }
+  return session;
+}
 
-    return result.session;
+// Framework-agnostic variant of getWorkOSSession: takes the raw cookie value
+// and returns the session along with any Set-Cookie header values that should
+// be added to the response. Used by Hono middlewares (which can't expose a
+// Next req/res pair).
+export async function getWorkOSSessionWithSetCookies(
+  workOSSessionCookie: string | undefined
+): Promise<{
+  session: SessionWithUser | undefined;
+  setCookies: string[];
+}> {
+  if (!workOSSessionCookie) {
+    return { session: undefined, setCookies: [] };
   }
 
-  return undefined;
+  const result = await getWorkOSSessionFromCookie(workOSSessionCookie);
+  const domain = config.getWorkOSSessionCookieDomain();
+  // In development (localhost), omit Secure flag as it requires HTTPS
+  // Safari strictly enforces this and will not set cookies with Secure flag on HTTP
+  const secureFlag = isDevelopment() ? "" : "; Secure";
+
+  let setCookies: string[] = [];
+  if (result.cookie === "") {
+    setCookies = domain
+      ? [
+          `workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
+          `workos_session=; Domain=${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
+        ]
+      : [
+          `workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
+        ];
+  } else if (result.cookie) {
+    setCookies = domain
+      ? [
+          `workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly${secureFlag}; SameSite=Lax`,
+          `workos_session=${result.cookie}; Domain=${domain}; Path=/; HttpOnly${secureFlag}; SameSite=Lax; Max-Age=2592000`,
+        ]
+      : [
+          `workos_session=${result.cookie}; Path=/; HttpOnly${secureFlag}; SameSite=Lax; Max-Age=2592000`,
+        ];
+  }
+
+  return { session: result.session, setCookies };
 }
 
 export async function _getRefreshedCookie(

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -24,6 +24,18 @@ vi.mock(import("../../lib/auth"), async (importOriginal) => {
   };
 });
 
+// Hono middlewares bypass `getSession` and call `getWorkOSSessionWithSetCookies`
+// directly. Mock it here so tests using `createPrivateApiMockRequest` against
+// Hono routes resolve the same authenticated session as Next tests.
+vi.mock(import("../../lib/api/workos/user"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    getWorkOSSessionWithSetCookies: vi.fn(),
+  };
+});
+
+import { getWorkOSSessionWithSetCookies } from "../../lib/api/workos/user";
 import { Authenticator, getSession } from "../../lib/auth";
 
 /**
@@ -69,25 +81,28 @@ export const createPrivateApiMockRequest = async ({
   });
 
   // Mock the getSession function to return the user without going through the workos session
-  vi.mocked(getSession).mockReturnValue(
-    Promise.resolve({
-      type: "workos",
-      sessionId: "test-session-id",
-      user: {
-        workOSUserId: user.workOSUserId!,
-        email: user.email!,
-        email_verified: true,
-        name: user.username!,
-        nickname: user.username!,
-        organizations: [],
-      },
-      authenticationMethod: "GoogleOAuth",
-      isSSO: false,
-      workspaceId: workspace.sId,
-      organizationId: workspace.workOSOrganizationId ?? undefined,
-      region: "us-central1",
-    })
-  );
+  const session = {
+    type: "workos" as const,
+    sessionId: "test-session-id",
+    user: {
+      workOSUserId: user.workOSUserId!,
+      email: user.email!,
+      email_verified: true,
+      name: user.username!,
+      nickname: user.username!,
+      organizations: [],
+    },
+    authenticationMethod: "GoogleOAuth",
+    isSSO: false,
+    workspaceId: workspace.sId,
+    organizationId: workspace.workOSOrganizationId ?? undefined,
+    region: "us-central1" as const,
+  };
+  vi.mocked(getSession).mockReturnValue(Promise.resolve(session));
+  vi.mocked(getWorkOSSessionWithSetCookies).mockResolvedValue({
+    session,
+    setCookies: [],
+  });
 
   const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
     method: method,


### PR DESCRIPTION
## Description

  - Add framework-agnostic `getWorkOSSessionWithSetCookies(cookie)` in
    `front/lib/api/workos/user.ts` returning `{ session, setCookies }`. The
    existing `getWorkOSSession(req, res)` keeps its contract and delegates
    to it, so no front callers or tests change.
  - Drop `buildNextLikeReqRes` from `front-api/middleware/utils.ts` — Hono
    no longer fabricates a Next `req`/`res` to call `getSession`.
  - Extract the bearer-then-cookie resolution that was duplicated across
    `session_auth`, `workspace_auth`, and `poke_auth` into a single
    `resolveSession(c)` helper in `front-api/middleware/session_resolution.ts`.
    Each middleware collapses to one call.
  - `generic_private_api_tests.ts` also mocks the new low-level fn so Hono
    routes using `createPrivateApiMockRequest` resolve the same session as
    Next handlers.
  - Update [API9] in `front-api/CODING_RULES.md`.

## Tests

All tests pass

## Risk

Change to Front is fairly harmless

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25790">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->