### PR TITLE
feat(sandbox): resume sandbox child action on user resolution

### DIFF
--- a/front/lib/api/assistant/conversation/answer_user_question.ts
+++ b/front/lib/api/assistant/conversation/answer_user_question.ts
@@ -1,8 +1,10 @@
 import { isToolAskUserQuestionEvent } from "@app/lib/actions/mcp";
 import type { UserQuestionAnswer } from "@app/lib/actions/types";
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import { resumeSandboxChildAction } from "@app/lib/api/sandbox/resume_child_action";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -106,6 +108,21 @@ export async function registerUserAnswer(
     const payload = JSON.parse(event.message["payload"]);
     return isToolAskUserQuestionEvent(payload) && payload.actionId === actionId;
   }, getMessageChannelId(messageId));
+
+  if (isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)) {
+    await resumeSandboxChildAction(auth, {
+      action,
+      conversationId,
+      conversationTitle,
+      agentMessageId,
+      agentMessageVersion,
+      branchId,
+      userMessageId,
+      userMessageVersion,
+      userMessageOrigin,
+    });
+    return new Ok(undefined);
+  }
 
   // Only launch the agent loop if there are no remaining blocked actions.
   const blockedActions =

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -2,11 +2,13 @@ import {
   isToolFileAuthRequiredEvent,
   isToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp";
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { resumeAncestorConversations as resumeAncestorConversationsHelper } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import { resumeSandboxChildAction } from "@app/lib/api/sandbox/resume_child_action";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -142,6 +144,23 @@ export async function resolveAuthentication(
       (payload as { actionId: string }).actionId === actionId
     );
   }, getMessageChannelId(messageId));
+
+  if (isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)) {
+    if (outcome === "completed") {
+      await resumeSandboxChildAction(auth, {
+        action,
+        conversationId,
+        conversationTitle,
+        agentMessageId,
+        agentMessageVersion,
+        branchId,
+        userMessageId,
+        userMessageVersion,
+        userMessageOrigin,
+      });
+    }
+    return new Ok(undefined);
+  }
 
   const blockedActions =
     await AgentMCPActionResource.listBlockedActionsForConversation(

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -7,10 +7,12 @@ import {
   extractArgRequiringApprovalValues,
   setUserAlwaysApprovedTool,
 } from "@app/lib/actions/tool_status";
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { resumeAncestorConversations as resumeAncestorConversationsHelper } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import { resumeSandboxChildAction } from "@app/lib/api/sandbox/resume_child_action";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
@@ -151,6 +153,23 @@ export async function validateAction(
       ? payload.actionId === actionId
       : false;
   }, getMessageChannelId(messageId));
+
+  if (isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)) {
+    if (approvalState !== "rejected") {
+      await resumeSandboxChildAction(auth, {
+        action,
+        conversationId,
+        conversationTitle,
+        agentMessageId,
+        agentMessageVersion,
+        branchId,
+        userMessageId,
+        userMessageVersion,
+        userMessageOrigin,
+      });
+    }
+    return new Ok(undefined);
+  }
 
   // We only launch the agent loop if there are no remaining blocked actions.
   const blockedActions =

--- a/front/lib/api/sandbox/resume_child_action.ts
+++ b/front/lib/api/sandbox/resume_child_action.ts
@@ -1,0 +1,56 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import logger from "@app/logger/logger";
+import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+
+export async function resumeSandboxChildAction(
+  auth: Authenticator,
+  {
+    action,
+    conversationId,
+    conversationTitle,
+    agentMessageId,
+    agentMessageVersion,
+    branchId,
+    userMessageId,
+    userMessageVersion,
+    userMessageOrigin,
+  }: {
+    action: AgentMCPActionResource;
+    conversationId: string;
+    conversationTitle: string | null;
+    agentMessageId: string;
+    agentMessageVersion: number;
+    branchId: string | null;
+    userMessageId: string;
+    userMessageVersion: number;
+    userMessageOrigin: UserMessageOrigin;
+  }
+): Promise<void> {
+  await launchSandboxChildToolWorkflow(auth, {
+    agentLoopArgs: {
+      agentMessageId,
+      agentMessageVersion,
+      conversationId,
+      conversationTitle,
+      conversationBranchId: branchId,
+      userMessageId,
+      userMessageVersion,
+      userMessageOrigin,
+      initialStartTime: Date.now(),
+    },
+    action,
+    step: action.stepContent.step,
+    waitForCompletion: true,
+  });
+
+  logger.info(
+    {
+      actionId: action.id,
+      conversationId,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    },
+    "Sandbox child action resumed"
+  );
+}


### PR DESCRIPTION
## Description

Closes the loop on the sandbox child action stack (#25774, #25775, #25776, #25777).

When a sandbox child MCP action blocks on tool approval, user question, or personal/file authentication, the existing resolution paths (`validateAction`, `registerUserAnswer`, `resolveAuthentication`) would re-launch the **agent loop**. That is the wrong workflow for a child action — its parent tool is parked on the sandbox polling endpoint, and only the sandbox child workflow can move it forward.

This PR:

- Adds `lib/api/sandbox/resume_child_action.ts`, a thin wrapper around `launchSandboxChildToolWorkflow` with `waitForCompletion: true` (mirrors the resume semantics of `launchAgentLoopWorkflow`).
- Short-circuits the three resolution paths when `action.stepContext.sandboxChildActionInfo` is set:
  - **Approve / answer / auth-completed** → call `resumeSandboxChildAction`.
  - **Reject / deny** → just persist the action status; the parent's poll surfaces the outcome.
- Skips the "blocked actions for conversation" check for sandbox children — they do not gate the agent loop.

## Tests

Manual end-to-end once the sandbox CLI calls the public API:
1. Sandbox parent tool requests a child action that needs validation / answer / auth.
2. Resolve via the regular UI.
3. Verify the child workflow resumes (and the agent loop does not get a stray re-launch).
4. Verify rejection surfaces as `rejected` on the polling endpoint without touching the agent loop.

No functional tests added here — they will land alongside the broader sandbox endpoint tests planned in a follow-up to #25777.

## Risk

Low. The new branch is gated on `sandboxChildActionInfo` being set on `stepContext`, which is only produced by `createSandboxChildAction` (itself feature-flagged behind `sandbox_dsbx_tools`). Existing tool resolution flows are untouched.

## Deploy Plan

Depends on #25774, #25775, #25776, #25777 (all merged). Safe to deploy on its own — nothing exercises the new branch until the sandbox CLI starts calling the public API.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25850">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->