### PR TITLE
[Forks] Block posting until GCS files are copied into child conversation

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -4351,6 +4351,7 @@ describe("conversation fetch forkingData", () => {
           sourceMessageId: sourceMessage.sId,
           branchedAt: branchedAt.getTime(),
           user: auth.getNonNullableUser().toJSON(),
+          fileCopyStatus: "pending",
         },
       });
     }
@@ -4369,6 +4370,7 @@ describe("conversation fetch forkingData", () => {
           sourceMessageId: sourceMessage.sId,
           branchedAt: branchedAt.getTime(),
           user: auth.getNonNullableUser().toJSON(),
+          fileCopyStatus: "pending",
         },
       });
     }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -611,6 +611,18 @@ export async function postUserMessage(
     return limitResult;
   }
 
+  // Block posting until GCS files have been copied into the child conversation.
+  if (conversation.forkingData?.forkedFrom?.fileCopyStatus === "pending") {
+    return new Err({
+      status_code: 409,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "User messages cannot be posted while the forked conversation is being prepared.",
+      },
+    });
+  }
+
   // Block posting while compaction is in progress, for now. It's not too hard to add support for
   // pending messages on top of compaction. We start without support for it to simplify. Note that
   // we don't currently re-check the existence of a compaction message inside the critical section

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -514,6 +514,7 @@ describe("createConversationFork", () => {
         sourceMessageId: sourceMessage.sId,
         branchedAt: expect.any(Number),
         user: user.toJSON(),
+        fileCopyStatus: "pending",
       },
     });
     expect(childConversation.content).toHaveLength(1);

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -36,6 +36,7 @@ function createForkedData(user: NonNullable<UserMessageType["user"]>) {
       sourceMessageId: "msg_parent_source",
       branchedAt: Date.now(),
       user,
+      fileCopyStatus: "done" as const,
     },
   };
 }

--- a/front/lib/resources/conversation_fork_resource.ts
+++ b/front/lib/resources/conversation_fork_resource.ts
@@ -200,6 +200,7 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
         createdByUserId: user.id,
         sourceMessageId: blob.sourceMessageModelId,
         branchedAt: blob.branchedAt,
+        fileCopyStatus: "pending",
       },
       { transaction }
     );
@@ -209,6 +210,23 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
     });
     assert(resource, "Created conversation fork must be fetchable.");
     return resource;
+  }
+
+  static async markFileCopied(
+    auth: Authenticator,
+    { childConversationModelId }: { childConversationModelId: ModelId }
+  ): Promise<void> {
+    const owner = auth.getNonNullableWorkspace();
+
+    await this.model.update(
+      { fileCopyStatus: "done" },
+      {
+        where: {
+          childConversationId: childConversationModelId,
+          workspaceId: owner.id,
+        },
+      }
+    );
   }
 
   static async fetchByModelIds(

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -210,6 +210,7 @@ describe("ConversationResource", () => {
           sourceMessageId: sourceMessage.sId,
           branchedAt: branchedAt.getTime(),
           user: auth.getNonNullableUser().toJSON(),
+          fileCopyStatus: "pending",
         },
       });
 
@@ -242,6 +243,7 @@ describe("ConversationResource", () => {
             sourceMessageId: sourceMessage.sId,
             branchedAt: branchedAt.getTime(),
             user: auth.getNonNullableUser().toJSON(),
+            fileCopyStatus: "pending",
           },
         });
       }
@@ -341,6 +343,7 @@ describe("ConversationResource", () => {
           sourceMessageId: sourceMessage.sId,
           branchedAt: branchedAt.getTime(),
           user: adminAuth.getNonNullableUser().toJSON(),
+          fileCopyStatus: "pending",
         },
       });
     });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -147,7 +147,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       {
         association: "forkedFrom" as const,
         required: false,
-        attributes: ["branchedAt", "childConversationId"],
+        attributes: ["branchedAt", "childConversationId", "fileCopyStatus"],
         include: [
           {
             association: "parentConversation" as const,
@@ -207,6 +207,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         UserResource.model,
         fork.createdByUser.get()
       ).toJSON(),
+      fileCopyStatus: fork.fileCopyStatus,
     };
   }
 
@@ -420,6 +421,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
                 sourceMessageId,
                 branchedAt: branchedAtMs,
                 user,
+                fileCopyStatus: "done" as const,
               },
             },
             title: fork.childConversation.title,

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -191,6 +191,7 @@
  *         - sourceMessageId
  *         - branchedAt
  *         - user
+ *         - fileCopyStatus
  *       properties:
  *         parentConversationId:
  *           type: string
@@ -203,6 +204,9 @@
  *           type: integer
  *         user:
  *           $ref: '#/components/schemas/PrivateConversationForkUser'
