### PR TITLE
[front] enh: reduce concurrency on Poke conversation endpoint

### DIFF
--- a/front/lib/poke/conversation.ts
+++ b/front/lib/poke/conversation.ts
@@ -32,16 +32,13 @@ export async function getPokeConversation(
       .flat()
       .filter((m): m is PokeAgentMessageType => m.type === "agent_message");
 
-    const agentMessagesWithRunIds =
-      agentMessages.length > 0
-        ? await AgentMessageModel.findAll({
-            where: {
-              id: [...new Set(agentMessages.map((m) => m.agentMessageId))],
-              workspaceId: owner.id,
-            },
-            attributes: ["id", "runIds"],
-          })
-        : [];
+    const agentMessagesWithRunIds = await AgentMessageModel.findAll({
+      where: {
+        id: [...new Set(agentMessages.map((m) => m.agentMessageId))],
+        workspaceId: owner.id,
+      },
+      attributes: ["id", "runIds"],
+    });
     const runIdsByAgentMessageId = new Map(
       agentMessagesWithRunIds.map((m) => [m.id, m.runIds])
     );

--- a/front/lib/poke/conversation.ts
+++ b/front/lib/poke/conversation.ts
@@ -2,10 +2,11 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
-import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { ConversationError } from "@app/types/assistant/conversation";
-import type { PokeConversationType } from "@app/types/poke";
-import type { ModelId } from "@app/types/shared/model_id";
+import type {
+  PokeAgentMessageType,
+  PokeConversationType,
+} from "@app/types/poke";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 
@@ -27,20 +28,29 @@ export async function getPokeConversation(
   if (conversation.isOk()) {
     const pokeConversation = conversation.value as PokeConversationType;
 
-    // Cycle through the message and actions and enrich them with the runId(s) and timestamps
+    const agentMessages = pokeConversation.content
+      .flat()
+      .filter((m): m is PokeAgentMessageType => m.type === "agent_message");
+
+    const agentMessagesWithRunIds =
+      agentMessages.length > 0
+        ? await AgentMessageModel.findAll({
+            where: {
+              id: [...new Set(agentMessages.map((m) => m.agentMessageId))],
+              workspaceId: owner.id,
+            },
+            attributes: ["id", "runIds"],
+          })
+        : [];
+    const runIdsByAgentMessageId = new Map(
+      agentMessagesWithRunIds.map((m) => [m.id, m.runIds])
+    );
+
+    // Cycle through the messages and actions and enrich them with runId(s) and timestamps.
     for (const messages of pokeConversation.content) {
       for (const m of messages) {
         if (m.type === "agent_message") {
-          const runIds = (
-            await AgentMessageModel.findOne({
-              where: {
-                id: m.agentMessageId,
-                workspaceId: owner.id,
-              },
-              attributes: ["runIds"],
-              raw: true,
-            })
-          )?.runIds;
+          const runIds = runIdsByAgentMessageId.get(m.agentMessageId) ?? null;
 
           m.runIds = runIds;
 
@@ -54,17 +64,6 @@ export async function getPokeConversation(
           }
 
           if (m.actions.length > 0) {
-            // Fetch timestamps for actions
-            const actionIds: ModelId[] = m.actions.map((a) => a.id);
-            const actionsWithTimestamps =
-              await AgentMCPActionResource.fetchByModelIds(auth, actionIds);
-            const timestampMap = new Map(
-              actionsWithTimestamps.map((action) => [
-                action.id,
-                action.createdAt.getTime(),
-              ])
-            );
-
             for (const a of m.actions) {
               a.mcpIO = {
                 params: a.params,
@@ -72,11 +71,7 @@ export async function getPokeConversation(
                 generatedFiles: a.generatedFiles,
                 isError: a.status === "errored",
               };
-              // Add timestamp if available
-              const timestamp = timestampMap.get(a.id);
-              if (timestamp) {
-                a.created = timestamp;
-              }
+              a.created = a.createdAt;
             }
           }
         }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2270,35 +2270,45 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       order: [["createdAt", "DESC"]],
     });
 
-    return Promise.all(
-      conversations.map(async (c) => {
-        const { actionRequired, lastReadAt } =
-          await ConversationResource.getActionRequiredAndLastReadAtForUser(
-            auth,
-            c.id
-          );
+    let participationByConversationId = new Map<ModelId, UserParticipation>();
+    let lastReadByConversationId = new Map<ModelId, Date>();
+    if (auth.user() && conversations.length > 0) {
+      const conversationIds = conversations.map((c) => c.id);
+      participationByConversationId =
+        await ConversationResource.fetchParticipationMapForUser(
+          auth,
+          conversationIds
+        );
+      lastReadByConversationId = await ConversationResource.fetchReadMapForUser(
+        auth,
+        conversationIds
+      );
+    }
 
-        return {
-          id: c.id,
-          created: c.createdAt.getTime(),
-          updated: c.updatedAt.getTime(),
-          sId: c.sId,
-          title: c.title,
-          triggerId: triggerId,
-          actionRequired,
-          unread: lastReadAt === null || c.updatedAt > lastReadAt,
-          lastReadMs: lastReadAt?.getTime() ?? null,
-          hasError: c.hasError,
-          requestedGroupIds: [],
-          requestedSpaceIds: c.getRequestedSpaceIdsFromModel(),
-          spaceId: c.space?.sId ?? null,
-          depth: c.depth,
-          metadata: c.metadata,
-          branchId: null,
-          isRunningAgentLoop: c.isRunningAgentLoop,
-        };
-      })
-    );
+    return conversations.map((c) => {
+      const participation = participationByConversationId.get(c.id);
+      const lastReadAt = lastReadByConversationId.get(c.id) ?? null;
+
+      return {
+        id: c.id,
+        created: c.createdAt.getTime(),
+        updated: c.updatedAt.getTime(),
+        sId: c.sId,
+        title: c.title,
+        triggerId: triggerId,
+        actionRequired: participation?.actionRequired ?? false,
+        unread: lastReadAt === null || c.updatedAt > lastReadAt,
+        lastReadMs: lastReadAt?.getTime() ?? null,
+        hasError: c.hasError,
+        requestedGroupIds: [],
+        requestedSpaceIds: c.getRequestedSpaceIdsFromModel(),
+        spaceId: c.space?.sId ?? null,
+        depth: c.depth,
+        metadata: c.metadata,
+        branchId: null,
+        isRunningAgentLoop: c.isRunningAgentLoop,
+      };
+    });
   }
 
   static async listSkillReinforcementConversations(


### PR DESCRIPTION
## Description

- This endpoint runs a huge number of concurrent database queries (it's actually unbounded with > 300 queries as seen in the [logs](https://app.datadoghq.eu/logs?query=%22Processed%20request%22%20service%3Afront%20%40peakConcurrentQueries%3A%3E4&agg_m=%40peakConcurrentQueries&agg_m_source=base&agg_q=%40route&agg_t=max&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40peakConcurrentQueries&flat_group_bys=true&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=%40peakConcurrentQueries&sort_t=max&storage=hot&stream_sort=desc&top_n=50&top_o=top&viz=toplist&x_missing=true&from_ts=1776327440318&to_ts=1776413840318&live=true))
- This PR reduces the concurrency by batching the hydration of trigger conversations
- Also removes unneeded extra fetch of timestamps for actions

## Tests

- Tested locally.

## Risk

- Low: Poke-only. Safe to rollback

## Deploy Plan

- Deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25870">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->