### PR TITLE
Add: drag & drop to move files in FileExplorer.

### DIFF
--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -3,6 +3,7 @@ import { FileExplorerFilters } from "@app/components/file_explorer/FileExplorerF
 import type { ViewMode } from "@app/components/file_explorer/FileExplorerItem";
 import { FileExplorerToolbar } from "@app/components/file_explorer/FileExplorerToolbar";
 import { FilePreviewDialog } from "@app/components/file_explorer/FilePreviewDialog";
+import { canMoveFileToParentFolder } from "@app/components/file_explorer/fileExplorerDragDrop";
 import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
 import { MoveFileToFolderDialog } from "@app/components/file_explorer/MoveFileToFolderDialog";
 import type {
@@ -18,6 +19,7 @@ import type {
 import {
   buildFolderTree,
   countFoldersInTree,
+  getScopedRelativePath,
 } from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
@@ -224,6 +226,31 @@ export function FileExplorer({
       ? "All files"
       : (folderStack.at(-2)?.name ?? "All files");
 
+  const parentFolderDropPath =
+    folderStack.length <= 1 ? "" : (folderStack.at(-2)?.path ?? "");
+
+  const fileDragEnabled = Boolean(onMoveFile && totalFolderCount > 0);
+
+  const handleMoveFileDrop = useCallback(
+    async (scopedFilePath: string, parentRelativePath: string) => {
+      if (
+        !onMoveFile ||
+        !canMoveFileToParentFolder(scopedFilePath, parentRelativePath)
+      ) {
+        return;
+      }
+
+      const relativePath = getScopedRelativePath(scopedFilePath);
+      const entry = entryByRelativePath.get(relativePath);
+      if (entry?.kind !== "file") {
+        return;
+      }
+
+      await onMoveFile(entry, parentRelativePath);
+    },
+    [entryByRelativePath, onMoveFile]
+  );
+
   const handleFileOpen = (entry: FileEntry) => {
     if (
       onOpenInteractive &&
@@ -316,6 +343,8 @@ export function FileExplorer({
             viewMode={viewMode}
             isEmpty={fileCount === 0 && folderCount === 0}
             emptyState={emptyState}
+            fileDragEnabled={fileDragEnabled}
+            parentFolderDropPath={parentFolderDropPath}
             parentFolderLabel={
               folderStack.length > 0 ? parentFolderLabel : undefined
             }
@@ -323,6 +352,7 @@ export function FileExplorer({
             onFolderNavigate={handleFolderNavigate}
             onFileOpen={handleFileOpen}
             onFileDownload={onFileDownload}
+            onMoveFileDrop={fileDragEnabled ? handleMoveFileDrop : undefined}
             onNodeOpen={handleNodeOpen}
             getFileMenuItems={
               onDelete || onRename || onMoveFile ? getMenuItems : undefined

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -27,11 +27,14 @@ interface FileExplorerContentProps {
   viewMode: ViewMode;
   isEmpty: boolean;
   emptyState?: React.ReactNode;
+  fileDragEnabled?: boolean;
+  parentFolderDropPath?: string;
   parentFolderLabel?: string;
   onGoUp?: () => void;
   onFolderNavigate: (node: SandboxTreeNode) => void;
   onFileOpen: (entry: FileEntry) => void;
   onFileDownload: (entry: FileEntry) => Promise<void>;
+  onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
   onNodeOpen: (entry: ContentNodeEntry) => void;
   getFileMenuItems?: (entry: FileExplorerEntry) => FileExplorerMenuAction[];
 }
@@ -43,11 +46,14 @@ export function FileExplorerContent({
   viewMode,
   isEmpty,
   emptyState,
+  fileDragEnabled,
+  parentFolderDropPath,
   parentFolderLabel,
   onGoUp,
   onFolderNavigate,
   onFileOpen,
   onFileDownload,
+  onMoveFileDrop,
   onNodeOpen,
   getFileMenuItems,
 }: FileExplorerContentProps) {
@@ -58,8 +64,10 @@ export function FileExplorerContent({
       <FileExplorerGoUpCard
         key="go-up"
         parentLabel={parentFolderLabel}
+        parentRelativePath={parentFolderDropPath ?? ""}
         viewMode={viewMode}
         onGoUp={onGoUp}
+        onMoveFileDrop={onMoveFileDrop}
       />
     ) : null;
 
@@ -71,6 +79,7 @@ export function FileExplorerContent({
           node={node}
           viewMode={viewMode}
           onNavigate={onFolderNavigate}
+          onMoveFileDrop={onMoveFileDrop}
         />
       );
     }
@@ -96,6 +105,7 @@ export function FileExplorerContent({
         return (
           <FileExplorerFileCard
             key={`file:${entry.path}`}
+            draggable={fileDragEnabled}
             entry={entry}
             viewMode={viewMode}
             onOpen={onFileOpen}

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -1,3 +1,8 @@
+import {
+  canMoveFileToParentFolder,
+  setFileExplorerDragData,
+  useFileExplorerDropTarget,
+} from "@app/components/file_explorer/fileExplorerDragDrop";
 import type {
   ContentNodeEntry,
   FileEntry,
@@ -35,29 +40,61 @@ import { useState } from "react";
 export type ViewMode = "grid" | "list";
 
 export type FileExplorerItemProps = {
+  draggable?: boolean;
+  extraMenuItems?: FileExplorerMenuAction[];
+  isDropActive?: boolean;
+  isDragging?: boolean;
   onDownload?: () => Promise<void>;
+  onDragEnd?: (e: React.DragEvent) => void;
+  onDragEnter?: (e: React.DragEvent) => void;
+  onDragLeave?: (e: React.DragEvent) => void;
+  onDragOver?: (e: React.DragEvent) => void;
+  onDragStart?: (e: React.DragEvent) => void;
+  onDrop?: (e: React.DragEvent) => void;
   onOpen: () => void;
   subtitle: string;
   title: string;
   titleClassName?: string;
   viewMode: ViewMode;
-  extraMenuItems?: FileExplorerMenuAction[];
 } & (
   | { kind: "icon"; visual: React.ComponentType }
   | { kind: "thumbnail"; thumbnailSrc: string | null }
 );
 
 // TODO(2026-04-27 FILE SYSTEM): Candidate for Sparkle once the GCS file explorer pattern stabilises.
+const dropActiveClasses = cn(
+  "ring-2 ring-primary-400 ring-inset dark:ring-primary-400-night",
+  "bg-primary-100 dark:bg-primary-100-night"
+);
+
 export function FileExplorerItem(props: FileExplorerItemProps) {
   const {
+    draggable,
+    extraMenuItems,
+    isDropActive,
+    isDragging,
     onDownload,
+    onDragEnd,
+    onDragEnter,
+    onDragLeave,
+    onDragOver,
+    onDragStart,
+    onDrop,
     onOpen,
     subtitle,
     title,
     titleClassName,
     viewMode,
-    extraMenuItems,
   } = props;
+
+  const interactionHandlers = {
+    onDragEnd,
+    onDragEnter,
+    onDragLeave,
+    onDragOver,
+    onDragStart,
+    onDrop,
+  };
 
   const thumbnailContent =
     props.kind === "icon" ? (
@@ -164,11 +201,17 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
   if (viewMode === "list") {
     return (
       <div
+        draggable={draggable}
         className={cn(
-          "flex cursor-pointer items-center gap-4 rounded-xl px-3 py-2",
-          "hover:bg-muted-background dark:hover:bg-muted-background-night"
+          "flex items-center gap-4 rounded-xl px-3 py-2",
+          draggable ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
+          isDragging && "opacity-50",
+          isDropActive
+            ? dropActiveClasses
+            : "hover:bg-muted-background dark:hover:bg-muted-background-night"
         )}
         onClick={onOpen}
+        {...interactionHandlers}
       >
         <div className="flex h-4 w-4 shrink-0 items-center justify-center">
           {thumbnailContent}
@@ -180,11 +223,23 @@ export function FileExplorerItem(props: FileExplorerItemProps) {
   }
 
   return (
-    <div className="flex flex-col gap-1">
+    <div
+      className={cn("flex flex-col gap-1", isDragging && "opacity-50")}
+      draggable={draggable}
+      onDragEnd={onDragEnd}
+      onDragEnter={onDragEnter}
+      onDragLeave={onDragLeave}
+      onDragOver={onDragOver}
+      onDragStart={onDragStart}
+      onDrop={onDrop}
+    >
       <div
         className={cn(
-          "flex h-24 cursor-pointer items-center justify-center overflow-hidden rounded-xl",
-          "bg-muted-background hover:brightness-95 dark:bg-muted-background-night",
+          "flex h-24 items-center justify-center overflow-hidden rounded-xl",
+          draggable ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
+          isDropActive
+            ? dropActiveClasses
+            : "bg-muted-background hover:brightness-95 dark:bg-muted-background-night",
           props.kind === "icon" && "p-4"
         )}
         onClick={onOpen}
@@ -213,15 +268,31 @@ function getFileSubtitle(entry: GCSMountFileEntry, viewMode: ViewMode): string {
 
 export interface FileExplorerGoUpCardProps {
   parentLabel: string;
+  parentRelativePath: string;
   viewMode: ViewMode;
   onGoUp: () => void;
+  onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
 }
 
 export function FileExplorerGoUpCard({
   parentLabel,
+  parentRelativePath,
   viewMode,
   onGoUp,
+  onMoveFileDrop,
 }: FileExplorerGoUpCardProps) {
+  const { isDragOver, dropTargetProps } = useFileExplorerDropTarget({
+    disabled: !onMoveFileDrop,
+    onDrop: (scopedFilePath) => {
+      if (
+        onMoveFileDrop &&
+        canMoveFileToParentFolder(scopedFilePath, parentRelativePath)
+      ) {
+        onMoveFileDrop(scopedFilePath, parentRelativePath);
+      }
+    },
+  });
+
   return (
     <FileExplorerItem
       kind="icon"
@@ -229,7 +300,9 @@ export function FileExplorerGoUpCard({
       viewMode={viewMode}
       title="Back"
       subtitle={`Browse "${parentLabel}"`}
+      isDropActive={isDragOver}
       onOpen={onGoUp}
+      {...dropTargetProps}
     />
   );
 }
@@ -238,13 +311,27 @@ export interface FileExplorerFolderCardProps {
   node: SandboxTreeNode;
   viewMode: ViewMode;
   onNavigate: (node: SandboxTreeNode) => void;
+  onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
 }
 
 export function FileExplorerFolderCard({
   node,
   viewMode,
   onNavigate,
+  onMoveFileDrop,
 }: FileExplorerFolderCardProps) {
+  const { isDragOver, dropTargetProps } = useFileExplorerDropTarget({
+    disabled: !onMoveFileDrop,
+    onDrop: (scopedFilePath) => {
+      if (
+        onMoveFileDrop &&
+        canMoveFileToParentFolder(scopedFilePath, node.path)
+      ) {
+        onMoveFileDrop(scopedFilePath, node.path);
+      }
+    },
+  });
+
   const childCount = node.children.length;
   const subtitle =
     childCount === 0
@@ -261,12 +348,15 @@ export function FileExplorerFolderCard({
       title={node.name}
       titleClassName="font-semibold"
       subtitle={subtitle}
+      isDropActive={isDragOver}
       onOpen={() => onNavigate(node)}
+      {...dropTargetProps}
     />
   );
 }
 
 export interface FileExplorerFileCardProps {
+  draggable?: boolean;
   entry: FileEntry;
   viewMode: ViewMode;
   onOpen: (entry: FileEntry) => void;
@@ -275,13 +365,37 @@ export interface FileExplorerFileCardProps {
 }
 
 export function FileExplorerFileCard({
+  draggable: draggableProp,
   entry,
   viewMode,
   onOpen,
   onDownload,
   extraMenuItems,
 }: FileExplorerFileCardProps) {
+  const [isDragging, setIsDragging] = useState(false);
   const subtitle = getFileSubtitle(entry, viewMode);
+
+  const handleDragStart = (e: React.DragEvent) => {
+    if (e.target instanceof HTMLElement && e.target.closest("button")) {
+      e.preventDefault();
+      return;
+    }
+    setFileExplorerDragData(e.dataTransfer, entry.path);
+    setIsDragging(true);
+  };
+
+  const handleDragEnd = () => {
+    setIsDragging(false);
+  };
+
+  const dragProps = draggableProp
+    ? {
+        draggable: true as const,
+        isDragging,
+        onDragEnd: handleDragEnd,
+        onDragStart: handleDragStart,
+      }
+    : {};
 
   if (
     getCategoryFromContentType(entry.contentType) === "image" &&
@@ -297,6 +411,7 @@ export function FileExplorerFileCard({
         onOpen={() => onOpen(entry)}
         onDownload={() => onDownload(entry)}
         extraMenuItems={extraMenuItems}
+        {...dragProps}
       />
     );
   }
@@ -312,6 +427,7 @@ export function FileExplorerFileCard({
       onOpen={() => onOpen(entry)}
       onDownload={() => onDownload(entry)}
       extraMenuItems={extraMenuItems}
+      {...dragProps}
     />
   );
 }

--- a/front/components/file_explorer/fileExplorerDragDrop.test.ts
+++ b/front/components/file_explorer/fileExplorerDragDrop.test.ts
@@ -1,0 +1,19 @@
+import {
+  canMoveFileToParentFolder,
+  getCurrentParentRelativePath,
+} from "@app/components/file_explorer/fileExplorerDragDrop";
+import { describe, expect, it } from "vitest";
+
+describe("fileExplorerDragDrop", () => {
+  it("resolves the current parent from a scoped file path", () => {
+    expect(getCurrentParentRelativePath("project/foo/bar.txt")).toBe("foo");
+    expect(getCurrentParentRelativePath("conversation/file.txt")).toBe("");
+  });
+
+  it("rejects moves to the current parent folder", () => {
+    expect(canMoveFileToParentFolder("project/foo/bar.txt", "foo")).toBe(false);
+    expect(canMoveFileToParentFolder("project/foo/bar.txt", "foo/baz")).toBe(
+      true
+    );
+  });
+});

--- a/front/components/file_explorer/fileExplorerDragDrop.ts
+++ b/front/components/file_explorer/fileExplorerDragDrop.ts
@@ -1,0 +1,126 @@
+import {
+  getParentFolderRelativePath,
+  getScopedRelativePath,
+} from "@app/components/file_explorer/utils";
+import type React from "react";
+import { useCallback, useRef, useState } from "react";
+
+/** Drag payload MIME type for file explorer file moves. */
+export const FILE_EXPLORER_DRAG_MIME = "application/x-dust-file-explorer-file";
+
+export function setFileExplorerDragData(
+  dataTransfer: DataTransfer,
+  scopedFilePath: string
+): void {
+  dataTransfer.effectAllowed = "move";
+  dataTransfer.setData(FILE_EXPLORER_DRAG_MIME, scopedFilePath);
+}
+
+export function getFileExplorerDragScopedPath(
+  dataTransfer: DataTransfer
+): string | null {
+  const path = dataTransfer.getData(FILE_EXPLORER_DRAG_MIME);
+  return path.length > 0 ? path : null;
+}
+
+export function hasFileExplorerDrag(dataTransfer: DataTransfer): boolean {
+  return dataTransfer.types.includes(FILE_EXPLORER_DRAG_MIME);
+}
+
+export function getCurrentParentRelativePath(fileScopedPath: string): string {
+  return getParentFolderRelativePath(getScopedRelativePath(fileScopedPath));
+}
+
+export function canMoveFileToParentFolder(
+  fileScopedPath: string,
+  targetParentRelativePath: string
+): boolean {
+  return (
+    getCurrentParentRelativePath(fileScopedPath) !== targetParentRelativePath
+  );
+}
+
+export function useFileExplorerDropTarget({
+  disabled,
+  onDrop,
+}: {
+  disabled?: boolean;
+  onDrop: (scopedFilePath: string) => void;
+}) {
+  const dragCounterRef = useRef(0);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const reset = useCallback(() => {
+    dragCounterRef.current = 0;
+    setIsDragOver(false);
+  }, []);
+
+  const onDragEnter = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled || !hasFileExplorerDrag(e.dataTransfer)) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      dragCounterRef.current += 1;
+      if (dragCounterRef.current === 1) {
+        setIsDragOver(true);
+      }
+    },
+    [disabled]
+  );
+
+  const onDragOver = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled || !hasFileExplorerDrag(e.dataTransfer)) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      e.dataTransfer.dropEffect = "move";
+    },
+    [disabled]
+  );
+
+  const onDragLeave = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled || !hasFileExplorerDrag(e.dataTransfer)) {
+        return;
+      }
+      e.stopPropagation();
+      dragCounterRef.current -= 1;
+      if (dragCounterRef.current <= 0) {
+        reset();
+      }
+    },
+    [disabled, reset]
+  );
+
+  const onDropHandler = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      reset();
+
+      const scopedFilePath = getFileExplorerDragScopedPath(e.dataTransfer);
+      if (!scopedFilePath) {
+        return;
+      }
+      onDrop(scopedFilePath);
+    },
+    [disabled, onDrop, reset]
+  );
+
+  return {
+    isDragOver,
+    dropTargetProps: {
+      onDragEnter,
+      onDragOver,
+      onDragLeave,
+      onDrop: onDropHandler,
+    },
+  };
+}


### PR DESCRIPTION
## Description

The "Move to" dialog from #25806 works but requires three clicks. Drag and drop is a more natural way to reorganize files in the explorer.

**`fileExplorerDragDrop.ts`**

New module with three exports:
- `setFileExplorerDragData(e, scopedFilePath)` — stamps `text/x-file-explorer-path` on the `DataTransfer` so internal file-explorer drags are distinguishable from external file uploads
- `canMoveFileToParentFolder(scopedFilePath, parentRelativePath)` — guards against no-op drops (same parent) and cycle drops (dropping into a descendant of self)
- `useFileExplorerDropTarget(targetRelativePath, onMoveFileDrop)` — returns `{ isOver, onDragOver, onDrop, onDragLeave }` handlers for a drop zone; reads the `text/x-file-explorer-path` header to extract the dragged path

**Component changes**

- `FileExplorerFileCard` — gains a `draggable` prop; when enabled, adds `draggable="true"` + `onDragStart` calling `setFileExplorerDragData`; drag is suppressed while `isLoading`
- `FileExplorerFolderCard` — wraps the card in a `useFileExplorerDropTarget` zone; shows a visible ring highlight when `isOver`
- `FileExplorerGoUpCard` — gains `parentRelativePath` + `onMoveFileDrop`; dropping a file onto the "Back" card moves it to the parent folder; highlights when `isOver`
- `FileExplorerContent` — threads `fileDragEnabled`, `parentFolderDropPath`, and `onMoveFileDrop` to all three card types
- `FileExplorer` — computes `fileDragEnabled = Boolean(onMoveFile && totalFolderCount > 0)` and `parentFolderDropPath` (parent of the current folder stack); wires `handleMoveFileDrop` which validates via `canMoveFileToParentFolder` before calling `onMoveFile`

## Tests

Local


https://github.com/user-attachments/assets/a9073325-4c6a-4e0a-b887-d4dabeb0bdbd


## Risk

Low — drag is opt-in (`fileDragEnabled` gate); external file drops (from OS) are unaffected because they don't carry the `text/x-file-explorer-path` header

## Deploy Plan

Deploy `front`
