### PR TITLE
[LLM] Mistral: bump SDK to v2, support response_format, fix regional availability

### DIFF
--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -25,6 +25,7 @@ import type {
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { Mistral } from "@mistralai/mistralai";
 import type { ChatCompletionRequest } from "@mistralai/mistralai/models/components";
 import {
@@ -169,7 +170,11 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
   override async getBatchStatus(batchId: string): Promise<BatchStatus> {
     const job = await this.client.batch.jobs.get({ jobId: batchId });
 
-    switch (job.status) {
+    // Narrow OpenEnum to known values for exhaustive switching.
+    const jobStatus =
+      job.status as (typeof BatchJobStatus)[keyof typeof BatchJobStatus];
+
+    switch (jobStatus) {
       case BatchJobStatus.Success:
         return "ready";
       case BatchJobStatus.Failed:
@@ -185,11 +190,7 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
       case BatchJobStatus.CancellationRequested:
         return "computing";
       default:
-        logger.error(
-          { batchId, status: job.status, provider: "mistral" },
-          "Unrecognized Mistral batch status"
-        );
-        throw new Error(`Unrecognized Mistral batch status: ${job.status}`);
+        assertNever(jobStatus);
     }
   }
 

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -22,7 +22,6 @@ import type {
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { Mistral } from "@mistralai/mistralai";
 import type { ChatCompletionRequest } from "@mistralai/mistralai/models/components";
 import {
@@ -182,7 +181,11 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
       case BatchJobStatus.CancellationRequested:
         return "computing";
       default:
-        assertNever(job.status);
+        logger.error(
+          { batchId, status: job.status, provider: "mistral" },
+          "Unrecognized Mistral batch status"
+        );
+        throw new Error(`Unrecognized Mistral batch status: ${job.status}`);
     }
   }
 

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -1,6 +1,9 @@
 import type { MistralWhitelistedModelId } from "@app/lib/api/llm/clients/mistral/types";
 import { MISTRAL_PROVIDER_ID } from "@app/lib/api/llm/clients/mistral/types";
-import { toToolChoiceParam } from "@app/lib/api/llm/clients/mistral/utils";
+import {
+  toResponseFormatParam,
+  toToolChoiceParam,
+} from "@app/lib/api/llm/clients/mistral/utils";
 import {
   toMessage,
   toTool,
@@ -93,6 +96,7 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
       model: this.modelId,
       messages,
       temperature: this.temperature ?? undefined,
+      responseFormat: toResponseFormatParam(this.responseFormat),
       toolChoice: toToolChoiceParam(specifications, forceToolCall),
       tools: specifications.map(toTool),
     };

--- a/front/lib/api/llm/clients/mistral/utils/index.ts
+++ b/front/lib/api/llm/clients/mistral/utils/index.ts
@@ -1,5 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import type { ToolChoice } from "@mistralai/mistralai/models/components";
+import { parseResponseFormatSchema } from "@app/lib/api/llm/utils";
+import type {
+  ResponseFormat,
+  ToolChoice,
+} from "@mistralai/mistralai/models/components";
 import type { ToolChoiceEnum } from "@mistralai/mistralai/models/components/toolchoiceenum";
 
 export function toToolChoiceParam(
@@ -9,4 +13,22 @@ export function toToolChoiceParam(
   return forceToolCall && specifications.some((s) => s.name === forceToolCall)
     ? { type: "function", function: { name: forceToolCall } }
     : ("auto" as const);
+}
+
+export function toResponseFormatParam(
+  responseFormat: string | null
+): ResponseFormat | undefined {
+  const responseFormatObject = parseResponseFormatSchema(responseFormat);
+  if (!responseFormatObject) {
+    return;
+  }
+  return {
+    type: "json_schema",
+    jsonSchema: {
+      name: responseFormatObject.json_schema.name,
+      description: responseFormatObject.json_schema.description,
+      schemaDefinition: responseFormatObject.json_schema.schema,
+      strict: responseFormatObject.json_schema.strict ?? undefined,
+    },
+  };
 }

--- a/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
+++ b/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
@@ -23,8 +23,8 @@ import type {
   UsageInfo,
 } from "@mistralai/mistralai/models/components";
 import {
+  ChatCompletionChoiceFinishReason,
   CompletionResponseStreamChoiceFinishReason,
-  FinishReason,
 } from "@mistralai/mistralai/models/components";
 import compact from "lodash/compact";
 
@@ -336,9 +336,13 @@ export function chatCompletionToLLMEvents(
 
   const choice = response.choices[0];
   switch (choice.finishReason) {
-    case FinishReason.Stop:
-    case FinishReason.ToolCalls: {
-      const { content, toolCalls } = choice.message;
+    case ChatCompletionChoiceFinishReason.Stop:
+    case ChatCompletionChoiceFinishReason.ToolCalls: {
+      const message = choice.message;
+      if (!message) {
+        break;
+      }
+      const { content, toolCalls } = message;
       if (content) {
         const text = batchContentToText(content);
         if (text.length > 0) {
@@ -359,8 +363,8 @@ export function chatCompletionToLLMEvents(
       }
       break;
     }
-    case FinishReason.Length:
-    case FinishReason.ModelLength: {
+    case ChatCompletionChoiceFinishReason.Length:
+    case ChatCompletionChoiceFinishReason.ModelLength: {
       addEvent(
         new EventError(
           {
@@ -374,7 +378,7 @@ export function chatCompletionToLLMEvents(
       );
       break;
     }
-    case FinishReason.Error: {
+    case ChatCompletionChoiceFinishReason.Error: {
       addEvent(
         new EventError(
           {

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -50,6 +50,7 @@ export async function getLLM(
       modelId,
       temperature,
       reasoningEffort,
+      responseFormat,
       bypassFeatureFlag,
       context,
     });

--- a/front/package.json
+++ b/front/package.json
@@ -60,7 +60,7 @@
     "@mendable/firecrawl-js": "^1.29.1",
     "@metronome/sdk": "^3.4.1",
     "@microsoft/microsoft-graph-client": "^3.0.7",
-    "@mistralai/mistralai": "^1.10.0",
+    "@mistralai/mistralai": "^2.2.1",
     "@modelcontextprotocol/sdk": "^1.27.0",
     "@napi-rs/blake-hash": "^1.3.6",
     "@notionhq/client": "^5.13.0",

--- a/front/types/assistant/models/mistral.ts
+++ b/front/types/assistant/models/mistral.ts
@@ -33,7 +33,7 @@ export const MISTRAL_LARGE_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "sentence_piece", base: "model_v2" },
   supportsBatchProcessing: true,
   regionalAvailability: {
-    "us-central1": true,
+    "us-central1": false,
     "europe-west1": true,
   },
 };
@@ -57,7 +57,7 @@ export const MISTRAL_MEDIUM_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "sentence_piece", base: "model_v2" },
   supportsBatchProcessing: true,
   regionalAvailability: {
-    "us-central1": true,
+    "us-central1": false,
     "europe-west1": true,
   },
 };
@@ -83,7 +83,7 @@ export const MISTRAL_MEDIUM_3_5_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   supportsResponseFormat: true,
   regionalAvailability: {
-    "us-central1": true,
+    "us-central1": false,
     "europe-west1": true,
   },
 };
@@ -107,7 +107,7 @@ export const MISTRAL_SMALL_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "sentence_piece", base: "model_v2" },
   supportsBatchProcessing: true,
   regionalAvailability: {
-    "us-central1": true,
+    "us-central1": false,
     "europe-west1": true,
   },
 };
@@ -132,7 +132,7 @@ export const MISTRAL_CODESTRAL_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "sentence_piece", base: "model_v2" },
   supportsBatchProcessing: true,
   regionalAvailability: {
-    "us-central1": true,
+    "us-central1": false,
     "europe-west1": true,
   },
 };

--- a/front/types/assistant/models/mistral.ts
+++ b/front/types/assistant/models/mistral.ts
@@ -81,6 +81,7 @@ export const MISTRAL_MEDIUM_3_5_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   tokenizer: { type: "sentence_piece", base: "model_v2" },
   supportsBatchProcessing: true,
+  supportsResponseFormat: true,
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -512,7 +512,7 @@
         "@mendable/firecrawl-js": "^1.29.1",
         "@metronome/sdk": "^3.4.1",
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@mistralai/mistralai": "^1.10.0",
+        "@mistralai/mistralai": "^2.2.1",
         "@modelcontextprotocol/sdk": "^1.27.0",
         "@napi-rs/blake-hash": "^1.3.6",
         "@notionhq/client": "^5.13.0",
@@ -8990,13 +8990,14 @@
       }
     },
     "node_modules/@mistralai/mistralai": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
-      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.24.1"
+        "zod-to-json-schema": "^3.25.0"
       }
     },
     "node_modules/@mixmark-io/domino": {


### PR DESCRIPTION
## Description

Bumps `@mistralai/mistralai` to v2, wires `responseFormat` through `getLLM` into `MistralLLM` (mapped to Mistral's `json_schema` shape) and enables it on Mistral Medium 3.5, and corrects `regionalAvailability` for all Mistral models — `us-central1` is flipped to `false` (no-op today since the flag isn't used for routing yet). The v2 SDK turns `BatchJobStatus` into an `OpenEnum`, so the exhaustive switch now logs and throws on unknown statuses instead of using `assertNever`.

## Tests

Tested with `llm.test.ts`.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->