### PR TITLE
Fix: no more empty list during files revalidation.

### DIFF
--- a/front/components/file_explorer/fileExplorerPipeline.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.ts
@@ -92,10 +92,13 @@ export function getFileExplorerPipeline({
   }));
 
   const currentNodes =
-    resolvedFolderStack.length === 0
-      ? [...tree, ...contentNodeTreeNodes]
-      : // Fresh `children` from the latest tree, not from nodes captured at click time.
-        (resolvedFolderStack.at(-1)?.children ?? []);
+    resolvedFolderStack.length > 0
+      ? // Fresh `children` from the latest tree, not from nodes captured at click time.
+        (resolvedFolderStack.at(-1)?.children ?? [])
+      : folderStack.length > 0
+        ? // Tree is rebuilding (e.g. during SWR revalidate); avoid flashing the root listing.
+          []
+        : [...tree, ...contentNodeTreeNodes];
 
   const q = searchQuery.trim().toLowerCase();
   const visibleNodes = currentNodes.filter((node) => {

--- a/front/hooks/conversations/useConversationSandboxFiles.ts
+++ b/front/hooks/conversations/useConversationSandboxFiles.ts
@@ -24,7 +24,7 @@ export function useConversationSandboxFiles({
       ? `/api/w/${owner.sId}/assistant/conversations/${conversationId}/files`
       : null,
     sandboxFilesFetcher,
-    options
+    { keepPreviousData: true, ...options }
   );
 
   const disabled = options?.disabled;

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -72,7 +72,8 @@ export function useProjectContextAttachments({
     useSWRWithDefaults(key, projectContextFetcher);
 
   const refreshProjectContextAttachments = useCallback(async () => {
-    await mutateRegardlessOfQueryParams(undefined, { revalidate: true });
+    // Do not pass `undefined` as data — it clears the cache and causes UI flicker.
+    await mutateRegardlessOfQueryParams();
   }, [mutateRegardlessOfQueryParams]);
 
   return {
@@ -101,11 +102,13 @@ export function useProjectFiles({
       disabled || !spaceId
         ? null
         : `/api/w/${owner.sId}/spaces/${spaceId}/files`,
-      projectFilesFetcher
+      projectFilesFetcher,
+      { keepPreviousData: true }
     );
 
   const refreshProjectFiles = useCallback(async () => {
-    await mutateRegardlessOfQueryParams(undefined, { revalidate: true });
+    // Do not pass `undefined` as data — it clears the cache and causes UI flicker.
+    await mutateRegardlessOfQueryParams();
   }, [mutateRegardlessOfQueryParams]);
 
   return {


### PR DESCRIPTION
## Description

Three sources of empty-list flashes during file revalidation, fixed.

**SWR cache clearing on refresh**

`useProjectFiles` and `useProjectContextAttachments` were calling `mutateRegardlessOfQueryParams(undefined, { revalidate: true })`. Passing `undefined` as data explicitly clears the cache before the new response arrives, causing a brief empty state. Dropping that argument (calling with no args) keeps the previous data visible while the fetch is in-flight.

**`keepPreviousData: true`**

Added to `useProjectFiles` and `useConversationSandboxFiles`. SWR keeps the last known value during revalidation instead of surfacing `undefined`, so the list never empties mid-refresh.

**Tree-rebuilding state in `getFileExplorerPipeline`**

When navigating into a subfolder and SWR revalidates (after a move, upload, etc.), the tree rebuilds from scratch. During that window, `folderStack` still has entries but `resolveFolderStackInTree` returns `[]` (the folder can't be located in the new tree yet). Previously this fell through to the root listing, flashing all root files. Now it returns `[]` for this transient state — the content area stays blank/stable until the path resolves successfully in the refreshed tree.

## Tests

Local

## Risk

Low — all three changes are purely about retaining previous data during async updates; no behavioral change once the new data arrives

## Deploy Plan

Deploy `front`
