### PR TITLE
Simplify buildFileSystemTree() and add tests

### DIFF
--- a/front/components/file_explorer/fileExplorerPipeline.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.ts
@@ -6,7 +6,7 @@ import type {
   FileSystemTreeNode,
 } from "@app/components/file_explorer/types";
 import {
-  buildSandboxTree,
+  buildFileSystemTree,
   compareTreeNodesForSort,
   getChildrenAtFolderPath,
   getFileExplorerBucket,
@@ -69,7 +69,7 @@ export function getFileExplorerPipeline({
     entryByRelativePath.set(node.path, node);
   }
 
-  const tree = buildSandboxTree(files);
+  const tree = buildFileSystemTree(files);
 
   // Synthetic tree nodes for content-node entries — always flat, at root level.
   const contentNodeTreeNodes: FileSystemTreeNode[] = contentNodes.map((cn) => ({

--- a/front/components/file_explorer/utils.test.ts
+++ b/front/components/file_explorer/utils.test.ts
@@ -1,7 +1,56 @@
-import type { FileEntry } from "@app/components/file_explorer/types";
-import { isFileExplorerMovableFile } from "@app/components/file_explorer/utils";
+import type {
+  FileEntry,
+  FileSystemTreeNode,
+} from "@app/components/file_explorer/types";
+import {
+  buildFileSystemTree,
+  buildFolderTree,
+  findTreeNodeByPath,
+  getChildrenAtFolderPath,
+  isFileExplorerMovableFile,
+} from "@app/components/file_explorer/utils";
+import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
 import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import { describe, expect, it } from "vitest";
+
+function mountFile(
+  relativePath: string,
+  useCase: "project" | "conversation" = "project"
+): GCSMountEntry {
+  return {
+    isDirectory: false,
+    fileName: relativePath.split("/").pop() ?? relativePath,
+    path: `${useCase}/${relativePath}`,
+    contentType: "text/plain",
+    fileId: "file-1",
+    sizeBytes: 100,
+    lastModifiedMs: 0,
+    thumbnailUrl: null,
+  };
+}
+
+function mountDir(
+  relativePath: string,
+  useCase: "project" | "conversation" = "project"
+): GCSMountEntry {
+  return {
+    isDirectory: true,
+    fileName: relativePath.split("/").pop() ?? relativePath,
+    path: `${useCase}/${relativePath}`,
+    sizeBytes: 0,
+    lastModifiedMs: 0,
+  };
+}
+
+function collectTreeNodes(nodes: FileSystemTreeNode[]): FileSystemTreeNode[] {
+  return nodes.flatMap((node) => [node, ...collectTreeNodes(node.children)]);
+}
+
+function sortedNodePaths(nodes: FileSystemTreeNode[]): string[] {
+  return collectTreeNodes(nodes)
+    .map((n) => `${n.isDirectory ? "d" : "f"}:${n.path}`)
+    .sort();
+}
 
 function makeFileEntry(contentType: string): FileEntry {
   return {
@@ -38,5 +87,164 @@ describe("isFileExplorerMovableFile", () => {
         fileId: null,
       })
     ).toBe(true);
+  });
+});
+
+describe("buildFileSystemTree", () => {
+  it("returns an empty tree for no entries", () => {
+    expect(buildFileSystemTree([])).toEqual([]);
+  });
+
+  it("places a root-level file without inferring directories", () => {
+    const tree = buildFileSystemTree([mountFile("readme.txt")]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0]).toMatchObject({
+      name: "readme.txt",
+      path: "readme.txt",
+      isDirectory: false,
+    });
+  });
+
+  it("infers ancestor directories from nested file paths", () => {
+    const tree = buildFileSystemTree([mountFile("reports/q1/summary.pdf")]);
+
+    const reports = findTreeNodeByPath(tree, "reports");
+    const q1 = findTreeNodeByPath(tree, "reports/q1");
+    const summary = findTreeNodeByPath(tree, "reports/q1/summary.pdf");
+
+    expect(reports?.isDirectory).toBe(true);
+    expect(q1?.isDirectory).toBe(true);
+    expect(summary?.isDirectory).toBe(false);
+    expect(q1?.children.map((n) => n.path)).toEqual(["reports/q1/summary.pdf"]);
+  });
+
+  it("adds empty folders from directory entries", () => {
+    const tree = buildFileSystemTree([mountDir("archive")]);
+
+    const archive = findTreeNodeByPath(tree, "archive");
+    expect(archive?.isDirectory).toBe(true);
+    expect(archive?.children).toEqual([]);
+  });
+
+  it("creates nested empty folders without files", () => {
+    const tree = buildFileSystemTree([mountDir("a/b")]);
+
+    expect(findTreeNodeByPath(tree, "a")?.isDirectory).toBe(true);
+    expect(findTreeNodeByPath(tree, "a/b")?.isDirectory).toBe(true);
+    expect(getChildrenAtFolderPath(tree, "a").map((n) => n.path)).toEqual([
+      "a/b",
+    ]);
+  });
+
+  it("merges inferred folders with empty sibling directory entries", () => {
+    const tree = buildFileSystemTree([
+      mountFile("docs/guide.txt"),
+      mountDir("docs/drafts"),
+    ]);
+
+    const docs = findTreeNodeByPath(tree, "docs");
+    expect(docs?.children.map((n) => n.path).sort()).toEqual([
+      "docs/drafts",
+      "docs/guide.txt",
+    ]);
+  });
+
+  it("skips directory entries when the path was already inferred from files", () => {
+    const withPlaceholder = buildFileSystemTree([
+      mountDir("reports"),
+      mountFile("reports/annual.pdf"),
+    ]);
+    const inferredOnly = buildFileSystemTree([mountFile("reports/annual.pdf")]);
+
+    expect(sortedNodePaths(withPlaceholder)).toEqual(
+      sortedNodePaths(inferredOnly)
+    );
+  });
+
+  it("produces the same tree regardless of entry order", () => {
+    const filesFirst = [
+      mountFile("a/x.txt"),
+      mountFile("b/y.txt"),
+      mountDir("a/empty"),
+      mountDir("c"),
+    ];
+    const dirsFirst = [
+      mountDir("c"),
+      mountDir("a/empty"),
+      mountFile("b/y.txt"),
+      mountFile("a/x.txt"),
+    ];
+    const mixed = [
+      mountFile("b/y.txt"),
+      mountDir("a/empty"),
+      mountFile("a/x.txt"),
+      mountDir("c"),
+    ];
+
+    const expected = sortedNodePaths(buildFileSystemTree(dirsFirst));
+    expect(sortedNodePaths(buildFileSystemTree(filesFirst))).toEqual(expected);
+    expect(sortedNodePaths(buildFileSystemTree(mixed))).toEqual(expected);
+  });
+
+  it("strips the scoped use-case prefix from paths", () => {
+    const tree = buildFileSystemTree([
+      mountFile("sandbox/out.txt", "conversation"),
+    ]);
+
+    expect(findTreeNodeByPath(tree, "sandbox/out.txt")).toBeDefined();
+    expect(findTreeNodeByPath(tree, "conversation/sandbox/out.txt")).toBe(
+      undefined
+    );
+  });
+
+  it("ignores entries with no path beyond the use-case prefix", () => {
+    const tree = buildFileSystemTree([
+      {
+        isDirectory: false,
+        fileName: "",
+        path: "project/",
+        contentType: "text/plain",
+        fileId: null,
+        sizeBytes: 0,
+        lastModifiedMs: 0,
+        thumbnailUrl: null,
+      },
+      mountFile("ok.txt"),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.path).toBe("ok.txt");
+  });
+
+  it("supports navigation helpers at inferred and explicit folders", () => {
+    const tree = buildFileSystemTree([
+      mountDir("shared"),
+      mountFile("shared/one.txt"),
+      mountFile("shared/two.txt"),
+    ]);
+
+    expect(getChildrenAtFolderPath(tree, "").map((n) => n.path)).toEqual([
+      "shared",
+    ]);
+    expect(
+      getChildrenAtFolderPath(tree, "shared")
+        .map((n) => n.path)
+        .sort()
+    ).toEqual(["shared/one.txt", "shared/two.txt"]);
+  });
+});
+
+describe("buildFolderTree", () => {
+  it("returns only directory nodes", () => {
+    const tree = buildFolderTree([
+      mountDir("docs"),
+      mountFile("docs/readme.txt"),
+      mountFile("notes.txt"),
+    ]);
+
+    expect(collectTreeNodes(tree).every((n) => n.isDirectory)).toBe(true);
+    expect(findTreeNodeByPath(tree, "docs/readme.txt")).toBeUndefined();
+    expect(findTreeNodeByPath(tree, "docs")?.isDirectory).toBe(true);
   });
 });

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -196,19 +196,48 @@ export function getCategoryFromContentType(
   }
 }
 
+function ensureDirectoryNode(
+  nodeMap: Map<string, FileSystemTreeNode>,
+  root: FileSystemTreeNode[],
+  path: string,
+  name: string
+): void {
+  if (nodeMap.has(path)) {
+    return;
+  }
+
+  const dirNode: FileSystemTreeNode = {
+    name,
+    path,
+    isDirectory: true,
+    contentType: null,
+    fileId: null,
+    children: [],
+  };
+  nodeMap.set(path, dirNode);
+
+  const parentPath = path.substring(0, path.lastIndexOf("/"));
+  const parent = parentPath ? nodeMap.get(parentPath) : undefined;
+  if (parent) {
+    parent.children.push(dirNode);
+  } else {
+    root.push(dirNode);
+  }
+}
+
 /**
  * Build a tree from flat file entries by inferring directories from paths.
  * entry.path is a scoped path (e.g. "conversation/subdir/file.png"); the
  * use-case prefix (first segment) is stripped so tree paths start at the
  * sandbox working directory root.
  */
-export function buildSandboxTree(
+export function buildFileSystemTree(
   entries: GCSMountEntry[]
 ): FileSystemTreeNode[] {
   const root: FileSystemTreeNode[] = [];
   const nodeMap = new Map<string, FileSystemTreeNode>();
 
-  for (const entry of entries.filter((e) => !e.isDirectory)) {
+  for (const entry of entries) {
     const slashIdx = entry.path.indexOf("/");
     const relativePath =
       slashIdx >= 0 ? entry.path.slice(slashIdx + 1) : entry.path;
@@ -219,35 +248,25 @@ export function buildSandboxTree(
 
     const parts = relativePath.split("/");
 
-    // Ensure all ancestor directories exist as nodes.
-    let currentPath = "";
-    for (let i = 0; i < parts.length - 1; i++) {
-      currentPath = currentPath ? `${currentPath}/${parts[i]}` : parts[i]!;
-      if (!nodeMap.has(currentPath)) {
-        const dirNode: FileSystemTreeNode = {
-          name: parts[i]!,
-          path: currentPath,
-          isDirectory: true,
-          contentType: null,
-          fileId: null,
-          children: [],
-        };
-        nodeMap.set(currentPath, dirNode);
-
-        const parentPath = currentPath.substring(
-          0,
-          currentPath.lastIndexOf("/")
-        );
-        const parent = parentPath ? nodeMap.get(parentPath) : undefined;
-        if (parent) {
-          parent.children.push(dirNode);
-        } else {
-          root.push(dirNode);
-        }
+    if (entry.isDirectory) {
+      if (nodeMap.has(relativePath)) {
+        continue;
       }
+
+      let currentPath = "";
+      for (let i = 0; i < parts.length; i++) {
+        currentPath = currentPath ? `${currentPath}/${parts[i]!}` : parts[i]!;
+        ensureDirectoryNode(nodeMap, root, currentPath, parts[i]!);
+      }
+      continue;
     }
 
-    // Add the file node.
+    let currentPath = "";
+    for (let i = 0; i < parts.length - 1; i++) {
+      currentPath = currentPath ? `${currentPath}/${parts[i]!}` : parts[i]!;
+      ensureDirectoryNode(nodeMap, root, currentPath, parts[i]!);
+    }
+
     const fileNode: FileSystemTreeNode = {
       name: parts[parts.length - 1]!,
       path: relativePath,
@@ -264,43 +283,6 @@ export function buildSandboxTree(
       parent.children.push(fileNode);
     } else {
       root.push(fileNode);
-    }
-  }
-
-  for (const entry of entries.filter((e) => e.isDirectory)) {
-    const slashIdx = entry.path.indexOf("/");
-    const relativePath =
-      slashIdx >= 0 ? entry.path.slice(slashIdx + 1) : entry.path;
-
-    if (!relativePath || nodeMap.has(relativePath)) {
-      continue;
-    }
-
-    const parts = relativePath.split("/");
-    let currentPath = "";
-    for (let i = 0; i < parts.length; i++) {
-      currentPath = currentPath ? `${currentPath}/${parts[i]!}` : parts[i]!;
-      if (nodeMap.has(currentPath)) {
-        continue;
-      }
-
-      const dirNode: FileSystemTreeNode = {
-        name: parts[i]!,
-        path: currentPath,
-        isDirectory: true,
-        contentType: null,
-        fileId: null,
-        children: [],
-      };
-      nodeMap.set(currentPath, dirNode);
-
-      const parentPath = currentPath.substring(0, currentPath.lastIndexOf("/"));
-      const parent = parentPath ? nodeMap.get(parentPath) : undefined;
-      if (parent) {
-        parent.children.push(dirNode);
-      } else {
-        root.push(dirNode);
-      }
     }
   }
 
@@ -342,7 +324,7 @@ function filterDirectoryNodes(
 export function buildFolderTree(
   entries: GCSMountEntry[]
 ): FileSystemTreeNode[] {
-  return filterDirectoryNodes(buildSandboxTree(entries));
+  return filterDirectoryNodes(buildFileSystemTree(entries));
 }
 
 export function countFoldersInTree(nodes: FileSystemTreeNode[]): number {


### PR DESCRIPTION
## Description

Renamed `buildSandboxTree` to `buildFileSystemTree` for accuracy (the function is not sandbox-specific). Extracted a shared `ensureDirectoryNode` helper to eliminate the duplicated inline directory-node creation logic, and collapsed the previous two-pass approach (files, then directories) into a single unified loop that handles both entry types in order.

## Tests

Added Vitest unit tests for `buildFileSystemTree` and `buildFolderTree` covering: empty input, root-level files, ancestor directory inference, explicit empty directories, nested empty folders, deduplication when a directory entry overlaps an inferred path, input-order independence, use-case prefix stripping, ignored entries with no relative path, and `getChildrenAtFolderPath` integration.

## Risk

Low. Pure refactor — no behavioural changes to the tree structure or public API surface. The rename of `buildSandboxTree` → `buildFileSystemTree` is fully internal to `front/components/file_explorer/`.

## Deploy Plan

Deploy `front`.
