### PR TITLE
Fix: skip large documens

### DIFF
--- a/connectors/src/connectors/dust_project/lib/sync_project_mount_files.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_project_mount_files.ts
@@ -6,6 +6,7 @@ import {
 import {
   deleteDataSourceDocument,
   MAX_FILE_SIZE_TO_DOWNLOAD,
+  MAX_SMALL_DOCUMENT_TXT_LEN,
   renderDocumentTitleAndContent,
   upsertDataSourceDocument,
 } from "@connectors/lib/data_sources";
@@ -200,7 +201,7 @@ export async function syncProjectMountFile({
       },
     });
   } else if (mimeType.startsWith("text/")) {
-    const textRes = handleTextFile(buffer, MAX_FILE_SIZE_TO_DOWNLOAD);
+    const textRes = handleTextFile(buffer, MAX_SMALL_DOCUMENT_TXT_LEN);
     if (textRes.isErr()) {
       localLogger.warn(
         { error: textRes.error },


### PR DESCRIPTION
`syncProjectMountFile` was passing `MAX_FILE_SIZE_TO_DOWNLOAD` to `handleTextFile` instead of `MAX_SMALL_DOCUMENT_TXT_LEN`, so oversized text documents weren't being skipped at the right threshold. Swapping to the correct constant ensures large text files are rejected before upsert, consistent with the rest of the data source pipeline.