### PR TITLE
[front] checkout: fix payment if invoice amount is zero

### DIFF
--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -547,6 +547,12 @@ export async function chargeFirstPeriodInvoice({
     return finalizeResult;
   }
 
+  // If invoice corresponds to a zero amount (for example with coupon applied)
+  // then it is automatically set as paid by Stripe and we do not need to pay it.
+  if (finalizeResult.value.status == "paid") {
+    return new Ok(undefined);
+  }
+
   const stripe = getStripeClient();
   try {
     const payResult = await stripe.invoices.pay(finalizeResult.value.id, {


### PR DESCRIPTION
## Description

Calling `stripe.invoices.pay()` with an invoice with an amount of zero actually throws as invoice is already paid
In checkout payment endpoint, skip actual payment if invoice is already paid after finalization (this can happens if the invoice has an amount of zero, for example with coupons).

## Tests

Tested locally with a coupon and an invoice of zero
=> before it failed, not it goes through as expected

## Risk

Low

## Deploy Plan

Deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25871">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->