### PR TITLE
Surface inference provider in logs and DD metrics

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -125,7 +125,10 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
 
     this.useVertex = llmParameters.useVertex ?? false;
     if (this.useVertex) {
-      this.metadata = { ...this.metadata, inferenceProvider: "google_vertex_ai" };
+      this.metadata = {
+        ...this.metadata,
+        inferenceProvider: "google_vertex_ai",
+      };
     }
     this.client = new Anthropic({
       apiKey: ANTHROPIC_API_KEY,

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -124,6 +124,9 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
     this.omittedThinking = params.omittedThinking ?? false;
 
     this.useVertex = llmParameters.useVertex ?? false;
+    if (this.useVertex) {
+      this.metadata = { ...this.metadata, inferenceProvider: "google_vertex_ai" };
+    }
     this.client = new Anthropic({
       apiKey: ANTHROPIC_API_KEY,
     });

--- a/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from "vitest";
 
 const metadata: LLMClientMetadata = {
   clientId: "anthropic" as const,
+  inferenceProvider: "anthropic",
   modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
 };
 

--- a/front/lib/api/llm/clients/anthropic/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/errors.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vitest";
 
 const metadata: LLMClientMetadata = {
   clientId: "anthropic" as const,
+  inferenceProvider: "anthropic",
   modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
 };
 

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
@@ -7,6 +7,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     content: { modelInteractionId: "msg_017KE6ziN29Ks5KyL3jGE7RR" },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -19,6 +20,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -26,6 +28,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     type: "tool_call_delta",
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -38,6 +41,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -54,6 +58,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -69,6 +74,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "anthropic" as const,
+          inferenceProvider: "anthropic",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
@@ -85,12 +91,14 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "anthropic" as const,
+          inferenceProvider: "anthropic",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
     ],
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
@@ -7,6 +7,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     content: { modelInteractionId: "msg_01Reasoning123" },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -17,6 +18,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -27,6 +29,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -37,6 +40,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
       encrypted_content: "",
     },
@@ -48,6 +52,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -58,6 +63,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -68,6 +74,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -84,6 +91,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -97,6 +105,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "anthropic" as const,
+          inferenceProvider: "anthropic",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
           encrypted_content: "",
         },
@@ -108,6 +117,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "anthropic" as const,
+          inferenceProvider: "anthropic",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
@@ -119,6 +129,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
       },
       metadata: {
         clientId: "anthropic" as const,
+        inferenceProvider: "anthropic",
         modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
       },
     },
@@ -129,6 +140,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
       },
       metadata: {
         clientId: "anthropic" as const,
+        inferenceProvider: "anthropic",
         modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         encrypted_content: "",
       },
@@ -136,6 +148,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     toolCalls: undefined,
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
@@ -7,6 +7,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     content: { modelInteractionId: "msg_017KE6ziN29Ks5KyL3jGE7RR" },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -17,6 +18,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -27,6 +29,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -37,6 +40,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -49,6 +53,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -56,6 +61,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     type: "tool_call_delta",
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -68,6 +74,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -84,6 +91,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -97,6 +105,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "anthropic" as const,
+          inferenceProvider: "anthropic",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
@@ -109,6 +118,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "anthropic" as const,
+          inferenceProvider: "anthropic",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
@@ -120,6 +130,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
       },
       metadata: {
         clientId: "anthropic" as const,
+        inferenceProvider: "anthropic",
         modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
       },
     },
@@ -133,12 +144,14 @@ export const toolUseLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "anthropic" as const,
+          inferenceProvider: "anthropic",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
     ],
     metadata: {
       clientId: "anthropic" as const,
+      inferenceProvider: "anthropic",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -51,6 +51,7 @@ async function contentToPart(
           },
           {
             clientId: "google_ai_studio",
+            inferenceProvider: "google_ai_studio",
             modelId,
           }
         );

