### PR TITLE
[front] feat: Warn admins before making an MCP tool "Available to all"

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -5,6 +5,7 @@ import {
   getMCPServerFormSchema,
 } from "@app/components/actions/mcp/forms/mcpServerFormSchema";
 import { MCPServerDetailsSheet } from "@app/components/actions/mcp/MCPServerDetailsSheet";
+import { ConfirmContext } from "@app/components/Confirm";
 import { useSensitivityLabelsController } from "@app/components/shared/labels/useSensitivityLabelsController";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -27,7 +28,7 @@ import datadogLogger from "@app/logger/datadogLogger";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 import { useForm } from "react-hook-form";
 
 async function patchServer(serverUrl: string, body: object) {
@@ -100,6 +101,7 @@ export function MCPServerDetails({
   const { mutate: mutateMCPServersViewsForAdmin } =
     useMutateMCPServersViewsForAdmin(owner);
   const sendNotification = useSendNotification(true);
+  const confirm = useContext(ConfirmContext);
 
   const defaults = useMemo<MCPServerFormValues>(() => {
     if (mcpServerView) {
@@ -283,6 +285,58 @@ export function MCPServerDetails({
               mcpServerView.server
             ),
           });
+
+          // Promoting to the global space hard-deletes any regular-space
+          // copies of this tool. Require confirmation before mutating when
+          // that's about to happen, naming the spaces that will lose their
+          // copy.
+          const isPromotingToGlobal = diff.sharingChanges?.some((change) => {
+            if (change.action !== "add") {
+              return false;
+            }
+            const space = spaces.find((s) => s.sId === change.spaceId);
+            return space?.kind === "global";
+          });
+          const affectedSpaceNames = (mcpServerWithViews?.views ?? []).flatMap(
+            (view) => {
+              const space = spaces.find((s) => s.sId === view.spaceId);
+              return space?.kind === "regular" ? [space.name] : [];
+            }
+          );
+          if (isPromotingToGlobal && affectedSpaceNames.length > 0) {
+            const confirmed = await confirm({
+              title: "This action will delete the tool's existing copies",
+              message: (
+                <>
+                  <div>
+                    Making the tool available to all will delete its copies in
+                    these spaces:
+                  </div>
+                  <ul className="list-disc pl-6">
+                    {affectedSpaceNames.map((name) => (
+                      <li key={name}>{name}</li>
+                    ))}
+                  </ul>
+                  <div>
+                    Any agents using the tool there will lose access until an
+                    admin manually re-adds the shared version to each one. If
+                    any agents are affected, you'll receive an email listing
+                    them.
+                  </div>
+                </>
+              ),
+              validateLabel: "Continue anyway",
+              validateVariant: "warning",
+            });
+            if (!confirmed) {
+              form.setValue("sharingSettings", defaults.sharingSettings, {
+                shouldDirty: false,
+                shouldTouch: false,
+              });
+              success = false;
+              return;
+            }
+          }
 
           // Apply tool changes if any.
           if (diff.toolChanges && diff.toolChanges.length > 0) {


### PR DESCRIPTION
fix for https://github.com/dust-tt/tasks/issues/7982
## Description
Promoting an MCP tool to the global space hard-deletes any regular-space
views for that server and silently breaks every agent that referenced
them. This PR adds a guardrail in front of the existing
behavior; the migration fix is tracked separately.

`MCPServerDetails.onSave` prompts via ConfirmContext before applying any
changes when the diff promotes the tool to the global space and the
tool is currently in any private space. The check uses views we already
loaded (no extra round-trip). Cancelling reverts the sharing toggle and
returns early — no mutations attempted. The destructive POST and the
post-action admin email are untouched.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="504" height="402" alt="Screenshot 2026-05-19 at 4 37 15 PM" src="https://github.com/user-attachments/assets/a373202e-643b-4836-9adf-352904f24fe5" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, adding a layer of protection against 
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25800">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->