### PR TITLE
feat(models): compile-time guard for SDK model id drift

### DIFF
--- a/front/types/assistant/models/sdk_drift.test.ts
+++ b/front/types/assistant/models/sdk_drift.test.ts
@@ -1,0 +1,32 @@
+import type { KnownModelLLMId } from "@dust-tt/client";
+import { describe, expect, it } from "vitest";
+
+import type { StaticModelIdType } from "./models";
+
+// Compile-time guard: every entry in `STATIC_MODEL_IDS` (front) must also be
+// declared in `KnownModelLLMId` (sdks/js/src/types.ts). If `tsgo` fails on the
+// line below, the failing type names the drifted model id(s) directly: add
+// them to the `KnownModelLLMId` union in sdks/js/src/types.ts. External SDK
+// consumers rely on that union for autocomplete and type narrowing;
+// out-of-sync ids cause drift like dust-tt/tasks#8200.
+//
+// The check is intentionally one-directional (front ⊆ SDK). The SDK union is
+// a loose superset that keeps deprecated ids around for backwards compat with
+// stored agents (e.g. `accounts/fireworks/models/kimi-k2-instruct`), so a
+// symmetric check would false-positive. `CUSTOM_MODEL_IDS` (GCS-generated at
+// build time) are dynamic by design and not covered here.
+//
+// Lives in a `.test.ts` file because the SDK is the public API contract and
+// front internals are otherwise not allowed to import from `@dust-tt/client`
+// (enforced by `.grit/patterns/enforceClientTypesInPublicApi.grit`). Test
+// files are exempt, and `tsgo` still typechecks them in CI.
+type _SdkModelIdDrift = Exclude<StaticModelIdType, KnownModelLLMId>;
+const _assertNoSdkModelIdDrift: [_SdkModelIdDrift] extends [never]
+  ? true
+  : _SdkModelIdDrift = true;
+
+describe("STATIC_MODEL_IDS vs SDK KnownModelLLMId", () => {
+  it("compiles (drift is caught at typecheck time, see assertion above)", () => {
+    expect(_assertNoSdkModelIdDrift).toBe(true);
+  });
+});

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -26,7 +26,7 @@ const ModelProviderIdSchema = FlexibleEnumSchema<
   | "noop"
 >();
 
-type KnownModelLLMId =
+export type KnownModelLLMId =
   | "gpt-3.5-turbo"
   | "gpt-4-turbo"
   | "gpt-4o-2024-08-06"


### PR DESCRIPTION
## Description

Adds a static type assertion in `front/types/assistant/models/sdk_drift.test.ts` that fails the front `tsgo` typecheck whenever a model id is added to `STATIC_MODEL_IDS` but missing from `KnownModelLLMId` in `sdks/js/src/types.ts`. That drift is exactly what shipped in dust-tt/tasks#8200 (`gemini-3.5-flash` listed in front but missing from the public SDK union, breaking external consumers and the strict zod enums derived from `MODEL_IDS`).

```ts
type _SdkModelIdDrift = Exclude<StaticModelIdType, KnownModelLLMId>;
const _assertNoSdkModelIdDrift: [_SdkModelIdDrift] extends [never]
  ? true
  : _SdkModelIdDrift = true;
```

Using `Exclude` (rather than a plain `extends` check) makes the compile error name the drifted id(s) directly, so the fix is obvious from the failure:

```
sdk_drift.test.ts(24,7): error TS2322: Type 'true' is not assignable to type '"gemini-3.5-flash"'.
```

The check is one-directional (front ⊆ SDK) on purpose: the SDK union is a loose superset that keeps deprecated ids (e.g. `accounts/fireworks/models/kimi-k2-instruct`) for backwards compat with stored agents, so a symmetric check would false-positive. `CUSTOM_MODEL_IDS` (GCS-generated at build time) are dynamic by design and not covered. Both points are spelled out in the comment block.

`KnownModelLLMId` is now exported from the SDK so front can reference it. This is a new public symbol in `@dust-tt/client`. The shape was already reachable indirectly via `z.infer<typeof ModelLLMIdSchema>`, so the increase in public surface is minimal: an explicit alias for a type external consumers could already derive.

### Why a `.test.ts` file

`.grit/patterns/enforceClientTypesInPublicApi.grit` blocks `@dust-tt/client` imports from front internals (front is the source of truth; internals should not depend on the public SDK shape). The rule exempts `.test.` files, which is the right escape hatch here: this is a compile-time assertion that needs to see the SDK type, not a runtime dependency. `tsgo` still typechecks the file in CI, so the guard runs in the existing job, no new workflow needed.

## Tests

Verified locally by removing `"gemini-3.5-flash"` from `KnownModelLLMId` and running `npx tsc --noEmit` in `front`: the guard fires at `sdk_drift.test.ts` with the exact id named in the error. Restored, the typecheck is clean. Also ran `biome check` on the new file (the rule that broke the previous push) to confirm it's clean.

## Risk

Low. Type-only change. The guard is a no-op on `main` (front and SDK are in sync after #25856).

## Deploy Plan

Standard deploy.