--- a/front/lib/api/llm/clients/google/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/errors.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 
 const metadata: LLMClientMetadata = {
   clientId: "google_ai_studio" as const,
+  inferenceProvider: "google_ai_studio",
   modelId: GEMINI_2_5_PRO_MODEL_ID,
 };
 

--- a/front/lib/api/llm/clients/google/utils/test/google_to_events.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/google_to_events.test.ts
@@ -166,6 +166,7 @@ const modelOutputFunctionCallEvents: PartialGenerateContentResponse[] = [
 
 const metadata = {
   clientId: "google_ai_studio",
+  inferenceProvider: "google_ai_studio",
   modelId: "gemini-2.5-pro",
 } as const;
 

--- a/front/lib/api/llm/clients/mistral/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/mistral/utils/test/errors.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 const metadata: LLMClientMetadata = {
   clientId: "mistral" as const,
+  inferenceProvider: "mistral",
   modelId: MISTRAL_LARGE_MODEL_ID,
 };
 

--- a/front/lib/api/llm/clients/mistral/utils/test/mistral_to_events.test.ts
+++ b/front/lib/api/llm/clients/mistral/utils/test/mistral_to_events.test.ts
@@ -142,6 +142,7 @@ const modelOutputFinishToolCallEvents: CompletionEvent[] = [
 
 const metadata = {
   clientId: "mistral",
+  inferenceProvider: "mistral",
   modelId: "mistral-large-latest",
 } as const;
 

--- a/front/lib/api/llm/clients/noop/index.ts
+++ b/front/lib/api/llm/clients/noop/index.ts
@@ -13,6 +13,7 @@ import { isTextContent } from "@app/types/assistant/generation";
 
 const metadata = {
   clientId: "noop" as const,
+  inferenceProvider: "noop",
   modelId: "noop" as const,
 };
 

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -83,6 +83,7 @@ export abstract class LLM<TPayload = unknown> {
     this.bypassFeatureFlag = bypassFeatureFlag;
     this.metadata = {
       clientId: providerId,
+      inferenceProvider: providerId,
       modelId: this.modelId,
     };
 
@@ -199,6 +200,7 @@ export abstract class LLM<TPayload = unknown> {
     const metricTags = [
       `model_id:${this.modelId}`,
       `client_id:${this.metadata.clientId}`,
+      `inference_provider:${this.metadata.inferenceProvider}`,
       `operation_type:${this.context.operationType}`,
     ];
 
@@ -245,6 +247,7 @@ export abstract class LLM<TPayload = unknown> {
               llmEventType: "error",
               errorContent: currentEvent.content,
               modelId: this.modelId,
+              inferenceProvider: this.metadata.inferenceProvider,
               context: this.context,
               traceId: this.traceId,
             },
@@ -260,6 +263,7 @@ export abstract class LLM<TPayload = unknown> {
             {
               llmEventType: "success",
               modelId: this.modelId,
+              inferenceProvider: this.metadata.inferenceProvider,
               context: this.context,
               traceId: this.traceId,
             },
@@ -571,6 +575,7 @@ export abstract class LLM<TPayload = unknown> {
       const metricTags = [
         `model_id:${this.modelId}`,
         `client_id:${this.metadata.clientId}`,
+        `inference_provider:${this.metadata.inferenceProvider}`,
         `operation_type:${this.context!.operationType}`,
       ];
 

--- a/front/lib/api/llm/test/errors.test.ts
+++ b/front/lib/api/llm/test/errors.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 const metadata: LLMClientMetadata = {
   clientId: "anthropic" as const,
+  inferenceProvider: "anthropic",
   modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
 };
 

--- a/front/lib/api/llm/traces/buffer.test.ts
+++ b/front/lib/api/llm/traces/buffer.test.ts
@@ -19,7 +19,11 @@ class LLMEventFactory {
     return {
       type: "text_delta",
       content: { delta },
-      metadata: { clientId: "openai", inferenceProvider: "openai", modelId: "gpt-4-turbo" },
+      metadata: {
+        clientId: "openai",
+        inferenceProvider: "openai",
+        modelId: "gpt-4-turbo",
+      },
     };
   }
 
@@ -29,7 +33,11 @@ class LLMEventFactory {
     return {
       type: "text_generated",
       content: { text },
-      metadata: { clientId: "openai", inferenceProvider: "openai", modelId: "gpt-4-turbo" },
+      metadata: {
+        clientId: "openai",
+        inferenceProvider: "openai",
+        modelId: "gpt-4-turbo",
+      },
     };
   }
 
@@ -41,7 +49,11 @@ class LLMEventFactory {
         name: faker.hacker.verb(),
         arguments: { query: faker.lorem.sentence() },
       },
-      metadata: { clientId: "openai", inferenceProvider: "openai", modelId: "gpt-4-turbo" },
+      metadata: {
+        clientId: "openai",
+        inferenceProvider: "openai",
+        modelId: "gpt-4-turbo",
+      },
     };
   }
 
@@ -53,7 +65,11 @@ class LLMEventFactory {
         outputTokens: faker.number.int({ min: 10, max: 1000 }),
         totalTokens: 0, // Will be calculated
       },
-      metadata: { clientId: "openai", inferenceProvider: "openai", modelId: "gpt-4-turbo" },
+      metadata: {
+        clientId: "openai",
+        inferenceProvider: "openai",
+        modelId: "gpt-4-turbo",
+      },
     };
   }
 
@@ -64,7 +80,11 @@ class LLMEventFactory {
         isRetryable: false,
         message: "Maximum length reached",
       },
-      { clientId: "openai", inferenceProvider: "openai", modelId: "gpt-4-turbo" }
+      {
+        clientId: "openai",
+        inferenceProvider: "openai",
+        modelId: "gpt-4-turbo",
+      }
     );
   }
 }

