### PR TITLE
Refactor moving files endpoints and backend.

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -1,6 +1,7 @@
 import {
   getProjectFilesBasePath,
-  parseScopedFilePath,
+  isResolveMountFilePathError,
+  resolveScopedMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import { MoveMountFileRequestBodySchema } from "@app/lib/api/files/mount_schemas";
 import {
@@ -10,12 +11,12 @@ import {
 } from "@app/lib/api/projects/context";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { withSpace } from "@front-api/middleware/with_space";
 import { Hono } from "hono";
-import path from "path";
 
 // Catch-all for /api/w/:wId/spaces/:spaceId/files/<...rel>.
 //
@@ -52,44 +53,40 @@ async function buildContext(ctx: any) {
     };
   }
 
-  const scopedPath = parseScopedFilePath(rel);
-  if (!scopedPath || scopedPath.prefix !== "project") {
-    return {
-      error: apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Path must start with the scope prefix `project/`.",
-        },
-      }),
-    };
-  }
-
   const owner = auth.getNonNullableWorkspace();
   const basePath = getProjectFilesBasePath({
     workspaceId: owner.sId,
     projectId: space.sId,
   });
-  const normalizedGcsPath = path.posix.normalize(
-    `${basePath}${scopedPath.rel}`
-  );
-  if (!normalizedGcsPath.startsWith(basePath)) {
+  const pathRes = resolveScopedMountFilePath({
+    relPath: rel,
+    expectedPrefix: "project",
+    mountBasePath: basePath,
+    outsideScopeMessage: "Access denied: path is outside project scope.",
+  });
+  if (pathRes.isErr()) {
+    const { code, message } = pathRes.error;
     return {
       error: apiError(ctx, {
-        status_code: 403,
+        status_code: code === "outside_scope" ? 403 : 400,
         api_error: {
-          type: "workspace_auth_error",
-          message: "Access denied: path is outside project scope.",
+          type:
+            code === "outside_scope"
+              ? "workspace_auth_error"
+              : "invalid_request_error",
+          message,
         },
       }),
     };
   }
 
+  const { normalizedGcsPath, normalizedRelative } = pathRes.value;
+
   return {
     auth,
     space,
     normalizedGcsPath,
-    normalizedRelative: scopedPath.rel,
+    normalizedRelative,
   };
 }
 
@@ -231,11 +228,29 @@ app.post(
   withSpace({ requireCanWrite: true }),
   validate("json", MoveMountFileRequestBodySchema),
   async (c) => {
-    const ctx = await buildContext(c);
-    if ("error" in ctx) {
-      return ctx.error;
+    const space = c.get("space");
+    const auth = c.get("auth");
+
+    if (!space.isProject()) {
+      return apiError(c, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Files are only available for project spaces.",
+        },
+      });
     }
-    const { auth, space, normalizedRelative } = ctx;
+
+    const rel = c.req.param("rel");
+    if (!isString(rel) || rel.length === 0) {
+      return apiError(c, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Missing file path.",
+        },
+      });
+    }
 
     if (!space.canWrite(auth)) {
       return apiError(c, {
@@ -247,19 +262,32 @@ app.post(
       });
     }
 
-    const { parentRelativePath } = c.req.valid("json");
+    const { destRelativeFilePath } = c.req.valid("json");
 
     const moveResult = await moveProjectFile(auth, {
       space,
-      relativeFilePath: normalizedRelative,
-      parentRelativePath,
+      sourcePath: rel,
+      destRelativeFilePath,
     });
     if (moveResult.isErr()) {
+      if (isResolveMountFilePathError(moveResult.error)) {
+        const { code, message } = moveResult.error;
+        return apiError(c, {
+          status_code: code === "outside_scope" ? 403 : 400,
+          api_error: {
+            type:
+              code === "outside_scope"
+                ? "workspace_auth_error"
+                : "invalid_request_error",
+            message,
+          },
+        });
+      }
       return apiError(c, {
         status_code: 500,
         api_error: {
           type: "internal_server_error",
-          message: moveResult.error.message,
+          message: normalizeError(moveResult.error).message,
         },
       });
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -76,7 +76,7 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
         "report.pdf",
       ]);
       expect(response.status).toBe(400);
