### PR TITLE
feat: read from pods path insted of project

### DIFF
--- a/connectors/src/connectors/dust_project/lib/mount_path_utils.test.ts
+++ b/connectors/src/connectors/dust_project/lib/mount_path_utils.test.ts
@@ -12,14 +12,15 @@ import { describe, expect, it } from "vitest";
 const PROJECT_ID = "spc_test123";
 
 describe("parseProjectScopedPath", () => {
-  it("strips the project scope prefix", () => {
-    expect(parseProjectScopedPath("project/reports/q1/summary.pdf")).toBe(
+  it("strips the pod scope prefix", () => {
+    expect(parseProjectScopedPath("pod/reports/q1/summary.pdf")).toBe(
       "reports/q1/summary.pdf"
     );
   });
 
-  it("returns null for non-project paths", () => {
+  it("returns null for non-pod paths", () => {
     expect(parseProjectScopedPath("conversation/file.pdf")).toBeNull();
+    expect(parseProjectScopedPath("project/file.pdf")).toBeNull();
   });
 });
 

--- a/connectors/src/connectors/dust_project/lib/mount_path_utils.ts
+++ b/connectors/src/connectors/dust_project/lib/mount_path_utils.ts
@@ -1,18 +1,18 @@
 import { PROJECT_CONTEXT_FOLDER_ID } from "@connectors/connectors/dust_project/lib/constants";
 import { createHash } from "crypto";
 
-const PROJECT_SCOPE_PREFIX = "project/";
+const POD_SCOPE_PREFIX = "pod/";
 
 /**
- * Strip the `project/` scope prefix from a scoped mount path.
- * Returns null when the path is not a project-scoped mount path.
+ * Strip the `pod/` scope prefix from a scoped mount path.
+ * Returns null when the path is not a pod-scoped mount path.
  */
 export function parseProjectScopedPath(scopedPath: string): string | null {
-  if (!scopedPath.startsWith(PROJECT_SCOPE_PREFIX)) {
+  if (!scopedPath.startsWith(POD_SCOPE_PREFIX)) {
     return null;
   }
 
-  const relativePath = scopedPath.slice(PROJECT_SCOPE_PREFIX.length);
+  const relativePath = scopedPath.slice(POD_SCOPE_PREFIX.length);
   return relativePath.length > 0 ? relativePath : null;
 }
 

--- a/front-api/routes/v1/viz/files/[...segments].ts
+++ b/front-api/routes/v1/viz/files/[...segments].ts
@@ -2,7 +2,7 @@
 
 import {
   getConversationFilesBasePath,
-  getProjectFilesBasePath,
+  getPodFilesBasePath,
   scopedFilePathPrefixSchema,
 } from "@app/lib/api/files/mount_path";
 import { extractAndVerifyVizAccessTokenFromHeader } from "@app/lib/api/viz/access_tokens";
@@ -145,17 +145,17 @@ app.get("/:scope/:rel{.+}", async (ctx) => {
   } else {
     // Project-scoped frames have spaceId directly. Conversation-scoped frames that live in
     // a project space get conversationSpaceId resolved by fetchByShareToken.
-    const projectId = frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId;
-    if (!isString(projectId)) {
+    const podId = frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId;
+    if (!isString(podId)) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: "Frame has no project context for this path.",
+          message: "Frame has no pod context for this path.",
         },
       });
     }
-    basePath = getProjectFilesBasePath({ workspaceId, projectId });
+    basePath = getPodFilesBasePath({ workspaceId, podId });
   }
 
   const gcsPath = `${basePath}${normalizedRel}`;

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -107,7 +107,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
     const mockFile = {
       isDirectory: false as const,
       fileName: "a.txt",
-      path: "project/a.txt",
+      path: "pod/a.txt",
       sizeBytes: 3,
       lastModifiedMs: 2000,
       contentType: "text/plain",
@@ -125,7 +125,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
       {
         isDirectory: false as const,
         fileName: "old.txt",
-        path: "project/old.txt",
+        path: "pod/old.txt",
         sizeBytes: 1,
         lastModifiedMs: 500,
         contentType: "text/plain",
@@ -143,8 +143,8 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
 
     expect(response.status).toBe(200);
     expect(listGCSMountFilesMock).toHaveBeenCalledWith(expect.anything(), {
-      useCase: "project",
-      projectId: space.sId,
+      useCase: "pod",
+      podId: space.sId,
     });
     expect(await response.json()).toEqual({
       files: [mockFileWithUrl],

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -83,8 +83,8 @@ app.get(
         : null;
 
     let files = await listGCSMountFiles(auth, {
-      useCase: "project",
-      projectId: space.sId,
+      useCase: "pod",
+      podId: space.sId,
     });
 
     if (updatedSinceFilter !== null) {
@@ -106,14 +106,14 @@ app.get(
         const gcsPath = getGCSPathFromScopedPath({
           prefix: gcsPrefix,
           scopedPath: entry.path,
-          useCase: "project",
+          useCase: "pod",
         });
         if (!gcsPath) {
           return { ...entry, signedDownloadUrl: null };
         }
         const signed = await getConversationFileMountSignedUrl(
           auth,
-          { useCase: "project", projectId: space.sId },
+          { useCase: "pod", podId: space.sId },
           gcsPath
         );
         return {

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -4,7 +4,7 @@ import {
   getGCSPathFromScopedPath,
   listGCSMountFiles,
 } from "@app/lib/api/files/gcs_mount/files";
-import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
+import { getPodFilesBasePath } from "@app/lib/api/files/mount_path";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -92,9 +92,9 @@ app.get(
     }
 
     const owner = auth.getNonNullableWorkspace();
-    const gcsPrefix = getProjectFilesBasePath({
+    const gcsPrefix = getPodFilesBasePath({
       workspaceId: owner.sId,
-      projectId: space.sId,
+      podId: space.sId,
     });
 
     const filesWithSignedUrls = await concurrentExecutor(

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -329,14 +329,14 @@ app.post("/", async (ctx) => {
         contentType: file.contentType,
         useCase: file.useCase,
         useCaseMetadata: file.useCaseMetadata,
-        message: "Failed to add the file to the project.",
+        message: "Failed to add the file to the Pod.",
         error: addFileToProjectRes.error,
       });
       return apiError(ctx, {
         status_code: 500,
         api_error: {
           type: "internal_server_error",
-          message: "Failed to add the file to the project.",
+          message: "Failed to add the file to the Pod.",
         },
       });
     }
@@ -405,7 +405,7 @@ async function checkFileAccess(
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: "Space is not a project",
+          message: "Space is not a Pod",
         },
       });
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -1,5 +1,5 @@
 import {
-  getProjectFilesBasePath,
+  getPodFilesBasePath,
   isResolveMountFilePathError,
   resolveScopedMountFilePath,
 } from "@app/lib/api/files/mount_path";
@@ -49,7 +49,7 @@ async function buildContext(ctx: Context): Promise<
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: "Files are only available for project spaces.",
+          message: "Files are only available for Pod spaces.",
         },
       }),
     };
@@ -69,15 +69,15 @@ async function buildContext(ctx: Context): Promise<
   }
 
   const owner = auth.getNonNullableWorkspace();
-  const basePath = getProjectFilesBasePath({
+  const basePath = getPodFilesBasePath({
     workspaceId: owner.sId,
-    projectId: space.sId,
+    podId: space.sId,
   });
   const pathRes = resolveScopedMountFilePath({
     relPath: rel,
-    expectedPrefix: "project",
+    expectedPrefix: "pod",
     mountBasePath: basePath,
-    outsideScopeMessage: "Access denied: path is outside project scope.",
+    outsideScopeMessage: "Access denied: path is outside Pod scope.",
   });
   if (pathRes.isErr()) {
     const { code, message } = pathRes.error;

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
@@ -40,14 +40,14 @@ app.get(
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: "Files are only available for project spaces.",
+          message: "Files are only available for Pod spaces.",
         },
       });
     }
 
     const files = await listGCSMountFiles(auth, {
-      useCase: "project",
-      projectId: space.sId,
+      useCase: "pod",
+      podId: space.sId,
     });
 
     return ctx.json({ files });
@@ -67,7 +67,7 @@ app.post(
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: "Files are only available for project spaces.",
+          message: "Files are only available for Pod spaces.",
         },
       });
     }
@@ -77,7 +77,7 @@ app.post(
         status_code: 403,
         api_error: {
           type: "workspace_auth_error",
-          message: "You do not have write access to this project.",
+          message: "You do not have write access to this Pod.",
         },
       });
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -63,14 +63,14 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "report.pdf"],
+        ["pod", "report.pdf"],
         { method: "GET" }
       );
       expect(response.status).toBe(200);
       expect(response.headers.get("Content-Type")).toBe("text/plain");
     });
 
