### PR TITLE
feat(dsbx): poll async sandbox actions endpoint from tool exec

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -1,8 +1,20 @@
+use std::io::IsTerminal;
+use std::time::{Duration, Instant};
+
 use anyhow::{bail, Context};
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use serde::{de::DeserializeOwned, Serialize};
+use tokio::time::sleep;
 
-use super::types::{CallToolRequest, CallToolResponse, MCPServerView, SandboxToolsResponse};
+use super::types::{
+    parse_action_poll_response, ActionPollResponse, CallToolPostResponse, CallToolRequest,
+    CallToolResponse, CallToolResult, MCPServerView, SandboxServerViewsResponse,
+};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+// Hard cap so a wedged action can't pin the CLI forever.
+const POLL_MAX_DURATION: Duration = Duration::from_secs(10 * 60);
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
 const API_URL_ENV: &str = "DUST_API_URL";
@@ -31,6 +43,7 @@ impl DustApiClient {
 
         let client = reqwest::Client::builder()
             .default_headers(headers)
+            .timeout(HTTP_REQUEST_TIMEOUT)
             .build()
             .context("failed to build HTTP client")?;
 
@@ -103,25 +116,78 @@ impl DustApiClient {
         if light {
             query.push(("light", "true"));
         }
-        let resp: SandboxToolsResponse = self.get("sandbox/tools", &query).await?;
+        let resp: SandboxServerViewsResponse = self.get("sandbox/actions", &query).await?;
         Ok(resp.server_views)
+    }
+
+    async fn get_action_status(&self, action_id: &str) -> anyhow::Result<ActionPollResponse> {
+        let path = format!("sandbox/actions/{action_id}");
+        let url = self.url(&path);
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context(format!("GET {url}"))?;
+
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .context(format!("failed to read response from GET {url}"))?;
+
+        match parse_action_poll_response(&body) {
+            Ok(poll) => Ok(poll),
+            Err(parse_err) if status.is_success() => Err(parse_err)
+                .with_context(|| format!("GET {url} (status {status}) returned unparseable body")),
+            Err(_) => bail!("GET {url} returned {status}: {body}"),
+        }
+    }
+
+    async fn poll_action_result(&self, action_id: &str) -> anyhow::Result<CallToolResponse> {
+        let deadline = Instant::now() + POLL_MAX_DURATION;
+        let mut announced = false;
+        loop {
+            match self.get_action_status(action_id).await? {
+                ActionPollResponse::Pending => {
+                    if Instant::now() >= deadline {
+                        bail!(
+                            "timed out waiting for action {action_id} after {} seconds",
+                            POLL_MAX_DURATION.as_secs()
+                        );
+                    }
+                    if !announced && std::io::stderr().is_terminal() {
+                        eprintln!("waiting on action {action_id}...");
+                        announced = true;
+                    }
+                    sleep(POLL_INTERVAL).await;
+                }
+                ActionPollResponse::Rejected => {
+                    bail!("action {action_id} was rejected");
+                }
+                ActionPollResponse::Success { content, is_error } => {
+                    return Ok(CallToolResponse {
+                        result: CallToolResult { content, is_error },
+                    });
+                }
+            }
+        }
     }
 
     pub async fn call_tool(
         &self,
-        space_id: &str,
         view_id: &str,
         tool_name: &str,
         arguments: Option<serde_json::Value>,
     ) -> anyhow::Result<CallToolResponse> {
         let body = CallToolRequest {
+            server_view_id: view_id.to_string(),
             tool_name: tool_name.to_string(),
             arguments,
         };
-        self.post(
-            &format!("spaces/{space_id}/mcp_server_views/{view_id}/call_tool"),
-            &body,
-        )
-        .await
+        let CallToolPostResponse::Pending { action_id } =
+            self.post("sandbox/actions/call", &body).await?;
+
+        self.poll_action_result(&action_id).await
     }
 }

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -1,8 +1,11 @@
+use std::io::IsTerminal;
+
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SandboxToolsResponse {
+pub struct SandboxServerViewsResponse {
     pub server_views: Vec<MCPServerView>,
 }
 
@@ -11,7 +14,6 @@ pub struct SandboxToolsResponse {
 pub struct MCPServerView {
     #[serde(rename = "sId")]
     pub s_id: String,
-    pub space_id: String,
     pub server: MCPServer,
 }
 
@@ -35,9 +37,94 @@ pub struct MCPTool {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallToolRequest {
+    pub server_view_id: String,
     pub tool_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum CallToolPostResponse {
+    Pending { action_id: String },
+}
+
+#[derive(Debug)]
+pub enum ActionPollResponse {
+    Pending,
+    Rejected,
+    Success {
+        content: Vec<ContentBlock>,
+        is_error: bool,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum ActionPollResponseRaw {
+    Pending,
+    Rejected,
+    Success { action: ActionData },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ActionData {
+    status: String,
+    #[serde(default)]
+    output: Option<Vec<serde_json::Value>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorEnvelope {
+    error: ApiErrorBody,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorBody {
+    #[serde(default)]
+    message: Option<String>,
+}
+
+pub fn parse_action_poll_response(body: &str) -> anyhow::Result<ActionPollResponse> {
+    if let Ok(envelope) = serde_json::from_str::<ApiErrorEnvelope>(body) {
+        let message = envelope
+            .error
+            .message
+            .as_deref()
+            .unwrap_or("unknown API error");
+        anyhow::bail!("API error: {message}");
+    }
+
+    let raw: ActionPollResponseRaw = serde_json::from_str(body)
+        .with_context(|| format!("failed to parse poll response: {body}"))?;
+
+    match raw {
+        ActionPollResponseRaw::Pending => Ok(ActionPollResponse::Pending),
+        ActionPollResponseRaw::Rejected => Ok(ActionPollResponse::Rejected),
+        ActionPollResponseRaw::Success { action } => {
+            let is_error = action.status == "errored";
+            let content = action
+                .output
+                .unwrap_or_default()
+                .iter()
+                .map(parse_content_block)
+                .collect();
+            Ok(ActionPollResponse::Success { content, is_error })
+        }
+    }
+}
+
+fn parse_content_block(value: &serde_json::Value) -> ContentBlock {
+    match serde_json::from_value::<ContentBlock>(value.clone()) {
+        Ok(block) => block,
+        Err(err) => {
+            if std::io::stderr().is_terminal() {
+                eprintln!("[warning] unrecognized content block, ignoring: {err}");
+            }
+            ContentBlock::Unknown
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -63,19 +150,24 @@ pub enum ContentBlock {
         text: String,
     },
     Image {
+        #[serde(default)]
         #[allow(dead_code)]
         data: String,
+        #[serde(default = "default_mime_type")]
         mime_type: String,
     },
     Audio {
+        #[serde(default)]
         #[allow(dead_code)]
         data: String,
+        #[serde(default = "default_mime_type")]
         mime_type: String,
     },
     Resource {
         resource: ResourceContent,
     },
     ResourceLink {
+        #[serde(default)]
         uri: String,
         name: Option<String>,
     },
@@ -86,10 +178,77 @@ pub enum ContentBlock {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceContent {
+    #[serde(default)]
     pub uri: String,
     #[allow(dead_code)]
     pub mime_type: Option<String>,
     pub text: Option<String>,
     #[allow(dead_code)]
     pub blob: Option<String>,
+}
+
+fn default_mime_type() -> String {
+    "application/octet-stream".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pending_poll_response() {
+        let resp = parse_action_poll_response(r#"{"status":"pending"}"#).expect("should parse");
+        assert!(matches!(resp, ActionPollResponse::Pending));
+    }
+
+    #[test]
+    fn parse_rejected_poll_response() {
+        let resp = parse_action_poll_response(r#"{"status":"rejected"}"#).expect("should parse");
+        assert!(matches!(resp, ActionPollResponse::Rejected));
+    }
+
+    #[test]
+    fn parse_success_poll_response() {
+        let resp = parse_action_poll_response(
+            r#"{
+                "status":"success",
+                "action":{
+                    "status":"succeeded",
+                    "output":[{"type":"text","text":"hello"}]
+                }
+            }"#,
+        )
+        .expect("should parse");
+        match resp {
+            ActionPollResponse::Success { content, is_error } => {
+                assert!(!is_error);
+                assert_eq!(content.len(), 1);
+            }
+            _ => panic!("expected success"),
+        }
+    }
+
+    #[test]
+    fn parse_errored_action() {
+        let resp = parse_action_poll_response(
+            r#"{
+                "status":"success",
+                "action":{"status":"errored","output":[{"type":"text","text":"boom"}]}
+            }"#,
+        )
+        .expect("should parse");
+        match resp {
+            ActionPollResponse::Success { is_error, .. } => assert!(is_error),
+            _ => panic!("expected success"),
+        }
+    }
+
+    #[test]
+    fn parse_error_envelope_bails() {
+        let err = parse_action_poll_response(
+            r#"{"error":{"type":"not_authenticated","message":"bad token"}}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("bad token"));
+    }
 }

--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -28,35 +28,36 @@ pub async fn cmd_exec(
 
     let arguments = parse_args(raw_args)?;
 
-    let resp = client
-        .call_tool(&view.space_id, &view.s_id, tool_name, arguments)
-        .await?;
+    let resp = client.call_tool(&view.s_id, tool_name, arguments).await?;
 
+    // All content blocks (text and sentinel markers) go to stdout so a caller
+    // capturing stdout sees the full tool output. stderr is reserved for
+    // ambient diagnostics.
     for block in &resp.result.content {
         match block {
             ContentBlock::Text { text } => {
                 println!("{text}");
             }
             ContentBlock::Image { mime_type, .. } => {
-                eprintln!("[image: {mime_type}]");
+                println!("[image: {mime_type}]");
             }
             ContentBlock::Audio { mime_type, .. } => {
-                eprintln!("[audio: {mime_type}]");
+                println!("[audio: {mime_type}]");
             }
             ContentBlock::Resource { resource } => {
                 if let Some(text) = &resource.text {
                     println!("{text}");
                 } else if resource.blob.is_some() {
-                    eprintln!("[binary resource: {}]", resource.uri);
+                    println!("[binary resource: {}]", resource.uri);
                 } else {
-                    eprintln!("[resource: {}]", resource.uri);
+                    println!("[resource: {}]", resource.uri);
                 }
             }
             ContentBlock::ResourceLink { uri, name } => {
                 if let Some(name) = name {
-                    eprintln!("[resource link: {name} — {uri}]");
+                    println!("[resource link: {name} - {uri}]");
                 } else {
-                    eprintln!("[resource link: {uri}]");
+                    println!("[resource link: {uri}]");
                 }
             }
             ContentBlock::Unknown => {}


### PR DESCRIPTION
## Description

Switches `dsbx tools exec` to the new async sandbox actions API: `POST sandbox/actions/call` returns an `actionId`, then we poll `GET sandbox/actions/{aId}` every 500ms until the action resolves. Replaces the synchronous `POST /spaces/.../mcp_server_views/.../call_tool` path.

Notable bits:
- **Hard timeouts.** Poll loop caps at 10 min; reqwest client has a 30s per-request timeout — a wedged backend can't pin the CLI forever.
- **Body shape over HTTP status.** The poll endpoint returns `{ status: "rejected" }` with HTTP 403, but `verifySandboxExecToken` failures also return 403 (with an `error` envelope). We parse the body first so auth failures surface their real message instead of being misclassified as "user rejected".
- **LLM-friendlier output.** All content blocks (text + `[image: ...]` / `[resource: ...]` sentinels) now go to stdout — a caller piping stdout sees the full tool output. The "waiting on action…" hint and the unknown-block warning are gated on `stderr.is_terminal()`, so scripted/LLM-driven invocations get silence.
- Dropped the dead `space_id` field on `MCPServerView` (no longer needed for the new endpoint).

## Tests

`cargo test` (67/67 passing) — added unit tests for `parse_action_poll_response`:
- pending / rejected / success / errored action states
- API error envelope is bubbled up with the real message

Manual smoke test pending against a workspace with `sandbox_dsbx_tools` enabled.

## Risk

Worst case, `dsbx tools exec` breaks for users on a CLI version that ships before the backend rolls out `sandbox/actions/*` everywhere.

## Deploy Plan

- [ ] Cut a new `dsbx` release once merged.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25874">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->