### PR TITLE
[LLM] Mistral reasoning effort + dust-mistral-medium global agents

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -62,6 +62,7 @@ import {
   GEMINI_3_5_FLASH_MODEL_CONFIG,
   GEMINI_3_FLASH_MODEL_CONFIG,
 } from "@app/types/assistant/models/google_ai_studio";
+import { MISTRAL_MEDIUM_3_5_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
 import { NOOP_MODEL_CONFIG } from "@app/types/assistant/models/noop";
 import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type {
@@ -786,6 +787,30 @@ export function _getDustDeepseekGlobalAgent(
     name: "dust-deepseek",
     preferredModelConfiguration: FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG,
     preferredReasoningEffort: "none",
+  });
+}
+
+export function _getDustMistralMediumNoneGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_NONE,
+    name: "dust-mistral-medium-none",
+    preferredModelConfiguration: MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
+    preferredReasoningEffort: "none",
+  });
+}
+
+export function _getDustMistralMediumHighGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_HIGH,
+    name: "dust-mistral-medium-high",
+    preferredModelConfiguration: MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
+    preferredReasoningEffort: "high",
   });
 }
 

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -469,6 +469,22 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "Same as dust but running DeepSeek V4 Pro.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_NONE:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_NONE,
+        name: "dust-mistral-medium-none",
+        description:
+          "Same as dust but running Mistral Medium 3.5 with no reasoning effort.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_HIGH:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_HIGH,
+        name: "dust-mistral-medium-high",
+        description:
+          "Same as dust but running Mistral Medium 3.5 with high reasoning effort.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -41,6 +41,8 @@ import {
   _getDustMinimaxGlobalAgent,
   _getDustMinimaxHighGlobalAgent,
   _getDustMinimaxMediumGlobalAgent,
+  _getDustMistralMediumHighGlobalAgent,
+  _getDustMistralMediumNoneGlobalAgent,
   _getDustNextGlobalAgent,
   _getDustNextHighGlobalAgent,
   _getDustNextMediumGlobalAgent,
