### PR TITLE
[front] enh: improve large IN clauses in agent step content fetches

### DIFF
--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -33,7 +33,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op } from "sequelize";
+import { Op, Sequelize } from "sequelize";
 
 export const FETCH_BY_AGENT_MESSAGES_CHUNK_SIZE = 512;
 
@@ -71,10 +71,20 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
   ): Promise<ModelId[]> {
     const uniqueAgentMessageIds = [...new Set(agentMessageIds)];
 
+    if (uniqueAgentMessageIds.length === 0) {
+      return [];
+    }
+
     const agentMessages = await AgentMessageModel.findAll({
+      attributes: ["id", "agentConfigurationId"],
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        id: { [Op.in]: uniqueAgentMessageIds },
+        id: {
+          [Op.any]: Sequelize.literal("$agentMessageIds::bigint[]"),
+        },
+      },
+      bind: {
+        agentMessageIds: uniqueAgentMessageIds,
       },
     });
 
@@ -196,7 +206,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
           where: {
             workspaceId: owner.id,
             agentMessageId: {
-              [Op.in]: chunk,
+              [Op.any]: Sequelize.literal("$agentMessageIds::bigint[]"),
             },
           },
           order: [
@@ -204,6 +214,9 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
             ["index", "ASC"],
             ["version", "DESC"],
           ],
+          bind: {
+            agentMessageIds: chunk,
+          },
           transaction,
         }),
       {


### PR DESCRIPTION
## Description

- Replace large expanded `IN (...)` clauses when fetching from `agent_step_contents` with `ANY($ids::bigint[])` array binds.
- I'm not sure we are grouping properly in GCP query insights, the goal here is to make sure query aggregation works properly and that queries are easier to read (we often go past the 2048 char limit)
- The change covers both queries that are subject to large IN clauses.

## Tests

- Tested locally and on front-edge (agent loop conversation rendering).

## Risk

- High: these queries are on a few commonly-used paths

## Deploy Plan

- Deploy front



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25878">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->