### PR TITLE
feat(deploy): add check-migrations gate to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,6 +138,84 @@ jobs:
             echo "matrix=[\"${{ inputs.regions }}\"]" >> $GITHUB_OUTPUT
           fi
 
+  check-migrations:
+    if: inputs.component == 'front' || inputs.component == 'connectors'
+    needs: [ create-matrix ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        region: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check pre-deploy migrations applied in ${{ matrix.region }}
+        env:
+          SECRET: ${{ secrets.DUST_MIGRATION_API_SECRET }}
+        run: |
+          COMPONENT="${{ inputs.component }}"
+          REGION="${{ matrix.region }}"
+
+          if [ "$COMPONENT" = "front" ]; then
+            if [ "$REGION" = "us-central1" ]; then
+              BASE_URL="https://dust.tt"
+            else
+              BASE_URL="https://eu.dust.tt"
+            fi
+            MIGRATION_DIR="front/migrations/pre-deploy"
+            API_PATH="/api/migration/applied/pre-deploy"
+          else
+            if [ "$REGION" = "us-central1" ]; then
+              BASE_URL="${{ secrets.CONNECTORS_API_URL_US }}"
+            else
+              BASE_URL="${{ secrets.CONNECTORS_API_URL_EU }}"
+            fi
+            MIGRATION_DIR="connectors/migrations/pre-deploy"
+            API_PATH="/migration/applied/pre-deploy"
+          fi
+
+          # Names are stored as "pre-deploy/<filename>" in schema_migrations.
+          mapfile -t RELEASE_FILES < <(
+            find "$MIGRATION_DIR" -maxdepth 1 -name "*.sql" \
+              | sort \
+              | while read -r f; do echo "pre-deploy/$(basename "$f")"; done
+          )
+
+          if [ ${#RELEASE_FILES[@]} -eq 0 ]; then
+            echo "No pre-deploy migrations in this release — gate passed."
+            exit 0
+          fi
+
+          echo "Release contains ${#RELEASE_FILES[@]} pre-deploy migration(s):"
+          printf '  %s\n' "${RELEASE_FILES[@]}"
+          echo ""
+
+          RESPONSE=$(curl -sf -H "Authorization: Bearer $SECRET" "$BASE_URL$API_PATH") || {
+            echo "ERROR: Failed to reach $BASE_URL$API_PATH"
+            echo "Ensure DUST_MIGRATION_API_SECRET is provisioned and the service is reachable."
+            exit 1
+          }
+
+          mapfile -t APPLIED < <(echo "$RESPONSE" | jq -r '.migrations[].name')
+          echo "Applied in $REGION: ${#APPLIED[@]} migration(s)"
+
+          MISSING=()
+          for F in "${RELEASE_FILES[@]}"; do
+            if ! printf '%s\n' "${APPLIED[@]}" | grep -qxF "$F"; then
+              MISSING+=("$F")
+            fi
+          done
+
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo ""
+            echo "ERROR: ${#MISSING[@]} pre-deploy migration(s) not yet applied in $REGION:"
+            printf '  - %s\n' "${MISSING[@]}"
+            echo ""
+            echo "Run 'npm run migration:apply:pre-deploy' in $REGION before deploying $COMPONENT."
+            exit 1
+          fi
+
+          echo "All pre-deploy migrations applied in $REGION ✓"
+
   build:
     permissions:
       contents: read
@@ -211,8 +289,8 @@ jobs:
           thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"
 
   deploy:
-    needs: [ prepare, notify-start, build, deploy-app, deploy-poke, deploy-app-bleeding-edge, deploy-poke-bleeding-edge, ensure-sandbox-images ]
-    if: ${{ !failure() && !cancelled() && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
+    needs: [ prepare, notify-start, build, check-migrations, deploy-app, deploy-poke, deploy-app-bleeding-edge, deploy-poke-bleeding-edge, ensure-sandbox-images ]
+    if: ${{ !failure() && !cancelled() && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') && (needs.check-migrations.result == 'success' || needs.check-migrations.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Description

Part of Phase 3 of the [database migration tooling design doc](
https://www.notion.so/dust-tt/Design-Doc-Database-Migration-Tooling-36528599d941818ab095e63f1481f9aa)
— the deploy gate that enforces pre-deploy migrations are applied before a rollout proceeds.

Adds a `check-migrations` job to the deploy workflow that runs in parallel with `build` (one
matrix entry per region) and blocks `deploy` if any `.sql` file in `migrations/pre-deploy/`
has not been applied in the target region.

**How it works:**

1. Enumerates `front/migrations/pre-deploy/*.sql` (or `connectors/`) from the checkout —
   these are the migrations shipping in the new release.
2. Calls `GET <service>/api/migration/applied/pre-deploy` (or `/migration/applied/pre-deploy`
   for connectors) authenticated with `DUST_MIGRATION_API_SECRET`.
3. Diffs the two lists; any file not yet applied prints a named list and fails the job.
4. If no `.sql` files exist in the release directory, the gate passes immediately.

The endpoint was introduced in #25840. The job only runs for `front` and `connectors`; other
components skip it (`check-migrations.result == 'skipped'` is allowed in the deploy
condition).

**Secrets required before the gate is active:**

- `DUST_MIGRATION_API_SECRET` — already needed by the endpoint (both services)
- `CONNECTORS_API_URL_US` / `CONNECTORS_API_URL_EU` — base URL of the connectors service
  in each region (connectors is not publicly addressed; front uses the known public URLs)

Until the secrets are provisioned, the `curl` call fails and the gate blocks the deploy.
Set the secrets before merging into a deploy-path branch.

## Deploy Plan

Provision the three GitHub Actions secrets before this workflow runs against `front` or
`connectors`. Until then the gate will fire (curl returns non-zero) and block those deploys.
The safe order:

1. Merge #25836 (runner) and #25840 (endpoint) and deploy them to all regions.
2. Provision `DUST_MIGRATION_API_SECRET`, `CONNECTORS_API_URL_US`, `CONNECTORS_API_URL_EU`
   in GitHub repo secrets.
3. Merge this PR — gate is now live.
