### PR TITLE
Fix webhook payload appearing empty when read by agent

### DIFF
--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -55,7 +55,8 @@ async function catText(
   file: GCSFile,
   path: string,
   startLine: number,
-  maxLines: number
+  maxLines: number,
+  fileSizeBytes: number
 ): Promise<ToolHandlerResult> {
   const lines: string[] = [];
   let lineNumber = 0;
@@ -80,6 +81,13 @@ async function catText(
       const lineBytes = Buffer.byteLength(lineWithNumber + "\n", "utf8");
 
       if (byteCount + lineBytes > FILE_OFFLOAD_TEXT_SIZE_BYTES) {
+        if (lines.length === 0) {
+          // Truncate the oversized line to the byte limit so we don't send huge payloads.
+          const truncated = Buffer.from(lineWithNumber, "utf8")
+            .slice(0, FILE_OFFLOAD_TEXT_SIZE_BYTES)
+            .toString("utf8");
+          lines.push(truncated);
+        }
         byteCapped = true;
         break;
       }
@@ -114,12 +122,15 @@ async function catText(
   }
 
   const endLine = startLine + lines.length - 1;
-
   let text = lines.join("\n");
+
+  const kb = FILE_OFFLOAD_TEXT_SIZE_BYTES / 1024;
+  const fileSizeKb = Math.ceil(fileSizeBytes / 1024);
+
   if (byteCapped) {
-    const kb = FILE_OFFLOAD_TEXT_SIZE_BYTES / 1024;
     text +=
-      `\n\n[Truncated at ${kb}KB. Showing lines ${startLine}-${endLine}.` +
+      `\n\n[Truncated at ${kb}KB. File is ${fileSizeKb}KB.` +
+      ` Showing lines ${startLine}-${endLine}.` +
       ` Use offset=${endLine + 1} to read more.]`;
   } else if (totalLines >= maxLines) {
     text += `\n\n[Showing lines ${startLine}-${endLine}. Use offset=${endLine + 1} to read more.]`;
@@ -158,5 +169,11 @@ export async function catHandler(
     ]);
   }
 
-  return catText(file, path, offset ?? 1, limit ?? CAT_LINES_DEFAULT);
+  return catText(
+    file,
+    path,
+    offset ?? 1,
+    limit ?? CAT_LINES_DEFAULT,
+    sizeBytes
+  );
 }

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -95,7 +95,7 @@ async function createConversationForAgentConfiguration({
       conversation: newConversation,
       contentFragment: {
         contentType: "application/json",
-        content: JSON.stringify(payloadRes.value.body),
+        content: JSON.stringify(payloadRes.value.body, null, 2),
         title: `Webhook body (source id: ${webhookRequest.webhookSourceId}, date: ${new Date().toISOString()})`,
       },
       fileName: `webhook_body_${webhookRequest.webhookSourceId}_${Date.now()}.json`,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/7993.

When a webhook trigger fires with a large payload (e.g. a GitHub event), the agent would call the cat tool on the attached file and get back "webhook_body_xxx.json is empty".Despite the file existing in GCS with valid content.

The root cause was a combination of two things. First, we were storing the webhook body with `JSON.stringify(body)` (no
formatting), producing a single-line minified JSON. Second, the cat tool reads files line by line and checks byte count before
pushing each line. So for a 24KB single-line file exceeding the 20KB display limit, the byte cap fired before any line was
added, leaving `lines.length === 0` and returning the misleading "is empty" message.

Two fixes:
1. the webhook body is now stored pretty-printed (`JSON.stringify(body, null, 2)`), so cat can chunk it naturally at line boundaries.
2. The cat tool is also hardened so that an oversized single-line file always returns the first 20KB of content
(truncated, not empty) with an explanatory message, as a safety net for any other large single-line file that reaches the
conversation context.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25882">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->