### PR TITLE
[connectors] fix: handle missing Microsoft parents during label reconciliation

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -861,13 +861,36 @@ export async function reconcileSensitivityLabelsForParent({
   const allowedLabels = providerConfig.allowedSensitivityLabels ?? [];
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const client = await getMicrosoftClient(connector.connectionId);
-  const childrenResult = await getFilesAndFolders(
-    logger,
-    client,
-    parentInternalId,
-    nextPageLink,
-    allowedLabels.length > 0
-  );
+
+  let childrenResult: {
+    results: DriveItem[];
+    nextLink?: string;
+  };
+  try {
+    childrenResult = await getFilesAndFolders(
+      logger,
+      client,
+      parentInternalId,
+      nextPageLink,
+      allowedLabels.length > 0
+    );
+  } catch (error) {
+    if (isItemNotFoundError(error) || isMalformedDriveError(error)) {
+      logger.info(
+        {
+          connectorId,
+          parentInternalId,
+          error: normalizeError(error).message,
+        },
+        "[ReconcileSensitivityLabels] Parent not found or malformed, skipping subtree"
+      );
+      return {
+        childNodes: [],
+        nextLink: undefined,
+      };
+    }
+    throw error;
+  }
 
   const mimeTypesToSync = await getMimeTypesToSync({
     pdfEnabled: providerConfig.pdfEnabled || false,


### PR DESCRIPTION
## Description

- Goal is to unstuck [this workflow](https://cloud.temporal.io/namespaces/eu-dust-prod.gmnlm/workflows/microsoft-sensitivityLabelsReconciliation-274877909627).
- Prevent Microsoft sensitivity-label reconciliation from failing when the Graph API returns a missing or malformed parent
drive/folder.
- The reconciliation activity now skips that subtree and logs the parent instead of retrying a non-actionable
external deletion or permission-change race.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25842">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->