### PR TITLE
Log when team mismatch for slack and slack tools connection

### DIFF
--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -10,6 +10,7 @@ import {
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import type {
   ExtraConfigType,
   OAuthConnectionType,
@@ -226,13 +227,26 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
       ) {
         return new Ok(undefined);
       }
+      logger.warn(
+        {
+          requestedTeamId: connection.metadata.requested_team_id,
+          requestedTeamName: connection.metadata.requested_team_name,
+          actualTeamId: connection.metadata.team_id,
+          actualTeamName: connection.metadata.team_name,
+        },
+        "OAuth: Slack team mismatch on connection"
+      );
       return new Err({
         message:
           "You must select `" +
           connection.metadata.requested_team_name +
-          "` as the team to connect, instead of `" +
+          " (" +
+          connection.metadata.requested_team_id +
+          ")` as the team to connect, instead of `" +
           connection.metadata.team_name +
-          "`.",
+          " (" +
+          connection.metadata.team_id +
+          ")`.",
       });
     }
     return new Ok(undefined);

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -180,13 +180,26 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
       ) {
         return new Ok(undefined);
       }
+      logger.warn(
+        {
+          requestedTeamId: connection.metadata.requested_team_id,
+          requestedTeamName: connection.metadata.requested_team_name,
+          actualTeamId: connection.metadata.team_id,
+          actualTeamName: connection.metadata.team_name,
+        },
+        "OAuth: Slack team mismatch on Slack tools connection"
+      );
       return new Err({
         message:
           "You must select `" +
           connection.metadata.requested_team_name +
-          "` as the team to connect, instead of `" +
+          " (" +
+          connection.metadata.requested_team_id +
+          ")` as the team to connect, instead of `" +
           connection.metadata.team_name +
-          "`.",
+          " (" +
+          connection.metadata.team_id +
+          ")`.",
       });
     }
     return new Ok(undefined);


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/8176

When it fails for a customer, there is no way for us to investigate what the targetted slack team is, so I have added a log to make sure we can help the customer find the correct team.
Also add in the error message so the customer can act without us.

## Tests

not tested

## Risk

low

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25826">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->