--- a/front/lib/api/llm/traces/buffer.test.ts
+++ b/front/lib/api/llm/traces/buffer.test.ts
@@ -19,7 +19,7 @@ class LLMEventFactory {
     return {
       type: "text_delta",
       content: { delta },
-      metadata: { clientId: "openai", modelId: "gpt-4-turbo" },
+      metadata: { clientId: "openai", inferenceProvider: "openai", modelId: "gpt-4-turbo" },
     };
   }
 
@@ -29,7 +29,7 @@ class LLMEventFactory {
     return {
       type: "text_generated",
       content: { text },
-      metadata: { clientId: "openai", modelId: "gpt-4-turbo" },
+      metadata: { clientId: "openai", inferenceProvider: "openai", modelId: "gpt-4-turbo" },
     };
   }
 
@@ -41,7 +41,7 @@ class LLMEventFactory {
         name: faker.hacker.verb(),
         arguments: { query: faker.lorem.sentence() },
       },
-      metadata: { clientId: "openai", modelId: "gpt-4-turbo" },
+      metadata: { clientId: "openai", inferenceProvider: "openai", modelId: "gpt-4-turbo" },
     };
   }
 
@@ -53,7 +53,7 @@ class LLMEventFactory {
         outputTokens: faker.number.int({ min: 10, max: 1000 }),
         totalTokens: 0, // Will be calculated
       },
-      metadata: { clientId: "openai", modelId: "gpt-4-turbo" },
+      metadata: { clientId: "openai", inferenceProvider: "openai", modelId: "gpt-4-turbo" },
     };
   }
 
@@ -64,7 +64,7 @@ class LLMEventFactory {
         isRetryable: false,
         message: "Maximum length reached",
       },
-      { clientId: "openai", modelId: "gpt-4-turbo" }
+      { clientId: "openai", inferenceProvider: "openai", modelId: "gpt-4-turbo" }
     );
   }
 }

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -114,6 +114,7 @@ export type LLMParameterOverwrites = Partial<
 
 export type LLMClientMetadata = {
   clientId: ModelProviderIdType;
+  inferenceProvider: string;
   modelId: ModelIdType;
 };
 

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 const metadata = {
   clientId: "openai",
+  inferenceProvider: "openai",
   modelId: "gpt-5",
 } as const;
 

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
@@ -10,6 +10,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -17,6 +18,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     type: "tool_call_delta",
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -24,6 +26,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     type: "tool_call_delta",
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -36,6 +39,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -43,6 +47,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     type: "tool_call_delta",
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -50,6 +55,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     type: "tool_call_delta",
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -62,6 +68,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -74,6 +81,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -88,6 +96,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -103,6 +112,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "openai",
+          inferenceProvider: "openai",
           modelId: "gpt-5",
         },
       },
