### PR TITLE
[front] rename user-facing "Sandbox" to "Computer"

### DIFF
--- a/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxActionDetails.tsx
@@ -113,8 +113,8 @@ export function MCPSandboxActionDetails({
   const isRunning = toolOutput === null;
 
   const actionName = isRunning
-    ? "Executing command in sandbox"
-    : "Executed command in sandbox";
+    ? "Executing command in the Computer"
+    : "Executed command in the Computer";
 
   const viewProps: SandboxViewProps = {
     command,

--- a/front/components/actions/mcp/details/MCPSandboxAddEgressDomainDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSandboxAddEgressDomainDetails.tsx
@@ -83,7 +83,7 @@ function statusLabel(status: EgressStatus, isRunning: boolean): string {
   }
   switch (status) {
     case "added":
-      return "Added to sandbox allowlist";
+      return "Added to Computer allowlist";
     case "already_allowed":
       return "Already allowed";
     case "unknown":

--- a/front/components/assistant/conversation/files_panel/SandboxStatusChip.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxStatusChip.tsx
@@ -9,13 +9,13 @@ interface SandboxStatusChipProps {
 export function SandboxStatusChip({ status }: SandboxStatusChipProps) {
   switch (status) {
     case "running":
-      return <Chip size="mini" color="success" label="Sandbox running" />;
+      return <Chip size="mini" color="success" label="Computer running" />;
     case "sleeping":
-      return <Chip size="mini" color="warning" label="Sandbox sleeping" />;
+      return <Chip size="mini" color="warning" label="Computer sleeping" />;
     case "pending_approval":
       return <Chip size="mini" color="warning" label="Waiting for approval" />;
     case "deleted":
-      return <Chip size="mini" color="primary" label="Sandbox expired" />;
+      return <Chip size="mini" color="primary" label="Computer expired" />;
     default:
       assertNever(status);
   }

--- a/front/components/assistant/conversation/files_panel/SandboxTab.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxTab.tsx
@@ -179,7 +179,7 @@ export function SandboxTab({
   if (files.length === 0) {
     return (
       <div className="p-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
-        No files in the sandbox yet.
+        No files in the Computer yet.
       </div>
     );
   }

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -335,7 +335,7 @@ export const subNavigationAdmin = ({
         },
         {
           id: "sandbox",
-          label: "Sandbox",
+          label: "Computer",
           icon: GlobeAltIcon,
           href: `/w/${owner.sId}/developers/sandbox`,
           current: isCurrent("sandbox"),

--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -19,7 +19,7 @@ export function SandboxPage() {
     if (!isAdmin) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Only workspace admins can manage sandbox settings.
+          Only workspace admins can manage Computer settings.
         </ContentMessage>
       );
     }
@@ -27,7 +27,7 @@ export function SandboxPage() {
     if (!hasSandboxAdmin) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Sandbox workspace administration is not enabled for this workspace.
+          Computer administration is not enabled for this workspace.
         </ContentMessage>
       );
     }
@@ -43,9 +43,9 @@ export function SandboxPage() {
   return (
     <Page.Vertical gap="xl" align="stretch">
       <Page.Header
-        title="Sandbox"
+        title="Computer"
         icon={CommandLineIcon}
-        description="Configure workspace-level sandbox network access and environment variables."
+        description="Configure workspace-level network access and environment variables for the Computer."
       />
       {renderBody()}
     </Page.Vertical>

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -420,14 +420,14 @@ export function EnvironmentSection() {
     if (!isAdmin) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Only workspace admins can manage sandbox environment variables.
+          Only workspace admins can manage Computer environment variables.
         </ContentMessage>
       );
     }
     if (!hasSandboxAdmin) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Sandbox workspace administration is not enabled for this workspace.
+          Computer administration is not enabled for this workspace.
         </ContentMessage>
       );
     }
@@ -442,7 +442,7 @@ export function EnvironmentSection() {
           size="lg"
           title="Failed to load"
         >
-          The sandbox environment variables could not be loaded.
+          The Computer environment variables could not be loaded.
         </ContentMessage>
       );
     }
@@ -451,7 +451,7 @@ export function EnvironmentSection() {
       <Page.Vertical align="stretch" gap="lg">
         <Page.SectionHeader
           title="Environment variables"
-          description="Secrets mounted as env vars on every sandbox in this workspace."
+          description="Secrets mounted as env vars on every Computer in this workspace."
         />
 
         <ContentMessage
@@ -465,7 +465,7 @@ export function EnvironmentSection() {
               <strong>HTTPS secrets (DSEC_)</strong> — for credentials and
               anything sensitive. Stored encrypted on the host. The dsbx
               forwarder injects the value only into outbound HTTPS requests to
-              the domains you whitelist; sandbox code never sees the raw value.
+              the domains you whitelist; Computer code never sees the raw value.
               Safe for API keys, tokens, and other secrets bound to a known
               external service.
             </div>
@@ -473,15 +473,15 @@ export function EnvironmentSection() {
               <strong>Config ({SANDBOX_ENV_VAR_PREFIX})</strong> — for
               non-sensitive configuration: feature flags, identifiers, public
               endpoints, model names. Mounted as plain env vars on every new
-              sandbox and read directly by the agent and the code it runs.
+              Computer and read directly by the agent and the code it runs.
               Anything you put here should be safe to log; do not use for
               credentials.
             </div>
             <div>
               Values are write-only: they cannot be viewed after saving, only
-              overwritten or deleted. Env vars are snapshotted at sandbox boot,
-              so running sandboxes keep their original values; new sandboxes
-              (new conversations, restarts) pick up the latest.
+              overwritten or deleted. Env vars are snapshotted when the Computer
+              starts, so running Computers keep their original values; new
+              Computers (new conversations, restarts) pick up the latest.
             </div>
           </div>
         </ContentMessage>
@@ -605,7 +605,7 @@ export function EnvironmentSection() {
                     <div className="flex flex-col">
                       <Label>HTTPS secret</Label>
                       <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                        Keep the value out of the sandbox environment.
+                        Keep the value out of the Computer environment.
                       </span>
                     </div>
                     <SliderToggle
@@ -632,12 +632,12 @@ export function EnvironmentSection() {
                     {kindValue === "https_secret" ? (
                       <>
                         Stored securely. The dsbx forwarder injects it only into
-                        outbound HTTPS requests to whitelisted domains; sandbox
+                        outbound HTTPS requests to whitelisted domains; Computer
                         code never reads it.
                       </>
                     ) : (
                       <>
-                        Mounted as a prefixed env var on every new sandbox and
+                        Mounted as a prefixed env var on every new Computer and
                         read directly by the agent and any code it runs. Use for
                         non-sensitive values.
                       </>
@@ -780,9 +780,9 @@ export function EnvironmentSection() {
                     icon={InformationCircleIcon}
                     title="Promotion only takes effect on next wake"
                   >
-                    Running sandboxes keep the previous {SANDBOX_ENV_VAR_PREFIX}
+                    Running Computers keep the previous {SANDBOX_ENV_VAR_PREFIX}
                     -prefixed value in their env until they are restarted. New
-                    sandboxes will receive the promoted secret only via
+                    Computers will receive the promoted secret only via
                     egress-time substitution to the allowed domains.
                   </ContentMessage>
                 ) : null}

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -465,9 +465,9 @@ export function EnvironmentSection() {
               <strong>HTTPS secrets (DSEC_)</strong> — for credentials and
               anything sensitive. Stored encrypted on the host. The dsbx
               forwarder injects the value only into outbound HTTPS requests to
-              the domains you whitelist; Computer code never sees the raw value.
-              Safe for API keys, tokens, and other secrets bound to a known
-              external service.
+              the domains you whitelist; code running in the Computer never sees
+              the raw value. Safe for API keys, tokens, and other secrets bound
+              to a known external service.
             </div>
             <div>
               <strong>Config ({SANDBOX_ENV_VAR_PREFIX})</strong> — for
@@ -480,8 +480,8 @@ export function EnvironmentSection() {
             <div>
               Values are write-only: they cannot be viewed after saving, only
               overwritten or deleted. Env vars are snapshotted when the Computer
-              starts, so running Computers keep their original values; new
-              Computers (new conversations, restarts) pick up the latest.
+              starts: an already-running Computer keeps its original values, and
+              any new Computer (new conversation, restart) picks up the latest.
             </div>
           </div>
         </ContentMessage>

--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -121,14 +121,14 @@ export function NetworkSection() {
     if (!isAdmin) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Only workspace admins can manage sandbox network settings.
+          Only workspace admins can manage Computer network settings.
         </ContentMessage>
       );
     }
     if (!hasSandboxAdmin) {
       return (
         <ContentMessage variant="info" icon={InformationCircleIcon} size="lg">
-          Sandbox workspace administration is not enabled for this workspace.
+          Computer administration is not enabled for this workspace.
         </ContentMessage>
       );
     }
@@ -143,7 +143,7 @@ export function NetworkSection() {
           size="lg"
           title="Failed to load"
         >
-          The sandbox network settings could not be loaded.
+          The Computer network settings could not be loaded.
         </ContentMessage>
       );
     }
@@ -156,7 +156,7 @@ export function NetworkSection() {
               Agent-requested domains
             </div>
             <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Allow agents using the sandbox to ask for additional domains, one
+              Allow agents using the Computer to ask for additional domains, one
               approval per domain, during the conversation. When disabled,
               agents cannot request new domains and should only rely on the
               domains listed below.
@@ -174,7 +174,7 @@ export function NetworkSection() {
 
         <Page.SectionHeader
           title="Allowed domains"
-          description="These domains apply to all sandboxes in this workspace. Changes are picked up by egress proxy cache refreshes, typically within 60 seconds."
+          description="These domains apply to every Computer in this workspace. Changes are picked up by egress proxy cache refreshes, typically within 60 seconds."
         />
 
         <form
@@ -256,11 +256,11 @@ export function NetworkSection() {
             </DialogTitle>
           </DialogHeader>
           <DialogContainer>
-            When enabled, any agent running in the sandbox can ask the user to
+            When enabled, any agent running in the Computer can ask the user to
             allow additional domains during the conversation. Each request is
             approval-gated, but a non-admin user in this workspace can grant
             network access to a domain you have not pre-approved. Domains added
-            this way last only for the current sandbox.
+            this way last only for the current Computer.
           </DialogContainer>
           <DialogFooter
             leftButtonProps={{

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -101,7 +101,7 @@ export const SANDBOX_SERVER = {
     name: "sandbox",
     version: "1.0.0",
     description:
-      "Execute code and commands in the conversation's Computer (an isolated Linux sandbox environment).",
+      "Execute code and commands in the conversation's Computer (an isolated Linux environment).",
     authorization: null,
     icon: "CommandLineIcon",
     documentationUrl: null,

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -39,8 +39,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Executing command in sandbox",
-      done: "Execute command in sandbox",
+      running: "Executing command in the Computer",
+      done: "Execute command in the Computer",
     },
   },
   describe_toolset: {
@@ -54,8 +54,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Describing sandbox toolset",
-      done: "Describe sandbox toolset",
+      running: "Describing Computer toolset",
+      done: "Describe Computer toolset",
     },
   },
   add_egress_domain: {
@@ -90,8 +90,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Requesting sandbox network access",
-      done: "Allow domain in sandbox",
+      running: "Requesting Computer network access",
+      done: "Allow domain in the Computer",
     },
   },
 });
@@ -101,7 +101,7 @@ export const SANDBOX_SERVER = {
     name: "sandbox",
     version: "1.0.0",
     description:
-      "Execute code and commands in an isolated Linux sandbox environment.",
+      "Execute code and commands in the conversation's Computer (an isolated Linux sandbox environment).",
     authorization: null,
     icon: "CommandLineIcon",
     documentationUrl: null,

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -22,9 +22,9 @@ function buildSandboxInstructionProse({
   hasDsbxTools: boolean;
 }): string {
   const instructions = [
-    "The sandbox provides an isolated Linux environment for running code, scripts, and shell commands.",
-    "Use `bash` to run commands and scripts.",
-    "The sandbox persists for the conversation duration.",
+    `You have access to the conversation's Computer: a sandboxed Linux environment for running code, scripts, and shell commands. When talking to the user, refer to it as "the Computer" (or "the conversation's Computer"), never as "the sandbox". (Internally these instructions still use the word "sandbox" to describe the underlying environment — that is for your context only and must not leak into messages you send to the user.)
+
+Use \`bash\` to run commands and scripts. The Computer persists for the conversation duration.`,
   ];
 
   if (hasDsbxTools) {
@@ -287,12 +287,14 @@ ${manifestYaml}
 
 export const sandboxSkill = {
   sId: "sandbox",
-  name: "Sandbox",
+  name: "Computer",
   userFacingDescription:
-    "Run code, scripts, and shell commands in an isolated Linux environment.",
+    "Run code, scripts, and shell commands in the conversation's Computer (a sandboxed Linux environment).",
   agentFacingDescription:
-    "Execute code and commands in an isolated Linux sandbox. Useful to parse lengthy tool outputs, run code, " +
-    "process data, install packages, manipulate files, or perform any task requiring shell access.",
+    "Execute code and commands in the conversation's Computer (an isolated Linux sandbox). " +
+    "Useful to parse lengthy tool outputs, run code, process data, install packages, " +
+    "manipulate files, or perform any task requiring shell access. " +
+    "When talking to the user, refer to it as 'the Computer', never as 'the sandbox'.",
   fetchInstructions: async (
     auth: Authenticator,
     {

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -22,9 +22,9 @@ function buildSandboxInstructionProse({
   hasDsbxTools: boolean;
 }): string {
   const instructions = [
-    `You have access to the conversation's Computer: a sandboxed Linux environment for running code, scripts, and shell commands. When talking to the user, refer to it as "the Computer" (or "the conversation's Computer"), never as "the sandbox". (Internally these instructions still use the word "sandbox" to describe the underlying environment — that is for your context only and must not leak into messages you send to the user.)
-
-Use \`bash\` to run commands and scripts. The Computer persists for the conversation duration.`,
+    'The sandbox provides an isolated Linux environment for running code, scripts, and shell commands. Always call this environment "the Computer" in any text you send to the user.',
+    "Use `bash` to run commands and scripts.",
+    "The sandbox persists for the conversation duration.",
   ];
 
   if (hasDsbxTools) {
@@ -291,10 +291,9 @@ export const sandboxSkill = {
   userFacingDescription:
     "Run code, scripts, and shell commands in the conversation's Computer (a sandboxed Linux environment).",
   agentFacingDescription:
-    "Execute code and commands in the conversation's Computer (an isolated Linux sandbox). " +
-    "Useful to parse lengthy tool outputs, run code, process data, install packages, " +
-    "manipulate files, or perform any task requiring shell access. " +
-    "When talking to the user, refer to it as 'the Computer', never as 'the sandbox'.",
+    "Execute code and commands in an isolated Linux sandbox. Useful to parse lengthy tool outputs, run code, " +
+    "process data, install packages, manipulate files, or perform any task requiring shell access. " +
+    "Always call this environment 'the Computer' in any text you send to the user.",
   fetchInstructions: async (
     auth: Authenticator,
     {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -209,17 +209,17 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   sandbox_tools: {
     description:
-      "Sandbox MCP tool for executing code in isolated Linux containers",
+      "Computer MCP tool for executing code in isolated Linux containers (a.k.a. sandbox)",
     stage: "dust_only",
   },
   sandbox_dsbx_tools: {
     description:
-      "Programmatic access to MCP tools from inside the sandbox via the dsbx CLI",
+      "Programmatic access to MCP tools from inside the Computer (sandbox) via the dsbx CLI",
     stage: "dust_only",
   },
   sandbox_workspace_admin: {
     description:
-      "Workspace admin configuration for the sandbox: whitelisted domains, environment variables, and the agent egress request setting/tool",
+      "Workspace admin configuration for the Computer (sandbox): whitelisted domains, environment variables, and the agent egress request setting/tool",
     stage: "dust_only",
   },
   skills_as_user_messages: {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -209,7 +209,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   sandbox_tools: {
     description:
-      "Computer MCP tool for executing code in isolated Linux containers (a.k.a. sandbox)",
+      "Computer MCP tool for executing code in isolated Linux containers (sandbox)",
     stage: "dust_only",
   },
   sandbox_dsbx_tools: {


### PR DESCRIPTION
## Description

Product name shown to users is now "Computer". Infrastructure naming stays "sandbox": code symbols, file paths, DB, feature flags, MCP server name, `dsbx` CLI, env var prefixes, routes are all unchanged.

Surfaces updated:
- Skill name + user/agent facing descriptions. The agent-facing system prompt also gains one short instruction telling the model to always call the environment "the Computer" in user-visible output; the rest of the reference prose still uses "sandbox". (System prompt change: expect a one-time prompt-cache invalidation for the sandbox skill on deploy.)
- MCP `displayLabels` (activity chips in the conversation) and server description.
- `SandboxStatusChip` labels (running / sleeping / expired).
- Files panel empty state.
- MCP action detail components ("Executing command in the Computer", "Added to Computer allowlist").
- Admin nav menu label, page title, page description, error messages.
- NetworkSection and EnvironmentSection body copy.
- Feature flag descriptions (with "(sandbox)" parenthetical for staff legibility).

## Tests

Copy + label change plus a one-line addition to the sandbox skill prompt. No behavior, schema, route, or flag changes. Typechecked locally.

## Risk

Low. UI strings only. The skill prompt addition is a single sentence, additive, no removed instructions; main side effect is one cold-cache cycle for the sandbox skill system prompt. Safe to rollback.

## Deploy Plan

Standard deploy.