### PR TITLE
Hono validateWorkspace support (dubious impl)

### DIFF
--- a/front-api/middleware/workspace_auth.ts
+++ b/front-api/middleware/workspace_auth.ts
@@ -1,5 +1,9 @@
 import type { MiddlewareHandler } from "hono";
 
+import {
+  ASSISTANT_CONVERSATION_ROUTE_FRAGMENT,
+  validateWorkspace,
+} from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import { getClientIp } from "@app/lib/utils/request";
 
@@ -17,59 +21,75 @@ declare module "hono" {
  * `Authenticator` on the Hono context under the `auth` variable.
  *
  * Mirrors the behavior of `withSessionAuthenticationForWorkspace` in
- * `front/lib/api/auth_wrappers.ts`. Apply to any route under
- * `/api/w/:wId/...`.
+ * `front/lib/api/auth_wrappers.ts`. Apply once at the top of each sub-app
+ * under `/api/w/:wId/...` (the parent `[wId]/index.ts` does NOT carry a
+ * wildcard) — this lets each sub-app declare its own auth requirements
+ * locally, the same way each Next handler passes its own opts to
+ * `withSessionAuthenticationForWorkspace`.
+ *
+ * Options mirror `withSessionAuthenticationForWorkspace`:
+ * - `doesNotRequireCanUseProduct`: when true, the `canUseProduct` paywall
+ *   gate is bypassed (use only for endpoints the user must reach while
+ *   paywalled, e.g. subscription/upgrade flows).
  */
-export const workspaceAuth: MiddlewareHandler = async (c, next) => {
-  const wId = c.req.param("wId");
-  if (!wId) {
-    return apiError(c, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
+export function workspaceAuth(opts?: {
+  doesNotRequireCanUseProduct?: boolean;
+}): MiddlewareHandler {
+  return async (c, next) => {
+    const wId = c.req.param("wId");
+    if (!wId) {
+      return apiError(c, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: "The workspace was not found.",
+        },
+      });
+    }
+
+    const sessionResult = await resolveSession(c);
+    if (sessionResult instanceof Response) {
+      return sessionResult;
+    }
+
+    const auth = await Authenticator.fromSession(sessionResult, wId);
+
+    const headers: Record<string, string | string[] | undefined> = {};
+    c.req.raw.headers.forEach((value, key) => {
+      headers[key] = value;
     });
-  }
+    const ip = getClientIp({ headers });
+    if (ip !== "internal") {
+      auth.setClientIp(ip);
+    }
 
-  const sessionResult = await resolveSession(c);
-  if (sessionResult instanceof Response) {
-    return sessionResult;
-  }
+    // For routes under /assistant/conversations/:cId, surface the cId so
+    // validateWorkspace can enforce the per-conversation kill switch.
+    const conversationId = c.req.path.includes(
+      ASSISTANT_CONVERSATION_ROUTE_FRAGMENT
+    )
+      ? (c.req.param("cId") ?? null)
+      : null;
 
-  const auth = await Authenticator.fromSession(sessionResult, wId);
-
-  const headers: Record<string, string | string[] | undefined> = {};
-  c.req.raw.headers.forEach((value, key) => {
-    headers[key] = value;
-  });
-  const ip = getClientIp({ headers });
-  if (ip !== "internal") {
-    auth.setClientIp(ip);
-  }
-
-  const owner = auth.workspace();
-  const plan = auth.plan();
-  if (!owner || !plan) {
-    return apiError(c, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
+    const workspaceError = validateWorkspace(auth, {
+      doesNotRequireCanUseProduct: opts?.doesNotRequireCanUseProduct,
+      conversationId,
     });
-  }
+    if (workspaceError) {
+      return apiError(c, workspaceError);
+    }
 
-  if (!auth.isUser()) {
-    return apiError(c, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Only users of the workspace can access this content.",
-      },
-    });
-  }
+    if (!auth.isUser()) {
+      return apiError(c, {
+        status_code: 401,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Only users of the workspace can access this content.",
+        },
+      });
+    }
 
-  c.set("auth", auth);
-  await next();
-};
+    c.set("auth", auth);
+    await next();
+  };
+}

