### PR TITLE
feat(sdk): add gemini-3.5-flash to KnownModelLLMId

### DIFF
--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -72,6 +72,7 @@ type KnownModelLLMId =
   | "gemini-3-pro-preview"
   | "gemini-3.1-pro-preview"
   | "gemini-3-flash-preview"
+  | "gemini-3.5-flash"
   | "meta-llama/Llama-3.3-70B-Instruct-Turbo" // togetherai
   | "Qwen/Qwen2.5-Coder-32B-Instruct" // togetherai
   | "Qwen/QwQ-32B-Preview" // togetherai


### PR DESCRIPTION
## Description

Adds \`gemini-3.5-flash\` to \`KnownModelLLMId\` in the public SDK. Backend support for the model landed in #25823 but the SDK enum was missed, so saving an agent on Gemini 3.5 Flash failed Zod validation with "Invalid enum value".

Union widening only, no breaking change for external SDK consumers.

Follow up of #25823. Fixes dust-tt/tasks#8200.

## Tests

None beyond CI. Schema-only change.

## Risk

Low. Append-only enum addition.

## Deploy Plan

Standard deploy. SDK consumers pick up the new value on next bump.