### PR TITLE
Disable moving for Frames.

### DIFF
--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -22,6 +22,7 @@ import {
   getFolderBreadcrumbSegments,
   getParentFolderRelativePath,
   getScopedRelativePath,
+  isFileExplorerMovableFile,
   ROOT_FOLDER_LABEL,
 } from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
@@ -177,7 +178,12 @@ export function FileExplorer({
           },
         });
       }
-      if (onMoveFile && totalFolderCount > 0 && entry.kind === "file") {
+      if (
+        onMoveFile &&
+        totalFolderCount > 0 &&
+        entry.kind === "file" &&
+        isFileExplorerMovableFile(entry)
+      ) {
         items.push({
           label: "Move to…",
           icon: FolderOpenIcon,
@@ -250,7 +256,7 @@ export function FileExplorer({
 
       const relativePath = getScopedRelativePath(scopedFilePath);
       const entry = entryByRelativePath.get(relativePath);
-      if (entry?.kind !== "file") {
+      if (entry?.kind !== "file" || !isFileExplorerMovableFile(entry)) {
         return;
       }
 

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -13,6 +13,7 @@ import type {
   FileExplorerMenuAction,
   FileSystemTreeNode,
 } from "@app/components/file_explorer/types";
+import { isFileExplorerMovableFile } from "@app/components/file_explorer/utils";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { CardGrid, ScrollArea, Spinner } from "@dust-tt/sparkle";
 import type React from "react";
@@ -105,7 +106,7 @@ export function FileExplorerContent({
         return (
           <FileExplorerFileCard
             key={`file:${entry.path}`}
-            draggable={fileDragEnabled}
+            draggable={fileDragEnabled && isFileExplorerMovableFile(entry)}
             entry={entry}
             viewMode={viewMode}
             onOpen={onFileOpen}

--- a/front/components/file_explorer/utils.test.ts
+++ b/front/components/file_explorer/utils.test.ts
@@ -1,0 +1,42 @@
+import type { FileEntry } from "@app/components/file_explorer/types";
+import { isFileExplorerMovableFile } from "@app/components/file_explorer/utils";
+import { frameContentType, frameSlideshowContentType } from "@app/types/files";
+import { describe, expect, it } from "vitest";
+
+function makeFileEntry(contentType: string): FileEntry {
+  return {
+    kind: "file",
+    path: "project/foo.txt",
+    fileName: "foo.txt",
+    contentType,
+    fileId: "file-1",
+    isDirectory: false,
+    lastModifiedMs: 0,
+    sizeBytes: 0,
+    thumbnailUrl: null,
+  };
+}
+
+describe("isFileExplorerMovableFile", () => {
+  it("returns false for fileId-backed frames and slideshows", () => {
+    expect(isFileExplorerMovableFile(makeFileEntry(frameContentType))).toBe(
+      false
+    );
+    expect(
+      isFileExplorerMovableFile(makeFileEntry(frameSlideshowContentType))
+    ).toBe(false);
+  });
+
+  it("returns true for mount-addressed files with a fileId", () => {
+    expect(isFileExplorerMovableFile(makeFileEntry("text/plain"))).toBe(true);
+  });
+
+  it("returns true for path-only files without a fileId", () => {
+    expect(
+      isFileExplorerMovableFile({
+        ...makeFileEntry("text/plain"),
+        fileId: null,
+      })
+    ).toBe(true);
+  });
+});

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/types/files";
 
 import type {
+  FileEntry,
   FileExplorerBucket,
   FileExplorerEntry,
   FileExplorerSortMode,
@@ -79,6 +80,20 @@ export function getFileExplorerBucket(
     default:
       return null;
   }
+}
+
+/**
+ * Whether mount-relative move (drag-and-drop, "Move to…") is allowed in the file explorer.
+ *
+ * Frames and slideshows are still keyed by `fileId` (canonical storage at
+ * `files/w/{wId}/{fileId}/…`), not mount-path relocation. Until they are fully on the mount
+ * filesystem, disable move for those entries.
+ */
+export function isFileExplorerMovableFile(entry: FileEntry): boolean {
+  if (isInteractiveContentType(entry.contentType)) {
+    return false;
+  }
+  return true;
 }
 
 /** Display order: Company Data refs, then folders, then GCS files. */


### PR DESCRIPTION
## Description

Frames and Slideshows are still keyed by `fileId` (canonical storage at `files/w/{wId}/{fileId}/…`) rather than mount-path, so mount-relative move — drag-and-drop and the "Move to…" context menu — doesn't work correctly for them. Adds `isFileExplorerMovableFile()` to `utils.ts` using `isInteractiveContentType()` to gate move eligibility, then threads that predicate through `FileExplorer` (context menu item + drop handler) and `FileExplorerContent` (`draggable` prop).

## Tests

Added unit tests for `isFileExplorerMovableFile` in `utils.test.ts` covering Frame/Slideshow content types (expect `false`), regular fileId-backed files, and path-only entries without a `fileId` (both expect `true`). Tested locally in the file explorer UI.

## Risk

Low. Purely additive predicate gate — no data mutations, no API changes, no behavioural change for non-Frame/Slideshow files. Safe to rollback.

## Deploy Plan

Deploy `front`.