--- a/front-api/routes/w/[wId]/analytics/index.ts
+++ b/front-api/routes/w/[wId]/analytics/index.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 import activeUsersExport from "./active-users-export";
 import activeUsers from "./active-users";
 import agentsExport from "./agents-export";
@@ -21,9 +23,10 @@ import usageMetricsExport from "./usage-metrics-export";
 import usageMetrics from "./usage-metrics";
 import usersExport from "./users-export";
 
-// Mounted at /api/w/:wId/analytics. workspaceAuth is applied by the parent
-// workspace sub-app.
+// Mounted at /api/w/:wId/analytics.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.route("/active-users-export", activeUsersExport);
 app.route("/active-users", activeUsers);

--- a/front-api/routes/w/[wId]/assistant/index.ts
+++ b/front-api/routes/w/[wId]/assistant/index.ts
@@ -1,14 +1,16 @@
 import { Hono } from "hono";
 
 import agentConfigurations from "./agent_configurations";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 import builder from "./builder";
 import conversations from "./conversations";
 import mentions from "./mentions";
 import skills from "./skills";
 
-// Mounted at /api/w/:wId/assistant. workspaceAuth is applied by the parent
-// workspace sub-app.
+// Mounted at /api/w/:wId/assistant.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.route("/agent_configurations", agentConfigurations);
 app.route("/builder", builder);

--- a/front-api/routes/w/[wId]/builder/index.ts
+++ b/front-api/routes/w/[wId]/builder/index.ts
@@ -1,11 +1,14 @@
 import { Hono } from "hono";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 import assistants from "./assistants";
 import skills from "./skills";
 
-// Mounted under /api/w/:wId/builder. workspaceAuth is applied by the parent
-// workspace sub-app.
+// Mounted under /api/w/:wId/builder.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.route("/assistants", assistants);
 app.route("/skills", skills);

--- a/front-api/routes/w/[wId]/coupon/index.ts
+++ b/front-api/routes/w/[wId]/coupon/index.ts
@@ -1,9 +1,13 @@
 import { Hono } from "hono";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 import validate from "./validate";
 
