### PR TITLE
[dsbx] wire request rewriter scaffolding (pass-through)

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/e2e/README.md
+++ b/cli/dust-sandbox/e2e/README.md
@@ -12,9 +12,9 @@ now runs through `dsbx forward`.
 ## What it covers
 
 - **Matrix** (6 cases): valid JWT + allowed domain (ALLOW), valid JWT + denied
-  domain (DENY + deny log entry with `reason: proxy_denied`), expired JWT,
+  domain (DENY + JSON deny log entry with `reason: proxy_denied`), expired JWT,
   wrong `iss`, wrong `aud`, bad signature. All DENY cases additionally verify
-  `/tmp/dust-egress-denied.log` contains a correctly-formatted line for the
+  `/tmp/dust-egress-denied.log` contains a structured JSON entry for the
   denied target.
 - **Streaming**: real agent call — POST a "write a short poem" message to the
   Dust agent (`sId=dust` by default) on your workspace, iterate the streamed
@@ -80,5 +80,4 @@ inside the container.
   it tears down and respawns `dsbx forward` so the new token is picked up
   (token-file hot-reload is out of scope in the forwarder for now).
 - For every DENY case, `smoke.ts` reads `/tmp/dust-egress-denied.log` and
-  asserts the expected `DENIED <domain>:<port> (reason: proxy_denied)` entry
-  is present.
+  asserts the expected structured JSON entry is present.

--- a/cli/dust-sandbox/e2e/smoke.ts
+++ b/cli/dust-sandbox/e2e/smoke.ts
@@ -239,6 +239,20 @@ function pad(value: string, width: number): string {
     : value + " ".repeat(width - value.length);
 }
 
