### PR TITLE
Add poke plugin to get MCP connection metadata

### DIFF
--- a/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-connection-metadata.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-connection-metadata.ts
@@ -49,25 +49,24 @@ export const getMcpServerViewConnectionMetadataPlugin = createPlugin({
     const connections = connectionsRes.value;
     const oauthConnections = connections.filter((c) => c.connectionId);
 
-    let connection: (typeof oauthConnections)[0] | null = null;
+    let matchingConnections: MCPServerConnectionResource[];
 
     if (connectionType === "workspace") {
-      connection =
-        oauthConnections.find((c) => c.connectionType === "workspace") ?? null;
+      matchingConnections = oauthConnections.filter(
+        (c) => c.connectionType === "workspace"
+      );
     } else {
       if (!userId.trim()) {
         return new Err(
           new Error("User ID cannot be empty for personal connections.")
         );
       }
-      connection =
-        oauthConnections.find(
-          (c) =>
-            c.connectionType === "personal" && c.user?.sId === userId.trim()
-        ) ?? null;
+      matchingConnections = oauthConnections.filter(
+        (c) => c.connectionType === "personal" && c.user?.sId === userId.trim()
+      );
     }
 
-    if (!connection) {
+    if (matchingConnections.length === 0) {
       return new Err(
         new Error(
           `No ${connectionType} OAuth connection found${connectionType === "personal" ? ` for user ${userId}` : ""}.`
@@ -75,30 +74,34 @@ export const getMcpServerViewConnectionMetadataPlugin = createPlugin({
       );
     }
 
-    if (!connection.connectionId) {
-      return new Err(
-        new Error(
-          `Connection found but has no OAuth connection ID${connectionType === "personal" ? ` for user ${userId}` : ""}.`
-        )
-      );
-    }
-
     const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-    const metadataRes = await oauthApi.getConnectionMetadata({
-      connectionId: connection.connectionId,
-    });
+    const results = [];
 
-    if (metadataRes.isErr()) {
-      return new Err(
-        new Error(
-          `Failed to fetch connection metadata: ${metadataRes.error.message}`
-        )
-      );
+    for (const connection of matchingConnections) {
+      if (!connection.connectionId) {
+        continue;
+      }
+
+      const metadataRes = await oauthApi.getConnectionMetadata({
+        connectionId: connection.connectionId,
+      });
+
+      if (metadataRes.isErr()) {
+        results.push({
+          connectionId: connection.connectionId,
+          error: metadataRes.error.message,
+        });
+      } else {
+        results.push({
+          connectionId: connection.connectionId,
+          metadata: metadataRes.value.connection.metadata,
+        });
+      }
     }
 
     return new Ok({
       display: "json",
-      value: metadataRes.value.connection.metadata,
+      value: { connections: results },
     });
   },
 });

--- a/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-connection-metadata.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/get-mcp-server-view-connection-metadata.ts
@@ -1,0 +1,104 @@
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const getMcpServerViewConnectionMetadataPlugin = createPlugin({
+  manifest: {
+    id: "get-mcp-server-view-connection-metadata",
+    name: "Get MCP Server View Connection Metadata",
+    description:
+      "Retrieve the OAuth connection metadata (team_id, team_name, etc.) for this MCP server view.",
+    resourceTypes: ["mcp_server_views"],
+    readonly: true,
+    args: {
+      userId: {
+        type: "string",
+        label: "User ID",
+        description:
+          "User ID to get personal connection metadata for. Leave empty to get the workspace connection metadata.",
+      },
+    },
+  },
+  isApplicableTo: (auth, resource) => {
+    return !!resource;
+  },
+  execute: async (auth, mcpServerView, args) => {
+    if (!mcpServerView) {
+      return new Err(new Error("MCP server view not found."));
+    }
+
+    const { userId } = args;
+    const connectionType = userId && userId.trim() ? "personal" : "workspace";
+
+    const connectionsRes = await MCPServerConnectionResource.listByMCPServer(
+      auth,
+      { mcpServerId: mcpServerView.mcpServerId }
+    );
+
+    if (connectionsRes.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to fetch connections: ${connectionsRes.error.message}`
+        )
+      );
+    }
+
+    const connections = connectionsRes.value;
+    const oauthConnections = connections.filter((c) => c.connectionId);
+
+    let connection: (typeof oauthConnections)[0] | null = null;
+
+    if (connectionType === "workspace") {
+      connection =
+        oauthConnections.find((c) => c.connectionType === "workspace") ?? null;
+    } else {
+      if (!userId.trim()) {
+        return new Err(
+          new Error("User ID cannot be empty for personal connections.")
+        );
+      }
+      connection =
+        oauthConnections.find(
+          (c) =>
+            c.connectionType === "personal" && c.user?.sId === userId.trim()
+        ) ?? null;
+    }
+
+    if (!connection) {
+      return new Err(
+        new Error(
+          `No ${connectionType} OAuth connection found${connectionType === "personal" ? ` for user ${userId}` : ""}.`
+        )
+      );
+    }
+
+    if (!connection.connectionId) {
+      return new Err(
+        new Error(
+          `Connection found but has no OAuth connection ID${connectionType === "personal" ? ` for user ${userId}` : ""}.`
+        )
+      );
+    }
+
+    const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+    const metadataRes = await oauthApi.getConnectionMetadata({
+      connectionId: connection.connectionId,
+    });
+
+    if (metadataRes.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to fetch connection metadata: ${metadataRes.error.message}`
+        )
+      );
+    }
+
+    return new Ok({
+      display: "json",
+      value: metadataRes.value.connection.metadata,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/mcp_server_views/index.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/index.ts
@@ -1,2 +1,3 @@
+export * from "./get-mcp-server-view-connection-metadata";
 export * from "./get-mcp-server-view-credentials";
 export * from "./update-mcp-url";


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/8176

 - Add a poke plugin to get connection metadata to help us debug connection issue.
 - similar to existing "Run Get MCP Server View Credentials plugin" but just for metadata

<img width="3396" height="870" alt="image" src="https://github.com/user-attachments/assets/c4c6d9b4-1450-4d9a-8530-0ed4966072c7" />


## Tests

Tested on google calendar locally

<img width="1616" height="982" alt="image" src="https://github.com/user-attachments/assets/7cf9adc4-6881-4569-865f-f3d30ee71800" />


## Risk

Low, this is poke plugin

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25822">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->