-    it("returns 400 when path lacks the project/ prefix", async () => {
+    it("returns 400 when path lacks the pod/ prefix", async () => {
       const { workspace, project } = await setupProject();
       const response = await fileRequest(workspace, project.sId, [
         "report.pdf",
@@ -82,7 +82,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
     it("returns 403 for path traversal attempts", async () => {
       const { workspace, project } = await setupProject();
       const response = await fileRequest(workspace, project.sId, [
-        "project",
+        "pod",
         "..",
         "..",
         "etc",
@@ -100,7 +100,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
 
       const { workspace, project } = await setupProject();
       const response = await fileRequest(workspace, project.sId, [
-        "project",
+        "pod",
         "missing.txt",
       ]);
       expect(response.status).toBe(404);
@@ -120,7 +120,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "old.txt"],
+        ["pod", "old.txt"],
         { method: "PATCH", body: { fileName: "new.txt" } }
       );
       expect(response.status).toBe(200);
@@ -139,7 +139,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { method: "PATCH", body: {} }
       );
       expect(response.status).toBe(400);
@@ -150,13 +150,13 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { method: "PATCH", body: { fileName: "sub/name.txt" } }
       );
       expect(response.status).toBe(400);
     });
 
-    it("returns 400 when path lacks the project/ prefix", async () => {
+    it("returns 400 when path lacks the pod/ prefix", async () => {
       const { workspace, project } = await setupProject();
       const response = await fileRequest(workspace, project.sId, ["file.txt"], {
         method: "PATCH",
@@ -170,7 +170,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "..", "evil.txt"],
+        ["pod", "..", "evil.txt"],
         { method: "PATCH", body: { fileName: "new.txt" } }
       );
       expect(response.status).toBe(403);
@@ -182,7 +182,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { method: "PATCH", body: { fileName: "new.txt" } }
       );
       expect(response.status).toBe(403);
@@ -196,7 +196,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { method: "PATCH", body: { fileName: "new.txt" } }
       );
       expect(response.status).toBe(500);
@@ -215,7 +215,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { method: "DELETE" }
       );
       expect(response.status).toBe(200);
@@ -228,7 +228,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       );
     });
 
-    it("returns 400 when path lacks the project/ prefix", async () => {
+    it("returns 400 when path lacks the pod/ prefix", async () => {
       const { workspace, project } = await setupProject();
       const response = await fileRequest(workspace, project.sId, ["file.txt"], {
         method: "DELETE",
@@ -241,7 +241,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "..", "evil.txt"],
+        ["pod", "..", "evil.txt"],
         { method: "DELETE" }
       );
       expect(response.status).toBe(403);
@@ -253,7 +253,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { method: "DELETE" }
       );
       expect(response.status).toBe(403);
@@ -267,7 +267,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
       const response = await fileRequest(
         workspace,
         project.sId,
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { method: "DELETE" }
       );
       expect(response.status).toBe(500);

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -193,6 +193,17 @@ function buildMountFilePreviewHref({
     return `${apiBaseUrl}/api/w/${ownerId}/spaces/${spaceId}/files/${filePath}`;
   }
 
+  // Legacy "project/" scope maps to the same Pod files endpoint; rewrite the prefix.
+  if (filePath.startsWith("project/")) {
+    if (!spaceId) {
+      return undefined;
+    }
+
+    const podFilePath = `pod/${filePath.slice("project/".length)}`;
+
+    return `${apiBaseUrl}/api/w/${ownerId}/spaces/${spaceId}/files/${podFilePath}`;
+  }
+
   return undefined;
 }
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -185,7 +185,7 @@ function buildMountFilePreviewHref({
     return `${apiBaseUrl}/api/w/${ownerId}/assistant/conversations/${conversationId}/files/${filePath}`;
   }
 
-  if (filePath.startsWith("project/")) {
+  if (filePath.startsWith("pod/")) {
     if (!spaceId) {
       return undefined;
     }

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -318,11 +318,24 @@ export const VisualizationActionIframe = forwardRef<
           return null;
         }
         url = `/api/w/${workspaceId}/assistant/conversations/${conversationId}/files/${fileId}`;
-      } else if (fileId.startsWith("project/")) {
+      } else if (fileId.startsWith("pod/")) {
         if (!spaceId) {
           return null;
         }
         url = `/api/w/${workspaceId}/spaces/${spaceId}/files/${fileId}`;
+      } else if (fileId.startsWith("project/")) {
+        // Legacy "project/" scope. The Pod files endpoint only accepts the
+        // "pod/" prefix and resolves everything under the pods/ base path, so
+        // we rewrite the prefix. Log remaining usage so we can drop this branch
+        // once no clients emit "project/" paths anymore.
+        if (!spaceId) {
+          return null;
+        }
+        datadogLogger.info("Legacy project/ file scope used in visualization", {
+          fileId,
+        });
+        const podFileId = `pod/${fileId.slice("project/".length)}`;
+        url = `/api/w/${workspaceId}/spaces/${spaceId}/files/${podFileId}`;
       } else {
         url = `/api/w/${workspaceId}/files/${fileId}?action=view`;
       }

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -137,7 +137,7 @@ const MOVE_SCHEMA = {
     ),
   dest: z
     .string()
-    .describe("Scoped path of the destination (e.g. `project/report.pdf`)."),
+    .describe("Scoped path of the destination (e.g. `pod/report.pdf`)."),
 };
 
 const MOVE_CONVERSATION_ONLY_TOOL = {
@@ -154,17 +154,17 @@ const MOVE_PROJECT_AWARE_TOOL = {
   description:
     `${MOVE_DESCRIPTION_BASE} ` +
     "Since this conversation belongs to a Pod, you can also move between scopes, " +
-    "e.g. `conversation/frame.html` -> `project/frame.html` to promote a frame into the Pod.",
+    "e.g. `conversation/frame.html` -> `pod/frame.html` to promote a frame into the Pod.",
   schema: {
     source: z
       .string()
       .describe(
-        "Scoped path of the file to move (e.g. `conversation/frame.html` or `project/data.csv`)."
+        "Scoped path of the file to move (e.g. `conversation/frame.html` or `pod/data.csv`)."
       ),
     dest: z
       .string()
       .describe(
-        "Scoped path of the destination (e.g. `project/frame.html` or `conversation/archive/data.csv`)."
+        "Scoped path of the destination (e.g. `pod/frame.html` or `conversation/archive/data.csv`)."
       ),
   },
   stake: "never_ask" as const,

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -35,8 +35,8 @@ const LIST_DESCRIPTION_PREFIX =
   `Read the sibling with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` to access the content of binary sources.`;
 
 // `list` tool variants. The conversation-only build takes no parameter and always lists
-// conversation files. The project-aware build accepts `scope: "conversation" | "project"` and is
-// only registered when the conversation belongs to a project.
+// conversation files. The project-aware build accepts `scope: "conversation" | "pod"` and is
+// only registered when the conversation belongs to a Pod.
 const LIST_CONVERSATION_ONLY_TOOL = {
   description: `${LIST_DESCRIPTION_PREFIX} Lists the conversation's files.`,
   schema: {},
@@ -50,14 +50,14 @@ const LIST_CONVERSATION_ONLY_TOOL = {
 const LIST_PROJECT_AWARE_TOOL = {
   description:
     `${LIST_DESCRIPTION_PREFIX} ` +
-    "Defaults to the conversation's files. Pass `scope: \"project\"` to list the Pod's " +
+    "Defaults to the conversation's files. Pass `scope: \"pod\"` to list the Pod's " +
     "shared files (visible to every conversation in the same Pod) instead.",
   schema: {
     scope: z
-      .enum(["conversation", "project"])
+      .enum(["conversation", "pod"])
       .optional()
       .describe(
-        "Which file system to list. Defaults to `conversation`. Pass `project` to list the Pod's shared files."
+        "Which file system to list. Defaults to `conversation`. Pass `pod` to list the Pod's shared files."
       ),
   },
   stake: "never_ask" as const,
@@ -108,18 +108,18 @@ const COPY_PROJECT_AWARE_TOOL = {
   description:
     `${COPY_DESCRIPTION_BASE} ` +
     "Since this conversation belongs to a Pod, you can also copy between scopes, " +
-    "e.g. `conversation/report.pdf` -> `project/report.pdf` to promote a file into the Pod, " +
-    "or `project/spec.md` -> `conversation/spec.md` to pull it into the conversation.",
+    "e.g. `conversation/report.pdf` -> `pod/report.pdf` to promote a file into the Pod, " +
+    "or `pod/spec.md` -> `conversation/spec.md` to pull it into the conversation.",
   schema: {
     source: z
       .string()
       .describe(
-        "Scoped path of the file to copy from (e.g. `conversation/report.pdf` or `project/spec.md`)."
+        "Scoped path of the file to copy from (e.g. `conversation/report.pdf` or `pod/spec.md`)."
       ),
     dest: z
       .string()
       .describe(
-        "Scoped path of the destination (e.g. `project/report.pdf` or `conversation/archive/report.pdf`)."
+        "Scoped path of the destination (e.g. `pod/report.pdf` or `conversation/archive/report.pdf`)."
       ),
   },
   stake: "never_ask" as const,
@@ -180,7 +180,7 @@ const FILES_TOOLS_COMMON_METADATA = {
   [FILES_RESOLVE_ACTION_NAME]: {
     description:
       "Resolve a file ID (e.g. `fil_abc123`) to its scoped file system path " +
-      "(e.g. `conversation/report.pdf` or `project/data.csv`). " +
+      "(e.g. `conversation/report.pdf` or `pod/data.csv`). " +
       "Use this when you have a raw file identifier but need the path accepted by other tools " +
       "such as `" +
       getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME) +

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -187,7 +187,7 @@ describe("copyHandler", () => {
     expect(result.error.message).toContain("Pod conversations");
   });
 
-  it("writes a single copyFile to the resolved Pod path", async () => {
+  it("dual-writes to the projects/ mirror when copying to a Pod mount", async () => {
     const { auth, conversation } = await setupProjectConversation();
     const workspaceId = auth.getNonNullableWorkspace().sId;
     const podId = conversation.spaceId;
@@ -214,8 +214,38 @@ describe("copyHandler", () => {
 
     const sourcePath = `w/${workspaceId}/conversations/${conversation.sId}/files/report.pdf`;
     const destPodPath = `w/${workspaceId}/pods/${podId}/files/report.pdf`;
+    const destProjectsPath = `w/${workspaceId}/projects/${podId}/files/report.pdf`;
 
+    expect(copyFileMock).toHaveBeenCalledTimes(2);
+    expect(copyFileMock).toHaveBeenNthCalledWith(1, sourcePath, destPodPath);
+    expect(copyFileMock).toHaveBeenNthCalledWith(
+      2,
+      sourcePath,
+      destProjectsPath
+    );
+  });
+
+  it("does not write to projects/ when copying to a conversation mount", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+
+    const copyFileMock = vi.fn().mockResolvedValue(undefined);
+    const getMetadataMock = vi
+      .fn()
+      .mockResolvedValue([{ contentType: "application/pdf", size: "100" }]);
+    const mockBucket = {
+      file: vi.fn(() => ({ getMetadata: getMetadataMock })),
+      copyFile: copyFileMock,
+    };
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(
+      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
+    );
+
+    const result = await copyHandler(
+      { source: "pod/spec.md", dest: "conversation/spec.md" },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
     expect(copyFileMock).toHaveBeenCalledTimes(1);
-    expect(copyFileMock).toHaveBeenCalledWith(sourcePath, destPodPath);
   });
 });

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -128,7 +128,7 @@ describe("copyHandler", () => {
     const result = await copyHandler(
       {
         source: "conversation/interactive.html",
-        dest: "project/interactive.html",
+        dest: "pod/interactive.html",
       },
       makeExtra(auth, conversation)
     );

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -51,11 +51,11 @@ async function setupProjectConversation(
 }
 
 describe("copyHandler", () => {
-  it("copies a file from conversation to project mount", async () => {
+  it("copies a file from conversation to Pod mount", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
     const result = await copyHandler(
-      { source: "conversation/report.pdf", dest: "project/report.pdf" },
+      { source: "conversation/report.pdf", dest: "pod/report.pdf" },
       makeExtra(auth, conversation)
     );
 
@@ -66,16 +66,16 @@ describe("copyHandler", () => {
     expect(result.value).toEqual([
       {
         type: "text",
-        text: "Copied `conversation/report.pdf` to `project/report.pdf`.",
+        text: "Copied `conversation/report.pdf` to `pod/report.pdf`.",
       },
     ]);
   });
 
-  it("copies a file from project to conversation mount", async () => {
+  it("copies a file from Pod to conversation mount", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
     const result = await copyHandler(
-      { source: "project/spec.md", dest: "conversation/spec.md" },
+      { source: "pod/spec.md", dest: "conversation/spec.md" },
       makeExtra(auth, conversation)
     );
 
@@ -97,7 +97,7 @@ describe("copyHandler", () => {
     );
 
     const result = await copyHandler(
-      { source: "conversation/missing.pdf", dest: "project/missing.pdf" },
+      { source: "conversation/missing.pdf", dest: "pod/missing.pdf" },
       makeExtra(auth, conversation)
     );
 
@@ -159,14 +159,14 @@ describe("copyHandler", () => {
     const { auth, conversation } = await setupProjectConversation();
 
     const result = await copyHandler(
-      { source: "other/foo.md", dest: "project/foo.md" },
+      { source: "other/foo.md", dest: "pod/foo.md" },
       makeExtra(auth, conversation)
     );
 
     expect(result.isErr()).toBe(true);
   });
 
-  it("returns Err for a project path in a non-project conversation", async () => {
+  it("returns Err for a Pod path in a non-Pod conversation", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
 
     const conversation = await createConversation(auth, {
@@ -176,7 +176,7 @@ describe("copyHandler", () => {
     });
 
     const result = await copyHandler(
-      { source: "conversation/x.md", dest: "project/x.md" },
+      { source: "conversation/x.md", dest: "pod/x.md" },
       makeExtra(auth, conversation)
     );
 
@@ -184,7 +184,7 @@ describe("copyHandler", () => {
     if (!result.isErr()) {
       return;
     }
-    expect(result.error.message).toContain("project conversations");
+    expect(result.error.message).toContain("Pod conversations");
   });
 
   it("dual-writes to the pods/ mirror when copying to a project mount", async () => {

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -187,11 +187,11 @@ describe("copyHandler", () => {
     expect(result.error.message).toContain("Pod conversations");
   });
 
-  it("dual-writes to the pods/ mirror when copying to a project mount", async () => {
+  it("writes a single copyFile to the resolved Pod path", async () => {
     const { auth, conversation } = await setupProjectConversation();
     const workspaceId = auth.getNonNullableWorkspace().sId;
-    const projectId = conversation.spaceId;
-    assert(projectId, "Expected project conversation to have a spaceId");
+    const podId = conversation.spaceId;
+    assert(podId, "Expected Pod conversation to have a spaceId");
 
     const copyFileMock = vi.fn().mockResolvedValue(undefined);
     const getMetadataMock = vi
@@ -206,46 +206,16 @@ describe("copyHandler", () => {
     );
 
     const result = await copyHandler(
-      { source: "conversation/report.pdf", dest: "project/report.pdf" },
+      { source: "conversation/report.pdf", dest: "pod/report.pdf" },
       makeExtra(auth, conversation)
     );
 
     assert(result.isOk());
 
     const sourcePath = `w/${workspaceId}/conversations/${conversation.sId}/files/report.pdf`;
-    const destProjectPath = `w/${workspaceId}/projects/${projectId}/files/report.pdf`;
-    const destPodsPath = `w/${workspaceId}/pods/${projectId}/files/report.pdf`;
+    const destPodPath = `w/${workspaceId}/pods/${podId}/files/report.pdf`;
 
-    expect(copyFileMock).toHaveBeenCalledTimes(2);
-    expect(copyFileMock).toHaveBeenNthCalledWith(
-      1,
-      sourcePath,
-      destProjectPath
-    );
-    expect(copyFileMock).toHaveBeenNthCalledWith(2, sourcePath, destPodsPath);
-  });
-
-  it("does not write to pods/ when copying to a conversation mount", async () => {
-    const { auth, conversation } = await setupProjectConversation();
-
-    const copyFileMock = vi.fn().mockResolvedValue(undefined);
-    const getMetadataMock = vi
-      .fn()
-      .mockResolvedValue([{ contentType: "application/pdf", size: "100" }]);
-    const mockBucket = {
-      file: vi.fn(() => ({ getMetadata: getMetadataMock })),
-      copyFile: copyFileMock,
-    };
-    vi.mocked(getPrivateUploadBucket).mockReturnValue(
-      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
-    );
-
-    const result = await copyHandler(
-      { source: "project/spec.md", dest: "conversation/spec.md" },
-      makeExtra(auth, conversation)
-    );
-
-    assert(result.isOk());
     expect(copyFileMock).toHaveBeenCalledTimes(1);
+    expect(copyFileMock).toHaveBeenCalledWith(sourcePath, destPodPath);
   });
 });

--- a/front/lib/api/actions/servers/files/tools/delete.test.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.test.ts
@@ -51,7 +51,7 @@ async function setupProjectConversation(
 }
 
 describe("deleteHandler", () => {
-  it("issues a single delete to the resolved Pod path", async () => {
+  it("dual-deletes from the projects/ mirror when deleting from a Pod mount", async () => {
     const { auth, conversation } = await setupProjectConversation();
     const workspaceId = auth.getNonNullableWorkspace().sId;
     const podId = conversation.spaceId;
@@ -75,9 +75,13 @@ describe("deleteHandler", () => {
     assert(result.isOk());
 
     const podPath = `w/${workspaceId}/pods/${podId}/files/report.pdf`;
+    const projectsPath = `w/${workspaceId}/projects/${podId}/files/report.pdf`;
 
-    expect(deleteMock).toHaveBeenCalledTimes(1);
-    expect(deleteMock).toHaveBeenCalledWith(podPath, {
+    expect(deleteMock).toHaveBeenCalledTimes(2);
+    expect(deleteMock).toHaveBeenNthCalledWith(1, podPath, {
+      ignoreNotFound: true,
+    });
+    expect(deleteMock).toHaveBeenNthCalledWith(2, projectsPath, {
       ignoreNotFound: true,
     });
   });

--- a/front/lib/api/actions/servers/files/tools/delete.test.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.test.ts
@@ -51,11 +51,11 @@ async function setupProjectConversation(
 }
 
 describe("deleteHandler", () => {
-  it("dual-deletes from the pods/ mirror when deleting from a project mount", async () => {
+  it("issues a single delete to the resolved Pod path", async () => {
     const { auth, conversation } = await setupProjectConversation();
     const workspaceId = auth.getNonNullableWorkspace().sId;
-    const projectId = conversation.spaceId;
-    assert(projectId, "Expected project conversation to have a spaceId");
+    const podId = conversation.spaceId;
+    assert(podId, "Expected Pod conversation to have a spaceId");
 
     const deleteMock = vi.fn().mockResolvedValue(undefined);
     const existsMock = vi.fn().mockResolvedValue([true]);
@@ -68,44 +68,18 @@ describe("deleteHandler", () => {
     );
 
     const result = await deleteHandler(
-      { path: "project/report.pdf" },
+      { path: "pod/report.pdf" },
       makeExtra(auth, conversation)
     );
 
     assert(result.isOk());
 
-    const projectPath = `w/${workspaceId}/projects/${projectId}/files/report.pdf`;
-    const podsPath = `w/${workspaceId}/pods/${projectId}/files/report.pdf`;
+    const podPath = `w/${workspaceId}/pods/${podId}/files/report.pdf`;
 
-    expect(deleteMock).toHaveBeenCalledTimes(2);
-    expect(deleteMock).toHaveBeenNthCalledWith(1, projectPath, {
-      ignoreNotFound: true,
-    });
-    expect(deleteMock).toHaveBeenNthCalledWith(2, podsPath, {
-      ignoreNotFound: true,
-    });
-  });
-
-  it("does not delete from pods/ when deleting from a conversation mount", async () => {
-    const { auth, conversation } = await setupProjectConversation();
-
-    const deleteMock = vi.fn().mockResolvedValue(undefined);
-    const existsMock = vi.fn().mockResolvedValue([true]);
-    const mockBucket = {
-      file: vi.fn(() => ({ exists: existsMock })),
-      delete: deleteMock,
-    };
-    vi.mocked(getPrivateUploadBucket).mockReturnValue(
-      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
-    );
-
-    const result = await deleteHandler(
-      { path: "conversation/report.pdf" },
-      makeExtra(auth, conversation)
-    );
-
-    assert(result.isOk());
     expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(deleteMock).toHaveBeenCalledWith(podPath, {
+      ignoreNotFound: true,
+    });
   });
 
   it("returns Err when the file does not exist", async () => {
@@ -121,7 +95,7 @@ describe("deleteHandler", () => {
     );
 
     const result = await deleteHandler(
-      { path: "project/missing.pdf" },
+      { path: "pod/missing.pdf" },
       makeExtra(auth, conversation)
     );
 

--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -36,7 +36,7 @@ function makeExtra(
 async function setupProjectConversation(): Promise<{
   auth: Authenticator;
   conversation: ConversationType;
-  projectId: string;
+  podId: string;
 }> {
   const { authenticator: auth, workspace } = await createResourceTest({
     role: "admin",
@@ -58,7 +58,7 @@ async function setupProjectConversation(): Promise<{
     spaceId: space.id,
   });
 
-  return { auth: projectAuth, conversation, projectId: space.sId };
+  return { auth: projectAuth, conversation, podId: space.sId };
 }
 
 describe("listHandler", () => {
@@ -107,18 +107,18 @@ describe("listHandler", () => {
     });
   });
 
-  it("lists the project mount when scope=project in a project conversation", async () => {
-    const { auth, conversation, projectId } = await setupProjectConversation();
+  it("lists the Pod mount when scope=pod in a Pod conversation", async () => {
+    const { auth, conversation, podId } = await setupProjectConversation();
 
     const result = await listHandler(
-      { scope: "project" },
+      { scope: "pod" },
       makeExtra(auth, conversation)
     );
 
     expect(result.isOk()).toBe(true);
     expect(mockListGCSMountFiles.mock.calls[0][1]).toEqual({
-      useCase: "project",
-      projectId: projectId,
+      useCase: "pod",
+      podId,
     });
   });
 
@@ -175,7 +175,7 @@ describe("listHandler", () => {
     expect(text.text).not.toContain("[id: fil_pdfdef456]");
   });
 
-  it("returns Err when scope=project in a non-project conversation", async () => {
+  it("returns Err when scope=pod in a non-Pod conversation", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
 
     const conversation = await createConversation(auth, {
@@ -185,7 +185,7 @@ describe("listHandler", () => {
     });
 
     const result = await listHandler(
-      { scope: "project" },
+      { scope: "pod" },
       makeExtra(auth, conversation)
     );
 
@@ -193,7 +193,7 @@ describe("listHandler", () => {
     if (!result.isErr()) {
       return;
     }
-    expect(result.error.message).toContain("project conversations");
+    expect(result.error.message).toContain("Pod conversations");
     expect(mockListGCSMountFiles).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -26,7 +26,7 @@ function getDirAndFileName(path: string): { dir: string; fileName: string } {
 }
 
 export async function listHandler(
-  { scope }: { scope?: "conversation" | "project" },
+  { scope }: { scope?: "conversation" | "pod" },
   extra: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   const conversation = extra.agentLoopContext?.runContext?.conversation;

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -51,11 +51,11 @@ async function setupProjectConversation(
 }
 
 describe("moveHandler", () => {
-  it("moves a file from conversation to project mount", async () => {
+  it("moves a file from conversation to Pod mount", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
     const result = await moveHandler(
-      { source: "conversation/report.pdf", dest: "project/report.pdf" },
+      { source: "conversation/report.pdf", dest: "pod/report.pdf" },
       makeExtra(auth, conversation)
     );
 
@@ -65,15 +65,15 @@ describe("moveHandler", () => {
     }
     expect(result.value[0]).toEqual({
       type: "text",
-      text: "Moved `conversation/report.pdf` to `project/report.pdf`.",
+      text: "Moved `conversation/report.pdf` to `pod/report.pdf`.",
     });
   });
 
-  it("moves a file from project to conversation mount", async () => {
+  it("moves a file from Pod to conversation mount", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
     const result = await moveHandler(
-      { source: "project/spec.md", dest: "conversation/spec.md" },
+      { source: "pod/spec.md", dest: "conversation/spec.md" },
       makeExtra(auth, conversation)
     );
 
@@ -95,7 +95,7 @@ describe("moveHandler", () => {
     );
 
     const result = await moveHandler(
-      { source: "conversation/missing.pdf", dest: "project/missing.pdf" },
+      { source: "conversation/missing.pdf", dest: "pod/missing.pdf" },
       makeExtra(auth, conversation)
     );
 
@@ -125,14 +125,14 @@ describe("moveHandler", () => {
     const { auth, conversation } = await setupProjectConversation();
 
     const result = await moveHandler(
-      { source: "other/foo.md", dest: "project/foo.md" },
+      { source: "other/foo.md", dest: "pod/foo.md" },
       makeExtra(auth, conversation)
     );
 
     expect(result.isErr()).toBe(true);
   });
 
-  it("returns Err for a project path in a non-project conversation", async () => {
+  it("returns Err for a Pod path in a non-Pod conversation", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
 
     const conversation = await createConversation(auth, {
@@ -142,7 +142,7 @@ describe("moveHandler", () => {
     });
 
     const result = await moveHandler(
-      { source: "conversation/x.md", dest: "project/x.md" },
+      { source: "conversation/x.md", dest: "pod/x.md" },
       makeExtra(auth, conversation)
     );
 
@@ -150,6 +150,6 @@ describe("moveHandler", () => {
     if (!result.isErr()) {
       return;
     }
-    expect(result.error.message).toContain("project conversations");
+    expect(result.error.message).toContain("Pod conversations");
   });
 });

--- a/front/lib/api/actions/servers/files/tools/move.ts
+++ b/front/lib/api/actions/servers/files/tools/move.ts
@@ -94,9 +94,9 @@ export async function moveHandler(
   let destUseCase: FileUseCase;
   let destUseCaseMetadata: FileUseCaseMetadata | undefined;
   switch (destScope.useCase) {
-    case "project":
+    case "pod":
       destUseCase = "project_context";
-      destUseCaseMetadata = { spaceId: destScope.projectId };
+      destUseCaseMetadata = { spaceId: destScope.podId };
       break;
     case "conversation":
       destUseCase = "tool_output";

--- a/front/lib/api/actions/servers/files/tools/resolve.ts
+++ b/front/lib/api/actions/servers/files/tools/resolve.ts
@@ -6,7 +6,7 @@ import type {
 import { getScopedPathFromGCSPath } from "@app/lib/api/files/gcs_mount/files";
 import {
   getConversationFilesBasePath,
-  getProjectFilesBasePath,
+  getPodFilesBasePath,
 } from "@app/lib/api/files/mount_path";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -78,7 +78,7 @@ export async function resolveHandler(
     if (!isProjectConversation(conversation)) {
       return new Err(
         new MCPError(
-          `File \`${file_id}\` is a project file but this is not a project conversation.`,
+          `File \`${file_id}\` is a Pod file but this is not a Pod conversation.`,
           { tracked: false }
         )
       );
@@ -88,7 +88,7 @@ export async function resolveHandler(
     if (!spaceId || spaceId !== conversation.spaceId) {
       return new Err(
         new MCPError(
-          `File \`${file_id}\` does not belong to the project of this conversation.`,
+          `File \`${file_id}\` does not belong to the Pod of this conversation.`,
           { tracked: false }
         )
       );
@@ -98,24 +98,27 @@ export async function resolveHandler(
     if (!space || !space.canRead(extra.auth)) {
       return new Err(
         new MCPError(
-          "You do not have read access to the project containing this file.",
+          "You do not have read access to the Pod containing this file.",
           { tracked: false }
         )
       );
     }
 
+    // The file's mount path might still use the old "project" prefix
+    const gcsPath = file.mountFilePath.replace("project/", "pod/");
+
     const scopedPath = getScopedPathFromGCSPath({
-      prefix: getProjectFilesBasePath({
+      prefix: getPodFilesBasePath({
         workspaceId: owner.sId,
-        projectId: spaceId,
+        podId: spaceId,
       }),
-      gcsPath: file.mountFilePath,
-      useCase: "project",
+      gcsPath,
+      useCase: "pod",
     });
     if (!scopedPath) {
       return new Err(
         new MCPError(
-          `File \`${file_id}\` does not belong to the project of this conversation.`,
+          `File \`${file_id}\` does not belong to the Pod of this conversation.`,
           { tracked: false }
         )
       );

--- a/front/lib/api/actions/servers/files/tools/resolve.ts
+++ b/front/lib/api/actions/servers/files/tools/resolve.ts
@@ -105,7 +105,7 @@ export async function resolveHandler(
     }
 
     // The file's mount path might still use the old "project" prefix
-    const gcsPath = file.mountFilePath.replace("project/", "pod/");
+    const gcsPath = file.mountFilePath.replace("/projects/", "/pods/");
 
     const scopedPath = getScopedPathFromGCSPath({
       prefix: getPodFilesBasePath({

--- a/front/lib/api/actions/servers/files/tools/utils.test.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.test.ts
@@ -57,8 +57,8 @@ describe("resolveMountPoint", () => {
     });
   });
 
-  describe("project paths", () => {
-    it("returns the project mount for a project conversation", async () => {
+  describe("Pod paths", () => {
+    it("returns the Pod mount for a Pod conversation", async () => {
       const { authenticator: auth, workspace } = await createResourceTest({
         role: "admin",
       });
@@ -84,7 +84,7 @@ describe("resolveMountPoint", () => {
 
       const result = await resolveMountPoint(projectAuth, conversation, {
         access: "read",
-        scopedPath: "project/spec.md",
+        scopedPath: "pod/spec.md",
       });
 
       expect(result.isOk()).toBe(true);
@@ -92,15 +92,15 @@ describe("resolveMountPoint", () => {
         return;
       }
       expect(result.value.scope).toEqual({
-        useCase: "project",
-        projectId: space.sId,
+        useCase: "pod",
+        podId: space.sId,
       });
       expect(result.value.prefix).toBe(
-        `w/${workspace.sId}/projects/${space.sId}/files/`
+        `w/${workspace.sId}/pods/${space.sId}/files/`
       );
     });
 
-    it("returns Err for a project path in a non-project conversation", async () => {
+    it("returns Err for a Pod path in a non-Pod conversation", async () => {
       const { authenticator: auth } = await createResourceTest({
         role: "admin",
       });
@@ -113,14 +113,14 @@ describe("resolveMountPoint", () => {
 
       const result = await resolveMountPoint(auth, conversation, {
         access: "read",
-        scopedPath: "project/spec.md",
+        scopedPath: "pod/spec.md",
       });
 
       expect(result.isErr()).toBe(true);
       if (!result.isErr()) {
         return;
       }
-      expect(result.error.message).toContain("project conversations");
+      expect(result.error.message).toContain("Pod conversations");
     });
   });
 

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/api/files/gcs_mount/files";
 import {
   getConversationFilesBasePath,
-  getProjectFilesBasePath,
+  getPodsFilesBasePath,
   parseScopedFilePath,
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
@@ -50,24 +50,23 @@ function buildConversationMountPoint(
   };
 }
 
-async function buildProjectMountPoint(
+async function buildPodMountPoint(
   auth: Authenticator,
   conversation: ConversationWithoutContentType,
   { access }: { access: Access }
 ): Promise<Result<MountPoint, MCPError>> {
   if (!isProjectConversation(conversation)) {
     return new Err(
-      new MCPError(
-        "Project file paths are only available in project conversations.",
-        { tracked: false }
-      )
+      new MCPError("Pod file paths are only available in Pod conversations.", {
+        tracked: false,
+      })
     );
   }
 
   const space = await SpaceResource.fetchById(auth, conversation.spaceId);
   if (!space) {
     return new Err(
-      new MCPError("Project not found for this conversation.", {
+      new MCPError("Pod not found for this conversation.", {
         tracked: false,
       })
     );
@@ -79,8 +78,8 @@ async function buildProjectMountPoint(
     return new Err(
       new MCPError(
         access === "write"
-          ? "You do not have write permissions for this project."
-          : "You do not have read permissions for this project.",
+          ? "You do not have write permissions for this Pod."
+          : "You do not have read permissions for this Pod.",
         { tracked: false }
       )
     );
@@ -88,17 +87,17 @@ async function buildProjectMountPoint(
 
   const owner = auth.getNonNullableWorkspace();
   return new Ok({
-    scope: { useCase: "project", projectId: space.sId },
-    prefix: getProjectFilesBasePath({
+    scope: { useCase: "pod", podId: space.sId },
+    prefix: getPodsFilesBasePath({
       workspaceId: owner.sId,
-      projectId: space.sId,
+      podId: space.sId,
     }),
   });
 }
 
 /**
  * Resolve the mount point a scoped path belongs to. Dispatches by the path's `conversation/` or
- * `project/` prefix, looks up the parent project space when needed, and verifies the requested
+ * `pod/` prefix, looks up the parent Pod space when needed, and verifies the requested
  * access level.
  */
 export async function resolveMountPoint(
@@ -110,7 +109,7 @@ export async function resolveMountPoint(
   if (!parsed) {
     return new Err(
       new MCPError(
-        `Invalid path: \`${scopedPath}\` must start with \`conversation/\` or \`project/\`.`,
+        `Invalid path: \`${scopedPath}\` must start with \`conversation/\` or \`pod/\`.`,
         { tracked: false }
       )
     );
@@ -135,8 +134,8 @@ export async function resolveMountByUseCase(
     case "conversation":
       return new Ok(buildConversationMountPoint(auth, conversation));
 
-    case "project":
-      return buildProjectMountPoint(auth, conversation, { access });
+    case "pod":
+      return buildPodMountPoint(auth, conversation, { access });
 
     default:
       assertNever(useCase);
@@ -144,7 +143,7 @@ export async function resolveMountByUseCase(
 }
 
 /**
- * List the files mounted under a project's GCS prefix. Verifies `space.canRead(auth)` before
+ * List the files mounted under a Pod's GCS prefix. Verifies `space.canRead(auth)` before
  * touching the bucket. Use this from callers that already hold a `SpaceResource` so the
  * file-listing path stays funneled through the same helper as `files__list`.
  */
@@ -153,20 +152,20 @@ export async function listProjectFiles(
   space: SpaceResource
 ): Promise<Result<GCSMountEntry[], MCPError>> {
   if (!space.isProject) {
-    return new Err(new MCPError("Space is not a project.", { tracked: false }));
+    return new Err(new MCPError("Space is not a Pod.", { tracked: false }));
   }
 
   if (!space.canRead(auth)) {
     return new Err(
-      new MCPError("You do not have read permissions for this project.", {
+      new MCPError("You do not have read permissions for this Pod.", {
         tracked: false,
       })
     );
   }
 
   const entries = await listGCSMountFiles(auth, {
-    useCase: "project",
-    projectId: space.sId,
+    useCase: "pod",
+    podId: space.sId,
   });
 
   return new Ok(entries);

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/api/files/gcs_mount/files";
 import {
   getConversationFilesBasePath,
-  getPodsFilesBasePath,
+  getPodFilesBasePath,
   parseScopedFilePath,
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
@@ -88,7 +88,7 @@ async function buildPodMountPoint(
   const owner = auth.getNonNullableWorkspace();
   return new Ok({
     scope: { useCase: "pod", podId: space.sId },
-    prefix: getPodsFilesBasePath({
+    prefix: getPodFilesBasePath({
       workspaceId: owner.sId,
       podId: space.sId,
     }),

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -130,7 +130,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     description:
       "Get information about the Pod: URL, title, description, pinned frame, and linked content nodes " +
       "attached to the Pod context. Does NOT list Pod files. Pod files live under " +
-      `\`project/<rel>\` scoped paths and are discovered through the \`${FILES_SERVER_NAME}\` MCP server.`,
+      `\`pod/<rel>\` scoped paths and are discovered through the \`${FILES_SERVER_NAME}\` MCP server.`,
     schema: {
       dustPod: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
@@ -360,7 +360,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
 
 const POD_MANAGER_INSTRUCTIONS =
   "Pod files and metadata are shared across all conversations in this Pod. " +
-  `Pod files are managed through the \`${FILES_SERVER_NAME}\` MCP server using \`project/<rel>\` scoped paths ` +
+  `Pod files are managed through the \`${FILES_SERVER_NAME}\` MCP server using \`pod/<rel>\` scoped paths ` +
   "(create, cat, grep, list, delete), not through this server. " +
   "Use `add_content_node` to reference a Company Data node in the Pod context, and " +
   "`remove_content_node` to remove such a reference. " +
@@ -379,7 +379,7 @@ export const POD_MANAGER_SERVER = {
     description:
       "Manage Pod metadata, members, conversations, and Company Data references. " +
       `Raw Pod file operations (create, read, search, write, delete) live in the \`${FILES_SERVER_NAME}\` MCP ` +
-      "server under `project/<rel>` scoped paths.",
+      "server under `pod/<rel>` scoped paths.",
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -419,8 +419,8 @@ export function createProjectManagerTools(
         );
 
         // Linked content nodes (Company Data references) have no other discovery surface, so we
-        // surface them here. Project files do (they live under `project/<rel>` scoped paths and
-        // are discovered through the `files` MCP server), so we only report a count plus a hint.
+        // surface them here. Pod files do (they live under `pod/<rel>` scoped paths and are
+        // discovered through the `files` MCP server), so we only report a count plus a hint.
         const attachments = await listProjectContextAttachments(auth, space);
         const contentNodes = attachments
           .filter(isContentNodeAttachmentType)
@@ -454,7 +454,7 @@ export function createProjectManagerTools(
               contentNodes,
               files: {
                 count: projectFileCount,
-                hint: `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` with \`scope: "project"\` to enumerate.`,
+                hint: `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` with \`scope: "pod"\` to enumerate.`,
               },
             },
             message: "Successfully retrieved Pod information",

--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -114,8 +114,8 @@ export async function getOrCreateConversation(
   }
 
   // Resolve scoped file paths in the parent's auth/conversation scope. Any failure here surfaces
-  // cleanly before the sub-conversation is created. `project/<rel>` paths are validated but not
-  // copied (the project mount is shared across the project's conversations).
+  // cleanly before the sub-conversation is created. `pod/<rel>` paths are validated but not
+  // copied (the Pod mount is shared across the Pod's conversations).
   // `conversation/<rel>` paths are copied to the sub-conversation's mount once the sub exists.
   // A short hint is appended to the sub's first message so it knows which paths were forwarded;
   // the sub reads them through the files MCP server.

--- a/front/lib/api/actions/servers/run_agent/file_paths.test.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.test.ts
@@ -68,18 +68,18 @@ describe("resolveFilePathsInParentScope", () => {
     expect(res.value[0].scopedPath).toBe("conversation/foo.md");
   });
 
-  it("resolves both conversation and project paths in a project conversation", async () => {
+  it("resolves both conversation and Pod paths in a Pod conversation", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
     const res = await resolveFilePathsInParentScope(auth, conversation, [
       "conversation/a.txt",
-      "project/b.txt",
+      "pod/b.txt",
     ]);
 
     assert(res.isOk());
     expect(res.value).toHaveLength(2);
     expect(res.value[0].useCase).toBe("conversation");
-    expect(res.value[1].useCase).toBe("project");
+    expect(res.value[1].useCase).toBe("pod");
     expect(res.value[1].rel).toBe("b.txt");
   });
 
@@ -96,16 +96,16 @@ describe("resolveFilePathsInParentScope", () => {
     }
   });
 
-  it("returns Err for a project path in a non-project conversation", async () => {
+  it("returns Err for a Pod path in a non-Pod conversation", async () => {
     const { auth, conversation } = await setupPlainConversation();
 
     const res = await resolveFilePathsInParentScope(auth, conversation, [
-      "project/spec.md",
+      "pod/spec.md",
     ]);
 
     expect(res.isErr()).toBe(true);
     if (res.isErr()) {
-      expect(res.error.message).toContain("project conversations");
+      expect(res.error.message).toContain("Pod conversations");
     }
   });
 
@@ -160,8 +160,8 @@ describe("copyConversationFilesIntoSub", () => {
       subConversationId: "sub_sid",
       resolvedFilePaths: [
         {
-          scopedPath: "project/spec.md",
-          useCase: "project",
+          scopedPath: "pod/spec.md",
+          useCase: "pod",
           rel: "spec.md",
         },
       ],
@@ -183,8 +183,8 @@ describe("copyConversationFilesIntoSub", () => {
           rel: "a.md",
         },
         {
-          scopedPath: "project/skipped.md",
-          useCase: "project",
+          scopedPath: "pod/skipped.md",
+          useCase: "pod",
           rel: "skipped.md",
         },
       ],

--- a/front/lib/api/actions/servers/run_agent/file_paths.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.ts
@@ -10,7 +10,7 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export type ResolvedScopedFilePath = {
   scopedPath: string;
-  useCase: "conversation" | "project";
+  useCase: "conversation" | "pod";
   rel: string;
 };
 
@@ -26,7 +26,7 @@ export async function resolveFilePathsInParentScope(
     if (!parsed) {
       return new Err(
         new MCPError(
-          `Invalid path: \`${scopedPath}\` must start with \`conversation/\` or \`project/\`.`,
+          `Invalid path: \`${scopedPath}\` must start with \`conversation/\` or \`pod/\`.`,
           { tracked: false }
         )
       );

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -86,11 +86,11 @@ export const RUN_AGENT_TOOL_SCHEMA = {
   filePaths: z
     .array(z.string())
     .describe(
-      "Scoped file paths (e.g. `conversation/foo.md`, `project/spec.md`) to forward to the " +
+      "Scoped file paths (e.g. `conversation/foo.md`, `pod/spec.md`) to forward to the " +
         "sub-agent. Use when you have a scoped path from a file-listing tool or that you " +
         "produced yourself in this conversation. `conversation/...` paths are copied into " +
-        "the sub-conversation; `project/...` paths are passed through (the project file " +
-        "system is shared across the project's conversations). " +
+        "the sub-conversation; `pod/...` paths are passed through (the Pod file " +
+        "system is shared across the Pod's conversations). " +
         "For binary sources (PDFs, images, audio), also include their `*.processed.<ext>` " +
         "sibling so the sub-agent can read the model-friendly representation."
     )

--- a/front/lib/api/assistant/pod_kickoff.ts
+++ b/front/lib/api/assistant/pod_kickoff.ts
@@ -33,7 +33,7 @@ Once the user provides context:
 2. If context suggests it is useful, search for related information in the company (use available tools)
 3. Never claim "I searched" or "I didn't find" unless you actually ran search tools in this conversation
 4. If relevant, suggest updating the Pod description based on what you learned
-5. If asked to create Pod documentation or save context for future conversations, use \`files__create\` with a \`project/<filename>\` scoped path and the text content (plain text or markdown)
+5. If asked to create Pod documentation or save context for future conversations, use \`files__create\` with a \`pod/<filename>\` scoped path and the text content (plain text or markdown)
 
 Quick reply formatting rules:
 - Quick replies MUST be the last lines of the message

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -128,47 +128,6 @@ describe("createGCSMountFile", () => {
     assert(entryRes.isOk());
     expect(entryRes.value.thumbnailUrl).toBeNull();
   });
-
-  it("dual-writes to the pods/ mirror for project use-case", async () => {
-    const content = Buffer.from("hello");
-
-    await createGCSMountFile(
-      auth,
-      { useCase: "project", projectId: "proj123" },
-      { relativeFilePath: "report.txt", content, contentType: "text/plain" }
-    );
-
-    const bucket = vi.mocked(getPrivateUploadBucket)();
-    expect(bucket.file).toHaveBeenCalledWith(
-      `w/${workspaceId}/projects/proj123/files/report.txt`
-    );
-    expect(bucket.file).toHaveBeenCalledWith(
-      `w/${workspaceId}/pods/proj123/files/report.txt`
-    );
-    expect(saveMock).toHaveBeenCalledTimes(2);
-    expect(saveMock).toHaveBeenNthCalledWith(1, content, {
-      contentType: "text/plain",
-    });
-    expect(saveMock).toHaveBeenNthCalledWith(2, content, {
-      contentType: "text/plain",
-    });
-  });
-
-  it("does not write to pods/ for conversation use-case", async () => {
-    await createGCSMountFile(
-      auth,
-      { useCase: "conversation", conversationId },
-      {
-        relativeFilePath: "report.txt",
-        content: Buffer.from("hello"),
-        contentType: "text/plain",
-      }
-    );
-
-    const bucket = vi.mocked(getPrivateUploadBucket)();
-    expect(bucket.file).toHaveBeenCalledTimes(1);
-    expect(saveMock).toHaveBeenCalledTimes(1);
-  });
 });
 
 describe("createGCSMountDirectory", () => {
@@ -858,32 +817,6 @@ describe("copyMountFile", () => {
       expect(result.error.message).toContain("GCS copy unavailable");
     }
   });
-
-  it("mirrors the destination write on pods/ when dest is a project", async () => {
-    const result = await copyMountFile(auth, {
-      source: {
-        scope: { useCase: "conversation", conversationId: "src-conv" },
-        relativeFilePath: "report.pdf",
-      },
-      dest: {
-        scope: { useCase: "project", projectId: "proj123" },
-        relativeFilePath: "report.pdf",
-      },
-    });
-
-    assert(result.isOk());
-    const sourcePath = `w/${workspaceId}/conversations/src-conv/files/report.pdf`;
-    const destProjectPath = `w/${workspaceId}/projects/proj123/files/report.pdf`;
-    const destPodsPath = `w/${workspaceId}/pods/proj123/files/report.pdf`;
-
-    expect(copyFileMock).toHaveBeenCalledTimes(2);
-    expect(copyFileMock).toHaveBeenNthCalledWith(
-      1,
-      sourcePath,
-      destProjectPath
-    );
-    expect(copyFileMock).toHaveBeenNthCalledWith(2, sourcePath, destPodsPath);
-  });
 });
 
 describe("renameGCSMountFile", () => {
@@ -957,49 +890,6 @@ describe("renameGCSMountFile", () => {
       expect(result.error.message).toContain("copy failed");
     }
     expect(deleteMock).not.toHaveBeenCalled();
-  });
-
-  it("mirrors rename on pods/ for project use-case using the new canonical as source", async () => {
-    await renameGCSMountFile(
-      auth,
-      { useCase: "project", projectId: "proj123" },
-      { relativeFilePath: "report.pdf", newFileName: "final.pdf" }
-    );
-
-    const projectPrefix = `w/${workspaceId}/projects/proj123/files/`;
-    const podsPrefix = `w/${workspaceId}/pods/proj123/files/`;
-
-    expect(copyFileMock).toHaveBeenCalledTimes(2);
-    expect(copyFileMock).toHaveBeenNthCalledWith(
-      1,
-      `${projectPrefix}report.pdf`,
-      `${projectPrefix}final.pdf`
-    );
-    // Pods mirror copies from the NEW canonical (not from an old pods/ source,
-    // which may not exist for files predating the dual-write).
-    expect(copyFileMock).toHaveBeenNthCalledWith(
-      2,
-      `${projectPrefix}final.pdf`,
-      `${podsPrefix}final.pdf`
-    );
-
-    expect(deleteMock).toHaveBeenCalledTimes(2);
-    expect(deleteMock).toHaveBeenNthCalledWith(1, `${projectPrefix}report.pdf`);
-    expect(deleteMock).toHaveBeenNthCalledWith(2, `${podsPrefix}report.pdf`, {
-      ignoreNotFound: true,
-    });
-  });
-
-  it("does not mirror rename on pods/ for conversation use-case", async () => {
-    const result = await renameGCSMountFile(
-      auth,
-      { useCase: "conversation", conversationId: "conv-rename" },
-      { relativeFilePath: "report.pdf", newFileName: "final.pdf" }
-    );
-
-    expect(result.isOk()).toBe(true);
-    expect(copyFileMock).toHaveBeenCalledTimes(1);
-    expect(deleteMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -1135,10 +1025,10 @@ describe("deleteGCSMountFile", () => {
     }
   });
 
-  it("mirrors delete on pods/ for project use-case", async () => {
+  it("mirrors delete on projects/ for project use-case", async () => {
     await deleteGCSMountFile(
       auth,
-      { useCase: "project", projectId: "proj123" },
+      { useCase: "pod", podId: "pod123" },
       { relativeFilePath: "archive/old.pdf" }
     );
 
@@ -1146,15 +1036,15 @@ describe("deleteGCSMountFile", () => {
     const podsPath = `w/${workspaceId}/pods/proj123/files/archive/old.pdf`;
 
     expect(deleteMock).toHaveBeenCalledTimes(2);
-    expect(deleteMock).toHaveBeenNthCalledWith(1, projectPath, {
+    expect(deleteMock).toHaveBeenNthCalledWith(1, podsPath, {
       ignoreNotFound: true,
     });
-    expect(deleteMock).toHaveBeenNthCalledWith(2, podsPath, {
+    expect(deleteMock).toHaveBeenNthCalledWith(2, projectPath, {
       ignoreNotFound: true,
     });
   });
 
-  it("does not mirror delete on pods/ for conversation use-case", async () => {
+  it("does not mirror delete on projects/ for conversation use-case", async () => {
     await deleteGCSMountFile(
       auth,
       { useCase: "conversation", conversationId: "conv-del" },
@@ -1171,7 +1061,7 @@ describe("deleteGCSMountFile", () => {
 
     const result = await deleteGCSMountFile(
       auth,
-      { useCase: "project", projectId: "proj123" },
+      { useCase: "pod", podId: "pod123" },
       { relativeFilePath: "archive" }
     );
 

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -200,41 +200,6 @@ describe("createGCSMountDirectory", () => {
     }
     expect(saveMock).not.toHaveBeenCalled();
   });
-
-  it("dual-writes the placeholder on the pods/ mirror for project use-case", async () => {
-    const entryRes = await createGCSMountDirectory(
-      auth,
-      { useCase: "project", projectId: "proj123" },
-      { relativeDirPath: "reports/q1" }
-    );
-
-    assert(entryRes.isOk());
-    const bucket = vi.mocked(getPrivateUploadBucket)();
-    expect(bucket.file).toHaveBeenCalledWith(
-      `w/${workspaceId}/projects/proj123/files/reports/q1/`
-    );
-    expect(bucket.file).toHaveBeenCalledWith(
-      `w/${workspaceId}/pods/proj123/files/reports/q1/`
-    );
-    expect(saveMock).toHaveBeenCalledTimes(2);
-    expect(saveMock).toHaveBeenNthCalledWith(1, Buffer.alloc(0), {
-      contentType: "application/x-directory",
-    });
-    expect(saveMock).toHaveBeenNthCalledWith(2, Buffer.alloc(0), {
-      contentType: "application/x-directory",
-    });
-  });
-
-  it("does not write to pods/ for conversation use-case", async () => {
-    const entryRes = await createGCSMountDirectory(
-      auth,
-      { useCase: "conversation", conversationId },
-      { relativeDirPath: "reports/q1" }
-    );
-
-    assert(entryRes.isOk());
-    expect(saveMock).toHaveBeenCalledTimes(1);
-  });
 });
 
 describe("listGCSMountFiles", () => {

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -1076,10 +1076,10 @@ describe("deleteGCSMountFile", () => {
 });
 
 describe("scoped path ↔ GCS path", () => {
-  const prefix = "w/ws1/projects/proj1/files/";
+  const prefix = "w/ws1/pods/proj1/files/";
 
   it("getScopedPathFromGCSPath is the inverse of getGCSPathFromScopedPath", () => {
-    const scopedPath = "project/reports/report_fil_abc.pdf";
+    const scopedPath = "pod/reports/report_fil_abc.pdf";
     const gcsPath = getGCSPathFromScopedPath({
       prefix,
       scopedPath,

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -1022,7 +1022,7 @@ describe("renameGCSMountDirectory", () => {
     auth = authenticator;
     workspaceId = auth.getNonNullableWorkspace().sId;
 
-    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    const prefix = `w/${workspaceId}/pods/pod123/files/`;
     getAllFilesByPrefixMock = vi.fn().mockResolvedValue({
       files: [
         { name: `${prefix}archive/` },
@@ -1044,27 +1044,40 @@ describe("renameGCSMountDirectory", () => {
       { relativeDirPath: "archive", newFolderName: "backup" }
     );
 
-    const prefix = `w/${workspaceId}/projects/pod123/files/`;
     const podsPrefix = `w/${workspaceId}/pods/pod123/files/`;
+    const projectsPrefix = `w/${workspaceId}/projects/pod123/files/`;
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value.newRelativeDirPath).toBe("backup");
     }
+    // Canonical copies happen on the pods/ side.
     expect(copyFileMock).toHaveBeenCalledWith(
-      `${prefix}archive/`,
-      `${prefix}backup/`
+      `${podsPrefix}archive/`,
+      `${podsPrefix}backup/`
     );
     expect(copyFileMock).toHaveBeenCalledWith(
-      `${prefix}archive/report.pdf`,
-      `${prefix}backup/report.pdf`
-    );
-    expect(deleteByPrefixMock).toHaveBeenCalledWith(`${prefix}archive/`);
-    expect(deleteByPrefixMock).toHaveBeenCalledWith(`${podsPrefix}archive/`);
-    expect(copyFileMock).toHaveBeenCalledWith(
-      `${prefix}backup/report.pdf`,
+      `${podsPrefix}archive/report.pdf`,
       `${podsPrefix}backup/report.pdf`
     );
+    // Old prefix is deleted on both the pods/ and projects/ sides.
+    expect(deleteByPrefixMock).toHaveBeenCalledWith(`${podsPrefix}archive/`);
+    expect(deleteByPrefixMock).toHaveBeenCalledWith(
+      `${projectsPrefix}archive/`
+    );
+    // Mirror copies from the new canonical pods/ path to the projects/ side.
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `${podsPrefix}backup/`,
+      `${projectsPrefix}backup/`
+    );
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `${podsPrefix}backup/report.pdf`,
+      `${projectsPrefix}backup/report.pdf`
+    );
+    // Double write: each of the 2 objects is copied on the pods/ side and
+    // mirrored to the projects/ side (2 canonical + 2 mirror = 4).
+    expect(copyFileMock).toHaveBeenCalledTimes(4);
+    expect(deleteByPrefixMock).toHaveBeenCalledTimes(2);
   });
 
   it("returns Err when the destination folder already exists", async () => {

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -1040,12 +1040,12 @@ describe("renameGCSMountDirectory", () => {
   it("moves all objects under the folder prefix and deletes the old prefix", async () => {
     const result = await renameGCSMountDirectory(
       auth,
-      { useCase: "project", projectId: "proj123" },
+      { useCase: "pod", podId: "pod123" },
       { relativeDirPath: "archive", newFolderName: "backup" }
     );
 
-    const prefix = `w/${workspaceId}/projects/proj123/files/`;
-    const podsPrefix = `w/${workspaceId}/pods/proj123/files/`;
+    const prefix = `w/${workspaceId}/projects/pod123/files/`;
+    const podsPrefix = `w/${workspaceId}/pods/pod123/files/`;
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -1072,7 +1072,7 @@ describe("renameGCSMountDirectory", () => {
 
     const result = await renameGCSMountDirectory(
       auth,
-      { useCase: "project", projectId: "proj123" },
+      { useCase: "pod", podId: "pod123" },
       { relativeDirPath: "archive", newFolderName: "backup" }
     );
 
@@ -1111,11 +1111,11 @@ describe("deleteGCSMountFile", () => {
   it("calls bucket.delete with the correct GCS path and ignoreNotFound", async () => {
     const result = await deleteGCSMountFile(
       auth,
-      { useCase: "pod", podId: "proj123" },
+      { useCase: "pod", podId: "pod123" },
       { relativeFilePath: "archive/old.pdf" }
     );
 
-    const prefix = `w/${workspaceId}/pods/proj123/files/`;
+    const prefix = `w/${workspaceId}/pods/pod123/files/`;
     expect(result.isOk()).toBe(true);
     expect(deleteMock).toHaveBeenCalledWith(`${prefix}archive/old.pdf`, {
       ignoreNotFound: true,
@@ -1127,7 +1127,7 @@ describe("deleteGCSMountFile", () => {
 
     const result = await deleteGCSMountFile(
       auth,
-      { useCase: "pod", podId: "proj123" },
+      { useCase: "pod", podId: "pod123" },
       { relativeFilePath: "file.pdf" }
     );
 
@@ -1140,12 +1140,12 @@ describe("deleteGCSMountFile", () => {
   it("mirrors delete on projects/ for pod use-case", async () => {
     await deleteGCSMountFile(
       auth,
-      { useCase: "pod", podId: "proj123" },
+      { useCase: "pod", podId: "pod123" },
       { relativeFilePath: "archive/old.pdf" }
     );
 
-    const podsPath = `w/${workspaceId}/pods/proj123/files/archive/old.pdf`;
-    const projectsPath = `w/${workspaceId}/projects/proj123/files/archive/old.pdf`;
+    const podsPath = `w/${workspaceId}/pods/pod123/files/archive/old.pdf`;
+    const projectsPath = `w/${workspaceId}/projects/pod123/files/archive/old.pdf`;
 
     expect(deleteMock).toHaveBeenCalledTimes(2);
     expect(deleteMock).toHaveBeenNthCalledWith(1, podsPath, {
@@ -1177,8 +1177,8 @@ describe("deleteGCSMountFile", () => {
       { relativeFilePath: "archive" }
     );
 
-    const prefix = `w/${workspaceId}/projects/proj123/files/`;
-    const podsPrefix = `w/${workspaceId}/pods/proj123/files/`;
+    const prefix = `w/${workspaceId}/projects/pod123/files/`;
+    const podsPrefix = `w/${workspaceId}/pods/pod123/files/`;
 
     expect(result.isOk()).toBe(true);
     expect(deleteByPrefixMock).toHaveBeenCalledWith(`${prefix}archive/`);
@@ -1188,7 +1188,7 @@ describe("deleteGCSMountFile", () => {
 });
 
 describe("scoped path ↔ GCS path", () => {
-  const prefix = "w/ws1/pods/proj1/files/";
+  const prefix = "w/ws1/pods/pod123/files/";
 
   it("getScopedPathFromGCSPath is the inverse of getGCSPathFromScopedPath", () => {
     const scopedPath = "pod/reports/report_fil_abc.pdf";

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -1083,7 +1083,7 @@ describe("scoped path ↔ GCS path", () => {
     const gcsPath = getGCSPathFromScopedPath({
       prefix,
       scopedPath,
-      useCase: "project",
+      useCase: "pod",
     });
     expect(gcsPath).toBe(`${prefix}reports/report_fil_abc.pdf`);
 
@@ -1091,7 +1091,7 @@ describe("scoped path ↔ GCS path", () => {
       getScopedPathFromGCSPath({
         prefix,
         gcsPath: gcsPath!,
-        useCase: "project",
+        useCase: "pod",
       })
     ).toBe(scopedPath);
   });
@@ -1101,7 +1101,7 @@ describe("scoped path ↔ GCS path", () => {
       getScopedPathFromGCSPath({
         prefix,
         gcsPath: "w/ws1/projects/other/files/file.txt",
-        useCase: "project",
+        useCase: "pod",
       })
     ).toBeNull();
   });

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -912,11 +912,11 @@ describe("renameGCSMountFile", () => {
   it("copies to the new path, deletes the old path, and returns the new GCS path", async () => {
     const result = await renameGCSMountFile(
       auth,
-      { useCase: "project", projectId: "proj123" },
+      { useCase: "pod", podId: "proj123" },
       { relativeFilePath: "report.pdf", newFileName: "final.pdf" }
     );
 
-    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    const prefix = `w/${workspaceId}/pods/proj123/files/`;
     expect(result.isOk()).toBe(true);
     expect(copyFileMock).toHaveBeenCalledWith(
       `${prefix}report.pdf`,
@@ -931,11 +931,11 @@ describe("renameGCSMountFile", () => {
   it("preserves directory structure when renaming a nested file", async () => {
     await renameGCSMountFile(
       auth,
-      { useCase: "project", projectId: "proj123" },
+      { useCase: "pod", podId: "proj123" },
       { relativeFilePath: "reports/q1.csv", newFileName: "q1-final.csv" }
     );
 
-    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    const prefix = `w/${workspaceId}/pods/proj123/files/`;
     expect(copyFileMock).toHaveBeenCalledWith(
       `${prefix}reports/q1.csv`,
       `${prefix}reports/q1-final.csv`
@@ -948,7 +948,7 @@ describe("renameGCSMountFile", () => {
 
     const result = await renameGCSMountFile(
       auth,
-      { useCase: "project", projectId: "proj123" },
+      { useCase: "pod", podId: "proj123" },
       { relativeFilePath: "report.pdf", newFileName: "final.pdf" }
     );
 
@@ -1109,11 +1109,11 @@ describe("deleteGCSMountFile", () => {
   it("calls bucket.delete with the correct GCS path and ignoreNotFound", async () => {
     const result = await deleteGCSMountFile(
       auth,
-      { useCase: "project", projectId: "proj123" },
+      { useCase: "pod", podId: "proj123" },
       { relativeFilePath: "archive/old.pdf" }
     );
 
-    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    const prefix = `w/${workspaceId}/pods/proj123/files/`;
     expect(result.isOk()).toBe(true);
     expect(deleteMock).toHaveBeenCalledWith(`${prefix}archive/old.pdf`, {
       ignoreNotFound: true,
@@ -1125,7 +1125,7 @@ describe("deleteGCSMountFile", () => {
 
     const result = await deleteGCSMountFile(
       auth,
-      { useCase: "project", projectId: "proj123" },
+      { useCase: "pod", podId: "proj123" },
       { relativeFilePath: "file.pdf" }
     );
 

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -128,6 +128,47 @@ describe("createGCSMountFile", () => {
     assert(entryRes.isOk());
     expect(entryRes.value.thumbnailUrl).toBeNull();
   });
+
+  it("dual-writes to the projects/ mirror for pod use-case", async () => {
+    const content = Buffer.from("hello");
+
+    await createGCSMountFile(
+      auth,
+      { useCase: "pod", podId: "proj123" },
+      { relativeFilePath: "report.txt", content, contentType: "text/plain" }
+    );
+
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${workspaceId}/pods/proj123/files/report.txt`
+    );
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${workspaceId}/projects/proj123/files/report.txt`
+    );
+    expect(saveMock).toHaveBeenCalledTimes(2);
+    expect(saveMock).toHaveBeenNthCalledWith(1, content, {
+      contentType: "text/plain",
+    });
+    expect(saveMock).toHaveBeenNthCalledWith(2, content, {
+      contentType: "text/plain",
+    });
+  });
+
+  it("does not write to projects/ for conversation use-case", async () => {
+    await createGCSMountFile(
+      auth,
+      { useCase: "conversation", conversationId },
+      {
+        relativeFilePath: "report.txt",
+        content: Buffer.from("hello"),
+        contentType: "text/plain",
+      }
+    );
+
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+    expect(bucket.file).toHaveBeenCalledTimes(1);
+    expect(saveMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("createGCSMountDirectory", () => {
@@ -199,6 +240,41 @@ describe("createGCSMountDirectory", () => {
       );
     }
     expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("dual-writes the placeholder on the projects/ mirror for pod use-case", async () => {
+    const entryRes = await createGCSMountDirectory(
+      auth,
+      { useCase: "pod", podId: "proj123" },
+      { relativeDirPath: "reports/q1" }
+    );
+
+    assert(entryRes.isOk());
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${workspaceId}/pods/proj123/files/reports/q1/`
+    );
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${workspaceId}/projects/proj123/files/reports/q1/`
+    );
+    expect(saveMock).toHaveBeenCalledTimes(2);
+    expect(saveMock).toHaveBeenNthCalledWith(1, Buffer.alloc(0), {
+      contentType: "application/x-directory",
+    });
+    expect(saveMock).toHaveBeenNthCalledWith(2, Buffer.alloc(0), {
+      contentType: "application/x-directory",
+    });
+  });
+
+  it("does not write to projects/ for conversation use-case", async () => {
+    const entryRes = await createGCSMountDirectory(
+      auth,
+      { useCase: "conversation", conversationId },
+      { relativeDirPath: "reports/q1" }
+    );
+
+    assert(entryRes.isOk());
+    expect(saveMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -782,6 +858,32 @@ describe("copyMountFile", () => {
       expect(result.error.message).toContain("GCS copy unavailable");
     }
   });
+
+  it("mirrors the destination write on projects/ when dest is a pod", async () => {
+    const result = await copyMountFile(auth, {
+      source: {
+        scope: { useCase: "conversation", conversationId: "src-conv" },
+        relativeFilePath: "report.pdf",
+      },
+      dest: {
+        scope: { useCase: "pod", podId: "proj123" },
+        relativeFilePath: "report.pdf",
+      },
+    });
+
+    assert(result.isOk());
+    const sourcePath = `w/${workspaceId}/conversations/src-conv/files/report.pdf`;
+    const destPodsPath = `w/${workspaceId}/pods/proj123/files/report.pdf`;
+    const destProjectsPath = `w/${workspaceId}/projects/proj123/files/report.pdf`;
+
+    expect(copyFileMock).toHaveBeenCalledTimes(2);
+    expect(copyFileMock).toHaveBeenNthCalledWith(1, sourcePath, destPodsPath);
+    expect(copyFileMock).toHaveBeenNthCalledWith(
+      2,
+      sourcePath,
+      destProjectsPath
+    );
+  });
 });
 
 describe("renameGCSMountFile", () => {
@@ -855,6 +957,51 @@ describe("renameGCSMountFile", () => {
       expect(result.error.message).toContain("copy failed");
     }
     expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("mirrors rename on projects/ for pod use-case using the new canonical as source", async () => {
+    await renameGCSMountFile(
+      auth,
+      { useCase: "pod", podId: "proj123" },
+      { relativeFilePath: "report.pdf", newFileName: "final.pdf" }
+    );
+
+    const podsPrefix = `w/${workspaceId}/pods/proj123/files/`;
+    const projectsPrefix = `w/${workspaceId}/projects/proj123/files/`;
+
+    expect(copyFileMock).toHaveBeenCalledTimes(2);
+    expect(copyFileMock).toHaveBeenNthCalledWith(
+      1,
+      `${podsPrefix}report.pdf`,
+      `${podsPrefix}final.pdf`
+    );
+    // Projects mirror copies from the NEW canonical (not from an old projects/ source,
+    // which may not exist for files written only to pods/).
+    expect(copyFileMock).toHaveBeenNthCalledWith(
+      2,
+      `${podsPrefix}final.pdf`,
+      `${projectsPrefix}final.pdf`
+    );
+
+    expect(deleteMock).toHaveBeenCalledTimes(2);
+    expect(deleteMock).toHaveBeenNthCalledWith(1, `${podsPrefix}report.pdf`);
+    expect(deleteMock).toHaveBeenNthCalledWith(
+      2,
+      `${projectsPrefix}report.pdf`,
+      { ignoreNotFound: true }
+    );
+  });
+
+  it("does not mirror rename on projects/ for conversation use-case", async () => {
+    const result = await renameGCSMountFile(
+      auth,
+      { useCase: "conversation", conversationId: "conv-rename" },
+      { relativeFilePath: "report.pdf", newFileName: "final.pdf" }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(copyFileMock).toHaveBeenCalledTimes(1);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -990,21 +1137,21 @@ describe("deleteGCSMountFile", () => {
     }
   });
 
-  it("mirrors delete on projects/ for project use-case", async () => {
+  it("mirrors delete on projects/ for pod use-case", async () => {
     await deleteGCSMountFile(
       auth,
-      { useCase: "pod", podId: "pod123" },
+      { useCase: "pod", podId: "proj123" },
       { relativeFilePath: "archive/old.pdf" }
     );
 
-    const projectPath = `w/${workspaceId}/projects/proj123/files/archive/old.pdf`;
     const podsPath = `w/${workspaceId}/pods/proj123/files/archive/old.pdf`;
+    const projectsPath = `w/${workspaceId}/projects/proj123/files/archive/old.pdf`;
 
     expect(deleteMock).toHaveBeenCalledTimes(2);
     expect(deleteMock).toHaveBeenNthCalledWith(1, podsPath, {
       ignoreNotFound: true,
     });
-    expect(deleteMock).toHaveBeenNthCalledWith(2, projectPath, {
+    expect(deleteMock).toHaveBeenNthCalledWith(2, projectsPath, {
       ignoreNotFound: true,
     });
   });

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -537,18 +537,6 @@ export async function createGCSMountDirectory(
     await bucket.file(gcsPath).save(Buffer.alloc(0), {
       contentType: "application/x-directory",
     });
-
-    // Mirror the directory placeholder on the pods/ side for project files.
-    if (scope.useCase === "project") {
-      const podsPrefix = getPodFilesBasePath({
-        workspaceId: owner.sId,
-        projectId: scope.projectId,
-      });
-      const podsGcsPath = `${podsPrefix}${normalized}/`;
-      await bucket.file(podsGcsPath).save(Buffer.alloc(0), {
-        contentType: "application/x-directory",
-      });
-    }
   } catch (error) {
     return new Err(normalizeError(error));
   }

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -8,7 +8,9 @@ import { GCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_moun
 import {
   getConversationFilesBasePath,
   getPodFilesBasePath,
+  getProjectFilesBasePath,
   TOOL_OUTPUTS_FOLDER_NAME,
+  toProjectMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -364,6 +366,19 @@ export async function renameGCSMountFile(
     await bucket.copyFile(oldGcsPath, newGcsPath);
     await bucket.delete(oldGcsPath);
 
+    // Mirror the rename on the projects/ side for pod files. We copy from the new canonical
+    // pods/ path (instead of an old projects/ path that may not exist).
+    if (scope.useCase === "pod") {
+      const projectsPrefix = getProjectFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: scope.podId,
+      });
+      const oldProjectsPath = `${projectsPrefix}${relativeFilePath}`;
+      const newProjectsPath = `${projectsPrefix}${dir}${newFileName}`;
+      await bucket.copyFile(newGcsPath, newProjectsPath);
+      await bucket.delete(oldProjectsPath, { ignoreNotFound: true });
+    }
+
     return new Ok({ newGcsPath });
   } catch (err) {
     return new Err(normalizeError(err));
@@ -488,6 +503,16 @@ export async function createGCSMountFile(
   const bucket = getPrivateUploadBucket();
   try {
     await bucket.file(gcsPath).save(content, { contentType });
+
+    // Mirror the write on the projects/ side for pod files.
+    if (scope.useCase === "pod") {
+      const projectsPrefix = getProjectFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: scope.podId,
+      });
+      const projectsGcsPath = `${projectsPrefix}${relativeFilePath}`;
+      await bucket.file(projectsGcsPath).save(content, { contentType });
+    }
   } catch (error) {
     return new Err(normalizeError(error));
   }
@@ -537,6 +562,18 @@ export async function createGCSMountDirectory(
     await bucket.file(gcsPath).save(Buffer.alloc(0), {
       contentType: "application/x-directory",
     });
+
+    // Mirror the directory placeholder on the projects/ side for pod files.
+    if (scope.useCase === "pod") {
+      const projectsPrefix = getProjectFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: scope.podId,
+      });
+      const projectsGcsPath = `${projectsPrefix}${normalized}/`;
+      await bucket.file(projectsGcsPath).save(Buffer.alloc(0), {
+        contentType: "application/x-directory",
+      });
+    }
   } catch (error) {
     return new Err(normalizeError(error));
   }
@@ -598,14 +635,14 @@ export async function deleteGCSMountFile(
 
     await bucket.delete(gcsPath, { ignoreNotFound: true });
 
-    // Mirror delete on the project/ side for pod files
+    // Mirror delete on the projects/ side for pod files.
     if (scope.useCase === "pod") {
-      const projectPrefix = getProjectFilesBasePath({
+      const projectsPrefix = getProjectFilesBasePath({
         workspaceId: owner.sId,
         projectId: scope.podId,
       });
-      const projectGcsPath = `${projectPrefix}${normalized}`;
-      await bucket.delete(projectGcsPath, { ignoreNotFound: true });
+      const projectsGcsPath = `${projectsPrefix}${normalized}`;
+      await bucket.delete(projectsGcsPath, { ignoreNotFound: true });
     }
 
     return new Ok(undefined);
@@ -635,6 +672,16 @@ export async function copyMountFile(
 
   try {
     await bucket.copyFile(sourceGcsPath, destGcsPath);
+
+    // Mirror the destination write on the projects/ side for pod files (double-write counterpart).
+    if (dest.scope.useCase === "pod") {
+      const projectsPrefix = getProjectFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: dest.scope.podId,
+      });
+      const destProjectsPath = `${projectsPrefix}${dest.relativeFilePath}`;
+      await bucket.copyFile(sourceGcsPath, destProjectsPath);
+    }
 
     return new Ok(undefined);
   } catch (err) {
@@ -880,6 +927,35 @@ export async function moveFile(
   });
   if (moveRes.isErr()) {
     return moveRes;
+  }
+
+  // Dual-write to the projects/ side. Copy from the new canonical so this works even when
+  // the source had no pre-existing projects/ mirror.
+  const bucket = getPrivateUploadBucket();
+  if (destScope.useCase === "pod") {
+    const projectsPrefix = getProjectFilesBasePath({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      projectId: destScope.podId,
+    });
+    const destProjectsPath = `${projectsPrefix}${destRelativeFilePath}`;
+    try {
+      await bucket.copyFile(destGcsPath, destProjectsPath);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  // Clean up the projects/ mirror of the source if the source was a pod mount path.
+  const sourceProjectsPath = toProjectMountFilePath(normalizedSourceGcsPath);
+  if (sourceProjectsPath) {
+    try {
+      await bucket.delete(sourceProjectsPath, { ignoreNotFound: true });
+    } catch (err) {
+      logger.error(
+        { sourceProjectsPath, err: normalizeError(err) },
+        "moveFile: source projects/ mirror delete failed after successful move"
+      );
+    }
   }
 
   if (file) {

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -433,20 +433,20 @@ export async function renameGCSMountDirectory(
     }
     await bucket.deleteByPrefix(oldDirPrefix);
 
-    if (scope.useCase === "project") {
-      const podsPrefix = getPodFilesBasePath({
+    if (scope.useCase === "pod") {
+      const projectsPrefix = getProjectFilesBasePath({
         workspaceId: owner.sId,
-        projectId: scope.projectId,
+        projectId: scope.podId,
       });
-      const oldPodsDirPrefix = `${podsPrefix}${normalized}/`;
+      const oldProjectsDirPrefix = `${projectsPrefix}${normalized}/`;
       for (const obj of objects) {
-        const newProjectsPath = obj.name.replace(oldDirPrefix, newDirPrefix);
-        const newPodsPath = toPodMountFilePath(newProjectsPath);
-        if (newPodsPath) {
-          await bucket.copyFile(newProjectsPath, newPodsPath);
+        const newPodsPath = obj.name.replace(oldDirPrefix, newDirPrefix);
+        const newProjectsPath = toProjectMountFilePath(newPodsPath);
+        if (newProjectsPath) {
+          await bucket.copyFile(newPodsPath, newProjectsPath);
         }
       }
-      await bucket.deleteByPrefix(oldPodsDirPrefix);
+      await bucket.deleteByPrefix(oldProjectsDirPrefix);
     }
 
     return new Ok({ newRelativeDirPath });

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -8,9 +8,7 @@ import { GCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_moun
 import {
   getConversationFilesBasePath,
   getPodFilesBasePath,
-  getProjectFilesBasePath,
   TOOL_OUTPUTS_FOLDER_NAME,
-  toPodMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -35,7 +33,7 @@ const GCS_MOUNT_COPY_MAX_FILES = 5000;
 
 type GCSMountEntryBase = {
   fileName: string;
-  /** Scoped path, e.g. `project/report.pdf` or `conversation/.tool_outputs/chart.png`. */
+  /** Scoped path, e.g. `pod/report.pdf` or `conversation/.tool_outputs/chart.png`. */
   path: string;
   sizeBytes: number;
   lastModifiedMs: number;
@@ -50,7 +48,7 @@ export type GCSMountFileEntry = GCSMountEntryBase & {
   contentType: string;
   fileId: string | null;
   thumbnailUrl: string | null;
-  /** Present when the listing endpoint adds read-signed URLs (e.g. system project_files API). */
+  /** Present when the listing endpoint adds read-signed URLs (e.g. system pod_files API). */
   signedDownloadUrl?: string | null;
 };
 
@@ -58,7 +56,7 @@ export type GCSMountEntry = GCSMountDirectoryEntry | GCSMountFileEntry;
 
 export type GCSMountPoint =
   | { useCase: "conversation"; conversationId: string }
-  | { useCase: "project"; projectId: string };
+  | { useCase: "pod"; podId: string };
 
 function resolvePrefix(
   owner: LightWorkspaceType,
@@ -71,10 +69,10 @@ function resolvePrefix(
         conversationId: scope.conversationId,
       });
 
-    case "project":
-      return getProjectFilesBasePath({
+    case "pod":
+      return getPodFilesBasePath({
         workspaceId: owner.sId,
-        projectId: scope.projectId,
+        podId: scope.podId,
       });
 
     default:
@@ -205,8 +203,8 @@ function makeThumbnailUrl({
     case "conversation":
       return `${config.getApiBaseUrl()}/api/w/${workspaceId}/assistant/conversations/${scope.conversationId}/files/thumbnail?filePath=${encodeURIComponent(`${scope.useCase}/${relativeFilePath}`)}`;
 
-    case "project":
-      // TODO(2026-05-10: FILE SYSTEM) Expose a project files thumbnail endpoint.
+    case "pod":
+      // TODO(2026-05-10: FILE SYSTEM) Expose a Pod files thumbnail endpoint.
       return null;
 
     default:
@@ -264,15 +262,23 @@ export async function listGCSMountFiles(
     return !name.includes(".processed.");
   });
 
+  // GCS files are listed under `pods/` but some FileResource rows still store the
+  // `projects/` form. Query both shapes so old rows still resolve.
   const mountPaths = regularFiles.map((f) => f.name);
-  const fileResources = await FileResource.fetchByMountFilePaths(
-    auth,
-    mountPaths
+  const legacyMountPaths = mountPaths.map((p) =>
+    p.replace("/pods/", "/projects/")
   );
+  const fileResources = await FileResource.fetchByMountFilePaths(auth, [
+    ...mountPaths,
+    ...legacyMountPaths,
+  ]);
   const fileResourceByMountPath = new Map<string, FileResource>();
   for (const r of fileResources) {
     if (r.mountFilePath) {
-      fileResourceByMountPath.set(r.mountFilePath, r);
+      fileResourceByMountPath.set(
+        r.mountFilePath.replace("/projects/", "/pods/"),
+        r
+      );
     }
   }
 
@@ -357,20 +363,6 @@ export async function renameGCSMountFile(
   try {
     await bucket.copyFile(oldGcsPath, newGcsPath);
     await bucket.delete(oldGcsPath);
-
-    // Mirror the rename on the pods/ side for project files. We copy from the new canonical
-    // projects/ path (instead of an old pods/ path that may not exist for files predating the
-    // dual-write) — this also opportunistically backfills the pods/ side as files get renamed.
-    if (scope.useCase === "project") {
-      const podsPrefix = getPodFilesBasePath({
-        workspaceId: owner.sId,
-        projectId: scope.projectId,
-      });
-      const oldPodsPath = `${podsPrefix}${relativeFilePath}`;
-      const newPodsPath = `${podsPrefix}${dir}${newFileName}`;
-      await bucket.copyFile(newGcsPath, newPodsPath);
-      await bucket.delete(oldPodsPath, { ignoreNotFound: true });
-    }
 
     return new Ok({ newGcsPath });
   } catch (err) {
@@ -496,16 +488,6 @@ export async function createGCSMountFile(
   const bucket = getPrivateUploadBucket();
   try {
     await bucket.file(gcsPath).save(content, { contentType });
-
-    // Mirror the write on the pods/ side for project files
-    if (scope.useCase === "project") {
-      const podsPrefix = getPodFilesBasePath({
-        workspaceId: owner.sId,
-        projectId: scope.projectId,
-      });
-      const podsGcsPath = `${podsPrefix}${relativeFilePath}`;
-      await bucket.file(podsGcsPath).save(content, { contentType });
-    }
   } catch (error) {
     return new Err(normalizeError(error));
   }
@@ -614,12 +596,12 @@ export async function deleteGCSMountFile(
       if (isDirectoryDelete) {
         await bucket.deleteByPrefix(dirGcsPrefix);
 
-        if (scope.useCase === "project") {
-          const podsPrefix = getPodFilesBasePath({
+        if (scope.useCase === "pod") {
+          const projectPrefix = getProjectFilesBasePath({
             workspaceId: owner.sId,
-            projectId: scope.projectId,
+            projectId: scope.podId,
           });
-          await bucket.deleteByPrefix(`${podsPrefix}${normalized}/`);
+          await bucket.deleteByPrefix(`${projectPrefix}${normalized}/`);
         }
 
         return new Ok(undefined);
@@ -628,14 +610,14 @@ export async function deleteGCSMountFile(
 
     await bucket.delete(gcsPath, { ignoreNotFound: true });
 
-    // Mirror delete on the pods/ side for project files
-    if (scope.useCase === "project") {
-      const podsPrefix = getPodFilesBasePath({
+    // Mirror delete on the project/ side for pod files
+    if (scope.useCase === "pod") {
+      const projectPrefix = getProjectFilesBasePath({
         workspaceId: owner.sId,
-        projectId: scope.projectId,
+        projectId: scope.podId,
       });
-      const podsGcsPath = `${podsPrefix}${normalized}`;
-      await bucket.delete(podsGcsPath, { ignoreNotFound: true });
+      const projectGcsPath = `${projectPrefix}${normalized}`;
+      await bucket.delete(projectGcsPath, { ignoreNotFound: true });
     }
 
     return new Ok(undefined);
@@ -665,16 +647,6 @@ export async function copyMountFile(
 
   try {
     await bucket.copyFile(sourceGcsPath, destGcsPath);
-
-    // Mirror the destination write on the pods/ side for project files (double-write counterpart).
-    if (dest.scope.useCase === "project") {
-      const podsPrefix = getPodFilesBasePath({
-        workspaceId: owner.sId,
-        projectId: dest.scope.projectId,
-      });
-      const destPodsPath = `${podsPrefix}${dest.relativeFilePath}`;
-      await bucket.copyFile(sourceGcsPath, destPodsPath);
-    }
 
     return new Ok(undefined);
   } catch (err) {
@@ -846,8 +818,8 @@ async function emitGCSMountFileMovedAuditLog(
   };
 
   switch (scope.useCase) {
-    case "project": {
-      const space = await SpaceResource.fetchById(auth, scope.projectId);
+    case "pod": {
+      const space = await SpaceResource.fetchById(auth, scope.podId);
       if (!space) {
         return;
       }
@@ -911,38 +883,15 @@ export async function moveFile(
 ): Promise<Result<void, Error>> {
   const destGcsPath = `${resolvePrefix(auth.getNonNullableWorkspace(), destScope)}${destRelativeFilePath}`;
 
-  const moveRes = await moveGCSMountFile({ sourceGcsPath, destGcsPath });
+  // Normalize legacy `projects/` source paths to their `pods/` counterpart. The GSC migration guarantees the `pods/` copy exists for all files, so this ensures the move works regardless of whether the source path has been backfilled.
+  const normalizedSourceGcsPath = sourceGcsPath.replace("/projects/", "/pods/");
+
+  const moveRes = await moveGCSMountFile({
+    sourceGcsPath: normalizedSourceGcsPath,
+    destGcsPath,
+  });
   if (moveRes.isErr()) {
     return moveRes;
-  }
-
-  // Dual-write to the pods/ side. Copy from the new canonical so this works even when the
-  // source was a non-project file (no pre-existing pods/ source to copy from).
-  const bucket = getPrivateUploadBucket();
-  if (destScope.useCase === "project") {
-    const podsPrefix = getPodFilesBasePath({
-      workspaceId: auth.getNonNullableWorkspace().sId,
-      projectId: destScope.projectId,
-    });
-    const destPodsPath = `${podsPrefix}${destRelativeFilePath}`;
-    try {
-      await bucket.copyFile(destGcsPath, destPodsPath);
-    } catch (err) {
-      return new Err(normalizeError(err));
-    }
-  }
-
-  // Clean up the pods/ mirror of the source if the source was a project mount path.
-  const sourcePodsPath = toPodMountFilePath(sourceGcsPath);
-  if (sourcePodsPath) {
-    try {
-      await bucket.delete(sourcePodsPath, { ignoreNotFound: true });
-    } catch (err) {
-      logger.error(
-        { sourcePodsPath, err: normalizeError(err) },
-        "moveFile: source pods/ mirror delete failed after successful move"
-      );
-    }
   }
 
   if (file) {

--- a/front/lib/api/files/mount_file_ops.ts
+++ b/front/lib/api/files/mount_file_ops.ts
@@ -23,10 +23,10 @@ function resolveMountPrefix(auth: Authenticator, scope: GCSMountPoint): string {
         workspaceId: owner.sId,
         conversationId: scope.conversationId,
       });
-    case "project":
+    case "pod":
       return getProjectFilesBasePath({
         workspaceId: owner.sId,
-        projectId: scope.projectId,
+        projectId: scope.podId,
       });
     default:
       return assertNever(scope);
@@ -34,15 +34,15 @@ function resolveMountPrefix(auth: Authenticator, scope: GCSMountPoint): string {
 }
 
 function defaultDestUseCase(scope: GCSMountPoint): FileUseCase {
-  return scope.useCase === "project" ? "project_context" : "conversation";
+  return scope.useCase === "pod" ? "project_context" : "conversation";
 }
 
 function defaultDestUseCaseMetadata(scope: GCSMountPoint): FileUseCaseMetadata {
   switch (scope.useCase) {
     case "conversation":
       return { conversationId: scope.conversationId };
-    case "project":
-      return { spaceId: scope.projectId };
+    case "pod":
+      return { spaceId: scope.podId };
     default:
       return assertNever(scope);
   }

--- a/front/lib/api/files/mount_file_ops.ts
+++ b/front/lib/api/files/mount_file_ops.ts
@@ -4,7 +4,7 @@ import {
 } from "@app/lib/api/files/gcs_mount/files";
 import {
   getConversationFilesBasePath,
-  getProjectFilesBasePath,
+  getPodFilesBasePath,
   normalizeAndValidateMountRelativeFilePath,
   type ResolveMountFilePathError,
   resolveMoveSourcePath,
@@ -24,9 +24,9 @@ function resolveMountPrefix(auth: Authenticator, scope: GCSMountPoint): string {
         conversationId: scope.conversationId,
       });
     case "pod":
-      return getProjectFilesBasePath({
+      return getPodFilesBasePath({
         workspaceId: owner.sId,
-        projectId: scope.podId,
+        podId: scope.podId,
       });
     default:
       return assertNever(scope);

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -16,6 +16,7 @@ import {
   resolveMoveSourcePath,
   resolveScopedMountFilePath,
   toPodMountFilePath,
+  toProjectMountFilePath,
   validateMountFolderName,
 } from "@app/lib/api/files/mount_path";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -87,6 +88,40 @@ describe("mount_path helpers", () => {
 
     it("returns null when nothing follows projects/", () => {
       expect(toPodMountFilePath("w/ws1/projects/")).toBeNull();
+    });
+  });
+
+  describe("toProjectMountFilePath", () => {
+    it("converts a pod mount file path to its projects/ counterpart", () => {
+      expect(toProjectMountFilePath("w/ws1/pods/p1/files/report.pdf")).toBe(
+        "w/ws1/projects/p1/files/report.pdf"
+      );
+    });
+
+    it("preserves nested directory structure", () => {
+      expect(
+        toProjectMountFilePath("w/ws1/pods/p1/files/dir/sub/report.pdf")
+      ).toBe("w/ws1/projects/p1/files/dir/sub/report.pdf");
+    });
+
+    it("returns null for conversation paths", () => {
+      expect(
+        toProjectMountFilePath("w/ws1/conversations/c1/files/report.pdf")
+      ).toBeNull();
+    });
+
+    it("returns null for already-projects paths (no double-rewrite)", () => {
+      expect(
+        toProjectMountFilePath("w/ws1/projects/p1/files/report.pdf")
+      ).toBeNull();
+    });
+
+    it("returns null when the w/ workspace prefix is missing", () => {
+      expect(toProjectMountFilePath("pods/p1/files/report.pdf")).toBeNull();
+    });
+
+    it("returns null when nothing follows pods/", () => {
+      expect(toProjectMountFilePath("w/ws1/pods/")).toBeNull();
     });
   });
 

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -53,7 +53,7 @@ describe("mount_path helpers", () => {
   describe("getPodFilesBasePath", () => {
     it("should return full pod files path", () => {
       expect(
-        getPodFilesBasePath({ workspaceId: "ws1", projectId: "spc1" })
+        getPodFilesBasePath({ workspaceId: "ws1", podId: "spc1" })
       ).toBe("w/ws1/pods/spc1/files/");
     });
   });
@@ -249,12 +249,12 @@ describe("mount_path helpers", () => {
   });
 
   describe("resolveScopedMountFilePath", () => {
-    const mountBasePath = "w/ws123/projects/proj456/files/";
+    const mountBasePath = "w/ws123/pods/pod456/files/";
 
     it("rejects invalid scope prefix", () => {
       const result = resolveScopedMountFilePath({
         relPath: "conversation/file.txt",
-        expectedPrefix: "project",
+        expectedPrefix: "pod",
         mountBasePath,
       });
       expect(result.isErr()).toBe(true);
@@ -276,8 +276,8 @@ describe("mount_path helpers", () => {
 
     it("rejects path traversal", () => {
       const result = resolveScopedMountFilePath({
-        relPath: "project/../other/file.txt",
-        expectedPrefix: "project",
+        relPath: "pod/../other/file.txt",
+        expectedPrefix: "pod",
         mountBasePath,
       });
       expect(result.isErr()).toBe(true);
@@ -299,8 +299,8 @@ describe("mount_path helpers", () => {
 
     it("returns normalized relative and GCS paths", () => {
       const result = resolveScopedMountFilePath({
-        relPath: "project/reports/../reports/file.txt",
-        expectedPrefix: "project",
+        relPath: "pod/reports/../reports/file.txt",
+        expectedPrefix: "pod",
         mountBasePath,
       });
       expect(result.isOk()).toBe(true);
@@ -314,12 +314,12 @@ describe("mount_path helpers", () => {
   });
 
   describe("resolveMoveSourcePath", () => {
-    const mountBasePath = "w/ws123/projects/proj1/files/";
+    const mountBasePath = "w/ws123/pods/pod1/files/";
 
     it("resolves a scoped listing path", () => {
       const result = resolveMoveSourcePath({
-        sourcePath: "project/reports/report_fil_abc.pdf",
-        expectedPrefix: "project",
+        sourcePath: "pod/reports/report_fil_abc.pdf",
+        expectedPrefix: "pod",
         mountBasePath,
       });
       expect(result.isOk()).toBe(true);
@@ -333,7 +333,7 @@ describe("mount_path helpers", () => {
     it("resolves a mount-relative path", () => {
       const result = resolveMoveSourcePath({
         sourcePath: "reports/file.txt",
-        expectedPrefix: "project",
+        expectedPrefix: "pod",
         mountBasePath,
       });
       expect(result.isOk()).toBe(true);
@@ -347,7 +347,7 @@ describe("mount_path helpers", () => {
     it("rejects a scoped path with the wrong prefix", () => {
       const result = resolveMoveSourcePath({
         sourcePath: "conversation/file.txt",
-        expectedPrefix: "project",
+        expectedPrefix: "pod",
         mountBasePath,
       });
       expect(result.isErr()).toBe(true);

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -98,9 +98,9 @@ describe("mount_path helpers", () => {
       });
     });
 
-    it("parses a project path", () => {
-      expect(parseScopedFilePath("project/notes/2026/draft.md")).toEqual({
-        prefix: "project",
+    it("parses a Pod path", () => {
+      expect(parseScopedFilePath("pod/notes/2026/draft.md")).toEqual({
+        prefix: "pod",
         rel: "notes/2026/draft.md",
       });
     });

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -52,9 +52,9 @@ describe("mount_path helpers", () => {
 
   describe("getPodFilesBasePath", () => {
     it("should return full pod files path", () => {
-      expect(
-        getPodFilesBasePath({ workspaceId: "ws1", podId: "spc1" })
-      ).toBe("w/ws1/pods/spc1/files/");
+      expect(getPodFilesBasePath({ workspaceId: "ws1", podId: "spc1" })).toBe(
+        "w/ws1/pods/spc1/files/"
+      );
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -90,6 +90,20 @@ export function toPodMountFilePath(
 }
 
 /**
+ * Convert a pod mount file path (`w/{wId}/pods/{pId}/files/...`) to its projects/ counterpart
+ * (`w/{wId}/projects/{pId}/files/...`). Returns `null` if the input is not a pod mount path.
+ */
+export function toProjectMountFilePath(
+  podMountFilePath: string
+): string | null {
+  const match = podMountFilePath.match(/^(w\/[^/]+\/)pods\/(.+)$/);
+  if (!match) {
+    return null;
+  }
+  return `${match[1]}projects/${match[2]}`;
+}
+
+/**
  * Given a mount file path like "w/.../files/report.pdf",
  * returns "w/.../files/report.processed.pdf".
  * For files without extension: "w/.../files/Makefile" -> "w/.../files/Makefile.processed".

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -2,9 +2,9 @@
 //
 // Two scoped mounts are supported:
 //   - "conversation": files scoped to a single conversation, mounted at /files/conversation
-//   - "project":      files scoped to a project (space), mounted at /files/project when the
-//                     conversation belongs to a project. Persistent across conversations within
-//                     the same project.
+//   - "pod":          files scoped to a Pod (project space), mounted at /files/pod when the
+//                     conversation belongs to a Pod. Persistent across conversations within
+//                     the same Pod.
 
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { AllSupportedFileContentType } from "@app/types/files";
@@ -67,12 +67,12 @@ export function getProjectFilesBasePath({
 
 export function getPodFilesBasePath({
   workspaceId,
-  projectId,
+  podId,
 }: {
   workspaceId: string;
-  projectId: string;
+  podId: string;
 }): string {
-  return `${getBaseMountPathForWorkspace({ workspaceId })}pods/${projectId}/files/`;
+  return `${getBaseMountPathForWorkspace({ workspaceId })}pods/${podId}/files/`;
 }
 
 /**
@@ -169,7 +169,7 @@ export function parseProcessedFilename(
   return { isProcessed: true, sourceBaseName: fileName.slice(0, idx) };
 }
 
-export const scopedFilePathPrefixSchema = z.enum(["conversation", "project"]);
+export const scopedFilePathPrefixSchema = z.enum(["conversation", "pod"]);
 export type ScopedFilePathPrefix = z.infer<typeof scopedFilePathPrefixSchema>;
 
 export type ScopedFilePath = {
@@ -178,7 +178,7 @@ export type ScopedFilePath = {
 };
 
 /**
- * Parse a scoped file path like "conversation/chart.png" or "project/report.pdf".
+ * Parse a scoped file path like "conversation/chart.png" or "pod/report.pdf".
  * Returns null if the path is missing a valid scope prefix.
  */
 export function parseScopedFilePath(filePath: string): ScopedFilePath | null {

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -342,7 +342,7 @@ export async function addFileToProject(
     return new Err({
       name: "dust_error",
       code: "invalid_request_error",
-      message: "Space is not a project.",
+      message: "Space is not a Pod.",
     });
   }
 
@@ -361,7 +361,7 @@ export async function addFileToProject(
       return new Err({
         name: "dust_error",
         code: "invalid_request_error",
-        message: "File has no mount path and cannot be moved to the project.",
+        message: "File has no mount path and cannot be moved to the Pod.",
       });
     }
 

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -17,7 +17,6 @@ import { moveMountFileWithinScope } from "@app/lib/api/files/mount_file_ops";
 import type { ResolveMountFilePathError } from "@app/lib/api/files/mount_path";
 import {
   getPodFilesBasePath,
-  getProjectFilesBasePath,
   joinMountRelativePath,
   normalizeMountParentRelativePath,
   validateMountFolderName,
@@ -348,9 +347,9 @@ export async function addFileToProject(
   }
 
   const owner = auth.getNonNullableWorkspace();
-  const projectFilesPrefix = getProjectFilesBasePath({
+  const projectFilesPrefix = getPodFilesBasePath({
     workspaceId: owner.sId,
-    projectId: space.sId,
+    podId: space.sId,
   });
 
   // Files already mounted under the project prefix only need content-fragment sync.

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -16,6 +16,7 @@ import {
 import { moveMountFileWithinScope } from "@app/lib/api/files/mount_file_ops";
 import type { ResolveMountFilePathError } from "@app/lib/api/files/mount_path";
 import {
+  getPodFilesBasePath,
   getProjectFilesBasePath,
   joinMountRelativePath,
   normalizeMountParentRelativePath,
@@ -369,7 +370,7 @@ export async function addFileToProject(
     const moveRes = await moveFile(auth, {
       file,
       sourceGcsPath: file.mountFilePath,
-      destScope: { useCase: "project", projectId: space.sId },
+      destScope: { useCase: "pod", podId: space.sId },
       destRelativeFilePath: destFileName,
       destFileName,
       destUseCase: "project_context",
@@ -595,7 +596,7 @@ export async function createProjectFolder(
 
   return createGCSMountDirectory(
     auth,
-    { useCase: "project", projectId: space.sId },
+    { useCase: "pod", podId: space.sId },
     { relativeDirPath }
   );
 }
@@ -626,7 +627,7 @@ export async function moveProjectFile(
 
   return moveMountFileWithinScope(
     auth,
-    { useCase: "project", projectId: space.sId },
+    { useCase: "pod", podId: space.sId },
     { sourcePath, destRelativeFilePath }
   );
 }
@@ -651,9 +652,9 @@ export async function renameProjectFile(
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
   const normalized = relativeFilePath.replace(/^\/+|\/+$/g, "");
-  const mountBasePath = getProjectFilesBasePath({
+  const mountBasePath = getPodFilesBasePath({
     workspaceId: owner.sId,
-    projectId: space.sId,
+    podId: space.sId,
   });
   const dirPrefix = `${mountBasePath}${normalized}/`;
 
@@ -681,7 +682,7 @@ export async function renameProjectFile(
 
     const renameResult = await renameGCSMountDirectory(
       auth,
-      { useCase: "project", projectId: space.sId },
+      { useCase: "pod", podId: space.sId },
       {
         relativeDirPath: normalized,
         newFolderName: folderNameRes.value,
@@ -707,15 +708,24 @@ export async function renameProjectFile(
     return new Ok(undefined);
   }
 
-  const oldGcsPath = `${mountBasePath}${normalized}`;
+   // Look up the linked FileResource by either the new `pods/` form or the old
+  // `projects/` form, since old DB rows are not yet backfilled.
+  const podsPrefix = getPodFilesBasePath({
+    workspaceId: owner.sId,
+    podId: space.sId,
+  });
+  const podsGcsPath = `${podsPrefix}${normalized}`;
+  const legacyGcsPath = podsGcsPath.replace("/pods/", "/projects/");
+
 
   const fileResources = await FileResource.fetchByMountFilePaths(auth, [
-    oldGcsPath,
+    podsGcsPath,
+    legacyGcsPath,
   ]);
 
   const renameResult = await renameGCSMountFile(
     auth,
-    { useCase: "project", projectId: space.sId },
+    { useCase: "pod", podId: space.sId },
     { relativeFilePath: normalized, newFileName }
   );
   if (renameResult.isErr()) {
@@ -751,9 +761,9 @@ export async function deleteProjectFile(
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
   const normalized = relativeFilePath.replace(/^\/+|\/+$/g, "");
-  const mountBasePath = getProjectFilesBasePath({
+  const mountBasePath = getPodFilesBasePath({
     workspaceId: owner.sId,
-    projectId: space.sId,
+    podId: space.sId,
   });
   const gcsPath = `${mountBasePath}${normalized}`;
   const dirPrefix = `${mountBasePath}${normalized}/`;
@@ -790,14 +800,19 @@ export async function deleteProjectFile(
 
       return deleteGCSMountFile(
         auth,
-        { useCase: "project", projectId: space.sId },
+        { useCase: "pod", podId: space.sId },
         { relativeFilePath: normalized }
       );
     }
   }
 
+  const podsGcsPath = `${mountBasePath}${normalized}`;
+  const legacyGcsPath = podsGcsPath.replace("/pods/", "/projects/");
+  
+
   const fileResources = await FileResource.fetchByMountFilePaths(auth, [
-    gcsPath,
+    podsGcsPath,
+    legacyGcsPath,
   ]);
   if (fileResources.length > 0) {
     return removeFileFromProject(auth, {
@@ -808,7 +823,7 @@ export async function deleteProjectFile(
 
   return deleteGCSMountFile(
     auth,
-    { useCase: "project", projectId: space.sId },
+    { useCase: "pod", podId: space.sId },
     { relativeFilePath: normalized }
   );
 }

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -707,7 +707,7 @@ export async function renameProjectFile(
     return new Ok(undefined);
   }
 
-   // Look up the linked FileResource by either the new `pods/` form or the old
+  // Look up the linked FileResource by either the new `pods/` form or the old
   // `projects/` form, since old DB rows are not yet backfilled.
   const podsPrefix = getPodFilesBasePath({
     workspaceId: owner.sId,
@@ -715,7 +715,6 @@ export async function renameProjectFile(
   });
   const podsGcsPath = `${podsPrefix}${normalized}`;
   const legacyGcsPath = podsGcsPath.replace("/pods/", "/projects/");
-
 
   const fileResources = await FileResource.fetchByMountFilePaths(auth, [
     podsGcsPath,
@@ -807,7 +806,6 @@ export async function deleteProjectFile(
 
   const podsGcsPath = `${mountBasePath}${normalized}`;
   const legacyGcsPath = podsGcsPath.replace("/pods/", "/projects/");
-  
 
   const fileResources = await FileResource.fetchByMountFilePaths(auth, [
     podsGcsPath,

--- a/front/lib/api/projects/pinned_frame.ts
+++ b/front/lib/api/projects/pinned_frame.ts
@@ -24,8 +24,8 @@ export async function validatePinnedFramePath(
     podId: space.sId,
   });
 
-  // Some DB rows still carry the legacy `project/` scope prefix; treat them as `pod/`
-  // for the existence check so re-submitting an unchanged value doesn't fail validation.
+  // Some DB rows still carry the legacy `project/` scope prefix; as they have not been
+  // migrated to the new `pod/` scope, treat them as `pod/`
   const normalizedScopedPath = pinnedFramePath.startsWith("project/")
     ? `pod/${pinnedFramePath.slice("project/".length)}`
     : pinnedFramePath;

--- a/front/lib/api/projects/pinned_frame.ts
+++ b/front/lib/api/projects/pinned_frame.ts
@@ -27,11 +27,11 @@ export async function validatePinnedFramePath(
   const gcsPath = getGCSPathFromScopedPath({
     prefix,
     scopedPath: pinnedFramePath,
-    useCase: "project",
+    useCase: "pod",
   });
   if (!gcsPath) {
     return new Err(
-      new Error("Path must start with project/ and be a valid file path.")
+      new Error("Path must start with pod/ and be a valid file path.")
     );
   }
 

--- a/front/lib/api/projects/pinned_frame.ts
+++ b/front/lib/api/projects/pinned_frame.ts
@@ -1,5 +1,5 @@
 import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
-import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
+import { getPodFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -7,7 +7,7 @@ import { Err, Ok, type Result } from "@app/types/shared/result";
 
 /**
  * Validate a pinned frame path for a project space.
- * Path must be scoped under `project/` and resolve to an existing GCS object.
+ * Path must be scoped under `pod/` and resolve to an existing GCS object.
  */
 export async function validatePinnedFramePath(
   auth: Authenticator,
@@ -19,14 +19,20 @@ export async function validatePinnedFramePath(
   }
 
   const owner = auth.getNonNullableWorkspace();
-  const prefix = getProjectFilesBasePath({
+  const prefix = getPodFilesBasePath({
     workspaceId: owner.sId,
-    projectId: space.sId,
+    podId: space.sId,
   });
+
+  // Some DB rows still carry the legacy `project/` scope prefix; treat them as `pod/`
+  // for the existence check so re-submitting an unchanged value doesn't fail validation.
+  const normalizedScopedPath = pinnedFramePath.startsWith("project/")
+    ? `pod/${pinnedFramePath.slice("project/".length)}`
+    : pinnedFramePath;
 
   const gcsPath = getGCSPathFromScopedPath({
     prefix,
-    scopedPath: pinnedFramePath,
+    scopedPath: normalizedScopedPath,
     useCase: "pod",
   });
   if (!gcsPath) {

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -760,7 +760,7 @@ describe("FileResource", () => {
         where: { id: file.id, workspaceId: workspace.id },
       });
       expect(row?.mountFilePath).toBe(
-        `w/${workspace.sId}/projects/spc-1/files/spec.md`
+        `w/${workspace.sId}/pods/spc-1/files/spec.md`
       );
     });
 
@@ -814,7 +814,7 @@ describe("FileResource", () => {
         where: { id: file2.id, workspaceId: workspace.id },
       });
       expect(row2?.mountFilePath).toBe(
-        `w/${workspace.sId}/projects/spc-1/files/notes_${file2.sId}.md`
+        `w/${workspace.sId}/pods/spc-1/files/notes_${file2.sId}.md`
       );
     });
   });

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -7,6 +7,7 @@ import {
   getConversationFilePath,
   getPodFilesBasePath,
   makeProcessedMountFileName,
+  toProjectMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import {
   getProcessedContentType,
@@ -935,11 +936,22 @@ export class FileResource extends BaseResource<FileModel> {
     // The mount path becomes the sole live version, and the canonical path stays as the immutable
     // original.
     if (this.mountFilePath) {
+      const podsMountFilePath = this.normalizeMountFilePath(this.mountFilePath);
       await getPrivateUploadBucket().uploadRawContentToBucket({
         content,
         contentType: this.contentType,
-        filePath: this.normalizeMountFilePath(this.mountFilePath),
+        filePath: podsMountFilePath,
       });
+
+      // Double-write to the projects/ path for pod mount paths.
+      const projectsMountFilePath = toProjectMountFilePath(podsMountFilePath);
+      if (projectsMountFilePath) {
+        await getPrivateUploadBucket().uploadRawContentToBucket({
+          content,
+          contentType: this.contentType,
+          filePath: projectsMountFilePath,
+        });
+      }
     }
 
     // Increment version after successful upload and mark as ready
@@ -1082,6 +1094,12 @@ export class FileResource extends BaseResource<FileModel> {
     const srcOriginalPath = this.getCloudStoragePath(auth, "original");
     await bucket.copyFile(srcOriginalPath, mountFilePath);
 
+    // Double-write to the projects/ path for pod mount paths.
+    const projectsMountFilePath = toProjectMountFilePath(mountFilePath);
+    if (projectsMountFilePath) {
+      await bucket.copyFile(srcOriginalPath, projectsMountFilePath);
+    }
+
     // Copy processed version only if this file type has real processing.
     if (this.getContentVersion() === "processed") {
       const srcProcessedPath = this.getCloudStoragePath(auth, "processed");
@@ -1090,6 +1108,12 @@ export class FileResource extends BaseResource<FileModel> {
         processedContentType: getProcessedContentType(this.contentType),
       });
       await bucket.copyFile(srcProcessedPath, processedMountPath);
+
+      const processedProjectsMountPath =
+        toProjectMountFilePath(processedMountPath);
+      if (processedProjectsMountPath) {
+        await bucket.copyFile(srcProcessedPath, processedProjectsMountPath);
+      }
     }
 
     await this.update({ mountFilePath });
@@ -1120,6 +1144,12 @@ export class FileResource extends BaseResource<FileModel> {
     const gcsMountFilePath = this.normalizeMountFilePath(this.mountFilePath);
     await bucket.delete(gcsMountFilePath, { ignoreNotFound: true });
 
+    // Mirror delete on the projects/ side for pod files (double-write counterpart).
+    const projectsMountFilePath = toProjectMountFilePath(gcsMountFilePath);
+    if (projectsMountFilePath) {
+      await bucket.delete(projectsMountFilePath, { ignoreNotFound: true });
+    }
+
     if (
       this.useCaseMetadata?.skipFileProcessing === true ||
       !hasProcessedVersion(this.contentType)
@@ -1133,6 +1163,12 @@ export class FileResource extends BaseResource<FileModel> {
       processedContentType: getProcessedContentType(this.contentType),
     });
     await bucket.delete(processedMountPath, { ignoreNotFound: true });
+
+    const processedProjectsMountPath =
+      toProjectMountFilePath(processedMountPath);
+    if (processedProjectsMountPath) {
+      await bucket.delete(processedProjectsMountPath, { ignoreNotFound: true });
+    }
   }
 
   static async bulkSetUseCaseMetadata(

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -5,9 +5,8 @@ import config from "@app/lib/api/config";
 import {
   disambiguateFileName,
   getConversationFilePath,
-  getProjectFilesBasePath,
+  getPodFilesBasePath,
   makeProcessedMountFileName,
-  toPodMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import {
   getProcessedContentType,
@@ -939,18 +938,8 @@ export class FileResource extends BaseResource<FileModel> {
       await getPrivateUploadBucket().uploadRawContentToBucket({
         content,
         contentType: this.contentType,
-        filePath: this.mountFilePath,
+        filePath: this.normalizeMountFilePath(this.mountFilePath),
       });
-
-      // Double-write to the pods/ path for project mount paths.
-      const podsMountFilePath = toPodMountFilePath(this.mountFilePath);
-      if (podsMountFilePath) {
-        await getPrivateUploadBucket().uploadRawContentToBucket({
-          content,
-          contentType: this.contentType,
-          filePath: podsMountFilePath,
-        });
-      }
     }
 
     // Increment version after successful upload and mark as ready
@@ -974,10 +963,10 @@ export class FileResource extends BaseResource<FileModel> {
 
   // Mount file path logic.
   //
-  // Files used in conversations or projects are copied to a gcsfuse-mountable GCS path so
+  // Files used in conversations or Pods are copied to a gcsfuse-mountable GCS path so
   // sandboxes can access them as a flat, human-readable filesystem:
   //   w/{wId}/conversations/{cId}/files/{fileName}
-  //   w/{wId}/projects/{spaceId}/files/{fileName}
+  //   w/{wId}/pods/{spaceId}/files/{fileName}
   //
   // The canonical path (files/w/{wId}/{fileId}/{version}) remains the immutable original. The mount
   // path is the mutable "live" version. Initial copy from canonical, then frame edits write
@@ -992,7 +981,7 @@ export class FileResource extends BaseResource<FileModel> {
    * Examines the file's use case and metadata to determine whether a mount path should be created.
    * Branches internally by use case:
    * - conversation / tool_output: mounts under w/{wId}/conversations/{cId}/files/
-   * - project_context:            mounts under w/{wId}/projects/{spaceId}/files/
+   * - project_context:            mounts under w/{wId}/pods/{spaceId}/files/
    *
    * No-ops if the file already has a mountFilePath or conditions aren't met.
    */
@@ -1011,7 +1000,7 @@ export class FileResource extends BaseResource<FileModel> {
       });
     } else if (useCase === "project_context" && useCaseMetadata?.spaceId) {
       resolvedPath = await this.resolveProjectMountPath(auth, {
-        projectId: useCaseMetadata.spaceId,
+        podId: useCaseMetadata.spaceId,
       });
     }
 
@@ -1053,18 +1042,27 @@ export class FileResource extends BaseResource<FileModel> {
    */
   private async resolveProjectMountPath(
     auth: Authenticator,
-    { projectId }: { projectId: string }
+    { podId }: { podId: string }
   ): Promise<string> {
     const owner = auth.getNonNullableWorkspace();
-    const basePath = getProjectFilesBasePath({
+    const basePath = getPodFilesBasePath({
       workspaceId: owner.sId,
-      projectId,
+      podId,
     });
 
     const desiredPath = `${basePath}${this.fileName}`;
     const isTaken = await this.isMountFilePathTaken(desiredPath);
 
     return isTaken ? `${basePath}${disambiguateFileName(this)}` : desiredPath;
+  }
+
+  /**
+   * Translate rows that still point to `projects/`. The gcs migration guaranteed the `pods/`
+   * copy exists for all such files. This translation can be removed once the DB
+   * migration is complete.
+   */
+  private normalizeMountFilePath(path: string): string {
+    return path.replace("/projects/", "/pods/");
   }
 
   /**
@@ -1084,12 +1082,6 @@ export class FileResource extends BaseResource<FileModel> {
     const srcOriginalPath = this.getCloudStoragePath(auth, "original");
     await bucket.copyFile(srcOriginalPath, mountFilePath);
 
-    // Double-write to the pods/ path for project mount paths.
-    const podsMountFilePath = toPodMountFilePath(mountFilePath);
-    if (podsMountFilePath) {
-      await bucket.copyFile(srcOriginalPath, podsMountFilePath);
-    }
-
     // Copy processed version only if this file type has real processing.
     if (this.getContentVersion() === "processed") {
       const srcProcessedPath = this.getCloudStoragePath(auth, "processed");
@@ -1098,22 +1090,21 @@ export class FileResource extends BaseResource<FileModel> {
         processedContentType: getProcessedContentType(this.contentType),
       });
       await bucket.copyFile(srcProcessedPath, processedMountPath);
-
-      const processedPodsMountPath = toPodMountFilePath(processedMountPath);
-      if (processedPodsMountPath) {
-        await bucket.copyFile(srcProcessedPath, processedPodsMountPath);
-      }
     }
 
     await this.update({ mountFilePath });
   }
 
   private async isMountFilePathTaken(mountFilePath: string): Promise<boolean> {
+    // Check both `pods/` (new) and `projects/` forms so a new file cannot collide
+    // with the disambiguated name of an old DB row whose mountFilePath still lives under
+    // `projects/`.
+    const legacyMountFilePath = mountFilePath.replace("/pods/", "/projects/");
     const existing = await FileResource.model.findOne({
       attributes: ["id"],
       where: {
         workspaceId: this.workspaceId,
-        mountFilePath,
+        mountFilePath: { [Op.in]: [mountFilePath, legacyMountFilePath] },
         id: { [Op.ne]: this.id },
       },
     });
@@ -1126,13 +1117,8 @@ export class FileResource extends BaseResource<FileModel> {
     }
 
     const bucket = getPrivateUploadBucket();
-    await bucket.delete(this.mountFilePath, { ignoreNotFound: true });
-
-    // Mirror delete on the pods/ side for project files (double-write counterpart).
-    const podsMountFilePath = toPodMountFilePath(this.mountFilePath);
-    if (podsMountFilePath) {
-      await bucket.delete(podsMountFilePath, { ignoreNotFound: true });
-    }
+    const gcsMountFilePath = this.normalizeMountFilePath(this.mountFilePath);
+    await bucket.delete(gcsMountFilePath, { ignoreNotFound: true });
 
     if (
       this.useCaseMetadata?.skipFileProcessing === true ||
@@ -1143,15 +1129,10 @@ export class FileResource extends BaseResource<FileModel> {
 
     // Only delete processed mount file if this file type has real processing.
     const processedMountPath = makeProcessedMountFileName({
-      mountFilePath: this.mountFilePath,
+      mountFilePath: gcsMountFilePath,
       processedContentType: getProcessedContentType(this.contentType),
     });
     await bucket.delete(processedMountPath, { ignoreNotFound: true });
-
-    const processedPodsMountPath = toPodMountFilePath(processedMountPath);
-    if (processedPodsMountPath) {
-      await bucket.delete(processedPodsMountPath, { ignoreNotFound: true });
-    }
   }
 
   static async bulkSetUseCaseMetadata(

--- a/front/lib/resources/skill/code_defined/projects.ts
+++ b/front/lib/resources/skill/code_defined/projects.ts
@@ -29,7 +29,7 @@ Note: Pods were previously called "Projects". Some users may still refer to them
 
 ## Persistent Knowledge
 
-Can be also referred to as the "Pod Context". Pod files live under \`project/<rel>\`
+Can be also referred to as the "Pod Context". Pod files live under \`pod/<rel>\`
 scoped paths and persist across every conversation in the Pod. Conversation-only files live
 under \`conversation/<rel>\` and are visible to this conversation only. Both surfaces are reached
 through the same file system; prefer the sandbox when it's available (see the sandbox skill for
@@ -37,7 +37,7 @@ the mount layout), and fall back to the \`${FILES_SERVER_NAME}\` MCP tools when 
 references to connected data nodes (Company Data); those are managed through the
 \`${POD_MANAGER_SERVER_NAME}\` server.
 
-To keep something for later Pod-wide use, write it under a \`project/<rel>\` path. To duplicate
+To keep something for later Pod-wide use, write it under a \`pod/<rel>\` path. To duplicate
 binary content (PDFs, images, audio) between scopes, use the dedicated copy tool rather than
 reading and rewriting, because the round-trip through the agent loses the bytes.
 
@@ -53,7 +53,7 @@ Use the \`sId\` from \`pod_tasks\` tools (e.g. \`list_tasks\`, \`create_tasks\`)
 
 When you need to find information, use this order (skip steps if the relevant tools are not in your tool list):
 1. **Pod overview**: \`${POD_MANAGER_SERVER_NAME}\` \`get_information\` returns the Pod URL, description, and what is attached to the Pod.
-2. **Pod files**: read and search \`project/<rel>\` files through the sandbox or the \`${FILES_SERVER_NAME}\` MCP tools.
+2. **Pod files**: read and search \`pod/<rel>\` files through the sandbox or the \`${FILES_SERVER_NAME}\` MCP tools.
 3. **Company-wide**: If still insufficient, use \`company_data_*\` tools and \`${SEARCH_SERVER_NAME}\` for broader company data sources.
 `,
 

--- a/front/pages/api/v1/viz/files/[...segments].ts
+++ b/front/pages/api/v1/viz/files/[...segments].ts
@@ -3,7 +3,7 @@
 
 import {
   getConversationFilesBasePath,
-  getProjectFilesBasePath,
+  getPodFilesBasePath,
   scopedFilePathPrefixSchema,
 } from "@app/lib/api/files/mount_path";
 import { extractAndVerifyVizAccessTokenFromHeader } from "@app/lib/api/viz/access_tokens";
@@ -165,19 +165,19 @@ async function handler(
     // endpoint can serve them.
     basePath = getConversationFilesBasePath({ workspaceId, conversationId });
   } else {
-    // Project-scoped frames have spaceId directly. Conversation-scoped frames that live in
-    // a project space get conversationSpaceId resolved by fetchByShareToken.
-    const projectId = frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId;
-    if (!isString(projectId)) {
+    // Pod-scoped frames have spaceId directly. Conversation-scoped frames that live in
+    // a pod space get conversationSpaceId resolved by fetchByShareToken.
+    const podId = frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId;
+    if (!isString(podId)) {
       return apiError(req, res, {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: "Frame has no project context for this path.",
+          message: "Frame has no pod context for this path.",
         },
       });
     }
-    basePath = getProjectFilesBasePath({ workspaceId, projectId });
+    basePath = getPodFilesBasePath({ workspaceId, podId });
   }
 
   const gcsPath = `${basePath}${normalizedRel}`;

--- a/front/pages/api/v1/viz/files/segments.test.ts
+++ b/front/pages/api/v1/viz/files/segments.test.ts
@@ -414,7 +414,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
     expect(res._getJSONData()).toEqual({
       error: {
         type: "invalid_request_error",
-        message: "Frame has no project context for this path.",
+        message: "Frame has no pod context for this path.",
       },
     });
   });

--- a/front/pages/api/v1/viz/files/segments.test.ts
+++ b/front/pages/api/v1/viz/files/segments.test.ts
@@ -332,14 +332,14 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
     expect(res._getStatusCode()).toBe(405);
   });
 
-  it("should serve a GCS file for a project-scoped frame (spaceId in metadata)", async () => {
+  it("should serve a GCS file for a pod-scoped frame (spaceId in metadata)", async () => {
     const { frameFile, accessToken } = await makeFrameAndToken({
       spaceId: "vlt_someSpaceId",
     });
 
     const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
       method: "GET",
-      query: { segments: ["project", "chart.png"] },
+      query: { segments: ["pod", "chart.png"] },
       headers: { authorization: `Bearer ${accessToken}` },
     });
 
@@ -368,7 +368,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
 
     const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
       method: "GET",
-      query: { segments: ["project", "chart.png"] },
+      query: { segments: ["pod", "chart.png"] },
       headers: { authorization: `Bearer ${accessToken}` },
     });
 
@@ -385,7 +385,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
     expect(res._getStatusCode()).toBe(200);
   });
 
-  it("should reject project-scoped path when frame has no project context", async () => {
+  it("should reject pod-scoped path when frame has no project context", async () => {
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
       messagesCreatedAt: [new Date()],
@@ -397,7 +397,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
 
     const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
       method: "GET",
-      query: { segments: ["project", "chart.png"] },
+      query: { segments: ["pod", "chart.png"] },
       headers: { authorization: `Bearer ${accessToken}` },
     });
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -133,7 +133,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
     const mockFile = {
       isDirectory: false as const,
       fileName: "a.txt",
-      path: "project/a.txt",
+      path: "pod/a.txt",
       sizeBytes: 3,
       lastModifiedMs: 2000,
       contentType: "text/plain",
@@ -151,7 +151,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
       {
         isDirectory: false as const,
         fileName: "old.txt",
-        path: "project/old.txt",
+        path: "pod/old.txt",
         sizeBytes: 1,
         lastModifiedMs: 500,
         contentType: "text/plain",
@@ -164,8 +164,8 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(listGCSMountFilesMock).toHaveBeenCalledWith(expect.anything(), {
-      useCase: "project",
-      projectId: space.sId,
+      useCase: "pod",
+      podId: space.sId,
     });
     expect(res._getJSONData()).toEqual({
       files: [mockFileWithUrl],

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -7,7 +7,7 @@ import {
   getGCSPathFromScopedPath,
   listGCSMountFiles,
 } from "@app/lib/api/files/gcs_mount/files";
-import { getPodsFilesBasePath } from "@app/lib/api/files/mount_path";
+import { getPodFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -103,7 +103,7 @@ async function handler(
       }
 
       const owner = auth.getNonNullableWorkspace();
-      const gcsPrefix = getPodsFilesBasePath({
+      const gcsPrefix = getPodFilesBasePath({
         workspaceId: owner.sId,
         podId: space.sId,
       });

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -7,7 +7,7 @@ import {
   getGCSPathFromScopedPath,
   listGCSMountFiles,
 } from "@app/lib/api/files/gcs_mount/files";
-import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
+import { getPodsFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -94,8 +94,8 @@ async function handler(
           : null;
 
       let files = await listGCSMountFiles(auth, {
-        useCase: "project",
-        projectId: space.sId,
+        useCase: "pod",
+        podId: space.sId,
       });
 
       if (updatedSinceFilter !== null) {
@@ -103,9 +103,9 @@ async function handler(
       }
 
       const owner = auth.getNonNullableWorkspace();
-      const gcsPrefix = getProjectFilesBasePath({
+      const gcsPrefix = getPodsFilesBasePath({
         workspaceId: owner.sId,
-        projectId: space.sId,
+        podId: space.sId,
       });
 
       const filesWithSignedUrls = await concurrentExecutor(
@@ -117,14 +117,14 @@ async function handler(
           const gcsPath = getGCSPathFromScopedPath({
             prefix: gcsPrefix,
             scopedPath: entry.path,
-            useCase: "project",
+            useCase: "pod",
           });
           if (!gcsPath) {
             return { ...entry, signedDownloadUrl: null };
           }
           const signed = await getConversationFileMountSignedUrl(
             auth,
-            { useCase: "project", projectId: space.sId },
+            { useCase: "pod", podId: space.sId },
             gcsPath
           );
           return {

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -171,7 +171,7 @@ function resolveUploadMountScopedPath(
         projectId: file.useCaseMetadata.spaceId,
       }),
       gcsPath: file.mountFilePath,
-      useCase: "project",
+      useCase: "pod",
     });
   }
 

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -125,7 +125,7 @@ import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sou
 import { getScopedPathFromGCSPath } from "@app/lib/api/files/gcs_mount/files";
 import {
   getConversationFilesBasePath,
-  getProjectFilesBasePath,
+  getPodFilesBasePath,
 } from "@app/lib/api/files/mount_path";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
 import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
@@ -166,9 +166,9 @@ function resolveUploadMountScopedPath(
 
   if (file.useCase === "project_context" && file.useCaseMetadata?.spaceId) {
     return getScopedPathFromGCSPath({
-      prefix: getProjectFilesBasePath({
+      prefix: getPodFilesBasePath({
         workspaceId: owner.sId,
-        projectId: file.useCaseMetadata.spaceId,
+        podId: file.useCaseMetadata.spaceId,
       }),
       gcsPath: file.mountFilePath,
       useCase: "pod",

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -5,6 +5,8 @@ import {
   getProjectFilesBasePath,
   isResolveMountFilePathError,
   resolveScopedMountFilePath,
+  getPodFilesBasePath,
+  parseScopedFilePath,
 } from "@app/lib/api/files/mount_path";
 import { MoveMountFileRequestBodySchema } from "@app/lib/api/files/mount_schemas";
 import {
@@ -37,7 +39,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Files are only available for project spaces.",
+        message: "Files are only available for Pod spaces.",
       },
     });
   }
@@ -54,18 +56,18 @@ async function handler(
   }
 
   const owner = auth.getNonNullableWorkspace();
-  const mountBasePath = getProjectFilesBasePath({
+  const mountBasePath = getPodFilesBasePath({
     workspaceId: owner.sId,
-    projectId: space.sId,
+    podId: space.sId,
   });
   const relPath = rel.join("/");
 
   const resolveScopedPath = () =>
     resolveScopedMountFilePath({
       relPath,
-      expectedPrefix: "project",
+      expectedPrefix: "pod",
       mountBasePath,
-      outsideScopeMessage: "Access denied: path is outside project scope.",
+      outsideScopeMessage: "Access denied: path is outside Pod scope.",
     });
 
   switch (req.method) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -1,10 +1,11 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
+  getPodFilesBasePath,
   isResolveMountFilePathError,
   resolveScopedMountFilePath,
-  getPodFilesBasePath,
 } from "@app/lib/api/files/mount_path";
 import { MoveMountFileRequestBodySchema } from "@app/lib/api/files/mount_schemas";
 import {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -2,11 +2,9 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
-  getProjectFilesBasePath,
   isResolveMountFilePathError,
   resolveScopedMountFilePath,
   getPodFilesBasePath,
-  parseScopedFilePath,
 } from "@app/lib/api/files/mount_path";
 import { MoveMountFileRequestBodySchema } from "@app/lib/api/files/mount_schemas";
 import {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/index.ts
@@ -43,7 +43,7 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Files are only available for project spaces.",
+        message: "Files are only available for Pod spaces.",
       },
     });
   }
@@ -51,8 +51,8 @@ async function handler(
   switch (req.method) {
     case "GET": {
       const files = await listGCSMountFiles(auth, {
-        useCase: "project",
-        projectId: space.sId,
+        useCase: "pod",
+        podId: space.sId,
       });
 
       return res.status(200).json({ files });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -303,10 +303,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
   });
 
   it("returns 405 for unsupported methods", async () => {
-    const { req, res } = await makeProjectRequest("PUT", [
-      "pod",
-      "file.txt",
-    ]);
+    const { req, res } = await makeProjectRequest("PUT", ["pod", "file.txt"]);
     await handler(req, res);
     expect(res._getStatusCode()).toBe(405);
   });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -71,7 +71,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
 
     it("returns 200 and streams a file for a valid scoped path", async () => {
       const { req, res } = await makeProjectRequest("GET", [
-        "project",
+        "pod",
         "report.pdf",
       ]);
       await handler(req, res);
@@ -79,7 +79,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
       expect(res.getHeader("Content-Type")).toBe("text/plain");
     });
 
-    it("returns 400 when path lacks the project/ prefix", async () => {
+    it("returns 400 when path lacks the pod/ prefix", async () => {
       const { req, res } = await makeProjectRequest("GET", ["report.pdf"]);
       await handler(req, res);
       expect(res._getStatusCode()).toBe(400);
@@ -88,7 +88,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
 
     it("returns 403 for path traversal attempts", async () => {
       const { req, res } = await makeProjectRequest("GET", [
-        "project",
+        "pod",
         "..",
         "..",
         "etc",
@@ -106,7 +106,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
       } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
       const { req, res } = await makeProjectRequest("GET", [
-        "project",
+        "pod",
         "missing.txt",
       ]);
       await handler(req, res);
@@ -125,7 +125,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
     it("returns 200 and calls renameProjectFile with the right args", async () => {
       const { req, res, project } = await makeProjectRequest(
         "PATCH",
-        ["project", "old.txt"],
+        ["pod", "old.txt"],
         { body: { fileName: "new.txt" } }
       );
       await handler(req, res);
@@ -143,7 +143,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
     it("returns 400 when fileName is missing", async () => {
       const { req, res } = await makeProjectRequest(
         "PATCH",
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { body: {} }
       );
       await handler(req, res);
@@ -153,14 +153,14 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
     it("returns 400 when fileName contains a slash", async () => {
       const { req, res } = await makeProjectRequest(
         "PATCH",
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { body: { fileName: "sub/name.txt" } }
       );
       await handler(req, res);
       expect(res._getStatusCode()).toBe(400);
     });
 
-    it("returns 400 when path lacks the project/ prefix", async () => {
+    it("returns 400 when path lacks the pod/ prefix", async () => {
       const { req, res } = await makeProjectRequest("PATCH", ["file.txt"], {
         body: { fileName: "new.txt" },
       });
@@ -171,7 +171,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
     it("returns 403 for path traversal attempts", async () => {
       const { req, res } = await makeProjectRequest(
         "PATCH",
-        ["project", "..", "evil.txt"],
+        ["pod", "..", "evil.txt"],
         { body: { fileName: "new.txt" } }
       );
       await handler(req, res);
@@ -182,7 +182,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
       vi.spyOn(SpaceResource.prototype, "canWrite").mockReturnValue(false);
       const { req, res } = await makeProjectRequest(
         "PATCH",
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { body: { fileName: "new.txt" } }
       );
       await handler(req, res);
@@ -195,7 +195,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
       );
       const { req, res } = await makeProjectRequest(
         "PATCH",
-        ["project", "file.txt"],
+        ["pod", "file.txt"],
         { body: { fileName: "new.txt" } }
       );
       await handler(req, res);
@@ -212,7 +212,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
 
     it("returns 200 and calls deleteProjectFile with the right args", async () => {
       const { req, res, project } = await makeProjectRequest("DELETE", [
-        "project",
+        "pod",
         "file.txt",
       ]);
       await handler(req, res);
@@ -226,7 +226,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
       );
     });
 
-    it("returns 400 when path lacks the project/ prefix", async () => {
+    it("returns 400 when path lacks the pod/ prefix", async () => {
       const { req, res } = await makeProjectRequest("DELETE", ["file.txt"]);
       await handler(req, res);
       expect(res._getStatusCode()).toBe(400);
@@ -234,7 +234,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
 
     it("returns 403 for path traversal attempts", async () => {
       const { req, res } = await makeProjectRequest("DELETE", [
-        "project",
+        "pod",
         "..",
         "evil.txt",
       ]);
@@ -245,7 +245,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
     it("returns 403 when the user lacks write permission", async () => {
       vi.spyOn(SpaceResource.prototype, "canWrite").mockReturnValue(false);
       const { req, res } = await makeProjectRequest("DELETE", [
-        "project",
+        "pod",
         "file.txt",
       ]);
       await handler(req, res);
@@ -257,7 +257,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
         new Err(new Error("GCS error"))
       );
       const { req, res } = await makeProjectRequest("DELETE", [
-        "project",
+        "pod",
         "file.txt",
       ]);
       await handler(req, res);
@@ -304,7 +304,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
 
   it("returns 405 for unsupported methods", async () => {
     const { req, res } = await makeProjectRequest("PUT", [
-      "project",
+      "pod",
       "file.txt",
     ]);
     await handler(req, res);

--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -25,10 +25,10 @@ async function fetchFileRefsRecursively(
       }
       visited.add(key);
 
-      // The files endpoint only accepts the "conversation/" and "pod/" prefixes. 
-      // Older frame code may still reference the legacy "project/" prefix, which 
-      // maps to the same Pod files. Rewrite only the request path; the prefetched 
-      // file stays keyed by the original scopedPath (`key`) so the frame's 
+      // The files endpoint only accepts the "conversation/" and "pod/" prefixes.
+      // Older frame code may still reference the legacy "project/" prefix, which
+      // maps to the same Pod files. Rewrite only the request path; the prefetched
+      // file stays keyed by the original scopedPath (`key`) so the frame's
       // useFile("project/...") lookup still resolves.
       let requestPath: string;
       if (ref.type === "fileId") {

--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -25,10 +25,25 @@ async function fetchFileRefsRecursively(
       }
       visited.add(key);
 
-      const fileEndpoint =
-        ref.type === "fileId"
-          ? `${frontApiUrl}/api/v1/viz/files/${ref.fileId}`
-          : `${frontApiUrl}/api/v1/viz/files/${ref.scopedPath}`;
+      // The files endpoint only accepts the "conversation/" and "pod/" prefixes. 
+      // Older frame code may still reference the legacy "project/" prefix, which 
+      // maps to the same Pod files. Rewrite only the request path; the prefetched 
+      // file stays keyed by the original scopedPath (`key`) so the frame's 
+      // useFile("project/...") lookup still resolves.
+      let requestPath: string;
+      if (ref.type === "fileId") {
+        requestPath = ref.fileId;
+      } else if (ref.scopedPath.startsWith("project/")) {
+        logger.info(
+          { scopedPath: ref.scopedPath },
+          "Legacy project/ file scope referenced in frame"
+        );
+        requestPath = `pod/${ref.scopedPath.slice("project/".length)}`;
+      } else {
+        requestPath = ref.scopedPath;
+      }
+
+      const fileEndpoint = `${frontApiUrl}/api/v1/viz/files/${requestPath}`;
 
       try {
         const fileResponse = await fetch(fileEndpoint, {

--- a/viz/app/lib/parseFileRefs.test.ts
+++ b/viz/app/lib/parseFileRefs.test.ts
@@ -46,6 +46,13 @@ describe("extractFileRefs", () => {
     ]);
   });
 
+  it("extracts scoped paths from string literals (pod/)", () => {
+    const code = `const path = "pod/abc/file.csv";`;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "path", scopedPath: "pod/abc/file.csv" },
+    ]);
+  });
+
   it("deduplicates refs across visitors", () => {
     const code = `
       function Comp() {

--- a/viz/app/lib/parseFileRefs.ts
+++ b/viz/app/lib/parseFileRefs.ts
@@ -6,7 +6,12 @@ export type FileRef =
   | { type: "path"; scopedPath: string };
 
 function isScopedPath(value: string): boolean {
-  return value.startsWith("conversation/") || value.startsWith("project/");
+  return (
+    value.startsWith("conversation/") ||
+    value.startsWith("pod/") ||
+    // Legacy prefix, still used by older frame code.
+    value.startsWith("project/")
+  );
 }
 
 export function extractFileRefs(code: string): FileRef[] {


### PR DESCRIPTION
## Description

This PR switches all file reads (not sandbox) from the legacy `projects/` GCS mount path to the new `pods/` path.
The double write logic for GCS is kept.

- **MCP file tools** (list, copy, move, resolve, utils): renames the `project` scope to `pod` everywhere, updates `getProjectFilesBasePath` → `getPodsFilesBasePath`, and renames `buildProjectMountPoint` → `buildPodMountPoint`.
- **FileResource** (`file_resource.ts`): starts saving `pods/` paths to the DB instead of `projects/`.
- **Backwards compatibility**: `listGCSMountFiles`, `resolveHandler`, and `moveFile` all handle old `FileResource` rows that still store the `projects/` form in `mountFilePath`.
- A follow-up PR (#25818) will remove all remaining `projects/` references once DB rows are fully migrated.

## Tests

Manually + existing unit tests updated.

## Risks

Old `FileResource` rows still storing `projects/` paths in the DB are handled, but this relies on the GCS backfill from #25815 having run successfully — if not, files written before the double-write (#25768) may not be readable.

**Important**: If needed to rollback notice that 
- in the Files table we have started to write mountFilePaths using the pods path
- the PR related to the sandbox has to be reverted too https://github.com/dust-tt/dust/pull/25855
- the pod connectors will delete all pods/ files and recreate projects/ files. After this PR is deployed they will start to delete projects/ files and create pods/ files
- this PR is keeping the double write on projects/ and pods/ paths in GCS

## Deploy Plan

Deploy after the GCS backfill script from #25815 has completed.
Deploy viz, front and then connectors.
Frames referencing a file in a project will not load the project file until both viz and front are deployed.
