### PR TITLE
[connectors] fix Microsoft label reconciliation folder traversal

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -969,7 +969,7 @@ export async function reconcileSensitivityLabelsForParent({
 
   const childNodes = childrenResult.results
     .filter((item) => item.folder)
-    .map((item) => getDriveInternalIdFromItem(item));
+    .map((item) => getDriveItemInternalId(item));
 
   return {
     childNodes,


### PR DESCRIPTION
## Description

- Fix Microsoft sensitivity-label reconciliation so folder children are re-enqueued using their folder item ids.
- This lets the reconciliation workflow descend into nested folders instead of reprocessing the containing drive when
a parent page includes folders.

## Tests

## Risk

- Low. Safe to rollback.

## Deploy Plan

- Deploy connectors


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25848">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->