### PR TITLE
Add project/ file path support in viz frames

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1267,6 +1267,7 @@ function AgentMessageContent({
       isLastMessage,
       handleToolSetupComplete,
       propsAdditionalMarkdownComponents,
+      spaceId,
     ]
   );
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1249,7 +1249,8 @@ function AgentMessageContent({
         agentConfiguration.sId,
         conversationId,
         sId,
-        vizUrl
+        vizUrl,
+        spaceId
       ),
       sup: CiteBlock,
       quickReply: getQuickReplyPlugin(onQuickReplySend, isLastMessage),

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -276,6 +276,7 @@ export const VisualizationActionIframe = forwardRef<
     conversationId,
     isInDrawer = false,
     isPublic = false,
+    spaceId,
     visualization,
     workspaceId,
   } = props;
@@ -288,9 +289,12 @@ export const VisualizationActionIframe = forwardRef<
         if (!conversationId) {
           return null;
         }
-
-        // TODO(20260428 FILE_SYSTEM): implement space files content endpoint when project-scoped files are added.
         url = `/api/w/${workspaceId}/assistant/conversations/${conversationId}/files/${fileId}`;
+      } else if (fileId.startsWith("project/")) {
+        if (!spaceId) {
+          return null;
+        }
+        url = `/api/w/${workspaceId}/spaces/${spaceId}/files/${fileId}`;
       } else {
         url = `/api/w/${workspaceId}/files/${fileId}?action=view`;
       }
@@ -306,7 +310,7 @@ export const VisualizationActionIframe = forwardRef<
         type: response.headers.get("Content-Type") ?? undefined,
       });
     },
-    [workspaceId, conversationId]
+    [workspaceId, conversationId, spaceId]
   );
 
   useVisualizationDataHandler({

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -92,6 +92,11 @@ export function FrameRenderer({
   const { closePanel, panelRef } = useConversationSidePanelContext();
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
+  // The space to resolve `project/` file paths inside the viz.
+  // Priority: explicit project the frame was saved to -> the conversation's own project space
+  // (a conversation can belong to a project space even before the frame is saved there).
+  const frameSpaceId = projectId ?? conversation?.spaceId ?? null;
+
   // eslint-disable-next-line react-hooks/refs
   const panel = panelRef?.current;
 
@@ -354,6 +359,7 @@ export function FrameRenderer({
               }}
               key={`viz-${fileId}`}
               conversationId={conversation?.sId ?? null}
+              spaceId={frameSpaceId}
               isInDrawer={true}
               ref={iframeRef}
             />

--- a/front/components/markdown/VisualizationBlock.tsx
+++ b/front/components/markdown/VisualizationBlock.tsx
@@ -55,7 +55,8 @@ export function getVisualizationPlugin(
   agentConfigurationId: string,
   conversationId: string,
   messageId: string,
-  vizUrl: string
+  vizUrl: string,
+  spaceId: string | null
 ) {
   const customRenderer = {
     visualization: (code: string, complete: boolean, lineStart: number) => {
@@ -71,6 +72,7 @@ export function getVisualizationPlugin(
           key={`viz-${messageId}-${lineStart}`}
           conversationId={conversationId}
           agentConfigurationId={agentConfigurationId}
+          spaceId={spaceId}
         />
       );
     },

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -182,13 +182,14 @@ export class FileResource extends BaseResource<FileModel> {
     file: FileResource;
     content: string;
     shareScope: FileShareScope;
+    conversationSpaceId: string | null;
   } | null> {
     const r = await this.fetchByShareToken(token);
     if (r.isErr()) {
       return null;
     }
 
-    const { file, shareScope, workspace } = r.value;
+    const { file, shareScope, workspace, conversationSpaceId } = r.value;
     const content = await file.getFileContent(workspace, "original");
     if (!content) {
       return null;
@@ -198,6 +199,7 @@ export class FileResource extends BaseResource<FileModel> {
       file,
       content,
       shareScope,
+      conversationSpaceId,
     };
   }
 
@@ -208,6 +210,8 @@ export class FileResource extends BaseResource<FileModel> {
         shareScope: FileShareScope;
         shareableFileId: ModelId;
         workspace: LightWorkspaceType;
+        // sId of the project space the frame's conversation belongs to, if any.
+        conversationSpaceId: string | null;
       },
       DustError
     >
@@ -247,6 +251,7 @@ export class FileResource extends BaseResource<FileModel> {
     }
 
     // Check if associated conversation still exist (not soft-deleted).
+    let conversationSpaceId: string | null = null;
     if (
       fileRes.useCase === "conversation" &&
       fileRes.useCaseMetadata?.conversationId
@@ -271,6 +276,14 @@ export class FileResource extends BaseResource<FileModel> {
           new DustError("conversation_not_found", "Conversation not found")
         );
       }
+
+      // Derive the project space sId from the conversation's spaceId.
+      if (conversation.spaceId) {
+        conversationSpaceId = SpaceResource.modelIdToSId({
+          id: conversation.spaceId,
+          workspaceId: workspace.id,
+        });
+      }
     }
 
     return new Ok({
@@ -278,6 +291,7 @@ export class FileResource extends BaseResource<FileModel> {
       workspace: renderLightWorkspaceType({ workspace }),
       shareScope: shareableFile.shareScope,
       shareableFileId: shareableFile.id,
+      conversationSpaceId,
     });
   }
 

--- a/front/pages/api/v1/viz/content.test.ts
+++ b/front/pages/api/v1/viz/content.test.ts
@@ -59,6 +59,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
       file: frameFile,
       content: "<html><h1>Interactive Frame</h1></html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     await handler(req, res);
@@ -274,6 +275,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
       file: frameFile,
       content: "<html><h1>Workspace Frame</h1></html>",
       shareScope: "workspace",
+      conversationSpaceId: null,
     });
 
     await handler(req, res);

--- a/front/pages/api/v1/viz/files/[...segments].ts
+++ b/front/pages/api/v1/viz/files/[...segments].ts
@@ -186,8 +186,7 @@ async function handler(
   } else {
     // Project-scoped frames have spaceId directly. Conversation-scoped frames that live in
     // a project space get conversationSpaceId resolved by fetchByShareToken.
-    const projectId =
-      frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId;
+    const projectId = frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId;
     if (!isString(projectId)) {
       return apiError(req, res, {
         status_code: 400,

--- a/front/pages/api/v1/viz/files/[...segments].ts
+++ b/front/pages/api/v1/viz/files/[...segments].ts
@@ -2,6 +2,7 @@
 
 import {
   getConversationFilesBasePath,
+  getProjectFilesBasePath,
   scopedFilePathPrefixSchema,
 } from "@app/lib/api/files/mount_path";
 import { verifyVizAccessToken } from "@app/lib/api/viz/access_tokens";
@@ -108,7 +109,7 @@ async function handler(
     });
   }
 
-  const { file: frameFile, shareScope } = result;
+  const { file: frameFile, shareScope, conversationSpaceId } = result;
 
   // If current share scope differs from token scope, reject. It means share scope changed.
   if (shareScope !== tokenPayload.shareScope) {
@@ -183,14 +184,20 @@ async function handler(
     // endpoint can serve them.
     basePath = getConversationFilesBasePath({ workspaceId, conversationId });
   } else {
-    // TODO(2026-04-28 FILE SYSTEM): Add project scope support.
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Project scope is not yet supported.",
-      },
-    });
+    // Project-scoped frames have spaceId directly. Conversation-scoped frames that live in
+    // a project space get conversationSpaceId resolved by fetchByShareToken.
+    const projectId =
+      frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId;
+    if (!isString(projectId)) {
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Frame has no project context for this path.",
+        },
+      });
+    }
+    basePath = getProjectFilesBasePath({ workspaceId, projectId });
   }
 
   const gcsPath = `${basePath}${normalizedRel}`;

--- a/front/pages/api/v1/viz/files/fileId.test.ts
+++ b/front/pages/api/v1/viz/files/fileId.test.ts
@@ -103,6 +103,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
@@ -172,6 +173,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
@@ -243,6 +245,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       content: "<html>Frame content</html>",
       // Current share scope is now 'workspace'.
       shareScope: "workspace",
+      conversationSpaceId: null,
     });
 
     vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
