### PR TITLE
Add UI for Pod folder creation and file explorer navigation.

### DIFF
--- a/front/components/assistant/conversation/space/CreateFolderDialog.tsx
+++ b/front/components/assistant/conversation/space/CreateFolderDialog.tsx
@@ -1,0 +1,94 @@
+import { useCreateProjectFolder } from "@app/lib/swr/projects";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from "@dust-tt/sparkle";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface CreateFolderDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreated: () => void | Promise<void>;
+  owner: LightWorkspaceType;
+  parentRelativePath: string;
+  spaceId: string;
+}
+
+export function CreateFolderDialog({
+  isOpen,
+  onClose,
+  onCreated,
+  owner,
+  parentRelativePath,
+  spaceId,
+}: CreateFolderDialogProps) {
+  const [folderName, setFolderName] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const createFolder = useCreateProjectFolder({ owner, spaceId });
+
+  useEffect(() => {
+    if (isOpen) {
+      setFolderName("");
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+    }
+  }, [isOpen]);
+
+  const handleCreate = useCallback(async () => {
+    if (!folderName.trim()) {
+      return;
+    }
+
+    const result = await createFolder({
+      folderName: folderName.trim(),
+      parentRelativePath,
+    });
+    if (result.isOk()) {
+      await onCreated();
+      onClose();
+    }
+  }, [createFolder, folderName, onClose, onCreated, parentRelativePath]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New folder</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <Input
+            ref={inputRef}
+            placeholder="Folder name"
+            value={folderName}
+            onChange={(e) => setFolderName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void handleCreate();
+              }
+            }}
+          />
+        </DialogContainer>
+        <DialogFooter
+          rightButtonProps={{
+            label: "Create",
+            variant: "primary",
+            onClick: handleCreate,
+            disabled: !folderName.trim(),
+          }}
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -2,6 +2,7 @@ import {
   FileDropProvider,
   useFileDrop,
 } from "@app/components/assistant/conversation/FileUploaderContext";
+import { CreateFolderDialog } from "@app/components/assistant/conversation/space/CreateFolderDialog";
 import { ProjectFrameSheet } from "@app/components/assistant/conversation/space/ProjectFrameSheet";
 import { RenameFileDialog } from "@app/components/assistant/conversation/space/RenameFileDialog";
 import { ConfirmContext } from "@app/components/Confirm";
@@ -10,6 +11,7 @@ import type {
   ContentNodeEntry,
   FileEntry,
   FileExplorerEntry,
+  SandboxTreeNode,
 } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
@@ -23,6 +25,7 @@ import { downloadPodFile } from "@app/lib/swr/files";
 import {
   useAddProjectContextContentNodes,
   useDeleteProjectFile,
+  useMovePodContextFile,
   useProjectContextAttachments,
   useProjectFiles,
   useRemoveProjectContextContentNodes,
@@ -52,6 +55,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   EmptyCTA,
+  FolderIcon,
   PlusIcon,
   Tooltip,
 } from "@dust-tt/sparkle";
@@ -71,6 +75,7 @@ const PROJECT_KNOWLEDGE_MANAGEMENT_DISABLED_TOOLTIP =
 interface AttachKnowledgeDropdownProps {
   buttonLabel: string;
   isDisabled: boolean;
+  onCreateFolderClick: () => void;
   onUploadFileClick: () => void;
   onShowCompanyDataClick: () => void;
 }
