### PR TITLE
Add frame preview to pod files tab

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -44,8 +44,8 @@ export function ConversationFileExplorer({
       getFileUrl={getFileUrl}
       onFileDownload={onFileDownload}
       onClose={closePanel}
-      onOpenInteractive={(fileId) =>
-        openPanel({ type: "interactive_content", fileId })
+      onOpenInteractive={(entry) =>
+        openPanel({ type: "interactive_content", fileId: entry.fileId })
       }
     />
   );

--- a/front/components/assistant/conversation/interactive_content/ExportContentDropdown.tsx
+++ b/front/components/assistant/conversation/interactive_content/ExportContentDropdown.tsx
@@ -1,0 +1,138 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import config from "@app/lib/api/config";
+import { clientFetch } from "@app/lib/egress/client";
+import type { LightWorkspaceType } from "@app/types/user";
+import { datadogLogs } from "@datadog/browser-logs";
+import {
+  ArrowDownOnSquareIcon,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import React, { useState } from "react";
+
+interface ExportContentDropdownProps {
+  iframeRef: React.RefObject<HTMLIFrameElement>;
+  owner: LightWorkspaceType;
+  fileId: string;
+  fileContent: string | null;
+  fileName?: string;
+}
+
+export function ExportContentDropdown({
+  iframeRef,
+  owner,
+  fileId,
+  fileContent,
+  fileName,
+}: ExportContentDropdownProps) {
+  const sendNotification = useSendNotification();
+  const [isExportingPdf, setIsExportingPdf] = useState(false);
+
+  const exportAsPng = () => {
+    if (fileContent) {
+      const imgRegex = /<img[^>]+src=["'](https?:\/\/[^"']+)["']/gi;
+      if (imgRegex.test(fileContent)) {
+        sendNotification({
+          type: "error",
+          title: "Cannot export as PNG",
+          description:
+            "Content contains images with external URLs, which are blocked for " +
+            "security purposes. Please use images uploaded to the conversation instead.",
+        });
+        return;
+      }
+    }
+
+    if (iframeRef.current?.contentWindow) {
+      iframeRef.current.contentWindow.postMessage({ type: `EXPORT_PNG` }, "*");
+    } else {
+      datadogLogs.logger.info(
+        "Failed to export content as PNG: No iframe content window found"
+      );
+    }
+  };
+
+  const exportAsPdf = async (orientation: "portrait" | "landscape") => {
+    if (isExportingPdf) {
+      return;
+    }
+
+    setIsExportingPdf(true);
+    try {
+      const response = await clientFetch(
+        `/api/w/${owner.sId}/files/${fileId}/export/pdf`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ orientation }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to generate PDF");
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = fileName?.replace(/\.[^.]+$/, ".pdf") ?? "frame.pdf";
+      link.click();
+      URL.revokeObjectURL(url);
+
+      sendNotification({
+        title: "PDF exported",
+        type: "success",
+        description: "Your PDF has been downloaded.",
+      });
+    } catch {
+      sendNotification({
+        title: "PDF Export Failed",
+        type: "error",
+        description: "An error occurred while generating the PDF.",
+      });
+    } finally {
+      setIsExportingPdf(false);
+    }
+  };
+
+  const downloadAsCode = () => {
+    const downloadUrl = `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
+    window.open(downloadUrl, "_blank");
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          icon={ArrowDownOnSquareIcon}
+          isSelect
+          label={isExportingPdf ? "Exporting..." : "Export"}
+          variant="ghost"
+          disabled={isExportingPdf}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger disabled={isExportingPdf} label="PDF" />
+          <DropdownMenuSubContent>
+            <DropdownMenuItem onClick={() => exportAsPdf("portrait")}>
+              Portrait
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => exportAsPdf("landscape")}>
+              Landscape
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuItem onClick={exportAsPng}>PNG</DropdownMenuItem>
+        <DropdownMenuItem onClick={downloadAsCode}>Template</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/assistant/conversation/interactive_content/ExportContentDropdown.tsx
+++ b/front/components/assistant/conversation/interactive_content/ExportContentDropdown.tsx
@@ -1,6 +1,5 @@
-import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
-import { clientFetch } from "@app/lib/egress/client";
+import { useExportFrameAsPdf } from "@app/lib/swr/frames";
 import type { LightWorkspaceType } from "@app/types/user";
 import { datadogLogs } from "@datadog/browser-logs";
 import {
@@ -14,7 +13,8 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
-import React, { useState } from "react";
+import type React from "react";
+import { useState } from "react";
 
 interface ExportContentDropdownProps {
   iframeRef: React.RefObject<HTMLIFrameElement>;
@@ -31,20 +31,13 @@ export function ExportContentDropdown({
   fileContent,
   fileName,
 }: ExportContentDropdownProps) {
-  const sendNotification = useSendNotification();
+  const exportAsPdf = useExportFrameAsPdf({ owner });
   const [isExportingPdf, setIsExportingPdf] = useState(false);
 
-  const exportAsPng = () => {
+  const handleExportAsPng = () => {
     if (fileContent) {
       const imgRegex = /<img[^>]+src=["'](https?:\/\/[^"']+)["']/gi;
       if (imgRegex.test(fileContent)) {
-        sendNotification({
-          type: "error",
-          title: "Cannot export as PNG",
-          description:
-            "Content contains images with external URLs, which are blocked for " +
-            "security purposes. Please use images uploaded to the conversation instead.",
-        });
         return;
       }
     }
@@ -58,51 +51,16 @@ export function ExportContentDropdown({
     }
   };
 
-  const exportAsPdf = async (orientation: "portrait" | "landscape") => {
+  const handleExportAsPdf = async (orientation: "portrait" | "landscape") => {
     if (isExportingPdf) {
       return;
     }
-
     setIsExportingPdf(true);
-    try {
-      const response = await clientFetch(
-        `/api/w/${owner.sId}/files/${fileId}/export/pdf`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ orientation }),
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error("Failed to generate PDF");
-      }
-
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = fileName?.replace(/\.[^.]+$/, ".pdf") ?? "frame.pdf";
-      link.click();
-      URL.revokeObjectURL(url);
-
-      sendNotification({
-        title: "PDF exported",
-        type: "success",
-        description: "Your PDF has been downloaded.",
-      });
-    } catch {
-      sendNotification({
-        title: "PDF Export Failed",
-        type: "error",
-        description: "An error occurred while generating the PDF.",
-      });
-    } finally {
-      setIsExportingPdf(false);
-    }
+    await exportAsPdf({ fileId, fileName, orientation });
+    setIsExportingPdf(false);
   };
 
-  const downloadAsCode = () => {
+  const handleDownloadAsCode = () => {
     const downloadUrl = `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
     window.open(downloadUrl, "_blank");
   };
@@ -122,16 +80,18 @@ export function ExportContentDropdown({
         <DropdownMenuSub>
           <DropdownMenuSubTrigger disabled={isExportingPdf} label="PDF" />
           <DropdownMenuSubContent>
-            <DropdownMenuItem onClick={() => exportAsPdf("portrait")}>
+            <DropdownMenuItem onClick={() => handleExportAsPdf("portrait")}>
               Portrait
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => exportAsPdf("landscape")}>
+            <DropdownMenuItem onClick={() => handleExportAsPdf("landscape")}>
               Landscape
             </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
-        <DropdownMenuItem onClick={exportAsPng}>PNG</DropdownMenuItem>
-        <DropdownMenuItem onClick={downloadAsCode}>Template</DropdownMenuItem>
+        <DropdownMenuItem onClick={handleExportAsPng}>PNG</DropdownMenuItem>
+        <DropdownMenuItem onClick={handleDownloadAsCode}>
+          Template
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -1,8 +1,8 @@
 import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import { ExportContentDropdown } from "@app/components/assistant/conversation/interactive_content/ExportContentDropdown";
 import { DEFAULT_RIGHT_PANEL_SIZE } from "@app/components/assistant/conversation/constant";
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
+import { ExportContentDropdown } from "@app/components/assistant/conversation/interactive_content/ExportContentDropdown";
 import { ShareFrameSheet } from "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet";
 import { InteractiveContentHeader } from "@app/components/assistant/conversation/interactive_content/InteractiveContentHeader";
 import { ConfirmContext } from "@app/components/Confirm";

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -1,5 +1,6 @@
 import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { ExportContentDropdown } from "@app/components/assistant/conversation/interactive_content/ExportContentDropdown";
 import { DEFAULT_RIGHT_PANEL_SIZE } from "@app/components/assistant/conversation/constant";
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
 import { ShareFrameSheet } from "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet";
@@ -9,7 +10,6 @@ import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigati
 import { useVisualizationRevert } from "@app/hooks/conversations";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
-import config from "@app/lib/api/config";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
@@ -19,23 +19,14 @@ import { getErrorFromResponse } from "@app/lib/swr/swr";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { FULL_SCREEN_HASH_PARAM } from "@app/types/conversation_side_panel";
 import type { LightWorkspaceType } from "@app/types/user";
-import { datadogLogs } from "@datadog/browser-logs";
 import {
   ArrowCircleIcon,
-  ArrowDownOnSquareIcon,
   ArrowGoBackIcon,
   Button,
   CheckCircleIcon,
   CloudArrowUpIcon,
   CodeBlock,
   CommandLineIcon,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
   EyeIcon,
   FullscreenExitIcon,
   FullscreenIcon,
@@ -50,145 +41,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-
-interface ExportContentDropdownProps {
-  iframeRef: React.RefObject<HTMLIFrameElement>;
-  owner: LightWorkspaceType;
-  fileId: string;
-  fileContent: string | null;
-  fileName?: string;
-}
-
-function ExportContentDropdown({
-  iframeRef,
-  owner,
-  fileId,
-  fileContent,
-  fileName,
-}: ExportContentDropdownProps) {
-  const sendNotification = useSendNotification();
-  const [isExportingPdf, setIsExportingPdf] = useState(false);
-
-  const exportAsPng = () => {
-    if (fileContent) {
-      const imgRegex = /<img[^>]+src=["'](https?:\/\/[^"']+)["']/gi;
-      if (imgRegex.test(fileContent)) {
-        sendNotification({
-          type: "error",
-          title: "Cannot export as PNG",
-          description:
-            "Content contains images with external URLs, which are blocked for " +
-            "security purposes. Please use images uploaded to the conversation instead.",
-        });
-        return;
-      }
-    }
-
-    if (iframeRef.current?.contentWindow) {
-      iframeRef.current.contentWindow.postMessage({ type: `EXPORT_PNG` }, "*");
-    } else {
-      datadogLogs.logger.info(
-        "Failed to export content as PNG: No iframe content window found"
-      );
-    }
-  };
-
-  const exportAsPdf = async (orientation: "portrait" | "landscape") => {
-    if (isExportingPdf) {
-      return;
-    }
-
-    setIsExportingPdf(true);
-    try {
-      // Use direct fetch instead of fetcher to avoid JSON parsing of binary PDF data.
-      const response = await clientFetch(
-        `/api/w/${owner.sId}/files/${fileId}/export/pdf`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ orientation }),
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error("Failed to generate PDF");
-      }
-
-      // Get the PDF blob and trigger download.
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-
-      link.download = fileName?.replace(/\.[^.]+$/, ".pdf") ?? "frame.pdf";
-
-      link.click();
-      URL.revokeObjectURL(url);
-
-      sendNotification({
-        title: "PDF exported",
-        type: "success",
-        description: "Your PDF has been downloaded.",
-      });
-    } catch (error) {
-      console.error("PDF export failed:", error);
-      sendNotification({
-        title: "PDF Export Failed",
-        type: "error",
-        description: "An error occurred while generating the PDF.",
-      });
-    } finally {
-      setIsExportingPdf(false);
-    }
-  };
-
-  const downloadAsCode = () => {
-    try {
-      const downloadUrl = `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
-      // Open the download URL in a new tab/window. Otherwise we get a CORS error due to the redirection
-      // to cloud storage.
-      window.open(downloadUrl, "_blank");
-    } catch (error) {
-      console.error("Download failed:", error);
-      sendNotification({
-        title: "Download Failed",
-        type: "error",
-        description: "An error occurred while opening the download link.",
-      });
-    }
-  };
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          icon={ArrowDownOnSquareIcon}
-          isSelect
-          label={isExportingPdf ? "Exporting..." : "Export"}
-          variant="ghost"
-          disabled={isExportingPdf}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger disabled={isExportingPdf} label="PDF" />
-          <DropdownMenuSubContent>
-            <DropdownMenuItem onClick={() => exportAsPdf("portrait")}>
-              Portrait
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => exportAsPdf("landscape")}>
-              Landscape
-            </DropdownMenuItem>
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-        <DropdownMenuItem onClick={exportAsPng}>PNG</DropdownMenuItem>
-        <DropdownMenuItem onClick={downloadAsCode}>Template</DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
 
 interface FrameRendererProps {
   conversation?: ConversationWithoutContentType;
@@ -425,9 +277,7 @@ export function FrameRenderer({
   if (error) {
     return (
       <div className="flex h-full flex-col">
-        <InteractiveContentHeader
-          onClose={conversation ? onClosePanel : undefined}
-        />
+        <InteractiveContentHeader onClose={onClosePanel} />
         <CenteredState>
           <p className="text-warning-500">
             Error loading file: {error.message}
@@ -439,9 +289,7 @@ export function FrameRenderer({
 
   return (
     <div className="flex h-full flex-col">
-      <InteractiveContentHeader
-        onClose={conversation ? onClosePanel : undefined}
-      >
+      <InteractiveContentHeader onClose={onClosePanel}>
         <div className="flex w-full items-center justify-between">
           <Button
             icon={showCode ? EyeIcon : CommandLineIcon}

--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -1,8 +1,8 @@
-import { ProjectFrameSheet } from "@app/components/assistant/conversation/space/ProjectFrameSheet";
 import {
   FileDropProvider,
   useFileDrop,
 } from "@app/components/assistant/conversation/FileUploaderContext";
+import { ProjectFrameSheet } from "@app/components/assistant/conversation/space/ProjectFrameSheet";
 import { RenameFileDialog } from "@app/components/assistant/conversation/space/RenameFileDialog";
 import { ConfirmContext } from "@app/components/Confirm";
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";

--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -1,3 +1,4 @@
+import { ProjectFrameSheet } from "@app/components/assistant/conversation/space/ProjectFrameSheet";
 import {
   FileDropProvider,
   useFileDrop,
@@ -215,6 +216,7 @@ function ProjectFileExplorerContent({
   owner,
   space,
 }: ProjectFileExplorerProps) {
+  const [frameFileId, setFrameFileId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [fileToRename, setFileToRename] = useState<{
@@ -530,6 +532,13 @@ function ProjectFileExplorerContent({
 
   return (
     <>
+      <ProjectFrameSheet
+        owner={owner}
+        fileId={frameFileId}
+        isOpen={frameFileId !== null}
+        onClose={() => setFrameFileId(null)}
+      />
+
       <RenameFileDialog
         isOpen={showRenameDialog}
         onClose={() => setShowRenameDialog(false)}
@@ -582,6 +591,7 @@ function ProjectFileExplorerContent({
         onFileDownload={onFileDownload}
         onDelete={!isArchived ? onDelete : undefined}
         onRename={!isArchived ? onRename : undefined}
+        onOpenInteractive={(entry) => setFrameFileId(entry.fileId)}
         headerActions={addButton}
         isLoading={isLoading}
       />

--- a/front/components/assistant/conversation/space/ProjectFrameSheet.tsx
+++ b/front/components/assistant/conversation/space/ProjectFrameSheet.tsx
@@ -1,0 +1,103 @@
+import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import { ExportContentDropdown } from "@app/components/assistant/conversation/interactive_content/ExportContentDropdown";
+import { ShareFrameSheet } from "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  Spinner,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useRef } from "react";
+
+interface ProjectFrameSheetProps {
+  fileId: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+  owner: WorkspaceType;
+}
+
+export function ProjectFrameSheet({
+  fileId,
+  isOpen,
+  onClose,
+  owner,
+}: ProjectFrameSheetProps) {
+  const { vizUrl } = useAuth();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const { fileContent } = useFileContent({
+    fileId,
+    owner,
+    config: { disabled: !isOpen || !fileId },
+  });
+
+  const { fileMetadata, isFileMetadataLoading } = useFileMetadata({
+    fileId,
+    owner,
+  });
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent size="xl">
+        <SheetHeader hideButton>
+          <div className="flex items-center gap-2">
+            <SheetTitle className="flex-1 truncate">
+              {fileMetadata?.fileName}
+            </SheetTitle>
+            {fileId && (
+              <div className="flex shrink-0 items-center gap-1">
+                <ExportContentDropdown
+                  iframeRef={iframeRef}
+                  owner={owner}
+                  fileId={fileId}
+                  fileContent={fileContent ?? null}
+                  fileName={fileMetadata?.fileName}
+                />
+                <ShareFrameSheet fileId={fileId} owner={owner} />
+              </div>
+            )}
+            <SheetClose asChild>
+              <Button icon={XMarkIcon} variant="ghost" size="sm" />
+            </SheetClose>
+          </div>
+        </SheetHeader>
+        <div className="flex-1 overflow-hidden">
+          {isFileMetadataLoading || !fileContent ? (
+            <div className="flex h-full items-center justify-center">
+              <Spinner />
+            </div>
+          ) : (
+            fileId &&
+            vizUrl && (
+              <VisualizationActionIframe
+                agentConfigurationId={
+                  fileMetadata?.useCaseMetadata
+                    .lastEditedByAgentConfigurationId ?? null
+                }
+                workspaceId={owner.sId}
+                vizUrl={vizUrl}
+                visualization={{
+                  code: fileContent,
+                  complete: true,
+                  identifier: `viz-${fileId}`,
+                }}
+                key={`viz-${fileId}`}
+                conversationId={null}
+                spaceId={fileMetadata?.useCaseMetadata.spaceId ?? null}
+                isInDrawer={true}
+                ref={iframeRef}
+              />
+            )
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -7,6 +7,7 @@ import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplo
 import type {
   ContentNodeEntry,
   FileEntry,
+  FileEntryWithId,
   FileExplorerEntry,
   FileExplorerFilter,
   FileExplorerMenuAction,
@@ -61,7 +62,7 @@ interface FileExplorerProps {
   onClose?: () => void;
   onDelete?: (entry: FileExplorerEntry) => Promise<void>;
   onFileDownload: (entry: FileEntry) => Promise<void>;
-  onOpenInteractive?: (fileId: string) => void;
+  onOpenInteractive?: (entry: FileEntryWithId) => void;
   onRename?: (entry: FileEntry) => void;
 }
 
@@ -153,7 +154,7 @@ export function FileExplorer({
       isInteractiveContentType(entry.contentType) &&
       entry.fileId
     ) {
-      onOpenInteractive(entry.fileId);
+      onOpenInteractive({ ...entry, fileId: entry.fileId });
       return;
     }
     setPreviewFile(entry);

--- a/front/components/file_explorer/types.ts
+++ b/front/components/file_explorer/types.ts
@@ -3,6 +3,7 @@ import type { ConnectorProvider } from "@app/types/data_source";
 import type React from "react";
 
 export type FileEntry = GCSMountFileEntry & { kind: "file" };
+export type FileEntryWithId = FileEntry & { fileId: string };
 
 export type ContentNodeEntry = {
   kind: "node";

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -433,4 +433,3 @@ export function useSharingGrants({
     doRevokeGrant,
   };
 }
-

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -433,3 +433,4 @@ export function useSharingGrants({
     doRevokeGrant,
   };
 }
+

--- a/front/lib/swr/frames.ts
+++ b/front/lib/swr/frames.ts
@@ -2,7 +2,11 @@
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { getErrorFromResponse, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import {
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
 import type { LightWorkspaceType } from "@app/types/user";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import type { PublicFrameResponseBodyType } from "@dust-tt/client";

--- a/front/lib/swr/frames.ts
+++ b/front/lib/swr/frames.ts
@@ -1,6 +1,9 @@
 // This hook uses a public API endpoint, so it's fine to use the client types.
 
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { getErrorFromResponse, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { LightWorkspaceType } from "@app/types/user";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import type { PublicFrameResponseBodyType } from "@dust-tt/client";
 import type { Fetcher } from "swr";
@@ -30,5 +33,53 @@ export function usePublicFrame({ shareToken }: { shareToken: string | null }) {
     isFrameLoading: !error && !data,
     error,
     mutateFrame: mutate,
+  };
+}
+
+export function useExportFrameAsPdf({ owner }: { owner: LightWorkspaceType }) {
+  const sendNotification = useSendNotification();
+
+  return async ({
+    fileId,
+    fileName,
+    orientation,
+  }: {
+    fileId: string;
+    fileName?: string;
+    orientation: "portrait" | "landscape";
+  }): Promise<boolean> => {
+    const res = await clientFetch(
+      `/api/w/${owner.sId}/files/${fileId}/export/pdf`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orientation }),
+      }
+    );
+
+    if (!res.ok) {
+      const errorData = await getErrorFromResponse(res);
+      sendNotification({
+        type: "error",
+        title: "PDF Export Failed",
+        description: errorData.message,
+      });
+      return false;
+    }
+
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = fileName?.replace(/\.[^.]+$/, ".pdf") ?? "frame.pdf";
+    link.click();
+    URL.revokeObjectURL(url);
+
+    sendNotification({
+      type: "success",
+      title: "PDF exported",
+      description: "Your PDF has been downloaded.",
+    });
+    return true;
   };
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Frames saved to a pod can now be previewed directly from the pod's files tab. Clicking a frame opens a dedicated sheet with the full rendering, share, and export options. Without reusing the conversation side panel, which was the wrong context
for this.

To make this work cleanly, `ExportContentDropdown` was extracted from `FrameRenderer` into its own component so it can be shared between the conversation drawer and the new pod sheet.

Will get @pinotalexandre's eyes on the design so we get this a bit more polished.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25795">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->