### PR TITLE
Migrate poke workspace routes for apps, projects, skills, and triggers to Hono

### DIFF
--- a/front-api/middleware/poke_workspace_auth.ts
+++ b/front-api/middleware/poke_workspace_auth.ts
@@ -1,9 +1,7 @@
-import type { MiddlewareHandler } from "hono";
-
 import { Authenticator } from "@app/lib/auth";
-
 import { resolveSession } from "@front-api/middleware/session_resolution";
 import { apiError } from "@front-api/middleware/utils";
+import type { MiddlewareHandler } from "hono";
 
 /**
  * Authenticates a workspace-scoped Poke (super-user) request and stores the
@@ -12,10 +10,10 @@ import { apiError } from "@front-api/middleware/utils";
  * Combines the super-user gate of `pokeAuth` with workspace resolution from
  * `workspaceAuth`. Apply to any route under `/api/poke/workspaces/:wId/...`.
  */
-export const pokeWorkspaceAuth: MiddlewareHandler = async (c, next) => {
-  const wId = c.req.param("wId");
+export const pokeWorkspaceAuth: MiddlewareHandler = async (ctx, next) => {
+  const wId = ctx.req.param("wId");
   if (!wId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "workspace_not_found",
@@ -24,7 +22,7 @@ export const pokeWorkspaceAuth: MiddlewareHandler = async (c, next) => {
     });
   }
 
-  const sessionResult = await resolveSession(c);
+  const sessionResult = await resolveSession(ctx);
   if (sessionResult instanceof Response) {
     return sessionResult;
   }
@@ -32,7 +30,7 @@ export const pokeWorkspaceAuth: MiddlewareHandler = async (c, next) => {
   const auth = await Authenticator.fromSuperUserSession(sessionResult, wId);
 
   if (!auth.isDustSuperUser()) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 401,
       api_error: {
         type: "not_authenticated",
@@ -42,7 +40,7 @@ export const pokeWorkspaceAuth: MiddlewareHandler = async (c, next) => {
   }
 
   if (!auth.workspace()) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "workspace_not_found",
@@ -51,6 +49,6 @@ export const pokeWorkspaceAuth: MiddlewareHandler = async (c, next) => {
     });
   }
 
-  c.set("auth", auth);
+  ctx.set("auth", auth);
   await next();
 };

--- a/front-api/middleware/poke_workspace_auth.ts
+++ b/front-api/middleware/poke_workspace_auth.ts
@@ -1,0 +1,56 @@
+import type { MiddlewareHandler } from "hono";
+
+import { Authenticator } from "@app/lib/auth";
+
+import { resolveSession } from "@front-api/middleware/session_resolution";
+import { apiError } from "@front-api/middleware/utils";
+
+/**
+ * Authenticates a workspace-scoped Poke (super-user) request and stores the
+ * resolved `Authenticator` on the Hono context under the `auth` variable.
+ *
+ * Combines the super-user gate of `pokeAuth` with workspace resolution from
+ * `workspaceAuth`. Apply to any route under `/api/poke/workspaces/:wId/...`.
+ */
+export const pokeWorkspaceAuth: MiddlewareHandler = async (c, next) => {
+  const wId = c.req.param("wId");
+  if (!wId) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
+  const sessionResult = await resolveSession(c);
+  if (sessionResult instanceof Response) {
+    return sessionResult;
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(sessionResult, wId);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(c, {
+      status_code: 401,
+      api_error: {
+        type: "not_authenticated",
+        message: "The user does not have permission",
+      },
+    });
+  }
+
+  if (!auth.workspace()) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace was not found.",
+      },
+    });
+  }
+
+  c.set("auth", auth);
+  await next();
+};

--- a/front-api/routes/poke/index.ts
+++ b/front-api/routes/poke/index.ts
@@ -2,6 +2,7 @@ import { pokeAuth } from "@front-api/middleware/poke_auth";
 import { Hono } from "hono";
 
 import plans from "./plans";
+import workspaces from "./workspaces";
 
 // Mounted at /api/poke. Every route below inherits pokeAuth, which resolves
 // the super-user Authenticator and stashes it on the context.
@@ -10,5 +11,6 @@ const app = new Hono();
 app.use("*", pokeAuth);
 
 app.route("/plans", plans);
+app.route("/workspaces", workspaces);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -1,6 +1,3 @@
-import { Hono } from "hono";
-import { z } from "zod";
-
 import config from "@app/lib/api/config";
 import { getSpecification } from "@app/lib/api/run";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -8,9 +5,10 @@ import { cleanSpecificationFromCore } from "@app/lib/specification";
 import logger from "@app/logger/logger";
 import type { AppType, SpecificationType } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
-
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
 
 export type PokeGetAppDetails = {
   app: AppType;
@@ -25,11 +23,11 @@ const DetailsQuerySchema = z.object({
 // Mounted at /api/poke/workspaces/:wId/apps/:aId/details.
 const app = new Hono();
 
-app.get("/", validate("query", DetailsQuerySchema), async (c) => {
-  const auth = c.get("auth");
-  const aId = c.req.param("aId");
+app.get("/", validate("query", DetailsQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const aId = ctx.req.param("aId");
   if (!aId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -38,11 +36,11 @@ app.get("/", validate("query", DetailsQuerySchema), async (c) => {
     });
   }
 
-  const { hash } = c.req.valid("query");
+  const { hash } = ctx.req.valid("query");
 
   const appResource = await AppResource.fetchById(auth, aId);
   if (!appResource) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "app_not_found",
@@ -75,7 +73,7 @@ app.get("/", validate("query", DetailsQuerySchema), async (c) => {
       ? specificationHashes.value.hashes.reverse()
       : null,
   };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -1,0 +1,81 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import config from "@app/lib/api/config";
+import { getSpecification } from "@app/lib/api/run";
+import { AppResource } from "@app/lib/resources/app_resource";
+import { cleanSpecificationFromCore } from "@app/lib/specification";
+import logger from "@app/logger/logger";
+import type { AppType, SpecificationType } from "@app/types/app";
+import { CoreAPI } from "@app/types/core/core_api";
+
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+export type PokeGetAppDetails = {
+  app: AppType;
+  specification: SpecificationType;
+  specificationHashes: string[] | null;
+};
+
+const DetailsQuerySchema = z.object({
+  hash: z.string().optional(),
+});
+
+// Mounted at /api/poke/workspaces/:wId/apps/:aId/details.
+const app = new Hono();
+
+app.get("/", validate("query", DetailsQuerySchema), async (c) => {
+  const auth = c.get("auth");
+  const aId = c.req.param("aId");
+  if (!aId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid app ID.",
+      },
+    });
+  }
+
+  const { hash } = c.req.valid("query");
+
+  const appResource = await AppResource.fetchById(auth, aId);
+  if (!appResource) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "app_not_found",
+        message: "App not found.",
+      },
+    });
+  }
+
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+  const specificationHashes = await coreAPI.getSpecificationHashes({
+    projectId: appResource.dustAPIProjectId,
+  });
+
+  let specification = JSON.parse(appResource.savedSpecification ?? "{}");
+  if (hash && hash.length > 0) {
+    const specificationFromCore = await getSpecification(
+      appResource.toJSON(),
+      hash
+    );
+    if (specificationFromCore) {
+      cleanSpecificationFromCore(specificationFromCore);
+      specification = specificationFromCore;
+    }
+  }
+
+  const body: PokeGetAppDetails = {
+    app: appResource.toJSON(),
+    specification,
+    specificationHashes: specificationHashes.isOk()
+      ? specificationHashes.value.hashes.reverse()
+      : null,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
@@ -1,15 +1,12 @@
 import { Hono } from "hono";
-import omit from "lodash/omit";
 
-import { getDatasetHash, getDatasets } from "@app/lib/api/datasets";
 import { AppResource } from "@app/lib/resources/app_resource";
-import type { AppType } from "@app/types/app";
-import type { DatasetType } from "@app/types/dataset";
+import { exportAppWithDatasets, type ExportedApp } from "@app/lib/utils/apps";
 
 import { apiError } from "@front-api/middleware/utils";
 
 export type ExportAppResponseBody = {
-  app: Omit<AppType, "space" | "id"> & { datasets: DatasetType[] };
+  app: ExportedApp;
 };
 
 // Mounted at /api/poke/workspaces/:wId/apps/:aId/export.
@@ -39,25 +36,9 @@ app.get("/", async (c) => {
     });
   }
 
-  const dataSetsToFetch = (await getDatasets(auth, appResource.toJSON())).map(
-    (ds) => ({ datasetId: ds.name, hash: "latest" })
-  );
-  const datasets: DatasetType[] = [];
-  for (const dataset of dataSetsToFetch) {
-    const fromCore = await getDatasetHash(
-      auth,
-      appResource,
-      dataset.datasetId,
-      dataset.hash,
-      { includeDeleted: true }
-    );
-    if (fromCore) {
-      datasets.push(fromCore);
-    }
-  }
-  const appJson = omit(appResource.toJSON(), "id", "space");
+  const exported = await exportAppWithDatasets(auth, appResource);
 
-  const body: ExportAppResponseBody = { app: { ...appJson, datasets } };
+  const body: ExportAppResponseBody = { app: exported };
   return c.json(body);
 });
 

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
@@ -1,0 +1,64 @@
+import { Hono } from "hono";
+import omit from "lodash/omit";
+
+import { getDatasetHash, getDatasets } from "@app/lib/api/datasets";
+import { AppResource } from "@app/lib/resources/app_resource";
+import type { AppType } from "@app/types/app";
+import type { DatasetType } from "@app/types/dataset";
+
+import { apiError } from "@front-api/middleware/utils";
+
+export type ExportAppResponseBody = {
+  app: Omit<AppType, "space" | "id"> & { datasets: DatasetType[] };
+};
+
+// Mounted at /api/poke/workspaces/:wId/apps/:aId/export.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const aId = c.req.param("aId");
+  if (!aId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const appResource = await AppResource.fetchById(auth, aId);
+  if (!appResource) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "app_not_found",
+        message: "The app you requested was not found.",
+      },
+    });
+  }
+
+  const dataSetsToFetch = (await getDatasets(auth, appResource.toJSON())).map(
+    (ds) => ({ datasetId: ds.name, hash: "latest" })
+  );
+  const datasets: DatasetType[] = [];
+  for (const dataset of dataSetsToFetch) {
+    const fromCore = await getDatasetHash(
+      auth,
+      appResource,
+      dataset.datasetId,
+      dataset.hash,
+      { includeDeleted: true }
+    );
+    if (fromCore) {
+      datasets.push(fromCore);
+    }
+  }
+  const appJson = omit(appResource.toJSON(), "id", "space");
+
+  const body: ExportAppResponseBody = { app: { ...appJson, datasets } };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
@@ -1,9 +1,7 @@
-import { Hono } from "hono";
-
 import { AppResource } from "@app/lib/resources/app_resource";
-import { exportAppWithDatasets, type ExportedApp } from "@app/lib/utils/apps";
-
+import { type ExportedApp, exportAppWithDatasets } from "@app/lib/utils/apps";
 import { apiError } from "@front-api/middleware/utils";
