### PR TITLE
Add backend support for creating folders in Pod file mounts.

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
@@ -1,6 +1,10 @@
+import { isGCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
 import { listGCSMountFiles } from "@app/lib/api/files/gcs_mount/files";
+import { createProjectFolder } from "@app/lib/api/projects/context";
+import { PostPodFolderRequestBodySchema } from "@app/lib/api/projects/pod_mount_schemas";
 import { spaceResource } from "@front-api/middleware/space_resource";
 import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
 
 import rel from "./[...rel]";
@@ -29,6 +33,57 @@ app.get("/", spaceResource({ requireCanRead: true }), async (c) => {
 
   return c.json({ files });
 });
+
+app.post(
+  "/",
+  spaceResource({ requireCanRead: true }),
+  validate("json", PostPodFolderRequestBodySchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const space = c.get("space");
+
+    if (!space.isProject()) {
+      return apiError(c, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Files are only available for project spaces.",
+        },
+      });
+    }
+
+    if (!space.canWrite(auth)) {
+      return apiError(c, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "You do not have write access to this project.",
+        },
+      });
+    }
+
+    const { folderName, parentRelativePath } = c.req.valid("json");
+
+    const createResult = await createProjectFolder(auth, {
+      space,
+      folderName,
+      parentRelativePath,
+    });
+    if (createResult.isErr()) {
+      return apiError(c, {
+        status_code: isGCSMountDirectoryAlreadyExistsError(createResult.error)
+          ? 409
+          : 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: createResult.error.message,
+        },
+      });
+    }
+
+    return c.json({ folder: createResult.value }, 201);
+  }
+);
 
 // Catch-all wildcard for /files/<...rel>. Registered AFTER `/` to avoid
 // swallowing requests to the bare /files endpoint.

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/files/[fileId]/move.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/files/[fileId]/move.ts
@@ -1,0 +1,79 @@
+import { moveProjectContextFile } from "@app/lib/api/projects/context";
+import { MovePodContextFileRequestBodySchema } from "@app/lib/api/projects/pod_mount_schemas";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { spaceResource } from "@front-api/middleware/space_resource";
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+
+// Mounted under /api/w/:wId/spaces/:spaceId/project_context/files/:fileId/move.
+const app = new Hono();
+
+app.post(
+  "/",
+  spaceResource({ requireCanRead: true }),
+  validate("json", MovePodContextFileRequestBodySchema),
+  async (c) => {
+    const auth = c.get("auth");
+    const space = c.get("space");
+    const fileId = c.req.param("fileId") ?? "";
+
+    if (!space.isProject()) {
+      return apiError(c, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Only project spaces support project context file moves.",
+        },
+      });
+    }
+
+    if (!space.canWrite(auth)) {
+      return apiError(c, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "You do not have write access to this project.",
+        },
+      });
+    }
+
+    const file = await FileResource.fetchById(auth, fileId);
+    if (!file) {
+      return apiError(c, {
+        status_code: 404,
+        api_error: {
+          type: "file_not_found",
+          message: "File not found.",
+        },
+      });
+    }
+
+    const { parentRelativePath } = c.req.valid("json");
+
+    const moveResult = await moveProjectContextFile(auth, {
+      space,
+      file,
+      parentRelativePath,
+    });
+    if (moveResult.isErr()) {
+      const error = moveResult.error;
+      const statusCode =
+        "code" in error && error.code === "invalid_request_error" ? 400 : 500;
+      return apiError(c, {
+        status_code: statusCode,
+        api_error: {
+          type:
+            statusCode === 400
+              ? "invalid_request_error"
+              : "internal_server_error",
+          message: error.message,
+        },
+      });
+    }
+
+    return c.json({});
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/files/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/files/index.ts
@@ -1,10 +1,12 @@
 import { Hono } from "hono";
 
 import fileId from "./[fileId]";
+import fileMove from "./[fileId]/move";
 
 // Mounted under /api/w/:wId/spaces/:spaceId/project_context/files.
 const app = new Hono();
 
+app.route("/:fileId/move", fileMove);
 app.route("/:fileId", fileId);
 
 export default app;