-      expect((await response.json()).error.message).toMatch(/project\//);
+      expect((await response.json()).error.message).toMatch(/scope prefix/i);
     });
 
     it("returns 403 for path traversal attempts", async () => {
@@ -270,6 +270,76 @@ describe("/api/w/:wId/spaces/:spaceId/files/<rel>", () => {
         ["project", "file.txt"],
         { method: "DELETE" }
       );
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("POST (move)", () => {
+    beforeEach(() => {
+      vi.spyOn(projectsContext, "moveProjectFile").mockResolvedValue(
+        new Ok(undefined)
+      );
+    });
+
+    it("returns 200 and calls moveProjectFile with the right args", async () => {
+      const { workspace, project } = await setupProject();
+      const response = await fileRequest(
+        workspace,
+        project.sId,
+        ["reports", "file.txt"],
+        {
+          method: "POST",
+          body: { destRelativeFilePath: "archive/file.txt" },
+        }
+      );
+      expect(response.status).toBe(200);
+      expect(projectsContext.moveProjectFile).toHaveBeenCalledWith(
+        expect.anything(),
+        {
+          space: expect.objectContaining({ sId: project.sId }),
+          sourcePath: "reports/file.txt",
+          destRelativeFilePath: "archive/file.txt",
+        }
+      );
+    });
+
+    it("returns 400 when destRelativeFilePath is missing", async () => {
+      const { workspace, project } = await setupProject();
+      const response = await fileRequest(
+        workspace,
+        project.sId,
+        ["reports", "file.txt"],
+        { method: "POST", body: {} }
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 404 when the user lacks write permission (requireCanWrite)", async () => {
+      vi.spyOn(SpaceResource.prototype, "canWrite").mockReturnValue(false);
+      const { workspace, project } = await setupProject();
+      const response = await fileRequest(
+        workspace,
+        project.sId,
+        ["reports", "file.txt"],
+        {
+          method: "POST",
+          body: { destRelativeFilePath: "archive/file.txt" },
+        }
+      );
+      // withSpace({ requireCanWrite }) masks denied write as space_not_found.
+      expect(response.status).toBe(404);
+      expect(projectsContext.moveProjectFile).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 when moveProjectFile fails", async () => {
+      vi.spyOn(projectsContext, "moveProjectFile").mockResolvedValue(
+        new Err(new Error("GCS error"))
+      );
+      const { workspace, project } = await setupProject();
+      const response = await fileRequest(workspace, project.sId, ["file.txt"], {
+        method: "POST",
+        body: { destRelativeFilePath: "file.txt" },
+      });
       expect(response.status).toBe(500);
     });
   });

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -2,6 +2,10 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
 import type { FileEntry } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
+import {
+  getScopedRelativePath,
+  joinMountRelativePath,
+} from "@app/components/file_explorer/utils";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import config from "@app/lib/api/config";
 import { downloadSandboxFile } from "@app/lib/swr/files";
@@ -44,11 +48,15 @@ export function ConversationFileExplorer({
 
   const onFileDownload = useFileDownload({ getFileResponse });
 
-  const onMoveFile = useCallback(
+  // Pass to FileExplorer component to enable file moving.
+  const _onMoveFile = useCallback(
     async (entry: FileEntry, parentRelativePath: string) => {
       const result = await moveMountFile({
-        scopedPath: entry.path,
-        parentRelativePath: parentRelativePath || undefined,
+        relativeFilePath: getScopedRelativePath(entry.path),
+        destRelativeFilePath: joinMountRelativePath(
+          parentRelativePath,
+          entry.fileName
+        ),
       });
       if (result.isOk()) {
         await mutateSandboxFiles();
@@ -64,7 +72,6 @@ export function ConversationFileExplorer({
       isLoading={isSandboxFilesLoading}
       getFileUrl={getFileUrl}
       onFileDownload={onFileDownload}
-      onMoveFile={onMoveFile}
       onClose={closePanel}
       onOpenInteractive={(entry) =>
         openPanel({ type: "interactive_content", fileId: entry.fileId })

--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -13,6 +13,10 @@ import type {
   FileExplorerEntry,
 } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
+import {
+  getScopedRelativePath,
+  joinMountRelativePath,
+} from "@app/components/file_explorer/utils";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
@@ -358,11 +362,27 @@ function ProjectFileExplorerContent({
 
       if (podMountParentRelativePath) {
         for (const blob of uploadedBlobs) {
+          if (!blob.path) {
+            console.error(
+              "File has no scoped mount path and cannot be moved within pod.",
+              blob
+            );
+            continue;
+          }
+          const fileName = blob.path.split("/").pop() ?? blob.filename;
           const moveResult = await moveMountFile({
-            scopedPath: `project/${blob.filename}`,
-            parentRelativePath: podMountParentRelativePath,
+            relativeFilePath: getScopedRelativePath(blob.path),
+            destRelativeFilePath: joinMountRelativePath(
+              podMountParentRelativePath,
+              fileName
+            ),
           });
           if (moveResult.isErr()) {
+            console.error(
+              "Failed to move file within pod.",
+              moveResult.error,
+              blob
+            );
             break;
           }
         }
@@ -452,8 +472,11 @@ function ProjectFileExplorerContent({
   const onMoveFile = useCallback(
     async (entry: FileEntry, parentRelativePath: string) => {
       const result = await moveMountFile({
-        scopedPath: entry.path,
-        parentRelativePath: parentRelativePath || undefined,
+        relativeFilePath: getScopedRelativePath(entry.path),
+        destRelativeFilePath: joinMountRelativePath(
+          parentRelativePath,
+          entry.fileName
+        ),
       });
       if (result.isOk()) {
         await refreshProjectFiles();

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -14,7 +14,7 @@ import type {
   FileExplorerFilter,
   FileExplorerMenuAction,
   FileExplorerSortMode,
-  SandboxTreeNode,
+  FileSystemTreeNode,
 } from "@app/components/file_explorer/types";
 import {
   buildFolderTree,
@@ -22,6 +22,7 @@ import {
   getFolderBreadcrumbSegments,
   getParentFolderRelativePath,
   getScopedRelativePath,
+  ROOT_FOLDER_LABEL,
 } from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
@@ -51,7 +52,7 @@ function FileExplorerBreadcrumb({
 }: FileExplorerBreadcrumbProps) {
   const segments = getFolderBreadcrumbSegments(currentFolderPath);
   const items: BreadcrumbItem[] = [
-    { label: "All files", onClick: () => onNavigate(-1) },
+    { label: ROOT_FOLDER_LABEL, onClick: () => onNavigate(-1) },
     ...segments.map((segment, i) => ({
       label: segment.label,
       onClick: () => onNavigate(i),
@@ -223,7 +224,7 @@ export function FileExplorer({
     setCurrentFolderPath(segments[index]?.path ?? "");
   };
 
-  const handleFolderNavigate = (node: SandboxTreeNode) => {
+  const handleFolderNavigate = (node: FileSystemTreeNode) => {
     setCurrentFolderPath(node.path);
   };
 
@@ -233,8 +234,8 @@ export function FileExplorer({
 
   const parentFolderPath = getParentFolderRelativePath(currentFolderPath);
   const parentFolderLabel = parentFolderPath
-    ? (parentFolderPath.split("/").at(-1) ?? "All files")
-    : "All files";
+    ? (parentFolderPath.split("/").at(-1) ?? ROOT_FOLDER_LABEL)
+    : ROOT_FOLDER_LABEL;
 
   const fileDragEnabled = Boolean(onMoveFile && totalFolderCount > 0);
 
@@ -380,7 +381,7 @@ export function FileExplorer({
 
       {onMoveFile && (
         <MoveFileToFolderDialog
-          files={files}
+          folderTree={folderTree}
           file={fileToMove}
           isOpen={showMoveDialog}
           onClose={() => setShowMoveDialog(false)}

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -11,7 +11,7 @@ import type {
   FileEntry,
   FileExplorerEntry,
   FileExplorerMenuAction,
-  SandboxTreeNode,
+  FileSystemTreeNode,
 } from "@app/components/file_explorer/types";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { CardGrid, ScrollArea, Spinner } from "@dust-tt/sparkle";
@@ -22,7 +22,7 @@ const cardGridClasses =
 
 interface FileExplorerContentProps {
   isLoading: boolean;
-  sortedNodes: SandboxTreeNode[];
+  sortedNodes: FileSystemTreeNode[];
   entryByRelativePath: Map<string, FileExplorerEntry>;
   viewMode: ViewMode;
   isEmpty: boolean;
@@ -31,7 +31,7 @@ interface FileExplorerContentProps {
   parentFolderDropPath?: string;
   parentFolderLabel?: string;
   onGoUp?: () => void;
-  onFolderNavigate: (node: SandboxTreeNode) => void;
+  onFolderNavigate: (node: FileSystemTreeNode) => void;
   onFileOpen: (entry: FileEntry) => void;
   onFileDownload: (entry: FileEntry) => Promise<void>;
   onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -7,7 +7,7 @@ import type {
   ContentNodeEntry,
   FileEntry,
   FileExplorerMenuAction,
-  SandboxTreeNode,
+  FileSystemTreeNode,
 } from "@app/components/file_explorer/types";
 import {
   getCategoryFromContentType,
@@ -308,9 +308,9 @@ export function FileExplorerGoUpCard({
 }
 
 export interface FileExplorerFolderCardProps {
-  node: SandboxTreeNode;
+  node: FileSystemTreeNode;
   viewMode: ViewMode;
-  onNavigate: (node: SandboxTreeNode) => void;
+  onNavigate: (node: FileSystemTreeNode) => void;
   onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
 }
 

--- a/front/components/file_explorer/MoveFileToFolderDialog.tsx
+++ b/front/components/file_explorer/MoveFileToFolderDialog.tsx
@@ -1,12 +1,11 @@
-import type { SandboxTreeNode } from "@app/components/file_explorer/types";
+import type { FileSystemTreeNode } from "@app/components/file_explorer/types";
 import {
-  buildFolderTree,
   formatFolderDestinationLabel,
   getAncestorFolderPaths,
   getParentFolderRelativePath,
   getScopedRelativePath,
+  ROOT_FOLDER_LABEL,
 } from "@app/components/file_explorer/utils";
-import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
 import type { Result } from "@app/types/shared/result";
 import {
   Dialog,
@@ -24,7 +23,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 interface FolderTreeNodeProps {
   currentParentPath: string;
   expandedPaths: Set<string>;
-  node: SandboxTreeNode;
+  node: FileSystemTreeNode;
   onSelect: (path: string) => void;
   selectedPath: string;
 }
@@ -68,7 +67,7 @@ function FolderTreeNode({
 }
 
 export interface MoveFileToFolderDialogProps {
-  files: GCSMountEntry[];
+  folderTree: FileSystemTreeNode[];
   file: { fileName: string; path: string } | null;
   isOpen: boolean;
   onClose: () => void;
@@ -76,14 +75,12 @@ export interface MoveFileToFolderDialogProps {
 }
 
 export function MoveFileToFolderDialog({
-  files,
+  folderTree,
   file,
   isOpen,
   onClose,
   onMove,
 }: MoveFileToFolderDialogProps) {
-  const folderTree = useMemo(() => buildFolderTree(files), [files]);
-
   const currentParentPath = useMemo(() => {
     if (!file) {
       return "";
@@ -152,8 +149,8 @@ export function MoveFileToFolderDialog({
               isNavigatable
               label={
                 currentParentPath === ""
-                  ? "All files (current location)"
-                  : "All files"
+                  ? `${ROOT_FOLDER_LABEL} (current location)`
+                  : ROOT_FOLDER_LABEL
               }
               visual={FolderIcon}
               type={hasFolders ? "node" : "leaf"}

--- a/front/components/file_explorer/fileExplorerPipeline.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.ts
@@ -3,7 +3,7 @@ import type {
   FileExplorerEntry,
   FileExplorerFilter,
   FileExplorerSortMode,
-  SandboxTreeNode,
+  FileSystemTreeNode,
 } from "@app/components/file_explorer/types";
 import {
   buildSandboxTree,
@@ -16,7 +16,7 @@ import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 
 export interface FileExplorerPipeline {
   /** Tree nodes at the current folder level, filtered + sorted. */
-  sortedNodes: SandboxTreeNode[];
+  sortedNodes: FileSystemTreeNode[];
   /** Count of items per filter bucket (post-search). Used by the chip row. */
   filterCounts: Partial<Record<FileExplorerFilter, number>>;
   folderCount: number;
@@ -72,7 +72,7 @@ export function getFileExplorerPipeline({
   const tree = buildSandboxTree(files);
 
   // Synthetic tree nodes for content-node entries — always flat, at root level.
-  const contentNodeTreeNodes: SandboxTreeNode[] = contentNodes.map((cn) => ({
+  const contentNodeTreeNodes: FileSystemTreeNode[] = contentNodes.map((cn) => ({
     name: cn.fileName,
     path: cn.path,
     isDirectory: false,

--- a/front/components/file_explorer/types.ts
+++ b/front/components/file_explorer/types.ts
@@ -36,13 +36,13 @@ export type FilePanelCategory =
   | "knowledge"
   | "other";
 
-export type SandboxTreeNode = {
+export type FileSystemTreeNode = {
   name: string;
   path: string;
   isDirectory: boolean;
   contentType: string | null;
   fileId: string | null;
-  children: SandboxTreeNode[];
+  children: FileSystemTreeNode[];
 };
 
 export type FileExplorerBucket =

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -10,10 +10,12 @@ import type {
   FileExplorerEntry,
   FileExplorerSortMode,
   FilePanelCategory,
-  SandboxTreeNode,
+  FileSystemTreeNode,
 } from "./types";
 
 export const MIN_FILES_FOR_SEARCH = 10;
+
+export const ROOT_FOLDER_LABEL = "All files";
 
 /**
  * Category display configuration, ordered by priority.
@@ -39,7 +41,7 @@ export const CATEGORY_CONFIG: {
  * unmapped type) return null and only surface under the "All" chip.
  */
 export function getFileExplorerBucket(
-  node: SandboxTreeNode
+  node: FileSystemTreeNode
 ): FileExplorerBucket | null {
   if (node.isDirectory) {
     return "folders";
@@ -81,7 +83,7 @@ export function getFileExplorerBucket(
 
 /** Display order: Company Data refs, then folders, then GCS files. */
 function getExplorerNodeSortRank(
-  node: SandboxTreeNode,
+  node: FileSystemTreeNode,
   entryByRelativePath: Map<string, FileExplorerEntry>
 ): number {
   if (entryByRelativePath.get(node.path)?.kind === "node") {
@@ -98,8 +100,8 @@ function getExplorerNodeSortRank(
  * nodes), then folders, then files; within each group the selected sort mode applies.
  */
 export function compareTreeNodesForSort(
-  a: SandboxTreeNode,
-  b: SandboxTreeNode,
+  a: FileSystemTreeNode,
+  b: FileSystemTreeNode,
   sortMode: FileExplorerSortMode,
   entryByRelativePath: Map<string, FileExplorerEntry>
 ): number {
@@ -185,9 +187,11 @@ export function getCategoryFromContentType(
  * use-case prefix (first segment) is stripped so tree paths start at the
  * sandbox working directory root.
  */
-export function buildSandboxTree(entries: GCSMountEntry[]): SandboxTreeNode[] {
-  const root: SandboxTreeNode[] = [];
-  const nodeMap = new Map<string, SandboxTreeNode>();
+export function buildSandboxTree(
+  entries: GCSMountEntry[]
+): FileSystemTreeNode[] {
+  const root: FileSystemTreeNode[] = [];
+  const nodeMap = new Map<string, FileSystemTreeNode>();
 
   for (const entry of entries.filter((e) => !e.isDirectory)) {
     const slashIdx = entry.path.indexOf("/");
@@ -205,7 +209,7 @@ export function buildSandboxTree(entries: GCSMountEntry[]): SandboxTreeNode[] {
     for (let i = 0; i < parts.length - 1; i++) {
       currentPath = currentPath ? `${currentPath}/${parts[i]}` : parts[i]!;
       if (!nodeMap.has(currentPath)) {
-        const dirNode: SandboxTreeNode = {
+        const dirNode: FileSystemTreeNode = {
           name: parts[i]!,
           path: currentPath,
           isDirectory: true,
@@ -229,7 +233,7 @@ export function buildSandboxTree(entries: GCSMountEntry[]): SandboxTreeNode[] {
     }
 
     // Add the file node.
-    const fileNode: SandboxTreeNode = {
+    const fileNode: FileSystemTreeNode = {
       name: parts[parts.length - 1]!,
       path: relativePath,
       isDirectory: false,
@@ -265,7 +269,7 @@ export function buildSandboxTree(entries: GCSMountEntry[]): SandboxTreeNode[] {
         continue;
       }
 
-      const dirNode: SandboxTreeNode = {
+      const dirNode: FileSystemTreeNode = {
         name: parts[i]!,
         path: currentPath,
         isDirectory: true,
@@ -300,7 +304,17 @@ export function getParentFolderRelativePath(relativeFilePath: string): string {
   return lastSlash >= 0 ? relativeFilePath.slice(0, lastSlash) : "";
 }
 
-function filterDirectoryNodes(nodes: SandboxTreeNode[]): SandboxTreeNode[] {
+/** Join a parent folder path and file name within a mount (no scope prefix). */
+export function joinMountRelativePath(
+  parentRelativePath: string,
+  fileName: string
+): string {
+  return parentRelativePath ? `${parentRelativePath}/${fileName}` : fileName;
+}
+
+function filterDirectoryNodes(
+  nodes: FileSystemTreeNode[]
+): FileSystemTreeNode[] {
   return nodes
     .filter((node) => node.isDirectory)
     .map((node) => ({
@@ -310,11 +324,13 @@ function filterDirectoryNodes(nodes: SandboxTreeNode[]): SandboxTreeNode[] {
 }
 
 /** Folder-only view of the sandbox tree (no files). */
-export function buildFolderTree(entries: GCSMountEntry[]): SandboxTreeNode[] {
+export function buildFolderTree(
+  entries: GCSMountEntry[]
+): FileSystemTreeNode[] {
   return filterDirectoryNodes(buildSandboxTree(entries));
 }
 
-export function countFoldersInTree(nodes: SandboxTreeNode[]): number {
+export function countFoldersInTree(nodes: FileSystemTreeNode[]): number {
   return nodes.reduce(
     (count, node) => count + 1 + countFoldersInTree(node.children),
     0
@@ -324,13 +340,13 @@ export function countFoldersInTree(nodes: SandboxTreeNode[]): number {
 /** Human-readable breadcrumb for a folder path in the move dialog. */
 export function formatFolderDestinationLabel(
   folderPath: string,
-  folderTree: SandboxTreeNode[]
+  folderTree: FileSystemTreeNode[]
 ): string {
   if (!folderPath) {
-    return "All files";
+    return ROOT_FOLDER_LABEL;
   }
 
-  const labels = ["All files"];
+  const labels = [ROOT_FOLDER_LABEL];
   let nodes = folderTree;
   let current = "";
   for (const part of folderPath.split("/")) {
@@ -379,9 +395,9 @@ export function getFolderBreadcrumbSegments(
 }
 
 export function findTreeNodeByPath(
-  nodes: SandboxTreeNode[],
+  nodes: FileSystemTreeNode[],
   path: string
-): SandboxTreeNode | undefined {
+): FileSystemTreeNode | undefined {
   for (const node of nodes) {
     if (node.path === path) {
       return node;
@@ -397,9 +413,9 @@ export function findTreeNodeByPath(
 
 /** Children of a folder in the sandbox tree; root when `folderPath` is empty. */
 export function getChildrenAtFolderPath(
-  tree: SandboxTreeNode[],
+  tree: FileSystemTreeNode[],
   folderPath: string
-): SandboxTreeNode[] {
+): FileSystemTreeNode[] {
   if (!folderPath) {
     return tree;
   }

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -37,6 +37,8 @@ export interface FileBlob {
   publicUrl?: string;
   iconName?: string;
   provider?: string;
+  /** Scoped mount path from upload (same as `GCSMountEntryBase.path`). */
+  path?: string | null;
 }
 export type FileBlobWithFileId = FileBlob & { fileId: string };
 
@@ -251,6 +253,7 @@ export function useFileUploaderService({
             isUploading: false,
             sourceUrl: fileUploaded.downloadUrl,
             publicUrl: file.publicUrl,
+            path: fileUploaded.path,
           });
         },
         { concurrency: 4 }

--- a/front/lib/api/actions/servers/files/tools/resolve.ts
+++ b/front/lib/api/actions/servers/files/tools/resolve.ts
@@ -3,6 +3,7 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getScopedPathFromGCSPath } from "@app/lib/api/files/gcs_mount/files";
 import {
   getConversationFilesBasePath,
   getProjectFilesBasePath,
@@ -53,13 +54,24 @@ export async function resolveHandler(
       );
     }
 
-    const prefix = getConversationFilesBasePath({
-      workspaceId: owner.sId,
-      conversationId: conversation.sId,
+    const scopedPath = getScopedPathFromGCSPath({
+      prefix: getConversationFilesBasePath({
+        workspaceId: owner.sId,
+        conversationId: conversation.sId,
+      }),
+      gcsPath: file.mountFilePath,
+      useCase: "conversation",
     });
-    const relPath = file.mountFilePath.slice(prefix.length);
+    if (!scopedPath) {
+      return new Err(
+        new MCPError(
+          `File \`${file_id}\` does not belong to this conversation.`,
+          { tracked: false }
+        )
+      );
+    }
 
-    return new Ok([{ type: "text", text: `conversation/${relPath}` }]);
+    return new Ok([{ type: "text", text: scopedPath }]);
   }
 
   if (useCase === "project_context") {
@@ -92,13 +104,24 @@ export async function resolveHandler(
       );
     }
 
-    const prefix = getProjectFilesBasePath({
-      workspaceId: owner.sId,
-      projectId: spaceId,
+    const scopedPath = getScopedPathFromGCSPath({
+      prefix: getProjectFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: spaceId,
+      }),
+      gcsPath: file.mountFilePath,
+      useCase: "project",
     });
-    const relPath = file.mountFilePath.slice(prefix.length);
+    if (!scopedPath) {
+      return new Err(
+        new MCPError(
+          `File \`${file_id}\` does not belong to the project of this conversation.`,
+          { tracked: false }
+        )
+      );
+    }
 
-    return new Ok([{ type: "text", text: `project/${relPath}` }]);
+    return new Ok([{ type: "text", text: scopedPath }]);
   }
 
   return new Err(

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -7,6 +7,8 @@ import {
   deleteGCSMountFile,
   type GCSMountFileEntry,
   getConversationFileMountSignedUrl,
+  getGCSPathFromScopedPath,
+  getScopedPathFromGCSPath,
   listGCSMountFiles,
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
@@ -724,5 +726,37 @@ describe("deleteGCSMountFile", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("delete failed");
     }
+  });
+});
+
+describe("scoped path ↔ GCS path", () => {
+  const prefix = "w/ws1/projects/proj1/files/";
+
+  it("getScopedPathFromGCSPath is the inverse of getGCSPathFromScopedPath", () => {
+    const scopedPath = "project/reports/report_fil_abc.pdf";
+    const gcsPath = getGCSPathFromScopedPath({
+      prefix,
+      scopedPath,
+      useCase: "project",
+    });
+    expect(gcsPath).toBe(`${prefix}reports/report_fil_abc.pdf`);
+
+    expect(
+      getScopedPathFromGCSPath({
+        prefix,
+        gcsPath: gcsPath!,
+        useCase: "project",
+      })
+    ).toBe(scopedPath);
+  });
+
+  it("getScopedPathFromGCSPath returns null when the path is outside the prefix", () => {
+    expect(
+      getScopedPathFromGCSPath({
+        prefix,
+        gcsPath: "w/ws1/projects/other/files/file.txt",
+        useCase: "project",
+      })
+    ).toBeNull();
   });
 });

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -101,6 +101,26 @@ export function getGCSPathFromScopedPath({
   return prefix + scopedPath.slice(scopePrefix.length);
 }
 
+/**
+ * Inverse of `getGCSPathFromScopedPath`: full GCS object path to scoped listing path
+ * (e.g. `w/.../files/report.pdf` → `project/report.pdf`).
+ */
+export function getScopedPathFromGCSPath({
+  prefix,
+  gcsPath,
+  useCase,
+}: {
+  prefix: string;
+  gcsPath: string;
+  useCase: GCSMountPoint["useCase"];
+}): string | null {
+  if (!gcsPath.startsWith(prefix)) {
+    return null;
+  }
+
+  return `${useCase}/${gcsPath.slice(prefix.length)}`;
+}
+
 function makeDirectoryEntry(
   {
     fileName,

--- a/front/lib/api/files/mount_file_ops.test.ts
+++ b/front/lib/api/files/mount_file_ops.test.ts
@@ -1,0 +1,57 @@
+import * as gcsMountFiles from "@app/lib/api/files/gcs_mount/files";
+import { moveMountFileWithinScope } from "@app/lib/api/files/mount_file_ops";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("moveMountFileWithinScope", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(gcsMountFiles, "moveFile").mockResolvedValue(new Ok(undefined));
+    vi.spyOn(FileResource, "fetchByMountFilePaths").mockResolvedValue([]);
+  });
+
+  it("returns ok without calling moveFile when source and destination are the same", async () => {
+    const { authenticator } = await createResourceTest({});
+    const conversationId = "conv_test";
+    const result = await moveMountFileWithinScope(
+      authenticator,
+      { useCase: "conversation", conversationId },
+      {
+        sourcePath: "reports/chart.png",
+        destRelativeFilePath: "reports/chart.png",
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(gcsMountFiles.moveFile).not.toHaveBeenCalled();
+    expect(FileResource.fetchByMountFilePaths).not.toHaveBeenCalled();
+  });
+
+  it("calls moveFile with the mount file path as source", async () => {
+    const { authenticator } = await createResourceTest({});
+    const workspaceId = authenticator.getNonNullableWorkspace().sId;
+    const conversationId = "conv_test";
+    const mountFilePath = `w/${workspaceId}/conversations/${conversationId}/files/reports/chart.png`;
+
+    const result = await moveMountFileWithinScope(
+      authenticator,
+      { useCase: "conversation", conversationId },
+      {
+        sourcePath: `conversation/reports/chart.png`,
+        destRelativeFilePath: "archive/chart.png",
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(gcsMountFiles.moveFile).toHaveBeenCalledWith(
+      authenticator,
+      expect.objectContaining({
+        sourceGcsPath: mountFilePath,
+        destRelativeFilePath: "archive/chart.png",
+        destFileName: "chart.png",
+      })
+    );
+  });
+});

--- a/front/lib/api/files/mount_file_ops.ts
+++ b/front/lib/api/files/mount_file_ops.ts
@@ -5,8 +5,9 @@ import {
 import {
   getConversationFilesBasePath,
   getProjectFilesBasePath,
-  joinMountRelativePath,
-  normalizeMountParentRelativePath,
+  normalizeAndValidateMountRelativeFilePath,
+  type ResolveMountFilePathError,
+  resolveMoveSourcePath,
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -48,38 +49,49 @@ function defaultDestUseCaseMetadata(scope: GCSMountPoint): FileUseCaseMetadata {
 }
 
 /**
- * Move a file within a GCS mount by its path relative to the mount root (no scope prefix).
- * Updates the linked FileResource when one exists at the source path; otherwise GCS only.
+ * Move a file within a GCS mount. Source accepts a scoped listing path
+ * (`project/foo.pdf`), a mount-relative path (`foo.pdf`), or a full GCS path (`w/...`).
+ * Destination is relative to the mount root (no scope prefix).
  */
-export async function moveMountFile(
+export async function moveMountFileWithinScope(
   auth: Authenticator,
   scope: GCSMountPoint,
   {
-    relativeFilePath,
-    parentRelativePath,
+    sourcePath,
+    destRelativeFilePath,
   }: {
-    relativeFilePath: string;
-    parentRelativePath?: string;
+    sourcePath: string;
+    destRelativeFilePath: string;
   }
-): Promise<Result<void, Error>> {
-  const parentRes = normalizeMountParentRelativePath(parentRelativePath);
-  if (parentRes.isErr()) {
-    return parentRes;
-  }
-
-  const fileName = relativeFilePath.split("/").pop();
-  if (!fileName) {
-    return new Err(new Error("Invalid file path."));
-  }
-
-  const destRelativeFilePath = joinMountRelativePath(parentRes.value, fileName);
-
+): Promise<Result<void, ResolveMountFilePathError | Error>> {
   const prefix = resolveMountPrefix(auth, scope);
-  const sourceGcsPath = `${prefix}${relativeFilePath}`;
-  const destGcsPath = `${prefix}${destRelativeFilePath}`;
 
+  const sourceRes = resolveMoveSourcePath({
+    sourcePath,
+    expectedPrefix: scope.useCase,
+    mountBasePath: prefix,
+  });
+  if (sourceRes.isErr()) {
+    return sourceRes;
+  }
+
+  const destRes =
+    normalizeAndValidateMountRelativeFilePath(destRelativeFilePath);
+  if (destRes.isErr()) {
+    return destRes;
+  }
+
+  const sourceGcsPath = sourceRes.value.normalizedMountFilePath;
+  const dest = destRes.value;
+
+  const destGcsPath = `${prefix}${dest}`;
   if (sourceGcsPath === destGcsPath) {
     return new Ok(undefined);
+  }
+
+  const destFileName = dest.split("/").pop();
+  if (!destFileName) {
+    return new Err(new Error("Invalid destination file path."));
   }
 
   const fileResources = await FileResource.fetchByMountFilePaths(auth, [
@@ -91,8 +103,8 @@ export async function moveMountFile(
     file,
     sourceGcsPath,
     destScope: scope,
-    destRelativeFilePath,
-    destFileName: fileName,
+    destRelativeFilePath: dest,
+    destFileName,
     destUseCase: file?.useCase ?? defaultDestUseCase(scope),
     destUseCaseMetadata:
       file?.useCaseMetadata ?? defaultDestUseCaseMetadata(scope),

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -5,9 +5,15 @@ import {
   getConversationFilesBasePath,
   getProjectFilesBasePath,
   makeProcessedMountFileName,
+  normalizeAndValidateMountRelativeFilePath,
   normalizeMountParentRelativePath,
   parseProcessedFilename,
   parseScopedFilePath,
+  ResolveScopedMountFilePathError,
+  resolveMountFilePath,
+  resolveMountFileSourcePath,
+  resolveMoveSourcePath,
+  resolveScopedMountFilePath,
   validateMountFolderName,
 } from "@app/lib/api/files/mount_path";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -197,6 +203,185 @@ describe("mount_path helpers", () => {
       expect(validateMountFolderName("").isErr()).toBe(true);
       expect(validateMountFolderName("a/b").isErr()).toBe(true);
       expect(validateMountFolderName("..").isErr()).toBe(true);
+    });
+  });
+
+  describe("resolveScopedMountFilePath", () => {
+    const mountBasePath = "w/ws123/projects/proj456/files/";
+
+    it("rejects invalid scope prefix", () => {
+      const result = resolveScopedMountFilePath({
+        relPath: "conversation/file.txt",
+        expectedPrefix: "project",
+        mountBasePath,
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(
+          ResolveScopedMountFilePathError.isResolveScopedMountFilePathError(
+            result.error
+          )
+        ).toBe(true);
+        if (
+          ResolveScopedMountFilePathError.isResolveScopedMountFilePathError(
+            result.error
+          )
+        ) {
+          expect(result.error.code).toBe("invalid_prefix");
+        }
+      }
+    });
+
+    it("rejects path traversal", () => {
+      const result = resolveScopedMountFilePath({
+        relPath: "project/../other/file.txt",
+        expectedPrefix: "project",
+        mountBasePath,
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(
+          ResolveScopedMountFilePathError.isResolveScopedMountFilePathError(
+            result.error
+          )
+        ).toBe(true);
+        if (
+          ResolveScopedMountFilePathError.isResolveScopedMountFilePathError(
+            result.error
+          )
+        ) {
+          expect(result.error.code).toBe("outside_scope");
+        }
+      }
+    });
+
+    it("returns normalized relative and GCS paths", () => {
+      const result = resolveScopedMountFilePath({
+        relPath: "project/reports/../reports/file.txt",
+        expectedPrefix: "project",
+        mountBasePath,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.normalizedRelative).toBe("reports/file.txt");
+        expect(result.value.normalizedGcsPath).toBe(
+          `${mountBasePath}reports/file.txt`
+        );
+      }
+    });
+  });
+
+  describe("resolveMoveSourcePath", () => {
+    const mountBasePath = "w/ws123/projects/proj1/files/";
+
+    it("resolves a scoped listing path", () => {
+      const result = resolveMoveSourcePath({
+        sourcePath: "project/reports/report_fil_abc.pdf",
+        expectedPrefix: "project",
+        mountBasePath,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.normalizedMountFilePath).toBe(
+          `${mountBasePath}reports/report_fil_abc.pdf`
+        );
+      }
+    });
+
+    it("resolves a mount-relative path", () => {
+      const result = resolveMoveSourcePath({
+        sourcePath: "reports/file.txt",
+        expectedPrefix: "project",
+        mountBasePath,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.normalizedMountFilePath).toBe(
+          `${mountBasePath}reports/file.txt`
+        );
+      }
+    });
+
+    it("rejects a scoped path with the wrong prefix", () => {
+      const result = resolveMoveSourcePath({
+        sourcePath: "conversation/file.txt",
+        expectedPrefix: "project",
+        mountBasePath,
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("invalid_path");
+      }
+    });
+  });
+
+  describe("resolveMountFileSourcePath", () => {
+    const mountBasePath = "w/ws123/conversations/conv1/files/";
+
+    it("resolves a mount-relative path", () => {
+      const result = resolveMountFileSourcePath({
+        sourcePath: "reports/file.txt",
+        mountBasePath,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.normalizedMountFilePath).toBe(
+          `${mountBasePath}reports/file.txt`
+        );
+      }
+    });
+  });
+
+  describe("resolveMountFilePath", () => {
+    const mountBasePath = "w/ws123/conversations/conv1/files/";
+
+    it("rejects path traversal", () => {
+      const result = resolveMountFilePath({
+        mountFilePath: `${mountBasePath}../other/file.txt`,
+        mountBasePath,
+      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("outside_scope");
+      }
+    });
+
+    it("returns the normalized mount file path", () => {
+      const result = resolveMountFilePath({
+        mountFilePath: `${mountBasePath}reports/../reports/file.txt`,
+        mountBasePath,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.normalizedMountFilePath).toBe(
+          `${mountBasePath}reports/file.txt`
+        );
+      }
+    });
+  });
+
+  describe("normalizeAndValidateMountRelativeFilePath", () => {
+    it("rejects empty paths", () => {
+      expect(normalizeAndValidateMountRelativeFilePath("").isErr()).toBe(true);
+      expect(normalizeAndValidateMountRelativeFilePath("  ").isErr()).toBe(
+        true
+      );
+    });
+
+    it("rejects path traversal", () => {
+      expect(
+        normalizeAndValidateMountRelativeFilePath("../evil.txt").isErr()
+      ).toBe(true);
+    });
+
+    it("normalizes nested file paths", () => {
+      const result = normalizeAndValidateMountRelativeFilePath(
+        "/archive/report.pdf"
+      );
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("archive/report.pdf");
+      }
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -171,6 +171,213 @@ export function parseScopedFilePath(filePath: string): ScopedFilePath | null {
   return { prefix: prefixResult.data, rel: filePath.slice(slashIdx + 1) };
 }
 
+export class ResolveScopedMountFilePathError extends Error {
+  constructor(
+    readonly code: "invalid_prefix" | "outside_scope",
+    message: string
+  ) {
+    super(message);
+    this.name = "ResolveScopedMountFilePathError";
+  }
+
+  static isResolveScopedMountFilePathError(
+    error: unknown
+  ): error is ResolveScopedMountFilePathError {
+    return error instanceof ResolveScopedMountFilePathError;
+  }
+}
+
+/**
+ * Parse a scoped rel path, normalize it under `mountBasePath`, and reject traversal.
+ */
+export function resolveScopedMountFilePath({
+  relPath,
+  expectedPrefix,
+  mountBasePath,
+  outsideScopeMessage = "Access denied: path is outside mount scope.",
+}: {
+  relPath: string;
+  expectedPrefix: ScopedFilePathPrefix;
+  mountBasePath: string;
+  outsideScopeMessage?: string;
+}): Result<
+  { normalizedRelative: string; normalizedGcsPath: string },
+  ResolveScopedMountFilePathError
+> {
+  const scopedPath = parseScopedFilePath(relPath);
+  if (!scopedPath || scopedPath.prefix !== expectedPrefix) {
+    return new Err(
+      new ResolveScopedMountFilePathError(
+        "invalid_prefix",
+        "Path must start with the correct scope prefix."
+      )
+    );
+  }
+
+  const normalizedGcsPath = path.posix.normalize(
+    `${mountBasePath}${scopedPath.rel}`
+  );
+  if (!normalizedGcsPath.startsWith(mountBasePath)) {
+    return new Err(
+      new ResolveScopedMountFilePathError("outside_scope", outsideScopeMessage)
+    );
+  }
+
+  return new Ok({
+    normalizedRelative: normalizedGcsPath.slice(mountBasePath.length),
+    normalizedGcsPath,
+  });
+}
+
+export type ResolveMountFilePathError = {
+  code: "invalid_path" | "outside_scope";
+  message: string;
+};
+
+export function isResolveMountFilePathError(
+  error: unknown
+): error is ResolveMountFilePathError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error.code === "invalid_path" || error.code === "outside_scope")
+  );
+}
+
+/**
+ * Validate a full GCS mount file path (as stored on `FileResource.mountFilePath`)
+ * and ensure it lies under `mountBasePath`.
+ */
+export function resolveMountFilePath({
+  mountFilePath,
+  mountBasePath,
+  outsideScopeMessage = "Access denied: path is outside mount scope.",
+}: {
+  mountFilePath: string;
+  mountBasePath: string;
+  outsideScopeMessage?: string;
+}): Result<{ normalizedMountFilePath: string }, ResolveMountFilePathError> {
+  const normalizedMountFilePath = path.posix.normalize(
+    mountFilePath.trim().replace(/^\/+/, "")
+  );
+  if (!normalizedMountFilePath.startsWith(mountBasePath)) {
+    return new Err({
+      code: "outside_scope",
+      message: outsideScopeMessage,
+    });
+  }
+
+  const mountRelative = normalizedMountFilePath.slice(mountBasePath.length);
+  const validated = normalizeAndValidateMountRelativeFilePath(mountRelative);
+  if (validated.isErr()) {
+    return new Err({
+      code: "invalid_path",
+      message: validated.error.message,
+    });
+  }
+
+  return new Ok({ normalizedMountFilePath });
+}
+
+/**
+ * Resolve a move source path: scoped listing path (`project/foo.pdf`),
+ * mount-relative path (`foo.pdf`), or full GCS path (`w/...`).
+ */
+export function resolveMoveSourcePath({
+  sourcePath,
+  expectedPrefix,
+  mountBasePath,
+  outsideScopeMessage = "Access denied: path is outside mount scope.",
+}: {
+  sourcePath: string;
+  expectedPrefix: ScopedFilePathPrefix;
+  mountBasePath: string;
+  outsideScopeMessage?: string;
+}): Result<{ normalizedMountFilePath: string }, ResolveMountFilePathError> {
+  const trimmed = sourcePath.trim().replace(/^\/+/, "");
+
+  const scoped = parseScopedFilePath(trimmed);
+  if (scoped) {
+    if (scoped.prefix !== expectedPrefix) {
+      return new Err({
+        code: "invalid_path",
+        message: "Path must start with the correct scope prefix.",
+      });
+    }
+
+    const relativeRes = normalizeAndValidateMountRelativeFilePath(scoped.rel);
+    if (relativeRes.isErr()) {
+      return new Err({
+        code: "invalid_path",
+        message: relativeRes.error.message,
+      });
+    }
+
+    const normalizedMountFilePath = path.posix.normalize(
+      `${mountBasePath}${relativeRes.value}`
+    );
+    if (!normalizedMountFilePath.startsWith(mountBasePath)) {
+      return new Err({
+        code: "outside_scope",
+        message: outsideScopeMessage,
+      });
+    }
+
+    return new Ok({ normalizedMountFilePath });
+  }
+
+  if (trimmed.startsWith("w/")) {
+    return resolveMountFilePath({
+      mountFilePath: trimmed,
+      mountBasePath,
+      outsideScopeMessage,
+    });
+  }
+
+  return resolveMountFileSourcePath({
+    sourcePath: trimmed,
+    mountBasePath,
+    outsideScopeMessage,
+  });
+}
+
+/**
+ * Resolve a move source path relative to the mount root (no scope prefix).
+ * Returns the normalized mount file path or an error if the path is invalid.
+ */
+export function resolveMountFileSourcePath({
+  sourcePath,
+  mountBasePath,
+  outsideScopeMessage = "Access denied: path is outside mount scope.",
+}: {
+  sourcePath: string;
+  mountBasePath: string;
+  outsideScopeMessage?: string;
+}): Result<{ normalizedMountFilePath: string }, ResolveMountFilePathError> {
+  const trimmed = sourcePath.trim().replace(/^\/+/, "");
+
+  const relativeRes = normalizeAndValidateMountRelativeFilePath(trimmed);
+  if (relativeRes.isErr()) {
+    return new Err({
+      code: "invalid_path",
+      message: relativeRes.error.message,
+    });
+  }
+
+  const normalizedMountFilePath = path.posix.normalize(
+    `${mountBasePath}${relativeRes.value}`
+  );
+  if (!normalizedMountFilePath.startsWith(mountBasePath)) {
+    return new Err({
+      code: "outside_scope",
+      message: outsideScopeMessage,
+    });
+  }
+
+  return new Ok({ normalizedMountFilePath });
+}
+
 /**
  * Disambiguate a filename by inserting the file's sId before the extension.
  * "report.pdf" + "fil_abc" → "report_fil_abc.pdf"
@@ -236,6 +443,37 @@ export function normalizeMountParentRelativePath(
     normalized.split("/").some((part) => part === "..")
   ) {
     return new Err(new Error("parentRelativePath is outside mount scope."));
+  }
+
+  return new Ok(normalized);
+}
+
+/**
+ * Normalize and validate a file path within a mount (no scope prefix).
+ */
+export function normalizeAndValidateMountRelativeFilePath(
+  relativeFilePath: string
+): Result<string, Error> {
+  const trimmed = relativeFilePath.trim();
+  if (trimmed === "") {
+    return new Err(new Error("relativeFilePath is required."));
+  }
+
+  const normalized = path.posix.normalize(trimmed.replace(/^\/+/, ""));
+  if (normalized === "." || normalized === "") {
+    return new Err(new Error("Invalid file path."));
+  }
+
+  if (
+    normalized.startsWith("..") ||
+    normalized.split("/").some((part) => part === "..")
+  ) {
+    return new Err(new Error("relativeFilePath is outside mount scope."));
+  }
+
+  const fileName = normalized.split("/").pop();
+  if (!fileName) {
+    return new Err(new Error("Invalid file path."));
   }
 
   return new Ok(normalized);

--- a/front/lib/api/files/mount_schemas.ts
+++ b/front/lib/api/files/mount_schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
 
 export const MoveMountFileRequestBodySchema = z.object({
-  parentRelativePath: z.string().optional(),
+  destRelativeFilePath: z.string().min(1),
 });

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -12,7 +12,8 @@ import {
   moveFile,
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
-import { moveMountFile } from "@app/lib/api/files/mount_file_ops";
+import { moveMountFileWithinScope } from "@app/lib/api/files/mount_file_ops";
+import type { ResolveMountFilePathError } from "@app/lib/api/files/mount_path";
 import {
   getProjectFilesBasePath,
   joinMountRelativePath,
@@ -519,14 +520,14 @@ export async function moveProjectFile(
   auth: Authenticator,
   {
     space,
-    relativeFilePath,
-    parentRelativePath,
+    sourcePath,
+    destRelativeFilePath,
   }: {
     space: SpaceResource;
-    relativeFilePath: string;
-    parentRelativePath?: string;
+    sourcePath: string;
+    destRelativeFilePath: string;
   }
-): Promise<Result<void, DustError | Error>> {
+): Promise<Result<void, DustError | ResolveMountFilePathError | Error>> {
   if (!space.isProject()) {
     return new Err({
       name: "dust_error",
@@ -535,10 +536,10 @@ export async function moveProjectFile(
     });
   }
 
-  return moveMountFile(
+  return moveMountFileWithinScope(
     auth,
     { useCase: "project", projectId: space.sId },
-    { relativeFilePath, parentRelativePath }
+    { sourcePath, destRelativeFilePath }
   );
 }
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -10,6 +10,7 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
+import { getScopedPathFromGCSPath } from "@app/lib/api/files/gcs_mount/files";
 import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import {
   PASTED_CONTENT_MAX_CHARACTERS,
@@ -93,16 +94,11 @@ function getConversationFilePath({
     return null;
   }
 
-  const prefix = getConversationFilesBasePath({
-    workspaceId,
-    conversationId,
+  return getScopedPathFromGCSPath({
+    prefix: getConversationFilesBasePath({ workspaceId, conversationId }),
+    gcsPath: mountFilePath,
+    useCase: "conversation",
   });
-
-  if (!mountFilePath.startsWith(prefix)) {
-    return null;
-  }
-
-  return `conversation/${mountFilePath.slice(prefix.length)}`;
 }
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.

--- a/front/lib/swr/mount_files.ts
+++ b/front/lib/swr/mount_files.ts
@@ -5,6 +5,10 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
+function sourcePathToUrlPath(sourcePath: string): string {
+  return sourcePath.split("/").map(encodeURIComponent).join("/");
+}
+
 /**
  * Move a file within a GCS mount listing API.
  *
@@ -19,21 +23,22 @@ export function useMoveMountFile({
   const sendNotification = useSendNotification();
 
   return async ({
-    scopedPath,
-    parentRelativePath,
+    relativeFilePath,
+    destRelativeFilePath,
   }: {
-    /** Scoped mount path, e.g. `project/reports/q1/file.pdf`. */
-    scopedPath: string;
-    parentRelativePath?: string;
+    /** Source path relative to the mount root (no scope prefix). */
+    relativeFilePath: string;
+    destRelativeFilePath: string;
   }): Promise<Result<void, Error>> => {
     try {
-      const res = await clientFetch(`${filesApiBasePath}/${scopedPath}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...(parentRelativePath ? { parentRelativePath } : {}),
-        }),
-      });
+      const res = await clientFetch(
+        `${filesApiBasePath}/${sourcePathToUrlPath(relativeFilePath)}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ destRelativeFilePath }),
+        }
+      );
 
       if (!res.ok) {
         const errorData = await getErrorFromResponse(res);

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -817,6 +817,10 @@
  *           type: string
  *         publicUrl:
  *           type: string
+ *         path:
+ *           type: string
+ *           nullable: true
+ *           description: path when the file is ready on a mount (e.g. `project/report.pdf` or `conversation/chart.png`). Same shape as mount file listing entries.
  *     PrivateSpace:
  *       type: object
  *       description: A space in the workspace.

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -1,9 +1,10 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { moveMountFile } from "@app/lib/api/files/mount_file_ops";
+import { moveMountFileWithinScope } from "@app/lib/api/files/mount_file_ops";
 import {
   getConversationFilesBasePath,
-  parseScopedFilePath,
+  isResolveMountFilePathError,
+  resolveScopedMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import { MoveMountFileRequestBodySchema } from "@app/lib/api/files/mount_schemas";
 import type { Authenticator } from "@app/lib/auth";
@@ -12,9 +13,9 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-import path from "path";
 import { fromError } from "zod-validation-error";
 
 export type ConversationFileRelResponseBody = Record<string, never>;
@@ -47,38 +48,36 @@ async function handler(
   }
 
   const owner = auth.getNonNullableWorkspace();
-
-  const scopedPath = parseScopedFilePath(rel.join("/"));
-  if (!scopedPath || scopedPath.prefix !== "conversation") {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Path must start with the scope prefix `conversation/`.",
-      },
-    });
-  }
-
-  const basePath = getConversationFilesBasePath({
+  const mountBasePath = getConversationFilesBasePath({
     workspaceId: owner.sId,
     conversationId: cId,
   });
-  const normalizedGcsPath = path.posix.normalize(
-    `${basePath}${scopedPath.rel}`
-  );
-  if (!normalizedGcsPath.startsWith(basePath)) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Access denied: path is outside conversation scope.",
-      },
-    });
-  }
-  const normalizedRelative = scopedPath.rel;
+  const relPath = rel.join("/");
 
   switch (req.method) {
     case "GET": {
+      const pathRes = resolveScopedMountFilePath({
+        relPath,
+        expectedPrefix: "conversation",
+        mountBasePath,
+        outsideScopeMessage:
+          "Access denied: path is outside conversation scope.",
+      });
+      if (pathRes.isErr()) {
+        const { code, message } = pathRes.error;
+        return apiError(req, res, {
+          status_code: code === "outside_scope" ? 403 : 400,
+          api_error: {
+            type:
+              code === "outside_scope"
+                ? "workspace_auth_error"
+                : "invalid_request_error",
+            message,
+          },
+        });
+      }
+      const { normalizedGcsPath } = pathRes.value;
+
       const bucket = getPrivateUploadBucket();
       const contentTypeResult =
         await bucket.getFileContentType(normalizedGcsPath);
@@ -119,20 +118,33 @@ async function handler(
         });
       }
 
-      const moveResult = await moveMountFile(
+      const moveResult = await moveMountFileWithinScope(
         auth,
         { useCase: "conversation", conversationId: cId },
         {
-          relativeFilePath: normalizedRelative,
-          parentRelativePath: bodyValidation.data.parentRelativePath,
+          sourcePath: relPath,
+          destRelativeFilePath: bodyValidation.data.destRelativeFilePath,
         }
       );
       if (moveResult.isErr()) {
+        if (isResolveMountFilePathError(moveResult.error)) {
+          const { code, message } = moveResult.error;
+          return apiError(req, res, {
+            status_code: code === "outside_scope" ? 403 : 400,
+            api_error: {
+              type:
+                code === "outside_scope"
+                  ? "workspace_auth_error"
+                  : "invalid_request_error",
+              message,
+            },
+          });
+        }
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: moveResult.error.message,
+            message: normalizeError(moveResult.error).message,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files/rel.test.ts
@@ -165,24 +165,21 @@ describe("POST /api/w/[wId]/assistant/conversations/[cId]/files/[...rel] (move)"
 
   it("should move a file within the conversation mount", async () => {
     const mountFileOps = await import("@app/lib/api/files/mount_file_ops");
-    vi.spyOn(mountFileOps, "moveMountFile").mockResolvedValue(
+    vi.spyOn(mountFileOps, "moveMountFileWithinScope").mockResolvedValue(
       new Ok(undefined)
     );
 
-    const { req, res } = await setupTest(
-      ["conversation", "reports", "chart.png"],
-      "POST"
-    );
-    req.body = { parentRelativePath: "archive" };
+    const { req, res } = await setupTest(["reports", "chart.png"], "POST");
+    req.body = { destRelativeFilePath: "archive/chart.png" };
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(mountFileOps.moveMountFile).toHaveBeenCalledWith(
+    expect(mountFileOps.moveMountFileWithinScope).toHaveBeenCalledWith(
       expect.anything(),
       { useCase: "conversation", conversationId: CONVERSATION_SID },
       {
-        relativeFilePath: "reports/chart.png",
-        parentRelativePath: "archive",
+        sourcePath: "reports/chart.png",
+        destRelativeFilePath: "archive/chart.png",
       }
     );
   });

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -122,6 +122,11 @@
  */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
+import { getScopedPathFromGCSPath } from "@app/lib/api/files/gcs_mount/files";
+import {
+  getConversationFilesBasePath,
+  getProjectFilesBasePath,
+} from "@app/lib/api/files/mount_path";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
 import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import {
@@ -143,7 +148,48 @@ import { isConversationFileUseCase } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export interface FileUploadedRequestResponseBody {
-  file: FileType;
+  file: FileType & {
+    /** Scoped mount path when the file is on GCS (same shape as `GCSMountEntryBase.path`). */
+    path: string | null;
+  };
+}
+
+function resolveUploadMountScopedPath(
+  auth: Authenticator,
+  file: FileResource
+): string | null {
+  if (!file.mountFilePath) {
+    return null;
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+
+  if (file.useCase === "project_context" && file.useCaseMetadata?.spaceId) {
+    return getScopedPathFromGCSPath({
+      prefix: getProjectFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: file.useCaseMetadata.spaceId,
+      }),
+      gcsPath: file.mountFilePath,
+      useCase: "project",
+    });
+  }
+
+  if (
+    isConversationFileUseCase(file.useCase) &&
+    file.useCaseMetadata?.conversationId
+  ) {
+    return getScopedPathFromGCSPath({
+      prefix: getConversationFilesBasePath({
+        workspaceId: owner.sId,
+        conversationId: file.useCaseMetadata.conversationId,
+      }),
+      gcsPath: file.mountFilePath,
+      useCase: "conversation",
+    });
+  }
+
+  return null;
 }
 
 export const config = {
@@ -507,7 +553,12 @@ async function handler(
         }
       }
 
-      return res.status(200).json({ file: file.toJSON(auth) });
+      return res.status(200).json({
+        file: {
+          ...file.toJSON(auth),
+          path: resolveUploadMountScopedPath(auth, file),
+        },
+      });
     }
 
     default:

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -3,7 +3,8 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   getProjectFilesBasePath,
-  parseScopedFilePath,
+  isResolveMountFilePathError,
+  resolveScopedMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import { MoveMountFileRequestBodySchema } from "@app/lib/api/files/mount_schemas";
 import {
@@ -18,9 +19,9 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-import path from "path";
 import { fromError } from "zod-validation-error";
 
 export type ProjectFileRelResponseBody = Record<string, never>;
@@ -52,39 +53,38 @@ async function handler(
     });
   }
 
-  const scopedPath = parseScopedFilePath(rel.join("/"));
-  if (!scopedPath || scopedPath.prefix !== "project") {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Path must start with the scope prefix `project/`.",
-      },
-    });
-  }
-
   const owner = auth.getNonNullableWorkspace();
-  const basePath = getProjectFilesBasePath({
+  const mountBasePath = getProjectFilesBasePath({
     workspaceId: owner.sId,
     projectId: space.sId,
   });
-  const normalizedGcsPath = path.posix.normalize(
-    `${basePath}${scopedPath.rel}`
-  );
-  if (!normalizedGcsPath.startsWith(basePath)) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Access denied: path is outside project scope.",
-      },
+  const relPath = rel.join("/");
+
+  const resolveScopedPath = () =>
+    resolveScopedMountFilePath({
+      relPath,
+      expectedPrefix: "project",
+      mountBasePath,
+      outsideScopeMessage: "Access denied: path is outside project scope.",
     });
-  }
-  const normalizedRelative = scopedPath.rel;
 
   switch (req.method) {
     case "GET": {
-      const gcsPath = normalizedGcsPath;
+      const pathRes = resolveScopedPath();
+      if (pathRes.isErr()) {
+        const { code, message } = pathRes.error;
+        return apiError(req, res, {
+          status_code: code === "outside_scope" ? 403 : 400,
+          api_error: {
+            type:
+              code === "outside_scope"
+                ? "workspace_auth_error"
+                : "invalid_request_error",
+            message,
+          },
+        });
+      }
+      const gcsPath = pathRes.value.normalizedGcsPath;
 
       const bucket = getPrivateUploadBucket();
       const contentTypeResult = await bucket.getFileContentType(gcsPath);
@@ -120,6 +120,22 @@ async function handler(
           },
         });
       }
+
+      const pathRes = resolveScopedPath();
+      if (pathRes.isErr()) {
+        const { code, message } = pathRes.error;
+        return apiError(req, res, {
+          status_code: code === "outside_scope" ? 403 : 400,
+          api_error: {
+            type:
+              code === "outside_scope"
+                ? "workspace_auth_error"
+                : "invalid_request_error",
+            message,
+          },
+        });
+      }
+      const { normalizedRelative } = pathRes.value;
 
       const { fileName } = req.body;
       if (
@@ -167,6 +183,22 @@ async function handler(
         });
       }
 
+      const pathRes = resolveScopedPath();
+      if (pathRes.isErr()) {
+        const { code, message } = pathRes.error;
+        return apiError(req, res, {
+          status_code: code === "outside_scope" ? 403 : 400,
+          api_error: {
+            type:
+              code === "outside_scope"
+                ? "workspace_auth_error"
+                : "invalid_request_error",
+            message,
+          },
+        });
+      }
+      const { normalizedRelative } = pathRes.value;
+
       const deleteResult = await deleteProjectFile(auth, {
         space,
         relativeFilePath: normalizedRelative,
@@ -208,15 +240,28 @@ async function handler(
 
       const moveResult = await moveProjectFile(auth, {
         space,
-        relativeFilePath: normalizedRelative,
-        parentRelativePath: bodyValidation.data.parentRelativePath,
+        sourcePath: relPath,
+        destRelativeFilePath: bodyValidation.data.destRelativeFilePath,
       });
       if (moveResult.isErr()) {
+        if (isResolveMountFilePathError(moveResult.error)) {
+          const { code, message } = moveResult.error;
+          return apiError(req, res, {
+            status_code: code === "outside_scope" ? 403 : 400,
+            api_error: {
+              type:
+                code === "outside_scope"
+                  ? "workspace_auth_error"
+                  : "invalid_request_error",
+              message,
+            },
+          });
+        }
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: moveResult.error.message,
+            message: normalizeError(moveResult.error).message,
           },
         });
       }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -83,7 +83,7 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
       const { req, res } = await makeProjectRequest("GET", ["report.pdf"]);
       await handler(req, res);
       expect(res._getStatusCode()).toBe(400);
-      expect(res._getJSONData().error.message).toMatch(/project\//);
+      expect(res._getJSONData().error.message).toMatch(/scope prefix/i);
     });
 
     it("returns 403 for path traversal attempts", async () => {
@@ -275,8 +275,8 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
     it("returns 200 and calls moveProjectFile with the right args", async () => {
       const { req, res, project } = await makeProjectRequest(
         "POST",
-        ["project", "reports", "file.txt"],
-        { body: { parentRelativePath: "archive" } }
+        ["reports", "file.txt"],
+        { body: { destRelativeFilePath: "archive/file.txt" } }
       );
       await handler(req, res);
       expect(res._getStatusCode()).toBe(200);
@@ -284,8 +284,8 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
         expect.anything(),
         {
           space: expect.objectContaining({ sId: project.sId }),
-          relativeFilePath: "reports/file.txt",
-          parentRelativePath: "archive",
+          sourcePath: "reports/file.txt",
+          destRelativeFilePath: "archive/file.txt",
         }
       );
     });
@@ -294,11 +294,9 @@ describe("/api/w/[wId]/spaces/[spaceId]/files/[...rel]", () => {
       vi.spyOn(projectsContext, "moveProjectFile").mockResolvedValue(
         new Err(new Error("GCS error"))
       );
-      const { req, res } = await makeProjectRequest(
-        "POST",
-        ["project", "file.txt"],
-        { body: {} }
-      );
+      const { req, res } = await makeProjectRequest("POST", ["file.txt"], {
+        body: { destRelativeFilePath: "file.txt" },
+      });
       await handler(req, res);
       expect(res._getStatusCode()).toBe(500);
     });

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -11101,6 +11101,11 @@
           },
           "publicUrl": {
             "type": "string"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true,
+            "description": "path when the file is ready on a mount (e.g. `project/report.pdf` or `conversation/chart.png`). Same shape as mount file listing entries."
           }
         }
       },

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -110,7 +110,9 @@ export interface FileType {
 /**
  * @swaggerschema PrivateFileWithUploadUrl (swagger_private_schemas.ts)
  */
-export type FileTypeWithUploadUrl = FileType & { uploadUrl: string };
+export type FileTypeWithUploadUrl = FileType & {
+  uploadUrl: string;
+};
 
 export type FileTypeWithMetadata = FileType & {
   useCaseMetadata: FileUseCaseMetadata;


### PR DESCRIPTION
## Description

Centralizes file-path validation behind `resolveScopedMountFilePath`, replacing the scattered `parseScopedFilePath` + `path.posix.normalize` + prefix-check pattern across the files route and backend. The move API now accepts `destRelativeFilePath` (full destination path including filename) instead of `parentRelativePath`, removing implicit filename-joining logic from `moveProjectFile` and making callers explicit about the target location. `ConversationFileExplorer` temporarily disables move while the sandbox path is updated to match.

## Tests

New unit tests added in `mount_path.test.ts` covering `resolveScopedMountFilePath` (valid paths, invalid prefix, path traversal outside scope). Move flow manually tested in project spaces.

## Risk

Low — internal refactor with no data or storage changes. The `destRelativeFilePath` rename is a breaking change to the move endpoint schema, but all callers are updated in this PR. Safe to rollback.

## Deploy Plan

Standard deploy, no migration required.