### PR TITLE
Ensure metronome webhook calls are idempotent

### DIFF
--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -56,6 +56,7 @@ export type RedisUsageTagsType =
   | "stripe_checkout_status"
   | "metronome_credit_cache"
   | "metronome_limit"
+  | "metronome_webhook_dedup"
   | "message_events"
   | "notion_url_sync"
   | "poke_cache_invalidation"

--- a/front/lib/metronome/webhook_idempotency.ts
+++ b/front/lib/metronome/webhook_idempotency.ts
@@ -1,0 +1,69 @@
+// Idempotency helpers for the Metronome webhook handler.
+//
+// Metronome may redeliver the same event (network timeouts, our own 5xx
+// responses, at-least-once delivery semantics). We dedupe on `event.id` via
+// Redis: SET NX EX atomically claims the id for the window during which a
+// redelivery is plausible. A duplicate finds the key already present and is
+// short-circuited at the handler. If processing fails (we return 5xx or
+// throw), the claim is released so the next retry can reprocess.
+
+import { getRedisCacheClient } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// 7 days — well above Metronome's redelivery window, low enough that Redis
+// memory stays bounded.
+const METRONOME_WEBHOOK_DEDUP_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+function dedupKey(eventId: string): string {
+  return `metronome:webhook:event:${eventId}`;
+}
+
+/**
+ * Atomically claim `eventId` for processing. Returns true if the caller now
+ * owns the claim (proceed), false if another delivery already claimed it
+ * (skip, ack 200).
+ *
+ * On Redis errors we fail open (return true) so that a transient cache
+ * outage does not silently drop billing events.
+ */
+export async function tryClaimMetronomeWebhookEvent(
+  eventId: string
+): Promise<boolean> {
+  try {
+    const client = await getRedisCacheClient({
+      origin: "metronome_webhook_dedup",
+    });
+    const result = await client.set(dedupKey(eventId), "1", {
+      NX: true,
+      EX: METRONOME_WEBHOOK_DEDUP_TTL_SECONDS,
+    });
+    return result === "OK";
+  } catch (err) {
+    logger.error(
+      { eventId, error: normalizeError(err) },
+      "[Metronome Webhook] Failed to claim event for dedup, proceeding without dedup"
+    );
+    return true;
+  }
+}
+
+/**
+ * Release the claim previously taken by `tryClaimMetronomeWebhookEvent`.
+ * Called on the failure path so Metronome's retry can reprocess.
+ */
+export async function releaseMetronomeWebhookEvent(
+  eventId: string
+): Promise<void> {
+  try {
+    const client = await getRedisCacheClient({
+      origin: "metronome_webhook_dedup",
+    });
+    await client.del(dedupKey(eventId));
+  } catch (err) {
+    logger.error(
+      { eventId, error: normalizeError(err) },
+      "[Metronome Webhook] Failed to release event dedup claim"
+    );
+  }
+}

--- a/front/pages/api/metronome/webhook.test.ts
+++ b/front/pages/api/metronome/webhook.test.ts
@@ -21,6 +21,7 @@ import {
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
+import type { ContractV2 } from "@metronome/sdk/resources";
 import { createResponse } from "node-mocks-http";
 import { Readable } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -493,8 +494,8 @@ describe("Metronome webhook — contract.end", () => {
           id: OLD_CONTRACT_ID,
           starting_at: new Date(Date.now() - 10_000).toISOString(),
           ending_before: new Date().toISOString(),
-        },
-      ] as never)
+        } as unknown as ContractV2,
+      ])
     );
     vi.mocked(launchScheduleWorkspaceScrubWorkflow).mockResolvedValueOnce(
       new Err(new Error("Temporal unavailable"))
@@ -541,7 +542,7 @@ describe("Metronome webhook — idempotency", () => {
     mockUnwrap(event);
     // Force the contract fetch to fail — this is one of the 500-return paths.
     vi.mocked(getMetronomeContractById).mockResolvedValue(
-      new Err({ message: "boom" } as never)
+      new Err(new Error("boom"))
     );
 
     const { req, res } = makeWebhookRequest(event);
@@ -562,7 +563,7 @@ describe("Metronome webhook — idempotency", () => {
         customer_id: METRONOME_CUSTOMER_ID,
         starting_at: new Date().toISOString(),
         custom_fields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
-      } as never)
+      } as unknown as ContractV2)
     );
 
     const { req, res } = makeWebhookRequest(event);

--- a/front/pages/api/metronome/webhook.test.ts
+++ b/front/pages/api/metronome/webhook.test.ts
@@ -5,6 +5,10 @@ import {
   listMetronomeContracts,
 } from "@app/lib/metronome/client";
 import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