@@ -307,6 +309,18 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsWorkspaceContext: false,
   },
   [GLOBAL_AGENTS_SID.DUST_DEEPSEEK]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_NONE]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_HIGH]: {
     injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
@@ -959,6 +973,22 @@ function getGlobalAgent({
         hasDeepDive,
       });
       break;
+    case GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_NONE:
+      agentConfiguration = _getDustMistralMediumNoneGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+      });
+      break;
+    case GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_HIGH:
+      agentConfiguration = _getDustMistralMediumHighGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+      });
+      break;
     case GLOBAL_AGENTS_SID.DUST_QUICK:
       agentConfiguration = _getDustQuickGlobalAgent(auth, {
         settings,
@@ -1248,6 +1278,8 @@ export async function getGlobalAgents(
     GLOBAL_AGENTS_SID.DUST_MINIMAX_MEDIUM,
     GLOBAL_AGENTS_SID.DUST_MINIMAX_HIGH,
     GLOBAL_AGENTS_SID.DUST_DEEPSEEK,
+    GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_NONE,
+    GLOBAL_AGENTS_SID.DUST_MISTRAL_MEDIUM_HIGH,
     GLOBAL_AGENTS_SID.DUST_QUICK,
     GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM,
     GLOBAL_AGENTS_SID.DUST_OAI,

--- a/front/lib/api/llm/clients/mistral/index.ts
+++ b/front/lib/api/llm/clients/mistral/index.ts
@@ -1,6 +1,10 @@
 import type { MistralWhitelistedModelId } from "@app/lib/api/llm/clients/mistral/types";
-import { MISTRAL_PROVIDER_ID } from "@app/lib/api/llm/clients/mistral/types";
 import {
+  MISTRAL_PROVIDER_ID,
+  overwriteLLMParameters,
+} from "@app/lib/api/llm/clients/mistral/types";
+import {
+  MISTRAL_REASONING_EFFORT_MAPPING,
   toResponseFormatParam,
   toToolChoiceParam,
 } from "@app/lib/api/llm/clients/mistral/utils";
@@ -70,7 +74,7 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
     auth: Authenticator,
     llmParameters: LLMParameters & { modelId: MistralWhitelistedModelId }
   ) {
-    super(auth, MISTRAL_PROVIDER_ID, llmParameters);
+    super(auth, MISTRAL_PROVIDER_ID, overwriteLLMParameters(llmParameters));
 
     const { MISTRAL_API_KEY } = llmParameters.credentials;
     assert(MISTRAL_API_KEY, "MISTRAL_API_KEY credential is required");
@@ -97,6 +101,9 @@ export class MistralLLM extends LLM<MistralChatStreamRequest> {
       model: this.modelId,
       messages,
       temperature: this.temperature ?? undefined,
+      reasoningEffort: this.reasoningEffort
+        ? MISTRAL_REASONING_EFFORT_MAPPING[this.reasoningEffort]
+        : undefined,
       responseFormat: toResponseFormatParam(this.responseFormat),
       toolChoice: toToolChoiceParam(specifications, forceToolCall),
       tools: specifications.map(toTool),

--- a/front/lib/api/llm/clients/mistral/types.ts
+++ b/front/lib/api/llm/clients/mistral/types.ts
@@ -1,4 +1,7 @@
-import type { LLMParameterOverwrites } from "@app/lib/api/llm/types/options";
+import type {
+  LLMParameterOverwrites,
+  LLMParameters,
+} from "@app/lib/api/llm/types/options";
 import {
   MISTRAL_CODESTRAL_MODEL_ID,
   MISTRAL_LARGE_MODEL_ID,
@@ -24,47 +27,40 @@ export const MISTRAL_GENERIC_WHITELISTED_MODEL_IDS = [
 export const MISTRAL_WHITELISTED_MODEL_IDS = [
   ...MISTRAL_GENERIC_WHITELISTED_MODEL_IDS,
   ...MISTRAL_WHITELISTED_MODEL_IDS_WITHOUT_IMAGE_SUPPORT,
-];
-
-export const MISTRAL_MODEL_FAMILY_CONFIGS: Record<
-  MistralModelFamily,
-  {
-    modelIds: ModelIdType[];
-    overwrites: LLMParameterOverwrites;
-  }
-> = {
-  reasoning: {
-    modelIds: MISTRAL_WHITELISTED_MODEL_IDS,
-    overwrites: { temperature: null },
-  },
-  "non-reasoning": {
-    modelIds: MISTRAL_WHITELISTED_MODEL_IDS,
-    overwrites: { reasoningEffort: null },
-  },
-} as const;
-
-export function getMistralModelFamilyFromModelId(
-  modelId: ModelIdType
-): MistralModelFamily {
-  const family = MISTRAL_MODEL_FAMILIES.find((family) =>
-    MISTRAL_MODEL_FAMILY_CONFIGS[family].modelIds.includes(modelId)
-  );
-  if (!family) {
-    throw new Error(
-      `Model ID ${modelId} does not belong to any Mistral model family`
-    );
-  }
-  return family;
-}
+] as const;
 
 export type MistralWhitelistedModelId =
   (typeof MISTRAL_WHITELISTED_MODEL_IDS)[number];
+
+const NON_REASONING_OVERWRITES: LLMParameterOverwrites = {
+  reasoningEffort: null,
+};
+const REASONING_OVERWRITES: LLMParameterOverwrites = {
+  temperature: null,
+};
+
+const MISTRAL_MODEL_CONFIGS: Record<
+  MistralWhitelistedModelId,
+  { overwrites: LLMParameterOverwrites }
+> = {
+  [MISTRAL_SMALL_MODEL_ID]: { overwrites: NON_REASONING_OVERWRITES },
+  [MISTRAL_MEDIUM_MODEL_ID]: { overwrites: NON_REASONING_OVERWRITES },
+  [MISTRAL_MEDIUM_3_5_MODEL_ID]: { overwrites: REASONING_OVERWRITES },
+  [MISTRAL_LARGE_MODEL_ID]: { overwrites: NON_REASONING_OVERWRITES },
+  [MISTRAL_CODESTRAL_MODEL_ID]: { overwrites: NON_REASONING_OVERWRITES },
+};
+
+export function overwriteLLMParameters(
+  llmParameters: LLMParameters & { modelId: MistralWhitelistedModelId }
+): LLMParameters & { modelId: MistralWhitelistedModelId } {
+  return {
+    ...llmParameters,
+    ...MISTRAL_MODEL_CONFIGS[llmParameters.modelId].overwrites,
+  };
+}
 
 export function isMistralWhitelistedModelId(
   modelId: ModelIdType
 ): modelId is MistralWhitelistedModelId {
   return new Set<string>(MISTRAL_WHITELISTED_MODEL_IDS).has(modelId);
 }
-
-export const MISTRAL_MODEL_FAMILIES = ["non-reasoning", "reasoning"] as const;
-export type MistralModelFamily = (typeof MISTRAL_MODEL_FAMILIES)[number];

--- a/front/lib/api/llm/clients/mistral/utils/index.ts
+++ b/front/lib/api/llm/clients/mistral/utils/index.ts
@@ -1,8 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { parseResponseFormatSchema } from "@app/lib/api/llm/utils";
-import type {
-  ResponseFormat,
-  ToolChoice,
+import {
+  ReasoningEffort,
+  type ResponseFormat,
+  type ToolChoice,
 } from "@mistralai/mistralai/models/components";
 import type { ToolChoiceEnum } from "@mistralai/mistralai/models/components/toolchoiceenum";
 
@@ -32,3 +33,12 @@ export function toResponseFormatParam(
     },
   };
 }
+
+export const MISTRAL_REASONING_EFFORT_MAPPING = {
+  none: ReasoningEffort.None,
+  // Mistral currently supports none and high
+  // light and medium are not selectable in the UI for mistral
+  light: ReasoningEffort.High,
+  medium: ReasoningEffort.High,
+  high: ReasoningEffort.High,
+};

--- a/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
+++ b/front/lib/api/llm/clients/mistral/utils/mistral_to_events.ts
@@ -19,6 +19,7 @@ import type {
   ChatCompletionResponse,
   CompletionEvent,
   ContentChunk,
+  ThinkChunk,
   ToolCall,
   UsageInfo,
 } from "@mistralai/mistralai/models/components";
@@ -38,6 +39,7 @@ export async function* streamLLMEvents({
   // Mistral does not send a "report" with concatenated text chunks
   // So we have to aggregate it ourselves as we receive text chunks
   let textDelta = "";
+  let reasoningDelta = "";
   let hasYieldedResponseId = false;
 
   const aggregate = new SuccessAggregate();
@@ -46,9 +48,24 @@ export async function* streamLLMEvents({
     for (const event of events) {
       if (event.type === "text_delta") {
         textDelta += event.content.delta;
+      } else if (event.type === "reasoning_delta") {
+        reasoningDelta += event.content.delta;
       }
       aggregate.add(event);
       yield event;
+    }
+  }
+
+  function* flushReasoning() {
+    if (reasoningDelta.length > 0) {
+      yield* yieldEvents([
+        {
+          type: "reasoning_generated" as const,
+          content: { text: reasoningDelta },
+          metadata,
+        },
+      ]);
+      reasoningDelta = "";
     }
   }
 
@@ -89,6 +106,7 @@ export async function* streamLLMEvents({
 
     switch (choice.finishReason) {
       case CompletionResponseStreamChoiceFinishReason.ToolCalls: {
+        yield* flushReasoning();
         const textGeneratedEvent = {
           type: "text_generated" as const,
           content: { text: textDelta },
@@ -106,6 +124,7 @@ export async function* streamLLMEvents({
         // yield error event after all received events
         yield* yieldEvents(events);
         textDelta = "";
+        reasoningDelta = "";
         yield* yieldEvents([
           new EventError(
             {
@@ -123,6 +142,7 @@ export async function* streamLLMEvents({
         // yield error event after all received events
         yield* yieldEvents(events);
         textDelta = "";
+        reasoningDelta = "";
         yield* yieldEvents([
           new EventError(
             {
@@ -140,6 +160,7 @@ export async function* streamLLMEvents({
       // Streaming ends with a text response
       case CompletionResponseStreamChoiceFinishReason.Stop: {
         yield* yieldEvents(events);
+        yield* flushReasoning();
         const textGeneratedEvent = {
           type: "text_generated" as const,
           content: { text: textDelta },
@@ -293,10 +314,26 @@ function contentChunkToLLMEvent({
           }
         : null;
     }
+    case "thinking": {
+      const text = thinkingChunkToText(chunk.thinking);
+      return text.length > 0
+        ? {
+            type: "reasoning_delta",
+            content: { delta: text },
+            metadata,
+          }
+        : null;
+    }
     default:
-      // Only support text for now
+      // Only text and thinking chunks are surfaced as events.
       return null;
   }
+}
+
+function thinkingChunkToText(thinking: ThinkChunk["thinking"]): string {
+  return thinking
+    .map((chunk) => (chunk.type === "text" ? chunk.text : ""))
+    .join("");
 }
 
 /**
@@ -344,7 +381,14 @@ export function chatCompletionToLLMEvents(
       }
       const { content, toolCalls } = message;
       if (content) {
-        const text = batchContentToText(content);
+        const { text, reasoning } = batchContentToParts(content);
+        if (reasoning.length > 0) {
+          addEvent({
+            type: "reasoning_generated",
+            content: { text: reasoning },
+            metadata,
+          });
+        }
         if (text.length > 0) {
           addEvent({
             type: "text_generated",
@@ -414,11 +458,21 @@ export function chatCompletionToLLMEvents(
   return events;
 }
 
-function batchContentToText(content: string | Array<ContentChunk>): string {
+function batchContentToParts(content: string | Array<ContentChunk>): {
+  text: string;
+  reasoning: string;
+} {
   if (isString(content)) {
-    return content;
+    return { text: content, reasoning: "" };
   }
-  return content
-    .map((chunk) => (chunk.type == "text" ? chunk.text : ""))
-    .join("");
+  let text = "";
+  let reasoning = "";
+  for (const chunk of content) {
+    if (chunk.type === "text") {
+      text += chunk.text;
+    } else if (chunk.type === "thinking") {
+      reasoning += thinkingChunkToText(chunk.thinking);
+    }
+  }
+  return { text, reasoning };
 }

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -85,6 +85,8 @@ export enum GLOBAL_AGENTS_SID {
   DUST_MINIMAX_MEDIUM = "dust-minimax-medium",
   DUST_MINIMAX_HIGH = "dust-minimax-high",
   DUST_DEEPSEEK = "dust-deepseek",
+  DUST_MISTRAL_MEDIUM_NONE = "dust-mistral-medium-none",
+  DUST_MISTRAL_MEDIUM_HIGH = "dust-mistral-medium-high",
   DUST_NEXT_HIGH = "dust-next-high",
   DEEP_DIVE = "deep-dive",
   DUST_TASK = "dust-task",

--- a/front/types/assistant/models/mistral.ts
+++ b/front/types/assistant/models/mistral.ts
@@ -88,7 +88,7 @@ export const MISTRAL_MEDIUM_3_5_MODEL_CONFIG: ModelConfigurationType = {
     none: true,
     light: false,
     medium: false,
-    high: false,
+    high: true,
   },
   defaultReasoningEffort: "none",
   tokenizer: { type: "sentence_piece", base: "model_v2" },


### PR DESCRIPTION
## Description

Adds reasoning-effort and thinking-chunk support to the Mistral LLM client, and exposes two dust-like global agents on Mistral Medium 3.5 (the only Mistral model that currently supports a non-`none` reasoning effort): `dust-mistral-medium-none` and `dust-mistral-medium-high`. Both new agents are gated behind the existing `dust_internal_global_agents` feature flag.

<img width="616" height="449" alt="image" src="https://github.com/user-attachments/assets/148df7c5-20e1-4260-927c-87bc00f9b46f" />


## Tests

Locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25835">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->