@@ -118,6 +128,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "openai",
+          inferenceProvider: "openai",
           modelId: "gpt-5",
         },
       },
@@ -132,6 +143,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "openai",
+          inferenceProvider: "openai",
           modelId: "gpt-5",
         },
       },
@@ -147,12 +159,14 @@ export const functionCallLLMEvents: LLMEvent[] = [
         },
         metadata: {
           clientId: "openai",
+          inferenceProvider: "openai",
           modelId: "gpt-5",
         },
       },
     ],
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning.ts
@@ -6,6 +6,7 @@ export const reasoningLLMEvents = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -16,6 +17,7 @@ export const reasoningLLMEvents = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -26,6 +28,7 @@ export const reasoningLLMEvents = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -36,6 +39,7 @@ export const reasoningLLMEvents = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -46,6 +50,7 @@ export const reasoningLLMEvents = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -56,6 +61,7 @@ export const reasoningLLMEvents = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -66,6 +72,7 @@ export const reasoningLLMEvents = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -78,6 +85,7 @@ export const reasoningLLMEvents = [
       id: "rs_06e2b572b276da09016901d7350ae08198ba76145524efe4b2",
       encrypted_content: undefined,
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -88,6 +96,7 @@ export const reasoningLLMEvents = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -102,6 +111,7 @@ export const reasoningLLMEvents = [
     },
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },
@@ -116,6 +126,7 @@ export const reasoningLLMEvents = [
         metadata: {
           id: "rs_06e2b572b276da09016901d7350ae08198ba76145524efe4b2",
           clientId: "openai",
+          inferenceProvider: "openai",
           modelId: "gpt-5",
           encrypted_content: undefined,
         },
@@ -127,6 +138,7 @@ export const reasoningLLMEvents = [
         },
         metadata: {
           clientId: "openai",
+          inferenceProvider: "openai",
           modelId: "gpt-5",
         },
       },
@@ -138,6 +150,7 @@ export const reasoningLLMEvents = [
       },
       metadata: {
         clientId: "openai",
+        inferenceProvider: "openai",
         modelId: "gpt-5",
       },
     },
@@ -149,6 +162,7 @@ export const reasoningLLMEvents = [
       metadata: {
         id: "rs_06e2b572b276da09016901d7350ae08198ba76145524efe4b2",
         clientId: "openai",
+        inferenceProvider: "openai",
         modelId: "gpt-5",
         encrypted_content: undefined,
       },
@@ -156,6 +170,7 @@ export const reasoningLLMEvents = [
     toolCalls: undefined,
     metadata: {
       clientId: "openai",
+      inferenceProvider: "openai",
       modelId: "gpt-5",
     },
   },

--- a/front/lib/api/llm/utils/openai_like/responses/test/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/openai_to_events.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 const metadata = {
   clientId: "openai",
+  inferenceProvider: "openai",
   modelId: "gpt-5",
 } as const;
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The LLM router logs and StatsD metrics only exposed `client_id` (e.g. anthropic), making it impossible to distinguish whether a request was served by the Anthropic API directly or via Google Vertex AI. Both share the same provider ID.

This adds an `inferenceProvider` field to `LLMClientMetadata` that captures the actual serving backend. It defaults to `clientId` for all providers, and is overridden to `google_vertex_ai` in `AnthropicLLM` when the Vertex feature flag is active. The field is surfaced as an `inference_provider` tag on all StatsD metrics and as a structured field in the LLM Error and LLM Success log entries.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25859">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->