### PR TITLE
Upg: improve FileExplorer component api.

### DIFF
--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -11,7 +11,6 @@ import type {
   ContentNodeEntry,
   FileEntry,
   FileExplorerEntry,
-  SandboxTreeNode,
 } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
@@ -232,7 +231,8 @@ function ProjectFileExplorerContent({
 }: ProjectFileExplorerProps) {
   const [frameFileId, setFrameFileId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [folderStack, setFolderStack] = useState<SandboxTreeNode[]>([]);
+  const [currentFolderPath, setCurrentFolderPath] = useState("");
+  const [navigationResetKey, setNavigationResetKey] = useState(0);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [showCreateFolderDialog, setShowCreateFolderDialog] = useState(false);
   const [fileToRename, setFileToRename] = useState<{
@@ -243,10 +243,7 @@ function ProjectFileExplorerContent({
     "companyData" | "noCompanyData" | null
   >(null);
 
-  const podMountParentRelativePath = useMemo(
-    () => (folderStack.length > 0 ? (folderStack.at(-1)?.path ?? "") : ""),
-    [folderStack]
-  );
+  const podMountParentRelativePath = currentFolderPath;
   const isArchived = !!space.archivedAt;
   const canManuallyManageProjectKnowledge =
     isManualProjectKnowledgeManagementAllowed(owner);
@@ -584,7 +581,7 @@ function ProjectFileExplorerContent({
       }
 
       await refreshProjectKnowledge();
-      setFolderStack([]);
+      setNavigationResetKey((key) => key + 1);
       return true;
     },
     [
@@ -682,12 +679,12 @@ function ProjectFileExplorerContent({
         defaultViewMode="list"
         emptyState={hasFiles ? undefined : emptyState}
         files={projectGCSFiles}
-        folderStack={folderStack}
         getFileUrl={getFileUrl}
         hideTitleBorder
+        navigationResetKey={navigationResetKey}
+        onCurrentFolderChange={setCurrentFolderPath}
         onFileDownload={onFileDownload}
         onDelete={!isArchived ? onDelete : undefined}
-        onFolderStackChange={setFolderStack}
         onMoveFile={!isArchived ? onMoveFile : undefined}
         onRename={!isArchived ? onRename : undefined}
         onOpenInteractive={(entry) => setFrameFileId(entry.fileId)}

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -19,6 +19,8 @@ import type {
 import {
   buildFolderTree,
   countFoldersInTree,
+  getFolderBreadcrumbSegments,
+  getParentFolderRelativePath,
   getScopedRelativePath,
 } from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
@@ -36,27 +38,22 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type React from "react";
-import {
-  type Dispatch,
-  type SetStateAction,
-  useCallback,
-  useMemo,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface FileExplorerBreadcrumbProps {
-  folderStack: SandboxTreeNode[];
+  currentFolderPath: string;
   onNavigate: (index: number) => void;
 }
 
 function FileExplorerBreadcrumb({
-  folderStack,
+  currentFolderPath,
   onNavigate,
 }: FileExplorerBreadcrumbProps) {
+  const segments = getFolderBreadcrumbSegments(currentFolderPath);
   const items: BreadcrumbItem[] = [
     { label: "All files", onClick: () => onNavigate(-1) },
-    ...folderStack.map((node, i) => ({
-      label: node.name,
+    ...segments.map((segment, i) => ({
+      label: segment.label,
       onClick: () => onNavigate(i),
     })),
   ];
@@ -69,16 +66,16 @@ interface FileExplorerProps {
   contentNodes?: ContentNodeEntry[];
   defaultViewMode?: ViewMode;
   emptyState?: React.ReactNode;
-  folderStack?: SandboxTreeNode[];
   hideTitleBorder?: boolean;
   files: GCSMountEntry[];
   getFileUrl: (path: string) => string;
   headerActions?: React.ReactNode;
   isLoading: boolean;
+  navigationResetKey?: number;
   onClose?: () => void;
+  onCurrentFolderChange?: (relativePath: string) => void;
   onDelete?: (entry: FileExplorerEntry) => Promise<void>;
   onFileDownload: (entry: FileEntry) => Promise<void>;
-  onFolderStackChange?: Dispatch<SetStateAction<SandboxTreeNode[]>>;
   onMoveFile?: (
     entry: FileEntry,
     parentRelativePath: string
@@ -92,36 +89,36 @@ export function FileExplorer({
   contentNodes = [],
   defaultViewMode = "grid",
   emptyState,
-  folderStack: folderStackProp,
   files,
   getFileUrl,
   headerActions,
   hideTitleBorder = false,
   isLoading,
+  navigationResetKey,
   onClose,
+  onCurrentFolderChange,
   onDelete,
   onFileDownload,
-  onFolderStackChange,
   onMoveFile,
   onOpenInteractive,
   onRename,
 }: FileExplorerProps) {
-  const [internalFolderStack, setInternalFolderStack] = useState<
-    SandboxTreeNode[]
-  >([]);
-  const folderStack = folderStackProp ?? internalFolderStack;
-  // Pass functional updates through to the parent setter. Applying `update(folderStack)`
-  // here would use a stale prop and can clear the stack (jump to root) on list refresh.
-  const setFolderStack = useCallback(
-    (update: SetStateAction<SandboxTreeNode[]>) => {
-      if (onFolderStackChange) {
-        onFolderStackChange(update);
-      } else {
-        setInternalFolderStack(update);
-      }
-    },
-    [onFolderStackChange]
-  );
+  const [currentFolderPath, setCurrentFolderPath] = useState("");
+  const prevNavigationResetKey = useRef(navigationResetKey);
+
+  useEffect(() => {
+    onCurrentFolderChange?.(currentFolderPath);
+  }, [currentFolderPath, onCurrentFolderChange]);
+
+  useEffect(() => {
+    if (
+      navigationResetKey !== undefined &&
+      prevNavigationResetKey.current !== navigationResetKey
+    ) {
+      setCurrentFolderPath("");
+    }
+    prevNavigationResetKey.current = navigationResetKey;
+  }, [navigationResetKey]);
 
   const [viewMode, setViewMode] = useState<ViewMode>(defaultViewMode);
   const [searchQuery, setSearchQuery] = useState("");
@@ -144,13 +141,20 @@ export function FileExplorer({
     () =>
       getFileExplorerPipeline({
         contentNodes,
+        currentFolderPath,
         files,
-        folderStack,
         searchQuery,
         activeFilter,
         sortMode,
       }),
-    [contentNodes, files, folderStack, searchQuery, activeFilter, sortMode]
+    [
+      contentNodes,
+      currentFolderPath,
+      files,
+      searchQuery,
+      activeFilter,
+      sortMode,
+    ]
   );
 
   const folderTree = useMemo(() => buildFolderTree(files), [files]);
@@ -210,24 +214,27 @@ export function FileExplorer({
   );
 
   const handleBreadcrumbNavigate = (index: number) => {
-    setFolderStack((prev) => (index < 0 ? [] : prev.slice(0, index + 1)));
+    if (index < 0) {
+      setCurrentFolderPath("");
+      return;
+    }
+
+    const segments = getFolderBreadcrumbSegments(currentFolderPath);
+    setCurrentFolderPath(segments[index]?.path ?? "");
   };
 
   const handleFolderNavigate = (node: SandboxTreeNode) => {
-    setFolderStack((prev) => [...prev, node]);
+    setCurrentFolderPath(node.path);
   };
 
   const handleGoUp = () => {
-    setFolderStack((prev) => prev.slice(0, -1));
+    setCurrentFolderPath(getParentFolderRelativePath(currentFolderPath));
   };
 
-  const parentFolderLabel =
-    folderStack.length <= 1
-      ? "All files"
-      : (folderStack.at(-2)?.name ?? "All files");
-
-  const parentFolderDropPath =
-    folderStack.length <= 1 ? "" : (folderStack.at(-2)?.path ?? "");
+  const parentFolderPath = getParentFolderRelativePath(currentFolderPath);
+  const parentFolderLabel = parentFolderPath
+    ? (parentFolderPath.split("/").at(-1) ?? "All files")
+    : "All files";
 
   const fileDragEnabled = Boolean(onMoveFile && totalFolderCount > 0);
 
@@ -297,7 +304,7 @@ export function FileExplorer({
             )}
           >
             <FileExplorerBreadcrumb
-              folderStack={folderStack}
+              currentFolderPath={currentFolderPath}
               onNavigate={handleBreadcrumbNavigate}
             />
             <div className="flex items-center gap-2">
@@ -344,11 +351,11 @@ export function FileExplorer({
             isEmpty={fileCount === 0 && folderCount === 0}
             emptyState={emptyState}
             fileDragEnabled={fileDragEnabled}
-            parentFolderDropPath={parentFolderDropPath}
+            parentFolderDropPath={parentFolderPath}
             parentFolderLabel={
-              folderStack.length > 0 ? parentFolderLabel : undefined
+              currentFolderPath ? parentFolderLabel : undefined
             }
-            onGoUp={folderStack.length > 0 ? handleGoUp : undefined}
+            onGoUp={currentFolderPath ? handleGoUp : undefined}
             onFolderNavigate={handleFolderNavigate}
             onFileOpen={handleFileOpen}
             onFileDownload={onFileDownload}

--- a/front/components/file_explorer/fileExplorerPipeline.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.ts
@@ -8,8 +8,8 @@ import type {
 import {
   buildSandboxTree,
   compareTreeNodesForSort,
+  getChildrenAtFolderPath,
   getFileExplorerBucket,
-  resolveFolderStackInTree,
 } from "@app/components/file_explorer/utils";
 import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
@@ -30,8 +30,8 @@ export interface FileExplorerPipeline {
 interface GetFileExplorerPipelineParams {
   activeFilter: FileExplorerFilter;
   contentNodes: ContentNodeEntry[];
+  currentFolderPath: string;
   files: GCSMountEntry[];
-  folderStack: SandboxTreeNode[];
   searchQuery: string;
   sortMode: FileExplorerSortMode;
 }
@@ -48,13 +48,12 @@ function toRelativePath(entry: GCSMountEntry): string {
 export function getFileExplorerPipeline({
   activeFilter,
   contentNodes,
+  currentFolderPath,
   files,
-  folderStack,
   searchQuery,
   sortMode,
 }: GetFileExplorerPipelineParams): FileExplorerPipeline {
   const entryByRelativePath = new Map<string, FileExplorerEntry>();
-  const timestampsByPath = new Map<string, number>();
   for (const f of files) {
     if (f.isDirectory) {
       continue;
@@ -62,24 +61,15 @@ export function getFileExplorerPipeline({
 
     const relativePath = toRelativePath(f);
     entryByRelativePath.set(relativePath, { ...f, kind: "file" });
-    timestampsByPath.set(relativePath, f.lastModifiedMs);
   }
 
   // Content nodes are always flat (no folder structure). They appear only at
   // the root level and are keyed by their synthetic path.
   for (const node of contentNodes) {
     entryByRelativePath.set(node.path, node);
-    if (node.lastModifiedMs !== null) {
-      timestampsByPath.set(node.path, node.lastModifiedMs);
-    }
   }
 
   const tree = buildSandboxTree(files);
-  // Navigation state holds node object references from an older tree; re-resolve by path
-  // on each render so the current folder lists fresh children after SWR refresh (without
-  // rewriting `folderStack` in state, which would jump the user to root — see
-  // `resolveFolderStackInTree`).
-  const resolvedFolderStack = resolveFolderStackInTree(tree, folderStack);
 
   // Synthetic tree nodes for content-node entries — always flat, at root level.
   const contentNodeTreeNodes: SandboxTreeNode[] = contentNodes.map((cn) => ({
@@ -91,14 +81,9 @@ export function getFileExplorerPipeline({
     children: [],
   }));
 
-  const currentNodes =
-    resolvedFolderStack.length > 0
-      ? // Fresh `children` from the latest tree, not from nodes captured at click time.
-        (resolvedFolderStack.at(-1)?.children ?? [])
-      : folderStack.length > 0
-        ? // Tree is rebuilding (e.g. during SWR revalidate); avoid flashing the root listing.
-          []
-        : [...tree, ...contentNodeTreeNodes];
+  const currentNodes = currentFolderPath
+    ? getChildrenAtFolderPath(tree, currentFolderPath)
+    : [...tree, ...contentNodeTreeNodes];
 
   const q = searchQuery.trim().toLowerCase();
   const visibleNodes = currentNodes.filter((node) => {
@@ -138,13 +123,7 @@ export function getFileExplorerPipeline({
         });
 
   const sortedNodes = [...matchingNodes].sort((a, b) =>
-    compareTreeNodesForSort(
-      a,
-      b,
-      sortMode,
-      timestampsByPath,
-      entryByRelativePath
-    )
+    compareTreeNodesForSort(a, b, sortMode, entryByRelativePath)
   );
 
   let folderCount = 0;

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -101,7 +101,6 @@ export function compareTreeNodesForSort(
   a: SandboxTreeNode,
   b: SandboxTreeNode,
   sortMode: FileExplorerSortMode,
-  timestampsByPath: Map<string, number>,
   entryByRelativePath: Map<string, FileExplorerEntry>
 ): number {
   const rankDiff =
@@ -121,8 +120,8 @@ export function compareTreeNodesForSort(
     case "last-modified": {
       // Folders have no timestamp on the tree (they're inferred from file paths). Among files,
       // sort by recency; tie-break by name.
-      const ta = timestampsByPath.get(a.path) ?? 0;
-      const tb = timestampsByPath.get(b.path) ?? 0;
+      const ta = entryByRelativePath.get(a.path)?.lastModifiedMs ?? 0;
+      const tb = entryByRelativePath.get(b.path)?.lastModifiedMs ?? 0;
       if (tb !== ta) {
         return tb - ta;
       }
@@ -362,41 +361,49 @@ export function getAncestorFolderPaths(folderPath: string): Set<string> {
   return paths;
 }
 
-/**
- * Re-resolve breadcrumb navigation against a freshly built tree.
- *
- * Folder navigation stores `SandboxTreeNode` object references in `folderStack`
- * (see `handleFolderNavigate`). The explorer tree is derived from `files` via
- * `buildSandboxTree` on every SWR refresh — each refresh allocates new node objects
- * with new `children` arrays.
- *
- * If we read `folderStack.at(-1).children` after an upload/rename/delete, we still
- * point at the *previous* tree: the list revalidates but the current folder looks
- * unchanged until the user leaves and re-enters the folder.
- *
- * We keep navigation stable by path (e.g. `reports/q1`) and look up the matching
- * directory nodes in the latest tree so `children` always reflects current `files`.
- */
-export function resolveFolderStackInTree(
-  tree: SandboxTreeNode[],
-  folderStack: SandboxTreeNode[]
-): SandboxTreeNode[] {
-  const resolved: SandboxTreeNode[] = [];
-  let currentLevel = tree;
-
-  for (const stackNode of folderStack) {
-    if (!stackNode.isDirectory) {
-      break;
-    }
-
-    const fresh = currentLevel.find((n) => n.path === stackNode.path);
-    if (!fresh?.isDirectory) {
-      break;
-    }
-
-    resolved.push(fresh);
-    currentLevel = fresh.children;
+/** Breadcrumb segments for a folder path (e.g. `reports/q1` → two segments). */
+export function getFolderBreadcrumbSegments(
+  folderPath: string
+): { label: string; path: string }[] {
+  if (!folderPath) {
+    return [];
   }
 
-  return resolved;
+  const segments: { label: string; path: string }[] = [];
+  let current = "";
+  for (const part of folderPath.split("/")) {
+    current = current ? `${current}/${part}` : part;
+    segments.push({ label: part, path: current });
+  }
+  return segments;
+}
+
+export function findTreeNodeByPath(
+  nodes: SandboxTreeNode[],
+  path: string
+): SandboxTreeNode | undefined {
+  for (const node of nodes) {
+    if (node.path === path) {
+      return node;
+    }
+
+    const found = findTreeNodeByPath(node.children, path);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+}
+
+/** Children of a folder in the sandbox tree; root when `folderPath` is empty. */
+export function getChildrenAtFolderPath(
+  tree: SandboxTreeNode[],
+  folderPath: string
+): SandboxTreeNode[] {
+  if (!folderPath) {
+    return tree;
+  }
+
+  const folder = findTreeNodeByPath(tree, folderPath);
+  return folder?.isDirectory ? folder.children : [];
 }


### PR DESCRIPTION
## Description

The `FileExplorer` API was leaking internal tree structure to callers: `folderStack: SandboxTreeNode[]` and `onFolderStackChange: Dispatch<SetStateAction<SandboxTreeNode[]>>` forced callers to manage an array of live node references, which caused stale-node bugs and made the state hard to persist or serialize.

This PR replaces the node-array API with a simple string path.

**API changes**

- `folderStack?: SandboxTreeNode[]` → removed; navigation state is fully internal
- `onFolderStackChange` → `onCurrentFolderChange?: (relativePath: string) => void` — callers receive a plain path string whenever the current folder changes
- `navigationResetKey?: number` — callers increment this counter to reset navigation to root (replaces `setFolderStack([])`)

**Internal changes**

- `FileExplorer` now owns a single `currentFolderPath: string` state; `useEffect` on `navigationResetKey` resets it to `""`
- `FileExplorerBreadcrumb` receives `currentFolderPath` instead of `folderStack`; new `getFolderBreadcrumbSegments(path)` utility derives label + path per segment; `onNavigate(i)` calls `navigateToPath(segments[i].path)` directly
- Add `getFolderBreadcrumbSegments` and `getParentFolderRelativePath` to `utils.ts`

**`ProjectFileExplorerContent`**

- `folderStack` + `setFolderStack` removed; replaced with `currentFolderPath` + `navigationResetKey`
- `podMountParentRelativePath` is now just `currentFolderPath` (no `useMemo` over the stack)
- `setFolderStack([])` → `setNavigationResetKey(k => k + 1)`

## Tests

Local

## Risk

Low — behavior unchanged; purely internal restructuring with a simplified external interface

## Deploy Plan

Deploy `front`
