### PR TITLE
remove browse agents link in slack message footer

### DIFF
--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -16,7 +16,6 @@ import {
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/api/webhooks/webhook_slack_bot_interaction";
 import type { MessageFootnotes } from "@connectors/lib/bot/citations";
-import { makeDustAppUrl } from "@connectors/lib/bot/conversation_utils";
 import { truncate } from "@connectors/types";
 import type {
   LightAgentConfigurationType,
@@ -112,7 +111,6 @@ function makeContextSectionBlocks({
       state,
       assistantName,
       conversationUrl,
-      workspaceId,
     })
   );
 
@@ -243,14 +241,11 @@ export function makeFooterBlock({
   state,
   assistantName,
   conversationUrl,
-  workspaceId,
 }: {
   state: "thinking" | "error" | "answered";
   assistantName?: string;
   conversationUrl: string | null;
-  workspaceId: string;
 }) {
-  const assistantsUrl = makeDustAppUrl(`/w/${workspaceId}/agent/new`);
   let attribution = "";
   if (assistantName) {
     if (state === "thinking") {
@@ -274,11 +269,11 @@ export function makeFooterBlock({
   if (conversationUrl) {
     links.push(`<${conversationUrl}|View full conversation>`);
   }
-  links.push(`<${assistantsUrl}|Browse agents>`);
 
-  const fullText = attribution
-    ? `${attribution} | ${links.join(" · ")}`
-    : links.join(" · ");
+  const fullText =
+    attribution && links.length > 0
+      ? `${attribution} | ${links.join(" · ")}`
+      : attribution || links.join(" · ");
 
   return {
     type: "context",
@@ -347,7 +342,6 @@ export function makeErrorBlock(
       makeFooterBlock({
         state: "error",
         conversationUrl,
-        workspaceId,
       }),
     ],
     mrkdwn: true,
@@ -429,7 +423,6 @@ export function makePlanMessage({
         state: "thinking",
         assistantName,
         conversationUrl,
-        workspaceId,
       }),
     ],
     text: planTitle,


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8190

remove the "browse agents" link at the bottom of slack message because agent.
Doing this as we are sunsetting custom agent

<img width="1202" height="674" alt="Image" src="https://github.com/user-attachments/assets/93b46351-e6c5-44f7-9560-312e865f8ac6" />

## Tests

not tested

## Risk

low, it's just a link

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25875">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->