+ *         fileCopyStatus:
+ *           type: string
+ *           enum: [pending, done]
  *     PrivateConversationForkedChild:
  *       type: object
  *       properties:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/forks/index.test.ts
@@ -159,6 +159,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
         sourceMessageId: sourceMessage.sId,
         branchedAt: expect.any(Number),
         user: auth.getNonNullableUser().toJSON(),
+        fileCopyStatus: "pending",
       },
     });
     expect(conversation.depth).toBe(1);
@@ -204,6 +205,7 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/forks", () => {
         sourceMessageId: sourceMessage.sId,
         branchedAt: expect.any(Number),
         user: auth.getNonNullableUser().toJSON(),
+        fileCopyStatus: "pending",
       },
     });
   });

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -10122,7 +10122,8 @@
           "parentConversationTitle",
           "sourceMessageId",
           "branchedAt",
-          "user"
+          "user",
+          "fileCopyStatus"
         ],
         "properties": {
           "parentConversationId": {
@@ -10140,6 +10141,13 @@
           },
           "user": {
             "$ref": "#/components/schemas/PrivateConversationForkUser"
+          },
+          "fileCopyStatus": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "done"
+            ]
           }
         }
       },

--- a/front/temporal/conversation_fork_queue/activities.ts
+++ b/front/temporal/conversation_fork_queue/activities.ts
@@ -1,5 +1,6 @@
 import { copyConversationGCSMount } from "@app/lib/api/files/gcs_mount/files";
 import { Authenticator } from "@app/lib/auth";
+import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 
@@ -31,21 +32,42 @@ export async function copyConversationGCSMountActivity({
       "[conversation_fork_queue] Source or destination conversation not found. Skipping mount copy."
     );
 
+    // Unblock the fork even if conversations are not found — nothing to copy.
+    if (dest) {
+      await ConversationForkResource.markFileCopied(auth, {
+        childConversationModelId: dest.id,
+      });
+    }
+
     return;
   }
 
   const result = await copyConversationGCSMount(auth, { source, dest });
   if (result.isErr()) {
-    throw result.error;
+    // GCS copy failed. Log and unblock anyway — permanently blocking the fork
+    // is worse than letting the user post with potentially missing files.
+    logger.error(
+      {
+        workspaceId,
+        sourceConversationId,
+        destConversationId,
+        error: result.error,
+      },
+      "[conversation_fork_queue] GCS mount copy failed. Unblocking fork."
+    );
+  } else {
+    logger.info(
+      {
+        workspaceId,
+        sourceConversationId,
+        destConversationId,
+        copiedCount: result.value.copiedCount,
+      },
+      "[conversation_fork_queue] Copied GCS mount files between conversations."
+    );
   }
 
-  logger.info(
-    {
-      workspaceId,
-      sourceConversationId,
-      destConversationId,
-      copiedCount: result.value.copiedCount,
-    },
-    "[conversation_fork_queue] Copied GCS mount files between conversations."
-  );
+  await ConversationForkResource.markFileCopied(auth, {
+    childConversationModelId: dest.id,
+  });
 }

--- a/front/types/assistant/conversation.test.ts
+++ b/front/types/assistant/conversation.test.ts
@@ -8,6 +8,7 @@ describe("getConversationDisplayTitle", () => {
     parentConversationTitle: "Quarterly review",
     sourceMessageId: "msg_source",
     branchedAt: now.getTime(),
+    fileCopyStatus: "done" as const,
     user: {
       sId: "user_1",
       id: 1,

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -490,6 +490,7 @@ export type ConversationForkedFromType = {
   sourceMessageId: string;
   branchedAt: number;
   user: UserType;
+  fileCopyStatus: "pending" | "done";
 };
 
 /**


### PR DESCRIPTION
## Description

Uses the `fileCopyStatus` column (added in the previous PR) to enforce that users cannot post to a forked conversation before the Temporal fork workflow has finished copying GCS files from the parent.

- `ConversationForkResource.makeNew` now inserts forks with`fileCopyStatus = "pending"` (overriding the `DEFAULT 'done'` which exists only for backcompat with existing rows)
- `copyConversationGCSMountActivity` calls the new `markFileCopied` method after a successful copy, flipping the row to `"done"`
- `createConversationMessage` returns 409 if `conversation.forkingData.forkedFrom.fileCopyStatus === "pending"`, with the same pattern as the existing compaction gate
- `fileCopyStatus` is plumbed through `ConversationForkedFromType`, the resource include, and the Swagger schema

## Tests

- [x] Create a fork, immediately try to post: should get 409
- [x] Wait for fork workflow to complete, post again: should succeed
- [ ] Existing conversations without forks are unaffected
- [x] CI green

## Risk

Can be rolled back. 
## Deploy Plan

Requires `migration_645.sql` from the previous PR to already be applied.
No additional migration needed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25849">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->