+function isProxyDenyEntry(value: unknown, expectedDomain: string): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (!("domain" in value && "port" in value && "reason" in value)) {
+    return false;
+  }
+  return (
+    value.domain === expectedDomain &&
+    value.port === 443 &&
+    value.reason === "proxy_denied"
+  );
+}
+
 async function runMatrixCase(c: MatrixCase): Promise<boolean> {
   await writeTokenFile(mintJwt(c.overrides));
   await truncateDenyLog();
@@ -255,11 +269,15 @@ async function runMatrixCase(c: MatrixCase): Promise<boolean> {
 
     if (c.expected === "DENY") {
       const log = await readDenyLogLines();
-      const expectedMarker = `DENIED ${c.domain}:443`;
-      const denyLine = log.find(
-        (line) =>
-          line.includes(expectedMarker) && line.includes("reason: proxy_denied")
-      );
+      const denyLine = log.find((line) => {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          return false;
+        }
+        return isProxyDenyEntry(parsed, c.domain);
+      });
       if (denyLine) {
         details = "deny_log=ok";
       } else {

--- a/cli/dust-sandbox/e2e/smoke.ts
+++ b/cli/dust-sandbox/e2e/smoke.ts
@@ -239,7 +239,16 @@ function pad(value: string, width: number): string {
     : value + " ".repeat(width - value.length);
 }
 
-function isProxyDenyEntry(value: unknown, expectedDomain: string): boolean {
+interface ProxyDenyEntry {
+  domain: string;
+  port: number;
+  reason: string;
+}
+
+function isProxyDenyEntry(
+  value: unknown,
+  expectedDomain: string
+): value is ProxyDenyEntry {
   if (!value || typeof value !== "object") {
     return false;
   }

--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -1,15 +1,30 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use tokio::io::AsyncWriteExt;
 
+// MITM-specific reasons are constructed by the request rewriter, which lands in
+// a follow-up PR. They are wired through the deny log shape now so the JSON
+// format does not have to change again.
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DenyReason {
     ProxyDenied,
     ProxyProtocolError,
     DomainExtractionFailed,
+    PlaceholderOnNonAllowed,
+    HostSniMismatch,
+    ValueControlChar,
+    UrlLinePlaceholder,
+    MalformedHeaders,
+    DuplicateHost,
+    MissingHost,
+    AbsoluteUriAuthorityMismatch,
+    Port80Placeholder,
+    HeaderSizeExceeded,
 }
 
 impl DenyReason {
@@ -18,61 +33,135 @@ impl DenyReason {
             Self::ProxyDenied => "proxy_denied",
             Self::ProxyProtocolError => "proxy_protocol_error",
             Self::DomainExtractionFailed => "domain_extraction_failed",
+            Self::PlaceholderOnNonAllowed => "placeholder_on_non_allowed",
+            Self::HostSniMismatch => "host_sni_mismatch",
+            Self::ValueControlChar => "value_control_char",
+            Self::UrlLinePlaceholder => "url_line_placeholder",
+            Self::MalformedHeaders => "malformed_headers",
+            Self::DuplicateHost => "duplicate_host",
+            Self::MissingHost => "missing_host",
+            Self::AbsoluteUriAuthorityMismatch => "absolute_uri_authority_mismatch",
+            Self::Port80Placeholder => "port_80_placeholder",
+            Self::HeaderSizeExceeded => "header_size_exceeded",
         }
     }
 }
 
-pub async fn append_deny_log(
-    path: &Path,
-    domain: &str,
-    port: u16,
-    reason: DenyReason,
-) -> Result<()> {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DenyLogEntry {
+    pub reason: DenyReason,
+    pub domain: Option<String>,
+    pub port: Option<u16>,
+    pub secret_name: Option<String>,
+    pub sni: Option<String>,
+    pub host: Option<String>,
+}
+
+impl DenyLogEntry {
+    pub fn proxy(domain: &str, port: u16, reason: DenyReason) -> Self {
+        Self {
+            reason,
+            domain: (!domain.is_empty()).then(|| domain.to_string()),
+            port: Some(port),
+            secret_name: None,
+            sni: None,
+            host: None,
+        }
+    }
+
+    // Constructed by the request rewriter (follow-up PR).
+    #[allow(dead_code)]
+    pub fn mitm(
+        reason: DenyReason,
+        domain: Option<&str>,
+        port: u16,
+        secret_name: Option<&str>,
+        sni: Option<&str>,
+        host: Option<&str>,
+    ) -> Self {
+        Self {
+            reason,
+            domain: domain.filter(|value| !value.is_empty()).map(str::to_string),
+            port: Some(port),
+            secret_name: secret_name.map(str::to_string),
+            sni: sni.filter(|value| !value.is_empty()).map(str::to_string),
+            host: host.filter(|value| !value.is_empty()).map(str::to_string),
+        }
+    }
+}
+
+pub async fn append_deny_log(path: &Path, entry: DenyLogEntry) -> Result<()> {
     let mut file = tokio::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
         .await
         .with_context(|| format!("failed to open deny log {}", path.display()))?;
-    let line = format_deny_log_line(domain, port, reason)?;
+    let line = format_deny_log_line(&entry)?;
     file.write_all(line.as_bytes())
         .await
         .with_context(|| format!("failed to write deny log {}", path.display()))?;
     Ok(())
 }
 
-fn format_deny_log_line(domain: &str, port: u16, reason: DenyReason) -> Result<String> {
+#[derive(Serialize)]
+struct JsonDenyLogLine<'a> {
+    ts: &'a str,
+    reason: &'a str,
+    domain: Option<&'a str>,
+    port: Option<u16>,
+    secret_name: &'a str,
+    sni: Option<&'a str>,
+    host: Option<&'a str>,
+}
+
+fn format_deny_log_line(entry: &DenyLogEntry) -> Result<String> {
     let timestamp = OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .context("failed to format deny log timestamp")?;
-    let domain = if domain.is_empty() {
-        "<unknown>"
-    } else {
-        domain
+    let line = JsonDenyLogLine {
+        ts: &timestamp,
+        reason: entry.reason.as_str(),
+        domain: entry.domain.as_deref(),
+        port: entry.port,
+        secret_name: entry.secret_name.as_deref().unwrap_or("unknown"),
+        sni: entry.sni.as_deref(),
+        host: entry.host.as_deref(),
     };
-    Ok(format!(
-        "{timestamp} DENIED {domain}:{port} (reason: {})\n",
-        reason.as_str()
-    ))
+    Ok(format!("{}\n", serde_json::to_string(&line)?))
 }
 
 #[cfg(test)]
 mod tests {
+    use serde_json::Value;
     use tempfile::tempdir;
 
-    use super::{append_deny_log, DenyReason};
+    use super::{append_deny_log, DenyLogEntry, DenyReason};
 
     #[tokio::test]
-    async fn appends_deny_log_entries() {
+    async fn appends_json_deny_log_entries() {
         let tempdir = tempdir().expect("tempdir should be created");
         let path = tempdir.path().join("deny.log");
 
-        append_deny_log(&path, "api.openai.com", 443, DenyReason::ProxyDenied)
-            .await
-            .expect("first append should succeed");
-        append_deny_log(&path, "", 80, DenyReason::DomainExtractionFailed)
-            .await
-            .expect("second append should succeed");
+        append_deny_log(
+            &path,
+            DenyLogEntry::proxy("api.openai.com", 443, DenyReason::ProxyDenied),
+        )
+        .await
+        .expect("first append should succeed");
+        append_deny_log(
+            &path,
+            DenyLogEntry::mitm(
+                DenyReason::HostSniMismatch,
+                Some("api.openai.com"),
+                443,
+                Some("OPENAI_API_KEY"),
+                Some("api.openai.com"),
+                Some("evil.example"),
+            ),
+        )
+        .await
+        .expect("second append should succeed");
 
         let content = tokio::fs::read_to_string(&path)
             .await
@@ -80,7 +169,17 @@ mod tests {
         let lines: Vec<&str> = content.lines().collect();
 
         assert_eq!(lines.len(), 2);
-        assert!(lines[0].contains("DENIED api.openai.com:443 (reason: proxy_denied)"));
-        assert!(lines[1].contains("DENIED <unknown>:80 (reason: domain_extraction_failed)"));
+
+        let first: Value = serde_json::from_str(lines[0]).expect("first line should be JSON");
+        assert_eq!(first["reason"], "proxy_denied");
+        assert_eq!(first["domain"], "api.openai.com");
+        assert_eq!(first["port"], 443);
+        assert_eq!(first["secret_name"], "unknown");
+
+        let second: Value = serde_json::from_str(lines[1]).expect("second line should be JSON");
+        assert_eq!(second["reason"], "host_sni_mismatch");
+        assert_eq!(second["secret_name"], "OPENAI_API_KEY");
+        assert_eq!(second["sni"], "api.openai.com");
+        assert_eq!(second["host"], "evil.example");
     }
 }

--- a/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
@@ -1,0 +1,80 @@
+// Pass-through wireup for the request rewriter. The full HTTP/1.1 parser,
+// placeholder substitution, host/SNI checks, and websocket upgrade handling
+// land in a follow-up PR that replaces these stubs. The module exists now so
+// `forward/mod.rs` can wire the split-stream + spawn structure end-to-end and
+// the deny log can grow its JSON shape independently of the rewriter logic.
+
+use std::io::ErrorKind;
+
+use anyhow::Result;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::egress_secrets::SecretTable;
+
+use super::deny_log::DenyLogEntry;
+
+// Mode plumbing for the follow-up rewriter. The stub forwards bytes blindly
+// and so does not read the inner fields, but the public shape is fixed now so
+// the call sites in `mod.rs` do not have to change later.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub(super) enum HttpRewriteMode<'a> {
+    Tls { sni: &'a str },
+    PlainHttp { domain: &'a str },
+}
+
+#[derive(Debug)]
+pub(super) enum HttpRewriteError {
+    #[allow(dead_code)]
+    Denied(DenyLogEntry),
+    Io(anyhow::Error),
+}
+
+#[allow(dead_code)]
+pub(super) struct WebSocketUpgradeWatch {
+    pub accepted_tx: oneshot::Sender<bool>,
+}
+
+pub(super) async fn forward_http1_requests<R, W>(
+    client_read: &mut R,
+    upstream_write: &mut W,
+    _secret_table: &SecretTable,
+    _mode: HttpRewriteMode<'_>,
+    _websocket_watch_tx: Option<&mpsc::Sender<WebSocketUpgradeWatch>>,
+) -> Result<(), HttpRewriteError>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    tokio::io::copy(client_read, upstream_write)
+        .await
+        .map_err(|error| HttpRewriteError::Io(error.into()))?;
+    // After the client closes, propagate the shutdown upstream so the upstream
+    // side gets EOF and can close its half, matching `copy_bidirectional`.
+    match upstream_write.shutdown().await {
+        Ok(()) => Ok(()),
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::BrokenPipe | ErrorKind::ConnectionReset | ErrorKind::UnexpectedEof,
+            ) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(HttpRewriteError::Io(error.into())),
+    }
+}
+
+pub(super) async fn copy_responses_with_websocket_watch<R, W>(
+    upstream_read: &mut R,
+    client_write: &mut W,
+    _websocket_watch_rx: mpsc::Receiver<WebSocketUpgradeWatch>,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    tokio::io::copy(upstream_read, client_write).await?;
+    Ok(())
+}

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -1,11 +1,11 @@
 mod deny_log;
 mod handshake;
 mod http_host;
+mod http_rewriter;
 mod original_dst;
 mod sni;
 mod tls_mitm;
 
-use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -25,9 +25,12 @@ use tracing::{debug, info, warn};
 
 use crate::egress_secrets::SecretTable;
 
-use self::deny_log::{append_deny_log, DenyReason};
+use self::deny_log::{append_deny_log, DenyLogEntry, DenyReason};
 use self::handshake::{build_handshake_frame, ALLOW_RESPONSE, DENY_RESPONSE};
 use self::http_host::parse_http_host;
+use self::http_rewriter::{
+    copy_responses_with_websocket_watch, forward_http1_requests, HttpRewriteError, HttpRewriteMode,
+};
 use self::original_dst::resolve_original_dst;
 use self::sni::parse_client_hello_sni;
 use self::tls_mitm::{MitmCa, HTTP_1_1_ALPN};
@@ -272,6 +275,15 @@ async fn handle_connection(
                 run_mitm_session(&runtime, sni, client_stream, proxy_stream)
                     .await
                     .context("MITM session failed")?;
+            } else if original_port == 80 {
+                run_plain_http_session(
+                    &runtime,
+                    &domain_extraction.domain,
+                    client_stream,
+                    proxy_stream,
+                )
+                .await
+                .context("plain HTTP guard session failed")?;
             } else {
                 tokio::io::copy_bidirectional(&mut client_stream, &mut proxy_stream)
                     .await
@@ -286,9 +298,7 @@ async fn handle_connection(
             };
             append_deny_log(
                 &runtime.deny_log,
-                &domain_extraction.domain,
-                original_port,
-                reason,
+                DenyLogEntry::proxy(&domain_extraction.domain, original_port, reason),
             )
             .await
             .context("failed to append deny log entry")?;
@@ -303,9 +313,11 @@ async fn handle_connection(
         ProxyDecision::ProtocolError => {
             append_deny_log(
                 &runtime.deny_log,
-                &domain_extraction.domain,
-                original_port,
-                DenyReason::ProxyProtocolError,
+                DenyLogEntry::proxy(
+                    &domain_extraction.domain,
+                    original_port,
+                    DenyReason::ProxyProtocolError,
+                ),
             )
             .await
             .context("failed to append protocol-error deny log entry")?;
@@ -340,12 +352,12 @@ async fn run_mitm_session<C, S>(
     proxy_stream: S,
 ) -> Result<()>
 where
-    C: AsyncRead + AsyncWrite + Unpin,
-    S: AsyncRead + AsyncWrite + Unpin,
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let upstream_server_name =
         ServerName::try_from(sni.to_string()).context("invalid upstream SNI for MITM TLS")?;
-    let mut upstream_tls = runtime
+    let upstream_tls = runtime
         .mitm_tls_connector
         .connect(upstream_server_name, proxy_stream)
         .await
@@ -357,29 +369,90 @@ where
         .await
         .context("failed to build MITM server config for SNI")?;
     let acceptor = TlsAcceptor::from(server_config);
-    let mut agent_tls = acceptor
+    let agent_tls = acceptor
         .accept(client_stream)
         .await
         .context("failed to accept agent TLS for MITM")?;
 
-    match tokio::io::copy_bidirectional(&mut agent_tls, &mut upstream_tls).await {
-        Ok(_) => {}
-        Err(error)
-            if matches!(
-                error.kind(),
-                ErrorKind::BrokenPipe | ErrorKind::ConnectionReset | ErrorKind::UnexpectedEof
-            ) =>
-        {
-            debug!(
-                sni,
-                error = %error,
-                "MITM bidirectional copy ended after peer closed the connection"
-            );
-        }
-        Err(error) => return Err(error).context("MITM bidirectional copy failed"),
-    }
+    run_rewritten_http_session(
+        runtime,
+        HttpRewriteMode::Tls { sni },
+        agent_tls,
+        upstream_tls,
+    )
+    .await
+}
 
-    Ok(())
+async fn run_plain_http_session<C, S>(
+    runtime: &ForwardRuntime,
+    domain: &str,
+    client_stream: C,
+    proxy_stream: S,
+) -> Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    run_rewritten_http_session(
+        runtime,
+        HttpRewriteMode::PlainHttp { domain },
+        client_stream,
+        proxy_stream,
+    )
+    .await
+}
+
+async fn run_rewritten_http_session<C, S>(
+    runtime: &ForwardRuntime,
+    mode: HttpRewriteMode<'_>,
+    client_stream: C,
+    upstream_stream: S,
+) -> Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let (mut client_read, mut client_write) = tokio::io::split(client_stream);
+    let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream_stream);
+    let (websocket_watch_tx, websocket_watch_rx) = tokio::sync::mpsc::channel(1);
+    let mut response_task = tokio::spawn(async move {
+        copy_responses_with_websocket_watch(
+            &mut upstream_read,
+            &mut client_write,
+            websocket_watch_rx,
+        )
+        .await
+    });
+
+    tokio::select! {
+        request_result = forward_http1_requests(
+            &mut client_read,
+            &mut upstream_write,
+            &runtime.secret_table,
+            mode,
+            Some(&websocket_watch_tx),
+        ) => {
+            match request_result {
+                Ok(()) => {
+                    response_task.await.context("response copy task panicked")?
+                }
+                Err(HttpRewriteError::Denied(entry)) => {
+                    response_task.abort();
+                    append_deny_log(&runtime.deny_log, entry)
+                        .await
+                        .context("failed to append MITM deny log entry")?;
+                    Ok(())
+                }
+                Err(HttpRewriteError::Io(error)) => {
+                    response_task.abort();
+                    Err(error).context("HTTP rewrite failed")
+                }
+            }
+        }
+        response_result = &mut response_task => {
+            response_result.context("response copy task panicked")?
+        }
+    }
 }
 
 fn display_domain(domain: &str) -> &str {

--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -203,12 +203,12 @@ mod tests {
 
     #[test]
     fn parse_float_args() {
-        let args = vec!["--ratio".to_string(), "3.14".to_string()];
+        let args = vec!["--ratio".to_string(), "3.125".to_string()];
         let result = parse_args(&args)
             .expect("should parse")
             .expect("should have value");
         let ratio = result["ratio"].as_f64().expect("should be f64");
-        assert!((ratio - 3.14).abs() < f64::EPSILON);
+        assert!((ratio - 3.125).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -309,29 +309,6 @@ describe("sandbox egress helpers", () => {
     expect(sandbox.exec).toHaveBeenCalledTimes(1);
   });
 
-  it("does not pass MITM-experiment-related flags to dsbx", async () => {
-    const sandbox = {
-      providerId: "provider-sandbox-id",
-      sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
-      exec: vi
-        .fn()
-        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
-        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
-        .mockResolvedValueOnce(
-          new Ok({ exitCode: 0, stdout: "1 0", stderr: "" })
-        )
-        .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
-    };
-
-    const result = await setupEgressForwarder(auth, sandbox as never);
-
-    expect(result).toEqual(new Ok(undefined));
-    const startCall = sandbox.exec.mock.calls[1][1] as string;
-    expect(startCall).not.toContain("--mitm-experiment-host");
-    expect(startCall).not.toContain("--mitm-ca-path");
-  });
-
   it("surfaces failures from the MITM trust bundle install", async () => {
     const sandbox = {
       providerId: "provider-sandbox-id",

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -52,7 +52,7 @@ describe("sandbox image registry", () => {
   test("bumps the base image for the scoped MITM rollout", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.12",
+      tag: "0.8.13",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -14,8 +14,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.12";
-const DSBX_CLI_VERSION = "0.1.8";
+const DUST_BASE_IMAGE_VERSION = "0.8.13";
+const DSBX_CLI_VERSION = "0.1.9";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.


### PR DESCRIPTION
## Description

Lands the pieces around the upcoming HTTP/1.1 request rewriter so the rewriter itself can ship as a focused follow-up PR.

- New `http_rewriter` module ships as a byte-level pass-through. It owns the public shape the real rewriter will fill in (`forward_http1_requests`, `copy_responses_with_websocket_watch`, `HttpRewriteMode`, `HttpRewriteError`) but for now just copies bytes. After the client closes, it propagates the shutdown upstream so behavior matches today's `copy_bidirectional` path.
- `run_rewritten_http_session` in `forward/mod.rs` does the split-streams + spawn + select dance so the parser can hook in later without touching call sites.
- `run_plain_http_session` routes port 80 through the same path. With the pass-through this is byte-for-byte equivalent to today.
- Deny log moves to structured JSON. New MITM-specific reason codes ship dormant (constructed by the rewriter in the follow-up).
- `e2e/smoke.ts` parses the JSON deny log entries via an in-place type guard.
- Bumps `dust-base` to 0.8.13 and `dsbx` to 0.1.9.
- Drops the now-irrelevant `--mitm-experiment-host` assertion.

Follow-up PR: replaces the pass-through module with the real HTTP/1.1 rewriter (header parsing, placeholder substitution, host/SNI checks, websocket upgrade handling, basic-auth rewriting). That diff is mostly one new file and is reviewable on its own.

## Tests

`cargo test` in `cli/dust-sandbox` (45 tests pass, including the MITM session pass-through test that drives a real TLS round-trip end-to-end through `run_rewritten_http_session`). `cargo clippy -- -D warnings` and `cargo fmt --check` are clean.

## Risk

Low. With the rewriter stubbed to a pass-through, this is byte-for-byte equivalent to today's MITM path for TLS connections and a no-op for port 80 (no agent currently routes plain HTTP through the proxy). The JSON deny log format is the only externally observable behavior change, and `smoke.ts` covers that. Safe to rollback (revert + redeploy dsbx 0.1.7 / dust-base 0.8.11).

## Deploy Plan

- [ ] Release dsbx 0.1.9 via the sandbox release workflow
- [ ] Confirm the 0.1.9 image is available in the registry
- [ ] Deploy front to pick up the dust-base 0.8.13 reference

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25792">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->