### PR TITLE
Poke: display if the skill is default or not

### DIFF
--- a/front/components/poke/skills/SkillOverviewTable.tsx
+++ b/front/components/poke/skills/SkillOverviewTable.tsx
@@ -57,6 +57,10 @@ export function SkillOverviewTable({
             </PokeTableCell>
           </PokeTableRow>
           <PokeTableRow>
+            <PokeTableCell>Default</PokeTableCell>
+            <PokeTableCell>{skill.isDefault ? "Yes" : "No"}</PokeTableCell>
+          </PokeTableRow>
+          <PokeTableRow>
             <PokeTableCell>Extended skill</PokeTableCell>
             <PokeTableCell>{skill.extendedSkillId ?? "None"}</PokeTableCell>
           </PokeTableRow>


### PR DESCRIPTION
## Description

Just display the info in poke so we don't have to do a DB query when investigating customer issues

<img width="1624" height="918" alt="image" src="https://github.com/user-attachments/assets/75b1e751-9f43-4c53-a37c-0e4701e90db0" />


## Tests

tested locally

## Risk

low, it's poke and only UI

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25841">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->