@@ -317,6 +320,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     await handler(req, res);
@@ -401,6 +405,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         file: frameFile,
         content: "<html>Frame content</html>",
         shareScope: "public",
+        conversationSpaceId: null,
       });
 
       vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
@@ -463,6 +468,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         file: frameFile,
         content: "<html>Frame content</html>",
         shareScope: "public",
+        conversationSpaceId: null,
       });
 
       vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
@@ -519,6 +525,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         file: frameFile,
         content: "<html>Frame content</html>",
         shareScope: "public",
+        conversationSpaceId: null,
       });
 
       await handler(req, res);
@@ -584,6 +591,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         file: frameFile,
         content: "<html>Frame content</html>",
         shareScope: "public",
+        conversationSpaceId: null,
       });
 
       await handler(req, res);
@@ -653,6 +661,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     await handler(req, res);
@@ -716,6 +725,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     await handler(req, res);
@@ -982,6 +992,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         file: frameFile,
         content: "<html>Frame content</html>",
         shareScope: "public",
+        conversationSpaceId: null,
       });
 
       vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
@@ -1120,6 +1131,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         file: frameFile,
         content: "<html>Frame content</html>",
         shareScope: "public",
+        conversationSpaceId: null,
       });
 
       vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(

--- a/front/pages/api/v1/viz/files/segments.test.ts
+++ b/front/pages/api/v1/viz/files/segments.test.ts
@@ -100,6 +100,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     mockGcsFound();
@@ -130,6 +131,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     mockGcsFound();
@@ -151,6 +153,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     await handler(req, res);
@@ -185,6 +188,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "workspace", // Changed from "public".
+      conversationSpaceId: null,
     });
 
     await handler(req, res);
