### PR TITLE
[dsbx] coordinate WebSocket upgrades between rewriter request and response tasks

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
@@ -77,11 +77,36 @@ pub(super) enum HttpRewriteError {
 // upgrade request. The response task sniffs the next response status line,
 // signals back through `accepted_tx` whether the upstream replied with 101
 // Switching Protocols, and the request task uses that signal to decide
-// whether to splice raw client→upstream frames (101) or tear the upstream
+// whether to splice raw client->upstream frames (101) or tear the upstream
 // write half down (non-101). The channel is `oneshot` because each upgrade
 // request gets exactly one verdict.
 pub(super) struct WebSocketUpgradeWatch {
     pub accepted_tx: oneshot::Sender<bool>,
+}
+
+enum UpgradeVerdict {
+    NotAnUpgrade,
+    AwaitingResponse(oneshot::Receiver<bool>),
+    ResponseTaskGone,
+    NoWatchWired,
+}
+
+async fn register_upgrade_verdict(
+    websocket_watch_tx: Option<&mpsc::Sender<WebSocketUpgradeWatch>>,
+) -> UpgradeVerdict {
+    let Some(tx) = websocket_watch_tx else {
+        return UpgradeVerdict::NoWatchWired;
+    };
+    let (accepted_tx, accepted_rx) = oneshot::channel();
+    if tx
+        .send(WebSocketUpgradeWatch { accepted_tx })
+        .await
+        .is_err()
+    {
+        UpgradeVerdict::ResponseTaskGone
+    } else {
+        UpgradeVerdict::AwaitingResponse(accepted_rx)
+    }
 }
 
 impl fmt::Display for HttpRewriteError {
@@ -171,27 +196,10 @@ where
         // by the time upstream's 101 (or non-101) reply arrives. Doing it
         // after forwarding would race in-flight upstream bytes against the
         // mpsc::send and the sniff could land on the wrong status line.
-        let upgrade_accepted_rx = if processed.websocket_upgrade {
-            match websocket_watch_tx {
-                Some(tx) => {
-                    let (accepted_tx, accepted_rx) = oneshot::channel();
-                    if tx
-                        .send(WebSocketUpgradeWatch { accepted_tx })
-                        .await
-                        .is_err()
-                    {
-                        // Response task has already exited; treat the upgrade
-                        // as rejected so we don't splice raw frames into a
-                        // half-closed connection.
-                        None
-                    } else {
-                        Some(accepted_rx)
-                    }
-                }
-                None => None,
-            }
+        let upgrade_verdict = if processed.websocket_upgrade {
+            register_upgrade_verdict(websocket_watch_tx).await
         } else {
-            None
+            UpgradeVerdict::NotAnUpgrade
         };
 
         reader.drain_front(header_len);
@@ -201,19 +209,30 @@ where
             .map_err(|error| HttpRewriteError::io(anyhow!(error)))?;
         forward_body(&mut reader, upstream, processed.body_kind, mode).await?;
 
-        if processed.websocket_upgrade {
-            let accepted = match upgrade_accepted_rx {
-                Some(accepted_rx) => accepted_rx.await.unwrap_or(false),
-                // No watch wired (unit tests that don't run the response
-                // copier). Preserve the message-loop-only behavior: splice raw.
-                None => websocket_watch_tx.is_none(),
-            };
-            if accepted {
-                copy_raw_client_to_upstream(&mut reader, upstream).await?;
-            } else {
-                shutdown_upstream(upstream).await?;
+        match upgrade_verdict {
+            UpgradeVerdict::NotAnUpgrade => continue,
+            UpgradeVerdict::AwaitingResponse(accepted_rx) => {
+                if accepted_rx.await.unwrap_or(false) {
+                    copy_raw_client_to_upstream(&mut reader, upstream).await?;
+                } else {
+                    shutdown_upstream(upstream).await?;
+                }
+                return Ok(());
             }
-            return Ok(());
+            UpgradeVerdict::ResponseTaskGone => {
+                // The response task has already exited (channel send failed),
+                // so we can't learn the 101 verdict. Tear down rather than
+                // splice raw frames into a half-closed connection.
+                shutdown_upstream(upstream).await?;
+                return Ok(());
+            }
+            UpgradeVerdict::NoWatchWired => {
+                // Unit tests that exercise the request rewriter without the
+                // response copier. Preserve the message-loop-only behavior
+                // (splice raw, let the test inspect what reached upstream).
+                copy_raw_client_to_upstream(&mut reader, upstream).await?;
+                return Ok(());
+            }
         }
     }
 }
@@ -1150,6 +1169,11 @@ struct UpgradeSniffState {
 }
 
 fn is_switching_protocols_response(status_line: &[u8]) -> bool {
+    // We only look at the very first status line. A WebSocket upgrade request
+    // does not include Expect: 100-continue, so a preceding `100 Continue`
+    // interim response should not occur in practice. If it ever does we treat
+    // it as not-101, the verdict is `rejected`, and we forward the bytes
+    // unchanged; clients see the real upstream reply either way.
     let Ok(text) = std::str::from_utf8(status_line) else {
         return false;
     };

--- a/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
@@ -88,17 +88,13 @@ enum UpgradeVerdict {
     NotAnUpgrade,
     AwaitingResponse(oneshot::Receiver<bool>),
     ResponseTaskGone,
-    NoWatchWired,
 }
 
 async fn register_upgrade_verdict(
-    websocket_watch_tx: Option<&mpsc::Sender<WebSocketUpgradeWatch>>,
+    websocket_watch_tx: &mpsc::Sender<WebSocketUpgradeWatch>,
 ) -> UpgradeVerdict {
-    let Some(tx) = websocket_watch_tx else {
-        return UpgradeVerdict::NoWatchWired;
-    };
     let (accepted_tx, accepted_rx) = oneshot::channel();
-    if tx
+    if websocket_watch_tx
         .send(WebSocketUpgradeWatch { accepted_tx })
         .await
         .is_err()
@@ -151,7 +147,7 @@ pub(super) async fn forward_http1_requests<R, W>(
     upstream: &mut W,
     secret_table: &SecretTable,
     mode: HttpRewriteMode<'_>,
-    websocket_watch_tx: Option<&mpsc::Sender<WebSocketUpgradeWatch>>,
+    websocket_watch_tx: &mpsc::Sender<WebSocketUpgradeWatch>,
 ) -> RewriteResult<()>
 where
     R: AsyncRead + Unpin,
@@ -224,13 +220,6 @@ where
                 // so we can't learn the 101 verdict. Tear down rather than
                 // splice raw frames into a half-closed connection.
                 shutdown_upstream(upstream).await?;
-                return Ok(());
-            }
-            UpgradeVerdict::NoWatchWired => {
-                // Unit tests that exercise the request rewriter without the
-                // response copier. Preserve the message-loop-only behavior
-                // (splice raw, let the test inspect what reached upstream).
-                copy_raw_client_to_upstream(&mut reader, upstream).await?;
                 return Ok(());
             }
         }
@@ -1924,8 +1913,30 @@ mod tests {
             Ok::<(), std::io::Error>(())
         });
 
-        let rewrite_result =
-            forward_http1_requests(&mut client_read, &mut upstream_write, table, mode, None).await;
+        // Tests don't run the response copier, so spawn an auto-accept task
+        // on the watch channel. This stands in for "upstream replied 101" so
+        // an upgrade request gets spliced raw, and otherwise the channel is
+        // never touched.
+        let (websocket_watch_tx, mut websocket_watch_rx) =
+            mpsc::channel::<WebSocketUpgradeWatch>(1);
+        let auto_accept_task = tokio::spawn(async move {
+            while let Some(watch) = websocket_watch_rx.recv().await {
+                let _ = watch.accepted_tx.send(true);
+            }
+        });
+
+        let rewrite_result = forward_http1_requests(
+            &mut client_read,
+            &mut upstream_write,
+            table,
+            mode,
+            &websocket_watch_tx,
+        )
+        .await;
+        drop(websocket_watch_tx);
+        auto_accept_task
+            .await
+            .map_err(|error| HttpRewriteError::io(anyhow!(error)))?;
         drop(upstream_write);
         // Drop client_read so a writer task still trying to push the tail of
         // an oversized input fails fast with BrokenPipe instead of hanging

--- a/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
@@ -27,6 +27,11 @@ const READ_CHUNK_BYTES: usize = 8 * 1024;
 const NON_HTTP_FALLBACK_BYTES: usize = 4 * 1024;
 const MAX_CHUNK_LINE_BYTES: usize = 8 * 1024;
 const MAX_TRAILER_BLOCK_BYTES: usize = 64 * 1024;
+// Cap how many bytes we stage while waiting for a CRLF on the upstream
+// response status line. A real `HTTP/1.x NNN ...` line is well under a few
+// hundred bytes; well past that we treat the upstream as non-HTTP and stop
+// sniffing rather than buffer responses indefinitely.
+const MAX_STATUS_LINE_BYTES: usize = 16 * 1024;
 
 const PLACEHOLDER_PREFIX: &[u8] = PLACEHOLDER_PREFIX_STR.as_bytes();
 const PLACEHOLDER_SUFFIX: &[u8] = PLACEHOLDER_SUFFIX_STR.as_bytes();
@@ -68,10 +73,13 @@ pub(super) enum HttpRewriteError {
     Io(anyhow::Error),
 }
 
-// Kept for API stability with the response-side websocket coordination that
-// lands in a follow-up PR. Nothing here sends on `accepted_tx` yet; the
-// upgrade path simply splices raw bytes once the request is forwarded.
-#[allow(dead_code)]
+// Sent by the request task to the response task after forwarding a WebSocket
+// upgrade request. The response task sniffs the next response status line,
+// signals back through `accepted_tx` whether the upstream replied with 101
+// Switching Protocols, and the request task uses that signal to decide
+// whether to splice raw client→upstream frames (101) or tear the upstream
+// write half down (non-101). The channel is `oneshot` because each upgrade
+// request gets exactly one verdict.
 pub(super) struct WebSocketUpgradeWatch {
     pub accepted_tx: oneshot::Sender<bool>,
 }
@@ -118,7 +126,7 @@ pub(super) async fn forward_http1_requests<R, W>(
     upstream: &mut W,
     secret_table: &SecretTable,
     mode: HttpRewriteMode<'_>,
-    _websocket_watch_tx: Option<&mpsc::Sender<WebSocketUpgradeWatch>>,
+    websocket_watch_tx: Option<&mpsc::Sender<WebSocketUpgradeWatch>>,
 ) -> RewriteResult<()>
 where
     R: AsyncRead + Unpin,
@@ -158,6 +166,34 @@ where
         parsed_first_http_request = true;
         let processed = process_request(&request, secret_table, mode)?;
 
+        // For a WebSocket upgrade we register the response-side sniff BEFORE
+        // forwarding any bytes so the response task is already in sniff mode
+        // by the time upstream's 101 (or non-101) reply arrives. Doing it
+        // after forwarding would race in-flight upstream bytes against the
+        // mpsc::send and the sniff could land on the wrong status line.
+        let upgrade_accepted_rx = if processed.websocket_upgrade {
+            match websocket_watch_tx {
+                Some(tx) => {
+                    let (accepted_tx, accepted_rx) = oneshot::channel();
+                    if tx
+                        .send(WebSocketUpgradeWatch { accepted_tx })
+                        .await
+                        .is_err()
+                    {
+                        // Response task has already exited; treat the upgrade
+                        // as rejected so we don't splice raw frames into a
+                        // half-closed connection.
+                        None
+                    } else {
+                        Some(accepted_rx)
+                    }
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
+
         reader.drain_front(header_len);
         upstream
             .write_all(&processed.header_bytes)
@@ -166,12 +202,17 @@ where
         forward_body(&mut reader, upstream, processed.body_kind, mode).await?;
 
         if processed.websocket_upgrade {
-            // After a WebSocket upgrade request, the client switches to raw
-            // frames. The response-side 101 sniff and accept/reject path
-            // lands in a follow-up PR; here we splice the rest of the
-            // connection and let the response copier ship the 101 (or any
-            // other status) back unmodified.
-            copy_raw_client_to_upstream(&mut reader, upstream).await?;
+            let accepted = match upgrade_accepted_rx {
+                Some(accepted_rx) => accepted_rx.await.unwrap_or(false),
+                // No watch wired (unit tests that don't run the response
+                // copier). Preserve the message-loop-only behavior: splice raw.
+                None => websocket_watch_tx.is_none(),
+            };
+            if accepted {
+                copy_raw_client_to_upstream(&mut reader, upstream).await?;
+            } else {
+                shutdown_upstream(upstream).await?;
+            }
             return Ok(());
         }
     }
@@ -1002,27 +1043,124 @@ fn is_websocket_upgrade(request: &RequestParts) -> bool {
 pub(super) async fn copy_responses_with_websocket_watch<R, W>(
     upstream: &mut R,
     client: &mut W,
-    _websocket_watch_rx: mpsc::Receiver<WebSocketUpgradeWatch>,
+    mut websocket_watch_rx: mpsc::Receiver<WebSocketUpgradeWatch>,
 ) -> Result<(), anyhow::Error>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
-    // Responses are streamed through unmodified. The follow-up PR adds a 101
-    // sniff that consumes the watch channel to gate raw splice once both
-    // sides have agreed on the WebSocket upgrade.
-    match tokio::io::copy(upstream, client).await {
-        Ok(_) => Ok(()),
-        Err(error)
-            if matches!(
-                error.kind(),
-                ErrorKind::BrokenPipe | ErrorKind::ConnectionReset | ErrorKind::UnexpectedEof
-            ) =>
-        {
-            Ok(())
+    // Responses are streamed through unmodified except when the request task
+    // forwarded a WebSocket upgrade. In that case it sends a
+    // `WebSocketUpgradeWatch` over the channel, and we sniff the next
+    // response status line: a 101 reply means the upgrade was accepted and
+    // raw frames will flow afterward; anything else means upstream rejected
+    // it. Either way we forward the bytes we read and keep copying.
+    //
+    // This assumes no HTTP/1.1 pipelining (i.e. the upgrade request is the
+    // only one in flight when its response arrives). Clients in the wild that
+    // pipeline a regular request before an upgrade on the same connection are
+    // essentially unheard of, so we don't try to track per-response framing
+    // here.
+    let mut buffer = vec![0_u8; READ_CHUNK_BYTES];
+    let mut sniff_state: Option<UpgradeSniffState> = None;
+    let mut watch_closed = false;
+
+    loop {
+        tokio::select! {
+            biased;
+
+            watch = websocket_watch_rx.recv(), if sniff_state.is_none() && !watch_closed => {
+                match watch {
+                    Some(watch) => {
+                        sniff_state = Some(UpgradeSniffState {
+                            accepted_tx: watch.accepted_tx,
+                            staged: Vec::new(),
+                        });
+                    }
+                    None => {
+                        watch_closed = true;
+                    }
+                }
+            }
+
+            read_result = upstream.read(&mut buffer) => {
+                let bytes_read = match read_result {
+                    Ok(bytes_read) => bytes_read,
+                    Err(error)
+                        if matches!(
+                            error.kind(),
+                            ErrorKind::BrokenPipe
+                                | ErrorKind::ConnectionReset
+                                | ErrorKind::UnexpectedEof,
+                        ) =>
+                    {
+                        if let Some(state) = sniff_state.take() {
+                            let _ = state.accepted_tx.send(false);
+                            if !state.staged.is_empty() {
+                                client.write_all(&state.staged).await?;
+                            }
+                        }
+                        return Ok(());
+                    }
+                    Err(error) => {
+                        if let Some(state) = sniff_state.take() {
+                            let _ = state.accepted_tx.send(false);
+                        }
+                        return Err(error.into());
+                    }
+                };
+
+                if bytes_read == 0 {
+                    if let Some(state) = sniff_state.take() {
+                        let _ = state.accepted_tx.send(false);
+                        if !state.staged.is_empty() {
+                            client.write_all(&state.staged).await?;
+                        }
+                    }
+                    return Ok(());
+                }
+
+                if let Some(mut state) = sniff_state.take() {
+                    state.staged.extend_from_slice(&buffer[..bytes_read]);
+                    if let Some(line_end) = find_subslice(&state.staged, b"\r\n") {
+                        let is_101 = is_switching_protocols_response(&state.staged[..line_end]);
+                        let _ = state.accepted_tx.send(is_101);
+                        client.write_all(&state.staged).await?;
+                    } else if state.staged.len() > MAX_STATUS_LINE_BYTES {
+                        // No CRLF in 16 KiB: upstream sent something that
+                        // isn't a status line. Treat as not-101 and flush the
+                        // bytes through so the agent sees whatever upstream
+                        // actually returned.
+                        let _ = state.accepted_tx.send(false);
+                        client.write_all(&state.staged).await?;
+                    } else {
+                        sniff_state = Some(state);
+                    }
+                } else {
+                    client.write_all(&buffer[..bytes_read]).await?;
+                }
+            }
         }
-        Err(error) => Err(error.into()),
     }
+}
+
+struct UpgradeSniffState {
+    accepted_tx: oneshot::Sender<bool>,
+    staged: Vec<u8>,
+}
+
+fn is_switching_protocols_response(status_line: &[u8]) -> bool {
+    let Ok(text) = std::str::from_utf8(status_line) else {
+        return false;
+    };
+    let rest = match text.strip_prefix("HTTP/1.1 ") {
+        Some(rest) => rest,
+        None => match text.strip_prefix("HTTP/1.0 ") {
+            Some(rest) => rest,
+            None => return false,
+        },
+    };
+    rest.split_whitespace().next() == Some("101")
 }
 
 fn header_value_eq_ascii(value: &[u8], expected: &str) -> bool {
@@ -1605,6 +1743,131 @@ mod tests {
         .await?;
         let text = String::from_utf8(output)?;
         assert!(text.contains("Authorization: ééééé\r\n"));
+        Ok(())
+    }
+
+    #[test]
+    fn parses_switching_protocols_status_line() {
+        assert!(is_switching_protocols_response(
+            b"HTTP/1.1 101 Switching Protocols"
+        ));
+        assert!(is_switching_protocols_response(b"HTTP/1.0 101"));
+        assert!(!is_switching_protocols_response(b"HTTP/1.1 200 OK"));
+        assert!(!is_switching_protocols_response(
+            b"HTTP/1.1 1010 Bogus Status"
+        ));
+        assert!(!is_switching_protocols_response(b"HTTP/2 101"));
+        assert!(!is_switching_protocols_response(b"garbage"));
+    }
+
+    #[tokio::test]
+    async fn response_copier_signals_accepted_when_upstream_returns_101() -> Result<()> {
+        let (mut upstream_write, mut upstream_read) = tokio::io::duplex(16 * 1024);
+        let (mut client_write, mut client_read) = tokio::io::duplex(16 * 1024);
+        let (websocket_watch_tx, websocket_watch_rx) = mpsc::channel(1);
+
+        let copier_task = tokio::spawn(async move {
+            copy_responses_with_websocket_watch(
+                &mut upstream_read,
+                &mut client_write,
+                websocket_watch_rx,
+            )
+            .await
+        });
+
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        websocket_watch_tx
+            .send(WebSocketUpgradeWatch { accepted_tx })
+            .await
+            .expect("watch channel should accept");
+
+        upstream_write
+            .write_all(
+                b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\nframe-payload",
+            )
+            .await?;
+
+        let accepted = accepted_rx.await.expect("accepted_tx should fire");
+        assert!(accepted, "101 reply should be reported as accepted");
+
+        drop(upstream_write);
+        let mut received = Vec::new();
+        client_read.read_to_end(&mut received).await?;
+        let text = String::from_utf8(received)?;
+        assert!(text.starts_with("HTTP/1.1 101 Switching Protocols\r\n"));
+        assert!(text.ends_with("frame-payload"));
+
+        copier_task.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn response_copier_signals_rejected_when_upstream_returns_non_101() -> Result<()> {
+        let (mut upstream_write, mut upstream_read) = tokio::io::duplex(16 * 1024);
+        let (mut client_write, mut client_read) = tokio::io::duplex(16 * 1024);
+        let (websocket_watch_tx, websocket_watch_rx) = mpsc::channel(1);
+
+        let copier_task = tokio::spawn(async move {
+            copy_responses_with_websocket_watch(
+                &mut upstream_read,
+                &mut client_write,
+                websocket_watch_rx,
+            )
+            .await
+        });
+
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        websocket_watch_tx
+            .send(WebSocketUpgradeWatch { accepted_tx })
+            .await
+            .expect("watch channel should accept");
+
+        upstream_write
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+            .await?;
+
+        let accepted = accepted_rx.await.expect("accepted_tx should fire");
+        assert!(!accepted, "200 reply should be reported as not accepted");
+
+        drop(upstream_write);
+        let mut received = Vec::new();
+        client_read.read_to_end(&mut received).await?;
+        let text = String::from_utf8(received)?;
+        assert!(text.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(text.ends_with("\r\n\r\nok"));
+
+        copier_task.await??;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn response_copier_passes_bytes_through_when_no_watch_is_sent() -> Result<()> {
+        let (mut upstream_write, mut upstream_read) = tokio::io::duplex(16 * 1024);
+        let (mut client_write, mut client_read) = tokio::io::duplex(16 * 1024);
+        let (_websocket_watch_tx, websocket_watch_rx) = mpsc::channel::<WebSocketUpgradeWatch>(1);
+
+        let copier_task = tokio::spawn(async move {
+            copy_responses_with_websocket_watch(
+                &mut upstream_read,
+                &mut client_write,
+                websocket_watch_rx,
+            )
+            .await
+        });
+
+        upstream_write
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello")
+            .await?;
+        drop(upstream_write);
+
+        let mut received = Vec::new();
+        client_read.read_to_end(&mut received).await?;
+        assert_eq!(
+            received,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello"
+        );
+
+        copier_task.await??;
         Ok(())
     }
 

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -430,7 +430,7 @@ where
             &mut upstream_write,
             &runtime.secret_table,
             mode,
-            Some(&websocket_watch_tx),
+            &websocket_watch_tx,
         ) => {
             match request_result {
                 Ok(()) => {

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -810,7 +810,7 @@ mod tests {
             .await
             .context("test upstream failed to write 101")?;
 
-            let mut frame = [0_u8; 12];
+            let mut frame = [0_u8; b"client-frame".len()];
             tls.read_exact(&mut frame)
                 .await
                 .context("test upstream failed to read raw client frame")?;
@@ -932,7 +932,9 @@ mod tests {
                 tail
             );
 
-            tls.shutdown().await.ok();
+            tls.shutdown()
+                .await
+                .context("test upstream failed to shut down TLS")?;
             Ok::<(), anyhow::Error>(())
         });
 

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -768,6 +768,230 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn mitm_session_completes_websocket_upgrade_when_upstream_returns_101() -> Result<()> {
+        let sni = "api.openai.com";
+        let mitm_ca = Arc::new(MitmCa::generate()?);
+        let (upstream_server_config, upstream_ca_der) = test_upstream_server_config(sni)?;
+        let mut runtime = test_runtime(Arc::clone(&mitm_ca), upstream_ca_der)?;
+        runtime.secret_table = Arc::new(secret_table(&[sni])?);
+
+        let (agent_client_io, agent_dsbx_io) = tokio::io::duplex(16 * 1024);
+        let (dsbx_proxy_io, upstream_server_io) = tokio::io::duplex(16 * 1024);
+
+        let upstream_task = tokio::spawn(async move {
+            let acceptor = TlsAcceptor::from(upstream_server_config);
+            let mut tls = acceptor
+                .accept(upstream_server_io)
+                .await
+                .context("test upstream failed to accept TLS")?;
+
+            let mut request = Vec::new();
+            loop {
+                let mut byte = [0_u8; 1];
+                tls.read_exact(&mut byte)
+                    .await
+                    .context("test upstream failed to read request byte")?;
+                request.push(byte[0]);
+                if request.ends_with(b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request_text = String::from_utf8(request).context("request should be utf8")?;
+            assert!(request_text.contains("Upgrade: websocket\r\n"));
+
+            tls.write_all(
+                b"HTTP/1.1 101 Switching Protocols\r\n\
+                  Upgrade: websocket\r\n\
+                  Connection: Upgrade\r\n\
+                  \r\n\
+                  server-frame",
+            )
+            .await
+            .context("test upstream failed to write 101")?;
+
+            let mut frame = [0_u8; 12];
+            tls.read_exact(&mut frame)
+                .await
+                .context("test upstream failed to read raw client frame")?;
+            assert_eq!(&frame, b"client-frame");
+
+            tls.shutdown()
+                .await
+                .context("test upstream failed to shut down TLS")?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        let agent_connector = test_tls_connector(
+            mitm_ca.ca_cert_der(),
+            vec![b"h2".to_vec(), HTTP_1_1_ALPN.to_vec()],
+        )?;
+        let agent_task = tokio::spawn(async move {
+            let server_name =
+                ServerName::try_from(sni.to_string()).context("invalid test agent SNI")?;
+            let mut tls = agent_connector
+                .connect(server_name, agent_client_io)
+                .await
+                .context("test agent failed to connect to dsbx MITM")?;
+
+            tls.write_all(
+                format!(
+                    "GET /realtime HTTP/1.1\r\nHost: {sni}\r\n\
+                     Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .context("test agent failed to write upgrade request")?;
+
+            let mut response = Vec::new();
+            let mut buffer = [0_u8; 256];
+            loop {
+                let bytes_read = tls
+                    .read(&mut buffer)
+                    .await
+                    .context("test agent failed to read response")?;
+                if bytes_read == 0 {
+                    break;
+                }
+                response.extend_from_slice(&buffer[..bytes_read]);
+                if response.ends_with(b"server-frame") {
+                    break;
+                }
+            }
+            let response_text =
+                String::from_utf8(response).context("upgrade response should be utf8")?;
+            assert!(response_text.starts_with("HTTP/1.1 101 Switching Protocols\r\n"));
+            assert!(response_text.ends_with("server-frame"));
+
+            tls.write_all(b"client-frame")
+                .await
+                .context("test agent failed to write raw frame")?;
+            tls.shutdown()
+                .await
+                .context("test agent failed to shut down TLS")?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        run_mitm_session(&runtime, sni, agent_dsbx_io, dsbx_proxy_io).await?;
+        agent_task.await.context("test agent task panicked")??;
+        upstream_task
+            .await
+            .context("test upstream task panicked")??;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mitm_session_does_not_splice_client_frames_when_upgrade_rejected() -> Result<()> {
+        let sni = "api.openai.com";
+        let mitm_ca = Arc::new(MitmCa::generate()?);
+        let (upstream_server_config, upstream_ca_der) = test_upstream_server_config(sni)?;
+        let mut runtime = test_runtime(Arc::clone(&mitm_ca), upstream_ca_der)?;
+        runtime.secret_table = Arc::new(secret_table(&[sni])?);
+
+        let (agent_client_io, agent_dsbx_io) = tokio::io::duplex(16 * 1024);
+        let (dsbx_proxy_io, upstream_server_io) = tokio::io::duplex(16 * 1024);
+
+        let upstream_task = tokio::spawn(async move {
+            let acceptor = TlsAcceptor::from(upstream_server_config);
+            let mut tls = acceptor
+                .accept(upstream_server_io)
+                .await
+                .context("test upstream failed to accept TLS")?;
+
+            let mut request = Vec::new();
+            loop {
+                let mut byte = [0_u8; 1];
+                tls.read_exact(&mut byte)
+                    .await
+                    .context("test upstream failed to read request byte")?;
+                request.push(byte[0]);
+                if request.ends_with(b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            tls.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\nrejected",
+            )
+            .await
+            .context("test upstream failed to write 200")?;
+
+            // After the rejection, dsbx must shut down the upstream write
+            // half, so anything the agent tries to send afterwards must not
+            // arrive. Drain to EOF and assert nothing follows the upgrade
+            // request bytes already consumed.
+            let mut tail = Vec::new();
+            tls.read_to_end(&mut tail)
+                .await
+                .context("test upstream failed to read tail")?;
+            assert!(
+                tail.is_empty(),
+                "no client bytes should have been spliced after rejection, got {:?}",
+                tail
+            );
+
+            tls.shutdown().await.ok();
+            Ok::<(), anyhow::Error>(())
+        });
+
+        let agent_connector = test_tls_connector(
+            mitm_ca.ca_cert_der(),
+            vec![b"h2".to_vec(), HTTP_1_1_ALPN.to_vec()],
+        )?;
+        let agent_task = tokio::spawn(async move {
+            let server_name =
+                ServerName::try_from(sni.to_string()).context("invalid test agent SNI")?;
+            let mut tls = agent_connector
+                .connect(server_name, agent_client_io)
+                .await
+                .context("test agent failed to connect to dsbx MITM")?;
+
+            tls.write_all(
+                format!(
+                    "GET /realtime HTTP/1.1\r\nHost: {sni}\r\n\
+                     Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .context("test agent failed to write upgrade request")?;
+
+            let mut response = Vec::new();
+            let mut buffer = [0_u8; 256];
+            loop {
+                let bytes_read = tls
+                    .read(&mut buffer)
+                    .await
+                    .context("test agent failed to read rejection")?;
+                if bytes_read == 0 {
+                    break;
+                }
+                response.extend_from_slice(&buffer[..bytes_read]);
+                if response.ends_with(b"rejected") {
+                    break;
+                }
+            }
+            let response_text = String::from_utf8(response).context("rejection should be utf8")?;
+            assert!(response_text.starts_with("HTTP/1.1 200 OK\r\n"));
+
+            // The agent attempts to send post-upgrade frames; dsbx must drop
+            // them on the floor because upstream did not accept the upgrade.
+            let _ = tls.write_all(b"client-frame").await;
+            let _ = tls.shutdown().await;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        run_mitm_session(&runtime, sni, agent_dsbx_io, dsbx_proxy_io).await?;
+        agent_task.await.context("test agent task panicked")??;
+        upstream_task
+            .await
+            .context("test upstream task panicked")??;
+
+        Ok(())
+    }
+
     // SNI-miss path: dsbx does not terminate, just splices. The agent's TLS
     // client must see the upstream's real cert chain (not the dsbx CA),
     // which is the load-bearing property of the splice branch.

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -52,7 +52,7 @@ describe("sandbox image registry", () => {
   test("bumps the base image for the scoped MITM rollout", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.15",
+      tag: "0.8.16",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -14,8 +14,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.15";
-const DSBX_CLI_VERSION = "0.1.11";
+const DUST_BASE_IMAGE_VERSION = "0.8.16";
+const DSBX_CLI_VERSION = "0.1.12";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.


### PR DESCRIPTION
Follow up of #25867.

## Description

After the rewriter forwards a WebSocket upgrade request, it now waits for upstream's actual response before splicing raw client frames. The request task sends a oneshot watch through the existing `WebSocketUpgradeWatch` channel *before* forwarding any upgrade bytes; the response task sniffs the next status line and signals back; the request task either raw-splices (101) or tears the upstream write half down (anything else). Client frames never reach an upstream that did not accept the upgrade.

Notes:

- The watch is registered before the request bytes leave dsbx, so the response task is already in sniff mode when upstream's 101 (or non-101) arrives. Registering after the write would race in-flight bytes against the mpsc send.
- Sniffing assumes no HTTP/1.1 pipelining on the same connection. Pipelining a normal request before a WS upgrade on one connection is essentially never seen in real clients, and the comment in `copy_responses_with_websocket_watch` calls this out.
- If the response copier exits before the request task sends the watch (or the oneshot is dropped without a verdict), the upgrade is treated as rejected so we don't splice into a half-closed connection.

Bumps `dsbx 0.1.11 -> 0.1.12` and `dust-base 0.8.15 -> 0.8.16`.

## Tests

Added unit tests in `http_rewriter.rs`:

- `parses_switching_protocols_status_line` covers the status-line parser edge cases (1.0/1.1, bogus 1010, HTTP/2, garbage).
- `response_copier_signals_accepted_when_upstream_returns_101` drives the new select loop end-to-end and asserts the oneshot fires `true` plus that all bytes pass through.
- `response_copier_signals_rejected_when_upstream_returns_non_101` does the same for 200.
- `response_copier_passes_bytes_through_when_no_watch_is_sent` keeps the no-upgrade path honest.

Added integration tests in `forward/mod.rs` that exercise the full TLS MITM stack:

- `mitm_session_completes_websocket_upgrade_when_upstream_returns_101` asserts the agent sees the 101 + server frame and the upstream sees the post-upgrade client frame.
- `mitm_session_does_not_splice_client_frames_when_upgrade_rejected` asserts the agent sees the non-101 response and upstream does *not* receive any post-upgrade client bytes.

All 78 dsbx tests pass. \`npm run test -- registry.test\` passes (4 tests).

## Risk

Low. The new path is only entered for requests that already carried \`Upgrade: websocket\` + \`Connection: Upgrade\`. Pre-upgrade traffic and the SNI-miss splice path are unchanged. Worst case the sniff stalls on a misbehaving upstream that never sends CRLF in 16 KiB; we then signal rejected and flush the bytes through. Safe to rollback.

## Deploy Plan

Order matters: the dust-base image build curls \`dsbx-v\${DSBX_CLI_VERSION}\` from GitHub releases, so the release must exist before front deploys.

- [ ] Run the \`Release dsbx CLI\` workflow on this branch (workflow_dispatch) to publish \`dsbx-v0.1.12\`.
- [ ] Deploy front (rebuilds and pushes \`dust-base:0.8.16\`).
- [ ] Hit \`/poke/kill\` to recycle running sandboxes onto the new image.