### PR TITLE
fix: move assert function step below create

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -212,11 +212,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       { transaction }
     );
 
-    assert(
-      stepContent.isFunctionCallContent(),
-      "Step content is not a function call."
-    );
-
     await AgentStepContentToolExecutionModel.create({
       workspaceId: workspace.id,
       agentMessageId: blob.agentMessageId,
@@ -224,6 +219,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       agentMCPActionId: action.id,
       stepContentId: stepContent.id,
     });
+
+    assert(
+      stepContent.isFunctionCallContent(),
+      "Step content is not a function call."
+    );
 
     return new this(this.model, action.get(), stepContent, {
       internalMCPServerName,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

We see some AgentMCPAction that have no AgentStepContentToolExecution.
Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1779197266061689

The only way were we create them is in there, so it's possible that the assert crashes in between.
Moving the assert down so we always have a stepContent for the action.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25791">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->