### PR TITLE
[sparkle] Add ImageGenerationPlaceholder component

### DIFF
--- a/sparkle/src/components/ImageGenerationPlaceholder.tsx
+++ b/sparkle/src/components/ImageGenerationPlaceholder.tsx
@@ -1,0 +1,310 @@
+import { motion } from "framer-motion";
+import React, { useCallback, useEffect, useId, useRef, useState } from "react";
+
+// ─── AnimatedGridPattern ──────────────────────────────────────────────────────
+// Adapted from https://magicui.design/docs/components/animated-grid-pattern
+
+interface AnimatedGridPatternProps {
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
+  strokeDasharray?: number;
+  numSquares?: number;
+  maxOpacity?: number;
+  duration?: number;
+  repeatDelay?: number;
+}
+
+type Square = { id: number; pos: [number, number]; iteration: number };
+
+function AnimatedGridPattern({
+  width = 22,
+  height = 22,
+  x = -1,
+  y = -1,
+  strokeDasharray = 0,
+  numSquares = 30,
+  maxOpacity = 0.28,
+  duration = 1.2,
+  repeatDelay = 0,
+}: AnimatedGridPatternProps) {
+  const id = useId();
+  const containerRef = useRef<SVGSVGElement | null>(null);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const [squares, setSquares] = useState<Array<Square>>([]);
+
+  const getPos = useCallback((): [number, number] => {
+    return [
+      Math.floor((Math.random() * dimensions.width) / width),
+      Math.floor((Math.random() * dimensions.height) / height),
+    ];
+  }, [dimensions.height, dimensions.width, height, width]);
+
+  const generateSquares = useCallback(
+    (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: i,
+        pos: getPos(),
+        iteration: 0,
+      })),
+    [getPos]
+  );
+
+  const updateSquarePosition = useCallback(
+    (squareId: number) => {
+      setSquares((curr) => {
+        const current = curr[squareId];
+        if (!current || current.id !== squareId) {
+          return curr;
+        }
+        const next = curr.slice();
+        next[squareId] = {
+          ...current,
+          pos: getPos(),
+          iteration: current.iteration + 1,
+        };
+        return next;
+      });
+    },
+    [getPos]
+  );
+
+  useEffect(() => {
+    if (dimensions.width && dimensions.height) {
+      setSquares(generateSquares(numSquares));
+    }
+  }, [dimensions.width, dimensions.height, generateSquares, numSquares]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) {
+      return;
+    }
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setDimensions((curr) => {
+          const w = entry.contentRect.width;
+          const h = entry.contentRect.height;
+          if (curr.width === w && curr.height === h) {
+            return curr;
+          }
+          return { width: w, height: h };
+        });
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  return (
+    <svg
+      ref={containerRef}
+      aria-hidden="true"
+      style={{
+        pointerEvents: "none",
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        color: "rgb(195,195,205)",
+        stroke: "rgba(156,163,175,0.12)",
+        fill: "none",
+      }}
+    >
+      <defs>
+        <pattern
+          id={id}
+          width={width}
+          height={height}
+          patternUnits="userSpaceOnUse"
+          x={x}
+          y={y}
+        >
+          <path
+            d={`M.5 ${height}V.5H${width}`}
+            fill="none"
+            strokeDasharray={strokeDasharray}
+          />
+        </pattern>
+      </defs>
+      <rect width="100%" height="100%" fill={`url(#${id})`} />
+      <svg x={x} y={y} className="s-overflow-visible">
+        {squares.map(({ pos: [sx, sy], id: sid, iteration }) => (
+          <motion.rect
+            key={`${sid}-${iteration}`}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: maxOpacity }}
+            transition={{
+              duration,
+              repeat: 1,
+              delay: sid * 0.1,
+              repeatType: "reverse",
+              repeatDelay,
+              ease: [0.645, 0.045, 0.355, 1],
+            }}
+            onAnimationComplete={() => updateSquarePosition(sid)}
+            width={width - 1}
+            height={height - 1}
+            x={sx * width + 1}
+            y={sy * height + 1}
+            fill="currentColor"
+            strokeWidth="0"
+          />
+        ))}
+      </svg>
+    </svg>
+  );
+}
+
+// ─── AnimatedDots ─────────────────────────────────────────────────────────────
+
+function AnimatedDots() {
+  const [n, setN] = useState(1);
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      return;
+    }
+    const t = setInterval(() => setN((c) => (c % 3) + 1), 500);
+    return () => clearInterval(t);
+  }, []);
+  return (
+    <span
+      aria-hidden="true"
+      style={{ display: "inline-block", width: "1.2ch", textAlign: "left" }}
+    >
+      {".".repeat(n)}
+    </span>
+  );
+}
+
+// ─── ImageGenerationPlaceholder ───────────────────────────────────────────────
+
+export interface ImageGenerationPlaceholderProps {
+  /**
+   * Image source URL. While undefined or null, the animated generating state
+   * is shown. Once set, the component crossfades into the image.
+   */
+  src?: string | null;
+  alt?: string;
+  /** Text shown while generating. Defaults to "Creating image". */
+  label?: string;
+  /** Size in px for both width and height. Defaults to 260. */
+  size?: number;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const EASE_OUT_QUART = "cubic-bezier(0.165, 0.84, 0.44, 1)";
+
+const PULSE_STYLE = `
+@keyframes igp-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.7; }
+}
+.igp-label {
+  animation: igp-pulse 2s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .igp-label { animation: none; }
+}
+`;
+
+export function ImageGenerationPlaceholder({
+  src,
+  alt = "Generated image",
+  label = "Creating image",
+  size = 260,
+  className,
+  style,
+}: ImageGenerationPlaceholderProps) {
+  const [gridOpacity, setGridOpacity] = useState(1);
+  const [imgMounted, setImgMounted] = useState(false);
+  const [imgOpacity, setImgOpacity] = useState(0);
+  const rafRef = useRef<number | null>(null);
+
+  // Trigger crossfade when src becomes available.
+  useEffect(() => {
+    if (!src) {
+      return;
+    }
+    // Fade out grid over 220ms
+    setGridOpacity(0);
+    // Mount image 120ms in so both overlap briefly
+    const t = setTimeout(() => {
+      setImgMounted(true);
+      rafRef.current = requestAnimationFrame(() => setImgOpacity(1));
+    }, 120);
+    return () => {
+      clearTimeout(t);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, [src]);
+
+  return (
+    <div
+      className={className}
+      style={{
+        position: "relative",
+        width: size,
+        height: size,
+        borderRadius: 16,
+        overflow: "hidden",
+        flexShrink: 0,
+        background: "#f8f8f8",
+        ...style,
+      }}
+    >
+      <style>{PULSE_STYLE}</style>
+
+      {/* Generating state — fades out when src arrives */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          opacity: gridOpacity,
+          transition: `opacity 220ms ${EASE_OUT_QUART}`,
+          pointerEvents: gridOpacity > 0 ? "auto" : "none",
+        }}
+      >
+        <span
+          className="igp-label"
+          style={{
+            position: "absolute",
+            top: 12,
+            left: 14,
+            fontSize: 13,
+            color: "#9ca3af",
+            fontWeight: 500,
+            zIndex: 1,
+            pointerEvents: "none",
+          }}
+        >
+          {label}
+          <AnimatedDots />
+        </span>
+        <AnimatedGridPattern />
+      </div>
+
+      {/* Image — fades in once src is available */}
+      {imgMounted && src && (
+        <img
+          src={src}
+          alt={alt}
+          draggable={false}
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            opacity: imgOpacity,
+            transition: `opacity 350ms ${EASE_OUT_QUART}`,
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/sparkle/src/components/ImageGenerationPlaceholder.tsx
+++ b/sparkle/src/components/ImageGenerationPlaceholder.tsx
@@ -2,9 +2,6 @@ import { cn } from "@sparkle/lib/utils";
 import { motion, useReducedMotion } from "framer-motion";
 import React, { useCallback, useEffect, useId, useRef, useState } from "react";
 
-// ─── AnimatedGridPattern ──────────────────────────────────────────────────────
-// Adapted from https://magicui.design/docs/components/animated-grid-pattern
-
 interface AnimatedGridPatternProps {
   width?: number;
   height?: number;
@@ -27,9 +24,9 @@ function AnimatedGridPattern({
   strokeDasharray = 0,
   numSquares = 30,
   maxOpacity = 0.28,
-  duration = 1.2,
-  duration: durationSeconds = 1.2,
-  repeatDelay: repeatDelaySeconds = 0,
+  durationSeconds = 1.2,
+  repeatDelaySeconds = 0,
+}: AnimatedGridPatternProps) {
   const shouldReduceMotion = useReducedMotion();
   const id = useId();
   const containerRef = useRef<SVGSVGElement | null>(null);
@@ -141,11 +138,11 @@ function AnimatedGridPattern({
               shouldReduceMotion
                 ? { duration: 0 }
                 : {
-                    duration,
+                    duration: durationSeconds,
                     repeat: 1,
                     delay: sid * 0.05,
                     repeatType: "reverse",
-                    repeatDelay,
+                    repeatDelay: repeatDelaySeconds,
                     ease: [0.645, 0.045, 0.355, 1],
                   }
             }
@@ -164,8 +161,6 @@ function AnimatedGridPattern({
     </svg>
   );
 }
-
-// ─── AnimatedDots ─────────────────────────────────────────────────────────────
 
 function AnimatedDots() {
   const [n, setN] = useState(1);
@@ -186,18 +181,10 @@ function AnimatedDots() {
   );
 }
 
-// ─── ImageGenerationPlaceholder ───────────────────────────────────────────────
-
 export interface ImageGenerationPlaceholderProps {
-  /**
-   * Image source URL. While undefined or null, the animated generating state
-   * is shown. Once set, the component crossfades into the image.
-   */
   src?: string | null;
   alt?: string;
-  /** Label shown while generating. Defaults to "Creating image". */
   label?: string;
-  /** Size in px for both width and height. Defaults to 260. */
   size?: number;
   className?: string;
 }
@@ -217,13 +204,11 @@ export function ImageGenerationPlaceholder({
   const [imgOpacity, setImgOpacity] = useState(0);
   const rafRef = useRef<number | null>(null);
 
-  // Trigger crossfade when src becomes available.
   useEffect(() => {
     if (!src) {
       return;
     }
     setGridOpacity(0);
-    // With reduced motion: mount image immediately with no transition overlap.
     const delay = shouldReduceMotion ? 0 : 120;
     const t = setTimeout(() => {
       setImgMounted(true);
@@ -246,7 +231,6 @@ export function ImageGenerationPlaceholder({
       )}
       style={{ width: size, height: size }}
     >
-      {/* Generating state — fades out when src arrives */}
       <div
         style={{
           position: "absolute",
@@ -272,7 +256,6 @@ export function ImageGenerationPlaceholder({
         <AnimatedGridPattern />
       </div>
 
-      {/* Image — fades in once src is available */}
       {imgMounted && src && (
         <img
           src={src}

--- a/sparkle/src/components/ImageGenerationPlaceholder.tsx
+++ b/sparkle/src/components/ImageGenerationPlaceholder.tsx
@@ -13,7 +13,7 @@ interface AnimatedGridPatternProps {
   strokeDasharray?: number;
   numSquares?: number;
   maxOpacity?: number;
-  duration?: number;
+  durationSeconds?: number;
   repeatDelay?: number;
 }
 

--- a/sparkle/src/components/ImageGenerationPlaceholder.tsx
+++ b/sparkle/src/components/ImageGenerationPlaceholder.tsx
@@ -14,7 +14,7 @@ interface AnimatedGridPatternProps {
   numSquares?: number;
   maxOpacity?: number;
   durationSeconds?: number;
-  repeatDelay?: number;
+  repeatDelaySeconds?: number;
 }
 
 type Square = { id: number; pos: [number, number]; iteration: number };

--- a/sparkle/src/components/ImageGenerationPlaceholder.tsx
+++ b/sparkle/src/components/ImageGenerationPlaceholder.tsx
@@ -28,7 +28,7 @@ function AnimatedGridPattern({
   numSquares = 30,
   maxOpacity = 0.28,
   duration = 1.2,
-  repeatDelay = 0,
+  duration: durationSeconds = 1.2,
   repeatDelay: repeatDelaySeconds = 0,
   const shouldReduceMotion = useReducedMotion();
   const id = useId();

--- a/sparkle/src/components/ImageGenerationPlaceholder.tsx
+++ b/sparkle/src/components/ImageGenerationPlaceholder.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@sparkle/lib/utils";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import React, { useCallback, useEffect, useId, useRef, useState } from "react";
 
 // ─── AnimatedGridPattern ──────────────────────────────────────────────────────
@@ -30,6 +30,7 @@ function AnimatedGridPattern({
   duration = 1.2,
   repeatDelay = 0,
 }: AnimatedGridPatternProps) {
+  const shouldReduceMotion = useReducedMotion();
   const id = useId();
   const containerRef = useRef<SVGSVGElement | null>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
@@ -135,16 +136,22 @@ function AnimatedGridPattern({
           <motion.rect
             key={`${sid}-${iteration}`}
             initial={{ opacity: 0 }}
-            animate={{ opacity: maxOpacity }}
-            transition={{
-              duration,
-              repeat: 1,
-              delay: sid * 0.1,
-              repeatType: "reverse",
-              repeatDelay,
-              ease: [0.645, 0.045, 0.355, 1],
-            }}
-            onAnimationComplete={() => updateSquarePosition(sid)}
+            animate={{ opacity: shouldReduceMotion ? 0 : maxOpacity }}
+            transition={
+              shouldReduceMotion
+                ? { duration: 0 }
+                : {
+                    duration,
+                    repeat: 1,
+                    delay: sid * 0.05,
+                    repeatType: "reverse",
+                    repeatDelay,
+                    ease: [0.645, 0.045, 0.355, 1],
+                  }
+            }
+            onAnimationComplete={
+              shouldReduceMotion ? undefined : () => updateSquarePosition(sid)
+            }
             width={width - 1}
             height={height - 1}
             x={sx * width + 1}
@@ -204,6 +211,7 @@ export function ImageGenerationPlaceholder({
   size = 260,
   className,
 }: ImageGenerationPlaceholderProps) {
+  const shouldReduceMotion = useReducedMotion();
   const [gridOpacity, setGridOpacity] = useState(1);
   const [imgMounted, setImgMounted] = useState(false);
   const [imgOpacity, setImgOpacity] = useState(0);
@@ -214,20 +222,20 @@ export function ImageGenerationPlaceholder({
     if (!src) {
       return;
     }
-    // Fade out grid over 220ms.
     setGridOpacity(0);
-    // Mount image 120ms in so both overlap briefly.
+    // With reduced motion: mount image immediately with no transition overlap.
+    const delay = shouldReduceMotion ? 0 : 120;
     const t = setTimeout(() => {
       setImgMounted(true);
       rafRef.current = requestAnimationFrame(() => setImgOpacity(1));
-    }, 120);
+    }, delay);
     return () => {
       clearTimeout(t);
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current);
       }
     };
-  }, [src]);
+  }, [src, shouldReduceMotion]);
 
   return (
     <div
@@ -244,7 +252,9 @@ export function ImageGenerationPlaceholder({
           position: "absolute",
           inset: 0,
           opacity: gridOpacity,
-          transition: `opacity 220ms ${EASE_OUT_QUART}`,
+          transition: shouldReduceMotion
+            ? "none"
+            : `opacity 220ms ${EASE_OUT_QUART}`,
           pointerEvents: gridOpacity > 0 ? "auto" : "none",
         }}
       >
@@ -275,7 +285,9 @@ export function ImageGenerationPlaceholder({
             height: "100%",
             objectFit: "cover",
             opacity: imgOpacity,
-            transition: `opacity 350ms ${EASE_OUT_QUART}`,
+            transition: shouldReduceMotion
+              ? "none"
+              : `opacity 350ms ${EASE_OUT_QUART}`,
           }}
         />
       )}

--- a/sparkle/src/components/ImageGenerationPlaceholder.tsx
+++ b/sparkle/src/components/ImageGenerationPlaceholder.tsx
@@ -29,7 +29,7 @@ function AnimatedGridPattern({
   maxOpacity = 0.28,
   duration = 1.2,
   repeatDelay = 0,
-}: AnimatedGridPatternProps) {
+  repeatDelay: repeatDelaySeconds = 0,
   const shouldReduceMotion = useReducedMotion();
   const id = useId();
   const containerRef = useRef<SVGSVGElement | null>(null);

--- a/sparkle/src/components/ImageGenerationPlaceholder.tsx
+++ b/sparkle/src/components/ImageGenerationPlaceholder.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@sparkle/lib/utils";
 import { motion } from "framer-motion";
 import React, { useCallback, useEffect, useId, useRef, useState } from "react";
 
@@ -129,7 +130,7 @@ function AnimatedGridPattern({
         </pattern>
       </defs>
       <rect width="100%" height="100%" fill={`url(#${id})`} />
-      <svg x={x} y={y} className="s-overflow-visible">
+      <svg x={x} y={y} style={{ overflow: "visible" }}>
         {squares.map(({ pos: [sx, sy], id: sid, iteration }) => (
           <motion.rect
             key={`${sid}-${iteration}`}
@@ -187,28 +188,14 @@ export interface ImageGenerationPlaceholderProps {
    */
   src?: string | null;
   alt?: string;
-  /** Text shown while generating. Defaults to "Creating image". */
+  /** Label shown while generating. Defaults to "Creating image". */
   label?: string;
   /** Size in px for both width and height. Defaults to 260. */
   size?: number;
   className?: string;
-  style?: React.CSSProperties;
 }
 
 const EASE_OUT_QUART = "cubic-bezier(0.165, 0.84, 0.44, 1)";
-
-const PULSE_STYLE = `
-@keyframes igp-pulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.7; }
-}
-.igp-label {
-  animation: igp-pulse 2s ease-in-out infinite;
-}
-@media (prefers-reduced-motion: reduce) {
-  .igp-label { animation: none; }
-}
-`;
 
 export function ImageGenerationPlaceholder({
   src,
@@ -216,7 +203,6 @@ export function ImageGenerationPlaceholder({
   label = "Creating image",
   size = 260,
   className,
-  style,
 }: ImageGenerationPlaceholderProps) {
   const [gridOpacity, setGridOpacity] = useState(1);
   const [imgMounted, setImgMounted] = useState(false);
@@ -228,9 +214,9 @@ export function ImageGenerationPlaceholder({
     if (!src) {
       return;
     }
-    // Fade out grid over 220ms
+    // Fade out grid over 220ms.
     setGridOpacity(0);
-    // Mount image 120ms in so both overlap briefly
+    // Mount image 120ms in so both overlap briefly.
     const t = setTimeout(() => {
       setImgMounted(true);
       rafRef.current = requestAnimationFrame(() => setImgOpacity(1));
@@ -245,20 +231,13 @@ export function ImageGenerationPlaceholder({
 
   return (
     <div
-      className={className}
-      style={{
-        position: "relative",
-        width: size,
-        height: size,
-        borderRadius: 16,
-        overflow: "hidden",
-        flexShrink: 0,
-        background: "#f8f8f8",
-        ...style,
-      }}
+      className={cn(
+        "s-relative s-overflow-hidden s-shrink-0 s-rounded-2xl",
+        "s-bg-muted-background dark:s-bg-muted-background-night",
+        className
+      )}
+      style={{ width: size, height: size }}
     >
-      <style>{PULSE_STYLE}</style>
-
       {/* Generating state — fades out when src arrives */}
       <div
         style={{
@@ -270,17 +249,12 @@ export function ImageGenerationPlaceholder({
         }}
       >
         <span
-          className="igp-label"
-          style={{
-            position: "absolute",
-            top: 12,
-            left: 14,
-            fontSize: 13,
-            color: "#9ca3af",
-            fontWeight: 500,
-            zIndex: 1,
-            pointerEvents: "none",
-          }}
+          className={cn(
+            "s-absolute s-top-3 s-left-3.5 s-z-10",
+            "s-text-xs s-font-medium s-pointer-events-none",
+            "s-text-muted-foreground dark:s-text-muted-foreground-night",
+            "motion-safe:s-animate-opacity-pulse"
+          )}
         >
           {label}
           <AnimatedDots />

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -130,6 +130,8 @@ export { Hoverable } from "./Hoverable";
 export { HoveringBar } from "./HoveringBar";
 export { DoubleIcon, Icon } from "./Icon";
 export { IconButton } from "./IconButton";
+export type { ImageGenerationPlaceholderProps } from "./ImageGenerationPlaceholder";
+export { ImageGenerationPlaceholder } from "./ImageGenerationPlaceholder";
 export type {
   ImagePreviewProps,
   ImagePreviewTitlePositionType,

--- a/sparkle/src/stories/ImageGenerationPlaceholder.stories.tsx
+++ b/sparkle/src/stories/ImageGenerationPlaceholder.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta } from "@storybook/react";
+import React, { useState } from "react";
+
+import { Button } from "../index_with_tw_base";
+import { ImageGenerationPlaceholder } from "../index_with_tw_base";
+
+const meta = {
+  title: "Effects/ImageGenerationPlaceholder",
+  component: ImageGenerationPlaceholder,
+} satisfies Meta<typeof ImageGenerationPlaceholder>;
+
+export default meta;
+
+const IMAGE_SRC = "https://picsum.photos/seed/city42/520/520";
+
+export function GeneratingState() {
+  return (
+    <div className="s-flex s-items-center s-justify-center s-p-12">
+      <ImageGenerationPlaceholder />
+    </div>
+  );
+}
+
+export function RevealedState() {
+  return (
+    <div className="s-flex s-items-center s-justify-center s-p-12">
+      <ImageGenerationPlaceholder src={IMAGE_SRC} alt="A futuristic city" />
+    </div>
+  );
+}
+
+export function LiveTransition() {
+  const [src, setSrc] = useState<string | undefined>(undefined);
+  const [key, setKey] = useState(0);
+
+  const reset = () => {
+    setSrc(undefined);
+    setKey((k) => k + 1);
+  };
+
+  return (
+    <div className="s-flex s-flex-col s-items-center s-gap-6 s-p-12">
+      <ImageGenerationPlaceholder key={key} src={src} alt="A futuristic city" />
+      <div className="s-flex s-gap-3">
+        <Button
+          label="Reveal image"
+          size="sm"
+          variant="primary"
+          disabled={!!src}
+          onClick={() => setSrc(IMAGE_SRC)}
+        />
+        <Button label="Reset" size="sm" variant="outline" onClick={reset} />
+      </div>
+    </div>
+  );
+}
+
+export function Sizes() {
+  return (
+    <div className="s-flex s-flex-wrap s-items-end s-gap-6 s-p-12">
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <ImageGenerationPlaceholder size={120} />
+        <span className="s-text-xs s-text-muted-foreground">120px</span>
+      </div>
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <ImageGenerationPlaceholder size={200} />
+        <span className="s-text-xs s-text-muted-foreground">200px</span>
+      </div>
+      <div className="s-flex s-flex-col s-items-center s-gap-2">
+        <ImageGenerationPlaceholder size={260} />
+        <span className="s-text-xs s-text-muted-foreground">
+          260px (default)
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function CustomLabel() {
+  return (
+    <div className="s-flex s-items-center s-justify-center s-p-12">
+      <ImageGenerationPlaceholder label="Generating scene" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `ImageGenerationPlaceholder`, a self-contained Sparkle component for AI image generation flows
- Shows an animated grid (from Magic UI) with a pulsing "Creating image..." label while generating
- Crossfades into the actual image when `src` is provided — grid fades out over 220ms, image fades in over 350ms with a 120ms overlap for a smooth transition
- Respects `prefers-reduced-motion`

## Usage

```tsx
<ImageGenerationPlaceholder
  src={imageSrc}      // undefined/null → generating state; string → shows image
  alt="Generated image"
  label="Creating image"  // optional, defaults to "Creating image"
  size={260}              // optional, defaults to 260px
/>
```

## Test plan

- [ ] Render with `src={undefined}` — should show animated grid and pulsing label
- [ ] Set `src` to a valid URL — should crossfade from grid to image
- [ ] Verify `prefers-reduced-motion` disables label pulse and grid animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25852">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->