-// Mounted under /api/w/:wId/coupon.
+// Mounted under /api/w/:wId/coupon. All children opt out of canUseProduct.
 const app = new Hono();
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.route("/validate", validate);
 

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import {
   ceilToMidnightUTC,
@@ -25,6 +26,8 @@ export type AwuPoolSummaryResponseBody = {
 
 // Mounted at /api/w/:wId/credits/awu-pool-summary.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import { getInvoicePaymentUrl } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
@@ -15,13 +16,18 @@ import awuPoolSummary from "./awu-pool-summary";
 import membersUsage from "./members-usage";
 import metronomeBalances from "./metronome-balances";
 
-// Mounted at /api/w/:wId/credits. workspaceAuth is applied by the parent
-// workspace sub-app.
+// Mounted at /api/w/:wId/credits.
+//
+// Mixed auth: children are mounted BEFORE the `app.use(...)` so they're
+// untouched by the workspaceAuth declared here (each child declares its
+// own). The root GET handler (registered after) gets the loose variant.
 const app = new Hono();
 
 app.route("/awu-pool-summary", awuPoolSummary);
 app.route("/members-usage", membersUsage);
 app.route("/metronome-balances", metronomeBalances);
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import {
   ceilToMidnightUTC,
@@ -137,6 +138,8 @@ async function fetchPerUserUsageCredits({
 
 // Mounted at /api/w/:wId/credits/members-usage.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", validate("query", MembersUsagePaginationSchema), async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/credits/metronome-balances.ts
+++ b/front-api/routes/w/[wId]/credits/metronome-balances.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import { metronomeBalanceToDisplayData } from "@app/lib/api/credits/metronome_balances";
 import { listMetronomeBalances } from "@app/lib/metronome/client";
@@ -13,6 +14,8 @@ import type {
 
 // Mounted at /api/w/:wId/credits/metronome-balances.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/data_source_views/index.ts
+++ b/front-api/routes/w/[wId]/data_source_views/index.ts
@@ -2,10 +2,14 @@ import { Hono } from "hono";
 
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 import tags from "./tags";
 
 // Mounted under /api/w/:wId/data_source_views.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/data_sources/index.ts
+++ b/front-api/routes/w/[wId]/data_sources/index.ts
@@ -1,11 +1,15 @@
 import { Hono } from "hono";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 import dsId from "./[dsId]";
 import botDataSources from "./bot-data-sources";
 import requestAccess from "./request_access";
 
 // Mounted under /api/w/:wId/data_sources.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 // Register static paths BEFORE `/:dsId` so the param route does not swallow
 // these names as ids.

--- a/front-api/routes/w/[wId]/extension/index.ts
+++ b/front-api/routes/w/[wId]/extension/index.ts
@@ -1,9 +1,13 @@
 import { Hono } from "hono";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 import config from "./config";
 
 // Mounted under /api/w/:wId/extension.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.route("/config", config);
 

--- a/front-api/routes/w/[wId]/feature-flags.ts
+++ b/front-api/routes/w/[wId]/feature-flags.ts
@@ -3,12 +3,16 @@ import { Hono } from "hono";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 export type GetWorkspaceFeatureFlagsResponseType = {
   feature_flags: WhitelistableFeature[];
 };
 
 // Mounted at /api/w/:wId/feature-flags.
 const app = new Hono();
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/groups.ts
+++ b/front-api/routes/w/[wId]/groups.ts
@@ -6,6 +6,7 @@ import type { GroupKind, GroupType } from "@app/types/groups";
 import { GroupKindCodec } from "@app/types/groups";
 
 import { validate } from "@front-api/middleware/validator";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 export type GetGroupsResponseBody = {
   groups: (GroupType & { memberCount: number })[];
@@ -18,6 +19,8 @@ const GetGroupsQuerySchema = z.object({
 
 // Mounted at /api/w/:wId/groups.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", validate("query", GetGroupsQuerySchema), async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -1,7 +1,5 @@
 import { Hono } from "hono";
 
-import { workspaceAuth } from "@front-api/middleware/workspace_auth";
-
 import analytics from "./analytics";
 import assistant from "./assistant";
 import builder from "./builder";
@@ -28,11 +26,14 @@ import verifiedDomains from "./verified-domains";
 import verify from "./verify";
 import welcome from "./welcome";
 
-// Mounted at /api/w/:wId. Every route below inherits workspaceAuth, which
-// resolves the Authenticator and stashes it on the context.
+// Mounted at /api/w/:wId. There is intentionally NO parent-level
+// `workspaceAuth` here: each sub-app (or leaf) declares its own
+// `app.use("*", workspaceAuth(opts))` so the auth options (e.g.
+// `doesNotRequireCanUseProduct`) live next to the routes they apply to,
+// mirroring how each Next handler passes its own opts to
+// `withSessionAuthenticationForWorkspace`. New migrations: add the
+// declaration inside your sub-app's `index.ts`, not here.
 const app = new Hono();
-
-app.use("*", workspaceAuth);
 
 app.route("/analytics", analytics);
 app.route("/assistant", assistant);

--- a/front-api/routes/w/[wId]/mcp/index.ts
+++ b/front-api/routes/w/[wId]/mcp/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@app/lib/api/mcp/servers";
 
 import { validate } from "@front-api/middleware/validator";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import server from "./[serverId]";
 import available from "./available";
@@ -68,9 +69,10 @@ const PostBodySchema = z.discriminatedUnion("serverType", [
   }),
 ]);
 
-// Mounted at /api/w/:wId/mcp. workspaceAuth is applied by the parent
-// workspace sub-app.
+// Mounted at /api/w/:wId/mcp.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/me/index.ts
+++ b/front-api/routes/w/[wId]/me/index.ts
@@ -1,11 +1,15 @@
 import { Hono } from "hono";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 import pendingInvitations from "./pending-invitations";
 import slackNotifications from "./slack-notifications";
 import triggers from "./triggers";
 
 // Mounted under /api/w/:wId/me.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.route("/pending-invitations", pendingInvitations);
 app.route("/slack-notifications", slackNotifications);

--- a/front-api/routes/w/[wId]/members/index.ts
+++ b/front-api/routes/w/[wId]/members/index.ts
@@ -1,10 +1,14 @@
 import { Hono } from "hono";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 import lookup from "./lookup";
 import search from "./search";
 
 // Mounted under /api/w/:wId/members.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.route("/lookup", lookup);
 app.route("/search", search);

--- a/front-api/routes/w/[wId]/models.ts
+++ b/front-api/routes/w/[wId]/models.ts
@@ -9,6 +9,8 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 export type GetAvailableModelsResponseType = {
   models: ModelConfigurationType[];
   reasoningModels: ModelConfigurationType[];
@@ -16,6 +18,8 @@ export type GetAvailableModelsResponseType = {
 
 // Mounted at /api/w/:wId/models.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/providers/index.ts
+++ b/front-api/routes/w/[wId]/providers/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import type { ProviderType } from "@app/types/provider";
@@ -21,6 +22,8 @@ function redactConfig(config: string) {
 
 // Mounted at /api/w/:wId/providers.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/provisioning-status.ts
+++ b/front-api/routes/w/[wId]/provisioning-status.ts
@@ -6,6 +6,8 @@ import {
   GroupResource,
 } from "@app/lib/resources/group_resource";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 export type GetProvisioningStatusResponseBody = {
   hasAdminGroup: boolean;
   hasBuilderGroup: boolean;
@@ -13,6 +15,8 @@ export type GetProvisioningStatusResponseBody = {
 
 // Mounted at /api/w/:wId/provisioning-status.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/seats/availability.ts
+++ b/front-api/routes/w/[wId]/seats/availability.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";
 
@@ -10,6 +11,8 @@ export type GetSeatAvailabilityResponseBody = {
 
 // Mounted at /api/w/:wId/seats/availability.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/seats/count.ts
+++ b/front-api/routes/w/[wId]/seats/count.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 
@@ -10,6 +11,8 @@ export type GetWorkspaceSeatsCountResponseBody = {
 
 // Mounted at /api/w/:wId/seats/count.
 const app = new Hono();
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/seats/index.ts
+++ b/front-api/routes/w/[wId]/seats/index.ts
@@ -4,8 +4,8 @@ import availability from "./availability";
 import count from "./count";
 import plan from "./plan";
 
-// Mounted at /api/w/:wId/seats. workspaceAuth is applied by the parent
-// workspace sub-app.
+// Mounted at /api/w/:wId/seats. Mixed auth: each child leaf declares its
+// own workspaceAuth.
 const app = new Hono();
 
 app.route("/availability", availability);

--- a/front-api/routes/w/[wId]/seats/plan.ts
+++ b/front-api/routes/w/[wId]/seats/plan.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import type {
   SeatPlanResponseBody,
@@ -23,6 +24,8 @@ type PriceKey = "pro" | "max";
 
 // Mounted at /api/w/:wId/seats/plan.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -24,6 +24,7 @@ import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { isBuilder } from "@app/types/user";
 
 import { validate } from "@front-api/middleware/validator";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import detect from "./detect";
 import importRoute from "./import";
@@ -105,6 +106,8 @@ const PostSkillRequestBodySchema = z.intersection(
 
 // Mounted at /api/w/:wId/skills.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 // Static sub-paths must be registered before the param sub-app.
 app.route("/detect", detect);

--- a/front-api/routes/w/[wId]/spaces/index.ts
+++ b/front-api/routes/w/[wId]/spaces/index.ts
@@ -16,6 +16,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { ProjectType, SpaceType } from "@app/types/space";
 
 import { validate } from "@front-api/middleware/validator";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import checkName from "./check-name";
 import projectsLookup from "./projects-lookup";
@@ -52,9 +53,10 @@ export type PostSpacesResponseBody = {
   space: SpaceType;
 };
 
-// Mounted under /api/w/:wId/spaces. workspaceAuth is applied by the parent
-// workspace sub-app, so c.get("auth") is always available here.
+// Mounted under /api/w/:wId/spaces.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/subscriptions/checkout-status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout-status.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 import { z } from "zod";
 
 import { validate } from "@front-api/middleware/validator";
@@ -20,6 +21,8 @@ const GetCheckoutStatusQuerySchema = z.object({
 // Mounted at /api/w/:wId/subscriptions/checkout-status. Endpoint used only
 // for the Stripe-only checkout flow (PaymentProcessingPage).
 const app = new Hono();
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.get("/", validate("query", GetCheckoutStatusQuerySchema), async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/subscriptions/index.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.ts
@@ -14,6 +14,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import checkoutStatus from "./checkout-status";
 import pricing from "./pricing";
@@ -31,7 +32,18 @@ const PatchSubscriptionRequestBody = z.object({
 
 // Mounted under /api/w/:wId/subscriptions. The bare `/` handles GET, POST,
 // and PATCH on the workspace's subscription itself; admin-only.
+//
+// Mixed auth: children are mounted BEFORE the `app.use(...)` so they're
+// untouched by the workspaceAuth declared here (each child declares its
+// own). The root handlers (registered after) get the loose variant.
 const app = new Hono();
+
+app.route("/checkout-status", checkoutStatus);
+app.route("/pricing", pricing);
+app.route("/status", status);
+app.route("/trial-info", trialInfo);
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 function requireAdmin(c: Context) {
   const auth = c.get("auth");
@@ -228,10 +240,5 @@ app.patch("/", validate("json", PatchSubscriptionRequestBody), async (c) => {
 
   return c.json({ success: true });
 });
-
-app.route("/checkout-status", checkoutStatus);
-app.route("/pricing", pricing);
-app.route("/status", status);
-app.route("/trial-info", trialInfo);
 
 export default app;

--- a/front-api/routes/w/[wId]/subscriptions/pricing.ts
+++ b/front-api/routes/w/[wId]/subscriptions/pricing.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import type { SubscriptionPerSeatPricing } from "@app/types/plan";
 
@@ -10,6 +11,8 @@ export type GetSubscriptionPricingResponseBody = {
 
 // Mounted at /api/w/:wId/subscriptions/pricing.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/subscriptions/status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/status.ts
@@ -4,6 +4,8 @@ import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 export type GetSubscriptionStatusResponseBody = {
   shouldRedirect: boolean;
   redirectUrl: string | null;
@@ -11,6 +13,8 @@ export type GetSubscriptionStatusResponseBody = {
 
 // Mounted at /api/w/:wId/subscriptions/status.
 const app = new Hono();
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/subscriptions/trial-info.ts
+++ b/front-api/routes/w/[wId]/subscriptions/trial-info.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 
@@ -10,6 +11,8 @@ export type GetSubscriptionTrialInfoResponseBody = {
 
 // Mounted at /api/w/:wId/subscriptions/trial-info.
 const app = new Hono();
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/trial-message-usage.ts
+++ b/front-api/routes/w/[wId]/trial-message-usage.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 
 import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 export type GetTrialMessageUsageResponseType = {
   count: number;
   limit: number;
@@ -9,6 +11,8 @@ export type GetTrialMessageUsageResponseType = {
 
 // Mounted at /api/w/:wId/trial-message-usage.
 const app = new Hono();
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/trial/index.ts
+++ b/front-api/routes/w/[wId]/trial/index.ts
@@ -1,9 +1,13 @@
 import { Hono } from "hono";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 import start from "./start";
 
-// Mounted under /api/w/:wId/trial.
+// Mounted under /api/w/:wId/trial. All children opt out of canUseProduct.
 const app = new Hono();
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.route("/start", start);
 

--- a/front-api/routes/w/[wId]/verified-domains.ts
+++ b/front-api/routes/w/[wId]/verified-domains.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { WorkspaceDomain } from "@app/types/workspace";
@@ -11,6 +12,8 @@ export type GetWorkspaceVerifiedDomainsResponseBody = {
 
 // Mounted at /api/w/:wId/verified-domains.
 const app = new Hono();
+
+app.use("*", workspaceAuth());
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/verify.ts
+++ b/front-api/routes/w/[wId]/verify.ts
@@ -1,4 +1,5 @@
 import { apiError } from "@front-api/middleware/utils";
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import type { Country } from "react-phone-number-input";
@@ -39,6 +40,8 @@ async function detectCountryFromIP(c: Context): Promise<Country> {
 
 // Mounted at /api/w/:wId/verify.
 const app = new Hono();
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front-api/routes/w/[wId]/welcome.ts
+++ b/front-api/routes/w/[wId]/welcome.ts
@@ -4,6 +4,8 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
 import { detectEmailProvider } from "@app/lib/utils/email_provider_detection";
 
+import { workspaceAuth } from "@front-api/middleware/workspace_auth";
+
 export type GetWelcomeResponseBody = {
   isFirstAdmin: boolean;
   emailProvider: EmailProviderType;
@@ -11,6 +13,8 @@ export type GetWelcomeResponseBody = {
 
 // Mounted at /api/w/:wId/welcome.
 const app = new Hono();
+
+app.use("*", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 
 app.get("/", async (c) => {
   const auth = c.get("auth");

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -78,7 +78,7 @@ function getConversationKillSwitchError(): APIErrorWithStatusCode {
   };
 }
 
-const ASSISTANT_CONVERSATION_ROUTE_FRAGMENT = "/assistant/conversations/";
+export const ASSISTANT_CONVERSATION_ROUTE_FRAGMENT = "/assistant/conversations/";
 
 function getAssistantConversationIdFromRequest(
   req: NextApiRequest
@@ -89,31 +89,21 @@ function getAssistantConversationIdFromRequest(
   return isString(req.query.cId) ? req.query.cId : null;
 }
 
-function getConversationKillSwitchErrorForRequest(
-  req: NextApiRequest,
-  killSwitched: unknown
-): APIErrorWithStatusCode | null {
-  const conversationId = getAssistantConversationIdFromRequest(req);
-  if (!conversationId) {
-    return null;
-  }
-
-  return WorkspaceResource.isWorkspaceConversationKillSwitched(
-    killSwitched,
-    conversationId
-  )
-    ? getConversationKillSwitchError()
-    : null;
-}
-
 /**
- * Checks workspace-level guards: owner/plan existence, canUseProduct, maintenance, and kill switches.
- * Returns an APIErrorWithStatusCode if any check fails, or null if all pass.
+ * Checks workspace-level guards: owner/plan existence, canUseProduct,
+ * maintenance, and kill switches. Returns an APIErrorWithStatusCode if any
+ * check fails, or null if all pass.
+ *
+ * Framework-agnostic: callers compute `conversationId` themselves (Next via
+ * `req.url` + `req.query.cId`, Hono via `c.req.path` + `c.req.param("cId")`)
+ * so this function does not need to know about the request type.
  */
-function validateWorkspace(
-  req: NextApiRequest,
+export function validateWorkspace(
   auth: Authenticator,
-  opts: { doesNotRequireCanUseProduct?: boolean } = {}
+  opts: {
+    doesNotRequireCanUseProduct?: boolean;
+    conversationId?: string | null;
+  } = {}
 ): APIErrorWithStatusCode | null {
   const owner = auth.workspace();
   const plan = auth.plan();
@@ -149,12 +139,14 @@ function validateWorkspace(
   ) {
     return getWorkspaceKillSwitchError();
   }
-  const conversationKillSwitchError = getConversationKillSwitchErrorForRequest(
-    req,
-    owner.metadata?.killSwitched
-  );
-  if (conversationKillSwitchError) {
-    return conversationKillSwitchError;
+  if (
+    opts.conversationId &&
+    WorkspaceResource.isWorkspaceConversationKillSwitched(
+      owner.metadata?.killSwitched,
+      opts.conversationId
+    )
+  ) {
+    return getConversationKillSwitchError();
   }
 
   return null;
@@ -288,8 +280,9 @@ export function withSessionAuthenticationForWorkspace<T>(
         return handler(req, res, auth, session);
       }
 
-      const workspaceError = validateWorkspace(req, auth, {
+      const workspaceError = validateWorkspace(auth, {
         doesNotRequireCanUseProduct: opts.doesNotRequireCanUseProduct,
+        conversationId: getAssistantConversationIdFromRequest(req),
       });
       if (workspaceError) {
         return apiError(req, res, workspaceError);
@@ -422,7 +415,9 @@ export function withPublicAPIAuthentication<T>(
           });
         }
 
-        const workspaceError = validateWorkspace(req, auth);
+        const workspaceError = validateWorkspace(auth, {
+          conversationId: getAssistantConversationIdFromRequest(req),
+        });
         if (workspaceError) {
           return apiError(req, res, workspaceError);
         }
@@ -447,7 +442,9 @@ export function withPublicAPIAuthentication<T>(
       );
       let { workspaceAuth } = keyAndWorkspaceAuth;
 
-      const workspaceError = validateWorkspace(req, workspaceAuth);
+      const workspaceError = validateWorkspace(workspaceAuth, {
+        conversationId: getAssistantConversationIdFromRequest(req),
+      });
       if (workspaceError) {
         return apiError(req, res, workspaceError);
       }


### PR DESCRIPTION
## Description

This approach doesn't seem good, with checks on every handler and no inheritance.

Here is Claude's summary.

  Framework-agnostic validateWorkspace (front/lib/api/auth_wrappers.ts):
  - Exported validateWorkspace(auth, { doesNotRequireCanUseProduct?, conversationId? }) and ASSISTANT_CONVERSATION_ROUTE_FRAGMENT.
  - 3 internal callers updated to pre-compute conversationId via getAssistantConversationIdFromRequest(req).

  Hono workspaceAuth factory (front-api/middleware/workspace_auth.ts):
  - workspaceAuth(opts?: { doesNotRequireCanUseProduct?: boolean }) returns a MiddlewareHandler.
  - Calls validateWorkspace after building the Authenticator, surfacing the 4 previously-missing gates: canUseProduct paywall (opt-out), maintenance mode, workspace kill switch, per-conversation kill switch.

  Distributed mounting:
  - Removed app.use("*", workspaceAuth) from front-api/routes/w/[wId]/index.ts with a comment explaining the convention.
  - Each sub-app / leaf now declares app.use("*", workspaceAuth(...)) itself:
    - Loose ({ doesNotRequireCanUseProduct: true }): feature-flags, welcome, verify, trial-message-usage, coupon, trial, all subscriptions leaves except pricing, subscriptions/ root handlers, credits/index root, seats/count.
    - Strict (workspaceAuth()): all other [wId]/* sub-apps and leaves.
  - For mixed sub-apps (subscriptions/, credits/, seats/): child mounts go BEFORE app.use(...) so they're untouched; each leaf declares its own.

  Future migration policy (encoded in the [wId]/index.ts comment): each new migration adds its own workspaceAuth(...) inside its sub-app — no central list to update.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25802">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->