### PR TITLE
[metronome] feat: per-user spend limit admin UI

### DIFF
--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -1,10 +1,5 @@
-import {
-  ceilToMidnightUTC,
-  floorToMidnightUTC,
-  listMetronomeDraftInvoices,
-  listMetronomeUsageWithGroups,
-} from "@app/lib/metronome/client";
-import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
+import { listMetronomePerUserCapsForWorkspace } from "@app/lib/metronome/per_user_alerts";
+import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import {
@@ -24,12 +19,19 @@ export type MemberUsageType = {
   email: string | null;
   image: string | null;
   seatType: MembershipSeatType | null;
+  // Percentage of seat allocation consumed (0–100), null when seat balances are unavailable.
   seatUsagePercent: number | null;
-  // Total user AWU consumption for the period (seat-covered + pool
-  // overflow). Matches the metric the per-user spend cap is configured
-  // against.
+  // Total user AWU consumption for the period, regardless of whether it
+  // was covered by the seat allocation or overflowed into the workspace
+  // pool.
   consumedAwuCredits: number;
+  // Billing cadence for the seat subscription the user is assigned to; null when unknown.
   billingFrequency: BillingFrequency | null;
+  // Set when a future seat change is scheduled (e.g. at the next credit refresh).
+  scheduledSeatType: MembershipSeatType | null;
+  scheduledSeatChangeAt: string | null;
+  // Per-user total spend cap in AWU credits for the billing period
+  spendLimitAwuCredits: number | null;
 };
 
 export type GetMembersUsageResponseBody = {
@@ -71,7 +73,7 @@ function buildUrlWithParams(
   return url.pathname + url.search;
 }
 
-async function fetchPerUserUsageCredits({
+async function fetchPerUserUsageCreditsForMembersTable({
   metronomeCustomerId,
   metronomeContractId,
 }: {
@@ -81,60 +83,14 @@ async function fetchPerUserUsageCredits({
   if (!metronomeCustomerId || !metronomeContractId) {
     return new Map();
   }
-
-  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
-  if (invoicesResult.isErr()) {
-    return new Map();
-  }
-
-  const now = Date.now();
-  const currentInvoice = invoicesResult.value.find((inv) => {
-    if (inv.contract_id !== metronomeContractId) {
-      return false;
-    }
-    if (!inv.start_timestamp || !inv.end_timestamp) {
-      return false;
-    }
-    const startMs = new Date(inv.start_timestamp).getTime();
-    const endMs = new Date(inv.end_timestamp).getTime();
-    return startMs <= now && now < endMs;
+  const result = await fetchPerUserAwuUsage({
+    metronomeCustomerId,
+    metronomeContractId,
   });
-
-  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+  if (result.isErr()) {
     return new Map();
   }
-
-  const startingOn = floorToMidnightUTC(
-    new Date(currentInvoice.start_timestamp)
-  ).toISOString();
-  const endingBefore = ceilToMidnightUTC(
-    new Date(currentInvoice.end_timestamp)
-  ).toISOString();
-
-  const usageResult = await listMetronomeUsageWithGroups({
-    customerId: metronomeCustomerId,
-    billableMetricId: getMetricLlmProviderCostAwuId(),
-    startingOn,
-    endingBefore,
-    windowSize: "NONE",
-    groupKey: ["user_id", "usage_type"],
-  });
-
-  if (usageResult.isErr()) {
-    return new Map();
-  }
-
-  const perUser = new Map<string, number>();
-  for (const entry of usageResult.value) {
-    const userId = entry.group?.["user_id"];
-    const usageType = entry.group?.["usage_type"];
-    if (!userId || usageType !== "user" || entry.value === null) {
-      continue;
-    }
-    const existing = perUser.get(userId) ?? 0;
-    perUser.set(userId, existing + entry.value);
-  }
-  return perUser;
+  return result.value;
 }
 
 // Mounted at /api/w/:wId/credits/members-usage.
@@ -162,25 +118,46 @@ app.get(
     const { metronomeCustomerId } = workspace;
     const metronomeContractId = subscription?.metronomeContractId ?? null;
 
-    const [membershipsResult, perUserTotalCredits, seatDataByUserId] =
-      await Promise.all([
-        MembershipResource.getActiveMemberships({
-          workspace,
-          paginationParams,
-        }),
-        fetchPerUserUsageCredits({
-          metronomeCustomerId: metronomeCustomerId ?? null,
-          metronomeContractId,
-        }),
-        metronomeCustomerId && metronomeContractId
-          ? buildSeatDataByUserId({
-              metronomeCustomerId,
-              contractId: metronomeContractId,
-            })
-          : Promise.resolve(new Map()),
-      ]);
+    const [
+      membershipsResult,
+      perUserTotalCredits,
+      seatDataByUserId,
+      perUserSpendLimitsResult,
+    ] = await Promise.all([
+      MembershipResource.getActiveMemberships({
+        workspace,
+        paginationParams,
+      }),
+      fetchPerUserUsageCreditsForMembersTable({
+        metronomeCustomerId: metronomeCustomerId ?? null,
+        metronomeContractId,
+      }),
+      metronomeCustomerId && metronomeContractId
+        ? buildSeatDataByUserId({
+            metronomeCustomerId,
+            contractId: metronomeContractId,
+          })
+        : Promise.resolve(new Map()),
+      metronomeCustomerId
+        ? listMetronomePerUserCapsForWorkspace({
+            metronomeCustomerId,
+            workspaceSId: workspace.sId,
+          })
+        : Promise.resolve(null),
+    ]);
+
+    const perUserSpendLimits =
+      perUserSpendLimitsResult && perUserSpendLimitsResult.isOk()
+        ? perUserSpendLimitsResult.value
+        : new Map<string, number>();
 
     const { memberships, total, nextPageParams } = membershipsResult;
+
+    const scheduledByUserId =
+      await MembershipResource.getScheduledMembershipsByUserIdInWorkspace({
+        workspace,
+        userIds: memberships.map((m) => m.userId),
+      });
 
     const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
       if (!m.user) {
@@ -197,6 +174,8 @@ app.get(
         seatUsagePercent = (seatConsumed / awuAllocation) * 100;
       }
 
+      const scheduled = scheduledByUserId.get(m.userId);
+
       return [
         {
           sId: userId,
@@ -207,15 +186,19 @@ app.get(
           seatUsagePercent,
           consumedAwuCredits: totalCredits,
           billingFrequency: seatData?.billingFrequency ?? null,
+          scheduledSeatType: scheduled?.seatType ?? null,
+          scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
+          spendLimitAwuCredits: perUserSpendLimits.get(userId) ?? null,
         },
       ];
     });
 
-    return ctx.json({
+    const body: GetMembersUsageResponseBody = {
       members: membersUsage,
       total,
       nextPageUrl: buildUrlWithParams(ctx.req.url, nextPageParams),
-    });
+    };
+    return ctx.json(body);
   }
 );
 

--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -1,133 +1,12 @@
-import { listMetronomePerUserCapsForWorkspace } from "@app/lib/metronome/per_user_alerts";
-import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
-import { buildSeatDataByUserId, type SeatData } from "@app/lib/metronome/seats";
-import type { BillingFrequency } from "@app/lib/metronome/types";
+import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import {
-  MembershipResource,
-  type MembershipsPaginationParams,
-} from "@app/lib/resources/membership_resource";
-import type { MembershipSeatType } from "@app/types/memberships";
+  getMembersUsage,
+  MembersUsagePaginationSchema,
+} from "@app/lib/api/credits/members_usage";
 import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
-import { z } from "zod";
-
-export type MemberUsageType = {
-  sId: string;
-  name: string;
-  email: string | null;
-  image: string | null;
-  seatType: MembershipSeatType | null;
-  // Percentage of seat allocation consumed (0–100), null when seat balances are unavailable.
-  seatUsagePercent: number | null;
-  // Total user AWU consumption for the period, regardless of whether it
-  // was covered by the seat allocation or overflowed into the workspace
-  // pool.
-  consumedAwuCredits: number;
-  // Billing cadence for the seat subscription the user is assigned to; null when unknown.
-  billingFrequency: BillingFrequency | null;
-  // Set when a future seat change is scheduled (e.g. at the next credit refresh).
-  scheduledSeatType: MembershipSeatType | null;
-  scheduledSeatChangeAt: string | null;
-  // Per-user total spend cap in AWU credits for the billing period
-  spendLimitAwuCredits: number | null;
-};
-
-export type GetMembersUsageResponseBody = {
-  members: MemberUsageType[];
-  total: number;
-  nextPageUrl?: string;
-};
-
-export const DEFAULT_MEMBERS_USAGE_PAGE_LIMIT = 50;
-export const MAX_MEMBERS_USAGE_PAGE_LIMIT = 150;
-
-const MembersUsagePaginationSchema = z.object({
-  limit: z.coerce
-    .number()
-    .int()
-    .min(0)
-    .max(MAX_MEMBERS_USAGE_PAGE_LIMIT)
-    .catch(DEFAULT_MEMBERS_USAGE_PAGE_LIMIT),
-  orderColumn: z.literal("createdAt").catch("createdAt"),
-  orderDirection: z.enum(["asc", "desc"]).catch("desc"),
-  lastValue: z.coerce.number().optional().catch(undefined),
-});
-
-function buildUrlWithParams(
-  currentUrl: string,
-  newParams: MembershipsPaginationParams | undefined
-) {
-  if (!newParams) {
-    return undefined;
-  }
-  const url = new URL(currentUrl);
-  Object.entries(newParams).forEach(([key, value]) => {
-    if (value === null || value === undefined) {
-      url.searchParams.delete(key);
-    } else {
-      url.searchParams.set(key, value.toString());
-    }
-  });
-  return url.pathname + url.search;
-}
-
-async function fetchPerUserUsageCreditsForMembersTable({
-  metronomeCustomerId,
-  metronomeContractId,
-}: {
-  metronomeCustomerId: string | null;
-  metronomeContractId: string | null;
-}): Promise<Map<string, number>> {
-  if (!metronomeCustomerId || !metronomeContractId) {
-    return new Map();
-  }
-  const result = await fetchPerUserAwuUsage({
-    metronomeCustomerId,
-    metronomeContractId,
-  });
-  if (result.isErr()) {
-    return new Map();
-  }
-  return result.value;
-}
-
-async function fetchSeatDataForMembersTable({
-  metronomeCustomerId,
-  metronomeContractId,
-}: {
-  metronomeCustomerId: string | null;
-  metronomeContractId: string | null;
-}): Promise<Map<string, SeatData>> {
-  if (!metronomeCustomerId || !metronomeContractId) {
-    return new Map();
-  }
-  return buildSeatDataByUserId({
-    metronomeCustomerId,
-    contractId: metronomeContractId,
-  });
-}
-
-async function fetchPerUserSpendLimitsForMembersTable({
-  metronomeCustomerId,
-  workspaceSId,
-}: {
-  metronomeCustomerId: string | null;
-  workspaceSId: string;
-}): Promise<Map<string, number>> {
-  if (!metronomeCustomerId) {
-    return new Map();
-  }
-  const result = await listMetronomePerUserCapsForWorkspace({
-    metronomeCustomerId,
-    workspaceSId,
-  });
-  if (result.isErr()) {
-    return new Map();
-  }
-  return result.value;
-}
 
 // Mounted at /api/w/:wId/credits/members-usage.
 const app = new Hono();
@@ -148,83 +27,11 @@ app.get(
       });
     }
 
-    const paginationParams = ctx.req.valid("query");
-    const workspace = auth.getNonNullableWorkspace();
-    const subscription = auth.subscription();
-    const { metronomeCustomerId } = workspace;
-    const metronomeContractId = subscription?.metronomeContractId ?? null;
-
-    const [
-      membershipsResult,
-      perUserTotalCredits,
-      seatDataByUserId,
-      perUserSpendLimits,
-    ] = await Promise.all([
-      MembershipResource.getActiveMemberships({
-        workspace,
-        paginationParams,
-      }),
-      fetchPerUserUsageCreditsForMembersTable({
-        metronomeCustomerId: metronomeCustomerId ?? null,
-        metronomeContractId,
-      }),
-      fetchSeatDataForMembersTable({
-        metronomeCustomerId: metronomeCustomerId ?? null,
-        metronomeContractId,
-      }),
-      fetchPerUserSpendLimitsForMembersTable({
-        metronomeCustomerId: metronomeCustomerId ?? null,
-        workspaceSId: workspace.sId,
-      }),
-    ]);
-
-    const { memberships, total, nextPageParams } = membershipsResult;
-
-    const scheduledByUserId =
-      await MembershipResource.getScheduledMembershipsByUserIdInWorkspace({
-        workspace,
-        userIds: memberships.map((m) => m.userId),
-      });
-
-    const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
-      if (!m.user) {
-        return [];
-      }
-      const userId = m.user.sId;
-      const totalCredits = perUserTotalCredits.get(userId) ?? 0;
-      const seatData = seatDataByUserId.get(userId);
-      const awuAllocation = seatData?.awuAllocation ?? 0;
-
-      let seatUsagePercent: number | null = null;
-      if (awuAllocation > 0) {
-        const seatConsumed = Math.min(totalCredits, awuAllocation);
-        seatUsagePercent = (seatConsumed / awuAllocation) * 100;
-      }
-
-      const scheduled = scheduledByUserId.get(m.userId);
-
-      return [
-        {
-          sId: userId,
-          name: m.user.name,
-          email: m.user.email ?? null,
-          image: m.user.imageUrl ?? null,
-          seatType: m.seatType ?? null,
-          seatUsagePercent,
-          consumedAwuCredits: totalCredits,
-          billingFrequency: seatData?.billingFrequency ?? null,
-          scheduledSeatType: scheduled?.seatType ?? null,
-          scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
-          spendLimitAwuCredits: perUserSpendLimits.get(userId) ?? null,
-        },
-      ];
+    const body = await getMembersUsage({
+      auth,
+      paginationParams: ctx.req.valid("query"),
+      currentUrl: ctx.req.url,
     });
-
-    const body: GetMembersUsageResponseBody = {
-      members: membersUsage,
-      total,
-      nextPageUrl: buildUrlWithParams(ctx.req.url, nextPageParams),
-    };
     return ctx.json(body);
   }
 );

--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -1,6 +1,6 @@
 import { listMetronomePerUserCapsForWorkspace } from "@app/lib/metronome/per_user_alerts";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
-import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
+import { buildSeatDataByUserId, type SeatData } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import {
   MembershipResource,
@@ -93,6 +93,42 @@ async function fetchPerUserUsageCreditsForMembersTable({
   return result.value;
 }
 
+async function fetchSeatDataForMembersTable({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string | null;
+  metronomeContractId: string | null;
+}): Promise<Map<string, SeatData>> {
+  if (!metronomeCustomerId || !metronomeContractId) {
+    return new Map();
+  }
+  return buildSeatDataByUserId({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+  });
+}
+
+async function fetchPerUserSpendLimitsForMembersTable({
+  metronomeCustomerId,
+  workspaceSId,
+}: {
+  metronomeCustomerId: string | null;
+  workspaceSId: string;
+}): Promise<Map<string, number>> {
+  if (!metronomeCustomerId) {
+    return new Map();
+  }
+  const result = await listMetronomePerUserCapsForWorkspace({
+    metronomeCustomerId,
+    workspaceSId,
+  });
+  if (result.isErr()) {
+    return new Map();
+  }
+  return result.value;
+}
+
 // Mounted at /api/w/:wId/credits/members-usage.
 const app = new Hono();
 
@@ -122,7 +158,7 @@ app.get(
       membershipsResult,
       perUserTotalCredits,
       seatDataByUserId,
-      perUserSpendLimitsResult,
+      perUserSpendLimits,
     ] = await Promise.all([
       MembershipResource.getActiveMemberships({
         workspace,
@@ -132,24 +168,15 @@ app.get(
         metronomeCustomerId: metronomeCustomerId ?? null,
         metronomeContractId,
       }),
-      metronomeCustomerId && metronomeContractId
-        ? buildSeatDataByUserId({
-            metronomeCustomerId,
-            contractId: metronomeContractId,
-          })
-        : Promise.resolve(new Map()),
-      metronomeCustomerId
-        ? listMetronomePerUserCapsForWorkspace({
-            metronomeCustomerId,
-            workspaceSId: workspace.sId,
-          })
-        : Promise.resolve(null),
+      fetchSeatDataForMembersTable({
+        metronomeCustomerId: metronomeCustomerId ?? null,
+        metronomeContractId,
+      }),
+      fetchPerUserSpendLimitsForMembersTable({
+        metronomeCustomerId: metronomeCustomerId ?? null,
+        workspaceSId: workspace.sId,
+      }),
     ]);
-
-    const perUserSpendLimits =
-      perUserSpendLimitsResult && perUserSpendLimitsResult.isOk()
-        ? perUserSpendLimitsResult.value
-        : new Map<string, number>();
 
     const { memberships, total, nextPageParams } = membershipsResult;
 

--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -25,7 +25,10 @@ export type MemberUsageType = {
   image: string | null;
   seatType: MembershipSeatType | null;
   seatUsagePercent: number | null;
-  consumedWorkplacePoolCredits: number;
+  // Total user AWU consumption for the period (seat-covered + pool
+  // overflow). Matches the metric the per-user spend cap is configured
+  // against.
+  consumedAwuCredits: number;
   billingFrequency: BillingFrequency | null;
 };
 
@@ -189,12 +192,9 @@ app.get(
       const awuAllocation = seatData?.awuAllocation ?? 0;
 
       let seatUsagePercent: number | null = null;
-      let poolConsumedCredits = totalCredits;
-
       if (awuAllocation > 0) {
         const seatConsumed = Math.min(totalCredits, awuAllocation);
         seatUsagePercent = (seatConsumed / awuAllocation) * 100;
-        poolConsumedCredits = Math.max(0, totalCredits - awuAllocation);
       }
 
       return [
@@ -205,7 +205,7 @@ app.get(
           image: m.user.imageUrl ?? null,
           seatType: m.seatType ?? null,
           seatUsagePercent,
-          consumedWorkplacePoolCredits: poolConsumedCredits,
+          consumedAwuCredits: totalCredits,
           billingFrequency: seatData?.billingFrequency ?? null,
         },
       ];

--- a/front/admin/audit_log_schemas/member.spend_limit_updated.json
+++ b/front/admin/audit_log_schemas/member.spend_limit_updated.json
@@ -1,0 +1,15 @@
+{
+  "action": "member.spend_limit_updated",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "user"
+    }
+  ],
+  "metadata": {
+    "kind": "string",
+    "awu_credits": "string"
+  }
+}

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -186,8 +186,8 @@ function getLimitPromptForCode(
             <Page.P>
               You have run out of credits.
               {isAdmin
-                ? "Please purchase more credits to continue using Dust."
-                : "Please contact your administrator to purchase more credits."}
+                ? " Please purchase more credits to continue using Dust."
+                : " Please contact your administrator to purchase more credits."}
             </Page.P>
           </>
         ),

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -3,6 +3,7 @@ import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
 import { BuyAwuCreditsDialog } from "@app/components/workspace/BuyAwuCreditsDialog";
 import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
+import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import {
@@ -145,6 +146,8 @@ export function UsagePage() {
   >(null);
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const [changeSeatMember, setChangeSeatMember] =
+    useState<MemberUsageType | null>(null);
+  const [editSpendLimitMember, setEditSpendLimitMember] =
     useState<MemberUsageType | null>(null);
   const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
     useState<WorkspaceLimit | null>(null);
@@ -376,6 +379,7 @@ export function UsagePage() {
             seatTypeFilter={seatTypeFilter}
             showSeatColumns={hasSeatSubscription}
             onChangeSeat={setChangeSeatMember}
+            onEditSpendLimit={setEditSpendLimitMember}
           />
         </Page.Vertical>
 
@@ -397,6 +401,15 @@ export function UsagePage() {
             member={changeSeatMember}
             owner={owner}
             seatPlans={seatPlans}
+          />
+        )}
+
+        {editSpendLimitMember && (
+          <EditSpendLimitModal
+            isOpen={true}
+            onClose={() => setEditSpendLimitMember(null)}
+            member={editSpendLimitMember}
+            owner={owner}
           />
         )}
 

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -1,0 +1,228 @@
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import {
+  useUpdateUserSpendLimit,
+  useUserSpendLimit,
+} from "@app/lib/swr/memberships";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  ActionCreditCoinsIcon,
+  Avatar,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Icon,
+  Input,
+  RadioGroup,
+  RadioGroupItem,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+const MIN_AWU_CREDITS = 1;
+const MAX_AWU_CREDITS = 1_000_000;
+
+type SpendLimitKind = "unlimited" | "limited";
+
+interface EditSpendLimitModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  member: MemberUsageType;
+  owner: WorkspaceType;
+}
+
+export function EditSpendLimitModal({
+  isOpen,
+  onClose,
+  member,
+  owner,
+}: EditSpendLimitModalProps) {
+  const { spendLimit, isSpendLimitLoading } = useUserSpendLimit({
+    workspaceId: owner.sId,
+    memberId: member.sId,
+    disabled: !isOpen,
+  });
+  const { doUpdateSpendLimit } = useUpdateUserSpendLimit({
+    workspaceId: owner.sId,
+  });
+
+  const [kind, setKind] = useState<SpendLimitKind>("limited");
+  const [creditsInput, setCreditsInput] = useState<string>("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [validationMessage, setValidationMessage] = useState<string | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    if (!spendLimit) {
+      return;
+    }
+    if (spendLimit.kind === "limited") {
+      setKind("limited");
+      setCreditsInput(String(spendLimit.awuCredits));
+    } else {
+      setKind("unlimited");
+      setCreditsInput("");
+    }
+    setValidationMessage(null);
+  }, [isOpen, spendLimit]);
+
+  function handleSelectKind(next: SpendLimitKind) {
+    setKind(next);
+    setValidationMessage(null);
+  }
+
+  function handleCreditsChange(value: string) {
+    // Keep only digits — credits are integers and the API range starts at 1.
+    const cleaned = value.replace(/[^\d]/g, "");
+    setCreditsInput(cleaned);
+    setValidationMessage(null);
+  }
+
+  function validate(): { ok: true; awuCredits: number } | { ok: false } {
+    if (kind === "unlimited") {
+      return { ok: true, awuCredits: 0 };
+    }
+    const parsed = Number(creditsInput);
+    if (!Number.isInteger(parsed) || parsed < MIN_AWU_CREDITS) {
+      setValidationMessage(
+        `Enter a whole number of credits between ${MIN_AWU_CREDITS.toLocaleString("en-US")} and ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
+      );
+      return { ok: false };
+    }
+    if (parsed > MAX_AWU_CREDITS) {
+      setValidationMessage(
+        `Credits cannot exceed ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
+      );
+      return { ok: false };
+    }
+    return { ok: true, awuCredits: parsed };
+  }
+
+  async function handleValidate() {
+    const result = validate();
+    if (!result.ok) {
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const limit =
+        kind === "unlimited"
+          ? ({ kind: "unlimited" } as const)
+          : ({ kind: "limited", awuCredits: result.awuCredits } as const);
+      const body = await doUpdateSpendLimit({
+        memberId: member.sId,
+        memberName: member.name,
+        limit,
+      });
+      if (body) {
+        onClose();
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const validateDisabled =
+    isSaving ||
+    isSpendLimitLoading ||
+    (kind === "limited" && creditsInput.length === 0);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <Avatar
+              visual={member.image ?? undefined}
+              name={member.name}
+              size="md"
+              isRounded
+            />
+            <div>
+              <DialogTitle>Edit spend limit for {member.name}</DialogTitle>
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                They will be able to consume this amount from the pool after
+                reaching their plan usage limit.
+              </p>
+            </div>
+          </div>
+        </DialogHeader>
+        <DialogContainer>
+          {isSpendLimitLoading ? (
+            <div className="flex justify-center py-6">
+              <Spinner />
+            </div>
+          ) : (
+            <RadioGroup
+              value={kind}
+              onValueChange={(v) => handleSelectKind(v as SpendLimitKind)}
+              className="flex flex-col gap-3"
+            >
+              <RadioGroupItem
+                value="unlimited"
+                id="spend-limit-unlimited"
+                label="Unlimited spend"
+              />
+              <RadioGroupItem
+                value="limited"
+                id="spend-limit-limited"
+                label="Set credit amount"
+              />
+
+              {kind === "limited" && (
+                <div className="flex flex-col gap-1.5 pl-6">
+                  <label
+                    htmlFor="spend-credit-limit-input"
+                    className="text-sm font-medium text-foreground dark:text-foreground-night"
+                  >
+                    Spend credit limit
+                  </label>
+                  <div className="relative">
+                    <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
+                      <Icon visual={ActionCreditCoinsIcon} size="xs" />
+                    </div>
+                    <Input
+                      id="spend-credit-limit-input"
+                      type="text"
+                      inputMode="numeric"
+                      pattern="[0-9]*"
+                      placeholder="1000"
+                      value={creditsInput}
+                      onChange={(e) => handleCreditsChange(e.target.value)}
+                      className="pl-8"
+                      isError={validationMessage !== null}
+                      message={validationMessage ?? undefined}
+                      messageStatus={
+                        validationMessage !== null ? "error" : undefined
+                      }
+                    />
+                  </div>
+                </div>
+              )}
+            </RadioGroup>
+          )}
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Validate",
+            variant: "primary",
+            disabled: validateDisabled,
+            onClick: handleValidate,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -26,6 +26,10 @@ const MAX_AWU_CREDITS = 1_000_000;
 
 type SpendLimitKind = "unlimited" | "limited";
 
+function isSpendLimitKind(value: string): value is SpendLimitKind {
+  return value === "unlimited" || value === "limited";
+}
+
 interface EditSpendLimitModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -162,7 +166,11 @@ export function EditSpendLimitModal({
           ) : (
             <RadioGroup
               value={kind}
-              onValueChange={(v) => handleSelectKind(v as SpendLimitKind)}
+              onValueChange={(v) => {
+                if (isSpendLimitKind(v)) {
+                  handleSelectKind(v);
+                }
+              }}
               className="flex flex-col gap-3"
             >
               <RadioGroupItem

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -22,7 +22,7 @@ type RowData = {
   image: string | null;
   seatType: MembershipSeatType | null;
   seatUsagePercent: number | null;
-  consumedWorkplacePoolCredits: number;
+  consumedAwuCredits: number;
   spendLimitAwuCredits: number | null;
   billingFrequency: BillingFrequency | null;
   scheduledSeatType: MembershipSeatType | null;
@@ -104,12 +104,12 @@ function formatCredits(credits: number): string {
   return credits.toLocaleString("en-US", { maximumFractionDigits: 1 });
 }
 
-interface WorkspaceUsageBarProps {
+interface AwuUsageBarProps {
   consumed: number;
   limit: number | null;
 }
 
-function WorkspaceUsageBar({ consumed, limit }: WorkspaceUsageBarProps) {
+function AwuUsageBar({ consumed, limit }: AwuUsageBarProps) {
   const percentage =
     limit !== null && limit > 0 ? Math.min((consumed / limit) * 100, 100) : 0;
 
@@ -260,19 +260,19 @@ const seatUsagePercentColumn: ColumnDef<RowData, string> = {
     (a.original.seatUsagePercent ?? -1) - (b.original.seatUsagePercent ?? -1),
 };
 
-const consumedWorkplacePoolCreditsColumn: ColumnDef<RowData, string> = {
-  id: "consumedWorkplacePoolCredits" as const,
+const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
+  id: "consumedAwuCredits" as const,
   header: () => (
     <span className="flex items-center gap-1.5">
       <Icon visual={ActionCreditCoinsIcon} size="xs" />
-      Workspace usage
+      AWU usage
     </span>
   ),
-  accessorFn: (row) => row.consumedWorkplacePoolCredits.toString(),
+  accessorFn: (row) => row.consumedAwuCredits.toString(),
   cell: (info: Info) => (
     <div className="w-full pr-3">
-      <WorkspaceUsageBar
-        consumed={info.row.original.consumedWorkplacePoolCredits}
+      <AwuUsageBar
+        consumed={info.row.original.consumedAwuCredits}
         limit={info.row.original.spendLimitAwuCredits}
       />
     </div>
@@ -282,8 +282,7 @@ const consumedWorkplacePoolCreditsColumn: ColumnDef<RowData, string> = {
   },
   enableSorting: true,
   sortingFn: (a, b) =>
-    a.original.consumedWorkplacePoolCredits -
-    b.original.consumedWorkplacePoolCredits,
+    a.original.consumedAwuCredits - b.original.consumedAwuCredits,
 };
 
 const actionsColumn: ColumnDef<RowData, string> = {
@@ -304,7 +303,7 @@ function buildColumns(showSeatColumns: boolean): ColumnDef<RowData, string>[] {
     ...(showSeatColumns
       ? [seatTypeColumn, billingFrequencyColumn, seatUsagePercentColumn]
       : []),
-    consumedWorkplacePoolCreditsColumn,
+    consumedAwuCreditsColumn,
     ...(showSeatColumns ? [actionsColumn] : []),
   ];
 }
@@ -367,7 +366,7 @@ export function MembersUsageTable({
     image: m.image,
     seatType: m.seatType,
     seatUsagePercent: m.seatUsagePercent,
-    consumedWorkplacePoolCredits: m.consumedWorkplacePoolCredits,
+    consumedAwuCredits: m.consumedAwuCredits,
     spendLimitAwuCredits: m.spendLimitAwuCredits,
     billingFrequency: m.billingFrequency,
     scheduledSeatType: m.scheduledSeatType,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -23,6 +23,7 @@ type RowData = {
   seatType: MembershipSeatType | null;
   seatUsagePercent: number | null;
   consumedWorkplacePoolCredits: number;
+  spendLimitAwuCredits: number | null;
   billingFrequency: BillingFrequency | null;
   scheduledSeatType: MembershipSeatType | null;
   scheduledSeatChangeAt: string | null;
@@ -272,7 +273,7 @@ const consumedWorkplacePoolCreditsColumn: ColumnDef<RowData, string> = {
     <div className="w-full pr-3">
       <WorkspaceUsageBar
         consumed={info.row.original.consumedWorkplacePoolCredits}
-        limit={null}
+        limit={info.row.original.spendLimitAwuCredits}
       />
     </div>
   ),
@@ -315,6 +316,7 @@ interface MembersUsageTableProps {
   seatTypeFilter: MembershipSeatType | "none" | null;
   showSeatColumns: boolean;
   onChangeSeat: (member: MemberUsageType) => void;
+  onEditSpendLimit: (member: MemberUsageType) => void;
 }
 
 export function MembersUsageTable({
@@ -324,6 +326,7 @@ export function MembersUsageTable({
   seatTypeFilter,
   showSeatColumns,
   onChangeSeat,
+  onEditSpendLimit,
 }: MembersUsageTableProps) {
   if (isLoading) {
     return (
@@ -365,6 +368,7 @@ export function MembersUsageTable({
     seatType: m.seatType,
     seatUsagePercent: m.seatUsagePercent,
     consumedWorkplacePoolCredits: m.consumedWorkplacePoolCredits,
+    spendLimitAwuCredits: m.spendLimitAwuCredits,
     billingFrequency: m.billingFrequency,
     scheduledSeatType: m.scheduledSeatType,
     scheduledSeatChangeAt: m.scheduledSeatChangeAt,
@@ -373,6 +377,11 @@ export function MembersUsageTable({
         kind: "item" as const,
         label: "Change Seat Type",
         onClick: () => onChangeSeat(m),
+      },
+      {
+        kind: "item" as const,
+        label: "Update User Spend Limit",
+        onClick: () => onEditSpendLimit(m),
       },
     ],
   }));

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -39,6 +39,7 @@ type AuditAction =
   | "invitation.role_updated"
   | "member.bulk_invited"
   | "member.bulk_revoked"
+  | "member.spend_limit_updated"
   // Domains & SSO.
   | "domain.verified"
   | "domain.verification_failed"

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,11 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
-import {
-  ceilToMidnightUTC,
-  floorToMidnightUTC,
-  listMetronomeDraftInvoices,
-  listMetronomeUsageWithGroups,
-} from "@app/lib/metronome/client";
-import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
+import { listMetronomePerUserCapsForWorkspace } from "@app/lib/metronome/per_user_alerts";
+import { fetchPerUserPoolUsage } from "@app/lib/metronome/per_user_usage";
 import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import {
@@ -34,6 +29,10 @@ export type MemberUsageType = {
   // Set when a future seat change is scheduled (e.g. at the next credit refresh).
   scheduledSeatType: MembershipSeatType | null;
   scheduledSeatChangeAt: string | null;
+  // Per-user spend cap in AWU credits (the upper bound on workspace pool
+  // consumption). `null` means no cap is set for this user (unlimited
+  // within the workspace pool).
+  spendLimitAwuCredits: number | null;
 };
 
 export type GetMembersUsageResponseBody = {
@@ -75,7 +74,7 @@ function buildUrlWithParams(
   return url.pathname + url.search;
 }
 
-async function fetchPerUserUsageCredits({
+async function fetchPerUserUsageCreditsForMembersTable({
   metronomeCustomerId,
   metronomeContractId,
 }: {
@@ -85,60 +84,14 @@ async function fetchPerUserUsageCredits({
   if (!metronomeCustomerId || !metronomeContractId) {
     return new Map();
   }
-
-  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
-  if (invoicesResult.isErr()) {
-    return new Map();
-  }
-
-  const now = Date.now();
-  const currentInvoice = invoicesResult.value.find((inv) => {
-    if (inv.contract_id !== metronomeContractId) {
-      return false;
-    }
-    if (!inv.start_timestamp || !inv.end_timestamp) {
-      return false;
-    }
-    const startMs = new Date(inv.start_timestamp).getTime();
-    const endMs = new Date(inv.end_timestamp).getTime();
-    return startMs <= now && now < endMs;
+  const result = await fetchPerUserPoolUsage({
+    metronomeCustomerId,
+    metronomeContractId,
   });
-
-  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+  if (result.isErr()) {
     return new Map();
   }
-
-  const startingOn = floorToMidnightUTC(
-    new Date(currentInvoice.start_timestamp)
-  ).toISOString();
-  const endingBefore = ceilToMidnightUTC(
-    new Date(currentInvoice.end_timestamp)
-  ).toISOString();
-
-  const usageResult = await listMetronomeUsageWithGroups({
-    customerId: metronomeCustomerId,
-    billableMetricId: getMetricLlmProviderCostAwuId(),
-    startingOn,
-    endingBefore,
-    windowSize: "NONE",
-    groupKey: ["user_id", "usage_type"],
-  });
-
-  if (usageResult.isErr()) {
-    return new Map();
-  }
-
-  const perUser = new Map<string, number>();
-  for (const entry of usageResult.value) {
-    const userId = entry.group?.["user_id"];
-    const usageType = entry.group?.["usage_type"];
-    if (!userId || usageType !== "user" || entry.value === null) {
-      continue;
-    }
-    const existing = perUser.get(userId) ?? 0;
-    perUser.set(userId, existing + entry.value);
-  }
-  return perUser;
+  return result.value;
 }
 
 export async function handleGetMembersUsageRequest(
@@ -175,23 +128,38 @@ export async function handleGetMembersUsageRequest(
       const { metronomeCustomerId } = workspace;
       const metronomeContractId = subscription?.metronomeContractId ?? null;
 
-      const [membershipsResult, perUserTotalCredits, seatDataByUserId] =
-        await Promise.all([
-          MembershipResource.getActiveMemberships({
-            workspace,
-            paginationParams,
-          }),
-          fetchPerUserUsageCredits({
-            metronomeCustomerId: metronomeCustomerId ?? null,
-            metronomeContractId,
-          }),
-          metronomeCustomerId && metronomeContractId
-            ? buildSeatDataByUserId({
-                metronomeCustomerId,
-                contractId: metronomeContractId,
-              })
-            : Promise.resolve(new Map()),
-        ]);
+      const [
+        membershipsResult,
+        perUserTotalCredits,
+        seatDataByUserId,
+        perUserSpendLimitsResult,
+      ] = await Promise.all([
+        MembershipResource.getActiveMemberships({
+          workspace,
+          paginationParams,
+        }),
+        fetchPerUserUsageCreditsForMembersTable({
+          metronomeCustomerId: metronomeCustomerId ?? null,
+          metronomeContractId,
+        }),
+        metronomeCustomerId && metronomeContractId
+          ? buildSeatDataByUserId({
+              metronomeCustomerId,
+              contractId: metronomeContractId,
+            })
+          : Promise.resolve(new Map()),
+        metronomeCustomerId
+          ? listMetronomePerUserCapsForWorkspace({
+              metronomeCustomerId,
+              workspaceSId: workspace.sId,
+            })
+          : Promise.resolve(null),
+      ]);
+
+      const perUserSpendLimits =
+        perUserSpendLimitsResult && perUserSpendLimitsResult.isOk()
+          ? perUserSpendLimitsResult.value
+          : new Map<string, number>();
 
       const { memberships, total, nextPageParams } = membershipsResult;
 
@@ -233,6 +201,7 @@ export async function handleGetMembersUsageRequest(
             billingFrequency: seatData?.billingFrequency ?? null,
             scheduledSeatType: scheduled?.seatType ?? null,
             scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
+            spendLimitAwuCredits: perUserSpendLimits.get(userId) ?? null,
           },
         ];
       });

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,7 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { listMetronomePerUserCapsForWorkspace } from "@app/lib/metronome/per_user_alerts";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
-import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
+import { buildSeatDataByUserId, type SeatData } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import {
   MembershipResource,
@@ -94,6 +94,42 @@ async function fetchPerUserUsageCreditsForMembersTable({
   return result.value;
 }
 
+async function fetchSeatDataForMembersTable({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string | null;
+  metronomeContractId: string | null;
+}): Promise<Map<string, SeatData>> {
+  if (!metronomeCustomerId || !metronomeContractId) {
+    return new Map();
+  }
+  return buildSeatDataByUserId({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+  });
+}
+
+async function fetchPerUserSpendLimitsForMembersTable({
+  metronomeCustomerId,
+  workspaceSId,
+}: {
+  metronomeCustomerId: string | null;
+  workspaceSId: string;
+}): Promise<Map<string, number>> {
+  if (!metronomeCustomerId) {
+    return new Map();
+  }
+  const result = await listMetronomePerUserCapsForWorkspace({
+    metronomeCustomerId,
+    workspaceSId,
+  });
+  if (result.isErr()) {
+    return new Map();
+  }
+  return result.value;
+}
+
 export async function handleGetMembersUsageRequest(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetMembersUsageResponseBody>>,
@@ -132,7 +168,7 @@ export async function handleGetMembersUsageRequest(
         membershipsResult,
         perUserTotalCredits,
         seatDataByUserId,
-        perUserSpendLimitsResult,
+        perUserSpendLimits,
       ] = await Promise.all([
         MembershipResource.getActiveMemberships({
           workspace,
@@ -142,24 +178,15 @@ export async function handleGetMembersUsageRequest(
           metronomeCustomerId: metronomeCustomerId ?? null,
           metronomeContractId,
         }),
-        metronomeCustomerId && metronomeContractId
-          ? buildSeatDataByUserId({
-              metronomeCustomerId,
-              contractId: metronomeContractId,
-            })
-          : Promise.resolve(new Map()),
-        metronomeCustomerId
-          ? listMetronomePerUserCapsForWorkspace({
-              metronomeCustomerId,
-              workspaceSId: workspace.sId,
-            })
-          : Promise.resolve(null),
+        fetchSeatDataForMembersTable({
+          metronomeCustomerId: metronomeCustomerId ?? null,
+          metronomeContractId,
+        }),
+        fetchPerUserSpendLimitsForMembersTable({
+          metronomeCustomerId: metronomeCustomerId ?? null,
+          workspaceSId: workspace.sId,
+        }),
       ]);
-
-      const perUserSpendLimits =
-        perUserSpendLimitsResult && perUserSpendLimitsResult.isOk()
-          ? perUserSpendLimitsResult.value
-          : new Map<string, number>();
 
       const { memberships, total, nextPageParams } = membershipsResult;
 

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { listMetronomePerUserCapsForWorkspace } from "@app/lib/metronome/per_user_alerts";
-import { fetchPerUserPoolUsage } from "@app/lib/metronome/per_user_usage";
+import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import {
@@ -22,8 +22,12 @@ export type MemberUsageType = {
   seatType: MembershipSeatType | null;
   // Percentage of seat allocation consumed (0–100), null when seat balances are unavailable.
   seatUsagePercent: number | null;
-  // Pool consumption only (AWU credits): total usage minus what was covered by the seat credit.
-  consumedWorkplacePoolCredits: number;
+  // Total user AWU consumption for the period, regardless of whether it
+  // was covered by the seat allocation or overflowed into the workspace
+  // pool. This is the value the per-user spend cap is compared against
+  // (the Metronome alert is configured on the same metric); to derive
+  // pool overflow, subtract the seat allocation client-side.
+  consumedAwuCredits: number;
   // Billing cadence for the seat subscription the user is assigned to; null when unknown.
   billingFrequency: BillingFrequency | null;
   // Set when a future seat change is scheduled (e.g. at the next credit refresh).
@@ -84,7 +88,7 @@ async function fetchPerUserUsageCreditsForMembersTable({
   if (!metronomeCustomerId || !metronomeContractId) {
     return new Map();
   }
-  const result = await fetchPerUserPoolUsage({
+  const result = await fetchPerUserAwuUsage({
     metronomeCustomerId,
     metronomeContractId,
   });
@@ -179,12 +183,9 @@ export async function handleGetMembersUsageRequest(
         const awuAllocation = seatData?.awuAllocation ?? 0;
 
         let seatUsagePercent: number | null = null;
-        let poolConsumedCredits = totalCredits;
-
         if (awuAllocation > 0) {
           const seatConsumed = Math.min(totalCredits, awuAllocation);
           seatUsagePercent = (seatConsumed / awuAllocation) * 100;
-          poolConsumedCredits = Math.max(0, totalCredits - awuAllocation);
         }
 
         const scheduled = scheduledByUserId.get(m.userId);
@@ -197,7 +198,7 @@ export async function handleGetMembersUsageRequest(
             image: m.user.imageUrl ?? null,
             seatType: m.seatType ?? null,
             seatUsagePercent,
-            consumedWorkplacePoolCredits: poolConsumedCredits,
+            consumedAwuCredits: totalCredits,
             billingFrequency: seatData?.billingFrequency ?? null,
             scheduledSeatType: scheduled?.seatType ?? null,
             scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -24,18 +24,14 @@ export type MemberUsageType = {
   seatUsagePercent: number | null;
   // Total user AWU consumption for the period, regardless of whether it
   // was covered by the seat allocation or overflowed into the workspace
-  // pool. This is the value the per-user spend cap is compared against
-  // (the Metronome alert is configured on the same metric); to derive
-  // pool overflow, subtract the seat allocation client-side.
+  // pool.
   consumedAwuCredits: number;
   // Billing cadence for the seat subscription the user is assigned to; null when unknown.
   billingFrequency: BillingFrequency | null;
   // Set when a future seat change is scheduled (e.g. at the next credit refresh).
   scheduledSeatType: MembershipSeatType | null;
   scheduledSeatChangeAt: string | null;
-  // Per-user spend cap in AWU credits (the upper bound on workspace pool
-  // consumption). `null` means no cap is set for this user (unlimited
-  // within the workspace pool).
+  // Per-user total spend cap in AWU credits for the billing period
   spendLimitAwuCredits: number | null;
 };
 

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -7,12 +7,8 @@ import {
   MembershipResource,
   type MembershipsPaginationParams,
 } from "@app/lib/resources/membership_resource";
-import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types/error";
 import type { MembershipSeatType } from "@app/types/memberships";
-import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
-import { fromError } from "zod-validation-error";
 
 export type MemberUsageType = {
   sId: string;
@@ -44,7 +40,7 @@ export type GetMembersUsageResponseBody = {
 export const DEFAULT_MEMBERS_USAGE_PAGE_LIMIT = 50;
 export const MAX_MEMBERS_USAGE_PAGE_LIMIT = 150;
 
-const MembersUsagePaginationSchema = z.object({
+export const MembersUsagePaginationSchema = z.object({
   limit: z.coerce
     .number()
     .int()
@@ -56,14 +52,18 @@ const MembersUsagePaginationSchema = z.object({
   lastValue: z.coerce.number().optional().catch(undefined),
 });
 
+export type MembersUsagePaginationInput = z.infer<
+  typeof MembersUsagePaginationSchema
+>;
+
 function buildUrlWithParams(
-  req: NextApiRequest,
+  currentUrl: string,
   newParams: MembershipsPaginationParams | undefined
 ) {
   if (!newParams) {
     return undefined;
   }
-  const url = new URL(req.url!, `http://${req.headers.host}`);
+  const url = new URL(currentUrl, "http://placeholder");
   Object.entries(newParams).forEach(([key, value]) => {
     if (value === null || value === undefined) {
       url.searchParams.delete(key);
@@ -130,119 +130,89 @@ async function fetchPerUserSpendLimitsForMembersTable({
   return result.value;
 }
 
-export async function handleGetMembersUsageRequest(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetMembersUsageResponseBody>>,
-  auth: Authenticator
-): Promise<void> {
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Only workspace admins can access the members usage list.",
-      },
+export async function getMembersUsage({
+  auth,
+  paginationParams,
+  currentUrl,
+}: {
+  auth: Authenticator;
+  paginationParams: MembersUsagePaginationInput;
+  currentUrl: string;
+}): Promise<GetMembersUsageResponseBody> {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+  const { metronomeCustomerId } = workspace;
+  const metronomeContractId = subscription?.metronomeContractId ?? null;
+
+  const [
+    membershipsResult,
+    perUserTotalCredits,
+    seatDataByUserId,
+    perUserSpendLimits,
+  ] = await Promise.all([
+    MembershipResource.getActiveMemberships({
+      workspace,
+      paginationParams,
+    }),
+    fetchPerUserUsageCreditsForMembersTable({
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      metronomeContractId,
+    }),
+    fetchSeatDataForMembersTable({
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      metronomeContractId,
+    }),
+    fetchPerUserSpendLimitsForMembersTable({
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      workspaceSId: workspace.sId,
+    }),
+  ]);
+
+  const { memberships, total, nextPageParams } = membershipsResult;
+
+  const scheduledByUserId =
+    await MembershipResource.getScheduledMembershipsByUserIdInWorkspace({
+      workspace,
+      userIds: memberships.map((m) => m.userId),
     });
-  }
 
-  switch (req.method) {
-    case "GET": {
-      const paginationRes = MembersUsagePaginationSchema.safeParse(req.query);
-      if (!paginationRes.success) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid pagination parameters: ${fromError(paginationRes.error).toString()}`,
-          },
-        });
-      }
-
-      const paginationParams = paginationRes.data;
-      const workspace = auth.getNonNullableWorkspace();
-      const subscription = auth.subscription();
-      const { metronomeCustomerId } = workspace;
-      const metronomeContractId = subscription?.metronomeContractId ?? null;
-
-      const [
-        membershipsResult,
-        perUserTotalCredits,
-        seatDataByUserId,
-        perUserSpendLimits,
-      ] = await Promise.all([
-        MembershipResource.getActiveMemberships({
-          workspace,
-          paginationParams,
-        }),
-        fetchPerUserUsageCreditsForMembersTable({
-          metronomeCustomerId: metronomeCustomerId ?? null,
-          metronomeContractId,
-        }),
-        fetchSeatDataForMembersTable({
-          metronomeCustomerId: metronomeCustomerId ?? null,
-          metronomeContractId,
-        }),
-        fetchPerUserSpendLimitsForMembersTable({
-          metronomeCustomerId: metronomeCustomerId ?? null,
-          workspaceSId: workspace.sId,
-        }),
-      ]);
-
-      const { memberships, total, nextPageParams } = membershipsResult;
-
-      const scheduledByUserId =
-        await MembershipResource.getScheduledMembershipsByUserIdInWorkspace({
-          workspace,
-          userIds: memberships.map((m) => m.userId),
-        });
-
-      const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
-        if (!m.user) {
-          return [];
-        }
-        const userId = m.user.sId;
-        const totalCredits = perUserTotalCredits.get(userId) ?? 0;
-        const seatData = seatDataByUserId.get(userId);
-        const awuAllocation = seatData?.awuAllocation ?? 0;
-
-        let seatUsagePercent: number | null = null;
-        if (awuAllocation > 0) {
-          const seatConsumed = Math.min(totalCredits, awuAllocation);
-          seatUsagePercent = (seatConsumed / awuAllocation) * 100;
-        }
-
-        const scheduled = scheduledByUserId.get(m.userId);
-
-        return [
-          {
-            sId: userId,
-            name: m.user.name,
-            email: m.user.email ?? null,
-            image: m.user.imageUrl ?? null,
-            seatType: m.seatType ?? null,
-            seatUsagePercent,
-            consumedAwuCredits: totalCredits,
-            billingFrequency: seatData?.billingFrequency ?? null,
-            scheduledSeatType: scheduled?.seatType ?? null,
-            scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
-            spendLimitAwuCredits: perUserSpendLimits.get(userId) ?? null,
-          },
-        ];
-      });
-
-      return res.status(200).json({
-        members: membersUsage,
-        total,
-        nextPageUrl: buildUrlWithParams(req, nextPageParams),
-      });
+  const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
+    if (!m.user) {
+      return [];
     }
-    default:
-      return apiError(req, res, {
-        status_code: 405,
-        api_error: {
-          type: "method_not_supported_error",
-          message: "The method passed is not supported, GET is expected.",
-        },
-      });
-  }
+    const userId = m.user.sId;
+    const totalCredits = perUserTotalCredits.get(userId) ?? 0;
+    const seatData = seatDataByUserId.get(userId);
+    const awuAllocation = seatData?.awuAllocation ?? 0;
+
+    let seatUsagePercent: number | null = null;
+    if (awuAllocation > 0) {
+      const seatConsumed = Math.min(totalCredits, awuAllocation);
+      seatUsagePercent = (seatConsumed / awuAllocation) * 100;
+    }
+
+    const scheduled = scheduledByUserId.get(m.userId);
+
+    return [
+      {
+        sId: userId,
+        name: m.user.name,
+        email: m.user.email ?? null,
+        image: m.user.imageUrl ?? null,
+        seatType: m.seatType ?? null,
+        seatUsagePercent,
+        consumedAwuCredits: totalCredits,
+        billingFrequency: seatData?.billingFrequency ?? null,
+        scheduledSeatType: scheduled?.seatType ?? null,
+        scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
+        spendLimitAwuCredits: perUserSpendLimits.get(userId) ?? null,
+      },
+    ];
+  });
+
+  return {
+    members: membersUsage,
+    total,
+    nextPageUrl: buildUrlWithParams(currentUrl, nextPageParams),
+  };
 }

--- a/front/lib/api/metronome/credit_state_dispatcher.test.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.test.ts
@@ -1,0 +1,84 @@
+import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchPerUserCapReached,
+  dispatchPerUserCapResolved,
+} from "./credit_state_dispatcher";
+
+vi.mock("@app/lib/metronome/user_credit_state_machine", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/user_credit_state_machine")
+  >("@app/lib/metronome/user_credit_state_machine");
+  return {
+    ...actual,
+    transitionUserCreditState: vi.fn(),
+  };
+});
+
+const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(transitionUserCreditState).mockResolvedValue(new Ok("normal"));
+});
+
+describe("credit_state_dispatcher per-user caps", () => {
+  it("dispatchPerUserCapReached transitions any seat type", async () => {
+    const workspaceType = await WorkspaceFactory.metronome({
+      metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+    });
+    const workspace = await WorkspaceResource.fetchById(workspaceType.sId);
+    expect(workspace).not.toBeNull();
+    if (!workspace) {
+      throw new Error("Workspace not found");
+    }
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspaceType, user, {
+      role: "user",
+      seatType: "pro",
+    });
+
+    await dispatchPerUserCapReached({
+      workspace,
+      userId: user.sId,
+    });
+
+    expect(transitionUserCreditState).toHaveBeenCalledWith(
+      expect.objectContaining({ seatType: "pro", creditState: "normal" }),
+      { type: "per_user_cap_reached" },
+      { workspaceId: workspaceType.sId, userId: user.sId }
+    );
+  });
+
+  it("dispatchPerUserCapResolved transitions any seat type", async () => {
+    const workspaceType = await WorkspaceFactory.metronome({
+      metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+    });
+    const workspace = await WorkspaceResource.fetchById(workspaceType.sId);
+    expect(workspace).not.toBeNull();
+    if (!workspace) {
+      throw new Error("Workspace not found");
+    }
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspaceType, user, {
+      role: "user",
+      seatType: "max",
+    });
+
+    await dispatchPerUserCapResolved({
+      workspace,
+      userId: user.sId,
+    });
+
+    expect(transitionUserCreditState).toHaveBeenCalledWith(
+      expect.objectContaining({ seatType: "max", creditState: "normal" }),
+      { type: "per_user_cap_resolved" },
+      { workspaceId: workspaceType.sId, userId: user.sId }
+    );
+  });
+});

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -1,9 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/payg";
-import {
-  clearUserCapBlocked,
-  setUserCapBlocked,
-} from "@app/lib/metronome/user_block";
+import { clearUserCapBlocked } from "@app/lib/metronome/user_block";
 import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
 import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_state_machine";
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
@@ -48,11 +45,6 @@ export async function dispatchPerUserCapReached({
     return;
   }
 
-  if (membership.seatType !== "workspace") {
-    await setUserCapBlocked(workspace.sId, userId);
-    return;
-  }
-
   await transitionUserCreditState(
     membership,
     { type: "per_user_cap_reached" },
@@ -89,11 +81,6 @@ export async function dispatchPerUserCapResolved({
       { workspaceId: workspace.sId, userId },
       "[CreditStateDispatcher] per_user_cap_resolved: no active membership, clearing legacy block"
     );
-    await clearUserCapBlocked(workspace.sId, userId);
-    return;
-  }
-
-  if (membership.seatType !== "workspace") {
     await clearUserCapBlocked(workspace.sId, userId);
     return;
   }

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -1,0 +1,257 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import {
+  dispatchPerUserCapReached,
+  dispatchPerUserCapResolved,
+} from "@app/lib/api/metronome/credit_state_dispatcher";
+import { getUserForWorkspace } from "@app/lib/api/user";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  clearMetronomePerUserCapAlert,
+  getMetronomePerUserCap,
+  syncMetronomePerUserCapAlert,
+} from "@app/lib/metronome/per_user_alerts";
+import { fetchPerUserPoolUsage } from "@app/lib/metronome/per_user_usage";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export const MIN_USER_SPEND_LIMIT_AWU_CREDITS = 1;
+export const MAX_USER_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
+
+export type UserSpendLimit =
+  | { kind: "unlimited" }
+  | { kind: "limited"; awuCredits: number };
+
+export type GetUserSpendLimitResponse = UserSpendLimit;
+
+export type SetUserSpendLimitResponse = {
+  limit: UserSpendLimit;
+  // The credit-state we transitioned the user to, computed locally from
+  // current pool consumption. `null` when usage couldn't be determined and
+  // we therefore did not dispatch a transition (the Metronome webhook
+  // will reconcile on the next state change).
+  transitionedTo: "reached" | "resolved" | null;
+};
+
+export type UserSpendLimitErrorType =
+  | "user_not_found"
+  | "workspace_not_metronome_billed"
+  | "metronome_error";
+
+export class UserSpendLimitError extends Error {
+  constructor(
+    readonly type: UserSpendLimitErrorType,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export async function getUserSpendLimit(
+  auth: Authenticator,
+  { userId }: { userId: string }
+): Promise<Result<GetUserSpendLimitResponse, UserSpendLimitError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return new Err(
+      new UserSpendLimitError(
+        "workspace_not_metronome_billed",
+        "Workspace is not on Metronome billing."
+      )
+    );
+  }
+
+  const user = await getUserForWorkspace(auth, { userId });
+  if (!user) {
+    return new Err(
+      new UserSpendLimitError(
+        "user_not_found",
+        "Could not find the user in this workspace."
+      )
+    );
+  }
+
+  const result = await getMetronomePerUserCap({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    workspaceSId: workspace.sId,
+    userSId: user.sId,
+  });
+  if (result.isErr()) {
+    return new Err(
+      new UserSpendLimitError("metronome_error", result.error.message)
+    );
+  }
+
+  if (!result.value) {
+    return new Ok({ kind: "unlimited" });
+  }
+  return new Ok({ kind: "limited", awuCredits: result.value.threshold });
+}
+
+/**
+ * Resolve the credit state for a user given a freshly applied cap, by
+ * comparing the user's current pool consumption to the cap. The Metronome
+ * alert we just created/cleared remains the source of truth for *future*
+ * crossings (the webhook keeps the state in sync); this local comparison
+ * just sets the immediate state without depending on Metronome's eventual-
+ * consistent alert evaluation (which can sit in `evaluating` for minutes).
+ *
+ * Returns `null` if usage couldn't be fetched — caller should not dispatch
+ * and let the webhook reconcile.
+ */
+async function resolveLocalCapState({
+  metronomeCustomerId,
+  metronomeContractId,
+  userSId,
+  awuCapCredits,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string | null;
+  userSId: string;
+  awuCapCredits: number;
+}): Promise<"reached" | "resolved" | null> {
+  if (!metronomeContractId) {
+    return null;
+  }
+  const usageResult = await fetchPerUserPoolUsage({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (usageResult.isErr()) {
+    logger.warn(
+      {
+        metronomeCustomerId,
+        userId: userSId,
+        err: usageResult.error,
+      },
+      "[Metronome PerUserCap] Could not fetch current usage; skipping immediate state dispatch"
+    );
+    return null;
+  }
+  const consumed = usageResult.value.get(userSId) ?? 0;
+  return consumed >= awuCapCredits ? "reached" : "resolved";
+}
+
+export async function setUserSpendLimit(
+  auth: Authenticator,
+  {
+    userId,
+    limit,
+  }: {
+    userId: string;
+    limit: UserSpendLimit;
+  }
+): Promise<Result<SetUserSpendLimitResponse, UserSpendLimitError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return new Err(
+      new UserSpendLimitError(
+        "workspace_not_metronome_billed",
+        "Workspace is not on Metronome billing."
+      )
+    );
+  }
+
+  const user = await getUserForWorkspace(auth, { userId });
+  if (!user) {
+    return new Err(
+      new UserSpendLimitError(
+        "user_not_found",
+        "Could not find the user in this workspace."
+      )
+    );
+  }
+
+  const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+  if (!workspaceResource) {
+    return new Err(
+      new UserSpendLimitError(
+        "user_not_found",
+        "Could not load workspace resource."
+      )
+    );
+  }
+
+  let transitionedTo: "reached" | "resolved" | null;
+
+  switch (limit.kind) {
+    case "unlimited": {
+      const clearResult = await clearMetronomePerUserCapAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceSId: workspace.sId,
+        userSId: user.sId,
+      });
+      if (clearResult.isErr()) {
+        return new Err(
+          new UserSpendLimitError("metronome_error", clearResult.error.message)
+        );
+      }
+      await dispatchPerUserCapResolved({
+        workspace: workspaceResource,
+        userId: user.sId,
+      });
+      transitionedTo = "resolved";
+      break;
+    }
+    case "limited": {
+      const syncResult = await syncMetronomePerUserCapAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceSId: workspace.sId,
+        userSId: user.sId,
+        awuCredits: limit.awuCredits,
+      });
+      if (syncResult.isErr()) {
+        return new Err(
+          new UserSpendLimitError("metronome_error", syncResult.error.message)
+        );
+      }
+      transitionedTo = await resolveLocalCapState({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
+        userSId: user.sId,
+        awuCapCredits: limit.awuCredits,
+      });
+      if (transitionedTo === "reached") {
+        await dispatchPerUserCapReached({
+          workspace: workspaceResource,
+          userId: user.sId,
+        });
+      } else if (transitionedTo === "resolved") {
+        await dispatchPerUserCapResolved({
+          workspace: workspaceResource,
+          userId: user.sId,
+        });
+      }
+      // transitionedTo === null: usage unavailable — let webhook reconcile.
+      break;
+    }
+    default:
+      assertNever(limit);
+  }
+
+  void emitAuditLogEvent({
+    auth,
+    action: "member.spend_limit_updated",
+    targets: [
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() ?? "unknown",
+      }),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      kind: limit.kind,
+      awu_credits:
+        limit.kind === "limited" ? String(limit.awuCredits) : "unlimited",
+    },
+  });
+
+  return new Ok({ limit, transitionedTo });
+}

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -14,7 +14,7 @@ import {
   getMetronomePerUserCap,
   syncMetronomePerUserCapAlert,
 } from "@app/lib/metronome/per_user_alerts";
-import { fetchPerUserPoolUsage } from "@app/lib/metronome/per_user_usage";
+import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -119,7 +119,7 @@ async function resolveLocalCapState({
   if (!metronomeContractId) {
     return null;
   }
-  const usageResult = await fetchPerUserPoolUsage({
+  const usageResult = await fetchPerUserAwuUsage({
     metronomeCustomerId,
     metronomeContractId,
   });

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -1,13 +1,13 @@
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
-  getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import {
   dispatchPerUserCapReached,
   dispatchPerUserCapResolved,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { getUserForWorkspace } from "@app/lib/api/user";
+import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomePerUserCapAlert,
@@ -143,9 +143,11 @@ export async function setUserSpendLimit(
   {
     userId,
     limit,
+    auditContext,
   }: {
     userId: string;
     limit: UserSpendLimit;
+    auditContext: AuditLogContext;
   }
 ): Promise<Result<SetUserSpendLimitResponse, UserSpendLimitError>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -192,10 +194,21 @@ export async function setUserSpendLimit(
           new UserSpendLimitError("metronome_error", clearResult.error.message)
         );
       }
-      await dispatchPerUserCapResolved({
-        workspace: workspaceResource,
-        userId: user.sId,
-      });
+      try {
+        await dispatchPerUserCapResolved({
+          workspace: workspaceResource,
+          userId: user.sId,
+        });
+      } catch (error) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            userId: user.sId,
+            err: error,
+          },
+          "[Metronome PerUserCap] dispatchPerUserCapResolved failed after spend-limit update; continuing"
+        );
+      }
       transitionedTo = "resolved";
       break;
     }
@@ -217,16 +230,28 @@ export async function setUserSpendLimit(
         userSId: user.sId,
         awuCapCredits: limit.awuCredits,
       });
-      if (transitionedTo === "reached") {
-        await dispatchPerUserCapReached({
-          workspace: workspaceResource,
-          userId: user.sId,
-        });
-      } else if (transitionedTo === "resolved") {
-        await dispatchPerUserCapResolved({
-          workspace: workspaceResource,
-          userId: user.sId,
-        });
+      try {
+        if (transitionedTo === "reached") {
+          await dispatchPerUserCapReached({
+            workspace: workspaceResource,
+            userId: user.sId,
+          });
+        } else if (transitionedTo === "resolved") {
+          await dispatchPerUserCapResolved({
+            workspace: workspaceResource,
+            userId: user.sId,
+          });
+        }
+      } catch (error) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            userId: user.sId,
+            transitionedTo,
+            err: error,
+          },
+          "[Metronome PerUserCap] dispatch after spend-limit update failed; continuing"
+        );
       }
       // transitionedTo === null: usage unavailable — let webhook reconcile.
       break;
@@ -245,7 +270,7 @@ export async function setUserSpendLimit(
         name: user.fullName() ?? "unknown",
       }),
     ],
-    context: getAuditLogContext(auth),
+    context: auditContext,
     metadata: {
       kind: limit.kind,
       awu_credits:

--- a/front/lib/metronome/per_user_alerts.ts
+++ b/front/lib/metronome/per_user_alerts.ts
@@ -1,0 +1,229 @@
+import { getMetronomeClient } from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+const USER_ID_GROUP_KEY = "user_id";
+
+function perUserAlertUniquenessKeyPrefix(workspaceSId: string): string {
+  return `per-user-cap-${workspaceSId}-`;
+}
+
+function perUserAlertUniquenessKey(
+  workspaceSId: string,
+  userSId: string
+): string {
+  return `${perUserAlertUniquenessKeyPrefix(workspaceSId)}${userSId}`;
+}
+
+async function findExistingPerUserAlert({
+  metronomeCustomerId,
+  workspaceSId,
+  userSId,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+  userSId: string;
+}): Promise<Result<{ id: string; threshold: number } | null, Error>> {
+  const target = perUserAlertUniquenessKey(workspaceSId, userSId);
+  try {
+    const client = getMetronomeClient();
+    for await (const entry of client.v1.customers.alerts.list({
+      customer_id: metronomeCustomerId,
+      alert_statuses: ["ENABLED", "DISABLED"],
+    })) {
+      if (entry.alert.uniqueness_key === target) {
+        return new Ok({
+          id: entry.alert.id,
+          threshold: entry.alert.threshold,
+        });
+      }
+    }
+    return new Ok(null);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Look up the current per-user cap (if any) for a workspace/user pair by
+ * matching `uniqueness_key`. Returns the alert id and threshold, or
+ * `null` if no cap is configured.
+ */
+export async function getMetronomePerUserCap({
+  metronomeCustomerId,
+  workspaceSId,
+  userSId,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+  userSId: string;
+}): Promise<Result<{ alertId: string; threshold: number } | null, Error>> {
+  const findResult = await findExistingPerUserAlert({
+    metronomeCustomerId,
+    workspaceSId,
+    userSId,
+  });
+  if (findResult.isErr()) {
+    return new Err(findResult.error);
+  }
+  const existing = findResult.value;
+  if (!existing) {
+    return new Ok(null);
+  }
+  return new Ok({ alertId: existing.id, threshold: existing.threshold });
+}
+
+/**
+ * List per-user cap thresholds for a workspace. Returns a `Map<userSId,
+ * threshold>` built from all enabled/disabled alerts whose
+ * `uniqueness_key` matches the per-user cap pattern for this workspace.
+ */
+export async function listMetronomePerUserCapsForWorkspace({
+  metronomeCustomerId,
+  workspaceSId,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+}): Promise<Result<Map<string, number>, Error>> {
+  const prefix = perUserAlertUniquenessKeyPrefix(workspaceSId);
+  const caps = new Map<string, number>();
+  try {
+    const client = getMetronomeClient();
+    for await (const entry of client.v1.customers.alerts.list({
+      customer_id: metronomeCustomerId,
+      alert_statuses: ["ENABLED", "DISABLED"],
+    })) {
+      const key = entry.alert.uniqueness_key;
+      if (!key || !key.startsWith(prefix)) {
+        continue;
+      }
+      const userSId = key.slice(prefix.length);
+      if (!userSId) {
+        continue;
+      }
+      caps.set(userSId, entry.alert.threshold);
+    }
+    return new Ok(caps);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Idempotently ensure a Metronome `spend_threshold_reached` alert exists on
+ * the customer for this user, with the given AWU threshold. If an alert
+ * with a different threshold already exists, it's archived (with key
+ * release) and recreated.
+ */
+export async function syncMetronomePerUserCapAlert({
+  metronomeCustomerId,
+  workspaceSId,
+  userSId,
+  awuCredits,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+  userSId: string;
+  awuCredits: number;
+}): Promise<Result<{ alertId: string }, Error>> {
+  const findResult = await findExistingPerUserAlert({
+    metronomeCustomerId,
+    workspaceSId,
+    userSId,
+  });
+  if (findResult.isErr()) {
+    return new Err(findResult.error);
+  }
+  const existing = findResult.value;
+
+  if (existing && existing.threshold === awuCredits) {
+    return new Ok({ alertId: existing.id });
+  }
+
+  const client = getMetronomeClient();
+  if (existing) {
+    try {
+      await client.v1.alerts.archive({
+        id: existing.id,
+        release_uniqueness_key: true,
+      });
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  try {
+    const created = await client.v1.alerts.create({
+      alert_type: "spend_threshold_reached",
+      name: `Per-user cap (${userSId})`,
+      threshold: awuCredits,
+      credit_type_id: getCreditTypeAwuId(),
+      customer_id: metronomeCustomerId,
+      group_values: [{ key: USER_ID_GROUP_KEY, value: userSId }],
+      uniqueness_key: perUserAlertUniquenessKey(workspaceSId, userSId),
+    });
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        userId: userSId,
+        metronomeCustomerId,
+        alertId: created.data.id,
+        awuCredits,
+      },
+      "[Metronome PerUserCap] Synced per-user cap alert"
+    );
+    return new Ok({ alertId: created.data.id });
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Archive the per-user cap alert for this workspace/user pair, if any.
+ * Idempotent — no-op when no matching alert exists.
+ */
+export async function clearMetronomePerUserCapAlert({
+  metronomeCustomerId,
+  workspaceSId,
+  userSId,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+  userSId: string;
+}): Promise<Result<void, Error>> {
+  const findResult = await findExistingPerUserAlert({
+    metronomeCustomerId,
+    workspaceSId,
+    userSId,
+  });
+  if (findResult.isErr()) {
+    return new Err(findResult.error);
+  }
+  const existing = findResult.value;
+  if (!existing) {
+    return new Ok(undefined);
+  }
+
+  try {
+    const client = getMetronomeClient();
+    await client.v1.alerts.archive({
+      id: existing.id,
+      release_uniqueness_key: true,
+    });
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        userId: userSId,
+        metronomeCustomerId,
+        alertId: existing.id,
+      },
+      "[Metronome PerUserCap] Cleared per-user cap alert"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -9,17 +9,23 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 /**
- * Fetch per-user pool consumption for the current billing period.
+ * Fetch per-user AWU consumption for the current billing period.
  *
  * Returns a `Map<userSId, awuCreditsConsumed>` covering only events tagged
- * `usage_type === "user"` (i.e. workspace pool consumption — not
- * programmatic). Period is derived from the customer's current draft
- * invoice for the given contract.
+ * `usage_type === "user"` (i.e. attributed to a human user, regardless of
+ * whether the spend is seat-covered or overflowing into the workspace
+ * pool — programmatic usage is excluded). This matches the metric the
+ * per-user Metronome alert is configured against, so it's the value to
+ * compare a per-user spend cap against. To derive workspace-pool overflow
+ * specifically, subtract each user's seat allocation; see
+ * `buildSeatDataByUserId` in `lib/metronome/seats.ts`.
  *
- * Empty map (Ok) when there is no current draft invoice — the user
- * legitimately has no period yet. Err only when a Metronome call fails.
+ * Period is derived from the customer's current draft invoice for the
+ * given contract. Empty map (Ok) when there is no current draft invoice —
+ * the user legitimately has no period yet. Err only when a Metronome call
+ * fails.
  */
-export async function fetchPerUserPoolUsage({
+export async function fetchPerUserAwuUsage({
   metronomeCustomerId,
   metronomeContractId,
 }: {

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -8,23 +8,6 @@ import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-/**
- * Fetch per-user AWU consumption for the current billing period.
- *
- * Returns a `Map<userSId, awuCreditsConsumed>` covering only events tagged
- * `usage_type === "user"` (i.e. attributed to a human user, regardless of
- * whether the spend is seat-covered or overflowing into the workspace
- * pool — programmatic usage is excluded). This matches the metric the
- * per-user Metronome alert is configured against, so it's the value to
- * compare a per-user spend cap against. To derive workspace-pool overflow
- * specifically, subtract each user's seat allocation; see
- * `buildSeatDataByUserId` in `lib/metronome/seats.ts`.
- *
- * Period is derived from the customer's current draft invoice for the
- * given contract. Empty map (Ok) when there is no current draft invoice —
- * the user legitimately has no period yet. Err only when a Metronome call
- * fails.
- */
 export async function fetchPerUserAwuUsage({
   metronomeCustomerId,
   metronomeContractId,

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -1,0 +1,82 @@
+import {
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
+  listMetronomeDraftInvoices,
+  listMetronomeUsageWithGroups,
+} from "@app/lib/metronome/client";
+import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Fetch per-user pool consumption for the current billing period.
+ *
+ * Returns a `Map<userSId, awuCreditsConsumed>` covering only events tagged
+ * `usage_type === "user"` (i.e. workspace pool consumption — not
+ * programmatic). Period is derived from the customer's current draft
+ * invoice for the given contract.
+ *
+ * Empty map (Ok) when there is no current draft invoice — the user
+ * legitimately has no period yet. Err only when a Metronome call fails.
+ */
+export async function fetchPerUserPoolUsage({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<Result<Map<string, number>, Error>> {
+  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
+  if (invoicesResult.isErr()) {
+    return new Err(invoicesResult.error);
+  }
+
+  const now = Date.now();
+  const currentInvoice = invoicesResult.value.find((inv) => {
+    if (inv.contract_id !== metronomeContractId) {
+      return false;
+    }
+    if (!inv.start_timestamp || !inv.end_timestamp) {
+      return false;
+    }
+    const startMs = new Date(inv.start_timestamp).getTime();
+    const endMs = new Date(inv.end_timestamp).getTime();
+    return startMs <= now && now < endMs;
+  });
+
+  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+    return new Ok(new Map());
+  }
+
+  const startingOn = floorToMidnightUTC(
+    new Date(currentInvoice.start_timestamp)
+  ).toISOString();
+  const endingBefore = ceilToMidnightUTC(
+    new Date(currentInvoice.end_timestamp)
+  ).toISOString();
+
+  const usageResult = await listMetronomeUsageWithGroups({
+    customerId: metronomeCustomerId,
+    billableMetricId: getMetricLlmProviderCostAwuId(),
+    startingOn,
+    endingBefore,
+    windowSize: "NONE",
+    groupKey: ["user_id", "usage_type"],
+  });
+
+  if (usageResult.isErr()) {
+    return new Err(usageResult.error);
+  }
+
+  const perUser = new Map<string, number>();
+  for (const entry of usageResult.value) {
+    const userId = entry.group?.["user_id"];
+    const usageType = entry.group?.["usage_type"];
+    if (!userId || usageType !== "user" || entry.value === null) {
+      continue;
+    }
+    const existing = perUser.get(userId) ?? 0;
+    perUser.set(userId, existing + entry.value);
+  }
+  return new Ok(perUser);
+}

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -18,6 +18,24 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 import { mutate } from "swr";
+import { z } from "zod";
+
+const SpendLimitResponseSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("unlimited") }),
+  z.object({
+    kind: z.literal("limited"),
+    awuCredits: z.number(),
+  }),
+]);
+
+const PytUserSpendLimitResponseSchema = z.object({
+  limit: SpendLimitResponseSchema,
+  transitionedTo: z.union([
+    z.literal("reached"),
+    z.literal("resolved"),
+    z.null(),
+  ]),
+});
 
 type PaginationParams = {
   orderColumn: "createdAt";
@@ -344,7 +362,7 @@ export function useUpdateUserSpendLimit({
         return null;
       }
 
-      const body = (await res.json()) as PutUserSpendLimitResponseBody;
+      const body = PytUserSpendLimitResponseSchema.parse(await res.json());
       sendNotification({
         type: "success",
         title: "Spend limit updated",

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -5,6 +5,10 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
+import type {
+  GetUserSpendLimitResponseBody,
+  PutUserSpendLimitResponseBody,
+} from "@app/pages/api/w/[wId]/members/[uId]/spend_limit";
 import type { MembersLookupResponseBody } from "@app/pages/api/w/[wId]/members/lookup";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type { GroupKind } from "@app/types/groups";
@@ -276,4 +280,86 @@ export function useUpdateMemberSeatType({
   );
 
   return { doUpdateSeatType };
+}
+
+function spendLimitUrl(workspaceId: string, memberId: string): string {
+  return `/api/w/${workspaceId}/members/${memberId}/spend_limit`;
+}
+
+export function useUserSpendLimit({
+  workspaceId,
+  memberId,
+  disabled,
+}: {
+  workspaceId: string;
+  memberId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const spendLimitFetcher: Fetcher<GetUserSpendLimitResponseBody> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    spendLimitUrl(workspaceId, memberId),
+    spendLimitFetcher,
+    { disabled }
+  );
+
+  return {
+    spendLimit: data,
+    isSpendLimitLoading: !error && !data && !disabled,
+    isSpendLimitError: !!error,
+    mutateSpendLimit: mutate,
+  };
+}
+
+export function useUpdateUserSpendLimit({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const doUpdateSpendLimit = useCallback(
+    async ({
+      memberId,
+      memberName,
+      limit,
+    }: {
+      memberId: string;
+      memberName: string;
+      limit: { kind: "unlimited" } | { kind: "limited"; awuCredits: number };
+    }): Promise<PutUserSpendLimitResponseBody | null> => {
+      const res = await clientFetch(spendLimitUrl(workspaceId, memberId), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(limit),
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to update spend limit",
+          description: error?.error?.message ?? "An unexpected error occurred.",
+        });
+        return null;
+      }
+
+      const body = (await res.json()) as PutUserSpendLimitResponseBody;
+      sendNotification({
+        type: "success",
+        title: "Spend limit updated",
+        description:
+          limit.kind === "unlimited"
+            ? `${memberName}'s spend limit has been removed.`
+            : `${memberName}'s spend limit has been set to ${limit.awuCredits.toLocaleString("en-US")} credits.`,
+      });
+
+      await mutate(spendLimitUrl(workspaceId, memberId));
+      await mutate(`/api/w/${workspaceId}/credits/members-usage`);
+      return body;
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { doUpdateSpendLimit };
 }

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -28,7 +28,7 @@ const SpendLimitResponseSchema = z.discriminatedUnion("kind", [
   }),
 ]);
 
-const PytUserSpendLimitResponseSchema = z.object({
+const PutUserSpendLimitResponseSchema = z.object({
   limit: SpendLimitResponseSchema,
   transitionedTo: z.union([
     z.literal("reached"),
@@ -362,7 +362,7 @@ export function useUpdateUserSpendLimit({
         return null;
       }
 
-      const body = PytUserSpendLimitResponseSchema.parse(await res.json());
+      const body = PutUserSpendLimitResponseSchema.parse(await res.json());
       sendNotification({
         type: "success",
         title: "Spend limit updated",

--- a/front/pages/api/w/[wId]/credits/members-usage.ts
+++ b/front/pages/api/w/[wId]/credits/members-usage.ts
@@ -3,17 +3,61 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
-import { handleGetMembersUsageRequest } from "@app/lib/api/credits/members_usage";
+import {
+  getMembersUsage,
+  MembersUsagePaginationSchema,
+} from "@app/lib/api/credits/members_usage";
 import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetMembersUsageResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  return handleGetMembersUsageRequest(req, res, auth);
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access the members usage list.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const paginationRes = MembersUsagePaginationSchema.safeParse(req.query);
+      if (!paginationRes.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid pagination parameters: ${fromError(paginationRes.error).toString()}`,
+          },
+        });
+      }
+
+      const body = await getMembersUsage({
+        auth,
+        paginationParams: paginationRes.data,
+        currentUrl: req.url ?? "/",
+      });
+
+      return res.status(200).json(body);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -1,0 +1,353 @@
+import * as creditStateDispatcher from "@app/lib/api/metronome/credit_state_dispatcher";
+import * as perUserAlerts from "@app/lib/metronome/per_user_alerts";
+import * as perUserUsage from "@app/lib/metronome/per_user_usage";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./spend_limit";
+
+vi.mock("@app/lib/metronome/per_user_alerts", async () => {
+  const actual = await vi.importActual<typeof perUserAlerts>(
+    "@app/lib/metronome/per_user_alerts"
+  );
+  return {
+    ...actual,
+    syncMetronomePerUserCapAlert: vi.fn(),
+    clearMetronomePerUserCapAlert: vi.fn(),
+    getMetronomePerUserCap: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/per_user_usage", async () => {
+  const actual = await vi.importActual<typeof perUserUsage>(
+    "@app/lib/metronome/per_user_usage"
+  );
+  return {
+    ...actual,
+    fetchPerUserPoolUsage: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/metronome/credit_state_dispatcher", async () => {
+  const actual = await vi.importActual<typeof creditStateDispatcher>(
+    "@app/lib/api/metronome/credit_state_dispatcher"
+  );
+  return {
+    ...actual,
+    dispatchPerUserCapReached: vi.fn(),
+    dispatchPerUserCapResolved: vi.fn(),
+  };
+});
+
+const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const TEST_ALERT_ID = "alert_test_xxx";
+
+async function makeMetronomeWorkspaceWithCustomer(): Promise<WorkspaceType> {
+  const workspace = await WorkspaceFactory.metronome();
+  await WorkspaceModel.update(
+    { metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID },
+    { where: { sId: workspace.sId } }
+  );
+  return workspace;
+}
+
+beforeEach(() => {
+  vi.mocked(perUserAlerts.syncMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok({ alertId: TEST_ALERT_ID })
+  );
+  vi.mocked(perUserAlerts.clearMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
+    new Ok(null)
+  );
+  vi.mocked(perUserUsage.fetchPerUserPoolUsage).mockResolvedValue(
+    new Ok(new Map())
+  );
+  vi.mocked(creditStateDispatcher.dispatchPerUserCapReached).mockResolvedValue(
+    undefined
+  );
+  vi.mocked(creditStateDispatcher.dispatchPerUserCapResolved).mockResolvedValue(
+    undefined
+  );
+});
+
+describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
+  describe("auth", () => {
+    it("returns 403 when caller is not an admin", async () => {
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+      req.query.uId = user.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData().error.type).toBe("workspace_auth_error");
+    });
+
+    it("returns 403 when workspace is not on Metronome billing", async () => {
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+      req.query.uId = user.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData().error.type).toBe("plan_limit_error");
+    });
+  });
+
+  describe("method validation", () => {
+    it("returns 405 for unsupported methods", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+    });
+  });
+
+  describe("input validation", () => {
+    it("returns 400 when uId is missing", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    });
+
+    it("returns 404 when uId does not exist", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = "nonexistent-user-id";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData().error.type).toBe("workspace_user_not_found");
+    });
+
+    it("returns 400 on PUT with negative awuCredits", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+      req.body = { kind: "limited", awuCredits: -1 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    });
+
+    it("returns 400 on PUT with non-integer awuCredits", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+      req.body = { kind: "limited", awuCredits: 1.5 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+    });
+
+    it("returns 400 on PUT with awuCredits above max", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+      req.body = { kind: "limited", awuCredits: 100_000_000 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+    });
+  });
+
+  describe("GET", () => {
+    it("returns unlimited when no per-user alert exists", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({ kind: "unlimited" });
+    });
+
+    it("returns limited with threshold when alert exists", async () => {
+      vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValueOnce(
+        new Ok({
+          alertId: TEST_ALERT_ID,
+          threshold: 2500,
+        })
+      );
+
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({ kind: "limited", awuCredits: 2500 });
+    });
+  });
+
+  describe("PUT", () => {
+    it("clears alert + dispatches resolved for unlimited", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = targetUser.sId;
+      req.body = { kind: "unlimited" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({
+        limit: { kind: "unlimited" },
+        transitionedTo: "resolved",
+      });
+      expect(perUserAlerts.clearMetronomePerUserCapAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+          workspaceSId: workspace.sId,
+          userSId: targetUser.sId,
+        })
+      );
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: targetUser.sId })
+      );
+      expect(perUserAlerts.syncMetronomePerUserCapAlert).not.toHaveBeenCalled();
+    });
+
+    it("syncs alert + dispatches resolved when usage is below cap", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      vi.mocked(perUserUsage.fetchPerUserPoolUsage).mockResolvedValueOnce(
+        new Ok(new Map([[targetUser.sId, 500]]))
+      );
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = targetUser.sId;
+      req.body = { kind: "limited", awuCredits: 1500 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({
+        limit: { kind: "limited", awuCredits: 1500 },
+        transitionedTo: "resolved",
+      });
+      expect(perUserAlerts.syncMetronomePerUserCapAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+          workspaceSId: workspace.sId,
+          userSId: targetUser.sId,
+          awuCredits: 1500,
+        })
+      );
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).toHaveBeenCalled();
+      expect(
+        creditStateDispatcher.dispatchPerUserCapReached
+      ).not.toHaveBeenCalled();
+    });
+
+    it("dispatches reached when usage is at/above cap", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      vi.mocked(perUserUsage.fetchPerUserPoolUsage).mockResolvedValueOnce(
+        new Ok(new Map([[targetUser.sId, 2000]]))
+      );
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = targetUser.sId;
+      req.body = { kind: "limited", awuCredits: 1500 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData().transitionedTo).toBe("reached");
+      expect(
+        creditStateDispatcher.dispatchPerUserCapReached
+      ).toHaveBeenCalled();
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -1,7 +1,6 @@
 import * as creditStateDispatcher from "@app/lib/api/metronome/credit_state_dispatcher";
 import * as perUserAlerts from "@app/lib/metronome/per_user_alerts";
 import * as perUserUsage from "@app/lib/metronome/per_user_usage";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -49,12 +48,9 @@ const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
 const TEST_ALERT_ID = "alert_test_xxx";
 
 async function makeMetronomeWorkspaceWithCustomer(): Promise<WorkspaceType> {
-  const workspace = await WorkspaceFactory.metronome();
-  await WorkspaceModel.update(
-    { metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID },
-    { where: { sId: workspace.sId } }
-  );
-  return workspace;
+  return WorkspaceFactory.metronome({
+    metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+  });
 }
 
 beforeEach(() => {

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -29,7 +29,7 @@ vi.mock("@app/lib/metronome/per_user_usage", async () => {
   );
   return {
     ...actual,
-    fetchPerUserPoolUsage: vi.fn(),
+    fetchPerUserAwuUsage: vi.fn(),
   };
 });
 
@@ -63,7 +63,7 @@ beforeEach(() => {
   vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
     new Ok(null)
   );
-  vi.mocked(perUserUsage.fetchPerUserPoolUsage).mockResolvedValue(
+  vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValue(
     new Ok(new Map())
   );
   vi.mocked(creditStateDispatcher.dispatchPerUserCapReached).mockResolvedValue(
@@ -280,7 +280,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         role: "user",
       });
 
-      vi.mocked(perUserUsage.fetchPerUserPoolUsage).mockResolvedValueOnce(
+      vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValueOnce(
         new Ok(new Map([[targetUser.sId, 500]]))
       );
 
@@ -322,7 +322,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         role: "user",
       });
 
-      vi.mocked(perUserUsage.fetchPerUserPoolUsage).mockResolvedValueOnce(
+      vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValueOnce(
         new Ok(new Map([[targetUser.sId, 2000]]))
       );
 

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.ts
@@ -1,0 +1,157 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  type GetUserSpendLimitResponse,
+  getUserSpendLimit,
+  MAX_USER_SPEND_LIMIT_AWU_CREDITS,
+  MIN_USER_SPEND_LIMIT_AWU_CREDITS,
+  type SetUserSpendLimitResponse,
+  setUserSpendLimit,
+  type UserSpendLimitError,
+} from "@app/lib/api/users/spend_limit";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("unlimited") }),
+  z.object({
+    kind: z.literal("limited"),
+    awuCredits: z
+      .number()
+      .int()
+      .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
+      .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
+  }),
+]);
+
+export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
+
+export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
+
+function mapErrorToHttp(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  error: UserSpendLimitError
+): void {
+  switch (error.type) {
+    case "user_not_found":
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_user_not_found",
+          message: error.message,
+        },
+      });
+    case "workspace_not_metronome_billed":
+      return apiError(req, res, {
+        status_code: 403,
+        api_error: {
+          type: "plan_limit_error",
+          message: error.message,
+        },
+      });
+    case "metronome_error":
+      return apiError(req, res, {
+        status_code: 502,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to update spend limit in billing system.",
+        },
+      });
+    default:
+      assertNever(error.type);
+  }
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      GetUserSpendLimitResponseBody | PutUserSpendLimitResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can manage member spend limits.",
+      },
+    });
+  }
+
+  if (!auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "plan_limit_error",
+        message:
+          "Per-user spend limits are only available on Metronome-billed workspaces.",
+      },
+    });
+  }
+
+  const { uId } = req.query;
+  if (!isString(uId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `uId` (string) is required.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const result = await getUserSpendLimit(auth, { userId: uId });
+      if (result.isErr()) {
+        return mapErrorToHttp(req, res, result.error);
+      }
+      return res.status(200).json(result.value);
+    }
+
+    case "PUT": {
+      const bodyValidation = UpdateUserSpendLimitBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
+          },
+        });
+      }
+
+      const result = await setUserSpendLimit(auth, {
+        userId: uId,
+        limit: bodyValidation.data,
+      });
+      if (result.isErr()) {
+        return mapErrorToHttp(req, res, result.error);
+      }
+      return res.status(200).json(result.value);
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or PUT is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.ts
@@ -1,4 +1,6 @@
 /** @ignoreswagger */
+
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   type GetUserSpendLimitResponse,
@@ -121,6 +123,7 @@ async function handler(
     }
 
     case "PUT": {
+      const auditContext = getAuditLogContext(auth, req);
       const bodyValidation = UpdateUserSpendLimitBodySchema.safeParse(req.body);
       if (!bodyValidation.success) {
         return apiError(req, res, {
@@ -135,6 +138,7 @@ async function handler(
       const result = await setUserSpendLimit(auth, {
         userId: uId,
         limit: bodyValidation.data,
+        auditContext,
       });
       if (result.isErr()) {
         return mapErrorToHttp(req, res, result.error);

--- a/front/tests/utils/MembershipFactory.ts
+++ b/front/tests/utils/MembershipFactory.ts
@@ -3,6 +3,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import type {
   MembershipOriginType,
   MembershipRoleType,
+  MembershipSeatType,
 } from "@app/types/memberships";
 import type { WorkspaceType } from "@app/types/user";
 import type { Transaction } from "sequelize";
@@ -14,9 +15,11 @@ export class MembershipFactory {
     {
       role,
       origin = "invited",
+      seatType,
     }: {
       role: MembershipRoleType;
       origin?: MembershipOriginType;
+      seatType?: MembershipSeatType;
     },
     t?: Transaction
   ) {
@@ -25,6 +28,7 @@ export class MembershipFactory {
       user,
       role,
       origin,
+      seatType,
       transaction: t,
     });
   }

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -16,6 +16,7 @@ import { expect } from "vitest";
 
 interface WorkspaceOverrides {
   whiteListedProviders?: ModelProviderIdType[] | null;
+  metronomeCustomerId?: string | null;
 }
 
 export class WorkspaceFactory {
@@ -53,6 +54,7 @@ export class WorkspaceFactory {
       name: faker.company.name(),
       description: workspaceDescription,
       workOSOrganizationId: faker.string.alpha(10),
+      metronomeCustomerId: overrides?.metronomeCustomerId ?? null,
       ...(overrides?.whiteListedProviders !== undefined && {
         whiteListedProviders: overrides.whiteListedProviders,
       }),


### PR DESCRIPTION
## Description

* Adds an admin-side modal on the Usage page to set a per-user AWU spend cap. Creates a scoped Metronome spend_threshold_reached alert per user so the existing webhook path keeps the credit state in sync, and dispatches the immediate user-credit-state transition by comparing current pool consumption to the new cap locally (Metronome alert evaluation can sit in EVALUATING for minutes, so we don't depend on it).
* Also includes a small copy fix in ReachedLimitPopup

## Tests

Local

## Risk

Low

## Deploy Plan

front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25884">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->