### PR TITLE
Wake-ups: make scheduling high stake

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -670,7 +670,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "wakeups": {
     "cancel_wakeup": "never_ask",
     "list_wakeups": "never_ask",
-    "schedule_wakeup": "never_ask",
+    "schedule_wakeup": "high",
   },
   "web_search_&_browse": {
     "webbrowser": "never_ask",

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -39,6 +39,10 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
             "If omitted, falls back to the user's timezone."
         ),
     },
+    // We want the wake-up creation high stake to ensure a human is in the loop to avoid agents
+    // scheduling themselves automatically for recurring wake-ups in an cascading way (we had an
+    // incident where an agent would wake-up itself every 2 minutes to process data in batch out of
+    // triggered conversations every hour creating a blowup of usage).
     stake: "high",
     displayLabels: {
       running: "Scheduling wake-up",

--- a/front/lib/api/actions/servers/wakeups/metadata.ts
+++ b/front/lib/api/actions/servers/wakeups/metadata.ts
@@ -39,7 +39,7 @@ export const WAKEUPS_TOOLS_METADATA = createToolsRecord({
             "If omitted, falls back to the user's timezone."
         ),
     },
-    stake: "never_ask",
+    stake: "high",
     displayLabels: {
       running: "Scheduling wake-up",
       done: "Schedule wake-up",


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C0B52JPMU7K/p1779272762767889 (inc-2026-05-20-70k-spend-suspect-through-wake-ups) 

Prevent cascading blow-outs. This creates some friction for some legit use-case (keeping a frame up to date) but this seems OK (eg will require a manual confirmation every 32 days if keeping up to date daily).

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25832">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->