--- a/front/lib/api/files/gcs_mount/errors.ts
+++ b/front/lib/api/files/gcs_mount/errors.ts
@@ -1,0 +1,12 @@
+export class GCSMountDirectoryAlreadyExistsError extends Error {
+  constructor() {
+    super("Folder already exists.");
+    this.name = "GCSMountDirectoryAlreadyExistsError";
+  }
+}
+
+export function isGCSMountDirectoryAlreadyExistsError(
+  error: unknown
+): error is GCSMountDirectoryAlreadyExistsError {
+  return error instanceof GCSMountDirectoryAlreadyExistsError;
+}

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -1,6 +1,8 @@
+import { GCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
 import {
   copyConversationGCSMount,
   copyMountFile,
+  createGCSMountDirectory,
   createGCSMountFile,
   deleteGCSMountFile,
   type GCSMountFileEntry,
@@ -121,6 +123,78 @@ describe("createGCSMountFile", () => {
 
     assert(entryRes.isOk());
     expect(entryRes.value.thumbnailUrl).toBeNull();
+  });
+});
+
+describe("createGCSMountDirectory", () => {
+  let auth: Authenticator;
+  let conversationId: string;
+  let workspaceId: string;
+  let saveMock: ReturnType<typeof vi.fn>;
+  let existsMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    existsMock = vi.fn().mockResolvedValue([false]);
+    saveMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({ save: saveMock, exists: existsMock })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator, conversationsSpace } = await createResourceTest({});
+    auth = authenticator;
+    workspaceId = auth.getNonNullableWorkspace().sId;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+    conversationId = conversation.sId;
+  });
+
+  it("writes a trailing-slash placeholder to the correct GCS path", async () => {
+    const entryRes = await createGCSMountDirectory(
+      auth,
+      { useCase: "conversation", conversationId },
+      { relativeDirPath: "reports/q1" }
+    );
+
+    assert(entryRes.isOk());
+    expect(entryRes.value).toMatchObject({
+      isDirectory: true,
+      fileName: "q1",
+      path: "conversation/reports/q1",
+      sizeBytes: 0,
+    });
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${workspaceId}/conversations/${conversationId}/files/reports/q1/`
+    );
+    expect(saveMock).toHaveBeenCalledWith(Buffer.alloc(0), {
+      contentType: "application/x-directory",
+    });
+  });
+
+  it("returns Err when the folder already exists", async () => {
+    existsMock.mockResolvedValue([true]);
+
+    const entryRes = await createGCSMountDirectory(
+      auth,
+      { useCase: "conversation", conversationId },
+      { relativeDirPath: "reports" }
+    );
+
+    expect(entryRes.isErr()).toBe(true);
+    if (entryRes.isErr()) {
+      expect(entryRes.error).toBeInstanceOf(
+        GCSMountDirectoryAlreadyExistsError
+      );
+    }
+    expect(saveMock).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { GCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
 import {
   getConversationFilesBasePath,
   getProjectFilesBasePath,
@@ -399,6 +400,52 @@ export async function createGCSMountFile(
       },
       scope,
       owner.sId
+    )
+  );
+}
+
+/**
+ * Create an empty folder in a GCS mount point via a zero-byte object whose name ends with "/".
+ * Returns the entry as it would appear in listGCSMountFiles.
+ */
+export async function createGCSMountDirectory(
+  auth: Authenticator,
+  scope: GCSMountPoint,
+  { relativeDirPath }: { relativeDirPath: string }
+): Promise<Result<GCSMountDirectoryEntry, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const prefix = resolvePrefix(owner, scope);
+
+  const normalized = relativeDirPath.replace(/^\/+|\/+$/g, "");
+  if (!normalized) {
+    return new Err(new Error("relativeDirPath is required."));
+  }
+
+  const gcsPath = `${prefix}${normalized}/`;
+  const bucket = getPrivateUploadBucket();
+  try {
+    const [exists] = await bucket.file(gcsPath).exists();
+    if (exists) {
+      return new Err(new GCSMountDirectoryAlreadyExistsError());
+    }
+
+    await bucket.file(gcsPath).save(Buffer.alloc(0), {
+      contentType: "application/x-directory",
+    });
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+
+  const fileName = normalized.split("/").pop() ?? normalized;
+  return new Ok(
+    makeDirectoryEntry(
+      {
+        fileName,
+        relativeFilePath: normalized,
+        sizeBytes: 0,
+        lastModifiedMs: Date.now(),
+      },
+      scope
     )
   );
 }

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -5,8 +5,10 @@ import {
   getConversationFilesBasePath,
   getProjectFilesBasePath,
   makeProcessedMountFileName,
+  normalizeMountParentRelativePath,
   parseProcessedFilename,
   parseScopedFilePath,
+  validateMountFolderName,
 } from "@app/lib/api/files/mount_path";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -179,6 +181,50 @@ describe("mount_path helpers", () => {
         isProcessed: false,
       });
       expect(parseProcessedFilename("")).toEqual({ isProcessed: false });
+    });
+  });
+
+  describe("validateMountFolderName", () => {
+    it("accepts a simple folder name", () => {
+      const result = validateMountFolderName("  Reports  ");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("Reports");
+      }
+    });
+
+    it("rejects path separators and empty names", () => {
+      expect(validateMountFolderName("").isErr()).toBe(true);
+      expect(validateMountFolderName("a/b").isErr()).toBe(true);
+      expect(validateMountFolderName("..").isErr()).toBe(true);
+    });
+  });
+
+  describe("normalizeMountParentRelativePath", () => {
+    it("normalizes empty to mount root", () => {
+      const undefinedResult = normalizeMountParentRelativePath(undefined);
+      expect(undefinedResult.isOk()).toBe(true);
+      if (undefinedResult.isOk()) {
+        expect(undefinedResult.value).toBe("");
+      }
+
+      const emptyResult = normalizeMountParentRelativePath("");
+      expect(emptyResult.isOk()).toBe(true);
+      if (emptyResult.isOk()) {
+        expect(emptyResult.value).toBe("");
+      }
+    });
+
+    it("rejects path traversal", () => {
+      expect(normalizeMountParentRelativePath("../evil").isErr()).toBe(true);
+    });
+
+    it("strips leading slashes", () => {
+      const result = normalizeMountParentRelativePath("/reports/q1");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("reports/q1");
+      }
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -9,6 +9,8 @@
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { extensionsForContentType } from "@app/types/files";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import path from "path";
 import { z } from "zod";
 
 export function getBaseMountPathForWorkspace({
@@ -185,4 +187,65 @@ export function disambiguateFileName(file: FileResource): string {
   const basename = fileName.substring(0, lastDot);
   const ext = fileName.substring(lastDot);
   return `${basename}_${sId}${ext}`;
+}
+
+/**
+ * Validate a single folder segment name (no path separators).
+ */
+export function validateMountFolderName(
+  folderName: string
+): Result<string, Error> {
+  const trimmed = folderName.trim();
+  if (
+    trimmed === "" ||
+    trimmed.includes("/") ||
+    trimmed.includes("\\") ||
+    trimmed === "." ||
+    trimmed === ".."
+  ) {
+    return new Err(
+      new Error(
+        "folderName is required and must be a non-empty string without path separators."
+      )
+    );
+  }
+
+  return new Ok(trimmed);
+}
+
+/**
+ * Normalize a parent directory path within a mount (no `project/` prefix).
+ * Returns an empty string for the mount root.
+ */
+export function normalizeMountParentRelativePath(
+  parentRelativePath: string | undefined
+): Result<string, Error> {
+  if (parentRelativePath === undefined || parentRelativePath.trim() === "") {
+    return new Ok("");
+  }
+
+  const normalized = path.posix.normalize(
+    parentRelativePath.replace(/^\/+/, "")
+  );
+  if (normalized === "." || normalized === "") {
+    return new Ok("");
+  }
+
+  if (
+    normalized.startsWith("..") ||
+    normalized.split("/").some((part) => part === "..")
+  ) {
+    return new Err(new Error("parentRelativePath is outside mount scope."));
+  }
+
+  return new Ok(normalized);
+}
+
+export function joinMountRelativePath(
+  parentRelativePath: string,
+  folderName: string
+): string {
+  return parentRelativePath
+    ? `${parentRelativePath}/${folderName}`
+    : folderName;
 }

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -6,11 +6,18 @@ import {
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import {
+  createGCSMountDirectory,
   deleteGCSMountFile,
+  type GCSMountDirectoryEntry,
   moveFile,
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
-import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
+import {
+  getProjectFilesBasePath,
+  joinMountRelativePath,
+  normalizeMountParentRelativePath,
+  validateMountFolderName,
+} from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { MessageModel } from "@app/lib/models/agent/conversation";
@@ -241,7 +248,7 @@ export async function addFileToProject(
     sourceConversationId?: string;
   }
 ): Promise<Result<ContentFragmentResource, DustError>> {
-  if (space.kind !== "project") {
+  if (!space.isProject()) {
     return new Err({
       name: "dust_error",
       code: "invalid_request_error",
@@ -249,30 +256,45 @@ export async function addFileToProject(
     });
   }
 
-  if (!file.mountFilePath) {
-    return new Err({
-      name: "dust_error",
-      code: "invalid_request_error",
-      message: "File has no mount path and cannot be moved to the project.",
-    });
-  }
-
-  const destFileName = file.fileName;
-  const moveRes = await moveFile(auth, {
-    file,
-    sourceGcsPath: file.mountFilePath,
-    destScope: { useCase: "project", projectId: space.sId },
-    destRelativeFilePath: destFileName,
-    destFileName,
-    destUseCase: "project_context",
-    destUseCaseMetadata: { spaceId: space.sId, sourceConversationId },
+  const owner = auth.getNonNullableWorkspace();
+  const projectFilesPrefix = getProjectFilesBasePath({
+    workspaceId: owner.sId,
+    projectId: space.sId,
   });
-  if (moveRes.isErr()) {
-    return new Err({
-      name: "dust_error",
-      code: "internal_error",
-      message: moveRes.error.message,
+
+  // Files already mounted under the project prefix only need content-fragment sync.
+  const isAlreadyOnProjectMount =
+    file.mountFilePath?.startsWith(projectFilesPrefix) ?? false;
+
+  if (!isAlreadyOnProjectMount) {
+    if (!file.mountFilePath) {
+      return new Err({
+        name: "dust_error",
+        code: "invalid_request_error",
+        message: "File has no mount path and cannot be moved to the project.",
+      });
+    }
+
+    const destFileName = file.fileName;
+    const moveRes = await moveFile(auth, {
+      file,
+      sourceGcsPath: file.mountFilePath,
+      destScope: { useCase: "project", projectId: space.sId },
+      destRelativeFilePath: destFileName,
+      destFileName,
+      destUseCase: "project_context",
+      destUseCaseMetadata: {
+        spaceId: space.sId,
+        ...(sourceConversationId ? { sourceConversationId } : {}),
+      },
     });
+    if (moveRes.isErr()) {
+      return new Err({
+        name: "dust_error",
+        code: "internal_error",
+        message: moveRes.error.message,
+      });
+    }
   }
 
   // TODO(projects) once the source of truth for the project's files is GCS, we can remove this.
@@ -309,7 +331,7 @@ export async function addContentNodeToProject(
     space: SpaceResource;
   }
 ): Promise<Result<ContentFragmentResource, DustError>> {
-  if (space.kind !== "project") {
+  if (!space.isProject()) {
     return new Err({
       name: "dust_error",
       code: "invalid_request_error",
@@ -442,6 +464,137 @@ export async function removeFileFromProject(
   const deleteRes = await file.delete(auth);
   if (deleteRes.isErr()) {
     return new Err(deleteRes.error);
+  }
+
+  return new Ok(undefined);
+}
+
+/**
+ * Create an empty folder in a project GCS mount via a trailing-slash placeholder object.
+ */
+export async function createProjectFolder(
+  auth: Authenticator,
+  {
+    space,
+    folderName,
+    parentRelativePath,
+  }: {
+    space: SpaceResource;
+    folderName: string;
+    parentRelativePath?: string;
+  }
+): Promise<Result<GCSMountDirectoryEntry, Error>> {
+  if (!space.isProject()) {
+    return new Err(new Error("Space is not a project."));
+  }
+
+  const folderNameRes = validateMountFolderName(folderName);
+  if (folderNameRes.isErr()) {
+    return folderNameRes;
+  }
+
+  const parentRes = normalizeMountParentRelativePath(parentRelativePath);
+  if (parentRes.isErr()) {
+    return parentRes;
+  }
+
+  const relativeDirPath = joinMountRelativePath(
+    parentRes.value,
+    folderNameRes.value
+  );
+
+  return createGCSMountDirectory(
+    auth,
+    { useCase: "project", projectId: space.sId },
+    { relativeDirPath }
+  );
+}
+
+/**
+ * Move a project-context file within the project GCS mount (e.g. into a subfolder).
+ * Upload via the File API first; call this to place the file under `parentRelativePath`.
+ */
+export async function moveProjectContextFile(
+  auth: Authenticator,
+  {
+    space,
+    file,
+    parentRelativePath,
+  }: {
+    space: SpaceResource;
+    file: FileResource;
+    parentRelativePath?: string;
+  }
+): Promise<Result<void, DustError | Error>> {
+  if (!space.isProject()) {
+    return new Err({
+      name: "dust_error",
+      code: "invalid_request_error",
+      message: "Space is not a project.",
+    });
+  }
+
+  if (file.useCase !== "project_context") {
+    return new Err({
+      name: "dust_error",
+      code: "invalid_request_error",
+      message:
+        "Only project context files can be moved within a project mount.",
+    });
+  }
+
+  if (file.useCaseMetadata?.spaceId !== space.sId) {
+    return new Err({
+      name: "dust_error",
+      code: "invalid_request_error",
+      message: "File does not belong to this project.",
+    });
+  }
+
+  if (!file.mountFilePath) {
+    return new Err({
+      name: "dust_error",
+      code: "invalid_request_error",
+      message: "File has no mount path and cannot be moved.",
+    });
+  }
+
+  const parentRes = normalizeMountParentRelativePath(parentRelativePath);
+  if (parentRes.isErr()) {
+    return new Err(parentRes.error);
+  }
+
+  const destRelativeFilePath = joinMountRelativePath(
+    parentRes.value,
+    file.fileName
+  );
+
+  const owner = auth.getNonNullableWorkspace();
+  const projectFilesPrefix = getProjectFilesBasePath({
+    workspaceId: owner.sId,
+    projectId: space.sId,
+  });
+  const destGcsPath = `${projectFilesPrefix}${destRelativeFilePath}`;
+
+  if (file.mountFilePath === destGcsPath) {
+    return new Ok(undefined);
+  }
+
+  const moveRes = await moveFile(auth, {
+    file,
+    sourceGcsPath: file.mountFilePath,
+    destScope: { useCase: "project", projectId: space.sId },
+    destRelativeFilePath,
+    destFileName: file.fileName,
+    destUseCase: "project_context",
+    destUseCaseMetadata: file.useCaseMetadata ?? { spaceId: space.sId },
+  });
+  if (moveRes.isErr()) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_error",
+      message: moveRes.error.message,
+    });
   }
 
   return new Ok(undefined);

--- a/front/lib/api/projects/pod_mount_schemas.ts
+++ b/front/lib/api/projects/pod_mount_schemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const PostPodFolderRequestBodySchema = z.object({
+  folderName: z.string().min(1, "folderName is required"),
+  parentRelativePath: z.string().optional(),
+});
+
+export const MovePodContextFileRequestBodySchema = z.object({
+  parentRelativePath: z.string().optional(),
+});

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -258,7 +258,7 @@ async function handler(
       });
     }
 
-    if (space.kind !== "project" && file.useCase === "project_context") {
+    if (!space.isProject() && file.useCase === "project_context") {
       return apiError(req, res, {
         status_code: 400,
         api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/index.ts
@@ -1,40 +1,43 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { isGCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
 import {
+  type GCSMountDirectoryEntry,
   type GCSMountEntry,
   type GCSMountFileEntry,
   listGCSMountFiles,
 } from "@app/lib/api/files/gcs_mount/files";
+import { createProjectFolder } from "@app/lib/api/projects/context";
+import { PostPodFolderRequestBodySchema } from "@app/lib/api/projects/pod_mount_schemas";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
 
-export type { GCSMountEntry, GCSMountFileEntry };
+export type { GCSMountDirectoryEntry, GCSMountEntry, GCSMountFileEntry };
 
 export type GetSpaceFilesResponseBody = {
   files: GCSMountEntry[];
 };
 
+export type PostSpaceFolderResponseBody = {
+  folder: GCSMountDirectoryEntry;
+};
+
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetSpaceFilesResponseBody>>,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      GetSpaceFilesResponseBody | PostSpaceFolderResponseBody
+    >
+  >,
   auth: Authenticator,
   { space }: { space: SpaceResource }
 ): Promise<void> {
-  if (req.method !== "GET") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message: "Only GET method is supported.",
-      },
-    });
-  }
-
   if (!space.isProject()) {
     return apiError(req, res, {
       status_code: 400,
@@ -45,12 +48,69 @@ async function handler(
     });
   }
 
-  const files = await listGCSMountFiles(auth, {
-    useCase: "project",
-    projectId: space.sId,
-  });
+  switch (req.method) {
+    case "GET": {
+      const files = await listGCSMountFiles(auth, {
+        useCase: "project",
+        projectId: space.sId,
+      });
 
-  return res.status(200).json({ files });
+      return res.status(200).json({ files });
+    }
+
+    case "POST": {
+      if (!space.canWrite(auth)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "You do not have write access to this project.",
+          },
+        });
+      }
+
+      const bodyValidation = PostPodFolderRequestBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
+          },
+        });
+      }
+
+      const { folderName, parentRelativePath } = bodyValidation.data;
+
+      const createResult = await createProjectFolder(auth, {
+        space,
+        folderName,
+        parentRelativePath,
+      });
+      if (createResult.isErr()) {
+        return apiError(req, res, {
+          status_code: isGCSMountDirectoryAlreadyExistsError(createResult.error)
+            ? 409
+            : 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: createResult.error.message,
+          },
+        });
+      }
+
+      return res.status(201).json({ folder: createResult.value });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "Only GET and POST methods are supported.",
+        },
+      });
+  }
 }
 
 export default withSessionAuthenticationForWorkspace(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/files/[fileId]/move.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/files/[fileId]/move.ts
@@ -1,0 +1,127 @@
+/** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { moveProjectContextFile } from "@app/lib/api/projects/context";
+import { MovePodContextFileRequestBodySchema } from "@app/lib/api/projects/pod_mount_schemas";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
+
+export type MoveProjectContextFileResponseBody = Record<string, never>;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<MoveProjectContextFileResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { spaceId, fileId } = req.query;
+  if (!isString(spaceId) || !isString(fileId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid spaceId or fileId query parameter.",
+      },
+    });
+  }
+
+  const space = await SpaceResource.fetchById(auth, spaceId);
+  if (!space || !space.canRead(auth)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "Space not found.",
+      },
+    });
+  }
+
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Only project spaces support project context file moves.",
+      },
+    });
+  }
+
+  if (!space.canWrite(auth)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "You do not have write access to this project.",
+      },
+    });
+  }
+
+  const file = await FileResource.fetchById(auth, fileId);
+  if (!file) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = MovePodContextFileRequestBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
+          },
+        });
+      }
+
+      const moveResult = await moveProjectContextFile(auth, {
+        space,
+        file,
+        parentRelativePath: bodyValidation.data.parentRelativePath,
+      });
+      if (moveResult.isErr()) {
+        const error = moveResult.error;
+        const statusCode =
+          "code" in error && error.code === "invalid_request_error" ? 400 : 500;
+        return apiError(req, res, {
+          status_code: statusCode,
+          api_error: {
+            type:
+              statusCode === 400
+                ? "invalid_request_error"
+                : "internal_server_error",
+            message: error.message,
+          },
+        });
+      }
+
+      return res.status(200).json({});
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "Only POST is supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/scripts/clean_project_tasks.ts
+++ b/front/scripts/clean_project_tasks.ts
@@ -65,7 +65,7 @@ makeScript(
     if (!space) {
       throw new Error(`Space not found: ${pId}`);
     }
-    if (space.kind !== "project") {
+    if (!space.isProject()) {
       throw new Error(
         `Space ${pId} is not a project space (kind=${space.kind}).`
       );

--- a/front/scripts/ensure_project_datasource_and_connector_created.ts
+++ b/front/scripts/ensure_project_datasource_and_connector_created.ts
@@ -53,7 +53,7 @@ async function processProjectSpace(
     return;
   }
   const space = spaces[0];
-  if (space.kind !== "project") {
+  if (!space.isProject()) {
     logger.warn(
       { workspaceId: workspaceResource.sId, spaceId, kind: space.kind },
       "Space is not a project, skipping"


### PR DESCRIPTION
## Description

Adds the backend primitives for folder creation in project file mounts.

**`createGCSMountDirectory`**

Writes a zero-byte GCS placeholder object with a trailing `/` and `content-type: application/x-directory`. Checks existence first and returns `Err("Folder already exists.")` on conflict so callers can distinguish 409 from other errors.

**`createProjectFolder`**

Validates `folderName` (rejects names containing `/` or `\`), resolves the full `relativeDirPath` from the optional `parentRelativePath`, and delegates to `createGCSMountDirectory` scoped to `useCase: "project_context"`.

**`POST /w/[wId]/spaces/[spaceId]/files/`**

New route on the existing files Hono router. Accepts `{ folderName: string, parentRelativePath?: string }`. Returns 201 with the new folder entry on success, 409 on name conflict, 403 without project write access, 400 for non-project spaces or invalid input.

**`useCreateProjectFolder`** — SWR hook POSTing to the new route.

## Tests

Green: GCS path format, zero-byte save, 409 on existing folder, `createProjectFolder` folderName validation, endpoint 403/400/409/201 cases.

## Risk

Low — creating a GCS placeholder doesn't affect existing files; folder creation is opt-in

## Deploy Plan

Deploy `front`
