### PR TITLE
[Forks] Add fileCopyStatus column to conversation_forks

### DIFF
--- a/front/lib/models/agent/conversation_fork.ts
+++ b/front/lib/models/agent/conversation_fork.ts
@@ -18,6 +18,8 @@ export class ConversationForkModel extends WorkspaceAwareModel<ConversationForkM
   declare sourceMessageId: ForeignKey<MessageModel["id"]>;
   declare branchedAt: Date;
 
+  declare fileCopyStatus: CreationOptional<"pending" | "done">;
+
   declare parentConversation?: NonAttribute<ConversationModel>;
   declare childConversation?: NonAttribute<ConversationModel>;
   declare createdByUser?: NonAttribute<UserModel>;
@@ -39,6 +41,11 @@ ConversationForkModel.init(
     branchedAt: {
       type: DataTypes.DATE,
       allowNull: false,
+    },
+    fileCopyStatus: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "done",
     },
   },
   {

--- a/front/migrations/db/migration_645.sql
+++ b/front/migrations/db/migration_645.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 20, 2026
+ALTER TABLE "public"."conversation_forks" ADD COLUMN "fileCopyStatus" VARCHAR(255) NOT NULL DEFAULT 'done';


### PR DESCRIPTION
## Description

Adds a `fileCopyStatus: "pending" | "done"` column to `conversation_forks` to track whether the Temporal fork workflow has finished copying GCS files for a child conversation.

- `DEFAULT 'done'` means existing rows are correct without any backfill: they were all created before this guard existed, so their files are already in place
- New forks will be inserted with `fileCopyStatus = 'pending'` and flipped to `'done'` once the workflow completes (in a follow-up PR)

This is a schema-only change. No business logic is wired yet.

Note: this is a split from https://github.com/dust-tt/dust/pull/25643 

## Tests

Dust is running and I can fork. 

## Risk

Column has a default and is not used yet so should be safe. 
Tables are quite new so do not contain yet a lot of rows. 

## Deploy Plan

Run `migration_645.sql` before deploying. No backfill needed.
Deploy front. 

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25838">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->