### PR TITLE
Add thomasvicaire-dust to .authors

### DIFF
--- a/.authors
+++ b/.authors
@@ -57,3 +57,4 @@ matteotrab: matteo@dust.tt
 martindust: martin@dust.tt
 thervier: thibault.hervier@dust.tt
 vincesarkisian: vince@dust.tt
+thomasvicaire-dust: thomas.vicaire@dust.tt


### PR DESCRIPTION
## Summary
- Adds `thomasvicaire-dust` (thomas.vicaire@dust.tt) to the `.authors` file

## Test plan
- [ ] No functional changes — file-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25825">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->