### PR TITLE
[front] document DSEC_ secrets and trust-store rules in the sandbox skill

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -115,6 +115,8 @@ async function redactSandboxEnvVarsFromOutput(
   auth: Authenticator,
   output: string
 ): Promise<Result<string, Error>> {
+  // loadEnv is intentionally config-only. HTTPS secrets are injected as DSEC
+  // placeholders and their real values should never be materialized here.
   const envResult = await WorkspaceSandboxEnvVarResource.loadEnv(auth);
   if (envResult.isErr()) {
     return envResult;

--- a/front/lib/resources/skill/code_defined/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.test.ts
@@ -44,6 +44,26 @@ describe("sandboxSkill", () => {
     expect(instructions).toContain("DuckDB");
   });
 
+  it("documents DSEC HTTPS secret handling and trust-store footguns", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+
+    const instructions = await sandboxSkill.fetchInstructions(auth, {
+      spaceIds: [],
+    });
+
+    expect(instructions).toContain("`DST_*`: configuration values");
+    expect(instructions).toContain("`DSEC_*`: HTTPS secret placeholders");
+    expect(instructions).toContain("Authorization: Basic");
+    expect(instructions).toContain(
+      'os.environ["OPENAI_API_KEY"] = os.environ["DSEC_OPENAI_API_KEY"]'
+    );
+    expect(instructions).toContain("rustls-tls-native-roots");
+    expect(instructions).toContain("PKIX path building failed");
+    expect(instructions).toContain("Do not pass custom TLS trust settings");
+  });
+
   it("hides agent egress request instructions until enabled", async () => {
     const {
       authenticator: auth,

--- a/front/lib/resources/skill/code_defined/sandbox.test.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.test.ts
@@ -57,6 +57,9 @@ describe("sandboxSkill", () => {
     expect(instructions).toContain("`DSEC_*`: HTTPS secret placeholders");
     expect(instructions).toContain("Authorization: Basic");
     expect(instructions).toContain(
+      "Do not put a `DSEC_*` placeholder in a URL or query string"
+    );
+    expect(instructions).toContain(
       'os.environ["OPENAI_API_KEY"] = os.environ["DSEC_OPENAI_API_KEY"]'
     );
     expect(instructions).toContain("rustls-tls-native-roots");

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -199,23 +199,61 @@ function buildEnvironmentVariablesSection(): string {
   return `#### Sandbox Environment Variables
 
 The sandbox may have workspace-configured environment variables available
-in the bash shell and to any code you run. All workspace-configured names
-are prefixed with \`DST_\` (e.g. \`DST_API_TOKEN\`, \`DST_SERVICE_KEY\`).
-If a tool, CLI, or SDK expects a specific unprefixed name, you must read
-the \`DST_\`-prefixed variable and re-export it under the expected name
-yourself before invoking the tool — for example
-\`SOMETOOL_TOKEN=\$DST_SOMETOOL_TOKEN some-cli ...\`. You may use these
-variables to authenticate with APIs or pass them into code paths that
-consume them, but you must never print, echo, \`cat\`, or otherwise
-disclose an environment variable value. Do not include a value in output,
-logs, error messages, or final answers. Do not re-encode, transform, or
-split a value to bypass this rule. Do not list available environment
-variable names just to enumerate what is configured.
+in the bash shell and to any code you run. Treat all of them as sensitive.
 
-If a user asks for a secret value, refuse and say it is not viewable. If you
-need to confirm a variable is set, check whether it is non-empty without
-printing its content (e.g. \`[ -n "\$DST_FOO" ]\` in bash) — do not read or
-print the value.
+There are two prefixes:
+
+- \`DST_*\`: configuration values injected as normal environment variables.
+  Use them for local configuration and API clients, but never print them.
+- \`DSEC_*\`: HTTPS secret placeholders. The value in the environment is
+  intentionally not the real secret. Send it as an HTTPS request header to
+  the domain approved for that secret; the egress proxy substitutes the real
+  value on the wire.
+
+Hard rules for environment variables:
+
+- Never print, echo, \`cat\`, log, summarize, or otherwise disclose a
+  configured value. If a user asks for a secret value, refuse and say it is
+  not viewable.
+- Do not try to extract, decode, recover, or inspect the real value behind a
+  \`DSEC_*\` placeholder. The placeholder is all your process is supposed to
+  see.
+- Do not transform a \`DSEC_*\` placeholder before sending it. Do not URL
+  encode it, split it across fields, put it in a request body, write it to a
+  file and re-read it, sign with it, or use it in HMAC/SigV4 flows. The
+  exception is standard HTTP Basic auth: it is OK to let a client encode
+  \`user:$DSEC_SECRET\` or \`$DSEC_SECRET:\` into
+  \`Authorization: Basic ...\`.
+- Use a \`DSEC_*\` secret only with its approved HTTPS destination. Cross-
+  domain use will not substitute and the request will fail.
+- Do not pass custom TLS trust settings such as Python \`verify=\`, Node
+  \`ca\`, Go \`RootCAs\`/\`tls.Config\`, Rust custom root stores, Java custom
+  trust managers, or \`-Djavax.net.ssl.trustStore\`. They can bypass the
+  sandbox trust bundle and break TLS to substituted domains.
+
+If a tool, CLI, or SDK expects a specific unprefixed name, re-export the
+prefixed variable under the expected name in the same process before using
+the tool. For example:
+
+\`\`\`python
+import os
+os.environ["OPENAI_API_KEY"] = os.environ["DSEC_OPENAI_API_KEY"]
+\`\`\`
+
+Then use the SDK normally. This only aliases the placeholder; the real value
+is still substituted by the egress proxy when the SDK sends HTTPS headers.
+
+For Rust HTTP clients, prefer \`reqwest\` default features or
+\`rustls-tls-native-roots\`. Do not use \`rustls-tls\` with webpki-roots for
+\`DSEC_*\` traffic because it ignores the system trust store. For Java/JVM,
+use the JDK that came with the sandbox image; do not install another JDK or
+override the trust store mid-session. If you ignore this, the usual symptom
+is a TLS error such as \`PKIX path building failed\`.
+
+If you need to confirm a variable is set, check whether it is non-empty
+without printing its content (e.g. \`[ -n "\$DST_FOO" ]\` or
+\`[ -n "\$DSEC_FOO" ]\` in bash). Do not list available environment variable
+names just to enumerate what is configured.
 
 Bash tool output that contains a configured environment variable value is
 post-processed and replaced with a marker like \`«redacted: $FOO»\`. If you

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -199,7 +199,7 @@ function buildEnvironmentVariablesSection(): string {
   return `#### Sandbox Environment Variables
 
 The sandbox may have workspace-configured environment variables available
-in the bash shell and to any code you run. Treat all of them as sensitive.
+in the bash shell and to any code you run. All of them are sensitive.
 
 There are two prefixes:
 
@@ -221,9 +221,14 @@ Hard rules for environment variables:
 - Do not transform a \`DSEC_*\` placeholder before sending it. Do not URL
   encode it, split it across fields, put it in a request body, write it to a
   file and re-read it, sign with it, or use it in HMAC/SigV4 flows. The
-  exception is standard HTTP Basic auth: it is OK to let a client encode
-  \`user:$DSEC_SECRET\` or \`$DSEC_SECRET:\` into
-  \`Authorization: Basic ...\`.
+  exception is standard HTTP Basic auth: it is OK to let a normal HTTP
+  client base64-encode \`user:$DSEC_SECRET\` or \`$DSEC_SECRET:\` into the
+  \`Authorization: Basic ...\` header (the egress proxy handles that case);
+  do not base64-encode the value yourself.
+- Do not put a \`DSEC_*\` placeholder in a URL or query string (e.g.
+  \`https://api.example.com/x?token=$DSEC_FOO\`). The egress proxy only
+  substitutes in HTTP headers; placeholders on the request line are
+  rejected and the connection is dropped.
 - Use a \`DSEC_*\` secret only with its approved HTTPS destination. Cross-
   domain use will not substitute and the request will fail.
 - Do not pass custom TLS trust settings such as Python \`verify=\`, Node


### PR DESCRIPTION
## Description

The sandbox already injects `DSEC_*` placeholders into agent envs (the MITM rewriter substitutes the real value on the wire), but the skill prompt still only described `DST_*`. Agents had no instruction on how to use placeholders correctly or what footguns to avoid.

This PR rewrites the env-var section of the sandbox skill to:

- Distinguish `DST_*` (configuration values) from `DSEC_*` (HTTPS secret placeholders).
- Forbid transforming, inspecting, splitting, URL-encoding, signing-with, or otherwise touching the placeholder before sending. Standard HTTP Basic auth is called out as the one carve-out (dsbx round-trips the base64).
- Pin `DSEC_*` to its approved HTTPS destination only.
- Warn against custom TLS trust settings (Python `verify=`, Node `ca`, Go `RootCAs`, Rust custom roots, Java trust managers / `-Djavax.net.ssl.trustStore`) because they bypass the sandbox CA and break substitution.
- Include the Python SDK alias snippet (`os.environ["OPENAI_API_KEY"] = os.environ["DSEC_OPENAI_API_KEY"]`) and a Rust/JVM note since those are where this trips up most.

Also drops a one-line comment on the bash redactor (`redactSandboxEnvVarsFromOutput`) explaining that `loadEnv` is config-only on purpose so a future refactor does not accidentally pull `DSEC_*` cleartext into the redactor path.

## Tests

`npm run test -- lib/resources/skill/code_defined/sandbox.test.ts` passes locally (4/4). Added a test that pins the new instruction strings.

## Risk

Low. Prompt-only change plus a comment. No behavior change to the redactor (which already filtered to `kind: "config"` at the resource layer).

## Deploy Plan

Standard deploy.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25877">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->