+import {
+  releaseMetronomeWebhookEvent,
+  tryClaimMetronomeWebhookEvent,
+} from "@app/lib/metronome/webhook_idempotency";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -51,6 +55,11 @@ vi.mock("@app/temporal/scrub_workspace/client", () => ({
 
 vi.mock("@app/lib/api/subscription", () => ({
   restoreWorkspaceAfterSubscription: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/webhook_idempotency", () => ({
+  tryClaimMetronomeWebhookEvent: vi.fn(),
+  releaseMetronomeWebhookEvent: vi.fn(),
 }));
 
 const METRONOME_CUSTOMER_ID = "cust_test_xxx";
@@ -165,6 +174,10 @@ beforeEach(() => {
     new Ok({} as never)
   );
   vi.mocked(restoreWorkspaceAfterSubscription).mockResolvedValue(undefined);
+  // Default: every event is freshly claimed. Tests that exercise the
+  // duplicate path override this with `mockResolvedValueOnce(false)`.
+  vi.mocked(tryClaimMetronomeWebhookEvent).mockResolvedValue(true);
+  vi.mocked(releaseMetronomeWebhookEvent).mockResolvedValue(undefined);
 });
 
 /** Stub `getMetronomeClient().webhooks.unwrap` to bypass signature verification. */
@@ -465,5 +478,98 @@ describe("Metronome webhook — contract.end", () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(launchScheduleWorkspaceScrubWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the subscription active when the scrub launch fails, so a retry can complete", async () => {
+    // Reordering guarantee: a scrub-launch failure must not leave the
+    // subscription in "ended" status, otherwise the retry would dispatch
+    // to the no-op branch and the scrub would never run.
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.end", OLD_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(listMetronomeContracts).mockResolvedValue(
+      new Ok([
+        {
+          id: OLD_CONTRACT_ID,
+          starting_at: new Date(Date.now() - 10_000).toISOString(),
+          ending_before: new Date().toISOString(),
+        },
+      ] as never)
+    );
+    vi.mocked(launchScheduleWorkspaceScrubWorkflow).mockResolvedValueOnce(
+      new Err(new Error("Temporal unavailable"))
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(500);
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(sub!.status).toBe("active");
+    expect(sub!.metronomeContractId).toBe(OLD_CONTRACT_ID);
+  });
+});
+
+describe("Metronome webhook — idempotency", () => {
+  it("short-circuits to 200 without side effects when the event id has already been processed", async () => {
+    await ensureEnterprisePlan();
+    await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    mockUnwrap(event);
+    // Simulate a redelivery: the claim helper reports the id is already held.
+    vi.mocked(tryClaimMetronomeWebhookEvent).mockResolvedValueOnce(false);
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    // No side effects: the handler returned before fetching the contract or
+    // touching the subscription.
+    expect(getMetronomeContractById).not.toHaveBeenCalled();
+    expect(restoreWorkspaceAfterSubscription).not.toHaveBeenCalled();
+    // We do not release the claim on the short-circuit path — the original
+    // delivery owns it.
+    expect(releaseMetronomeWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it("releases the claim when processing fails so a retry can reprocess", async () => {
+    await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    mockUnwrap(event);
+    // Force the contract fetch to fail — this is one of the 500-return paths.
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Err({ message: "boom" } as never)
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(releaseMetronomeWebhookEvent).toHaveBeenCalledWith(event.id);
+  });
+
+  it("does not release the claim on a successful run", async () => {
+    await ensureEnterprisePlan();
+    await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    mockUnwrap(event);
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: NEW_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        custom_fields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
+      } as never)
+    );
+
+    const { req, res } = makeWebhookRequest(event);
+    await handler(req, res as never);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(tryClaimMetronomeWebhookEvent).toHaveBeenCalledWith(event.id);
+    expect(releaseMetronomeWebhookEvent).not.toHaveBeenCalled();
   });
 });

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -18,6 +18,7 @@ import {
 import {
   getMetronomeClient,
   getMetronomeContractById,
+  listMetronomeBalances,
   listMetronomeContracts,
   updateMetronomeCreditSegmentAmount,
 } from "@app/lib/metronome/client";
@@ -28,6 +29,10 @@ import {
   getCustomerIdFromEvent,
   MetronomeWebhookEventSchema,
 } from "@app/lib/metronome/webhook_events";
+import {
+  releaseMetronomeWebhookEvent,
+  tryClaimMetronomeWebhookEvent,
+} from "@app/lib/metronome/webhook_idempotency";
 import { PlanModel } from "@app/lib/models/plan";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -133,711 +138,748 @@ async function handler(
 
       logger.info({ event, rawEvent }, "[Metronome Webhook] Event received");
 
-      // Resolve the workspace once for any event that carries a customer_id
-      // (every type except `integration.issue`). If the customer can't be
-      // mapped to a workspace, ack and stop — Metronome would otherwise
-      // retry-storm a payload we have nothing to do with.
-      const customerId = getCustomerIdFromEvent(event);
-      const workspace = customerId
-        ? await WorkspaceResource.fetchByMetronomeCustomerId(customerId)
-        : null;
-
-      if (!workspace) {
+      // Idempotency: Metronome may redeliver the same event (network
+      // timeouts, our own 5xx, at-least-once delivery). Atomically claim
+      // `event.id` in Redis; a duplicate finds the key set and short-
+      // circuits to 200. The claim is released on the failure path below
+      // so a retry can reprocess.
+      const claimed = await tryClaimMetronomeWebhookEvent(event.id);
+      if (!claimed) {
         logger.info(
-          { customerId, eventType: event.type },
-          "[Metronome Webhook] Workspace not found for customer, skipping"
+          { eventId: event.id, eventType: event.type },
+          "[Metronome Webhook] Event already processed (duplicate), skipping"
         );
         return res.status(200).json({ success: true });
       }
 
-      switch (event.type) {
-        case "alerts.spend_threshold_reached": {
-          // Two flavours land on this event type:
-          //   - Per-user cap: scoped via `presentation_group_key = user_id`,
-          //   so `group_values` includes a `{ key: "user_id" }` entry
-          //   (with or without a populated `value`).
-          //   - Workspace-level PAYG cap: no `user_id` key in group_values.
-          // The presence of the user_id key, not its value, decides the routing.
-          // A missing value still means "this is a per-user alert",
-          // it's just one we cannot act on.
-          const userIdGroup = event.properties.group_values?.find(
-            (g) => g.key === "user_id"
-          );
-          const isPerUser = userIdGroup !== undefined;
-          const userId = userIdGroup?.value;
+      let processingSucceeded = false;
+      try {
+        // Resolve the workspace once for any event that carries a customer_id
+        // (every type except `integration.issue`). If the customer can't be
+        // mapped to a workspace, ack and stop — Metronome would otherwise
+        // retry-storm a payload we have nothing to do with.
+        const customerId = getCustomerIdFromEvent(event);
+        const workspace = customerId
+          ? await WorkspaceResource.fetchByMetronomeCustomerId(customerId)
+          : null;
 
-          if (isPerUser) {
-            if (!userId) {
-              logger.warn(
+        if (!workspace) {
+          processingSucceeded = true;
+          return res.status(200).json({ success: true });
+        }
+
+        switch (event.type) {
+          case "alerts.spend_threshold_reached": {
+            // Two flavours land on this event type:
+            //   - Per-user cap: scoped via `presentation_group_key = user_id`,
+            //   so `group_values` includes a `{ key: "user_id" }` entry
+            //   (with or without a populated `value`).
+            //   - Workspace-level PAYG cap: no `user_id` key in group_values.
+            // The presence of the user_id key, not its value, decides the routing.
+            // A missing value still means "this is a per-user alert",
+            // it's just one we cannot act on.
+            const userIdGroup = event.properties.group_values?.find(
+              (g) => g.key === "user_id"
+            );
+            const isPerUser = userIdGroup !== undefined;
+            const userId = userIdGroup?.value;
+
+            if (isPerUser) {
+              if (!userId) {
+                logger.warn(
+                  { eventId: event.id, workspaceId: workspace.sId },
+                  "[Metronome Webhook] spend_threshold_reached: per-user alert with no user_id value, skipping"
+                );
+                break;
+              }
+              await dispatchPerUserCapReached({ workspace, userId });
+              logger.info(
+                {
+                  eventId: event.id,
+                  workspaceId: workspace.sId,
+                  userId,
+                  currentSpend: event.properties.current_spend,
+                },
+                "[Metronome Webhook] spend_threshold_reached: per_user dispatched"
+              );
+            } else {
+              await dispatchPaygCapReached({ workspace });
+              logger.info(
+                {
+                  eventId: event.id,
+                  workspaceId: workspace.sId,
+                  currentSpend: event.properties.current_spend,
+                },
+                "[Metronome Webhook] spend_threshold_reached: payg cap dispatched"
+              );
+            }
+            break;
+          }
+          case "alerts.spend_threshold_resolved": {
+            // Per-user: at billing-cycle renewal current_spend resets to 0, so
+            // Metronome fires this for every previously-capped user, we uncap them.
+            //
+            // Workspace-level: a `payg_cap_resolved` event means
+            // spend dropped back below the PAYG threshold. We do not transition
+            // on this signal: once the workspace is `depleted`, only a real
+            // pool replenishment (commit.segment.start) brings it back.
+            const userIdGroup = event.properties.group_values?.find(
+              (g) => g.key === "user_id"
+            );
+            const isPerUser = userIdGroup !== undefined;
+            const userId = userIdGroup?.value;
+
+            if (isPerUser) {
+              if (!userId) {
+                logger.warn(
+                  { eventId: event.id, workspaceId: workspace.sId },
+                  "[Metronome Webhook] spend_threshold_resolved: per-user alert with no user_id value, skipping"
+                );
+                break;
+              }
+
+              await dispatchPerUserCapResolved({ workspace, userId });
+              logger.info(
+                {
+                  eventId: event.id,
+                  workspaceId: workspace.sId,
+                  userId,
+                },
+                "[Metronome Webhook] spend_threshold_resolved: per-user dispatched"
+              );
+            } else {
+              logger.info(
                 { eventId: event.id, workspaceId: workspace.sId },
-                "[Metronome Webhook] spend_threshold_reached: per-user alert with no user_id value, skipping"
+                "[Metronome Webhook] spend_threshold_resolved: workspace-level, no transition"
+              );
+            }
+            break;
+          }
+          case "alerts.low_remaining_contract_credit_and_commit_balance_reached": {
+            // Pool-exhaustion signal: total remaining (contract credits + commit balance)
+            // hit zero. The commit-only and contract-credit-only alerts fire too early
+            // when only one side is exhausted, so we listen to this combined alert
+            // exclusively.
+            //
+            // Gate on `remaining_balance` defensively in case a non-zero warning threshold
+            // is added under the same alert type later (e.g. early warning notification).
+            const remaining = event.properties.remaining_balance;
+            if (remaining == null || remaining <= 0) {
+              await dispatchPoolExhausted({ workspace });
+              logger.info(
+                {
+                  eventId: event.id,
+                  workspaceId: workspace.sId,
+                  remaining,
+                },
+                "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_reached: pool exhausted dispatched"
+              );
+            }
+            break;
+          }
+          case "alerts.low_remaining_contract_credit_and_commit_balance_resolved": {
+            await dispatchCreditsAdded({ workspace });
+            logger.info(
+              {
+                eventId: event.id,
+                workspaceId: workspace.sId,
+                remaining: event.properties.remaining_balance,
+              },
+              "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_resolved: credits added dispatched"
+            );
+            break;
+          }
+          case "alerts.invoice_total_reached":
+          case "alerts.invoice_total_resolved":
+          case "alerts.low_remaining_commit_balance_reached":
+          case "alerts.low_remaining_commit_balance_resolved":
+          case "alerts.low_remaining_contract_credit_balance_reached":
+          case "alerts.low_remaining_contract_credit_balance_resolved":
+          case "alerts.low_remaining_credit_balance_reached":
+          case "alerts.low_remaining_credit_balance_resolved":
+          case "alerts.low_remaining_seat_balance_reached":
+          case "alerts.low_remaining_seat_balance_resolved":
+          case "alerts.usage_threshold_reached":
+          case "alerts.usage_threshold_resolved":
+          case "commit.archive":
+          case "commit.create":
+          case "commit.edit":
+          case "commit.segment.end":
+          case "commit.segment.start":
+          case "contract.archive":
+          case "contract.create":
+          case "contract.edit":
+          case "credit.archive":
+          case "credit.create":
+          case "credit.edit":
+          case "credit.segment.end":
+          case "invoice.billing_provider_error":
+          case "invoice.finalized":
+            break;
+
+          // Payment-gated commit lifecycle. Metronome activates the commit
+          // itself on success, so we don't grant credits here — just log the
+          // outcome for observability (and surface failures with their
+          // Stripe error message). AWU credit top-ups go through this flow
+          // via `addPaymentGatedCommitToContract`.
+          case "payment_gate.payment_status": {
+            const {
+              customer_id: customerId,
+              contract_id: contractId,
+              invoice_id: invoiceId,
+              payment_status: paymentStatus,
+              error_message: errorMessage,
+            } = event.properties;
+            if (paymentStatus === "succeeded") {
+              logger.info(
+                { customerId, contractId, invoiceId, paymentStatus },
+                "[Metronome Webhook] Payment-gated commit paid"
+              );
+            } else {
+              logger.warn(
+                {
+                  customerId,
+                  contractId,
+                  invoiceId,
+                  paymentStatus,
+                  errorMessage,
+                },
+                "[Metronome Webhook] Payment-gated commit payment failed"
+              );
+            }
+            break;
+          }
+
+          case "payment_gate.payment_pending_action_required":
+          case "payment_gate.threshold_reached":
+          case "payment_gate.external_initiate":
+            break;
+
+          case "credit.segment.start": {
+            const {
+              customer_id: customerId,
+              contract_id: contractId,
+              credit_id: creditId,
+              segment_id: segmentId,
+            } = event;
+
+            // Customer-level credits with no parent contract can't be the
+            // managed free monthly credit (which is provisioned on a contract).
+            if (!contractId) {
+              logger.info(
+                { customerId, creditId, workspaceId: workspace.sId },
+                "[Metronome Webhook] credit.segment.start: no contract_id on credit, ignoring"
               );
               break;
             }
-            await dispatchPerUserCapReached({ workspace, userId });
-            logger.info(
-              {
-                eventId: event.id,
-                workspaceId: workspace.sId,
-                userId,
-                currentSpend: event.properties.current_spend,
-              },
-              "[Metronome Webhook] spend_threshold_reached: per_user dispatched"
-            );
-          } else {
-            await dispatchPaygCapReached({ workspace });
-            logger.info(
-              {
-                eventId: event.id,
-                workspaceId: workspace.sId,
-                currentSpend: event.properties.current_spend,
-              },
-              "[Metronome Webhook] spend_threshold_reached: payg cap dispatched"
-            );
-          }
-          break;
-        }
-        case "alerts.spend_threshold_resolved": {
-          // Per-user: at billing-cycle renewal current_spend resets to 0, so
-          // Metronome fires this for every previously-capped user, we uncap them.
-          //
-          // Workspace-level: a `payg_cap_resolved` event means
-          // spend dropped back below the PAYG threshold. We do not transition
-          // on this signal: once the workspace is `depleted`, only a real
-          // pool replenishment (commit.segment.start) brings it back.
-          const userIdGroup = event.properties.group_values?.find(
-            (g) => g.key === "user_id"
-          );
-          const isPerUser = userIdGroup !== undefined;
-          const userId = userIdGroup?.value;
 
-          if (isPerUser) {
-            if (!userId) {
-              logger.warn(
-                { eventId: event.id, workspaceId: workspace.sId },
-                "[Metronome Webhook] spend_threshold_resolved: per-user alert with no user_id value, skipping"
+            // The webhook payload does not include the credit's product or
+            // credit type, so fetch the contract to identify whether this
+            // segment belongs to the free monthly credit we manage.
+            const contractResult = await getMetronomeContractById({
+              metronomeCustomerId: customerId,
+              metronomeContractId: contractId,
+            });
+            if (contractResult.isErr()) {
+              logger.error(
+                {
+                  customerId,
+                  contractId,
+                  creditId,
+                  error: contractResult.error,
+                },
+                "[Metronome Webhook] credit.segment.start: failed to fetch contract"
+              );
+              return apiError(req, res, {
+                status_code: 500,
+                api_error: {
+                  type: "internal_server_error",
+                  message: `Error fetching contract: ${contractResult.error.message}`,
+                },
+              });
+            }
+
+            const credit = contractResult.value.credits?.find(
+              (c) => c.id === creditId
+            );
+            if (!credit) {
+              logger.info(
+                { customerId, contractId, creditId },
+                "[Metronome Webhook] credit.segment.start: credit not found on contract, ignoring"
               );
               break;
             }
 
-            await dispatchPerUserCapResolved({ workspace, userId });
-            logger.info(
-              {
-                eventId: event.id,
-                workspaceId: workspace.sId,
-                userId,
-              },
-              "[Metronome Webhook] spend_threshold_resolved: per-user dispatched"
+            if (!isMetronomeFreeCredit(credit)) {
+              logger.info(
+                {
+                  customerId,
+                  creditId,
+                  productId: credit.product.id,
+                  creditTypeId: credit.access_schedule?.credit_type?.id,
+                },
+                "[Metronome Webhook] credit.segment.start: ignoring non-free-credit segment"
+              );
+              break;
+            }
+
+            // Detect whether this credit comes from an annual recurring credit
+            // (annual contracts) so we grant a yearly amount instead of monthly.
+            const recurringCredit = credit.recurring_credit_id
+              ? contractResult.value.recurring_credits?.find(
+                  (rc) => rc.id === credit.recurring_credit_id
+                )
+              : undefined;
+            const isAnnual = recurringCredit?.recurrence_frequency === "ANNUAL";
+
+            // ProgrammaticUsageConfiguration.freeCreditMicroUsd, if set,
+            // overrides the brackets-based calculation. Same convention as
+            // grantFreeCreditsFromSubscriptionStateChange{,Yearly}: the
+            // configured amount is the full-period amount (monthly or yearly
+            // matching the recurring credit cadence) and is used as-is.
+            const auth = await Authenticator.internalAdminForWorkspace(
+              workspace.sId
             );
-          } else {
-            logger.info(
-              { eventId: event.id, workspaceId: workspace.sId },
-              "[Metronome Webhook] spend_threshold_resolved: workspace-level, no transition"
-            );
-          }
-          break;
-        }
-        case "alerts.low_remaining_contract_credit_and_commit_balance_reached": {
-          // Pool-exhaustion signal: total remaining (contract credits + commit balance)
-          // hit zero. The commit-only and contract-credit-only alerts fire too early
-          // when only one side is exhausted, so we listen to this combined alert
-          // exclusively.
-          //
-          // Gate on `remaining_balance` defensively in case a non-zero warning threshold
-          // is added under the same alert type later (e.g. early warning notification).
-          const remaining = event.properties.remaining_balance;
-          if (remaining == null || remaining <= 0) {
-            await dispatchPoolExhausted({ workspace });
-            logger.info(
-              {
-                eventId: event.id,
-                workspaceId: workspace.sId,
-                remaining,
-              },
-              "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_reached: pool exhausted dispatched"
-            );
-          }
-          break;
-        }
-        case "alerts.low_remaining_contract_credit_and_commit_balance_resolved": {
-          await dispatchCreditsAdded({ workspace });
-          logger.info(
-            {
-              eventId: event.id,
-              workspaceId: workspace.sId,
-              remaining: event.properties.remaining_balance,
-            },
-            "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_resolved: credits added dispatched"
-          );
-          break;
-        }
-        case "alerts.invoice_total_reached":
-        case "alerts.invoice_total_resolved":
-        case "alerts.low_remaining_commit_balance_reached":
-        case "alerts.low_remaining_commit_balance_resolved":
-        case "alerts.low_remaining_contract_credit_balance_reached":
-        case "alerts.low_remaining_contract_credit_balance_resolved":
-        case "alerts.low_remaining_credit_balance_reached":
-        case "alerts.low_remaining_credit_balance_resolved":
-        case "alerts.low_remaining_seat_balance_reached":
-        case "alerts.low_remaining_seat_balance_resolved":
-        case "alerts.usage_threshold_reached":
-        case "alerts.usage_threshold_resolved":
-        case "commit.archive":
-        case "commit.create":
-        case "commit.edit":
-        case "commit.segment.end":
-        case "commit.segment.start":
-        case "contract.archive":
-        case "contract.create":
-        case "contract.edit":
-        case "credit.archive":
-        case "credit.create":
-        case "credit.edit":
-        case "credit.segment.end":
-        case "invoice.billing_provider_error":
-        case "invoice.finalized":
-          break;
+            const programmaticConfig =
+              await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(
+                auth
+              );
 
-        // Payment-gated commit lifecycle. Metronome activates the commit
-        // itself on success, so we don't grant credits here — just log the
-        // outcome for observability (and surface failures with their
-        // Stripe error message). AWU credit top-ups go through this flow
-        // via `addPaymentGatedCommitToContract`.
-        case "payment_gate.payment_status": {
-          const {
-            customer_id: customerId,
-            contract_id: contractId,
-            invoice_id: invoiceId,
-            payment_status: paymentStatus,
-            error_message: errorMessage,
-          } = event.properties;
-          if (paymentStatus === "succeeded") {
-            logger.info(
-              { customerId, contractId, invoiceId, paymentStatus },
-              "[Metronome Webhook] Payment-gated commit paid"
-            );
-          } else {
-            logger.warn(
-              {
-                customerId,
-                contractId,
-                invoiceId,
-                paymentStatus,
-                errorMessage,
-              },
-              "[Metronome Webhook] Payment-gated commit payment failed"
-            );
-          }
-          break;
-        }
+            let amountMicroUsd: number;
+            let userCount: number | undefined;
+            if (
+              programmaticConfig &&
+              programmaticConfig.freeCreditMicroUsd !== null
+            ) {
+              amountMicroUsd = programmaticConfig.freeCreditMicroUsd;
+            } else {
+              userCount = await countEligibleUsersForFreeCredits(workspace);
+              const monthlyAmountMicroUsd =
+                calculateFreeCreditAmountMicroUsd(userCount);
+              amountMicroUsd = isAnnual
+                ? monthlyAmountMicroUsd * YEARLY_MULTIPLIER
+                : monthlyAmountMicroUsd;
+            }
+            const amount = amountMicroUsd / 1_000_000;
 
-        case "payment_gate.payment_pending_action_required":
-        case "payment_gate.threshold_reached":
-        case "payment_gate.external_initiate":
-          break;
-
-        case "credit.segment.start": {
-          const {
-            customer_id: customerId,
-            contract_id: contractId,
-            credit_id: creditId,
-            segment_id: segmentId,
-          } = event;
-
-          // Customer-level credits with no parent contract can't be the
-          // managed free monthly credit (which is provisioned on a contract).
-          if (!contractId) {
-            logger.info(
-              { customerId, creditId, workspaceId: workspace.sId },
-              "[Metronome Webhook] credit.segment.start: no contract_id on credit, ignoring"
-            );
-            break;
-          }
-
-          // The webhook payload does not include the credit's product or
-          // credit type, so fetch the contract to identify whether this
-          // segment belongs to the free monthly credit we manage.
-          const contractResult = await getMetronomeContractById({
-            metronomeCustomerId: customerId,
-            metronomeContractId: contractId,
-          });
-          if (contractResult.isErr()) {
-            logger.error(
-              {
-                customerId,
-                contractId,
-                creditId,
-                error: contractResult.error,
-              },
-              "[Metronome Webhook] credit.segment.start: failed to fetch contract"
-            );
-            return apiError(req, res, {
-              status_code: 500,
-              api_error: {
-                type: "internal_server_error",
-                message: `Error fetching contract: ${contractResult.error.message}`,
-              },
-            });
-          }
-
-          const credit = contractResult.value.credits?.find(
-            (c) => c.id === creditId
-          );
-          if (!credit) {
-            logger.info(
-              { customerId, contractId, creditId },
-              "[Metronome Webhook] credit.segment.start: credit not found on contract, ignoring"
-            );
-            break;
-          }
-
-          if (!isMetronomeFreeCredit(credit)) {
-            logger.info(
-              {
-                customerId,
-                creditId,
-                productId: credit.product.id,
-                creditTypeId: credit.access_schedule?.credit_type?.id,
-              },
-              "[Metronome Webhook] credit.segment.start: ignoring non-free-credit segment"
-            );
-            break;
-          }
-
-          // Detect whether this credit comes from an annual recurring credit
-          // (annual contracts) so we grant a yearly amount instead of monthly.
-          const recurringCredit = credit.recurring_credit_id
-            ? contractResult.value.recurring_credits?.find(
-                (rc) => rc.id === credit.recurring_credit_id
-              )
-            : undefined;
-          const isAnnual = recurringCredit?.recurrence_frequency === "ANNUAL";
-
-          // ProgrammaticUsageConfiguration.freeCreditMicroUsd, if set,
-          // overrides the brackets-based calculation. Same convention as
-          // grantFreeCreditsFromSubscriptionStateChange{,Yearly}: the
-          // configured amount is the full-period amount (monthly or yearly
-          // matching the recurring credit cadence) and is used as-is.
-          const auth = await Authenticator.internalAdminForWorkspace(
-            workspace.sId
-          );
-          const programmaticConfig =
-            await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(
-              auth
-            );
-
-          let amountMicroUsd: number;
-          let userCount: number | undefined;
-          if (
-            programmaticConfig &&
-            programmaticConfig.freeCreditMicroUsd !== null
-          ) {
-            amountMicroUsd = programmaticConfig.freeCreditMicroUsd;
-          } else {
-            userCount = await countEligibleUsersForFreeCredits(workspace);
-            const monthlyAmountMicroUsd =
-              calculateFreeCreditAmountMicroUsd(userCount);
-            amountMicroUsd = isAnnual
-              ? monthlyAmountMicroUsd * YEARLY_MULTIPLIER
-              : monthlyAmountMicroUsd;
-          }
-          const amount = amountMicroUsd / 1_000_000;
-
-          const updateResult = await updateMetronomeCreditSegmentAmount({
-            metronomeCustomerId: customerId,
-            contractId,
-            creditId,
-            segmentId,
-            amount,
-          });
-
-          if (updateResult.isErr()) {
-            logger.error(
-              {
-                customerId,
-                contractId,
-                creditId,
-                segmentId,
-                error: updateResult.error,
-                workspaceId: workspace.sId,
-              },
-              "[Metronome Webhook] credit.segment.start: failed to update free credit amount"
-            );
-            return apiError(req, res, {
-              status_code: 500,
-              api_error: {
-                type: "internal_server_error",
-                message: `Error updating free credit amount: ${updateResult.error.message}`,
-              },
-            });
-          }
-
-          // Metronome is the source of truth for the recurring free credit:
-          // create + start the matching DB credit linked by metronomeCreditId.
-          // The Stripe webhook will dedup against this when it fires.
-          const segment = credit.access_schedule?.schedule_items.find(
-            (s) => s.id === segmentId
-          );
-          if (!segment) {
-            logger.warn(
-              {
-                customerId,
-                contractId,
-                creditId,
-                segmentId,
-                workspaceId: workspace.sId,
-              },
-              "[Metronome Webhook] credit.segment.start: segment not found in access_schedule, skipping DB credit creation"
-            );
-            break;
-          }
-          const periodStart = new Date(segment.starting_at);
-          const periodEnd = new Date(segment.ending_before);
-
-          const grantResult = await grantFreeCreditFromMetronomeSegment({
-            auth,
-            metronomeCreditId: creditId,
-            contractId,
-            segmentId,
-            isAnnual,
-            amountMicroUsd,
-            periodStart,
-            periodEnd,
-          });
-
-          if (grantResult.isErr()) {
-            // The grant helper has already logged the failure with `panic`;
-            // ack the webhook so Metronome doesn't retry-storm — operators
-            // will reconcile from logs / the sync script.
-            logger.error(
-              {
-                customerId,
-                contractId,
-                creditId,
-                segmentId,
-                error: grantResult.error,
-                workspaceId: workspace.sId,
-              },
-              "[Metronome Webhook] credit.segment.start: failed to ensure DB credit"
-            );
-            break;
-          }
-
-          logger.info(
-            {
-              customerId,
+            const updateResult = await updateMetronomeCreditSegmentAmount({
+              metronomeCustomerId: customerId,
               contractId,
               creditId,
               segmentId,
-              amountMicroUsd,
-              userCount,
+              amount,
+            });
+
+            if (updateResult.isErr()) {
+              logger.error(
+                {
+                  customerId,
+                  contractId,
+                  creditId,
+                  segmentId,
+                  error: updateResult.error,
+                  workspaceId: workspace.sId,
+                },
+                "[Metronome Webhook] credit.segment.start: failed to update free credit amount"
+              );
+              return apiError(req, res, {
+                status_code: 500,
+                api_error: {
+                  type: "internal_server_error",
+                  message: `Error updating free credit amount: ${updateResult.error.message}`,
+                },
+              });
+            }
+
+            // Metronome is the source of truth for the recurring free credit:
+            // create + start the matching DB credit linked by metronomeCreditId.
+            // The Stripe webhook will dedup against this when it fires.
+            const segment = credit.access_schedule?.schedule_items.find(
+              (s) => s.id === segmentId
+            );
+            if (!segment) {
+              logger.warn(
+                {
+                  customerId,
+                  contractId,
+                  creditId,
+                  segmentId,
+                  workspaceId: workspace.sId,
+                },
+                "[Metronome Webhook] credit.segment.start: segment not found in access_schedule, skipping DB credit creation"
+              );
+              break;
+            }
+            const periodStart = new Date(segment.starting_at);
+            const periodEnd = new Date(segment.ending_before);
+
+            const grantResult = await grantFreeCreditFromMetronomeSegment({
+              auth,
+              metronomeCreditId: creditId,
+              contractId,
+              segmentId,
               isAnnual,
-              usedProgrammaticOverride:
-                programmaticConfig?.freeCreditMicroUsd != null,
-              dbCreditId: grantResult.value.credit.id,
-              dbCreditCreated: grantResult.value.created,
-              dbCreditAlreadyExisted: grantResult.value.alreadyExisted,
+              amountMicroUsd,
               periodStart,
               periodEnd,
-              workspaceId: workspace.sId,
-            },
-            "[Metronome Webhook] credit.segment.start: free credit amount updated and DB credit ensured"
-          );
-          break;
-        }
+            });
 
-        case "contract.start": {
-          const { contract_id: contractId, customer_id: customerId } = event;
+            if (grantResult.isErr()) {
+              // The grant helper has already logged the failure with `panic`;
+              // ack the webhook so Metronome doesn't retry-storm — operators
+              // will reconcile from logs / the sync script.
+              logger.error(
+                {
+                  customerId,
+                  contractId,
+                  creditId,
+                  segmentId,
+                  error: grantResult.error,
+                  workspaceId: workspace.sId,
+                },
+                "[Metronome Webhook] credit.segment.start: failed to ensure DB credit"
+              );
+              break;
+            }
 
-          // Read the PLAN_CODE custom field to know which plan to swap the
-          // workspace subscription onto. The actual swap is gated below on
-          // `isMetronomeOnlyBilled` — other billing paths (shadow, pure
-          // Stripe) handle their own state transitions, and contracts whose
-          // start aligns with a synchronous DB flip get caught by the
-          // idempotency check.
-          const contractResult = await getMetronomeContractById({
-            metronomeCustomerId: customerId,
-            metronomeContractId: contractId,
-          });
-          if (contractResult.isErr()) {
-            logger.error(
+            logger.info(
               {
-                contractId,
                 customerId,
-                error: contractResult.error,
+                contractId,
+                creditId,
+                segmentId,
+                amountMicroUsd,
+                userCount,
+                isAnnual,
+                usedProgrammaticOverride:
+                  programmaticConfig?.freeCreditMicroUsd != null,
+                dbCreditId: grantResult.value.credit.id,
+                dbCreditCreated: grantResult.value.created,
+                dbCreditAlreadyExisted: grantResult.value.alreadyExisted,
+                periodStart,
+                periodEnd,
                 workspaceId: workspace.sId,
               },
-              "[Metronome Webhook] contract.start: failed to fetch contract"
+              "[Metronome Webhook] credit.segment.start: free credit amount updated and DB credit ensured"
             );
-            return apiError(req, res, {
-              status_code: 500,
-              api_error: {
-                type: "internal_server_error",
-                message: `Error fetching contract: ${contractResult.error.message}`,
-              },
+            break;
+          }
+
+          case "contract.start": {
+            const { contract_id: contractId, customer_id: customerId } = event;
+
+            // Read the PLAN_CODE custom field to know which plan to swap the
+            // workspace subscription onto. The actual swap is gated below on
+            // `isMetronomeOnlyBilled` — other billing paths (shadow, pure
+            // Stripe) handle their own state transitions, and contracts whose
+            // start aligns with a synchronous DB flip get caught by the
+            // idempotency check.
+            const contractResult = await getMetronomeContractById({
+              metronomeCustomerId: customerId,
+              metronomeContractId: contractId,
             });
-          }
+            if (contractResult.isErr()) {
+              logger.error(
+                {
+                  contractId,
+                  customerId,
+                  error: contractResult.error,
+                  workspaceId: workspace.sId,
+                },
+                "[Metronome Webhook] contract.start: failed to fetch contract"
+              );
+              return apiError(req, res, {
+                status_code: 500,
+                api_error: {
+                  type: "internal_server_error",
+                  message: `Error fetching contract: ${contractResult.error.message}`,
+                },
+              });
+            }
 
-          const targetPlanCode =
-            contractResult.value.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];
-          if (!targetPlanCode) {
-            logger.info(
-              { contractId, workspaceId: workspace.sId },
-              `[Metronome Webhook] contract.start: no ${PLAN_CODE_CUSTOM_FIELD_KEY} custom field, leaving subscription alone`
-            );
-            break;
-          }
+            const targetPlanCode =
+              contractResult.value.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];
+            if (!targetPlanCode) {
+              logger.info(
+                { contractId, workspaceId: workspace.sId },
+                `[Metronome Webhook] contract.start: no ${PLAN_CODE_CUSTOM_FIELD_KEY} custom field, leaving subscription alone`
+              );
+              break;
+            }
 
-          const targetPlan = await PlanModel.findOne({
-            where: { code: targetPlanCode },
-          });
-          if (!targetPlan) {
-            logger.info(
-              { contractId, targetPlanCode, workspaceId: workspace.sId },
-              `[Metronome Webhook] contract.start: ${PLAN_CODE_CUSTOM_FIELD_KEY} not found, leaving subscription alone`
-            );
-            break;
-          }
+            const targetPlan = await PlanModel.findOne({
+              where: { code: targetPlanCode },
+            });
+            if (!targetPlan) {
+              logger.info(
+                { contractId, targetPlanCode, workspaceId: workspace.sId },
+                `[Metronome Webhook] contract.start: ${PLAN_CODE_CUSTOM_FIELD_KEY} not found, leaving subscription alone`
+              );
+              break;
+            }
 
-          const activeSubscription =
-            await SubscriptionResource.fetchActiveByWorkspaceModelId(
-              workspace.id
-            );
-          if (!activeSubscription) {
-            logger.warn(
-              { contractId, customerId, workspaceId: workspace.sId },
-              "[Metronome Webhook] contract.start: no active subscription"
-            );
-            break;
-          }
+            const activeSubscription =
+              await SubscriptionResource.fetchActiveByWorkspaceModelId(
+                workspace.id
+              );
+            if (!activeSubscription) {
+              logger.warn(
+                { contractId, customerId, workspaceId: workspace.sId },
+                "[Metronome Webhook] contract.start: no active subscription"
+              );
+              break;
+            }
 
-          // Idempotency: re-deliveries land here with the active subscription
-          // already pointing at the new contract.
-          if (activeSubscription.metronomeContractId === contractId) {
-            logger.info(
-              { contractId, workspaceId: workspace.sId },
-              "[Metronome Webhook] contract.start: subscription already swapped, skipping"
-            );
-            break;
-          }
+            // Idempotency: re-deliveries land here with the active subscription
+            // already pointing at the new contract.
+            if (activeSubscription.metronomeContractId === contractId) {
+              logger.info(
+                { contractId, workspaceId: workspace.sId },
+                "[Metronome Webhook] contract.start: subscription already swapped, skipping"
+              );
+              break;
+            }
 
-          // Preferred path: a pending (created_backend_only) subscription was
-          // staged when the contract was provisioned. Flip it to active and
-          // end whatever active sub the workspace currently holds.
-          const pendingSubscription =
-            await SubscriptionResource.fetchByMetronomeContractId(
-              workspace,
-              contractId
-            );
-          if (
-            pendingSubscription &&
-            pendingSubscription.status === "created_backend_only"
-          ) {
-            await pendingSubscription.activatePending();
+            // Preferred path: a pending (created_backend_only) subscription was
+            // staged when the contract was provisioned. Flip it to active and
+            // end whatever active sub the workspace currently holds.
+            const pendingSubscription =
+              await SubscriptionResource.fetchByMetronomeContractId(
+                workspace,
+                contractId
+              );
+            if (
+              pendingSubscription &&
+              pendingSubscription.status === "created_backend_only"
+            ) {
+              await pendingSubscription.activatePending();
+              await invalidateContractCache(workspace.sId);
+              const auth = await Authenticator.internalAdminForWorkspace(
+                workspace.sId
+              );
+              await restoreWorkspaceAfterSubscription(auth);
+              logger.info(
+                {
+                  contractId,
+                  planCode: targetPlan.code,
+                  workspaceId: workspace.sId,
+                },
+                "[Metronome Webhook] contract.start: pending subscription activated"
+              );
+              break;
+            }
+
+            // Legacy fallback: no pending row was staged. Only swap when the
+            // workspace is Metronome-only billed, or not billed at all. Shadow
+            // billed subscriptions (Stripe + Metronome) follow Stripe's signal,
+            // and pure Stripe subs have no Metronome contract at all.
+            if (
+              !activeSubscription.isMetronomeOnlyBilled &&
+              activeSubscription.isBilled
+            ) {
+              logger.info(
+                {
+                  contractId,
+                  targetPlanCode,
+                  workspaceId: workspace.sId,
+                },
+                "[Metronome Webhook] contract.start: subscription is not Metronome-only billed, leaving subscription alone"
+              );
+              break;
+            }
+
+            // End the current subscription as `ended_backend_only` and create
+            // a new active subscription on the target plan + new contract.
+            await activeSubscription.swapMetronomeContract({
+              metronomeContractId: contractId,
+              planCode: targetPlan.code,
+            });
+
             await invalidateContractCache(workspace.sId);
+
+            // Cancel any scheduled scrub workflow, unpause connectors, re-enable
+            // triggers. Idempotent — safe to call regardless of prior state.
             const auth = await Authenticator.internalAdminForWorkspace(
               workspace.sId
             );
             await restoreWorkspaceAfterSubscription(auth);
+
+            const balance = await listMetronomeBalances();
+            if (balance.isErr()) {
+              logger.error(
+                { error: balance.error },
+                "[Metronome Webhook] contract.start: failed to get Metronome balance"
+              );
+            }
             logger.info(
               {
                 contractId,
                 planCode: targetPlan.code,
                 workspaceId: workspace.sId,
               },
-              "[Metronome Webhook] contract.start: pending subscription activated"
+              "[Metronome Webhook] contract.start: subscription upgraded"
             );
             break;
           }
 
-          // Legacy fallback: no pending row was staged. Only swap when the
-          // workspace is Metronome-only billed, or not billed at all. Shadow
-          // billed subscriptions (Stripe + Metronome) follow Stripe's signal,
-          // and pure Stripe subs have no Metronome contract at all.
-          if (
-            !activeSubscription.isMetronomeOnlyBilled &&
-            activeSubscription.isBilled
-          ) {
-            logger.info(
-              {
-                contractId,
-                targetPlanCode,
-                workspaceId: workspace.sId,
-              },
-              "[Metronome Webhook] contract.start: subscription is not Metronome-only billed, leaving subscription alone"
-            );
-            break;
-          }
+          case "contract.end": {
+            const { contract_id: contractId, customer_id: customerId } = event;
 
-          // End the current subscription as `ended_backend_only` and create
-          // a new active subscription on the target plan + new contract.
-          await activeSubscription.swapMetronomeContract({
-            metronomeContractId: contractId,
-            planCode: targetPlan.code,
-          });
+            // Workspace is guaranteed by the pre-switch check (customerId is
+            // present for contract.* events).
+            if (!workspace) {
+              break;
+            }
 
-          await invalidateContractCache(workspace.sId);
+            await invalidateContractCache(workspace.sId);
 
-          // Cancel any scheduled scrub workflow, unpause connectors, re-enable
-          // triggers. Idempotent — safe to call regardless of prior state.
-          const auth = await Authenticator.internalAdminForWorkspace(
-            workspace.sId
-          );
-          await restoreWorkspaceAfterSubscription(auth);
-
-          logger.info(
-            {
-              contractId,
-              planCode: targetPlan.code,
-              workspaceId: workspace.sId,
-            },
-            "[Metronome Webhook] contract.start: subscription upgraded"
-          );
-          break;
-        }
-
-        case "contract.end": {
-          const { contract_id: contractId, customer_id: customerId } = event;
-
-          // Workspace is guaranteed by the pre-switch check (customerId is
-          // present for contract.* events).
-          if (!workspace) {
-            break;
-          }
-
-          await invalidateContractCache(workspace.sId);
-
-          const subscription =
-            await SubscriptionResource.fetchByMetronomeContractId(
-              workspace,
-              contractId
-            );
-          if (!subscription) {
-            logger.warn(
-              { contractId, customerId, workspaceId: workspace.sId },
-              "[Metronome Webhook] contract.end: subscription not found"
-            );
-            break;
-          }
-
-          if (subscription.isMetronomeShadowBilled) {
-            logger.info(
-              { contractId, workspaceId: workspace.sId },
-              "[Metronome Webhook] contract.end: shadow contract ended, Stripe handles subscription"
-            );
-            break;
-          }
-
-          switch (subscription.status) {
-            case "ended":
-              logger.info(
-                { contractId, workspaceId: workspace.sId },
-                "[Metronome Webhook] contract.end: subscription already ended"
+            const subscription =
+              await SubscriptionResource.fetchByMetronomeContractId(
+                workspace,
+                contractId
+              );
+            if (!subscription) {
+              logger.warn(
+                { contractId, customerId, workspaceId: workspace.sId },
+                "[Metronome Webhook] contract.end: subscription not found"
               );
               break;
+            }
 
-            case "ended_backend_only":
+            if (subscription.isMetronomeShadowBilled) {
               logger.info(
                 { contractId, workspaceId: workspace.sId },
-                "[Metronome Webhook] contract.end: marking as ended (backend-initiated)"
+                "[Metronome Webhook] contract.end: shadow contract ended, Stripe handles subscription"
               );
-              await subscription.markAsEnded("ended");
               break;
+            }
 
-            case "created_backend_only":
-              // Pending sub whose contract ended before activating (e.g.
-              // sunset by an overlapping new contract). No active billing —
-              // just close out the pending row.
-              logger.info(
-                { contractId, workspaceId: workspace.sId },
-                "[Metronome Webhook] contract.end: pending subscription never activated, marking as ended"
-              );
-              await subscription.markAsEnded("ended");
-              break;
-
-            case "active": {
-              // Race-safety: an Enterprise upgrade scheduled this end as part
-              // of a transition. If a successor contract is already running
-              // on this customer, contract.start (whether already processed
-              // or arriving shortly) will swap the subscription — leave the
-              // subscription alone here and skip the scrub.
-              const successorsResult = await listMetronomeContracts(
-                customerId,
-                { coveringDate: new Date() }
-              );
-              if (successorsResult.isErr()) {
-                logger.error(
-                  {
-                    contractId,
-                    error: successorsResult.error,
-                    workspaceId: workspace.sId,
-                  },
-                  "[Metronome Webhook] contract.end: failed to list contracts for successor check"
-                );
-                return apiError(req, res, {
-                  status_code: 500,
-                  api_error: {
-                    type: "internal_server_error",
-                    message: "Error listing contracts for successor check.",
-                  },
-                });
-              }
-
-              const hasActiveSuccessor = successorsResult.value.some(
-                (c) => c.id !== contractId
-              );
-              if (hasActiveSuccessor) {
+            switch (subscription.status) {
+              case "ended":
                 logger.info(
                   { contractId, workspaceId: workspace.sId },
-                  "[Metronome Webhook] contract.end: successor contract active, skipping scrub (contract.start will swap subscription)"
+                  "[Metronome Webhook] contract.end: subscription already ended"
+                );
+                break;
+
+              case "ended_backend_only":
+                logger.info(
+                  { contractId, workspaceId: workspace.sId },
+                  "[Metronome Webhook] contract.end: marking as ended (backend-initiated)"
+                );
+                await subscription.markAsEnded("ended");
+                break;
+
+              case "created_backend_only":
+                // Pending sub whose contract ended before activating (e.g.
+                // sunset by an overlapping new contract). No active billing —
+                // just close out the pending row.
+                logger.info(
+                  { contractId, workspaceId: workspace.sId },
+                  "[Metronome Webhook] contract.end: pending subscription never activated, marking as ended"
+                );
+                await subscription.markAsEnded("ended");
+                break;
+
+              case "active": {
+                // Race-safety: an Enterprise upgrade scheduled this end as part
+                // of a transition. If a successor contract is already running
+                // on this customer, contract.start (whether already processed
+                // or arriving shortly) will swap the subscription — leave the
+                // subscription alone here and skip the scrub.
+                const successorsResult = await listMetronomeContracts(
+                  customerId,
+                  { coveringDate: new Date() }
+                );
+                if (successorsResult.isErr()) {
+                  logger.error(
+                    {
+                      contractId,
+                      error: successorsResult.error,
+                      workspaceId: workspace.sId,
+                    },
+                    "[Metronome Webhook] contract.end: failed to list contracts for successor check"
+                  );
+                  return apiError(req, res, {
+                    status_code: 500,
+                    api_error: {
+                      type: "internal_server_error",
+                      message: "Error listing contracts for successor check.",
+                    },
+                  });
+                }
+
+                const hasActiveSuccessor = successorsResult.value.some(
+                  (c) => c.id !== contractId
+                );
+                if (hasActiveSuccessor) {
+                  logger.info(
+                    { contractId, workspaceId: workspace.sId },
+                    "[Metronome Webhook] contract.end: successor contract active, skipping scrub (contract.start will swap subscription)"
+                  );
+                  break;
+                }
+
+                // Launch the scrub workflow BEFORE marking the subscription
+                // ended. If the launch fails the subscription stays "active",
+                // so Metronome's retry re-enters this branch and tries again.
+                // Reversing the order would mark the subscription ended on
+                // first attempt; the retry would then dispatch to the "ended"
+                // no-op branch and the scrub would never launch.
+                // The launcher itself is idempotent (swallows
+                // WorkflowExecutionAlreadyStartedError), so a retry after a
+                // partial success — workflow started, response lost — also
+                // converges.
+                const scrubRes = await launchScheduleWorkspaceScrubWorkflow({
+                  workspaceId: workspace.sId,
+                });
+                if (scrubRes.isErr()) {
+                  logger.error(
+                    {
+                      workspaceId: workspace.sId,
+                      contractId,
+                      error: scrubRes.error,
+                    },
+                    "[Metronome Webhook] Error launching scrub workspace workflow"
+                  );
+                  return apiError(req, res, {
+                    status_code: 500,
+                    api_error: {
+                      type: "internal_server_error",
+                      message: `Error launching scrub workspace workflow: ${scrubRes.error.message}`,
+                    },
+                  });
+                }
+                await subscription.markAsEnded("ended");
+                logger.info(
+                  { contractId, workspaceId: workspace.sId },
+                  "[Metronome Webhook] contract.end: subscription ended and scrub workflow scheduled"
                 );
                 break;
               }
 
-              await subscription.markAsEnded("ended");
-              logger.info(
-                { contractId, workspaceId: workspace.sId },
-                "[Metronome Webhook] contract.end: ending subscription and scrubbing workspace"
-              );
-              const scrubRes = await launchScheduleWorkspaceScrubWorkflow({
-                workspaceId: workspace.sId,
-              });
-              if (scrubRes.isErr()) {
-                logger.error(
-                  {
-                    workspaceId: workspace.sId,
-                    contractId,
-                    error: scrubRes.error,
-                  },
-                  "[Metronome Webhook] Error launching scrub workspace workflow"
-                );
-                return apiError(req, res, {
-                  status_code: 500,
-                  api_error: {
-                    type: "internal_server_error",
-                    message: `Error launching scrub workspace workflow: ${scrubRes.error.message}`,
-                  },
-                });
-              }
-              break;
+              default:
+                assertNever(subscription.status);
             }
-
-            default:
-              assertNever(subscription.status);
+            break;
           }
-          break;
+
+          default:
+            logger.info(
+              { eventType: event.type },
+              "[Metronome Webhook] Unhandled event type"
+            );
+            break;
         }
 
-        default:
-          logger.info(
-            { eventType: event.type },
-            "[Metronome Webhook] Unhandled event type"
-          );
-          break;
+        processingSucceeded = true;
+        return res.status(200).json({ success: true });
+      } finally {
+        if (!processingSucceeded) {
+          // Release the claim so Metronome's retry can reprocess.
+          await releaseMetronomeWebhookEvent(event.id);
+        }
       }
-
-      return res.status(200).json({ success: true });
     }
 
     default:

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -18,7 +18,6 @@ import {
 import {
   getMetronomeClient,
   getMetronomeContractById,
-  listMetronomeBalances,
   listMetronomeContracts,
   updateMetronomeCreditSegmentAmount,
 } from "@app/lib/metronome/client";
@@ -704,13 +703,6 @@ async function handler(
             );
             await restoreWorkspaceAfterSubscription(auth);
 
-            const balance = await listMetronomeBalances();
-            if (balance.isErr()) {
-              logger.error(
-                { error: balance.error },
-                "[Metronome Webhook] contract.start: failed to get Metronome balance"
-              );
-            }
             logger.info(
               {
                 contractId,

--- a/front/temporal/scrub_workspace/client.ts
+++ b/front/temporal/scrub_workspace/client.ts
@@ -9,7 +9,10 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkflowHandle } from "@temporalio/client";
-import { WorkflowNotFoundError } from "@temporalio/client";
+import {
+  WorkflowExecutionAlreadyStartedError,
+  WorkflowNotFoundError,
+} from "@temporalio/client";
 
 import {
   DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID,
@@ -42,6 +45,16 @@ export async function launchScheduleWorkspaceScrubWorkflow({
     );
     return new Ok(workflowId);
   } catch (e) {
+    // Idempotency: if a previous call already started this workflow
+    // (concurrent webhook deliveries, retry after partial success), treat
+    // it as a successful no-op rather than a failure.
+    if (e instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        { workflowId },
+        "Scrub workspace workflow already started, treating as success."
+      );
+      return new Ok(workflowId);
+    }
     logger.error(
       {
         workflowId,


### PR DESCRIPTION
## Description

Make the Metronome webhook safe against redeliveries (Metronome has at-least-once delivery, and our own 5xx responses trigger retries).

- **Event-level dedup** — claim `event.id` in Redis (`SET NX EX 7d`) at the top of the POST handler. Duplicates short-circuit to 200. The claim is released on the 5xx/throw path so genuine retries can reprocess. Fails open if Redis is unavailable so billing events aren't silently dropped.
- **`contract.end` partial-failure fix** — launch the scrub workflow *before* `markAsEnded`. Previously a scrub-launch failure left the subscription `"ended"`, and the retry dispatched to the no-op `"ended"` branch — scrub never ran.
- **Idempotent scrub launcher** — `launchScheduleWorkspaceScrubWorkflow` now swallows `WorkflowExecutionAlreadyStartedError` and returns `Ok`, matching the pattern in `temporal/credit_alerts/client.ts`. Safe for concurrent deliveries and retries after a partial success (workflow started, response lost).

## Tests

`pages/api/metronome/webhook.test.ts` (13 passing). New cases:
- duplicate event short-circuits with no side effects
- failure path releases the claim so a retry can reprocess
- successful run keeps the claim
- scrub-launch failure leaves subscription `active` (retry invariant)

## Risk

Low. Behaviour change is additive — existing logic is unchanged on the success path. Redis-cache outage falls open (proceeds without dedup, same behaviour as before). Worst case is a brief window where a duplicate gets processed, which most handlers already tolerate via state-machine no-ops and inline idempotency checks.

## Deploy Plan

Standard rollout. No migration; new Redis key namespace (`metronome:webhook:event:*`) appears on first delivery.