### PR TITLE
Use typed responses in Hono handlers

### DIFF
--- a/front-api/middleware/utils.ts
+++ b/front-api/middleware/utils.ts
@@ -1,9 +1,19 @@
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
-import type { APIErrorWithStatusCode } from "@app/types/error";
-import type { Context } from "hono";
+import type {
+  APIErrorResponse,
+  APIErrorWithStatusCode,
+} from "@app/types/error";
+import type { Context, TypedResponse } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
+
+/**
+ * Return type for a Hono JSON handler. Wraps the success body type with the
+ * shared API error envelope so `ctx.json(...)` success returns and
+ * `apiError(...)` returns are both assignable.
+ */
+export type HandlerResult<T> = Promise<TypedResponse<T | APIErrorResponse>>;
 
 /**
  * Returns a JSON error response from an `APIErrorWithStatusCode` and emits

--- a/front-api/routes/v1/w/[wId]/spaces.ts
+++ b/front-api/routes/v1/w/[wId]/spaces.ts
@@ -1,5 +1,6 @@
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { SpaceType } from "@app/types/space";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type GetPublicSpacesResponseBody = {
@@ -10,16 +11,15 @@ export type GetPublicSpacesResponseBody = {
 // v1 workspace sub-app, so ctx.get("auth") is always available here.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetPublicSpacesResponseBody> => {
   const auth = ctx.get("auth");
 
   const allSpaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
   const spaces = allSpaces.filter((space) => space.kind !== "conversations");
 
-  const body: GetPublicSpacesResponseBody = {
+  return ctx.json({
     spaces: spaces.map((space) => space.toJSON()),
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
@@ -3,6 +3,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ProjectListItemType } from "@app/types/space";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 import spaceId from "./[spaceId]";
@@ -37,7 +38,7 @@ export function sortSpacesSummary<T extends { id: number }>(
 // Mounted under /api/w/:wId/assistant/conversations/spaces.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetBySpacesSummaryResponseBody> => {
   const auth = ctx.get("auth");
 
   const { nonArchivedSpaces, metadataMap } =
@@ -101,7 +102,7 @@ app.get("/", async (ctx) => {
   const filteredSpaces = nonArchivedSpaces.filter(
     (space) => space.kind === "project" || conversationsBySpace.has(space.id)
   );
-  const response: GetBySpacesSummaryResponseBody = {
+  return ctx.json({
     summary: sortSpacesSummary(
       filteredSpaces,
       conversationsBySpace,
@@ -121,9 +122,7 @@ app.get("/", async (ctx) => {
         conversationsBySpace.get(space.id)?.nonParticipantUnreadConversations ??
         [],
     })),
-  };
-
-  return ctx.json(response);
+  });
 });
 
 app.route("/:spaceId", spaceId);

--- a/front-api/routes/w/[wId]/assistant/skills/[sId]/suggestions.ts
+++ b/front-api/routes/w/[wId]/assistant/skills/[sId]/suggestions.ts
@@ -3,6 +3,7 @@ import { hasReinforcementEnabled } from "@app/lib/reinforcement/workspace_check"
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import { SkillSuggestionSchema } from "@app/types/suggestions/skill_suggestion";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -51,7 +52,7 @@ export type PatchSkillSuggestionResponseBody = z.infer<
 // middleware, which also enforces canWrite.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetSkillSuggestionsResponseBody> => {
   const auth = ctx.get("auth");
   const skill = ctx.get("skill");
 
@@ -107,7 +108,7 @@ app.get("/", async (ctx) => {
 app.patch(
   "/",
   validate("json", PatchSkillSuggestionRequestBodySchema),
-  async (ctx) => {
+  async (ctx): HandlerResult<PatchSkillSuggestionResponseBody> => {
     const auth = ctx.get("auth");
     const skill = ctx.get("skill");
 

--- a/front-api/routes/w/[wId]/builder/assistants/[aId]/actions.ts
+++ b/front-api/routes/w/[wId]/builder/assistants/[aId]/actions.ts
@@ -4,6 +4,7 @@ import {
   getAccessibleSourcesAndAppsForActions,
 } from "@app/lib/agent_builder/server_side_props_helpers";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -14,7 +15,7 @@ export type GetActionsResponseBody = {
 // Mounted at /api/w/:wId/builder/assistants/:aId/actions.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetActionsResponseBody> => {
   const auth = ctx.get("auth");
   const aId = ctx.req.param("aId") ?? "";
 

--- a/front-api/routes/w/[wId]/coupon/validate.ts
+++ b/front-api/routes/w/[wId]/coupon/validate.ts
@@ -17,65 +17,61 @@ const GetCouponValidateQuerySchema = z.object({
 // Mounted at /api/w/:wId/coupon/validate.
 const app = new Hono();
 
-app.get(
-  "/",
-  validate("query", GetCouponValidateQuerySchema),
-  async (ctx) => {
-    const auth = ctx.get("auth");
+app.get("/", validate("query", GetCouponValidateQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
 
-    if (!auth.isAdmin()) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "Only users that are `admins` for the current workspace can access this endpoint.",
-        },
-      });
-    }
-
-    const { code } = ctx.req.valid("query");
-
-    const coupon = await CouponResource.findByCode(code);
-    if (!coupon) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "coupon_not_found",
-          message: "Coupon not found.",
-        },
-      });
-    }
-
-    const validationResult = coupon.validateRedemption();
-    if (validationResult.isErr()) {
-      const { code: errorCode } = validationResult.error;
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "coupon_not_redeemable",
-          message: `Coupon is not redeemable: ${errorCode}.`,
-        },
-      });
-    }
-
-    const existingRedemption =
-      await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
-        auth,
-        { coupon }
-      );
-    if (existingRedemption) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "coupon_already_redeemed",
-          message: "This coupon has already been redeemed by this workspace.",
-        },
-      });
-    }
-
-    return ctx.json({ coupon: coupon.toJSON() });
+  if (!auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
+      },
+    });
   }
-);
+
+  const { code } = ctx.req.valid("query");
+
+  const coupon = await CouponResource.findByCode(code);
+  if (!coupon) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "coupon_not_found",
+        message: "Coupon not found.",
+      },
+    });
+  }
+
+  const validationResult = coupon.validateRedemption();
+  if (validationResult.isErr()) {
+    const { code: errorCode } = validationResult.error;
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "coupon_not_redeemable",
+        message: `Coupon is not redeemable: ${errorCode}.`,
+      },
+    });
+  }
+
+  const existingRedemption =
+    await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
+      auth,
+      { coupon }
+    );
+  if (existingRedemption) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "coupon_already_redeemed",
+        message: "This coupon has already been redeemed by this workspace.",
+      },
+    });
+  }
+
+  return ctx.json({ coupon: coupon.toJSON() });
+});
 
 export default app;

--- a/front-api/routes/w/[wId]/coupon/validate.ts
+++ b/front-api/routes/w/[wId]/coupon/validate.ts
@@ -17,62 +17,65 @@ const GetCouponValidateQuerySchema = z.object({
 // Mounted at /api/w/:wId/coupon/validate.
 const app = new Hono();
 
-app.get("/", validate("query", GetCouponValidateQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  validate("query", GetCouponValidateQuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
 
-  if (!auth.isAdmin()) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can access this endpoint.",
-      },
-    });
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can access this endpoint.",
+        },
+      });
+    }
+
+    const { code } = ctx.req.valid("query");
+
+    const coupon = await CouponResource.findByCode(code);
+    if (!coupon) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "coupon_not_found",
+          message: "Coupon not found.",
+        },
+      });
+    }
+
+    const validationResult = coupon.validateRedemption();
+    if (validationResult.isErr()) {
+      const { code: errorCode } = validationResult.error;
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "coupon_not_redeemable",
+          message: `Coupon is not redeemable: ${errorCode}.`,
+        },
+      });
+    }
+
+    const existingRedemption =
+      await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
+        auth,
+        { coupon }
+      );
+    if (existingRedemption) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "coupon_already_redeemed",
+          message: "This coupon has already been redeemed by this workspace.",
+        },
+      });
+    }
+
+    return ctx.json({ coupon: coupon.toJSON() });
   }
-
-  const { code } = ctx.req.valid("query");
-
-  const coupon = await CouponResource.findByCode(code);
-  if (!coupon) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "coupon_not_found",
-        message: "Coupon not found.",
-      },
-    });
-  }
-
-  const validationResult = coupon.validateRedemption();
-  if (validationResult.isErr()) {
-    const { code: errorCode } = validationResult.error;
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "coupon_not_redeemable",
-        message: `Coupon is not redeemable: ${errorCode}.`,
-      },
-    });
-  }
-
-  const existingRedemption =
-    await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
-      auth,
-      { coupon }
-    );
-  if (existingRedemption) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "coupon_already_redeemed",
-        message: "This coupon has already been redeemed by this workspace.",
-      },
-    });
-  }
-
-  const body: GetCouponValidateResponseBody = { coupon: coupon.toJSON() };
-  return ctx.json(body);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -15,6 +15,7 @@ import {
   getSeatTypesByProductIdFromContract,
 } from "@app/lib/metronome/seat_types";
 import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -28,7 +29,7 @@ export type AwuPoolSummaryResponseBody = {
 // Mounted at /api/w/:wId/credits/awu-pool-summary.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
   const auth = ctx.get("auth");
 
   if (!auth.isAdmin()) {
@@ -95,13 +96,12 @@ app.get("/", async (ctx) => {
   });
 
   if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
-    const emptyBody: AwuPoolSummaryResponseBody = {
+    return ctx.json({
       totalCredits: 0,
       consumedByUsersCredits: 0,
       consumedByProgrammaticCredits: 0,
       resetDate: "",
-    };
-    return ctx.json(emptyBody);
+    });
   }
 
   const resetDate = ceilToMidnightUTC(
@@ -196,13 +196,12 @@ app.get("/", async (ctx) => {
     consumedByUsersCredits += Math.max(0, userCredits - seatAllocation);
   }
 
-  const body: AwuPoolSummaryResponseBody = {
+  return ctx.json({
     totalCredits,
     consumedByUsersCredits,
     consumedByProgrammaticCredits,
     resetDate,
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -12,6 +12,7 @@ import {
   type MembershipsPaginationParams,
 } from "@app/lib/resources/membership_resource";
 import type { MembershipSeatType } from "@app/types/memberships";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -136,83 +137,86 @@ async function fetchPerUserUsageCredits({
 // Mounted at /api/w/:wId/credits/members-usage.
 const app = new Hono();
 
-app.get("/", validate("query", MembersUsagePaginationSchema), async (ctx) => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  validate("query", MembersUsagePaginationSchema),
+  async (ctx): HandlerResult<GetMembersUsageResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!auth.isAdmin()) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Only workspace admins can access the members usage list.",
-      },
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Only workspace admins can access the members usage list.",
+        },
+      });
+    }
+
+    const paginationParams = ctx.req.valid("query");
+    const workspace = auth.getNonNullableWorkspace();
+    const subscription = auth.subscription();
+    const { metronomeCustomerId } = workspace;
+    const metronomeContractId = subscription?.metronomeContractId ?? null;
+
+    const [membershipsResult, perUserTotalCredits, seatDataByUserId] =
+      await Promise.all([
+        MembershipResource.getActiveMemberships({
+          workspace,
+          paginationParams,
+        }),
+        fetchPerUserUsageCredits({
+          metronomeCustomerId: metronomeCustomerId ?? null,
+          metronomeContractId,
+        }),
+        metronomeCustomerId && metronomeContractId
+          ? buildSeatDataByUserId({
+              metronomeCustomerId,
+              contractId: metronomeContractId,
+            })
+          : Promise.resolve(new Map()),
+      ]);
+
+    const { memberships, total, nextPageParams } = membershipsResult;
+
+    const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
+      if (!m.user) {
+        return [];
+      }
+      const userId = m.user.sId;
+      const totalCredits = perUserTotalCredits.get(userId) ?? 0;
+      const seatData = seatDataByUserId.get(userId);
+      const awuAllocation = seatData?.awuAllocation ?? 0;
+
+      let seatUsagePercent: number | null = null;
+      let poolConsumedCredits = totalCredits;
+
+      if (awuAllocation > 0) {
+        const seatConsumed = Math.min(totalCredits, awuAllocation);
+        seatUsagePercent = (seatConsumed / awuAllocation) * 100;
+        poolConsumedCredits = Math.max(0, totalCredits - awuAllocation);
+      }
+
+      return [
+        {
+          sId: userId,
+          name: m.user.name,
+          email: m.user.email ?? null,
+          image: m.user.imageUrl ?? null,
+          seatType: m.seatType ?? null,
+          seatUsagePercent,
+          consumedWorkplacePoolCredits: poolConsumedCredits,
+          billingFrequency: seatData?.billingFrequency ?? null,
+        },
+      ];
+    });
+
+    return ctx.json({
+      members: membersUsage,
+      total,
+      nextPageUrl: buildUrlWithParams(ctx.req.url, nextPageParams),
     });
   }
-
-  const paginationParams = ctx.req.valid("query");
-  const workspace = auth.getNonNullableWorkspace();
-  const subscription = auth.subscription();
-  const { metronomeCustomerId } = workspace;
-  const metronomeContractId = subscription?.metronomeContractId ?? null;
-
-  const [membershipsResult, perUserTotalCredits, seatDataByUserId] =
-    await Promise.all([
-      MembershipResource.getActiveMemberships({
-        workspace,
-        paginationParams,
-      }),
-      fetchPerUserUsageCredits({
-        metronomeCustomerId: metronomeCustomerId ?? null,
-        metronomeContractId,
-      }),
-      metronomeCustomerId && metronomeContractId
-        ? buildSeatDataByUserId({
-            metronomeCustomerId,
-            contractId: metronomeContractId,
-          })
-        : Promise.resolve(new Map()),
-    ]);
-
-  const { memberships, total, nextPageParams } = membershipsResult;
-
-  const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
-    if (!m.user) {
-      return [];
-    }
-    const userId = m.user.sId;
-    const totalCredits = perUserTotalCredits.get(userId) ?? 0;
-    const seatData = seatDataByUserId.get(userId);
-    const awuAllocation = seatData?.awuAllocation ?? 0;
-
-    let seatUsagePercent: number | null = null;
-    let poolConsumedCredits = totalCredits;
-
-    if (awuAllocation > 0) {
-      const seatConsumed = Math.min(totalCredits, awuAllocation);
-      seatUsagePercent = (seatConsumed / awuAllocation) * 100;
-      poolConsumedCredits = Math.max(0, totalCredits - awuAllocation);
-    }
-
-    return [
-      {
-        sId: userId,
-        name: m.user.name,
-        email: m.user.email ?? null,
-        image: m.user.imageUrl ?? null,
-        seatType: m.seatType ?? null,
-        seatUsagePercent,
-        consumedWorkplacePoolCredits: poolConsumedCredits,
-        billingFrequency: seatData?.billingFrequency ?? null,
-      },
-    ];
-  });
-
-  const body: GetMembersUsageResponseBody = {
-    members: membersUsage,
-    total,
-    nextPageUrl: buildUrlWithParams(ctx.req.url, nextPageParams),
-  };
-  return ctx.json(body);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/extension/config.ts
+++ b/front-api/routes/w/[wId]/extension/config.ts
@@ -1,4 +1,5 @@
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type GetExtensionConfigResponseBody = {
@@ -8,15 +9,14 @@ export type GetExtensionConfigResponseBody = {
 // Mounted at /api/w/:wId/extension/config.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetExtensionConfigResponseBody> => {
   const auth = ctx.get("auth");
 
   const config = await ExtensionConfigurationResource.fetchForWorkspace(auth);
 
-  const body: GetExtensionConfigResponseBody = {
+  return ctx.json({
     blacklistedDomains: config?.blacklistedDomains ?? [],
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/groups.ts
+++ b/front-api/routes/w/[wId]/groups.ts
@@ -1,6 +1,7 @@
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { GroupKind, GroupType } from "@app/types/groups";
 import { GroupKindCodec } from "@app/types/groups";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -17,32 +18,35 @@ const GetGroupsQuerySchema = z.object({
 // Mounted at /api/w/:wId/groups.
 const app = new Hono();
 
-app.get("/", validate("query", GetGroupsQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const { kind, spaceId } = ctx.req.valid("query");
+app.get(
+  "/",
+  validate("query", GetGroupsQuerySchema),
+  async (ctx): HandlerResult<GetGroupsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { kind, spaceId } = ctx.req.valid("query");
 
-  const groupKinds: GroupKind[] = kind
-    ? Array.isArray(kind)
-      ? kind
-      : [kind]
-    : ["global", "regular", "space_editors"];
+    const groupKinds: GroupKind[] = kind
+      ? Array.isArray(kind)
+        ? kind
+        : [kind]
+      : ["global", "regular", "space_editors"];
 
-  const groups: GroupResource[] = spaceId
-    ? await GroupResource.listForSpaceById(auth, spaceId, { groupKinds })
-    : await GroupResource.listAllWorkspaceGroups(auth, { groupKinds });
+    const groups: GroupResource[] = spaceId
+      ? await GroupResource.listForSpaceById(auth, spaceId, { groupKinds })
+      : await GroupResource.listAllWorkspaceGroups(auth, { groupKinds });
 
-  const memberCounts = await GroupResource.getMemberCountsForGroups(
-    auth,
-    groups
-  );
+    const memberCounts = await GroupResource.getMemberCountsForGroups(
+      auth,
+      groups
+    );
 
-  const groupsWithMemberCount = groups.map((group) => ({
-    ...group.toJSON(),
-    memberCount: memberCounts.get(group.id) ?? 0,
-  }));
+    const groupsWithMemberCount = groups.map((group) => ({
+      ...group.toJSON(),
+      memberCount: memberCounts.get(group.id) ?? 0,
+    }));
 
-  const body: GetGroupsResponseBody = { groups: groupsWithMemberCount };
-  return ctx.json(body);
-});
+    return ctx.json({ groups: groupsWithMemberCount });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/mcp/[serverId]/sync.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/sync.ts
@@ -1,6 +1,7 @@
 import { fetchRemoteServerMetaDataByServerId } from "@app/lib/actions/mcp_metadata";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -13,7 +14,7 @@ export type SyncMCPServerResponseBody = {
 // metadata for a remote MCP server.
 const app = new Hono();
 
-app.post("/", async (ctx) => {
+app.post("/", async (ctx): HandlerResult<SyncMCPServerResponseBody> => {
   const auth = ctx.get("auth");
   const serverId = ctx.req.param("serverId") ?? "";
 

--- a/front-api/routes/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
@@ -1,6 +1,7 @@
 import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -32,7 +33,7 @@ const app = new Hono();
 app.patch(
   "/",
   validate("json", UpdateMCPToolSettingsBodySchema),
-  async (ctx) => {
+  async (ctx): HandlerResult<PatchMCPServerToolsPermissionsResponseBody> => {
     const auth = ctx.get("auth");
     const serverId = ctx.req.param("serverId") ?? "";
     const toolName = ctx.req.param("toolName") ?? "";

--- a/front-api/routes/w/[wId]/mcp/available.ts
+++ b/front-api/routes/w/[wId]/mcp/available.ts
@@ -1,6 +1,7 @@
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { DefaultRemoteMCPServerInMemoryResource } from "@app/lib/resources/default_remote_mcp_server_in_memory_resource";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type GetMCPServersResponseBody = {
@@ -11,7 +12,7 @@ export type GetMCPServersResponseBody = {
 // Mounted at /api/w/:wId/mcp/available.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetMCPServersResponseBody> => {
   const auth = ctx.get("auth");
 
   const internalServers = (

--- a/front-api/routes/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front-api/routes/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -4,6 +4,7 @@ import { MCPOAuthProvider } from "@app/lib/actions/mcp_oauth_provider";
 import type { MCPOAuthConnectionMetadataType } from "@app/lib/api/oauth/providers/mcp";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -34,62 +35,66 @@ const app = new Hono();
 //
 // Note: callers should not invoke this frequently — the remote server is
 // likely to rate-limit.
-app.post("/", validate("json", PostBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const { url, customHeaders } = ctx.req.valid("json");
+app.post(
+  "/",
+  validate("json", PostBodySchema),
+  async (ctx): HandlerResult<DiscoverOAuthMetadataResponseBody> => {
+    const auth = ctx.get("auth");
+    const { url, customHeaders } = ctx.req.valid("json");
 
-  try {
-    new URL(url);
-  } catch {
+    try {
+      new URL(url);
+    } catch {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid URL format. Please provide a valid URL.",
+        },
+      });
+    }
+
+    const headers = headersArrayToRecord(customHeaders);
+
+    // Try a direct connection without auth first.
+    const directConnectRes = await connectToMCPServer(auth, {
+      params: {
+        type: "remoteMCPServerUrl",
+        remoteMCPServerUrl: url,
+        headers,
+      },
+    });
+
+    if (directConnectRes.isOk()) {
+      return ctx.json({ oauthRequired: false });
+    }
+
+    // Direct connect failed — try discovery.
+    const defaultServerConfig = getDefaultRemoteMCPServerByURL(url);
+    const extraScopes = defaultServerConfig?.scope;
+
+    const discoveryRes = await RemoteMCPServerResource.discoverOAuthMetadata({
+      serverUrl: url,
+      provider: new MCPOAuthProvider(),
+      customHeaders: headers,
+      extraScopes,
+    });
+
+    if (discoveryRes.isOk()) {
+      return ctx.json({
+        oauthRequired: true,
+        connectionMetadata: discoveryRes.value,
+      });
+    }
+
     return apiError(ctx, {
-      status_code: 400,
+      status_code: 500,
       api_error: {
-        type: "invalid_request_error",
-        message: "Invalid URL format. Please provide a valid URL.",
+        type: "internal_server_error",
+        message: discoveryRes.error.message,
       },
     });
   }
-
-  const headers = headersArrayToRecord(customHeaders);
-
-  // Try a direct connection without auth first.
-  const directConnectRes = await connectToMCPServer(auth, {
-    params: {
-      type: "remoteMCPServerUrl",
-      remoteMCPServerUrl: url,
-      headers,
-    },
-  });
-
-  if (directConnectRes.isOk()) {
-    return ctx.json({ oauthRequired: false });
-  }
-
-  // Direct connect failed — try discovery.
-  const defaultServerConfig = getDefaultRemoteMCPServerByURL(url);
-  const extraScopes = defaultServerConfig?.scope;
-
-  const discoveryRes = await RemoteMCPServerResource.discoverOAuthMetadata({
-    serverUrl: url,
-    provider: new MCPOAuthProvider(),
-    customHeaders: headers,
-    extraScopes,
-  });
-
-  if (discoveryRes.isOk()) {
-    return ctx.json({
-      oauthRequired: true,
-      connectionMetadata: discoveryRes.value,
-    });
-  }
-
-  return apiError(ctx, {
-    status_code: 500,
-    api_error: {
-      type: "internal_server_error",
-      message: discoveryRes.error.message,
-    },
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/mcp/index.ts
+++ b/front-api/routes/w/[wId]/mcp/index.ts
@@ -5,6 +5,7 @@ import {
   createRemoteMCPServer,
   listMCPServersWithViews,
 } from "@app/lib/api/mcp/servers";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -69,7 +70,7 @@ const PostBodySchema = z.discriminatedUnion("serverType", [
 // workspace sub-app.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetMCPServersResponseBody> => {
   const auth = ctx.get("auth");
   const servers = await listMCPServersWithViews(auth);
   return ctx.json({ success: true, servers });

--- a/front-api/routes/w/[wId]/mcp/usage.ts
+++ b/front-api/routes/w/[wId]/mcp/usage.ts
@@ -1,5 +1,6 @@
 import type { MCPServersUsageByAgent } from "@app/lib/api/agent_actions";
 import { getToolsUsage } from "@app/lib/api/agent_actions";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type GetMCPServersUsageResponseBody = {
@@ -9,7 +10,7 @@ export type GetMCPServersUsageResponseBody = {
 // Mounted at /api/w/:wId/mcp/usage.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetMCPServersUsageResponseBody> => {
   const auth = ctx.get("auth");
   const usage = await getToolsUsage(auth);
   return ctx.json({ usage });

--- a/front-api/routes/w/[wId]/mcp/views/index.ts
+++ b/front-api/routes/w/[wId]/mcp/views/index.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/api/mcp_oauth_prerequisites";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -35,7 +36,7 @@ function isAllowedAvailability(
 // Mounted at /api/w/:wId/mcp/views.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetMCPServerViewsListResponseBody> => {
   const auth = ctx.get("auth");
   const spaceIds = ctx.req.query("spaceIds");
   const availabilities = ctx.req.query("availabilities");

--- a/front-api/routes/w/[wId]/me/pending-invitations.ts
+++ b/front-api/routes/w/[wId]/me/pending-invitations.ts
@@ -1,6 +1,7 @@
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type GetPendingInvitationsResponseBody = {
@@ -10,7 +11,7 @@ export type GetPendingInvitationsResponseBody = {
 // Mounted at /api/w/:wId/me/pending-invitations.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetPendingInvitationsResponseBody> => {
   const auth = ctx.get("auth");
   const user = auth.getNonNullableUser();
 
@@ -32,8 +33,7 @@ app.get("/", async (ctx) => {
     }
   );
 
-  const body: GetPendingInvitationsResponseBody = { pendingInvitations };
-  return ctx.json(body);
+  return ctx.json({ pendingInvitations });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/me/slack-notifications.ts
+++ b/front-api/routes/w/[wId]/me/slack-notifications.ts
@@ -1,5 +1,6 @@
 import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type GetSlackNotificationResponseBody = {
@@ -9,7 +10,7 @@ export type GetSlackNotificationResponseBody = {
 // Mounted at /api/w/:wId/me/slack-notifications.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetSlackNotificationResponseBody> => {
   const auth = ctx.get("auth");
 
   const featureFlags = await getFeatureFlags(auth);
@@ -18,8 +19,7 @@ app.get("/", async (ctx) => {
   );
 
   if (!isFeatureEnabled) {
-    const body: GetSlackNotificationResponseBody = { canConfigure: false };
-    return ctx.json(body);
+    return ctx.json({ canConfigure: false });
   }
 
   const slackBotConnections = await DataSourceResource.listByConnectorProvider(
@@ -27,10 +27,9 @@ app.get("/", async (ctx) => {
     "slack_bot"
   );
 
-  const body: GetSlackNotificationResponseBody = {
+  return ctx.json({
     canConfigure: slackBotConnections.length > 0,
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/me/triggers.ts
+++ b/front-api/routes/w/[wId]/me/triggers.ts
@@ -2,6 +2,7 @@ import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/age
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import { removeNulls } from "@app/types/shared/utils/general";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type GetUserTriggersResponseBody = {
@@ -15,7 +16,7 @@ export type GetUserTriggersResponseBody = {
 // Mounted at /api/w/:wId/me/triggers.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetUserTriggersResponseBody> => {
   const auth = ctx.get("auth");
 
   const editorTriggers = await TriggerResource.listByUserEditor(
@@ -49,8 +50,7 @@ app.get("/", async (ctx) => {
     })
   );
 
-  const body: GetUserTriggersResponseBody = { triggers };
-  return ctx.json(body);
+  return ctx.json({ triggers });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/members/lookup.ts
+++ b/front-api/routes/w/[wId]/members/lookup.ts
@@ -1,6 +1,7 @@
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { UserType } from "@app/types/user";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -23,47 +24,48 @@ export type MembersLookupResponseBody = {
 // Mounted at /api/w/:wId/members/lookup.
 const app = new Hono();
 
-app.get("/", validate("query", MembersLookupQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const { ids: rawIds } = ctx.req.valid("query");
-  const ids = Array.isArray(rawIds) ? rawIds : [rawIds];
+app.get(
+  "/",
+  validate("query", MembersLookupQuerySchema),
+  async (ctx): HandlerResult<MembersLookupResponseBody> => {
+    const auth = ctx.get("auth");
+    const { ids: rawIds } = ctx.req.valid("query");
+    const ids = Array.isArray(rawIds) ? rawIds : [rawIds];
 
-  if (ids.length === 0) {
-    const body: MembersLookupResponseBody = { users: [] };
-    return ctx.json(body);
-  }
+    if (ids.length === 0) {
+      return ctx.json({ users: [] });
+    }
 
-  if (ids.length > MEMBERS_LOOKUP_MAX_IDS) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Too many ids provided. Maximum is ${MEMBERS_LOOKUP_MAX_IDS}.`,
-      },
+    if (ids.length > MEMBERS_LOOKUP_MAX_IDS) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Too many ids provided. Maximum is ${MEMBERS_LOOKUP_MAX_IDS}.`,
+        },
+      });
+    }
+
+    const uniqueIds = Array.from(new Set(ids));
+    const users = await UserResource.fetchByModelIds(uniqueIds);
+
+    if (users.length === 0) {
+      return ctx.json({ users: [] });
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const { memberships } = await MembershipResource.getLatestMemberships({
+      users,
+      workspace: owner,
+    });
+
+    const validUserIds = new Set(memberships.map((m) => m.userId));
+    const filteredUsers = users.filter((user) => validUserIds.has(user.id));
+
+    return ctx.json({
+      users: filteredUsers.map((user) => user.toJSON()),
     });
   }
-
-  const uniqueIds = Array.from(new Set(ids));
-  const users = await UserResource.fetchByModelIds(uniqueIds);
-
-  if (users.length === 0) {
-    const body: MembersLookupResponseBody = { users: [] };
-    return ctx.json(body);
-  }
-
-  const owner = auth.getNonNullableWorkspace();
-  const { memberships } = await MembershipResource.getLatestMemberships({
-    users,
-    workspace: owner,
-  });
-
-  const validUserIds = new Set(memberships.map((m) => m.userId));
-  const filteredUsers = users.filter((user) => validUserIds.has(user.id));
-
-  const body: MembersLookupResponseBody = {
-    users: filteredUsers.map((user) => user.toJSON()),
-  };
-  return ctx.json(body);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/members/search.ts
+++ b/front-api/routes/w/[wId]/members/search.ts
@@ -2,6 +2,7 @@ import { searchMembers } from "@app/lib/api/workspace";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { GROUP_KINDS } from "@app/types/groups";
 import type { UserTypeWithWorkspace } from "@app/types/user";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -29,34 +30,37 @@ export type SearchMembersResponseBody = {
 // Mounted at /api/w/:wId/members/search.
 const app = new Hono();
 
-app.get("/", validate("query", SearchMembersQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const query = ctx.req.valid("query");
+app.get(
+  "/",
+  validate("query", SearchMembersQuerySchema),
+  async (ctx): HandlerResult<SearchMembersResponseBody> => {
+    const auth = ctx.get("auth");
+    const query = ctx.req.valid("query");
 
-  const emails = query.searchEmails?.split(",");
-  if (emails?.length && emails.length > MAX_SEARCH_EMAILS) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Too many emails provided. Maximum is ${MAX_SEARCH_EMAILS}.`,
+    const emails = query.searchEmails?.split(",");
+    if (emails?.length && emails.length > MAX_SEARCH_EMAILS) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Too many emails provided. Maximum is ${MAX_SEARCH_EMAILS}.`,
+        },
+      });
+    }
+
+    const { members, total } = await searchMembers(
+      auth,
+      {
+        searchTerm: query.searchTerm,
+        searchEmails: emails,
+        groupKind: query.groupKind,
+        buildersOnly: query.buildersOnly,
       },
-    });
+      query
+    );
+
+    return ctx.json({ members, total });
   }
-
-  const { members, total } = await searchMembers(
-    auth,
-    {
-      searchTerm: query.searchTerm,
-      searchEmails: emails,
-      groupKind: query.groupKind,
-      buildersOnly: query.buildersOnly,
-    },
-    query
-  );
-
-  const body: SearchMembersResponseBody = { members, total };
-  return ctx.json(body);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/providers/index.ts
+++ b/front-api/routes/w/[wId]/providers/index.ts
@@ -1,6 +1,7 @@
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import type { ProviderType } from "@app/types/provider";
 import { redactString } from "@app/types/shared/utils/string_utils";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -20,7 +21,7 @@ function redactConfig(config: string) {
 // Mounted at /api/w/:wId/providers.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetProvidersResponseBody> => {
   const auth = ctx.get("auth");
 
   if (!auth.isBuilder()) {
@@ -41,13 +42,12 @@ app.get("/", async (ctx) => {
     },
   });
 
-  const body: GetProvidersResponseBody = {
+  return ctx.json({
     providers: providers.map((p) => ({
       providerId: p.providerId,
       config: redactConfig(p.config),
     })),
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/provisioning-status.ts
+++ b/front-api/routes/w/[wId]/provisioning-status.ts
@@ -3,6 +3,7 @@ import {
   BUILDER_GROUP_NAME,
   GroupResource,
 } from "@app/lib/resources/group_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type GetProvisioningStatusResponseBody = {
@@ -13,17 +14,16 @@ export type GetProvisioningStatusResponseBody = {
 // Mounted at /api/w/:wId/provisioning-status.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetProvisioningStatusResponseBody> => {
   const auth = ctx.get("auth");
 
   const groups =
     await GroupResource.listRoleProvisioningGroupsForWorkspace(auth);
 
-  const body: GetProvisioningStatusResponseBody = {
+  return ctx.json({
     hasAdminGroup: groups.some((g) => g.name === ADMIN_GROUP_NAME),
     hasBuilderGroup: groups.some((g) => g.name === BUILDER_GROUP_NAME),
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/seats/availability.ts
+++ b/front-api/routes/w/[wId]/seats/availability.ts
@@ -1,5 +1,6 @@
 import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";
 
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -10,7 +11,7 @@ export type GetSeatAvailabilityResponseBody = {
 // Mounted at /api/w/:wId/seats/availability.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetSeatAvailabilityResponseBody> => {
   const auth = ctx.get("auth");
 
   if (!auth.isAdmin()) {
@@ -25,8 +26,7 @@ app.get("/", async (ctx) => {
   }
 
   const hasAvailableSeats = await checkWorkspaceSeatAvailabilityUsingAuth(auth);
-  const body: GetSeatAvailabilityResponseBody = { hasAvailableSeats };
-  return ctx.json(body);
+  return ctx.json({ hasAvailableSeats });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/seats/count.ts
+++ b/front-api/routes/w/[wId]/seats/count.ts
@@ -1,5 +1,6 @@
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -10,7 +11,7 @@ export type GetWorkspaceSeatsCountResponseBody = {
 // Mounted at /api/w/:wId/seats/count.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetWorkspaceSeatsCountResponseBody> => {
   const auth = ctx.get("auth");
 
   if (!auth.isAdmin()) {
@@ -29,8 +30,7 @@ app.get("/", async (ctx) => {
   const seatsCount = await MembershipResource.countActiveSeatsInWorkspace(
     owner.sId
   );
-  const body: GetWorkspaceSeatsCountResponseBody = { seatsCount };
-  return ctx.json(body);
+  return ctx.json({ seatsCount });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
@@ -3,6 +3,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { GetSkillHistoryQuerySchema } from "@app/types/api/internal/skill";
 import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
 import { isString } from "@app/types/shared/utils/general";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 import { fromError } from "zod-validation-error";
@@ -14,7 +15,7 @@ export type GetSkillHistoryResponseBody = {
 // Mounted at /api/w/:wId/skills/:sId/history.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetSkillHistoryResponseBody> => {
   const auth = ctx.get("auth");
   const sId = ctx.req.param("sId");
 

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -14,9 +14,11 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 import type { ModelId } from "@app/types/shared/model_id";
 import { isString } from "@app/types/shared/utils/general";
+import type { APIErrorResponse } from "@app/types/error";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
-import type { Context } from "hono";
+import type { Context, TypedResponse } from "hono";
 import { Hono } from "hono";
 import uniq from "lodash/uniq";
 import { z } from "zod";
@@ -75,7 +77,10 @@ const PatchSkillRequestBodySchema = z.object({
 // failure Response. See [API10].
 async function loadSkill(
   ctx: Context
-): Promise<{ skill: SkillResource; sId: string } | Response> {
+): Promise<
+  | { skill: SkillResource; sId: string }
+  | (Response & TypedResponse<APIErrorResponse>)
+> {
   const auth = ctx.get("auth");
   const sId = ctx.req.param("sId");
 
@@ -113,272 +118,286 @@ app.route("/reinforcement", reinforcement);
 app.route("/restore", restore);
 app.route("/files/:fileId/content", filesRoute);
 
-app.get("/", async (ctx) => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  async (
+    ctx
+  ): HandlerResult<
+    GetSkillResponseBody | GetSkillWithRelationsResponseBody
+  > => {
+    const auth = ctx.get("auth");
 
-  const loaded = await loadSkill(ctx);
-  if (loaded instanceof Response) {
-    return loaded;
+    const loaded = await loadSkill(ctx);
+    if (loaded instanceof Response) {
+      return loaded;
+    }
+    const { skill } = loaded;
+
+    const withRelations = ctx.req.query("withRelations");
+
+    const serializedSkill = skill.toJSON(auth);
+
+    if (withRelations === "true") {
+      const usage = await skill.fetchUsage(auth);
+      const editors = await skill.listEditors(auth);
+      const editedByUser = await skill.fetchEditedByUser(auth);
+      const extendedSkill = serializedSkill.extendedSkillId
+        ? await SkillResource.fetchById(auth, serializedSkill.extendedSkillId)
+        : null;
+
+      const skillWithRelations: SkillWithRelationsType = {
+        ...serializedSkill,
+        relations: {
+          usage,
+          editors: editors ? editors.map((e) => e.toJSON()) : null,
+          editedByUser: editedByUser ? editedByUser.toJSON() : null,
+          extendedSkill: extendedSkill ? extendedSkill.toJSON(auth) : null,
+        },
+      };
+
+      return ctx.json({ skill: skillWithRelations });
+    }
+    return ctx.json({ skill: serializedSkill });
   }
-  const { skill } = loaded;
+);
 
-  const withRelations = ctx.req.query("withRelations");
+app.patch(
+  "/",
+  validate("json", PatchSkillRequestBodySchema),
+  async (ctx): HandlerResult<PatchSkillResponseBody> => {
+    const auth = ctx.get("auth");
+    const owner = auth.getNonNullableWorkspace();
 
-  const serializedSkill = skill.toJSON(auth);
+    const loaded = await loadSkill(ctx);
+    if (loaded instanceof Response) {
+      return loaded;
+    }
+    const { skill } = loaded;
 
-  if (withRelations === "true") {
-    const usage = await skill.fetchUsage(auth);
-    const editors = await skill.listEditors(auth);
-    const editedByUser = await skill.fetchEditedByUser(auth);
-    const extendedSkill = serializedSkill.extendedSkillId
-      ? await SkillResource.fetchById(auth, serializedSkill.extendedSkillId)
-      : null;
+    const body = ctx.req.valid("json");
+    const name = body.name.trim();
 
-    const skillWithRelations: SkillWithRelationsType = {
-      ...serializedSkill,
-      relations: {
-        usage,
-        editors: editors ? editors.map((e) => e.toJSON()) : null,
-        editedByUser: editedByUser ? editedByUser.toJSON() : null,
-        extendedSkill: extendedSkill ? extendedSkill.toJSON(auth) : null,
-      },
-    };
-
-    return ctx.json({ skill: skillWithRelations });
-  }
-  return ctx.json({ skill: serializedSkill });
-});
-
-app.patch("/", validate("json", PatchSkillRequestBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const owner = auth.getNonNullableWorkspace();
-
-  const loaded = await loadSkill(ctx);
-  if (loaded instanceof Response) {
-    return loaded;
-  }
-  const { skill } = loaded;
-
-  const body = ctx.req.valid("json");
-  const name = body.name.trim();
-
-  if (!name) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Skill name cannot be empty.",
-      },
-    });
-  }
-
-  // Check if user can write.
-  if (!skill.canWrite(auth)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only editors can modify this skill.",
-      },
-    });
-  }
-
-  // Check for existing active skill with the same name (excluding current skill).
-  const existingSkill = await SkillResource.fetchActiveByName(auth, name);
-
-  if (existingSkill && existingSkill.id !== skill.id) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `A skill with the name "${name}" already exists.`,
-      },
-    });
-  }
-
-  // Validate MCP server view IDs.
-  for (const tool of body.tools) {
-    if (!isResourceSId("mcp_server_view", tool.mcpServerViewId)) {
+    if (!name) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: `Invalid MCP server view ID: ${tool.mcpServerViewId}`,
-        },
-      });
-    }
-  }
-
-  // Fetch MCP server views first to compute requestedSpaceIds.
-  const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
-  const mcpServerViews = await MCPServerViewResource.fetchByIds(
-    auth,
-    mcpServerViewIds
-  );
-
-  if (mcpServerViewIds.length !== mcpServerViews.length) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "invalid_request_error",
-        message: `MCP server views not all found, ${mcpServerViews.length} found, ${mcpServerViewIds.length} requested`,
-      },
-    });
-  }
-
-  const { attachedKnowledge, fileAttachments } = body;
-
-  // Validate all data source views from attached knowledge exist and user has access.
-  const dataSourceViewIds = uniq(
-    attachedKnowledge.map((attachment) => attachment.dataSourceViewId)
-  );
-
-  const dataSourceViews = await DataSourceViewResource.fetchByIds(
-    auth,
-    dataSourceViewIds
-  );
-  if (dataSourceViews.length !== dataSourceViewIds.length) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Data source views not all found, ${dataSourceViews.length} found, ${dataSourceViewIds.length} requested`,
-      },
-    });
-  }
-
-  const dataSourceViewIdMap = new Map(
-    dataSourceViews.map((dsv) => [dsv.sId, dsv])
-  );
-
-  const attachedKnowledgeWithDataSourceViews = attachedKnowledge.map(
-    (attachment) => ({
-      dataSourceView: dataSourceViewIdMap.get(attachment.dataSourceViewId)!,
-      nodeId: attachment.nodeId,
-    })
-  );
-
-  const computedRequestedSpaceIds =
-    await SkillResource.computeRequestedSpaceIds(auth, {
-      mcpServerViews,
-      attachedKnowledge: attachedKnowledgeWithDataSourceViews,
-    });
-
-  let additionalRequestedSpaceIds: ModelId[];
-
-  if (body.additionalRequestedSpaceIds !== undefined) {
-    const additionalRequestedSpaceIdsRes =
-      await resolveAdditionalRequestedSpaceModelIds(
-        auth,
-        body.additionalRequestedSpaceIds
-      );
-
-    if (additionalRequestedSpaceIdsRes.isErr()) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: additionalRequestedSpaceIdsRes.error.message,
+          message: "Skill name cannot be empty.",
         },
       });
     }
 
-    additionalRequestedSpaceIds = additionalRequestedSpaceIdsRes.value;
-  } else {
-    const previousAttachedKnowledge = await skill.getAttachedKnowledge(auth);
-    const previousComputedRequestedSpaceIds =
-      await SkillResource.computeRequestedSpaceIds(auth, {
-        mcpServerViews: skill.mcpServerViews,
-        attachedKnowledge: previousAttachedKnowledge,
-      });
-    const previousComputedRequestedSpaceIdsSet = new Set(
-      previousComputedRequestedSpaceIds
-    );
-
-    additionalRequestedSpaceIds = skill.requestedSpaceIds.filter(
-      (spaceId) => !previousComputedRequestedSpaceIdsSet.has(spaceId)
-    );
-  }
-
-  const requestedSpaceIds = uniq([
-    ...computedRequestedSpaceIds,
-    ...additionalRequestedSpaceIds,
-  ]);
-
-  // Validate file attachments if provided (gated behind sandbox_tools).
-  let files: FileResource[] | undefined;
-  if (fileAttachments) {
-    const featureFlags = await getFeatureFlags(auth);
-    if (!featureFlags.includes("sandbox_tools") && fileAttachments.length > 0) {
+    // Check if user can write.
+    if (!skill.canWrite(auth)) {
       return apiError(ctx, {
         status_code: 403,
         api_error: {
-          type: "invalid_request_error",
-          message: "File attachments are not supported.",
+          type: "app_auth_error",
+          message: "Only editors can modify this skill.",
         },
       });
     }
 
-    const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
-    files = await FileResource.fetchByIds(auth, fileAttachmentIds);
-    if (files.length !== fileAttachmentIds.length) {
+    // Check for existing active skill with the same name (excluding current skill).
+    const existingSkill = await SkillResource.fetchActiveByName(auth, name);
+
+    if (existingSkill && existingSkill.id !== skill.id) {
       return apiError(ctx, {
-        status_code: 404,
+        status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: `File attachments not all found, ${files.length} found, ${fileAttachmentIds.length} requested`,
+          message: `A skill with the name "${name}" already exists.`,
         },
       });
     }
 
-    for (const file of files) {
-      if (!file.isReady || file.useCase !== "skill_attachment") {
+    // Validate MCP server view IDs.
+    for (const tool of body.tools) {
+      if (!isResourceSId("mcp_server_view", tool.mcpServerViewId)) {
         return apiError(ctx, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `File ${file.sId} is not ready or not a skill_attachment.`,
+            message: `Invalid MCP server view ID: ${tool.mcpServerViewId}`,
           },
         });
       }
     }
-  }
 
-  // When saving a suggested skill, automatically activate it.
-  const shouldActivate = skill.status === "suggested";
-
-  if (shouldActivate) {
-    logger.info(
-      {
-        skillId: skill.sId,
-        workspaceId: owner.sId,
-      },
-      "Suggested skill accepted"
+    // Fetch MCP server views first to compute requestedSpaceIds.
+    const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
+    const mcpServerViews = await MCPServerViewResource.fetchByIds(
+      auth,
+      mcpServerViewIds
     );
+
+    if (mcpServerViewIds.length !== mcpServerViews.length) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: `MCP server views not all found, ${mcpServerViews.length} found, ${mcpServerViewIds.length} requested`,
+        },
+      });
+    }
+
+    const { attachedKnowledge, fileAttachments } = body;
+
+    // Validate all data source views from attached knowledge exist and user has access.
+    const dataSourceViewIds = uniq(
+      attachedKnowledge.map((attachment) => attachment.dataSourceViewId)
+    );
+
+    const dataSourceViews = await DataSourceViewResource.fetchByIds(
+      auth,
+      dataSourceViewIds
+    );
+    if (dataSourceViews.length !== dataSourceViewIds.length) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Data source views not all found, ${dataSourceViews.length} found, ${dataSourceViewIds.length} requested`,
+        },
+      });
+    }
+
+    const dataSourceViewIdMap = new Map(
+      dataSourceViews.map((dsv) => [dsv.sId, dsv])
+    );
+
+    const attachedKnowledgeWithDataSourceViews = attachedKnowledge.map(
+      (attachment) => ({
+        dataSourceView: dataSourceViewIdMap.get(attachment.dataSourceViewId)!,
+        nodeId: attachment.nodeId,
+      })
+    );
+
+    const computedRequestedSpaceIds =
+      await SkillResource.computeRequestedSpaceIds(auth, {
+        mcpServerViews,
+        attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+      });
+
+    let additionalRequestedSpaceIds: ModelId[];
+
+    if (body.additionalRequestedSpaceIds !== undefined) {
+      const additionalRequestedSpaceIdsRes =
+        await resolveAdditionalRequestedSpaceModelIds(
+          auth,
+          body.additionalRequestedSpaceIds
+        );
+
+      if (additionalRequestedSpaceIdsRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: additionalRequestedSpaceIdsRes.error.message,
+          },
+        });
+      }
+
+      additionalRequestedSpaceIds = additionalRequestedSpaceIdsRes.value;
+    } else {
+      const previousAttachedKnowledge = await skill.getAttachedKnowledge(auth);
+      const previousComputedRequestedSpaceIds =
+        await SkillResource.computeRequestedSpaceIds(auth, {
+          mcpServerViews: skill.mcpServerViews,
+          attachedKnowledge: previousAttachedKnowledge,
+        });
+      const previousComputedRequestedSpaceIdsSet = new Set(
+        previousComputedRequestedSpaceIds
+      );
+
+      additionalRequestedSpaceIds = skill.requestedSpaceIds.filter(
+        (spaceId) => !previousComputedRequestedSpaceIdsSet.has(spaceId)
+      );
+    }
+
+    const requestedSpaceIds = uniq([
+      ...computedRequestedSpaceIds,
+      ...additionalRequestedSpaceIds,
+    ]);
+
+    // Validate file attachments if provided (gated behind sandbox_tools).
+    let files: FileResource[] | undefined;
+    if (fileAttachments) {
+      const featureFlags = await getFeatureFlags(auth);
+      if (
+        !featureFlags.includes("sandbox_tools") &&
+        fileAttachments.length > 0
+      ) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message: "File attachments are not supported.",
+          },
+        });
+      }
+
+      const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
+      files = await FileResource.fetchByIds(auth, fileAttachmentIds);
+      if (files.length !== fileAttachmentIds.length) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: `File attachments not all found, ${files.length} found, ${fileAttachmentIds.length} requested`,
+          },
+        });
+      }
+
+      for (const file of files) {
+        if (!file.isReady || file.useCase !== "skill_attachment") {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `File ${file.sId} is not ready or not a skill_attachment.`,
+            },
+          });
+        }
+      }
+    }
+
+    // When saving a suggested skill, automatically activate it.
+    const shouldActivate = skill.status === "suggested";
+
+    if (shouldActivate) {
+      logger.info(
+        {
+          skillId: skill.sId,
+          workspaceId: owner.sId,
+        },
+        "Suggested skill accepted"
+      );
+    }
+
+    await skill.updateSkill(auth, {
+      agentFacingDescription: body.agentFacingDescription,
+      attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+      fileAttachments: files,
+      icon: body.icon,
+      instructions: body.instructions,
+      instructionsHtml: body.instructionsHtml,
+      isDefault: body.isDefault,
+      mcpServerViews,
+      name,
+      reinforcement: body.reinforcement,
+      requestedSpaceIds,
+      userFacingDescription: body.userFacingDescription,
+      ...(shouldActivate ? { status: "active" as const } : {}),
+    });
+
+    await pruneOutdatedSkillEditSuggestions(auth, skill);
+
+    return ctx.json({ skill: skill.toJSON(auth) });
   }
+);
 
-  await skill.updateSkill(auth, {
-    agentFacingDescription: body.agentFacingDescription,
-    attachedKnowledge: attachedKnowledgeWithDataSourceViews,
-    fileAttachments: files,
-    icon: body.icon,
-    instructions: body.instructions,
-    instructionsHtml: body.instructionsHtml,
-    isDefault: body.isDefault,
-    mcpServerViews,
-    name,
-    reinforcement: body.reinforcement,
-    requestedSpaceIds,
-    userFacingDescription: body.userFacingDescription,
-    ...(shouldActivate ? { status: "active" as const } : {}),
-  });
-
-  await pruneOutdatedSkillEditSuggestions(auth, skill);
-
-  return ctx.json({ skill: skill.toJSON(auth) });
-});
-
-app.delete("/", async (ctx) => {
+app.delete("/", async (ctx): HandlerResult<DeleteSkillResponseBody> => {
   const auth = ctx.get("auth");
   const owner = auth.getNonNullableWorkspace();
 

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -12,9 +12,9 @@ import type {
   SkillType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
+import type { APIErrorResponse } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import { isString } from "@app/types/shared/utils/general";
-import type { APIErrorResponse } from "@app/types/error";
 import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";

--- a/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
@@ -7,6 +7,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { SKILL_REINFORCEMENT_MODES } from "@app/types/assistant/skill_configuration";
 import { isString } from "@app/types/shared/utils/general";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -41,7 +42,7 @@ const app = new Hono();
 app.patch(
   "/",
   validate("json", PatchSkillReinforcementBodySchema),
-  async (ctx) => {
+  async (ctx): HandlerResult<PatchSkillReinforcementResponseBody> => {
     const auth = ctx.get("auth");
     const sId = ctx.req.param("sId");
 

--- a/front-api/routes/w/[wId]/skills/[sId]/restore.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/restore.ts
@@ -1,5 +1,6 @@
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isString } from "@app/types/shared/utils/general";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -10,60 +11,63 @@ export type RestoreSkillConfigurationResponseBody = {
 // Mounted at /api/w/:wId/skills/:sId/restore.
 const app = new Hono();
 
-app.post("/", async (ctx) => {
-  const auth = ctx.get("auth");
-  const sId = ctx.req.param("sId");
+app.post(
+  "/",
+  async (ctx): HandlerResult<RestoreSkillConfigurationResponseBody> => {
+    const auth = ctx.get("auth");
+    const sId = ctx.req.param("sId");
 
-  if (!isString(sId)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid skill ID.",
-      },
-    });
+    if (!isString(sId)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid skill ID.",
+        },
+      });
+    }
+
+    const skillResource = await SkillResource.fetchById(auth, sId);
+
+    if (!skillResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "The skill you're trying to access was not found.",
+        },
+      });
+    }
+
+    if (!skillResource.canWrite(auth)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only editors can restore this skill.",
+        },
+      });
+    }
+
+    // Check for existing active skill with the same name.
+    const existingSkill = await SkillResource.fetchActiveByName(
+      auth,
+      skillResource.name
+    );
+    if (existingSkill) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `A skill with the name "${skillResource.name}" already exists.`,
+        },
+      });
+    }
+
+    await skillResource.restore(auth);
+
+    return ctx.json({ success: true });
   }
-
-  const skillResource = await SkillResource.fetchById(auth, sId);
-
-  if (!skillResource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "skill_not_found",
-        message: "The skill you're trying to access was not found.",
-      },
-    });
-  }
-
-  if (!skillResource.canWrite(auth)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only editors can restore this skill.",
-      },
-    });
-  }
-
-  // Check for existing active skill with the same name.
-  const existingSkill = await SkillResource.fetchActiveByName(
-    auth,
-    skillResource.name
-  );
-  if (existingSkill) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `A skill with the name "${skillResource.name}" already exists.`,
-      },
-    });
-  }
-
-  await skillResource.restore(auth);
-
-  return ctx.json({ success: true });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/skills/detect/index.ts
+++ b/front-api/routes/w/[wId]/skills/detect/index.ts
@@ -9,6 +9,7 @@ import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -23,7 +24,7 @@ const app = new Hono();
 
 app.route("/upload", upload);
 
-app.post("/", async (ctx) => {
+app.post("/", async (ctx): HandlerResult<DetectSkillsResponseBody> => {
   const auth = ctx.get("auth");
   const owner = auth.getNonNullableWorkspace();
 

--- a/front-api/routes/w/[wId]/skills/import/index.ts
+++ b/front-api/routes/w/[wId]/skills/import/index.ts
@@ -2,6 +2,7 @@ import { importSkillsFromGitHub } from "@app/lib/api/skills/detection/github/imp
 import logger from "@app/logger/logger";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -29,62 +30,84 @@ const app = new Hono();
 
 app.route("/upload", upload);
 
-app.post("/", validate("json", ImportSkillsRequestBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const owner = auth.getNonNullableWorkspace();
+app.post(
+  "/",
+  validate("json", ImportSkillsRequestBodySchema),
+  async (ctx): HandlerResult<ImportSkillsResponseBody> => {
+    const auth = ctx.get("auth");
+    const owner = auth.getNonNullableWorkspace();
 
-  if (!auth.isBuilder()) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: { type: "app_auth_error", message: "User is not a builder." },
+    if (!auth.isBuilder()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "User is not a builder.",
+        },
+      });
+    }
+
+    const { repoUrl, names } = ctx.req.valid("json");
+
+    const result = await importSkillsFromGitHub(auth, { repoUrl, names });
+    if (result.isErr()) {
+      const error = result.error;
+      switch (error.type) {
+        case "invalid_url":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        case "not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        case "auth_error":
+          return apiError(ctx, {
+            status_code: 401,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        case "github_api_error":
+          logger.error(
+            { error, workspaceId: owner.sId },
+            "Error detecting skills from GitHub repo during import"
+          );
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        case "validation_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        default:
+          assertNever(error);
+      }
+    }
+
+    return ctx.json({
+      imported: result.value.imported.map((skill) => skill.toJSON(auth)),
+      updated: result.value.updated.map((skill) => skill.toJSON(auth)),
+      skipped: result.value.skipped,
     });
   }
-
-  const { repoUrl, names } = ctx.req.valid("json");
-
-  const result = await importSkillsFromGitHub(auth, { repoUrl, names });
-  if (result.isErr()) {
-    const error = result.error;
-    switch (error.type) {
-      case "invalid_url":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: { type: "invalid_request_error", message: error.message },
-        });
-      case "not_found":
-        return apiError(ctx, {
-          status_code: 404,
-          api_error: { type: "invalid_request_error", message: error.message },
-        });
-      case "auth_error":
-        return apiError(ctx, {
-          status_code: 401,
-          api_error: { type: "invalid_request_error", message: error.message },
-        });
-      case "github_api_error":
-        logger.error(
-          { error, workspaceId: owner.sId },
-          "Error detecting skills from GitHub repo during import"
-        );
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: { type: "invalid_request_error", message: error.message },
-        });
-      case "validation_error":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: { type: "invalid_request_error", message: error.message },
-        });
-      default:
-        assertNever(error);
-    }
-  }
-
-  return ctx.json({
-    imported: result.value.imported.map((skill) => skill.toJSON(auth)),
-    updated: result.value.updated.map((skill) => skill.toJSON(auth)),
-    skipped: result.value.skipped,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -16,6 +16,7 @@ import {
 } from "@app/types/assistant/skill_configuration";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { isBuilder } from "@app/types/user";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -109,333 +110,352 @@ app.route("/reinforcement_daily_spend", reinforcementDailySpend);
 app.route("/reinforcement_spend", reinforcementSpend);
 app.route("/similar", similar);
 
-app.get("/", async (ctx) => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  async (
+    ctx
+  ): HandlerResult<
+    | GetSkillsResponseBody
+    | GetSkillsWithRelationsResponseBody
+    | GetSkillsWithoutInstructionsAndToolsResponseBody
+  > => {
+    const auth = ctx.get("auth");
 
-  const withRelations = ctx.req.query("withRelations");
-  const status = ctx.req.query("status");
-  const globalSpaceOnly = ctx.req.query("globalSpaceOnly");
-  const onlyCustom = ctx.req.query("onlyCustom");
-  const isDefault = ctx.req.query("isDefault");
-  const viewType = ctx.req.query("viewType");
+    const withRelations = ctx.req.query("withRelations");
+    const status = ctx.req.query("status");
+    const globalSpaceOnly = ctx.req.query("globalSpaceOnly");
+    const onlyCustom = ctx.req.query("onlyCustom");
+    const isDefault = ctx.req.query("isDefault");
+    const viewType = ctx.req.query("viewType");
 
-  let skillView: SkillViewType = "full";
-  if (viewType !== undefined) {
-    if (!isString(viewType) || !isSkillViewType(viewType)) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: `Invalid viewType: ${viewType}. Expected "full" or "summary".`,
-        },
-      });
-    }
-
-    skillView = viewType;
-  }
-
-  if (withRelations === "true" && skillView === "summary") {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "viewType=summary is incompatible with withRelations=true.",
-      },
-    });
-  }
-
-  const statusValidation = SkillStatusSchema.safeParse(status);
-  if (!statusValidation.success) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Invalid status: ${status}. Expected "active", "archived", or "suggested".`,
-      },
-    });
-  }
-  const skillStatus = statusValidation.data;
-
-  const skills = await SkillResource.listByWorkspace(auth, {
-    status: skillStatus,
-    globalSpaceOnly: globalSpaceOnly === "true",
-    onlyCustom: onlyCustom === "true",
-    isDefault: isDefault === "true" ? true : undefined,
-    withInstructions: skillView !== "summary",
-    withTools: skillView === "full",
-  });
-
-  if (withRelations === "true") {
-    const extendedSkills = await SkillResource.fetchByIds(
-      auth,
-      removeNulls(uniq(skills.map((s) => s.extendedSkillId)))
-    );
-    const extendedSkillsMap = new Map(extendedSkills.map((s) => [s.sId, s]));
-
-    const skillsWithRelations = await concurrentExecutor(
-      skills,
-      async (sc) => {
-        const usage = await sc.fetchUsage(auth);
-        const editors = await sc.listEditors(auth);
-        const editedByUser = await sc.fetchEditedByUser(auth);
-
-        return {
-          ...sc.toJSON(auth),
-          relations: {
-            usage,
-            editors: editors ? editors.map((e) => e.toJSON()) : null,
-            editedByUser: editedByUser ? editedByUser.toJSON() : null,
-            extendedSkill: sc.extendedSkillId
-              ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
-                null)
-              : null,
-          },
-        } satisfies SkillWithRelationsType;
-      },
-      { concurrency: 10 }
-    );
-
-    return ctx.json({ skills: skillsWithRelations });
-  }
-
-  if (skillView === "summary") {
-    return ctx.json({
-      skills: skills.map((sc) => {
-        const {
-          instructions,
-          instructionsHtml,
-          tools,
-          ...skillWithoutInstructionsAndTools
-        } = sc.toJSON(auth);
-
-        return skillWithoutInstructionsAndTools;
-      }),
-    });
-  }
-
-  return ctx.json({
-    skills: skills.map((sc) => sc.toJSON(auth)),
-  });
-});
-
-app.post("/", validate("json", PostSkillRequestBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const owner = auth.getNonNullableWorkspace();
-
-  if (!isBuilder(owner)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: { type: "app_auth_error", message: "User is not a builder." },
-    });
-  }
-
-  const user = auth.getNonNullableUser();
-
-  const body = ctx.req.valid("json");
-  const name = body.name.trim();
-
-  if (!name) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Skill name cannot be empty.",
-      },
-    });
-  }
-
-  const existingSkill = await SkillResource.fetchActiveByName(auth, name);
-
-  if (existingSkill) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `A skill with the name "${name}" already exists.`,
-      },
-    });
-  }
-
-  // Validate all MCP server views exist before creating anything.
-  const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
-  const mcpServerViews = await MCPServerViewResource.fetchByIds(
-    auth,
-    mcpServerViewIds
-  );
-
-  if (mcpServerViewIds.length !== mcpServerViews.length) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "invalid_request_error",
-        message: `MCP server views not all found, ${mcpServerViews.length} found, ${mcpServerViewIds.length} requested`,
-      },
-    });
-  }
-
-  const { attachedKnowledge, fileAttachments } = body;
-
-  const dataSourceViewIds = uniq(
-    attachedKnowledge.map((attachment) => attachment.dataSourceViewId)
-  );
-
-  const dataSourceViews = await DataSourceViewResource.fetchByIds(
-    auth,
-    dataSourceViewIds
-  );
-  if (dataSourceViews.length !== dataSourceViewIds.length) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Data source views not all found, ${dataSourceViews.length} found, ${dataSourceViewIds.length} requested`,
-      },
-    });
-  }
-
-  const dataSourceViewIdMap = new Map(
-    dataSourceViews.map((dsv) => [dsv.sId, dsv])
-  );
-
-  const attachedKnowledgeWithDataSourceViews = attachedKnowledge.map(
-    (attachment) => ({
-      dataSourceView: dataSourceViewIdMap.get(attachment.dataSourceViewId)!,
-      nodeId: attachment.nodeId,
-    })
-  );
-
-  const computedRequestedSpaceIds =
-    await SkillResource.computeRequestedSpaceIds(auth, {
-      mcpServerViews,
-      attachedKnowledge: attachedKnowledgeWithDataSourceViews,
-    });
-
-  const additionalRequestedSpaceIdsRes =
-    await resolveAdditionalRequestedSpaceModelIds(
-      auth,
-      body.additionalRequestedSpaceIds
-    );
-
-  if (additionalRequestedSpaceIdsRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: additionalRequestedSpaceIdsRes.error.message,
-      },
-    });
-  }
-
-  const requestedSpaceIds = uniq([
-    ...computedRequestedSpaceIds,
-    ...additionalRequestedSpaceIdsRes.value,
-  ]);
-
-  const extendedSkill = body.extendedSkillId
-    ? await SkillResource.fetchById(auth, body.extendedSkillId)
-    : null;
-
-  // Only global skills can be extended.
-  if (extendedSkill !== null && !extendedSkill.isExtendable) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `The extended skill with id "${body.extendedSkillId}" cannot be extended.`,
-      },
-    });
-  }
-
-  // Validate file attachments if provided (gated behind sandbox_tools).
-  let files: FileResource[] | undefined;
-  if (fileAttachments) {
-    const featureFlags = await getFeatureFlags(auth);
-    if (!featureFlags.includes("sandbox_tools") && fileAttachments.length > 0) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "invalid_request_error",
-          message: "File attachments are not supported.",
-        },
-      });
-    }
-
-    const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
-    files = await FileResource.fetchByIds(auth, fileAttachmentIds);
-    if (files.length !== fileAttachmentIds.length) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "invalid_request_error",
-          message: `File attachments not all found, ${files.length} found, ${fileAttachmentIds.length} requested`,
-        },
-      });
-    }
-
-    for (const file of files) {
-      if (!file.isReady || file.useCase !== "skill_attachment") {
+    let skillView: SkillViewType = "full";
+    if (viewType !== undefined) {
+      if (!isString(viewType) || !isSkillViewType(viewType)) {
         return apiError(ctx, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `File ${file.sId} is not ready or not a skill_attachment.`,
+            message: `Invalid viewType: ${viewType}. Expected "full" or "summary".`,
           },
         });
       }
-    }
-  }
 
-  // Generate icon suggestion if not provided.
-  let icon = body.icon;
-  if (!icon) {
-    const iconResult = await getSkillIconSuggestion(auth, {
-      name,
-      instructions: body.instructions,
-      agentFacingDescription: body.agentFacingDescription,
+      skillView = viewType;
+    }
+
+    if (withRelations === "true" && skillView === "summary") {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "viewType=summary is incompatible with withRelations=true.",
+        },
+      });
+    }
+
+    const statusValidation = SkillStatusSchema.safeParse(status);
+    if (!statusValidation.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Invalid status: ${status}. Expected "active", "archived", or "suggested".`,
+        },
+      });
+    }
+    const skillStatus = statusValidation.data;
+
+    const skills = await SkillResource.listByWorkspace(auth, {
+      status: skillStatus,
+      globalSpaceOnly: globalSpaceOnly === "true",
+      onlyCustom: onlyCustom === "true",
+      isDefault: isDefault === "true" ? true : undefined,
+      withInstructions: skillView !== "summary",
+      withTools: skillView === "full",
     });
-    if (iconResult.isOk()) {
-      icon = iconResult.value;
-    } else {
-      logger.warn(
-        { error: iconResult.error },
-        "Failed to generate icon suggestion for skill"
+
+    if (withRelations === "true") {
+      const extendedSkills = await SkillResource.fetchByIds(
+        auth,
+        removeNulls(uniq(skills.map((s) => s.extendedSkillId)))
       );
-    }
-  }
+      const extendedSkillsMap = new Map(extendedSkills.map((s) => [s.sId, s]));
 
-  const newSkill = await SkillResource.makeNew(
-    auth,
-    {
-      status: "active",
-      name,
-      agentFacingDescription: body.agentFacingDescription,
-      userFacingDescription: body.userFacingDescription,
-      instructions: body.instructions,
-      instructionsHtml: body.instructionsHtml,
-      editedBy: user.id,
-      requestedSpaceIds,
-      extendedSkillId: body.extendedSkillId,
-      icon,
-      source: body.source ?? "web_app",
-      sourceMetadata: body.sourceMetadata ?? null,
-      isDefault: body.isDefault ?? false,
-    },
-    {
-      mcpServerViews,
-      attachedKnowledge: attachedKnowledgeWithDataSourceViews,
-      fileAttachments: files,
-    }
-  );
+      const skillsWithRelations = await concurrentExecutor(
+        skills,
+        async (sc) => {
+          const usage = await sc.fetchUsage(auth);
+          const editors = await sc.listEditors(auth);
+          const editedByUser = await sc.fetchEditedByUser(auth);
 
-  // Update file useCaseMetadata with the newly created skill's sId.
-  if (files) {
-    await FileResource.bulkSetUseCaseMetadata(auth, files, {
-      skillId: newSkill.sId,
+          return {
+            ...sc.toJSON(auth),
+            relations: {
+              usage,
+              editors: editors ? editors.map((e) => e.toJSON()) : null,
+              editedByUser: editedByUser ? editedByUser.toJSON() : null,
+              extendedSkill: sc.extendedSkillId
+                ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
+                  null)
+                : null,
+            },
+          } satisfies SkillWithRelationsType;
+        },
+        { concurrency: 10 }
+      );
+
+      return ctx.json({ skills: skillsWithRelations });
+    }
+
+    if (skillView === "summary") {
+      return ctx.json({
+        skills: skills.map((sc) => {
+          const {
+            instructions,
+            instructionsHtml,
+            tools,
+            ...skillWithoutInstructionsAndTools
+          } = sc.toJSON(auth);
+
+          return skillWithoutInstructionsAndTools;
+        }),
+      });
+    }
+
+    return ctx.json({
+      skills: skills.map((sc) => sc.toJSON(auth)),
     });
   }
+);
 
-  return ctx.json({ skill: newSkill.toJSON(auth) });
-});
+app.post(
+  "/",
+  validate("json", PostSkillRequestBodySchema),
+  async (ctx): HandlerResult<PostSkillResponseBody> => {
+    const auth = ctx.get("auth");
+    const owner = auth.getNonNullableWorkspace();
+
+    if (!isBuilder(owner)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "User is not a builder.",
+        },
+      });
+    }
+
+    const user = auth.getNonNullableUser();
+
+    const body = ctx.req.valid("json");
+    const name = body.name.trim();
+
+    if (!name) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Skill name cannot be empty.",
+        },
+      });
+    }
+
+    const existingSkill = await SkillResource.fetchActiveByName(auth, name);
+
+    if (existingSkill) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `A skill with the name "${name}" already exists.`,
+        },
+      });
+    }
+
+    // Validate all MCP server views exist before creating anything.
+    const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
+    const mcpServerViews = await MCPServerViewResource.fetchByIds(
+      auth,
+      mcpServerViewIds
+    );
+
+    if (mcpServerViewIds.length !== mcpServerViews.length) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: `MCP server views not all found, ${mcpServerViews.length} found, ${mcpServerViewIds.length} requested`,
+        },
+      });
+    }
+
+    const { attachedKnowledge, fileAttachments } = body;
+
+    const dataSourceViewIds = uniq(
+      attachedKnowledge.map((attachment) => attachment.dataSourceViewId)
+    );
+
+    const dataSourceViews = await DataSourceViewResource.fetchByIds(
+      auth,
+      dataSourceViewIds
+    );
+    if (dataSourceViews.length !== dataSourceViewIds.length) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Data source views not all found, ${dataSourceViews.length} found, ${dataSourceViewIds.length} requested`,
+        },
+      });
+    }
+
+    const dataSourceViewIdMap = new Map(
+      dataSourceViews.map((dsv) => [dsv.sId, dsv])
+    );
+
+    const attachedKnowledgeWithDataSourceViews = attachedKnowledge.map(
+      (attachment) => ({
+        dataSourceView: dataSourceViewIdMap.get(attachment.dataSourceViewId)!,
+        nodeId: attachment.nodeId,
+      })
+    );
+
+    const computedRequestedSpaceIds =
+      await SkillResource.computeRequestedSpaceIds(auth, {
+        mcpServerViews,
+        attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+      });
+
+    const additionalRequestedSpaceIdsRes =
+      await resolveAdditionalRequestedSpaceModelIds(
+        auth,
+        body.additionalRequestedSpaceIds
+      );
+
+    if (additionalRequestedSpaceIdsRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: additionalRequestedSpaceIdsRes.error.message,
+        },
+      });
+    }
+
+    const requestedSpaceIds = uniq([
+      ...computedRequestedSpaceIds,
+      ...additionalRequestedSpaceIdsRes.value,
+    ]);
+
+    const extendedSkill = body.extendedSkillId
+      ? await SkillResource.fetchById(auth, body.extendedSkillId)
+      : null;
+
+    // Only global skills can be extended.
+    if (extendedSkill !== null && !extendedSkill.isExtendable) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `The extended skill with id "${body.extendedSkillId}" cannot be extended.`,
+        },
+      });
+    }
+
+    // Validate file attachments if provided (gated behind sandbox_tools).
+    let files: FileResource[] | undefined;
+    if (fileAttachments) {
+      const featureFlags = await getFeatureFlags(auth);
+      if (
+        !featureFlags.includes("sandbox_tools") &&
+        fileAttachments.length > 0
+      ) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message: "File attachments are not supported.",
+          },
+        });
+      }
+
+      const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
+      files = await FileResource.fetchByIds(auth, fileAttachmentIds);
+      if (files.length !== fileAttachmentIds.length) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: `File attachments not all found, ${files.length} found, ${fileAttachmentIds.length} requested`,
+          },
+        });
+      }
+
+      for (const file of files) {
+        if (!file.isReady || file.useCase !== "skill_attachment") {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `File ${file.sId} is not ready or not a skill_attachment.`,
+            },
+          });
+        }
+      }
+    }
+
+    // Generate icon suggestion if not provided.
+    let icon = body.icon;
+    if (!icon) {
+      const iconResult = await getSkillIconSuggestion(auth, {
+        name,
+        instructions: body.instructions,
+        agentFacingDescription: body.agentFacingDescription,
+      });
+      if (iconResult.isOk()) {
+        icon = iconResult.value;
+      } else {
+        logger.warn(
+          { error: iconResult.error },
+          "Failed to generate icon suggestion for skill"
+        );
+      }
+    }
+
+    const newSkill = await SkillResource.makeNew(
+      auth,
+      {
+        status: "active",
+        name,
+        agentFacingDescription: body.agentFacingDescription,
+        userFacingDescription: body.userFacingDescription,
+        instructions: body.instructions,
+        instructionsHtml: body.instructionsHtml,
+        editedBy: user.id,
+        requestedSpaceIds,
+        extendedSkillId: body.extendedSkillId,
+        icon,
+        source: body.source ?? "web_app",
+        sourceMetadata: body.sourceMetadata ?? null,
+        isDefault: body.isDefault ?? false,
+      },
+      {
+        mcpServerViews,
+        attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+        fileAttachments: files,
+      }
+    );
+
+    // Update file useCaseMetadata with the newly created skill's sId.
+    if (files) {
+      await FileResource.bulkSetUseCaseMetadata(auth, files, {
+        skillId: newSkill.sId,
+      });
+    }
+
+    return ctx.json({ skill: newSkill.toJSON(auth) });
+  }
+);
 
 // Per-skill operations: mounted at /:sId so child routes can read it.
 app.route("/:sId", skill);

--- a/front-api/routes/w/[wId]/skills/reinforcement_daily_spend.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_daily_spend.ts
@@ -1,5 +1,6 @@
 import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -13,40 +14,43 @@ export type GetReinforcementDailySpendResponseBody = {
 // Mounted at /api/w/:wId/skills/reinforcement_daily_spend.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  async (ctx): HandlerResult<GetReinforcementDailySpendResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!auth.isAdmin()) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Only admins can view self-improving skills daily spend.",
-      },
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Only admins can view self-improving skills daily spend.",
+        },
+      });
+    }
+
+    const period = await getCurrentPeriod(auth);
+
+    const dailyMap =
+      await SelfImprovingSkillsUsageResource.getDailySpendMicroUsdWithMarkup(
+        auth,
+        {
+          startDate: period.cycleStart,
+          endDate: period.cycleEnd,
+        }
+      );
+
+    const dailySpendMicroUsd: Record<string, number> = {};
+    for (const [day, spend] of dailyMap) {
+      dailySpendMicroUsd[day] = spend;
+    }
+
+    return ctx.json({
+      dailySpendMicroUsd,
+      periodStartDate: period.cycleStart.toISOString(),
+      periodEndDate: period.cycleEnd.toISOString(),
     });
   }
-
-  const period = await getCurrentPeriod(auth);
-
-  const dailyMap =
-    await SelfImprovingSkillsUsageResource.getDailySpendMicroUsdWithMarkup(
-      auth,
-      {
-        startDate: period.cycleStart,
-        endDate: period.cycleEnd,
-      }
-    );
-
-  const dailySpendMicroUsd: Record<string, number> = {};
-  for (const [day, spend] of dailyMap) {
-    dailySpendMicroUsd[day] = spend;
-  }
-
-  return ctx.json({
-    dailySpendMicroUsd,
-    periodStartDate: period.cycleStart.toISOString(),
-    periodEndDate: period.cycleEnd.toISOString(),
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/skills/reinforcement_spend.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_spend.ts
@@ -1,6 +1,7 @@
 import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -13,7 +14,7 @@ export type GetSkillsSpendResponseBody = {
 // Mounted at /api/w/:wId/skills/reinforcement_spend.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetSkillsSpendResponseBody> => {
   const auth = ctx.get("auth");
 
   if (!auth.isAdmin()) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -45,6 +45,7 @@ import type { LLMCredentialsType } from "@app/types/provider_credential";
 import { sendUserOperationMessage } from "@app/types/shared/user_operation";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { withSpace } from "@front-api/middleware/with_space";
@@ -90,7 +91,7 @@ app.post(
   "/",
   withSpace({ requireCanReadOrAdministrate: true }),
   validate("json", PostDataSourceRequestBodySchema),
-  async (ctx) => {
+  async (ctx): HandlerResult<PostSpaceDataSourceResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
     const owner = auth.getNonNullableWorkspace();
@@ -215,7 +216,7 @@ async function handleDataSourceWithProvider({
   owner: WorkspaceType;
   space: SpaceResource;
   body: z.infer<typeof PostDataSourceWithProviderRequestBodySchema>;
-}) {
+}): HandlerResult<PostSpaceDataSourceResponseBody> {
   const { provider, name, connectionId, relatedCredentialId, extraConfig } =
     body;
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp/available.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp/available.ts
@@ -2,6 +2,7 @@ import type { MCPServerType } from "@app/lib/api/mcp";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { withSpace } from "@front-api/middleware/with_space";
 import { Hono } from "hono";
 
@@ -17,51 +18,57 @@ export type GetMCPServersResponseBody = {
 // space.
 const app = new Hono();
 
-app.get("/", withSpace({ requireCanRead: true }), async (ctx) => {
-  const auth = ctx.get("auth");
-  const space = ctx.get("space");
+app.get(
+  "/",
+  withSpace({ requireCanRead: true }),
+  async (ctx): HandlerResult<GetMCPServersResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
 
-  const [
-    internalInstalledServers,
-    remoteInstalledServers,
-    workspaceServerViews,
-  ] = await Promise.all([
-    InternalMCPServerInMemoryResource.listByWorkspace(auth),
-    RemoteMCPServerResource.listByWorkspace(auth),
-    MCPServerViewResource.listByWorkspace(auth),
-  ]);
+    const [
+      internalInstalledServers,
+      remoteInstalledServers,
+      workspaceServerViews,
+    ] = await Promise.all([
+      InternalMCPServerInMemoryResource.listByWorkspace(auth),
+      RemoteMCPServerResource.listByWorkspace(auth),
+      MCPServerViewResource.listByWorkspace(auth),
+    ]);
 
-  const globalServersId = workspaceServerViews
-    .filter((s) => s.space.kind === "global")
-    .map((s) => s.toJSON().server.sId);
+    const globalServersId = workspaceServerViews
+      .filter((s) => s.space.kind === "global")
+      .map((s) => s.toJSON().server.sId);
 
-  const spaceServerViews = workspaceServerViews.filter(
-    (s) => s.space.id === space.id
-  );
-  const spaceServersId = spaceServerViews.map((s) => s.toJSON().server.sId);
+    const spaceServerViews = workspaceServerViews.filter(
+      (s) => s.space.id === space.id
+    );
+    const spaceServersId = spaceServerViews.map((s) => s.toJSON().server.sId);
 
-  const availableServer: MCPServerType[] = [];
+    const availableServer: MCPServerType[] = [];
 
-  for (const srv of internalInstalledServers) {
-    if (!spaceServersId.includes(srv.id) && !globalServersId.includes(srv.id)) {
-      availableServer.push(srv.toJSON());
+    for (const srv of internalInstalledServers) {
+      if (
+        !spaceServersId.includes(srv.id) &&
+        !globalServersId.includes(srv.id)
+      ) {
+        availableServer.push(srv.toJSON());
+      }
     }
-  }
 
-  for (const srv of remoteInstalledServers) {
-    if (
-      !spaceServersId.includes(srv.sId) &&
-      !globalServersId.includes(srv.sId)
-    ) {
-      availableServer.push(srv.toJSON());
+    for (const srv of remoteInstalledServers) {
+      if (
+        !spaceServersId.includes(srv.sId) &&
+        !globalServersId.includes(srv.sId)
+      ) {
+        availableServer.push(srv.toJSON());
+      }
     }
-  }
 
-  const body: GetMCPServersResponseBody = {
-    success: true,
-    servers: availableServer,
-  };
-  return ctx.json(body);
-});
+    return ctx.json({
+      success: true,
+      servers: availableServer,
+    });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
@@ -1,9 +1,8 @@
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import type { APIErrorResponse } from "@app/types/error";
 import type { SpaceKind } from "@app/types/space";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { withSpace } from "@front-api/middleware/with_space";
-import type { TypedResponse } from "hono";
 import { Hono } from "hono";
 
 export type DeleteMCPServerViewResponseBody = {
@@ -16,11 +15,7 @@ const app = new Hono();
 app.delete(
   "/",
   withSpace({ requireCanReadOrAdministrate: true }),
-  async (
-    ctx
-  ): Promise<
-    TypedResponse<DeleteMCPServerViewResponseBody | APIErrorResponse>
-  > => {
+  async (ctx): HandlerResult<DeleteMCPServerViewResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
     const serverViewId = ctx.req.param("svId") ?? "";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
@@ -1,8 +1,14 @@
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { APIErrorResponse } from "@app/types/error";
 import type { SpaceKind } from "@app/types/space";
 import { apiError } from "@front-api/middleware/utils";
 import { withSpace } from "@front-api/middleware/with_space";
+import type { TypedResponse } from "hono";
 import { Hono } from "hono";
+
+export type DeleteMCPServerViewResponseBody = {
+  deleted: boolean;
+};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/mcp_views/:svId.
 const app = new Hono();
@@ -10,7 +16,11 @@ const app = new Hono();
 app.delete(
   "/",
   withSpace({ requireCanReadOrAdministrate: true }),
-  async (ctx) => {
+  async (
+    ctx
+  ): Promise<
+    TypedResponse<DeleteMCPServerViewResponseBody | APIErrorResponse>
+  > => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
     const serverViewId = ctx.req.param("svId") ?? "";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -11,15 +11,14 @@ import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_conne
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { APIErrorResponse } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { SpaceKind } from "@app/types/space";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { withSpace } from "@front-api/middleware/with_space";
-import type { TypedResponse } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import svId from "./[svId]";
@@ -119,11 +118,7 @@ const app = new Hono();
 app.get(
   "/",
   withSpace({ requireCanReadOrAdministrate: true }),
-  async (
-    ctx
-  ): Promise<
-    TypedResponse<GetMCPServerViewsResponseBody | APIErrorResponse>
-  > => {
+  async (ctx): HandlerResult<GetMCPServerViewsResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
 
@@ -211,11 +206,7 @@ app.post(
   "/",
   withSpace({ requireCanReadOrAdministrate: true }),
   validate("json", PostBodySchema),
-  async (
-    ctx
-  ): Promise<
-    TypedResponse<PostMCPServerViewResponseBody | APIErrorResponse>
-  > => {
+  async (ctx): HandlerResult<PostMCPServerViewResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -1,5 +1,6 @@
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { sendMCPGlobalSharingReconfigurationEmail } from "@app/lib/api/email";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   oauthProviderRequiresWorkspaceConnectionForPersonalAuth,
   withWorkspaceConnectionRequirement,
@@ -21,6 +22,16 @@ import { Hono } from "hono";
 import { z } from "zod";
 import svId from "./[svId]";
 import notActivated from "./not_activated";
+
+export type GetMCPServerViewsResponseBody = {
+  success: boolean;
+  serverViews: MCPServerViewType[];
+};
+
+export type PostMCPServerViewResponseBody = {
+  success: boolean;
+  serverView: MCPServerViewType;
+};
 
 const GetQueryParamsSchema = z.object({
   availability: z
@@ -150,10 +161,11 @@ app.get("/", withSpace({ requireCanReadOrAdministrate: true }), async (ctx) => {
   ];
 
   if (mcpServerIdsRequiringWorkspaceConnection.length === 0) {
-    return ctx.json({
+    const body: GetMCPServerViewsResponseBody = {
       success: true,
       serverViews: filteredServerViews,
-    });
+    };
+    return ctx.json(body);
   }
 
   const workspaceConnections =
@@ -167,7 +179,7 @@ app.get("/", withSpace({ requireCanReadOrAdministrate: true }), async (ctx) => {
     workspaceConnections.map((connection) => connection.mcpServerId)
   );
 
-  return ctx.json({
+  const body: GetMCPServerViewsResponseBody = {
     success: true,
     serverViews: filteredServerViews.map((serverView) => ({
       ...serverView,
@@ -183,7 +195,8 @@ app.get("/", withSpace({ requireCanReadOrAdministrate: true }), async (ctx) => {
         ),
       },
     })),
-  });
+  };
+  return ctx.json(body);
 });
 
 app.post(
@@ -268,10 +281,11 @@ app.post(
       });
     }
 
-    return ctx.json({
+    const body: PostMCPServerViewResponseBody = {
       success: true,
       serverView: serverView.toJSON(),
-    });
+    };
+    return ctx.json(body);
   }
 );
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -11,6 +11,7 @@ import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_conne
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { APIErrorResponse } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -18,6 +19,7 @@ import type { SpaceKind } from "@app/types/space";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { withSpace } from "@front-api/middleware/with_space";
+import type { TypedResponse } from "hono";
 import { Hono } from "hono";
 import { z } from "zod";
 import svId from "./[svId]";
@@ -114,96 +116,106 @@ async function notifyWorkspaceAdminsAboutAffectedAgents(
 // Mounted under /api/w/:wId/spaces/:spaceId/mcp_views.
 const app = new Hono();
 
-app.get("/", withSpace({ requireCanReadOrAdministrate: true }), async (ctx) => {
-  const auth = ctx.get("auth");
-  const space = ctx.get("space");
+app.get(
+  "/",
+  withSpace({ requireCanReadOrAdministrate: true }),
+  async (
+    ctx
+  ): Promise<
+    TypedResponse<GetMCPServerViewsResponseBody | APIErrorResponse>
+  > => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
 
-  const r = GetQueryParamsSchema.safeParse({
-    availability: ctx.req.query("availability"),
-  });
+    const r = GetQueryParamsSchema.safeParse({
+      availability: ctx.req.query("availability"),
+    });
 
-  if (!r.success) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid query parameters.",
-      },
+    if (!r.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid query parameters.",
+        },
+      });
+    }
+
+    const { availability = "manual" } = r.data;
+
+    const serverViews = (
+      await MCPServerViewResource.listBySpace(auth, space)
+    ).map((view) => view.toJSON());
+
+    const filteredServerViews = serverViews.filter(
+      (s) => availability === "all" || s.server.availability === availability
+    );
+
+    // Some OAuth providers require a workspace-level connection before users
+    // can set up personal connections. We enrich the authorization info so the
+    // client can block the OAuth popup and show an inline error instead.
+    // The DB query is only made for servers in the list that need it.
+    const mcpServerIdsRequiringWorkspaceConnection = [
+      ...new Set(
+        filteredServerViews
+          .filter(
+            (s) =>
+              s.server.authorization !== null &&
+              oauthProviderRequiresWorkspaceConnectionForPersonalAuth(
+                s.server.authorization.provider
+              )
+          )
+          .map((s) => s.server.sId)
+      ),
+    ];
+
+    if (mcpServerIdsRequiringWorkspaceConnection.length === 0) {
+      return ctx.json({
+        success: true,
+        serverViews: filteredServerViews,
+      });
+    }
+
+    const workspaceConnections =
+      await MCPServerConnectionResource.listWorkspaceConnectionsByMCPServerIds(
+        auth,
+        {
+          mcpServerIds: mcpServerIdsRequiringWorkspaceConnection,
+        }
+      );
+    const workspaceConnectedMCPServerIds = new Set(
+      workspaceConnections.map((connection) => connection.mcpServerId)
+    );
+
+    return ctx.json({
+      success: true,
+      serverViews: filteredServerViews.map((serverView) => ({
+        ...serverView,
+        server: {
+          ...serverView.server,
+          authorization: withWorkspaceConnectionRequirement(
+            serverView.server.authorization,
+            {
+              isWorkspaceConnected: workspaceConnectedMCPServerIds.has(
+                serverView.server.sId
+              ),
+            }
+          ),
+        },
+      })),
     });
   }
-
-  const { availability = "manual" } = r.data;
-
-  const serverViews = (
-    await MCPServerViewResource.listBySpace(auth, space)
-  ).map((view) => view.toJSON());
-
-  const filteredServerViews = serverViews.filter(
-    (s) => availability === "all" || s.server.availability === availability
-  );
-
-  // Some OAuth providers require a workspace-level connection before users
-  // can set up personal connections. We enrich the authorization info so the
-  // client can block the OAuth popup and show an inline error instead.
-  // The DB query is only made for servers in the list that need it.
-  const mcpServerIdsRequiringWorkspaceConnection = [
-    ...new Set(
-      filteredServerViews
-        .filter(
-          (s) =>
-            s.server.authorization !== null &&
-            oauthProviderRequiresWorkspaceConnectionForPersonalAuth(
-              s.server.authorization.provider
-            )
-        )
-        .map((s) => s.server.sId)
-    ),
-  ];
-
-  if (mcpServerIdsRequiringWorkspaceConnection.length === 0) {
-    const body: GetMCPServerViewsResponseBody = {
-      success: true,
-      serverViews: filteredServerViews,
-    };
-    return ctx.json(body);
-  }
-
-  const workspaceConnections =
-    await MCPServerConnectionResource.listWorkspaceConnectionsByMCPServerIds(
-      auth,
-      {
-        mcpServerIds: mcpServerIdsRequiringWorkspaceConnection,
-      }
-    );
-  const workspaceConnectedMCPServerIds = new Set(
-    workspaceConnections.map((connection) => connection.mcpServerId)
-  );
-
-  const body: GetMCPServerViewsResponseBody = {
-    success: true,
-    serverViews: filteredServerViews.map((serverView) => ({
-      ...serverView,
-      server: {
-        ...serverView.server,
-        authorization: withWorkspaceConnectionRequirement(
-          serverView.server.authorization,
-          {
-            isWorkspaceConnected: workspaceConnectedMCPServerIds.has(
-              serverView.server.sId
-            ),
-          }
-        ),
-      },
-    })),
-  };
-  return ctx.json(body);
-});
+);
 
 app.post(
   "/",
   withSpace({ requireCanReadOrAdministrate: true }),
   validate("json", PostBodySchema),
-  async (ctx) => {
+  async (
+    ctx
+  ): Promise<
+    TypedResponse<PostMCPServerViewResponseBody | APIErrorResponse>
+  > => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
 
@@ -281,11 +293,10 @@ app.post(
       });
     }
 
-    const body: PostMCPServerViewResponseBody = {
+    return ctx.json({
       success: true,
       serverView: serverView.toJSON(),
-    };
-    return ctx.json(body);
+    });
   }
 );
 

--- a/front-api/routes/w/[wId]/spaces/index.ts
+++ b/front-api/routes/w/[wId]/spaces/index.ts
@@ -9,6 +9,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { areOpenProjectsAllowed } from "@app/lib/workspace_policies";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { ProjectType, SpaceType } from "@app/types/space";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -52,7 +53,7 @@ export type PostSpacesResponseBody = {
 // workspace sub-app, so ctx.get("auth") is always available here.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetSpacesResponseBody> => {
   const auth = ctx.get("auth");
   const role = ctx.req.query("role");
   const kind = ctx.req.query("kind");
@@ -79,93 +80,96 @@ app.get("/", async (ctx) => {
     projectSpaces
   );
 
-  const body: GetSpacesResponseBody = {
+  return ctx.json({
     spaces: [...nonProjectsJson, ...projectsJson],
-  };
-  return ctx.json(body);
+  });
 });
 
-app.post("/", validate("json", PostSpaceRequestBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const requestBody = ctx.req.valid("json");
-  const owner = auth.getNonNullableWorkspace();
+app.post(
+  "/",
+  validate("json", PostSpaceRequestBodySchema),
+  async (ctx): HandlerResult<PostSpacesResponseBody> => {
+    const auth = ctx.get("auth");
+    const requestBody = ctx.req.valid("json");
+    const owner = auth.getNonNullableWorkspace();
 
-  if (
-    requestBody.spaceKind === "project" &&
-    !requestBody.isRestricted &&
-    !areOpenProjectsAllowed(owner)
-  ) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "Open projects are disabled by your workspace admin. Create a private project instead.",
+    if (
+      requestBody.spaceKind === "project" &&
+      !requestBody.isRestricted &&
+      !areOpenProjectsAllowed(owner)
+    ) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Open projects are disabled by your workspace admin. Create a private project instead.",
+        },
+      });
+    }
+
+    const spaceRes = await createSpaceAndGroup(auth, requestBody);
+    if (spaceRes.isErr()) {
+      switch (spaceRes.error.code) {
+        case "limit_reached":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "plan_limit_error",
+              message:
+                "Limit of spaces allowed for your plan reached. Contact support to upgrade.",
+            },
+          });
+        case "space_already_exists":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "space_already_exists",
+              message: "Space with that name already exists.",
+            },
+          });
+        case "internal_error":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: spaceRes.error.message,
+            },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message:
+                "Only users that are `admins` can create regular spaces.",
+            },
+          });
+        default:
+          assertNever(spaceRes.error.code);
+      }
+    }
+
+    const space = spaceRes.value;
+
+    void emitAuditLogEvent({
+      auth,
+      action: "space.created",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("space", space),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        space_name: space.name,
+        space_kind: space.kind,
+        is_restricted: String(requestBody.isRestricted),
       },
     });
+
+    return ctx.json({ space: space.toJSON() }, 201);
   }
-
-  const spaceRes = await createSpaceAndGroup(auth, requestBody);
-  if (spaceRes.isErr()) {
-    switch (spaceRes.error.code) {
-      case "limit_reached":
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "plan_limit_error",
-            message:
-              "Limit of spaces allowed for your plan reached. Contact support to upgrade.",
-          },
-        });
-      case "space_already_exists":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "space_already_exists",
-            message: "Space with that name already exists.",
-          },
-        });
-      case "internal_error":
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: spaceRes.error.message,
-          },
-        });
-      case "unauthorized":
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "Only users that are `admins` can create regular spaces.",
-          },
-        });
-      default:
-        assertNever(spaceRes.error.code);
-    }
-  }
-
-  const space = spaceRes.value;
-
-  void emitAuditLogEvent({
-    auth,
-    action: "space.created",
-    targets: [
-      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-      buildAuditLogTarget("space", space),
-    ],
-    context: getAuditLogContext(auth),
-    metadata: {
-      space_name: space.name,
-      space_kind: space.kind,
-      is_restricted: String(requestBody.isRestricted),
-    },
-  });
-
-  const responseBody: PostSpacesResponseBody = { space: space.toJSON() };
-  return ctx.json(responseBody, 201);
-});
+);
 
 // Register static paths BEFORE `/:spaceId` so the param route does not
 // swallow these names as ids.

--- a/front-api/routes/w/[wId]/subscriptions/checkout-status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout-status.ts
@@ -1,3 +1,4 @@
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -19,30 +20,32 @@ const GetCheckoutStatusQuerySchema = z.object({
 // for the Stripe-only checkout flow (PaymentProcessingPage).
 const app = new Hono();
 
-app.get("/", validate("query", GetCheckoutStatusQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  validate("query", GetCheckoutStatusQuerySchema),
+  async (ctx): HandlerResult<GetCheckoutStatusResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!auth.isAdmin()) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can access this endpoint.",
-      },
-    });
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can access this endpoint.",
+        },
+      });
+    }
+
+    const { plan_code } = ctx.req.valid("query");
+
+    const subscription = auth.subscription();
+    if (subscription?.plan.code === plan_code) {
+      return ctx.json({ status: "success" });
+    }
+
+    return ctx.json({ status: "pending" });
   }
-
-  const { plan_code } = ctx.req.valid("query");
-
-  const subscription = auth.subscription();
-  if (subscription?.plan.code === plan_code) {
-    const body: GetCheckoutStatusResponseBody = { status: "success" };
-    return ctx.json(body);
-  }
-
-  const body: GetCheckoutStatusResponseBody = { status: "pending" };
-  return ctx.json(body);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/subscriptions/pricing.ts
+++ b/front-api/routes/w/[wId]/subscriptions/pricing.ts
@@ -1,5 +1,6 @@
 import type { SubscriptionPerSeatPricing } from "@app/types/plan";
 
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -10,7 +11,7 @@ export type GetSubscriptionPricingResponseBody = {
 // Mounted at /api/w/:wId/subscriptions/pricing.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetSubscriptionPricingResponseBody> => {
   const auth = ctx.get("auth");
 
   if (!auth.isAdmin()) {
@@ -26,13 +27,11 @@ app.get("/", async (ctx) => {
 
   const subscriptionResource = auth.subscriptionResource();
   if (!subscriptionResource) {
-    const body: GetSubscriptionPricingResponseBody = { perSeatPricing: null };
-    return ctx.json(body);
+    return ctx.json({ perSeatPricing: null });
   }
 
   const perSeatPricing = await subscriptionResource.getPerSeatPricing();
-  const body: GetSubscriptionPricingResponseBody = { perSeatPricing };
-  return ctx.json(body);
+  return ctx.json({ perSeatPricing });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/subscriptions/status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/status.ts
@@ -1,6 +1,7 @@
 import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type GetSubscriptionStatusResponseBody = {
@@ -11,17 +12,16 @@ export type GetSubscriptionStatusResponseBody = {
 // Mounted at /api/w/:wId/subscriptions/status.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetSubscriptionStatusResponseBody> => {
   const auth = ctx.get("auth");
   const owner = auth.getNonNullableWorkspace();
 
   // Only admins can be redirected to trial-ended page.
   if (!auth.isAdmin()) {
-    const body: GetSubscriptionStatusResponseBody = {
+    return ctx.json({
       shouldRedirect: false,
       redirectUrl: null,
-    };
-    return ctx.json(body);
+    });
   }
 
   const subscription = auth.subscription();
@@ -30,11 +30,10 @@ app.get("/", async (ctx) => {
     try {
       const { count, limit } = await getMessageUsageCount(auth);
       if (limit !== -1 && count >= limit) {
-        const body: GetSubscriptionStatusResponseBody = {
+        return ctx.json({
           shouldRedirect: true,
           redirectUrl: `/w/${owner.sId}/trial-ended`,
-        };
-        return ctx.json(body);
+        });
       }
     } catch {
       // If we can't check message usage, don't redirect.
@@ -49,19 +48,17 @@ app.get("/", async (ctx) => {
       isFreeTrialPhonePlan(lastSubscription.getPlan().code) &&
       lastSubscription.toJSON().status === "ended"
     ) {
-      const body: GetSubscriptionStatusResponseBody = {
+      return ctx.json({
         shouldRedirect: true,
         redirectUrl: `/w/${owner.sId}/trial-ended`,
-      };
-      return ctx.json(body);
+      });
     }
   }
 
-  const body: GetSubscriptionStatusResponseBody = {
+  return ctx.json({
     shouldRedirect: false,
     redirectUrl: null,
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/subscriptions/trial-info.ts
+++ b/front-api/routes/w/[wId]/subscriptions/trial-info.ts
@@ -1,5 +1,6 @@
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -10,44 +11,45 @@ export type GetSubscriptionTrialInfoResponseBody = {
 // Mounted at /api/w/:wId/subscriptions/trial-info.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  async (ctx): HandlerResult<GetSubscriptionTrialInfoResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!auth.isAdmin()) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can access this endpoint.",
-      },
-    });
-  }
-
-  const subscription = auth.subscription();
-  if (!subscription) {
-    const body: GetSubscriptionTrialInfoResponseBody = {
-      trialDaysRemaining: null,
-    };
-    return ctx.json(body);
-  }
-
-  let trialDaysRemaining: number | null = null;
-
-  if (subscription.trialing && subscription.stripeSubscriptionId) {
-    const stripeSubscription = await getStripeSubscription(
-      subscription.stripeSubscriptionId
-    );
-    if (stripeSubscription && stripeSubscription.trial_end) {
-      trialDaysRemaining = Math.ceil(
-        (stripeSubscription.trial_end * 1000 - Date.now()) /
-          (1000 * 60 * 60 * 24)
-      );
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can access this endpoint.",
+        },
+      });
     }
-  }
 
-  const body: GetSubscriptionTrialInfoResponseBody = { trialDaysRemaining };
-  return ctx.json(body);
-});
+    const subscription = auth.subscription();
+    if (!subscription) {
+      return ctx.json({
+        trialDaysRemaining: null,
+      });
+    }
+
+    let trialDaysRemaining: number | null = null;
+
+    if (subscription.trialing && subscription.stripeSubscriptionId) {
+      const stripeSubscription = await getStripeSubscription(
+        subscription.stripeSubscriptionId
+      );
+      if (stripeSubscription && stripeSubscription.trial_end) {
+        trialDaysRemaining = Math.ceil(
+          (stripeSubscription.trial_end * 1000 - Date.now()) /
+            (1000 * 60 * 60 * 24)
+        );
+      }
+    }
+
+    return ctx.json({ trialDaysRemaining });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/trial/start.ts
+++ b/front-api/routes/w/[wId]/trial/start.ts
@@ -3,6 +3,7 @@ import {
   isWorkspaceEligibleForTrial,
 } from "@app/lib/plans/trial";
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -13,7 +14,7 @@ export type PostTrialVerifyResponseBody = {
 // Mounted at /api/w/:wId/trial/start.
 const app = new Hono();
 
-app.post("/", async (ctx) => {
+app.post("/", async (ctx): HandlerResult<PostTrialVerifyResponseBody> => {
   const auth = ctx.get("auth");
 
   if (!auth.isAdmin()) {
@@ -52,8 +53,7 @@ app.post("/", async (ctx) => {
 
   await activatePhoneTrial(auth);
 
-  const body: PostTrialVerifyResponseBody = { success: true };
-  return ctx.json(body);
+  return ctx.json({ success: true });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/verified-domains.ts
+++ b/front-api/routes/w/[wId]/verified-domains.ts
@@ -1,5 +1,6 @@
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { WorkspaceDomain } from "@app/types/workspace";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -10,36 +11,38 @@ export type GetWorkspaceVerifiedDomainsResponseBody = {
 // Mounted at /api/w/:wId/verified-domains.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  async (ctx): HandlerResult<GetWorkspaceVerifiedDomainsResponseBody> => {
+    const auth = ctx.get("auth");
 
-  if (!auth.isAdmin()) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can access this endpoint.",
-      },
-    });
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can access this endpoint.",
+        },
+      });
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+
+    if (!workspaceResource) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to fetch the workspace.",
+        },
+      });
+    }
+
+    const verifiedDomains = await workspaceResource.getVerifiedDomains();
+    return ctx.json({ verifiedDomains });
   }
-
-  const workspace = auth.getNonNullableWorkspace();
-  const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
-
-  if (!workspaceResource) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to fetch the workspace.",
-      },
-    });
-  }
-
-  const verifiedDomains = await workspaceResource.getVerifiedDomains();
-  const body: GetWorkspaceVerifiedDomainsResponseBody = { verifiedDomains };
-  return ctx.json(body);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/verify.ts
+++ b/front-api/routes/w/[wId]/verify.ts
@@ -2,6 +2,7 @@ import { resolveCountryCode } from "@app/lib/geo/country-detection";
 import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial/index";
 import { getClientIp } from "@app/lib/utils/request";
 import logger from "@app/logger/logger";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -39,7 +40,7 @@ async function detectCountryFromIP(ctx: Context): Promise<Country> {
 // Mounted at /api/w/:wId/verify.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetVerifyResponseBody> => {
   const auth = ctx.get("auth");
 
   if (!auth.isAdmin()) {
@@ -55,11 +56,10 @@ app.get("/", async (ctx) => {
   const isEligibleForTrial = await isWorkspaceEligibleForTrial(auth);
   const initialCountryCode = await detectCountryFromIP(ctx);
 
-  const body: GetVerifyResponseBody = {
+  return ctx.json({
     isEligibleForTrial,
     initialCountryCode,
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/welcome.ts
+++ b/front-api/routes/w/[wId]/welcome.ts
@@ -1,6 +1,7 @@
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
 import { detectEmailProvider } from "@app/lib/utils/email_provider_detection";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type GetWelcomeResponseBody = {
@@ -11,7 +12,7 @@ export type GetWelcomeResponseBody = {
 // Mounted at /api/w/:wId/welcome.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetWelcomeResponseBody> => {
   const auth = ctx.get("auth");
 
   const owner = auth.getNonNullableWorkspace();
@@ -30,8 +31,7 @@ app.get("/", async (ctx) => {
     `user-${userJson.sId}`
   );
 
-  const body: GetWelcomeResponseBody = { isFirstAdmin, emailProvider };
-  return ctx.json(body);
+  return ctx.json({ isFirstAdmin, emailProvider });
 });
 
 export default app;


### PR DESCRIPTION
## Description

Use new pattern for typed response, e.g.

```
app.get(
  "/",
  validate("query", SearchMembersQuerySchema),
  async (ctx): HandlerResult<SearchMembersResponseBody> => {
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Hono only

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25858">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->