@@ -212,6 +216,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     await handler(req, res);
@@ -245,6 +250,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     await handler(req, res);
@@ -275,6 +281,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
       file: frameFile,
       content: "<html>Frame content</html>",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     await handler(req, res);
@@ -354,6 +361,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
       file: nonFrameFile,
       content: "",
       shareScope: "public",
+      conversationSpaceId: null,
     });
 
     await handler(req, res);

--- a/front/pages/api/v1/viz/files/segments.test.ts
+++ b/front/pages/api/v1/viz/files/segments.test.ts
@@ -332,6 +332,93 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
     expect(res._getStatusCode()).toBe(405);
   });
 
+  it("should serve a GCS file for a project-scoped frame (spaceId in metadata)", async () => {
+    const { frameFile, accessToken } = await makeFrameAndToken({
+      spaceId: "vlt_someSpaceId",
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["project", "chart.png"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: "<html>Frame content</html>",
+      shareScope: "public",
+      conversationSpaceId: null,
+    });
+
+    mockGcsFound();
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("should serve a GCS file for a conversation-scoped frame via conversationSpaceId", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const { frameFile, accessToken } = await makeFrameAndToken({
+      conversationId: conversation.sId,
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["project", "chart.png"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: "<html>Frame content</html>",
+      shareScope: "public",
+      conversationSpaceId: "vlt_derivedSpaceId",
+    });
+
+    mockGcsFound();
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it("should reject project-scoped path when frame has no project context", async () => {
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const { frameFile, accessToken } = await makeFrameAndToken({
+      conversationId: conversation.sId,
+    });
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { segments: ["project", "chart.png"] },
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: "<html>Frame content</html>",
+      shareScope: "public",
+      conversationSpaceId: null,
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Frame has no project context for this path.",
+      },
+    });
+  });
+
   it("should reject non-frame files as the frame", async () => {
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,

--- a/viz/app/lib/data-apis/rpc-data-api.ts
+++ b/viz/app/lib/data-apis/rpc-data-api.ts
@@ -26,7 +26,7 @@ export class RPCDataAPI implements VisualizationDataAPI {
 
   async fetchFile(fileId: string): Promise<File | null> {
     try {
-      console.log(">> RPCDataAPI: Fetching file via RPC", this.sendMessage);
+      console.log(">> RPCDataAPI: Fetching file via RPC", fileId);
 
       const res = await this.sendMessage("getFile", { fileId });
       const { fileBlob: blob } = res;
@@ -44,7 +44,6 @@ export class RPCDataAPI implements VisualizationDataAPI {
 
   async fetchCode(): Promise<string | null> {
     try {
-      console.log(">> RPCDataAPI: Fetching code via RPC", this.sendMessage);
       const result = await this.sendMessage("getCodeToExecute", null);
       const { code } = result;
       return code || null;

--- a/viz/app/lib/parseFileRefs.test.ts
+++ b/viz/app/lib/parseFileRefs.test.ts
@@ -32,10 +32,17 @@ describe("extractFileRefs", () => {
     ]);
   });
 
-  it("extracts scoped paths from string literals", () => {
+  it("extracts scoped paths from string literals (conversation/)", () => {
     const code = `const path = "conversation/abc/file.csv";`;
     expect(extractFileRefs(code)).toEqual([
       { type: "path", scopedPath: "conversation/abc/file.csv" },
+    ]);
+  });
+
+  it("extracts scoped paths from string literals (project/)", () => {
+    const code = `const path = "project/abc/file.csv";`;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "path", scopedPath: "project/abc/file.csv" },
     ]);
   });
 

--- a/viz/app/lib/parseFileRefs.ts
+++ b/viz/app/lib/parseFileRefs.ts
@@ -6,8 +6,7 @@ export type FileRef =
   | { type: "path"; scopedPath: string };
 
 function isScopedPath(value: string): boolean {
-  // TODO(20260428 FILE SYSTEM) Add support for project.
-  return value.startsWith("conversation/");
+  return value.startsWith("conversation/") || value.startsWith("project/");
 }
 
 export function extractFileRefs(code: string): FileRef[] {
@@ -26,7 +25,7 @@ export function extractFileRefs(code: string): FileRef[] {
   };
 
   try {
-    // TypeScript's parser is tolerant by design It produces a (partial) AST even for code with
+    // TypeScript's parser is tolerant by design. It produces a (partial) AST even for code with
     // syntax errors (errors are reported via parseDiagnostics rather than thrown), which is what
     // we want for AI-generated frame code.
     const sourceFile = ts.createSourceFile(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This wires up the missing plumbing so viz frames can load files from a project space using `project/` scoped paths, regardless of whether the frame itself lives in a conversation or a project. For frames displayed in the conversation context, the space is resolved client-side: `FrameRenderer` now derives the space from whichever is available first (the project the frame was saved to, or the conversation's own project space). `AgentMessage` threads the space through to inline streaming viz as well. For publicly shared frames, `fetchByShareToken` already fetches the conversation to check it exists. It now also loads the conversation's space so `[...segments].ts` can resolve `project/` paths without any extra round-trips.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25844">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->