+import { Hono } from "hono";
 
 export type ExportAppResponseBody = {
   app: ExportedApp;
@@ -12,11 +10,11 @@ export type ExportAppResponseBody = {
 // Mounted at /api/poke/workspaces/:wId/apps/:aId/export.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
-  const aId = c.req.param("aId");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const aId = ctx.req.param("aId");
   if (!aId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -27,7 +25,7 @@ app.get("/", async (c) => {
 
   const appResource = await AppResource.fetchById(auth, aId);
   if (!appResource) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "app_not_found",
@@ -39,7 +37,7 @@ app.get("/", async (c) => {
   const exported = await exportAppWithDatasets(auth, appResource);
 
   const body: ExportAppResponseBody = { app: exported };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/index.ts
@@ -1,0 +1,13 @@
+import { Hono } from "hono";
+
+import details from "./details";
+import exportApp from "./export";
+import state from "./state";
+
+const app = new Hono();
+
+app.route("/details", details);
+app.route("/export", exportApp);
+app.route("/state", state);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
@@ -1,22 +1,20 @@
-import { Hono } from "hono";
-
 import { AppResource } from "@app/lib/resources/app_resource";
 import {
   PostStateRequestBodySchema,
   type PostStateResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/state";
-
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
 
 // Mounted at /api/poke/workspaces/:wId/apps/:aId/state.
 const app = new Hono();
 
-app.post("/", validate("json", PostStateRequestBodySchema), async (c) => {
-  const auth = c.get("auth");
-  const aId = c.req.param("aId");
+app.post("/", validate("json", PostStateRequestBodySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const aId = ctx.req.param("aId");
   if (!aId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -27,7 +25,7 @@ app.post("/", validate("json", PostStateRequestBodySchema), async (c) => {
 
   const appResource = await AppResource.fetchById(auth, aId);
   if (!appResource) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "app_not_found",
@@ -36,7 +34,7 @@ app.post("/", validate("json", PostStateRequestBodySchema), async (c) => {
     });
   }
 
-  const body = c.req.valid("json");
+  const body = ctx.req.valid("json");
 
   const updateParams: {
     savedSpecification: string;
@@ -54,7 +52,7 @@ app.post("/", validate("json", PostStateRequestBodySchema), async (c) => {
   await appResource.updateState(auth, updateParams);
 
   const responseBody: PostStateResponseBody = { app: appResource.toJSON() };
-  return c.json(responseBody);
+  return ctx.json(responseBody);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
@@ -1,11 +1,19 @@
 import { AppResource } from "@app/lib/resources/app_resource";
-import {
-  PostStateRequestBodySchema,
-  type PostStateResponseBody,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/state";
+import type { AppType } from "@app/types/app";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
+import { z } from "zod";
+
+const PostStateRequestBodySchema = z.object({
+  specification: z.string(),
+  config: z.string(),
+  run: z.string().optional(),
+});
+
+type PostStateResponseBody = {
+  app: AppType;
+};
 
 // Mounted at /api/poke/workspaces/:wId/apps/:aId/state.
 const app = new Hono();

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
@@ -1,0 +1,60 @@
+import { Hono } from "hono";
+
+import { AppResource } from "@app/lib/resources/app_resource";
+import {
+  PostStateRequestBodySchema,
+  type PostStateResponseBody,
+} from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/state";
+
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+// Mounted at /api/poke/workspaces/:wId/apps/:aId/state.
+const app = new Hono();
+
+app.post("/", validate("json", PostStateRequestBodySchema), async (c) => {
+  const auth = c.get("auth");
+  const aId = c.req.param("aId");
+  if (!aId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const appResource = await AppResource.fetchById(auth, aId);
+  if (!appResource) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "app_not_found",
+        message: "The app was not found.",
+      },
+    });
+  }
+
+  const body = c.req.valid("json");
+
+  const updateParams: {
+    savedSpecification: string;
+    savedConfig: string;
+    savedRun?: string;
+  } = {
+    savedSpecification: body.specification,
+    savedConfig: body.config,
+  };
+
+  if (body.run) {
+    updateParams.savedRun = body.run;
+  }
+
+  await appResource.updateState(auth, updateParams);
+
+  const responseBody: PostStateResponseBody = { app: appResource.toJSON() };
+  return c.json(responseBody);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/import.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/import.ts
@@ -1,0 +1,87 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { importApp } from "@app/lib/utils/apps";
+import type { AppType } from "@app/types/app";
+
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+export const AppTypeSchema = z.object({
+  sId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  savedSpecification: z.string().nullable(),
+  savedConfig: z.string().nullable(),
+  savedRun: z.string().nullable(),
+  dustAPIProjectId: z.string(),
+  datasets: z
+    .array(
+      z.object({
+        name: z.string(),
+        description: z.string().nullable(),
+        schema: z
+          .array(
+            z.object({
+              type: z.enum(["string", "number", "boolean", "json"]),
+              description: z.string().nullable(),
+              key: z.string(),
+            })
+          )
+          .nullish(),
+        data: z.array(z.record(z.string(), z.any())).nullish(),
+      })
+    )
+    .optional(),
+  coreSpecifications: z.record(z.string(), z.string()).optional(),
+});
+
+export const ImportAppBody = z.object({
+  app: AppTypeSchema,
+});
+
+const ImportQuerySchema = z.object({
+  spaceId: z.string(),
+});
+
+// Mounted at /api/poke/workspaces/:wId/apps/import.
+const app = new Hono();
+
+app.post(
+  "/",
+  validate("query", ImportQuerySchema),
+  validate("json", ImportAppBody),
+  async (c) => {
+    const auth = c.get("auth");
+    const { spaceId } = c.req.valid("query");
+    const body = c.req.valid("json");
+
+    const space = await SpaceResource.fetchById(auth, spaceId);
+    if (!space) {
+      return apiError(c, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Space not found.",
+        },
+      });
+    }
+
+    const result = await importApp(auth, space, body.app);
+    if (result.isErr()) {
+      return apiError(c, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    const responseBody: { app: AppType } = { app: result.value.app.toJSON() };
+    return c.json(responseBody);
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/import.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/import.ts
@@ -1,12 +1,10 @@
-import { Hono } from "hono";
-import { z } from "zod";
-
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { importApp } from "@app/lib/utils/apps";
 import type { AppType } from "@app/types/app";
-
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
 
 export const AppTypeSchema = z.object({
   sId: z.string(),
@@ -52,14 +50,14 @@ app.post(
   "/",
   validate("query", ImportQuerySchema),
   validate("json", ImportAppBody),
-  async (c) => {
-    const auth = c.get("auth");
-    const { spaceId } = c.req.valid("query");
-    const body = c.req.valid("json");
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { spaceId } = ctx.req.valid("query");
+    const body = ctx.req.valid("json");
 
     const space = await SpaceResource.fetchById(auth, spaceId);
     if (!space) {
-      return apiError(c, {
+      return apiError(ctx, {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
@@ -70,7 +68,7 @@ app.post(
 
     const result = await importApp(auth, space, body.app);
     if (result.isErr()) {
-      return apiError(c, {
+      return apiError(ctx, {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
@@ -80,7 +78,7 @@ app.post(
     }
 
     const responseBody: { app: AppType } = { app: result.value.app.toJSON() };
-    return c.json(responseBody);
+    return ctx.json(responseBody);
   }
 );
 

--- a/front-api/routes/poke/workspaces/[wId]/apps/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/index.ts
@@ -1,7 +1,6 @@
-import { Hono } from "hono";
-
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { AppType } from "@app/types/app";
+import { Hono } from "hono";
 
 import aId from "./[aId]";
 import importApp from "./import";
@@ -14,12 +13,12 @@ export type PokeListApps = {
 // the parent workspaces/[wId] sub-app.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
   const apps = await AppResource.listByWorkspace(auth);
 
   const body: PokeListApps = { apps: apps.map((a) => a.toJSON()) };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 // Literal segments before param segments.

--- a/front-api/routes/poke/workspaces/[wId]/apps/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/index.ts
@@ -1,0 +1,29 @@
+import { Hono } from "hono";
+
+import { AppResource } from "@app/lib/resources/app_resource";
+import type { AppType } from "@app/types/app";
+
+import aId from "./[aId]";
+import importApp from "./import";
+
+export type PokeListApps = {
+  apps: AppType[];
+};
+
+// Mounted at /api/poke/workspaces/:wId/apps. pokeWorkspaceAuth is applied by
+// the parent workspaces/[wId] sub-app.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const apps = await AppResource.listByWorkspace(auth);
+
+  const body: PokeListApps = { apps: apps.map((a) => a.toJSON()) };
+  return c.json(body);
+});
+
+// Literal segments before param segments.
+app.route("/import", importApp);
+app.route("/:aId", aId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/index.ts
@@ -1,6 +1,5 @@
-import { Hono } from "hono";
-
 import { pokeWorkspaceAuth } from "@front-api/middleware/poke_workspace_auth";
+import { Hono } from "hono";
 
 import apps from "./apps";
 import projects from "./projects";

--- a/front-api/routes/poke/workspaces/[wId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/index.ts
@@ -1,0 +1,24 @@
+import { Hono } from "hono";
+
+import { pokeWorkspaceAuth } from "@front-api/middleware/poke_workspace_auth";
+
+import apps from "./apps";
+import projects from "./projects";
+import skillSuggestions from "./skill_suggestions";
+import skills from "./skills";
+import triggers from "./triggers";
+
+// Mounted at /api/poke/workspaces/:wId. Every route below inherits
+// pokeWorkspaceAuth, which resolves the super-user Authenticator for the
+// target workspace and stashes it on the context.
+const app = new Hono();
+
+app.use("*", pokeWorkspaceAuth);
+
+app.route("/apps", apps);
+app.route("/projects", projects);
+app.route("/skill_suggestions", skillSuggestions);
+app.route("/skills", skills);
+app.route("/triggers", triggers);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
@@ -1,12 +1,10 @@
-import { Hono } from "hono";
-
 import {
   listProjectKnowledgeFromConnectors,
   type ProjectKnowledgeFromConnectorItem,
 } from "@app/lib/api/projects/context";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-
 import { apiError } from "@front-api/middleware/utils";
+import { Hono } from "hono";
 
 export type PokeProjectKnowledgeFromConnectorItem =
   ProjectKnowledgeFromConnectorItem;
@@ -18,11 +16,11 @@ export type PokeListProjectKnowledgeFromConnectors = {
 // Mounted at /api/poke/workspaces/:wId/projects/:projectId/connector-knowledge.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
-  const projectId = c.req.param("projectId");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const projectId = ctx.req.param("projectId");
   if (!projectId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -33,7 +31,7 @@ app.get("/", async (c) => {
 
   const space = await SpaceResource.fetchById(auth, projectId);
   if (!space || !space.isProject()) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "space_not_found",
@@ -45,7 +43,7 @@ app.get("/", async (c) => {
   const items = await listProjectKnowledgeFromConnectors(auth, space);
 
   const body: PokeListProjectKnowledgeFromConnectors = { items };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
@@ -1,29 +1,15 @@
 import { Hono } from "hono";
 
-import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
-import { listProjectContextAttachments } from "@app/lib/api/projects/context";
-import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import {
+  listProjectKnowledgeFromConnectors,
+  type ProjectKnowledgeFromConnectorItem,
+} from "@app/lib/api/projects/context";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { ContentNodeType } from "@app/types/core/content_node";
-import type { ConnectorProvider } from "@app/types/data_source";
 
 import { apiError } from "@front-api/middleware/utils";
 
-export type PokeProjectKnowledgeFromConnectorItem = {
-  contentFragmentId: string;
-  nodeId: string;
-  nodeType: ContentNodeType;
-  nodeDataSourceViewId: string;
-  title: string;
-  contentType: string;
-  sourceUrl: string | null;
-  lastUpdatedAt: number | null;
-  creator: string | null;
-  sourceDataSourceViewSpaceSId: string | null;
-  sourceDataSourceName: string | null;
-  sourceConnectorProvider: ConnectorProvider | null;
-};
+export type PokeProjectKnowledgeFromConnectorItem =
+  ProjectKnowledgeFromConnectorItem;
 
 export type PokeListProjectKnowledgeFromConnectors = {
   items: PokeProjectKnowledgeFromConnectorItem[];
@@ -56,55 +42,7 @@ app.get("/", async (c) => {
     });
   }
 
-  const attachments = await listProjectContextAttachments(auth, space);
-  const contentNodes = attachments.filter(isContentNodeAttachmentType);
-
-  const dsvSIds = Array.from(
-    new Set(contentNodes.map((a) => a.nodeDataSourceViewId))
-  );
-
-  const dsvBySId = new Map<
-    string,
-    {
-      spaceSId: string;
-      dataSourceName: string;
-      connectorProvider: ConnectorProvider | null;
-    }
-  >();
-  if (dsvSIds.length > 0) {
-    const dsvs = await DataSourceViewResource.fetchByIds(auth, dsvSIds);
-    for (const dsv of dsvs) {
-      const json = dsv.toJSON();
-      dsvBySId.set(dsv.sId, {
-        spaceSId: json.spaceId,
-        dataSourceName: getDisplayNameForDataSource(json.dataSource),
-        connectorProvider: json.dataSource.connectorProvider,
-      });
-    }
-  }
-
-  const items: PokeProjectKnowledgeFromConnectorItem[] = contentNodes.map(
-    (a) => {
-      const creator = a.creator
-        ? `${a.creator.type === "agent" ? "agent: " : ""}${a.creator.name}`
-        : null;
-      const dsv = dsvBySId.get(a.nodeDataSourceViewId);
-      return {
-        contentFragmentId: a.contentFragmentId,
-        nodeId: a.nodeId,
-        nodeType: a.nodeType,
-        nodeDataSourceViewId: a.nodeDataSourceViewId,
-        title: a.title,
-        contentType: a.contentType,
-        sourceUrl: a.sourceUrl,
-        lastUpdatedAt: a.lastUpdatedAt ?? null,
-        creator,
-        sourceDataSourceViewSpaceSId: dsv?.spaceSId ?? null,
-        sourceDataSourceName: dsv?.dataSourceName ?? null,
-        sourceConnectorProvider: dsv?.connectorProvider ?? null,
-      };
-    }
-  );
+  const items = await listProjectKnowledgeFromConnectors(auth, space);
 
   const body: PokeListProjectKnowledgeFromConnectors = { items };
   return c.json(body);

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
@@ -1,20 +1,14 @@
-/** @ignoreswagger */
-// @migration-status: MIGRATED_TO_HONO
+import { Hono } from "hono";
 
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
-import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { listProjectContextAttachments } from "@app/lib/api/projects/context";
-import { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { apiError } from "@app/logger/withlogging";
 import type { ContentNodeType } from "@app/types/core/content_node";
 import type { ConnectorProvider } from "@app/types/data_source";
-import type { WithAPIErrorResponse } from "@app/types/error";
-import { isString } from "@app/types/shared/utils/general";
-import type { NextApiRequest, NextApiResponse } from "next";
+
+import { apiError } from "@front-api/middleware/utils";
 
 export type PokeProjectKnowledgeFromConnectorItem = {
   contentFragmentId: string;
@@ -35,50 +29,25 @@ export type PokeListProjectKnowledgeFromConnectors = {
   items: PokeProjectKnowledgeFromConnectorItem[];
 };
 
-async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<PokeListProjectKnowledgeFromConnectors>
-  >,
-  session: SessionWithUser
-): Promise<void> {
-  const { wId, projectId } = req.query;
-  if (!isString(wId) || !isString(projectId)) {
-    return apiError(req, res, {
+// Mounted at /api/poke/workspaces/:wId/projects/:projectId/connector-knowledge.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const projectId = c.req.param("projectId");
+  if (!projectId) {
+    return apiError(c, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid workspace or project ID.",
-      },
-    });
-  }
-
-  const auth = await Authenticator.fromSuperUserSession(session, wId);
-  const owner = auth.workspace();
-
-  if (!owner || !auth.isDustSuperUser()) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "Workspace not found.",
-      },
-    });
-  }
-
-  if (req.method !== "GET") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message: "The method passed is not supported, GET is expected.",
+        message: "Invalid project ID.",
       },
     });
   }
 
   const space = await SpaceResource.fetchById(auth, projectId);
   if (!space || !space.isProject()) {
-    return apiError(req, res, {
+    return apiError(c, {
       status_code: 404,
       api_error: {
         type: "space_not_found",
@@ -137,7 +106,8 @@ async function handler(
     }
   );
 
-  return res.status(200).json({ items });
-}
+  const body: PokeListProjectKnowledgeFromConnectors = { items };
+  return c.json(body);
+});
 
-export default withSessionAuthenticationForPoke(handler);
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/index.ts
@@ -1,0 +1,13 @@
+import { Hono } from "hono";
+
+import connectorKnowledge from "./connector-knowledge";
+import tasks from "./tasks";
+import tasksWorkflow from "./tasks-workflow";
+
+const app = new Hono();
+
+app.route("/connector-knowledge", connectorKnowledge);
+app.route("/tasks-workflow", tasksWorkflow);
+app.route("/tasks", tasks);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -1,12 +1,10 @@
-import { Hono } from "hono";
-
 import config from "@app/lib/api/config";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import type { ProjectMetadataType } from "@app/types/project_metadata";
-
 import { apiError } from "@front-api/middleware/utils";
+import { Hono } from "hono";
 
 export type PokeProjectWorkflowInfo = {
   workflowId: string;
@@ -26,11 +24,11 @@ export type PokeGetProjectWorkflow = {
 // Mounted at /api/poke/workspaces/:wId/projects/:projectId/tasks-workflow.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
-  const projectId = c.req.param("projectId");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const projectId = ctx.req.param("projectId");
   if (!projectId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -43,7 +41,7 @@ app.get("/", async (c) => {
 
   const space = await SpaceResource.fetchById(auth, projectId);
   if (!space || !space.isProject()) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "space_not_found",
@@ -74,7 +72,7 @@ app.get("/", async (c) => {
     workflowId,
     latestWorkflow,
   };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -1,0 +1,80 @@
+import { Hono } from "hono";
+
+import config from "@app/lib/api/config";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import type { ProjectMetadataType } from "@app/types/project_metadata";
+
+import { apiError } from "@front-api/middleware/utils";
+
+export type PokeProjectWorkflowInfo = {
+  workflowId: string;
+  runId: string;
+  status: string;
+  startTime: number | null;
+  closeTime: number | null;
+};
+
+export type PokeGetProjectWorkflow = {
+  metadata: ProjectMetadataType | null;
+  temporalNamespace: string;
+  workflowId: string;
+  latestWorkflow: PokeProjectWorkflowInfo | null;
+};
+
+// Mounted at /api/poke/workspaces/:wId/projects/:projectId/tasks-workflow.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const projectId = c.req.param("projectId");
+  if (!projectId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid project ID.",
+      },
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+
+  const space = await SpaceResource.fetchById(auth, projectId);
+  if (!space || !space.isProject()) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "Project not found.",
+      },
+    });
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+  const workflowId = `project-todo-${owner.sId}-${space.sId}`;
+
+  const temporalClient = await getTemporalClientForFrontNamespace();
+
+  const description = await temporalClient.workflow
+    .getHandle(workflowId)
+    .describe();
+  const latestWorkflow: PokeProjectWorkflowInfo = {
+    workflowId,
+    runId: description.runId,
+    status: description.status.name,
+    startTime: description.startTime?.getTime() ?? null,
+    closeTime: description.closeTime?.getTime() ?? null,
+  };
+
+  const body: PokeGetProjectWorkflow = {
+    metadata: metadata ? metadata.toJSON() : null,
+    temporalNamespace: config.getTemporalFrontNamespace() ?? "",
+    workflowId,
+    latestWorkflow,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
@@ -1,0 +1,49 @@
+import { Hono } from "hono";
+
+import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ProjectTaskType } from "@app/types/project_task";
+
+import { apiError } from "@front-api/middleware/utils";
+
+export type PokeListProjectTasks = {
+  tasks: ProjectTaskType[];
+};
+
+// Mounted at /api/poke/workspaces/:wId/projects/:projectId/tasks.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const projectId = c.req.param("projectId");
+  if (!projectId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid project ID.",
+      },
+    });
+  }
+
+  const space = await SpaceResource.fetchById(auth, projectId);
+  if (!space || !space.isProject()) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "Project not found.",
+      },
+    });
+  }
+
+  const tasks = await ProjectTaskResource.fetchBySpace(auth, {
+    spaceId: space.id,
+    timeScope: "all",
+  });
+
+  const body: PokeListProjectTasks = { tasks: tasks.map((t) => t.toJSON()) };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
@@ -1,10 +1,8 @@
-import { Hono } from "hono";
-
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ProjectTaskType } from "@app/types/project_task";
-
 import { apiError } from "@front-api/middleware/utils";
+import { Hono } from "hono";
 
 export type PokeListProjectTasks = {
   tasks: ProjectTaskType[];
@@ -13,11 +11,11 @@ export type PokeListProjectTasks = {
 // Mounted at /api/poke/workspaces/:wId/projects/:projectId/tasks.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
-  const projectId = c.req.param("projectId");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const projectId = ctx.req.param("projectId");
   if (!projectId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -28,7 +26,7 @@ app.get("/", async (c) => {
 
   const space = await SpaceResource.fetchById(auth, projectId);
   if (!space || !space.isProject()) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "space_not_found",
@@ -43,7 +41,7 @@ app.get("/", async (c) => {
   });
 
   const body: PokeListProjectTasks = { tasks: tasks.map((t) => t.toJSON()) };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/index.ts
@@ -1,0 +1,51 @@
+import { Hono } from "hono";
+
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceType } from "@app/types/space";
+
+import projectId from "./[projectId]";
+
+export type PokeProjectType = SpaceType & {
+  description: string | null;
+  archivedAt: number | null;
+  todoGenerationEnabled: boolean;
+};
+
+export type PokeListProjects = {
+  projects: PokeProjectType[];
+};
+
+// Mounted at /api/poke/workspaces/:wId/projects.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+
+  const projectSpaces = await SpaceResource.listProjectSpaces(auth);
+
+  const metadataResources = await ProjectMetadataResource.fetchBySpaceIds(
+    auth,
+    projectSpaces.map((s) => s.id)
+  );
+  const metadataBySpaceId = new Map(
+    metadataResources.map((m) => [m.spaceId, m])
+  );
+
+  const projects: PokeProjectType[] = projectSpaces.map((space) => {
+    const metadata = metadataBySpaceId.get(space.id);
+    return {
+      ...space.toJSON(),
+      description: metadata?.description ?? null,
+      archivedAt: metadata?.archivedAt?.getTime() ?? null,
+      todoGenerationEnabled: metadata?.todoGenerationEnabled ?? false,
+    };
+  });
+
+  const body: PokeListProjects = { projects };
+  return c.json(body);
+});
+
+app.route("/:projectId", projectId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/index.ts
@@ -1,9 +1,8 @@
-import { Hono } from "hono";
-
 import {
   listAllProjectsWithAdminMetadata,
   type ProjectWithAdminMetadata,
 } from "@app/lib/api/projects/list";
+import { Hono } from "hono";
 
 import projectId from "./[projectId]";
 
@@ -16,13 +15,13 @@ export type PokeListProjects = {
 // Mounted at /api/poke/workspaces/:wId/projects.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
 
   const projects = await listAllProjectsWithAdminMetadata(auth);
 
   const body: PokeListProjects = { projects };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 app.route("/:projectId", projectId);

--- a/front-api/routes/poke/workspaces/[wId]/projects/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/index.ts
@@ -1,16 +1,13 @@
 import { Hono } from "hono";
 
-import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { SpaceType } from "@app/types/space";
+import {
+  listAllProjectsWithAdminMetadata,
+  type ProjectWithAdminMetadata,
+} from "@app/lib/api/projects/list";
 
 import projectId from "./[projectId]";
 
-export type PokeProjectType = SpaceType & {
-  description: string | null;
-  archivedAt: number | null;
-  todoGenerationEnabled: boolean;
-};
+export type PokeProjectType = ProjectWithAdminMetadata;
 
 export type PokeListProjects = {
   projects: PokeProjectType[];
@@ -22,25 +19,7 @@ const app = new Hono();
 app.get("/", async (c) => {
   const auth = c.get("auth");
 
-  const projectSpaces = await SpaceResource.listProjectSpaces(auth);
-
-  const metadataResources = await ProjectMetadataResource.fetchBySpaceIds(
-    auth,
-    projectSpaces.map((s) => s.id)
-  );
-  const metadataBySpaceId = new Map(
-    metadataResources.map((m) => [m.spaceId, m])
-  );
-
-  const projects: PokeProjectType[] = projectSpaces.map((space) => {
-    const metadata = metadataBySpaceId.get(space.id);
-    return {
-      ...space.toJSON(),
-      description: metadata?.description ?? null,
-      archivedAt: metadata?.archivedAt?.getTime() ?? null,
-      todoGenerationEnabled: metadata?.todoGenerationEnabled ?? false,
-    };
-  });
+  const projects = await listAllProjectsWithAdminMetadata(auth);
 
   const body: PokeListProjects = { projects };
   return c.json(body);

--- a/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -1,0 +1,60 @@
+import { Hono } from "hono";
+
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+
+import { apiError } from "@front-api/middleware/utils";
+
+export type PokeGetSkillSuggestionDetails = {
+  suggestion: SkillSuggestionType;
+  skillInstructionsHtml: string | null;
+  skillAgentFacingDescription: string | null;
+};
+
+// Mounted at /api/poke/workspaces/:wId/skill_suggestions/:suggestionId/details.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const suggestionId = c.req.param("suggestionId");
+  if (!suggestionId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid suggestion ID.",
+      },
+    });
+  }
+
+  const suggestion = await SkillSuggestionResource.fetchById(
+    auth,
+    suggestionId,
+    { dangerouslyBypassConversationsVisibilityCheck: true }
+  );
+  if (!suggestion) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "skill_not_found",
+        message: "The suggestion was not found.",
+      },
+    });
+  }
+
+  const skill = await SkillResource.fetchById(
+    auth,
+    suggestion.skillConfigurationSId
+  );
+
+  const skillJson = skill?.toJSON(auth);
+  const body: PokeGetSkillSuggestionDetails = {
+    suggestion: suggestion.toJSON(),
+    skillInstructionsHtml: skillJson?.instructionsHtml ?? null,
+    skillAgentFacingDescription: skillJson?.agentFacingDescription ?? null,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -1,10 +1,8 @@
-import { Hono } from "hono";
-
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
-
 import { apiError } from "@front-api/middleware/utils";
+import { Hono } from "hono";
 
 export type PokeGetSkillSuggestionDetails = {
   suggestion: SkillSuggestionType;
@@ -15,11 +13,11 @@ export type PokeGetSkillSuggestionDetails = {
 // Mounted at /api/poke/workspaces/:wId/skill_suggestions/:suggestionId/details.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
-  const suggestionId = c.req.param("suggestionId");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const suggestionId = ctx.req.param("suggestionId");
   if (!suggestionId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -34,7 +32,7 @@ app.get("/", async (c) => {
     { dangerouslyBypassConversationsVisibilityCheck: true }
   );
   if (!suggestion) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "skill_not_found",
@@ -54,7 +52,7 @@ app.get("/", async (c) => {
     skillInstructionsHtml: skillJson?.instructionsHtml ?? null,
     skillAgentFacingDescription: skillJson?.agentFacingDescription ?? null,
   };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import details from "./details";
+
+const app = new Hono();
+
+app.route("/details", details);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skill_suggestions/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skill_suggestions/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import suggestionId from "./[suggestionId]";
+
+const app = new Hono();
+
+app.route("/:suggestionId", suggestionId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -1,0 +1,59 @@
+import { Hono } from "hono";
+
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { SpaceType } from "@app/types/space";
+import type { UserType } from "@app/types/user";
+
+import { apiError } from "@front-api/middleware/utils";
+
+export type PokeGetSkillDetails = {
+  skill: SkillType;
+  editedByUser: UserType | null;
+  spaces: SpaceType[];
+};
+
+// Mounted at /api/poke/workspaces/:wId/skills/:sId/details.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const sId = c.req.param("sId");
+  if (!sId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid skill ID.",
+      },
+    });
+  }
+
+  const skill = await SkillResource.fetchById(auth, sId);
+  if (!skill) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "skill_not_found",
+        message: "Skill not found.",
+      },
+    });
+  }
+
+  const serializedSkill = skill.toJSON(auth);
+  const editedByUser = await skill.fetchEditedByUser(auth);
+  const spaces = await SpaceResource.fetchByIds(
+    auth,
+    serializedSkill.requestedSpaceIds
+  );
+
+  const body: PokeGetSkillDetails = {
+    skill: serializedSkill,
+    editedByUser: editedByUser ? editedByUser.toJSON() : null,
+    spaces: spaces.map((s) => s.toJSON()),
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -1,12 +1,10 @@
-import { Hono } from "hono";
-
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { SpaceType } from "@app/types/space";
 import type { UserType } from "@app/types/user";
-
 import { apiError } from "@front-api/middleware/utils";
+import { Hono } from "hono";
 
 export type PokeGetSkillDetails = {
   skill: SkillType;
@@ -17,11 +15,11 @@ export type PokeGetSkillDetails = {
 // Mounted at /api/poke/workspaces/:wId/skills/:sId/details.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
-  const sId = c.req.param("sId");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const sId = ctx.req.param("sId");
   if (!sId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -32,7 +30,7 @@ app.get("/", async (c) => {
 
   const skill = await SkillResource.fetchById(auth, sId);
   if (!skill) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "skill_not_found",
@@ -53,7 +51,7 @@ app.get("/", async (c) => {
     editedByUser: editedByUser ? editedByUser.toJSON() : null,
     spaces: spaces.map((s) => s.toJSON()),
   };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/index.ts
@@ -1,0 +1,13 @@
+import { Hono } from "hono";
+
+import details from "./details";
+import suggestions from "./suggestions";
+import versions from "./versions";
+
+const app = new Hono();
+
+app.route("/details", details);
+app.route("/suggestions", suggestions);
+app.route("/versions", versions);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
+
+import { honoApp } from "@front-api/app";
+
+function listSuggestions(workspace: { sId: string }, skillSId: string) {
+  return honoApp.request(
+    `/api/poke/workspaces/${workspace.sId}/skills/${skillSId}/suggestions`
+  );
+}
+
+function deleteSuggestion(
+  workspace: { sId: string },
+  skillSId: string,
+  query: Record<string, string> = {}
+) {
+  const search = new URLSearchParams(query).toString();
+  return honoApp.request(
+    `/api/poke/workspaces/${workspace.sId}/skills/${skillSId}/suggestions${
+      search ? `?${search}` : ""
+    }`,
+    { method: "DELETE" }
+  );
+}
+
+describe("GET /api/poke/workspaces/:wId/skills/:sId/suggestions", () => {
+  it("returns 401 for non super users", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: false,
+      role: "admin",
+    });
+
+    const response = await listSuggestions(workspace, "some-skill-id");
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns suggestions for a given skill", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const skill = await SkillFactory.create(auth);
+    await SkillSuggestionFactory.create(auth, skill);
+
+    const response = await listSuggestions(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.suggestions).toHaveLength(1);
+    expect(data.suggestions[0].kind).toBe("edit");
+  });
+
+  it("returns empty array when skill has no suggestions", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const skill = await SkillFactory.create(auth);
+
+    const response = await listSuggestions(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.suggestions).toHaveLength(0);
+  });
+});
+
+describe("DELETE /api/poke/workspaces/:wId/skills/:sId/suggestions", () => {
+  it("returns 400 when suggestionSId query param is missing", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const response = await deleteSuggestion(workspace, "some-skill-id");
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 when suggestion does not exist", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const response = await deleteSuggestion(workspace, "some-skill-id", {
+      suggestionSId: "non-existent-suggestion-id",
+    });
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error.type).toBe("skill_not_found");
+  });
+
+  it("deletes the suggestion and returns 204", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const skill = await SkillFactory.create(auth);
+    const suggestion = await SkillSuggestionFactory.create(auth, skill);
+
+    const response = await deleteSuggestion(workspace, skill.sId, {
+      suggestionSId: suggestion.sId,
+    });
+
+    expect(response.status).toBe(204);
+
+    // Verify the suggestion is actually deleted.
+    const deleted = await SkillSuggestionResource.fetchById(
+      auth,
+      suggestion.sId
+    );
+    expect(deleted).toBeNull();
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.test.ts
@@ -1,11 +1,9 @@
-import { describe, expect, it } from "vitest";
-
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SkillSuggestionFactory } from "@app/tests/utils/SkillSuggestionFactory";
-
 import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
 
 function listSuggestions(workspace: { sId: string }, skillSId: string) {
   return honoApp.request(

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
@@ -1,0 +1,82 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import { SKILL_SUGGESTION_SOURCES } from "@app/types/suggestions/skill_suggestion";
+
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+export type PokeListSkillSuggestions = {
+  suggestions: SkillSuggestionType[];
+};
+
+const DeleteSuggestionQuerySchema = z.object({
+  suggestionSId: z.string(),
+});
+
+// Mounted at /api/poke/workspaces/:wId/skills/:sId/suggestions.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const sId = c.req.param("sId");
+  if (!sId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid skill ID.",
+      },
+    });
+  }
+
+  const suggestions = await SkillSuggestionResource.listBySkillConfigurationId(
+    auth,
+    sId,
+    {
+      sources: [...SKILL_SUGGESTION_SOURCES],
+      dangerouslyBypassConversationsVisibilityCheck: true,
+    }
+  );
+
+  const body: PokeListSkillSuggestions = {
+    suggestions: suggestions.map((s) => s.toJSON()),
+  };
+  return c.json(body);
+});
+
+app.delete("/", validate("query", DeleteSuggestionQuerySchema), async (c) => {
+  const auth = c.get("auth");
+  const { suggestionSId } = c.req.valid("query");
+
+  const suggestion = await SkillSuggestionResource.fetchById(
+    auth,
+    suggestionSId
+  );
+  if (!suggestion) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "skill_not_found",
+        message: "The suggestion was not found.",
+      },
+    });
+  }
+
+  const deleteResult = await suggestion.delete(auth);
+  if (deleteResult.isErr()) {
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to delete suggestion.",
+      },
+    });
+  }
+
+  return c.body(null, 204);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
@@ -1,12 +1,10 @@
-import { Hono } from "hono";
-import { z } from "zod";
-
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import { SKILL_SUGGESTION_SOURCES } from "@app/types/suggestions/skill_suggestion";
-
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
 
 export type PokeListSkillSuggestions = {
   suggestions: SkillSuggestionType[];
@@ -19,11 +17,11 @@ const DeleteSuggestionQuerySchema = z.object({
 // Mounted at /api/poke/workspaces/:wId/skills/:sId/suggestions.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
-  const sId = c.req.param("sId");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const sId = ctx.req.param("sId");
   if (!sId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -44,19 +42,19 @@ app.get("/", async (c) => {
   const body: PokeListSkillSuggestions = {
     suggestions: suggestions.map((s) => s.toJSON()),
   };
-  return c.json(body);
+  return ctx.json(body);
 });
 
-app.delete("/", validate("query", DeleteSuggestionQuerySchema), async (c) => {
-  const auth = c.get("auth");
-  const { suggestionSId } = c.req.valid("query");
+app.delete("/", validate("query", DeleteSuggestionQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const { suggestionSId } = ctx.req.valid("query");
 
   const suggestion = await SkillSuggestionResource.fetchById(
     auth,
     suggestionSId
   );
   if (!suggestion) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "skill_not_found",
@@ -67,7 +65,7 @@ app.delete("/", validate("query", DeleteSuggestionQuerySchema), async (c) => {
 
   const deleteResult = await suggestion.delete(auth);
   if (deleteResult.isErr()) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 500,
       api_error: {
         type: "internal_server_error",
@@ -76,7 +74,7 @@ app.delete("/", validate("query", DeleteSuggestionQuerySchema), async (c) => {
     });
   }
 
-  return c.body(null, 204);
+  return ctx.body(null, 204);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
@@ -1,0 +1,50 @@
+import { Hono } from "hono";
+
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
+
+import { apiError } from "@front-api/middleware/utils";
+
+export type PokeGetSkillVersions = {
+  versions: SkillWithVersionType[];
+};
+
+// Mounted at /api/poke/workspaces/:wId/skills/:sId/versions.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const sId = c.req.param("sId");
+  if (!sId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid skill ID.",
+      },
+    });
+  }
+
+  const skill = await SkillResource.fetchById(auth, sId);
+  if (!skill) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "skill_not_found",
+        message: "Skill not found.",
+      },
+    });
+  }
+
+  const versions = await skill.listVersions(auth);
+
+  const body: PokeGetSkillVersions = {
+    versions: versions.map((v) => ({
+      ...v.toJSON(auth),
+      version: v.version,
+    })),
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
@@ -1,9 +1,7 @@
-import { Hono } from "hono";
-
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
-
 import { apiError } from "@front-api/middleware/utils";
+import { Hono } from "hono";
 
 export type PokeGetSkillVersions = {
   versions: SkillWithVersionType[];
@@ -12,11 +10,11 @@ export type PokeGetSkillVersions = {
 // Mounted at /api/poke/workspaces/:wId/skills/:sId/versions.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
-  const sId = c.req.param("sId");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const sId = ctx.req.param("sId");
   if (!sId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -27,7 +25,7 @@ app.get("/", async (c) => {
 
   const skill = await SkillResource.fetchById(auth, sId);
   if (!skill) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "skill_not_found",
@@ -44,7 +42,7 @@ app.get("/", async (c) => {
       version: v.version,
     })),
   };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/index.ts
@@ -1,7 +1,6 @@
-import { Hono } from "hono";
-
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { Hono } from "hono";
 
 import sId from "./[sId]";
 import suggestions from "./suggestions";
@@ -13,8 +12,8 @@ export type GetPokeSkillsResponseBody = {
 // Mounted at /api/poke/workspaces/:wId/skills.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
 
   const skills = await SkillResource.listByWorkspace(auth, {
     status: ["active", "archived", "suggested"],
@@ -23,7 +22,7 @@ app.get("/", async (c) => {
   const body: GetPokeSkillsResponseBody = {
     skills: skills.map((skill) => skill.toJSON(auth)),
   };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 // Literal segments before param segments.

--- a/front-api/routes/poke/workspaces/[wId]/skills/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/index.ts
@@ -1,0 +1,33 @@
+import { Hono } from "hono";
+
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+import sId from "./[sId]";
+import suggestions from "./suggestions";
+
+export type GetPokeSkillsResponseBody = {
+  skills: SkillType[];
+};
+
+// Mounted at /api/poke/workspaces/:wId/skills.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+
+  const skills = await SkillResource.listByWorkspace(auth, {
+    status: ["active", "archived", "suggested"],
+  });
+
+  const body: GetPokeSkillsResponseBody = {
+    skills: skills.map((skill) => skill.toJSON(auth)),
+  };
+  return c.json(body);
+});
+
+// Literal segments before param segments.
+app.route("/suggestions", suggestions);
+app.route("/:sId", sId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
@@ -1,14 +1,12 @@
-import { Hono } from "hono";
-import { z } from "zod";
-
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
 
-const PostSkillSuggestionBodySchema = z.object({
+export const PostSkillSuggestionBodySchema = z.object({
   name: z.string().min(1, "Name is required."),
   userFacingDescription: z.string().min(1, "Description is required."),
   agentFacingDescription: z
@@ -19,10 +17,6 @@ const PostSkillSuggestionBodySchema = z.object({
   mcpServerViewIds: z.array(z.string()),
 });
 
-export type PostSkillSuggestionBodyType = z.infer<
-  typeof PostSkillSuggestionBodySchema
->;
-
 export type PostPokeSkillSuggestionResponseBody = {
   skill: SkillType;
 };
@@ -30,8 +24,8 @@ export type PostPokeSkillSuggestionResponseBody = {
 // Mounted at /api/poke/workspaces/:wId/skills/suggestions.
 const app = new Hono();
 
-app.post("/", validate("json", PostSkillSuggestionBodySchema), async (c) => {
-  const auth = c.get("auth");
+app.post("/", validate("json", PostSkillSuggestionBodySchema), async (ctx) => {
+  const auth = ctx.get("auth");
   const {
     name,
     userFacingDescription,
@@ -39,7 +33,7 @@ app.post("/", validate("json", PostSkillSuggestionBodySchema), async (c) => {
     instructions,
     icon,
     mcpServerViewIds,
-  } = c.req.valid("json");
+  } = ctx.req.valid("json");
 
   let skillIcon = icon;
 
@@ -71,7 +65,7 @@ app.post("/", validate("json", PostSkillSuggestionBodySchema), async (c) => {
   );
 
   if (result.isErr()) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 500,
       api_error: {
         type: "internal_server_error",
@@ -83,7 +77,7 @@ app.post("/", validate("json", PostSkillSuggestionBodySchema), async (c) => {
   const body: PostPokeSkillSuggestionResponseBody = {
     skill: result.value.toJSON(auth),
   };
-  return c.json(body, 201);
+  return ctx.json(body, 201);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
@@ -1,0 +1,89 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+const PostSkillSuggestionBodySchema = z.object({
+  name: z.string().min(1, "Name is required."),
+  userFacingDescription: z.string().min(1, "Description is required."),
+  agentFacingDescription: z
+    .string()
+    .min(1, "What will this skill be used for is required."),
+  instructions: z.string().min(1, "Instructions are required."),
+  icon: z.string().nullable(),
+  mcpServerViewIds: z.array(z.string()),
+});
+
+export type PostSkillSuggestionBodyType = z.infer<
+  typeof PostSkillSuggestionBodySchema
+>;
+
+export type PostPokeSkillSuggestionResponseBody = {
+  skill: SkillType;
+};
+
+// Mounted at /api/poke/workspaces/:wId/skills/suggestions.
+const app = new Hono();
+
+app.post("/", validate("json", PostSkillSuggestionBodySchema), async (c) => {
+  const auth = c.get("auth");
+  const {
+    name,
+    userFacingDescription,
+    agentFacingDescription,
+    instructions,
+    icon,
+    mcpServerViewIds,
+  } = c.req.valid("json");
+
+  let skillIcon = icon;
+
+  if (!skillIcon) {
+    const iconSuggestionResult = await getSkillIconSuggestion(auth, {
+      name,
+      agentFacingDescription,
+      instructions,
+    });
+    if (iconSuggestionResult.isOk()) {
+      skillIcon = iconSuggestionResult.value;
+    }
+  }
+
+  const result = await SkillResource.makeSuggestion(
+    auth,
+    {
+      name,
+      userFacingDescription,
+      agentFacingDescription,
+      instructions,
+      icon: skillIcon,
+      extendedSkillId: null,
+      isDefault: false,
+    },
+    {
+      mcpServerViewIds,
+    }
+  );
+
+  if (result.isErr()) {
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to create skill suggestion: ${result.error.message}`,
+      },
+    });
+  }
+
+  const body: PostPokeSkillSuggestionResponseBody = {
+    skill: result.value.toJSON(auth),
+  };
+  return c.json(body, 201);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { TriggerType } from "@app/types/assistant/triggers";
+import type { UserType } from "@app/types/user";
+
+import { apiError } from "@front-api/middleware/utils";
+
+export type PokeGetTriggerDetails = {
+  trigger: TriggerType;
+  agent: LightAgentConfigurationType;
+  editorUser: UserType | null;
+};
+
+// Mounted at /api/poke/workspaces/:wId/triggers/:tId/details.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const tId = c.req.param("tId");
+  if (!tId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid trigger ID.",
+      },
+    });
+  }
+
+  const trigger = await TriggerResource.fetchById(auth, tId);
+  if (!trigger) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "trigger_not_found",
+        message: "Trigger not found.",
+      },
+    });
+  }
+
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: trigger.agentConfigurationId,
+    variant: "full",
+  });
+  if (!agentConfiguration) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "Agent configuration not found.",
+      },
+    });
+  }
+
+  const editorUsers = trigger.editor
+    ? await UserResource.fetchByModelIds([trigger.editor])
+    : [];
+  const editorUser = editorUsers.length > 0 ? editorUsers[0].toJSON() : null;
+
+  const body: PokeGetTriggerDetails = {
+    trigger: trigger.toJSON(),
+    agent: agentConfiguration,
+    editorUser,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -1,13 +1,11 @@
-import { Hono } from "hono";
-
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { UserType } from "@app/types/user";
-
 import { apiError } from "@front-api/middleware/utils";
+import { Hono } from "hono";
 
 export type PokeGetTriggerDetails = {
   trigger: TriggerType;
@@ -18,11 +16,11 @@ export type PokeGetTriggerDetails = {
 // Mounted at /api/poke/workspaces/:wId/triggers/:tId/details.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
-  const tId = c.req.param("tId");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const tId = ctx.req.param("tId");
   if (!tId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -33,7 +31,7 @@ app.get("/", async (c) => {
 
   const trigger = await TriggerResource.fetchById(auth, tId);
   if (!trigger) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "trigger_not_found",
@@ -47,7 +45,7 @@ app.get("/", async (c) => {
     variant: "full",
   });
   if (!agentConfiguration) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "agent_configuration_not_found",
@@ -66,7 +64,7 @@ app.get("/", async (c) => {
     agent: agentConfiguration,
     editorUser,
   };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
@@ -1,0 +1,58 @@
+import { Hono } from "hono";
+
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
+
+import { apiError } from "@front-api/middleware/utils";
+
+export type PokeGetTriggerExecutionStats = {
+  statusBreakdown: Record<string, number>;
+  dailyVolume: Array<{
+    date: string;
+    succeeded: number;
+    failed: number;
+    notMatched: number;
+    rateLimited: number;
+  }>;
+};
+
+// Mounted at /api/poke/workspaces/:wId/triggers/:tId/execution_stats.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+  const tId = c.req.param("tId");
+  if (!tId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid trigger ID.",
+      },
+    });
+  }
+
+  const trigger = await TriggerResource.fetchById(auth, tId);
+  if (!trigger) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "trigger_not_found",
+        message: "Trigger not found.",
+      },
+    });
+  }
+
+  const stats = await WebhookRequestResource.getExecutionStatsForTrigger(
+    auth,
+    trigger.id
+  );
+
+  const body: PokeGetTriggerExecutionStats = {
+    statusBreakdown: stats.statusBreakdown,
+    dailyVolume: stats.dailyVolume,
+  };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
@@ -1,9 +1,7 @@
-import { Hono } from "hono";
-
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
-
 import { apiError } from "@front-api/middleware/utils";
+import { Hono } from "hono";
 
 export type PokeGetTriggerExecutionStats = {
   statusBreakdown: Record<string, number>;
@@ -19,11 +17,11 @@ export type PokeGetTriggerExecutionStats = {
 // Mounted at /api/poke/workspaces/:wId/triggers/:tId/execution_stats.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
-  const tId = c.req.param("tId");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const tId = ctx.req.param("tId");
   if (!tId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -34,7 +32,7 @@ app.get("/", async (c) => {
 
   const trigger = await TriggerResource.fetchById(auth, tId);
   if (!trigger) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "trigger_not_found",
@@ -52,7 +50,7 @@ app.get("/", async (c) => {
     statusBreakdown: stats.statusBreakdown,
     dailyVolume: stats.dailyVolume,
   };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/index.ts
@@ -1,0 +1,13 @@
+import { Hono } from "hono";
+
+import details from "./details";
+import executionStats from "./execution_stats";
+import webhookRequests from "./webhook_requests";
+
+const app = new Hono();
+
+app.route("/details", details);
+app.route("/execution_stats", executionStats);
+app.route("/webhook_requests", webhookRequests);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -1,0 +1,68 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { fetchRecentWebhookRequestTriggersWithPayload } from "@app/lib/triggers/webhook";
+import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
+import { WEBHOOK_REQUEST_TRIGGER_STATUSES } from "@app/types/assistant/triggers";
+
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+export interface PokeGetWebhookRequestsResponseBody {
+  requests: {
+    id: number;
+    timestamp: number;
+    status: WebhookRequestTriggerStatus;
+    payload?: {
+      headers?: Record<string, string | string[]>;
+      body?: unknown;
+    };
+  }[];
+}
+
+const WebhookRequestsQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().optional(),
+  status: z.enum(WEBHOOK_REQUEST_TRIGGER_STATUSES).optional(),
+});
+
+// Mounted at /api/poke/workspaces/:wId/triggers/:tId/webhook_requests.
+const app = new Hono();
+
+app.get("/", validate("query", WebhookRequestsQuerySchema), async (c) => {
+  const auth = c.get("auth");
+  const tId = c.req.param("tId");
+  if (!tId) {
+    return apiError(c, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid trigger ID.",
+      },
+    });
+  }
+
+  const trigger = await TriggerResource.fetchById(auth, tId);
+  if (!trigger) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "trigger_not_found",
+        message: "Trigger not found.",
+      },
+    });
+  }
+
+  const { limit, status } = c.req.valid("query");
+
+  const requests = await fetchRecentWebhookRequestTriggersWithPayload(auth, {
+    trigger: trigger.toJSON(),
+    ...(limit !== undefined ? { limit } : {}),
+    status,
+  });
+
+  const body: PokeGetWebhookRequestsResponseBody = { requests };
+  return c.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -1,13 +1,11 @@
-import { Hono } from "hono";
-import { z } from "zod";
-
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { fetchRecentWebhookRequestTriggersWithPayload } from "@app/lib/triggers/webhook";
 import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import { WEBHOOK_REQUEST_TRIGGER_STATUSES } from "@app/types/assistant/triggers";
-
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
 
 export interface PokeGetWebhookRequestsResponseBody {
   requests: {
@@ -29,11 +27,11 @@ const WebhookRequestsQuerySchema = z.object({
 // Mounted at /api/poke/workspaces/:wId/triggers/:tId/webhook_requests.
 const app = new Hono();
 
-app.get("/", validate("query", WebhookRequestsQuerySchema), async (c) => {
-  const auth = c.get("auth");
-  const tId = c.req.param("tId");
+app.get("/", validate("query", WebhookRequestsQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const tId = ctx.req.param("tId");
   if (!tId) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -44,7 +42,7 @@ app.get("/", validate("query", WebhookRequestsQuerySchema), async (c) => {
 
   const trigger = await TriggerResource.fetchById(auth, tId);
   if (!trigger) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "trigger_not_found",
@@ -53,7 +51,7 @@ app.get("/", validate("query", WebhookRequestsQuerySchema), async (c) => {
     });
   }
 
-  const { limit, status } = c.req.valid("query");
+  const { limit, status } = ctx.req.valid("query");
 
   const requests = await fetchRecentWebhookRequestTriggersWithPayload(auth, {
     trigger: trigger.toJSON(),
@@ -62,7 +60,7 @@ app.get("/", validate("query", WebhookRequestsQuerySchema), async (c) => {
   });
 
   const body: PokeGetWebhookRequestsResponseBody = { requests };
-  return c.json(body);
+  return ctx.json(body);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/index.ts
@@ -1,0 +1,114 @@
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import type { TriggerType } from "@app/types/assistant/triggers";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { WebhookProvider } from "@app/types/triggers/webhooks";
+import type { UserType } from "@app/types/user";
+
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+
+import tId from "./[tId]";
+
+export type TriggerWithProviderType = TriggerType & {
+  provider?: WebhookProvider | null;
+  editorUser?: UserType | null;
+};
+
+export type PokeListTriggers = {
+  triggers: TriggerWithProviderType[];
+};
+
+const DeleteTriggerQuerySchema = z.object({
+  tId: z.string(),
+});
+
+// Mounted at /api/poke/workspaces/:wId/triggers.
+const app = new Hono();
+
+app.get("/", async (c) => {
+  const auth = c.get("auth");
+
+  const triggers = await TriggerResource.listByWorkspace(auth);
+  const triggerJSONs = triggers.map((t) => t.toJSON());
+
+  const webhookSourceViewIds = removeNulls(
+    triggerJSONs.map((t) =>
+      t.kind === "webhook" ? t.webhookSourceViewId : null
+    )
+  );
+
+  const webhookSourceViews =
+    webhookSourceViewIds.length > 0
+      ? await WebhookSourcesViewResource.fetchByIds(auth, webhookSourceViewIds)
+      : [];
+
+  const providerMap = new Map<string, WebhookProvider | null>();
+  for (const view of webhookSourceViews) {
+    const viewJSON = view.toJSON();
+    providerMap.set(viewJSON.sId, viewJSON.provider);
+  }
+
+  const editorIds = removeNulls(triggerJSONs.map((t) => t.editor));
+  const editorUsers =
+    editorIds.length > 0 ? await UserResource.fetchByModelIds(editorIds) : [];
+  const editorUserMap = new Map(editorUsers.map((u) => [u.id, u.toJSON()]));
+
+  const triggersWithProvider: TriggerWithProviderType[] = triggerJSONs.map(
+    (t) => {
+      const editorUser = editorUserMap.get(t.editor) ?? null;
+      if (t.kind === "webhook" && t.webhookSourceViewId) {
+        return {
+          ...t,
+          provider: providerMap.get(t.webhookSourceViewId) ?? null,
+          editorUser,
+        };
+      }
+      return {
+        ...t,
+        provider: t.kind === "schedule" ? undefined : null,
+        editorUser,
+      };
+    }
+  );
+
+  const body: PokeListTriggers = { triggers: triggersWithProvider };
+  return c.json(body);
+});
+
+app.delete("/", validate("query", DeleteTriggerQuerySchema), async (c) => {
+  const auth = c.get("auth");
+  const { tId } = c.req.valid("query");
+
+  const trigger = await TriggerResource.fetchById(auth, tId);
+  if (!trigger) {
+    return apiError(c, {
+      status_code: 404,
+      api_error: {
+        type: "trigger_not_found",
+        message: "The trigger was not found.",
+      },
+    });
+  }
+
+  const deleteResult = await trigger.delete(auth);
+  if (deleteResult.isErr()) {
+    return apiError(c, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to delete trigger.",
+      },
+    });
+  }
+
+  return c.body(null, 204);
+});
+
+app.route("/:tId", tId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/index.ts
@@ -1,14 +1,12 @@
-import { Hono } from "hono";
-import { z } from "zod";
-
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import {
   listTriggersWithProviderAndEditor,
   type TriggerWithProviderAndEditor,
 } from "@app/lib/triggers/admin/list_with_metadata";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
-
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
 
 import tId from "./[tId]";
 
@@ -25,22 +23,22 @@ const DeleteTriggerQuerySchema = z.object({
 // Mounted at /api/poke/workspaces/:wId/triggers.
 const app = new Hono();
 
-app.get("/", async (c) => {
-  const auth = c.get("auth");
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
 
   const triggers = await listTriggersWithProviderAndEditor(auth);
 
   const body: PokeListTriggers = { triggers };
-  return c.json(body);
+  return ctx.json(body);
 });
 
-app.delete("/", validate("query", DeleteTriggerQuerySchema), async (c) => {
-  const auth = c.get("auth");
-  const { tId } = c.req.valid("query");
+app.delete("/", validate("query", DeleteTriggerQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const { tId } = ctx.req.valid("query");
 
   const trigger = await TriggerResource.fetchById(auth, tId);
   if (!trigger) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 404,
       api_error: {
         type: "trigger_not_found",
@@ -51,7 +49,7 @@ app.delete("/", validate("query", DeleteTriggerQuerySchema), async (c) => {
 
   const deleteResult = await trigger.delete(auth);
   if (deleteResult.isErr()) {
-    return apiError(c, {
+    return apiError(ctx, {
       status_code: 500,
       api_error: {
         type: "internal_server_error",
@@ -60,7 +58,7 @@ app.delete("/", validate("query", DeleteTriggerQuerySchema), async (c) => {
     });
   }
 
-  return c.body(null, 204);
+  return ctx.body(null, 204);
 });
 
 app.route("/:tId", tId);

--- a/front-api/routes/poke/workspaces/[wId]/triggers/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/index.ts
@@ -1,23 +1,18 @@
 import { Hono } from "hono";
 import { z } from "zod";
 
+import {
+  listTriggersWithProviderAndEditor,
+  type TriggerWithProviderAndEditor,
+} from "@app/lib/triggers/admin/list_with_metadata";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
-import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
-import type { TriggerType } from "@app/types/assistant/triggers";
-import { removeNulls } from "@app/types/shared/utils/general";
-import type { WebhookProvider } from "@app/types/triggers/webhooks";
-import type { UserType } from "@app/types/user";
 
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 
 import tId from "./[tId]";
 
-export type TriggerWithProviderType = TriggerType & {
-  provider?: WebhookProvider | null;
-  editorUser?: UserType | null;
-};
+export type TriggerWithProviderType = TriggerWithProviderAndEditor;
 
 export type PokeListTriggers = {
   triggers: TriggerWithProviderType[];
@@ -33,50 +28,9 @@ const app = new Hono();
 app.get("/", async (c) => {
   const auth = c.get("auth");
 
-  const triggers = await TriggerResource.listByWorkspace(auth);
-  const triggerJSONs = triggers.map((t) => t.toJSON());
+  const triggers = await listTriggersWithProviderAndEditor(auth);
 
-  const webhookSourceViewIds = removeNulls(
-    triggerJSONs.map((t) =>
-      t.kind === "webhook" ? t.webhookSourceViewId : null
-    )
-  );
-
-  const webhookSourceViews =
-    webhookSourceViewIds.length > 0
-      ? await WebhookSourcesViewResource.fetchByIds(auth, webhookSourceViewIds)
-      : [];
-
-  const providerMap = new Map<string, WebhookProvider | null>();
-  for (const view of webhookSourceViews) {
-    const viewJSON = view.toJSON();
-    providerMap.set(viewJSON.sId, viewJSON.provider);
-  }
-
-  const editorIds = removeNulls(triggerJSONs.map((t) => t.editor));
-  const editorUsers =
-    editorIds.length > 0 ? await UserResource.fetchByModelIds(editorIds) : [];
-  const editorUserMap = new Map(editorUsers.map((u) => [u.id, u.toJSON()]));
-
-  const triggersWithProvider: TriggerWithProviderType[] = triggerJSONs.map(
-    (t) => {
-      const editorUser = editorUserMap.get(t.editor) ?? null;
-      if (t.kind === "webhook" && t.webhookSourceViewId) {
-        return {
-          ...t,
-          provider: providerMap.get(t.webhookSourceViewId) ?? null,
-          editorUser,
-        };
-      }
-      return {
-        ...t,
-        provider: t.kind === "schedule" ? undefined : null,
-        editorUser,
-      };
-    }
-  );
-
-  const body: PokeListTriggers = { triggers: triggersWithProvider };
+  const body: PokeListTriggers = { triggers };
   return c.json(body);
 });
 

--- a/front-api/routes/poke/workspaces/index.ts
+++ b/front-api/routes/poke/workspaces/index.ts
@@ -1,0 +1,12 @@
+import { Hono } from "hono";
+
+import wId from "./[wId]";
+
+// Note: the parent poke/index.ts already applies pokeAuth (super-user gate).
+// This sub-router adds workspace resolution on top via pokeWorkspaceAuth on
+// the [wId] sub-app.
+const app = new Hono();
+
+app.route("/:wId", wId);
+
+export default app;

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -20,6 +20,7 @@ import {
   validateMountFolderName,
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import type { DustError } from "@app/lib/error";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
@@ -28,6 +29,8 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
+import type { ContentNodeType } from "@app/types/core/content_node";
+import type { ConnectorProvider } from "@app/types/data_source";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -183,6 +186,79 @@ export async function listProjectContextAttachments(
       lastUpdatedByViewAndNode.get(a.nodeDataSourceViewId)?.get(a.nodeId) ??
       null;
     return { ...a, lastUpdatedAt: ts };
+  });
+}
+
+export type ProjectKnowledgeFromConnectorItem = {
+  contentFragmentId: string;
+  nodeId: string;
+  nodeType: ContentNodeType;
+  nodeDataSourceViewId: string;
+  title: string;
+  contentType: string;
+  sourceUrl: string | null;
+  lastUpdatedAt: number | null;
+  creator: string | null;
+  sourceDataSourceViewSpaceSId: string | null;
+  sourceDataSourceName: string | null;
+  sourceConnectorProvider: ConnectorProvider | null;
+};
+
+/**
+ * For a project space, return the connector-backed content nodes currently in
+ * the project context, enriched with the source data source view's space,
+ * display name and connector provider. Used by the poke admin UI.
+ */
+export async function listProjectKnowledgeFromConnectors(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<ProjectKnowledgeFromConnectorItem[]> {
+  const attachments = await listProjectContextAttachments(auth, space);
+  const contentNodes = attachments.filter(isContentNodeAttachmentType);
+
+  const dsvSIds = Array.from(
+    new Set(contentNodes.map((a) => a.nodeDataSourceViewId))
+  );
+
+  const dsvBySId = new Map<
+    string,
+    {
+      spaceSId: string;
+      dataSourceName: string;
+      connectorProvider: ConnectorProvider | null;
+    }
+  >();
+  if (dsvSIds.length > 0) {
+    const dsvs = await DataSourceViewResource.fetchByIds(auth, dsvSIds);
+    for (const dsv of dsvs) {
+      const json = dsv.toJSON();
+      dsvBySId.set(dsv.sId, {
+        spaceSId: json.spaceId,
+        dataSourceName: getDisplayNameForDataSource(json.dataSource),
+        connectorProvider: json.dataSource.connectorProvider,
+      });
+    }
+  }
+
+  return contentNodes.map((a) => {
+    const creator = a.creator
+      ? `${a.creator.type === "agent" ? "agent: " : ""}${a.creator.name}`
+      : null;
+    const dsv = dsvBySId.get(a.nodeDataSourceViewId);
+    return {
+      contentFragmentId: a.contentFragmentId,
+      nodeId: a.nodeId,
+      nodeType: a.nodeType,
+      nodeDataSourceViewId: a.nodeDataSourceViewId,
+      title: a.title,
+      contentType: a.contentType,
+      sourceUrl: a.sourceUrl,
+      lastUpdatedAt: a.lastUpdatedAt ?? null,
+      creator,
+      sourceDataSourceViewSpaceSId: dsv?.spaceSId ?? null,
+      sourceDataSourceName: dsv?.dataSourceName ?? null,
+      sourceConnectorProvider: dsv?.connectorProvider ?? null,
+    };
   });
 }
 

--- a/front/lib/api/projects/list.ts
+++ b/front/lib/api/projects/list.ts
@@ -1,7 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { ProjectType } from "@app/types/space";
+import type { ProjectType, SpaceType } from "@app/types/space";
 
 /**
  * Spaces the user is a member of, with project metadata loaded, excluding
@@ -51,4 +51,37 @@ export async function enrichProjectsWithMetadata(
     isMember: space.isMember(auth),
     archivedAt: metadataMap.get(space.id)?.archivedAt?.getTime() ?? null,
   }));
+}
+
+export type ProjectWithAdminMetadata = SpaceType & {
+  description: string | null;
+  archivedAt: number | null;
+  todoGenerationEnabled: boolean;
+};
+
+/**
+ * Every project space in the workspace, with the admin-relevant metadata
+ * (description, archived state, todo-generation flag) merged in. Used by the
+ * poke admin UI.
+ */
+export async function listAllProjectsWithAdminMetadata(
+  auth: Authenticator
+): Promise<ProjectWithAdminMetadata[]> {
+  const projectSpaces = await SpaceResource.listProjectSpaces(auth);
+
+  const metadatas = await ProjectMetadataResource.fetchBySpaceIds(
+    auth,
+    projectSpaces.map((s) => s.id)
+  );
+  const metadataMap = new Map(metadatas.map((m) => [m.spaceId, m]));
+
+  return projectSpaces.map((space) => {
+    const metadata = metadataMap.get(space.id);
+    return {
+      ...space.toJSON(),
+      description: metadata?.description ?? null,
+      archivedAt: metadata?.archivedAt?.getTime() ?? null,
+      todoGenerationEnabled: metadata?.todoGenerationEnabled ?? false,
+    };
+  });
 }

--- a/front/lib/triggers/admin/list_with_metadata.ts
+++ b/front/lib/triggers/admin/list_with_metadata.ts
@@ -1,0 +1,63 @@
+import type { Authenticator } from "@app/lib/auth";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import type { TriggerType } from "@app/types/assistant/triggers";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { WebhookProvider } from "@app/types/triggers/webhooks";
+import type { UserType } from "@app/types/user";
+
+export type TriggerWithProviderAndEditor = TriggerType & {
+  provider?: WebhookProvider | null;
+  editorUser?: UserType | null;
+};
+
+/**
+ * Returns every trigger in the workspace, enriched with the webhook provider
+ * of its source view (when applicable) and the editor's user record. Used by
+ * the poke admin UI.
+ */
+export async function listTriggersWithProviderAndEditor(
+  auth: Authenticator
+): Promise<TriggerWithProviderAndEditor[]> {
+  const triggers = await TriggerResource.listByWorkspace(auth);
+  const triggerJSONs = triggers.map((t) => t.toJSON());
+
+  const webhookSourceViewIds = removeNulls(
+    triggerJSONs.map((t) =>
+      t.kind === "webhook" ? t.webhookSourceViewId : null
+    )
+  );
+
+  const webhookSourceViews =
+    webhookSourceViewIds.length > 0
+      ? await WebhookSourcesViewResource.fetchByIds(auth, webhookSourceViewIds)
+      : [];
+
+  const providerMap = new Map<string, WebhookProvider | null>();
+  for (const view of webhookSourceViews) {
+    const viewJSON = view.toJSON();
+    providerMap.set(viewJSON.sId, viewJSON.provider);
+  }
+
+  const editorIds = removeNulls(triggerJSONs.map((t) => t.editor));
+  const editorUsers =
+    editorIds.length > 0 ? await UserResource.fetchByModelIds(editorIds) : [];
+  const editorUserMap = new Map(editorUsers.map((u) => [u.id, u.toJSON()]));
+
+  return triggerJSONs.map((t) => {
+    const editorUser = editorUserMap.get(t.editor) ?? null;
+    if (t.kind === "webhook" && t.webhookSourceViewId) {
+      return {
+        ...t,
+        provider: providerMap.get(t.webhookSourceViewId) ?? null,
+        editorUser,
+      };
+    }
+    return {
+      ...t,
+      provider: t.kind === "schedule" ? undefined : null,
+      editorUser,
+    };
+  });
+}

--- a/front/lib/utils/apps.ts
+++ b/front/lib/utils/apps.ts
@@ -8,8 +8,10 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { DatasetModel } from "@app/lib/resources/storage/models/apps";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { AppType } from "@app/types/app";
 import type { CoreAPIError } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { DatasetType } from "@app/types/dataset";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
@@ -353,6 +355,40 @@ export const extractDatasetIdsAndHashes = (specification: string) => {
   }
   return dataSetsToFetch;
 };
+
+export type ExportedApp = Omit<AppType, "space" | "id"> & {
+  datasets: DatasetType[];
+};
+
+/**
+ * Returns the serialized app along with the latest version of each dataset
+ * it references (including soft-deleted ones). Used by the poke admin UI
+ * to export a single app for re-import elsewhere.
+ */
+export async function exportAppWithDatasets(
+  auth: Authenticator,
+  app: AppResource
+): Promise<ExportedApp> {
+  const dataSetsToFetch = (await getDatasets(auth, app.toJSON())).map((ds) => ({
+    datasetId: ds.name,
+    hash: "latest",
+  }));
+  const datasets: DatasetType[] = [];
+  for (const dataset of dataSetsToFetch) {
+    const fromCore = await getDatasetHash(
+      auth,
+      app,
+      dataset.datasetId,
+      dataset.hash,
+      { includeDeleted: true }
+    );
+    if (fromCore) {
+      datasets.push(fromCore);
+    }
+  }
+  const appJson = omit(app.toJSON(), "id", "space");
+  return { ...appJson, datasets };
+}
 
 export async function exportApps(
   auth: Authenticator,

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getSpecification } from "@app/lib/api/run";

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/export.ts
@@ -1,18 +1,15 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import { getDatasetHash, getDatasets } from "@app/lib/api/datasets";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AppResource } from "@app/lib/resources/app_resource";
+import { type ExportedApp, exportAppWithDatasets } from "@app/lib/utils/apps";
 import { apiError } from "@app/logger/withlogging";
-import type { AppType } from "@app/types/app";
-import type { DatasetType } from "@app/types/dataset";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import omit from "lodash/omit";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type ExportAppResponseBody = {
-  app: Omit<AppType, "space" | "id"> & { datasets: DatasetType[] };
+  app: ExportedApp;
 };
 
 /**
@@ -63,25 +60,8 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const dataSetsToFetch = (await getDatasets(auth, app.toJSON())).map(
-        (ds) => ({ datasetId: ds.name, hash: "latest" })
-      );
-      const datasets = [];
-      for (const dataset of dataSetsToFetch) {
-        const fromCore = await getDatasetHash(
-          auth,
-          app,
-          dataset.datasetId,
-          dataset.hash,
-          { includeDeleted: true }
-        );
-        if (fromCore) {
-          datasets.push(fromCore);
-        }
-      }
-      const appJson = omit(app.toJSON(), "id", "space");
-
-      res.status(200).json({ app: { ...appJson, datasets } });
+      const exported = await exportAppWithDatasets(auth, app);
+      res.status(200).json({ app: exported });
       return;
 
     default:

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/export.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getDatasetHash, getDatasets } from "@app/lib/api/datasets";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/state.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/state.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/apps/import.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/import.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/apps/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
@@ -1,35 +1,21 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 
-import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import { listProjectContextAttachments } from "@app/lib/api/projects/context";
+import {
+  listProjectKnowledgeFromConnectors,
+  type ProjectKnowledgeFromConnectorItem,
+} from "@app/lib/api/projects/context";
 import { Authenticator } from "@app/lib/auth";
-import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { ContentNodeType } from "@app/types/core/content_node";
-import type { ConnectorProvider } from "@app/types/data_source";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type PokeProjectKnowledgeFromConnectorItem = {
-  contentFragmentId: string;
-  nodeId: string;
-  nodeType: ContentNodeType;
-  nodeDataSourceViewId: string;
-  title: string;
-  contentType: string;
-  sourceUrl: string | null;
-  lastUpdatedAt: number | null;
-  creator: string | null;
-  sourceDataSourceViewSpaceSId: string | null;
-  sourceDataSourceName: string | null;
-  sourceConnectorProvider: ConnectorProvider | null;
-};
+export type PokeProjectKnowledgeFromConnectorItem =
+  ProjectKnowledgeFromConnectorItem;
 
 export type PokeListProjectKnowledgeFromConnectors = {
   items: PokeProjectKnowledgeFromConnectorItem[];
@@ -87,55 +73,7 @@ async function handler(
     });
   }
 
-  const attachments = await listProjectContextAttachments(auth, space);
-  const contentNodes = attachments.filter(isContentNodeAttachmentType);
-
-  const dsvSIds = Array.from(
-    new Set(contentNodes.map((a) => a.nodeDataSourceViewId))
-  );
-
-  const dsvBySId = new Map<
-    string,
-    {
-      spaceSId: string;
-      dataSourceName: string;
-      connectorProvider: ConnectorProvider | null;
-    }
-  >();
-  if (dsvSIds.length > 0) {
-    const dsvs = await DataSourceViewResource.fetchByIds(auth, dsvSIds);
-    for (const dsv of dsvs) {
-      const json = dsv.toJSON();
-      dsvBySId.set(dsv.sId, {
-        spaceSId: json.spaceId,
-        dataSourceName: getDisplayNameForDataSource(json.dataSource),
-        connectorProvider: json.dataSource.connectorProvider,
-      });
-    }
-  }
-
-  const items: PokeProjectKnowledgeFromConnectorItem[] = contentNodes.map(
-    (a) => {
-      const creator = a.creator
-        ? `${a.creator.type === "agent" ? "agent: " : ""}${a.creator.name}`
-        : null;
-      const dsv = dsvBySId.get(a.nodeDataSourceViewId);
-      return {
-        contentFragmentId: a.contentFragmentId,
-        nodeId: a.nodeId,
-        nodeType: a.nodeType,
-        nodeDataSourceViewId: a.nodeDataSourceViewId,
-        title: a.title,
-        contentType: a.contentType,
-        sourceUrl: a.sourceUrl,
-        lastUpdatedAt: a.lastUpdatedAt ?? null,
-        creator,
-        sourceDataSourceViewSpaceSId: dsv?.spaceSId ?? null,
-        sourceDataSourceName: dsv?.dataSourceName ?? null,
-        sourceConnectorProvider: dsv?.connectorProvider ?? null,
-      };
-    }
-  );
+  const items = await listProjectKnowledgeFromConnectors(auth, space);
 
   return res.status(200).json({ items });
 }

--- a/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/projects/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/index.ts
@@ -1,20 +1,17 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import {
+  listAllProjectsWithAdminMetadata,
+  type ProjectWithAdminMetadata,
+} from "@app/lib/api/projects/list";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { SpaceType } from "@app/types/space";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type PokeProjectType = SpaceType & {
-  description: string | null;
-  archivedAt: number | null;
-  todoGenerationEnabled: boolean;
-};
+export type PokeProjectType = ProjectWithAdminMetadata;
 
 export type PokeListProjects = {
   projects: PokeProjectType[];
@@ -51,26 +48,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const projectSpaces = await SpaceResource.listProjectSpaces(auth);
-
-      const metadataResources = await ProjectMetadataResource.fetchBySpaceIds(
-        auth,
-        projectSpaces.map((s) => s.id)
-      );
-      const metadataBySpaceId = new Map(
-        metadataResources.map((m) => [m.spaceId, m])
-      );
-
-      const projects: PokeProjectType[] = projectSpaces.map((space) => {
-        const metadata = metadataBySpaceId.get(space.id);
-        return {
-          ...space.toJSON(),
-          description: metadata?.description ?? null,
-          archivedAt: metadata?.archivedAt?.getTime() ?? null,
-          todoGenerationEnabled: metadata?.todoGenerationEnabled ?? false,
-        };
-      });
-
+      const projects = await listAllProjectsWithAdminMetadata(auth);
       return res.status(200).json({ projects });
 
     default:

--- a/front/pages/api/poke/workspaces/[wId]/projects/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/versions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/versions.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/skills/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
@@ -12,7 +12,7 @@ import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export const PostSkillSuggestionBodySchema = z.object({
+const PostSkillSuggestionBodySchema = z.object({
   name: z.string().min(1, "Name is required."),
   userFacingDescription: z.string().min(1, "Description is required."),
   agentFacingDescription: z

--- a/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
@@ -12,7 +12,7 @@ import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-const PostSkillSuggestionBodySchema = z.object({
+export const PostSkillSuggestionBodySchema = z.object({
   name: z.string().min(1, "Name is required."),
   userFacingDescription: z.string().min(1, "Description is required."),
   agentFacingDescription: z

--- a/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/index.ts
@@ -4,20 +4,15 @@ import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
-import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import {
+  listTriggersWithProviderAndEditor,
+  type TriggerWithProviderAndEditor,
+} from "@app/lib/triggers/admin/list_with_metadata";
 import { apiError } from "@app/logger/withlogging";
-import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { removeNulls } from "@app/types/shared/utils/general";
-import type { WebhookProvider } from "@app/types/triggers/webhooks";
-import type { UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type TriggerWithProviderType = TriggerType & {
-  provider?: WebhookProvider | null;
-  editorUser?: UserType | null;
-};
+export type TriggerWithProviderType = TriggerWithProviderAndEditor;
 
 export type PokeListTriggers = {
   triggers: TriggerWithProviderType[];
@@ -54,58 +49,8 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const triggers = await TriggerResource.listByWorkspace(auth);
-      const triggerJSONs = triggers.map((t) => t.toJSON());
-
-      const webhookSourceViewIds = removeNulls(
-        triggerJSONs.map((t) =>
-          t.kind === "webhook" ? t.webhookSourceViewId : null
-        )
-      );
-
-      const webhookSourceViews =
-        webhookSourceViewIds.length > 0
-          ? await WebhookSourcesViewResource.fetchByIds(
-              auth,
-              webhookSourceViewIds
-            )
-          : [];
-
-      const providerMap = new Map<string, WebhookProvider | null>();
-      for (const view of webhookSourceViews) {
-        const viewJSON = view.toJSON();
-        providerMap.set(viewJSON.sId, viewJSON.provider);
-      }
-
-      // Fetch editor users
-      const editorIds = removeNulls(triggerJSONs.map((t) => t.editor));
-      const editorUsers =
-        editorIds.length > 0
-          ? await UserResource.fetchByModelIds(editorIds)
-          : [];
-      const editorUserMap = new Map(editorUsers.map((u) => [u.id, u.toJSON()]));
-
-      const triggersWithProvider: TriggerWithProviderType[] = triggerJSONs.map(
-        (t) => {
-          const editorUser = editorUserMap.get(t.editor) ?? null;
-          if (t.kind === "webhook" && t.webhookSourceViewId) {
-            return {
-              ...t,
-              provider: providerMap.get(t.webhookSourceViewId) ?? null,
-              editorUser,
-            };
-          }
-          return {
-            ...t,
-            provider: t.kind === "schedule" ? undefined : null,
-            editorUser,
-          };
-        }
-      );
-
-      return res.status(200).json({
-        triggers: triggersWithProvider,
-      });
+      const triggers = await listTriggersWithProviderAndEditor(auth);
+      return res.status(200).json({ triggers });
 
     case "DELETE":
       const { tId } = req.query;


### PR DESCRIPTION
## Description
Adds pokeWorkspaceAuth middleware combining super-user gate with workspace resolution, plus 19 route migrations under /api/poke/workspaces/:wId.
Commits:
1. Migrate poke workspace routes (the migration with response types inline in both Next + Hono)
2. Extract poke admin business logic (lib helpers for connector-knowledge, projects list, triggers list, app export, with their domain types like ProjectWithAdminMetadata, TriggerWithProviderAndEditor, ExportedApp, ProjectKnowledgeFromConnectorItem)
3. Apply new front-api lint rules and rename context to ctx

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Smoke test poke

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
None needed
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25805">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->