### PR TITLE
Pass inviteToken in returnTo param when SSO login is forced

### DIFF
--- a/front/lib/api/login.ts
+++ b/front/lib/api/login.ts
@@ -244,9 +244,13 @@ export async function performLogin(
         await user.unsafeDelete();
       }
 
+      const returnToAfterSSO = inviteToken
+        ? `/api/login?inviteToken=${encodeURIComponent(inviteToken)}&wId=${encodeURIComponent(error.workspaceId)}`
+        : null;
+
       const ssoLoginUrl = await makeEnterpriseConnectionInitiateLoginUrl(
         error.workspaceId,
-        null
+        returnToAfterSSO
       );
 
       logger.error(


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/8202

When SSO is enforced, the user receiving a invite are redirected to their SSO to login, but when coming back they no longer have the invite token.
This pass the invite token into the return link of the SSO login attempt.

## Tests

not tested

## Risk

?

## Deploy Plan

deploy front


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25885">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->