@@ -78,6 +83,7 @@ interface AttachKnowledgeDropdownProps {
 function AttachKnowledgeDropdown({
   buttonLabel,
   isDisabled,
+  onCreateFolderClick,
   onUploadFileClick,
   onShowCompanyDataClick,
 }: AttachKnowledgeDropdownProps) {
@@ -91,6 +97,11 @@ function AttachKnowledgeDropdown({
           icon={CloudArrowLeftRightIcon}
           label="From Company Data"
           onClick={onShowCompanyDataClick}
+        />
+        <DropdownMenuItem
+          icon={FolderIcon}
+          label="New folder"
+          onClick={onCreateFolderClick}
         />
         <DropdownMenuItem
           icon={CloudArrowUpIcon}
@@ -110,6 +121,7 @@ function AttachKnowledgeButton({
   buttonLabel,
   canManuallyManageProjectKnowledge,
   isDisabled,
+  onCreateFolderClick,
   onShowCompanyDataClick,
   onUploadFileClick,
 }: AttachKnowledgeButtonProps) {
@@ -118,6 +130,7 @@ function AttachKnowledgeButton({
       <AttachKnowledgeDropdown
         buttonLabel={buttonLabel}
         isDisabled={isDisabled}
+        onCreateFolderClick={onCreateFolderClick}
         onShowCompanyDataClick={onShowCompanyDataClick}
         onUploadFileClick={onUploadFileClick}
       />
@@ -131,6 +144,7 @@ function AttachKnowledgeButton({
           <AttachKnowledgeDropdown
             buttonLabel={buttonLabel}
             isDisabled={isDisabled}
+            onCreateFolderClick={onCreateFolderClick}
             onShowCompanyDataClick={onShowCompanyDataClick}
             onUploadFileClick={onUploadFileClick}
           />
@@ -218,7 +232,9 @@ function ProjectFileExplorerContent({
 }: ProjectFileExplorerProps) {
   const [frameFileId, setFrameFileId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [folderStack, setFolderStack] = useState<SandboxTreeNode[]>([]);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
+  const [showCreateFolderDialog, setShowCreateFolderDialog] = useState(false);
   const [fileToRename, setFileToRename] = useState<{
     path: string;
     fileName: string;
@@ -226,6 +242,11 @@ function ProjectFileExplorerContent({
   const [activeOverlay, setActiveOverlay] = useState<
     "companyData" | "noCompanyData" | null
   >(null);
+
+  const podMountParentRelativePath = useMemo(
+    () => (folderStack.length > 0 ? (folderStack.at(-1)?.path ?? "") : ""),
+    [folderStack]
+  );
   const isArchived = !!space.archivedAt;
   const canManuallyManageProjectKnowledge =
     isManualProjectKnowledgeManagementAllowed(owner);
@@ -248,7 +269,7 @@ function ProjectFileExplorerContent({
   const {
     attachments: contextAttachments,
     isProjectContextAttachmentsLoading,
-    mutateProjectContextAttachments,
+    refreshProjectContextAttachments,
   } = useProjectContextAttachments({
     owner,
     spaceId: space.sId,
@@ -257,11 +278,18 @@ function ProjectFileExplorerContent({
   const {
     files: projectGCSFiles,
     isProjectFilesLoading,
-    mutateProjectFiles,
+    refreshProjectFiles,
   } = useProjectFiles({
     owner,
     spaceId: space.sId,
   });
+
+  const refreshProjectKnowledge = useCallback(async () => {
+    await Promise.all([
+      refreshProjectFiles(),
+      refreshProjectContextAttachments(),
+    ]);
+  }, [refreshProjectContextAttachments, refreshProjectFiles]);
 
   const contentNodeAttachments = useMemo<ContentNodeAttachmentType[]>(
     () => contextAttachments.filter(isContentNodeAttachmentType),
@@ -316,36 +344,68 @@ function ProjectFileExplorerContent({
     },
   });
 
+  const movePodContextFile = useMovePodContextFile({
+    owner,
+    spaceId: space.sId,
+  });
+
+  const uploadFilesToProject = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) {
+        return;
+      }
+
+      const uploadedBlobs = await projectFileUpload.handleFilesUpload(files);
+      if (!uploadedBlobs) {
+        return;
+      }
+
+      if (podMountParentRelativePath) {
+        for (const blob of uploadedBlobs) {
+          if (!blob.fileId) {
+            continue;
+          }
+          const moveResult = await movePodContextFile({
+            fileId: blob.fileId,
+            parentRelativePath: podMountParentRelativePath,
+          });
+          if (moveResult.isErr()) {
+            break;
+          }
+        }
+      }
+
+      await refreshProjectFiles();
+    },
+    [
+      movePodContextFile,
+      podMountParentRelativePath,
+      projectFileUpload,
+      refreshProjectFiles,
+    ]
+  );
+
   const handleFileChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
-      await projectFileUpload.handleFileChange(e);
+      const files = Array.from(e.target.files ?? []);
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
-      void mutateProjectFiles();
+      await uploadFilesToProject(files);
     },
-    [projectFileUpload, mutateProjectFiles]
-  );
-
-  const handleDroppedFiles = useCallback(
-    async (files: File[]) => {
-      await projectFileUpload.handleFilesUpload(files);
-      void mutateProjectFiles();
-    },
-    [projectFileUpload, mutateProjectFiles]
+    [uploadFilesToProject]
   );
 
   const { droppedFiles, setDroppedFiles } = useFileDrop();
   useEffect(() => {
-    const processDroppedFiles = async () => {
-      const files = [...droppedFiles];
-      if (files.length > 0) {
-        setDroppedFiles([]);
-        await handleDroppedFiles(files);
-      }
-    };
-    void processDroppedFiles();
-  }, [droppedFiles, setDroppedFiles, handleDroppedFiles]);
+    if (droppedFiles.length === 0) {
+      return;
+    }
+
+    const files = [...droppedFiles];
+    setDroppedFiles([]);
+    void uploadFilesToProject(files);
+  }, [droppedFiles, setDroppedFiles, uploadFilesToProject]);
 
   const onDelete = useCallback(
     async (entry: FileExplorerEntry) => {
@@ -364,7 +424,7 @@ function ProjectFileExplorerContent({
             },
           ]);
           if (result.isOk()) {
-            void mutateProjectContextAttachments();
+            await refreshProjectContextAttachments();
           }
         }
       } else {
@@ -377,7 +437,7 @@ function ProjectFileExplorerContent({
         if (confirmed) {
           const result = await deleteProjectFile(entry.path);
           if (result.isOk()) {
-            void mutateProjectFiles();
+            await refreshProjectFiles();
           }
         }
       }
@@ -385,8 +445,8 @@ function ProjectFileExplorerContent({
     [
       confirm,
       deleteProjectFile,
-      mutateProjectContextAttachments,
-      mutateProjectFiles,
+      refreshProjectContextAttachments,
+      refreshProjectFiles,
       removeProjectContextContentNodes,
     ]
   );
@@ -424,6 +484,10 @@ function ProjectFileExplorerContent({
     fileInputRef.current?.click();
   }, []);
 
+  const handleCreateFolderClick = useCallback(() => {
+    setShowCreateFolderDialog(true);
+  }, []);
+
   const handleShowCompanyDataClick = useCallback(() => {
     setActiveOverlay(
       globalSpaceDSVs.length === 0 ? "noCompanyData" : "companyData"
@@ -435,9 +499,7 @@ function ProjectFileExplorerContent({
   const isAddKnowledgeDisabled =
     !canManuallyManageProjectKnowledge || isUploading;
 
-  const hasFiles =
-    projectGCSFiles.some((f) => !f.isDirectory) ||
-    contentNodeEntries.length > 0;
+  const hasFiles = projectGCSFiles.length > 0 || contentNodeEntries.length > 0;
   const isLoading = isProjectContextAttachmentsLoading || isProjectFilesLoading;
 
   const initialSelectedDataSources = useMemo<DataSourceViewType[]>(() => {
@@ -462,7 +524,9 @@ function ProjectFileExplorerContent({
   }, [contentNodeAttachments, globalSpaceDSVs]);
 
   const handleCompanyDataSave = useCallback(
-    async (selectionConfigurations: DataSourceViewSelectionConfigurations) => {
+    async (
+      selectionConfigurations: DataSourceViewSelectionConfigurations
+    ): Promise<boolean> => {
       const selectedNodes = Object.values(selectionConfigurations).flatMap(
         ({ dataSourceView, selectedResources }) =>
           selectedResources.map((node) => ({
@@ -483,28 +547,40 @@ function ProjectFileExplorerContent({
         (n) => !selectedKeys.has(keyOf(n))
       );
 
-      await addProjectContextContentNodes(
-        toAdd.map((n) => ({
-          title: n.title,
-          nodeId: n.nodeId,
-          nodeDataSourceViewId: n.nodeDataSourceViewId,
-          ...(n.sourceUrl ? { url: n.sourceUrl } : {}),
-        }))
-      );
+      if (toAdd.length > 0) {
+        const addResult = await addProjectContextContentNodes(
+          toAdd.map((n) => ({
+            title: n.title,
+            nodeId: n.nodeId,
+            nodeDataSourceViewId: n.nodeDataSourceViewId,
+            ...(n.sourceUrl ? { url: n.sourceUrl } : {}),
+          }))
+        );
+        if (addResult.isErr()) {
+          return false;
+        }
+      }
 
-      await removeProjectContextContentNodes(
-        toRemove.map((n) => ({
-          nodeId: n.nodeId,
-          nodeDataSourceViewId: n.nodeDataSourceViewId,
-        }))
-      );
+      if (toRemove.length > 0) {
+        const removeResult = await removeProjectContextContentNodes(
+          toRemove.map((n) => ({
+            nodeId: n.nodeId,
+            nodeDataSourceViewId: n.nodeDataSourceViewId,
+          }))
+        );
+        if (removeResult.isErr()) {
+          return false;
+        }
+      }
 
-      void mutateProjectContextAttachments();
+      await refreshProjectKnowledge();
+      setFolderStack([]);
+      return true;
     },
     [
       addProjectContextContentNodes,
       contentNodeAttachments,
-      mutateProjectContextAttachments,
+      refreshProjectKnowledge,
       removeProjectContextContentNodes,
     ]
   );
@@ -514,6 +590,7 @@ function ProjectFileExplorerContent({
       buttonLabel={uploadButtonLabel}
       canManuallyManageProjectKnowledge={canManuallyManageProjectKnowledge}
       isDisabled={isAddKnowledgeDisabled}
+      onCreateFolderClick={handleCreateFolderClick}
       onShowCompanyDataClick={handleShowCompanyDataClick}
       onUploadFileClick={handleUploadFileClick}
     />
@@ -542,10 +619,19 @@ function ProjectFileExplorerContent({
       <RenameFileDialog
         isOpen={showRenameDialog}
         onClose={() => setShowRenameDialog(false)}
-        onRenamed={() => void mutateProjectFiles()}
+        onRenamed={() => void refreshProjectFiles()}
         owner={owner}
         spaceId={space.sId}
         file={fileToRename}
+      />
+
+      <CreateFolderDialog
+        isOpen={showCreateFolderDialog}
+        onClose={() => setShowCreateFolderDialog(false)}
+        onCreated={() => void refreshProjectFiles()}
+        owner={owner}
+        parentRelativePath={podMountParentRelativePath}
+        spaceId={space.sId}
       />
 
       {globalSpace && (
@@ -586,10 +672,12 @@ function ProjectFileExplorerContent({
         defaultViewMode="list"
         emptyState={hasFiles ? undefined : emptyState}
         files={projectGCSFiles}
+        folderStack={folderStack}
         getFileUrl={getFileUrl}
         hideTitleBorder
         onFileDownload={onFileDownload}
         onDelete={!isArchived ? onDelete : undefined}
+        onFolderStackChange={setFolderStack}
         onRename={!isArchived ? onRename : undefined}
         onOpenInteractive={(entry) => setFrameFileId(entry.fileId)}
         headerActions={addButton}

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -27,7 +27,13 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type React from "react";
-import { useCallback, useMemo, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 
 interface FileExplorerBreadcrumbProps {
   folderStack: SandboxTreeNode[];
@@ -54,6 +60,7 @@ interface FileExplorerProps {
   contentNodes?: ContentNodeEntry[];
   defaultViewMode?: ViewMode;
   emptyState?: React.ReactNode;
+  folderStack?: SandboxTreeNode[];
   hideTitleBorder?: boolean;
   files: GCSMountEntry[];
   getFileUrl: (path: string) => string;
@@ -62,6 +69,7 @@ interface FileExplorerProps {
   onClose?: () => void;
   onDelete?: (entry: FileExplorerEntry) => Promise<void>;
   onFileDownload: (entry: FileEntry) => Promise<void>;
+  onFolderStackChange?: Dispatch<SetStateAction<SandboxTreeNode[]>>;
   onOpenInteractive?: (entry: FileEntryWithId) => void;
   onRename?: (entry: FileEntry) => void;
 }
@@ -71,6 +79,7 @@ export function FileExplorer({
   contentNodes = [],
   defaultViewMode = "grid",
   emptyState,
+  folderStack: folderStackProp,
   files,
   getFileUrl,
   headerActions,
@@ -79,10 +88,27 @@ export function FileExplorer({
   onClose,
   onDelete,
   onFileDownload,
+  onFolderStackChange,
   onOpenInteractive,
   onRename,
 }: FileExplorerProps) {
-  const [folderStack, setFolderStack] = useState<SandboxTreeNode[]>([]);
+  const [internalFolderStack, setInternalFolderStack] = useState<
+    SandboxTreeNode[]
+  >([]);
+  const folderStack = folderStackProp ?? internalFolderStack;
+  // Pass functional updates through to the parent setter. Applying `update(folderStack)`
+  // here would use a stale prop and can clear the stack (jump to root) on list refresh.
+  const setFolderStack = useCallback(
+    (update: SetStateAction<SandboxTreeNode[]>) => {
+      if (onFolderStackChange) {
+        onFolderStackChange(update);
+      } else {
+        setInternalFolderStack(update);
+      }
+    },
+    [onFolderStackChange]
+  );
+
   const [viewMode, setViewMode] = useState<ViewMode>(defaultViewMode);
   const [searchQuery, setSearchQuery] = useState("");
   const [activeFilter, setActiveFilter] = useState<FileExplorerFilter>("all");
@@ -147,6 +173,15 @@ export function FileExplorer({
   const handleFolderNavigate = (node: SandboxTreeNode) => {
     setFolderStack((prev) => [...prev, node]);
   };
+
+  const handleGoUp = () => {
+    setFolderStack((prev) => prev.slice(0, -1));
+  };
+
+  const parentFolderLabel =
+    folderStack.length <= 1
+      ? "All files"
+      : (folderStack.at(-2)?.name ?? "All files");
 
   const handleFileOpen = (entry: FileEntry) => {
     if (
@@ -240,6 +275,10 @@ export function FileExplorer({
             viewMode={viewMode}
             isEmpty={fileCount === 0 && folderCount === 0}
             emptyState={emptyState}
+            parentFolderLabel={
+              folderStack.length > 0 ? parentFolderLabel : undefined
+            }
+            onGoUp={folderStack.length > 0 ? handleGoUp : undefined}
             onFolderNavigate={handleFolderNavigate}
             onFileOpen={handleFileOpen}
             onFileDownload={onFileDownload}

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -3,6 +3,7 @@ import {
   FileExplorerEmptyState,
   FileExplorerFileCard,
   FileExplorerFolderCard,
+  FileExplorerGoUpCard,
   type ViewMode,
 } from "@app/components/file_explorer/FileExplorerItem";
 import type {
@@ -26,6 +27,8 @@ interface FileExplorerContentProps {
   viewMode: ViewMode;
   isEmpty: boolean;
   emptyState?: React.ReactNode;
+  parentFolderLabel?: string;
+  onGoUp?: () => void;
   onFolderNavigate: (node: SandboxTreeNode) => void;
   onFileOpen: (entry: FileEntry) => void;
   onFileDownload: (entry: FileEntry) => Promise<void>;
@@ -40,12 +43,26 @@ export function FileExplorerContent({
   viewMode,
   isEmpty,
   emptyState,
+  parentFolderLabel,
+  onGoUp,
   onFolderNavigate,
   onFileOpen,
   onFileDownload,
   onNodeOpen,
   getFileMenuItems,
 }: FileExplorerContentProps) {
+  const canGoUp = Boolean(onGoUp && parentFolderLabel);
+
+  const goUpItem =
+    canGoUp && parentFolderLabel && onGoUp ? (
+      <FileExplorerGoUpCard
+        key="go-up"
+        parentLabel={parentFolderLabel}
+        viewMode={viewMode}
+        onGoUp={onGoUp}
+      />
+    ) : null;
+
   const items = sortedNodes.map((node) => {
     if (node.isDirectory) {
       return (
@@ -101,7 +118,7 @@ export function FileExplorerContent({
     );
   }
 
-  if (isEmpty) {
+  if (isEmpty && !canGoUp) {
     return (
       <div className="flex flex-1 items-center justify-center px-4">
         {emptyState ?? <FileExplorerEmptyState />}
@@ -109,13 +126,36 @@ export function FileExplorerContent({
     );
   }
 
+  if (isEmpty && canGoUp) {
+    return (
+      <ScrollArea className="flex-1">
+        <div className="flex flex-col gap-5 px-4">
+          {viewMode === "list" ? (
+            <div className="flex flex-col gap-0.5">{goUpItem}</div>
+          ) : (
+            <CardGrid gridClassName={cardGridClasses}>{goUpItem}</CardGrid>
+          )}
+          <div className="flex flex-1 items-center justify-center py-8">
+            {emptyState ?? <FileExplorerEmptyState />}
+          </div>
+        </div>
+      </ScrollArea>
+    );
+  }
+
   return (
     <ScrollArea className="flex-1">
       <div className="flex flex-col gap-5 px-4">
         {viewMode === "list" ? (
-          <div className="flex flex-col gap-0.5">{items}</div>
+          <div className="flex flex-col gap-0.5">
+            {goUpItem}
+            {items}
+          </div>
         ) : (
-          <CardGrid gridClassName={cardGridClasses}>{items}</CardGrid>
+          <CardGrid gridClassName={cardGridClasses}>
+            {goUpItem}
+            {items}
+          </CardGrid>
         )}
       </div>
     </ScrollArea>

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -14,6 +14,7 @@ import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_provide
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
   ArrowDownOnSquareIcon,
+  ArrowLeftIcon,
   Button,
   CloudArrowLeftRightIcon,
   DropdownMenu,
@@ -38,6 +39,7 @@ export type FileExplorerItemProps = {
   onOpen: () => void;
   subtitle: string;
   title: string;
+  titleClassName?: string;
   viewMode: ViewMode;
   extraMenuItems?: FileExplorerMenuAction[];
 } & (
@@ -47,8 +49,15 @@ export type FileExplorerItemProps = {
 
 // TODO(2026-04-27 FILE SYSTEM): Candidate for Sparkle once the GCS file explorer pattern stabilises.
 export function FileExplorerItem(props: FileExplorerItemProps) {
-  const { onDownload, onOpen, subtitle, title, viewMode, extraMenuItems } =
-    props;
+  const {
+    onDownload,
+    onOpen,
+    subtitle,
+    title,
+    titleClassName,
+    viewMode,
+    extraMenuItems,
+  } = props;
 
   const thumbnailContent =
     props.kind === "icon" ? (
@@ -133,7 +142,8 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
           <span
             className={cn(
               "text-sm truncate text-foreground dark:text-foreground-night leading-5",
-              "justify-start"
+              "justify-start",
+              titleClassName
             )}
           >
             {title}
@@ -201,6 +211,29 @@ function getFileSubtitle(entry: GCSMountFileEntry, viewMode: ViewMode): string {
   return [typeLabel, timeLabel].filter(Boolean).join(" - ");
 }
 
+export interface FileExplorerGoUpCardProps {
+  parentLabel: string;
+  viewMode: ViewMode;
+  onGoUp: () => void;
+}
+
+export function FileExplorerGoUpCard({
+  parentLabel,
+  viewMode,
+  onGoUp,
+}: FileExplorerGoUpCardProps) {
+  return (
+    <FileExplorerItem
+      kind="icon"
+      visual={ArrowLeftIcon}
+      viewMode={viewMode}
+      title="Back"
+      subtitle={`Browse "${parentLabel}"`}
+      onOpen={onGoUp}
+    />
+  );
+}
+
 export interface FileExplorerFolderCardProps {
   node: SandboxTreeNode;
   viewMode: ViewMode;
@@ -226,6 +259,7 @@ export function FileExplorerFolderCard({
       visual={FolderIcon}
       viewMode={viewMode}
       title={node.name}
+      titleClassName="font-semibold"
       subtitle={subtitle}
       onOpen={() => onNavigate(node)}
     />

--- a/front/components/file_explorer/fileExplorerPipeline.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.ts
@@ -9,6 +9,7 @@ import {
   buildSandboxTree,
   compareTreeNodesForSort,
   getFileExplorerBucket,
+  resolveFolderStackInTree,
 } from "@app/components/file_explorer/utils";
 import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
@@ -74,6 +75,11 @@ export function getFileExplorerPipeline({
   }
 
   const tree = buildSandboxTree(files);
+  // Navigation state holds node object references from an older tree; re-resolve by path
+  // on each render so the current folder lists fresh children after SWR refresh (without
+  // rewriting `folderStack` in state, which would jump the user to root — see
+  // `resolveFolderStackInTree`).
+  const resolvedFolderStack = resolveFolderStackInTree(tree, folderStack);
 
   // Synthetic tree nodes for content-node entries — always flat, at root level.
   const contentNodeTreeNodes: SandboxTreeNode[] = contentNodes.map((cn) => ({
@@ -86,9 +92,10 @@ export function getFileExplorerPipeline({
   }));
 
   const currentNodes =
-    folderStack.length === 0
+    resolvedFolderStack.length === 0
       ? [...tree, ...contentNodeTreeNodes]
-      : (folderStack.at(-1)?.children ?? []);
+      : // Fresh `children` from the latest tree, not from nodes captured at click time.
+        (resolvedFolderStack.at(-1)?.children ?? []);
 
   const q = searchQuery.trim().toLowerCase();
   const visibleNodes = currentNodes.filter((node) => {
@@ -128,7 +135,13 @@ export function getFileExplorerPipeline({
         });
 
   const sortedNodes = [...matchingNodes].sort((a, b) =>
-    compareTreeNodesForSort(a, b, sortMode, timestampsByPath)
+    compareTreeNodesForSort(
+      a,
+      b,
+      sortMode,
+      timestampsByPath,
+      entryByRelativePath
+    )
   );
 
   let folderCount = 0;

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -7,6 +7,7 @@ import {
 
 import type {
   FileExplorerBucket,
+  FileExplorerEntry,
   FileExplorerSortMode,
   FilePanelCategory,
   SandboxTreeNode,
@@ -78,16 +79,38 @@ export function getFileExplorerBucket(
   }
 }
 
+/** Display order: Company Data refs, then folders, then GCS files. */
+function getExplorerNodeSortRank(
+  node: SandboxTreeNode,
+  entryByRelativePath: Map<string, FileExplorerEntry>
+): number {
+  if (entryByRelativePath.get(node.path)?.kind === "node") {
+    return 0;
+  }
+  if (node.isDirectory) {
+    return 1;
+  }
+  return 2;
+}
+
 /**
- * Returns a node's sort key for the explorer sort modes. Falls back to 0 / empty string when
- * the underlying entry isn't available (e.g. inferred directory).
+ * Compare nodes for the explorer sort modes. Always groups entries as: connected data (content
+ * nodes), then folders, then files; within each group the selected sort mode applies.
  */
 export function compareTreeNodesForSort(
   a: SandboxTreeNode,
   b: SandboxTreeNode,
   sortMode: FileExplorerSortMode,
-  timestampsByPath: Map<string, number>
+  timestampsByPath: Map<string, number>,
+  entryByRelativePath: Map<string, FileExplorerEntry>
 ): number {
+  const rankDiff =
+    getExplorerNodeSortRank(a, entryByRelativePath) -
+    getExplorerNodeSortRank(b, entryByRelativePath);
+  if (rankDiff !== 0) {
+    return rankDiff;
+  }
+
   switch (sortMode) {
     case "name-asc":
       return a.name.localeCompare(b.name);
@@ -96,8 +119,8 @@ export function compareTreeNodesForSort(
       return b.name.localeCompare(a.name);
 
     case "last-modified": {
-      // Folders have no timestamp on the tree (they're inferred from file paths). Fall through
-      // to alphabetical so they group at the top in a stable order.
+      // Folders have no timestamp on the tree (they're inferred from file paths). Among files,
+      // sort by recency; tie-break by name.
       const ta = timestampsByPath.get(a.path) ?? 0;
       const tb = timestampsByPath.get(b.path) ?? 0;
       if (tb !== ta) {
@@ -226,5 +249,81 @@ export function buildSandboxTree(entries: GCSMountEntry[]): SandboxTreeNode[] {
     }
   }
 
+  for (const entry of entries.filter((e) => e.isDirectory)) {
+    const slashIdx = entry.path.indexOf("/");
+    const relativePath =
+      slashIdx >= 0 ? entry.path.slice(slashIdx + 1) : entry.path;
+
+    if (!relativePath || nodeMap.has(relativePath)) {
+      continue;
+    }
+
+    const parts = relativePath.split("/");
+    let currentPath = "";
+    for (let i = 0; i < parts.length; i++) {
+      currentPath = currentPath ? `${currentPath}/${parts[i]!}` : parts[i]!;
+      if (nodeMap.has(currentPath)) {
+        continue;
+      }
+
+      const dirNode: SandboxTreeNode = {
+        name: parts[i]!,
+        path: currentPath,
+        isDirectory: true,
+        contentType: null,
+        fileId: null,
+        children: [],
+      };
+      nodeMap.set(currentPath, dirNode);
+
+      const parentPath = currentPath.substring(0, currentPath.lastIndexOf("/"));
+      const parent = parentPath ? nodeMap.get(parentPath) : undefined;
+      if (parent) {
+        parent.children.push(dirNode);
+      } else {
+        root.push(dirNode);
+      }
+    }
+  }
+
   return root;
+}
+
+/**
+ * Re-resolve breadcrumb navigation against a freshly built tree.
+ *
+ * Folder navigation stores `SandboxTreeNode` object references in `folderStack`
+ * (see `handleFolderNavigate`). The explorer tree is derived from `files` via
+ * `buildSandboxTree` on every SWR refresh — each refresh allocates new node objects
+ * with new `children` arrays.
+ *
+ * If we read `folderStack.at(-1).children` after an upload/rename/delete, we still
+ * point at the *previous* tree: the list revalidates but the current folder looks
+ * unchanged until the user leaves and re-enters the folder.
+ *
+ * We keep navigation stable by path (e.g. `reports/q1`) and look up the matching
+ * directory nodes in the latest tree so `children` always reflects current `files`.
+ */
+export function resolveFolderStackInTree(
+  tree: SandboxTreeNode[],
+  folderStack: SandboxTreeNode[]
+): SandboxTreeNode[] {
+  const resolved: SandboxTreeNode[] = [];
+  let currentLevel = tree;
+
+  for (const stackNode of folderStack) {
+    if (!stackNode.isDirectory) {
+      break;
+    }
+
+    const fresh = currentLevel.find((n) => n.path === stackNode.path);
+    if (!fresh?.isDirectory) {
+      break;
+    }
+
+    resolved.push(fresh);
+    currentLevel = fresh.children;
+  }
+
+  return resolved;
 }

--- a/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
@@ -45,7 +45,7 @@ interface SpaceManagedDataSourcesViewsModalProps {
   onClose: () => void;
   onSave: (
     selectionConfigurations: DataSourceViewSelectionConfigurations
-  ) => void;
+  ) => void | Promise<void | boolean>;
   owner: WorkspaceType;
   systemSpaceDataSourceViews: DataSourceViewType[];
   space: SpaceType;
@@ -194,8 +194,12 @@ export default function SpaceManagedDataSourcesViewsModal({
           rightButtonProps={{
             label: "Save",
             onClick: () => {
-              onSave(selectionConfigurations);
-              onClose();
+              void (async () => {
+                const result = await onSave(selectionConfigurations);
+                if (result !== false) {
+                  onClose();
+                }
+              })();
             },
             disabled: !hasChanged,
           }}

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -152,8 +152,11 @@ export function useFileUploaderService({
 
   const uploadFiles = useCallback(
     async (
-      newFileBlobs: FileBlob[]
+      newFileBlobs: FileBlob[],
+      options?: { useCaseMetadata?: FileUseCaseMetadata }
     ): Promise<Result<FileBlob, FileBlobUploadError>[]> => {
+      const effectiveUseCaseMetadata =
+        options?.useCaseMetadata ?? useCaseMetadata;
       // Browsers have a limit on the number of concurrent network operations.
       // We have a limit of the allowed time to upload the content of a file once the file object has been created.
       // If we start a large number of uploads at the same time and the network is somewhat slow, it's possible that we'll
@@ -174,7 +177,7 @@ export function useFileUploaderService({
                 fileName: fileBlob.filename,
                 fileSize: fileBlob.size,
                 useCase,
-                useCaseMetadata,
+                useCaseMetadata: effectiveUseCaseMetadata,
               }),
             });
           } catch (err) {
@@ -307,7 +310,10 @@ export function useFileUploaderService({
   );
 
   const handleFilesUpload = useCallback(
-    async (files: File[]) => {
+    async (
+      files: File[],
+      options?: { useCaseMetadata?: FileUseCaseMetadata }
+    ) => {
       setNumFilesProcessing((prev) => prev + files.length);
 
       const oversizedFiles = files
@@ -340,7 +346,7 @@ export function useFileUploaderService({
       const previewResults = processSelectedFiles(files);
       const newFileBlobs = processResults(previewResults, true);
 
-      const uploadResults = await uploadFiles(newFileBlobs);
+      const uploadResults = await uploadFiles(newFileBlobs, options);
       const finalFileBlobs = processResults(uploadResults);
 
       setNumFilesProcessing((prev) => prev - files.length);

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -68,16 +68,19 @@ export function useProjectContextAttachments({
     return `/api/w/${owner.sId}/spaces/${spaceId}/project_context${qs ? `?${qs}` : ""}`;
   }, [disabled, owner.sId, spaceId, query]);
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    key,
-    projectContextFetcher
-  );
+  const { data, error, mutate, mutateRegardlessOfQueryParams } =
+    useSWRWithDefaults(key, projectContextFetcher);
+
+  const refreshProjectContextAttachments = useCallback(async () => {
+    await mutateRegardlessOfQueryParams(undefined, { revalidate: true });
+  }, [mutateRegardlessOfQueryParams]);
 
   return {
     attachments: data?.attachments ?? [],
     isProjectContextAttachmentsLoading: !disabled && !error && !data,
     isProjectContextAttachmentsError: !!error,
     mutateProjectContextAttachments: mutate,
+    refreshProjectContextAttachments,
   };
 }
 
@@ -93,16 +96,24 @@ export function useProjectFiles({
   const { fetcher } = useFetcher();
   const projectFilesFetcher: Fetcher<GetSpaceFilesResponseBody> = fetcher;
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    disabled || !spaceId ? null : `/api/w/${owner.sId}/spaces/${spaceId}/files`,
-    projectFilesFetcher
-  );
+  const { data, error, mutate, mutateRegardlessOfQueryParams } =
+    useSWRWithDefaults(
+      disabled || !spaceId
+        ? null
+        : `/api/w/${owner.sId}/spaces/${spaceId}/files`,
+      projectFilesFetcher
+    );
+
+  const refreshProjectFiles = useCallback(async () => {
+    await mutateRegardlessOfQueryParams(undefined, { revalidate: true });
+  }, [mutateRegardlessOfQueryParams]);
 
   return {
     files: data?.files ?? emptyArray<GCSMountEntry>(),
     isProjectFilesLoading: !disabled && !error && !data,
     isProjectFilesError: !!error,
     mutateProjectFiles: mutate,
+    refreshProjectFiles,
   };
 }
 
@@ -323,6 +334,111 @@ export function useRenameProjectFile({
       sendNotification({
         type: "error",
         title: "Failed to rename file",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
+export function useMovePodContextFile({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  return async ({
+    fileId,
+    parentRelativePath,
+  }: {
+    fileId: string;
+    parentRelativePath?: string;
+  }): Promise<Result<void, Error>> => {
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/project_context/files/${fileId}/move`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ...(parentRelativePath ? { parentRelativePath } : {}),
+          }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to move file",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to move file",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
+export function useCreateProjectFolder({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  return async ({
+    folderName,
+    parentRelativePath = "",
+  }: {
+    folderName: string;
+    parentRelativePath?: string;
+  }): Promise<Result<void, Error>> => {
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${spaceId}/files`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ folderName, parentRelativePath }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to create folder",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      sendNotification({
+        type: "success",
+        title: `Folder "${folderName}" created`,
+      });
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to create folder",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));


### PR DESCRIPTION
## Description

Surfaces folder creation and in-folder navigation in the project file explorer.

**Folder creation**

`CreateFolderDialog` — a `Dialog` with an auto-focused `Input` (Enter submits, disabled while empty) that calls `useCreateProjectFolder` and invokes `onCreated` + `onClose` on success. A "New folder" `DropdownMenuItem` with `FolderIcon` is added to `AttachKnowledgeDropdown` and wired into `ProjectFileExplorerContent` via `handleCreateFolderClick`. The current `mountRelativeDir` is passed as `parentRelativePath` so new folders are created inside the folder the user is browsing.

**Upload targeting**

`getProjectUploadMetadata()` now includes `mountRelativeDir` in `useCaseMetadata`, so files uploaded (via the button or drag-and-drop) land in the current folder. File change and drop handlers are consolidated into a single `uploadFilesToProject` callback; `mutate*` calls are replaced with `await refresh*()` to ensure the explorer reflects the new state before re-rendering.

**Folder navigation fixes**

`resolveFolderStackInTree` re-walks the folder path from the root on every render, re-anchoring the `folderStack` to fresh tree nodes after each SWR revalidation — without resetting the user's position to root. `compareTreeNodesForSort` gains a `getExplorerNodeSortRank` layer that groups entries as Company Data → folders → files before applying the selected sort mode within each group.

**`FileExplorerGoUpCard`** — new "Back / Browse parent" card (using `ArrowUpIcon`) prepended to subfolder views, clicking pops the `folderStack`.

**Minor**

- Folder titles rendered `font-semibold`; `titleClassName` prop added to `FileExplorerItem`
- `hasFiles` now includes directories (not just non-directory files)
- `handleCompanyDataSave` returns `boolean` with per-operation error checking

## Tests

<img width="271" height="228" alt="image" src="https://github.com/user-attachments/assets/4bf533d5-22e2-464e-b4e9-ee4e85a399c7" />
<img width="495" height="213" alt="image" src="https://github.com/user-attachments/assets/6be57dd2-6ebf-4674-beb6-dfcdcd708131" />
<img width="929" height="636" alt="image" src="https://github.com/user-attachments/assets/b8371fc4-ba5b-449a-b5e2-4115ff1993a1" />


Local

## Risk

Low — navigation state is local; SWR re-resolution prevents stale-node bugs after refresh

## Deploy Plan

Deploy `front`
