### PR TITLE
feat: rename project mount to pod in sandbox

### DIFF
--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -1,6 +1,6 @@
 import {
   getConversationFilesBasePath,
-  getProjectFilesBasePath,
+  getPodsFilesBasePath,
 } from "@app/lib/api/files/mount_path";
 import { mintDownscopedGcsToken } from "@app/lib/api/sandbox/gcs/token";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
@@ -18,17 +18,17 @@ import { Err, Ok } from "@app/types/shared/result";
 const MOUNT_TIMEOUT_MS = 30_000;
 
 const MOUNT_POINT_CONVERSATION = "/files/conversation";
-const MOUNT_POINT_PROJECT = "/files/project";
+const MOUNT_POINT_POD = "/files/pod";
 
 interface MountTarget {
-  label: "conversation" | "project";
+  label: "conversation" | "pod";
   mountPoint: string;
   prefix: string;
 }
 
 /**
  * Compute the set of GCS prefixes / sandbox mount points for the given conversation.
- * Always includes the conversation mount. Add the project mount when the conversation belongs to a
+ * Always includes the conversation mount. Add the Pod mount when the conversation belongs to a
  * project space.
  */
 function buildMountTargets(
@@ -52,12 +52,12 @@ function buildMountTargets(
 
   if (isProjectConversation(conversation)) {
     targets.push({
-      label: "project",
-      prefix: getProjectFilesBasePath({
+      label: "pod",
+      prefix: getPodsFilesBasePath({
         workspaceId,
-        projectId: conversation.spaceId,
+        podId: conversation.spaceId,
       }).replace(/\/$/, ""),
-      mountPoint: MOUNT_POINT_PROJECT,
+      mountPoint: MOUNT_POINT_POD,
     });
   }
 
@@ -68,7 +68,7 @@ function buildMountTargets(
  * Mount GCS files into a running sandbox via gcsfuse.
  *
  * Always mounts the conversation prefix at /files/conversation. When the conversation belongs to
- * a project, also mounts the project prefix at /files/project. Both gcsfuse processes share the
+ * a Pod, also mounts the Pod prefix at /files/pod. Both gcsfuse processes share the
  * same token server on :9876, fed by a single multi-prefix downscoped token.
  *
  * The mount sequence:

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -1,6 +1,6 @@
 import {
   getConversationFilesBasePath,
-  getPodsFilesBasePath,
+  getPodFilesBasePath,
 } from "@app/lib/api/files/mount_path";
 import { mintDownscopedGcsToken } from "@app/lib/api/sandbox/gcs/token";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
@@ -53,7 +53,7 @@ function buildMountTargets(
   if (isProjectConversation(conversation)) {
     targets.push({
       label: "pod",
-      prefix: getPodsFilesBasePath({
+      prefix: getPodFilesBasePath({
         workspaceId,
         podId: conversation.spaceId,
       }).replace(/\/$/, ""),

--- a/front/lib/api/sandbox/gcs/token.test.ts
+++ b/front/lib/api/sandbox/gcs/token.test.ts
@@ -148,7 +148,7 @@ describe("buildAccessBoundaryRules", () => {
   it("scales linearly with the number of prefixes", () => {
     const rules = buildAccessBoundaryRules("bucket-x", [
       "w/ws1/conversations/c1/files",
-      "w/ws1/projects/spc1/files",
+      "w/ws1/pods/spc1/files",
     ]);
     expect(rules).toHaveLength(5);
   });
@@ -162,10 +162,7 @@ describe("buildAccessBoundaryRules", () => {
   });
 
   it("references every prefix in list and resource.name conditions", () => {
-    const prefixes = [
-      "w/ws1/conversations/c1/files",
-      "w/ws1/projects/spc1/files",
-    ];
+    const prefixes = ["w/ws1/conversations/c1/files", "w/ws1/pods/spc1/files"];
     const rules = buildAccessBoundaryRules("bucket-x", prefixes);
 
     const listRules = rules.filter((r) =>

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -72,7 +72,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.30",
+      tag: "0.8.31",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.30";
+const DUST_BASE_IMAGE_VERSION = "0.8.31";
 const DSBX_CLI_VERSION = "0.1.23";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -170,10 +170,10 @@ function getAgentProxiedSetupCommand(): string {
   return [
     "install -d -o agent -g agent -m 2775 /home/agent/.local /home/agent/.local/bin",
     `useradd --create-home --uid ${AGENT_PROXIED_UID} --gid agent --shell /bin/bash agent-proxied`,
-    "chgrp agent /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
-    "chmod g+ws /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
-    "setfacl -R -d -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
-    "setfacl -R -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
+    "chgrp agent /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/pod",
+    "chmod g+ws /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/pod",
+    "setfacl -R -d -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/pod",
+    "setfacl -R -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/pod",
   ].join(" && ");
 }
 
@@ -241,12 +241,12 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
 )
   // Create agent user first so e2b creates /home/agent with correct ownership.
   .setUser("agent")
-  // Conversation + project files bootstrap.
-  // Pre-create mount directories for faster GCS mounts. `/files/project` is only mounted when the
-  // conversation belongs to a project; the directory always exists in the image so the path is
+  // Conversation + Pod files bootstrap.
+  // Pre-create mount directories for faster GCS mounts. `/files/pod` is only mounted when the
+  // conversation belongs to a Pod; the directory always exists in the image so the path is
   // predictable for the agent prompt.
   .runCmd(
-    "mkdir -p /files/conversation /files/project && chmod 777 /files/conversation /files/project",
+    "mkdir -p /files/conversation /files/pod && chmod 777 /files/conversation /files/pod",
     {
       user: "root",
     }
@@ -269,9 +269,9 @@ SHELLEOF`,
   .runCmd("chmod 755 /home/agent/.bin/token-server.sh", { user: "root" })
   .runCmd(getEgressResolverUserSetupCommand(), { user: "root" })
   // Add sentinel file to indicate when the conversation mount is pending. We intentionally do
-  // NOT add an equivalent marker under /files/project: the project mount is conditional (only
-  // happens for project conversations), so a baked marker would be misleading in non-project
-  // conversations where no mount ever lands.
+  // NOT add an equivalent marker under /files/pod: the Pod mount is conditional (only happens
+  // for Pod conversations), so a baked marker would be misleading in non-Pod conversations where
+  // no mount ever lands.
   .runCmd("touch /files/conversation/.mount-pending", { user: "root" })
   // Hidden tools: installed but not in manifest (back profile functions)
   .runCmd("apt-get update && apt-get install -y ripgrep fd-find sd", {

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -99,7 +99,7 @@ function buildProjectFilesSection(): string {
   return `#### Sandbox Project File System
 
 This conversation belongs to a Pod, so the Pod's file system is also
-mounted read-write inside the sandbox at \`/files/project\`. These files are
+mounted read-write inside the sandbox at \`/files/pod\`. These files are
 shared across every conversation in the same Pod and **persist beyond
 this conversation** — anything you write or delete here is visible to other
 conversations in the same Pod.
@@ -107,12 +107,12 @@ conversations in the same Pod.
 Use this surface for files that belong to the Pod as a whole (specs,
 knowledge bases, shared scripts, recurring data sets), and use
 \`/files/conversation\` for ephemeral or per-conversation artifacts. When
-both are relevant, prefer reading from \`/files/project\` and writing
+both are relevant, prefer reading from \`/files/pod\` and writing
 deliverables to \`/files/conversation\` unless the user has asked you to
 update the Pod's files specifically.
 
 The same files are also exposed by the \`files\` MCP server under scoped
-paths like \`project/<rel>\`. Sandbox writes and MCP writes are two views on
+paths like \`pod/<rel>\`. Sandbox writes and MCP writes are two views on
 the same underlying storage.`;
 }
 

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -226,7 +226,7 @@ async function checkBasicSandboxFunctionality(
 set -euo pipefail
 echo "shell-ok"
 /opt/bin/dsbx version >/dev/null
-for dir in /files/conversation /files/project; do
+for dir in /files/conversation /files/pod; do
   test -d "$dir"
   proof="$dir/dust-security-smoke-$$"
   printf 'file-ok' > "$proof"


### PR DESCRIPTION
## Description

This PR renames all `project` references to `pod` in the sandbox layer, aligning the sandbox mount path terminology with the pods path migration introduced in previous PRs.

- Renames the GCS mount point from `/files/project` to `/files/pod` and switches from `getProjectFilesBasePath` to `getPodsFilesBasePath` in `mount.ts`
- Updates the sandbox image registry to pre-create `/files/pod` instead of `/files/project` and adjusts permissions accordingly in `registry.ts`
- Updates the skill instructions to reference `/files/pod` instead of `/files/project` in `sandbox.ts`
- Updates GCS token tests to use the pods path prefix

## Tests


## Risks

## Deploy Plan
Deploy after the gcs migration has been completed
