### PR TITLE
Handle error and taxes in credits purchase

### DIFF
--- a/front-api/routes/metronome/webhook.ts
+++ b/front-api/routes/metronome/webhook.ts
@@ -9,6 +9,10 @@ import {
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import {
+  markAwuPurchaseAttemptFailed,
+  markAwuPurchaseAttemptSucceeded,
+} from "@app/lib/credits/awu_purchase_status";
+import {
   calculateFreeCreditAmountMicroUsd,
   countEligibleUsersForFreeCredits,
   grantFreeCreditFromMetronomeSegment,
@@ -315,6 +319,14 @@ app.post("/", async (ctx): HandlerResult<ResponseBody> => {
           { customerId, contractId, invoiceId, paymentStatus },
           "[Metronome Webhook] Payment-gated commit paid"
         );
+        // Resolve the AWU purchase attempt the UI is polling for. The
+        // store ignores the call if no attempt is pending on this
+        // contract (e.g. a non-AWU payment-gated commit).
+        await markAwuPurchaseAttemptSucceeded({
+          workspaceId: workspace.sId,
+          contractId,
+          invoiceId,
+        });
       } else {
         logger.warn(
           {
@@ -326,6 +338,12 @@ app.post("/", async (ctx): HandlerResult<ResponseBody> => {
           },
           "[Metronome Webhook] Payment-gated commit payment failed"
         );
+        await markAwuPurchaseAttemptFailed({
+          workspaceId: workspace.sId,
+          contractId,
+          errorMessage: errorMessage ?? "Payment failed",
+          invoiceId: invoiceId || undefined,
+        });
       }
       break;
     }

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -9,6 +9,7 @@ import {
   awuCreditsToCurrency,
   currencyToAwuCredits,
 } from "@app/lib/metronome/amounts";
+import { useAwuPurchaseStatus } from "@app/lib/swr/credits";
 import { CURRENCY_SYMBOLS } from "@app/types/currency";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
@@ -31,7 +32,7 @@ import {
   TabsTrigger,
   XCircleIcon,
 } from "@dust-tt/sparkle";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 type PurchaseState = "idle" | "processing" | "success" | "error";
 type TopUpTab = "one-time" | "automatic";
@@ -112,13 +113,53 @@ export function BuyAwuCreditsDialog({
   const [selectedTab, setSelectedTab] = useState<TopUpTab>("one-time");
   const [purchaseState, setPurchaseState] = useState<PurchaseState>("idle");
   const [errorMessage, setErrorMessage] = useState<string>("");
+  // Ignore polled attempts older than the one we just started, so a cached
+  // "succeeded" entry from a previous purchase can't flash through.
+  const [purchaseStartedAtMs, setPurchaseStartedAtMs] = useState<number | null>(
+    null
+  );
   const { purchaseAwuCredits } = useAwuPurchase({ workspaceId });
+
+  // Poll the payment-gated commit status only while waiting on the webhook
+  // outcome. The Metronome -> Stripe payment is async, so the dialog can't
+  // know success/failure from the POST response alone.
+  const { attempt, mutateAwuPurchaseStatus } = useAwuPurchaseStatus({
+    workspaceId,
+    disabled: !isOpen || purchaseState !== "processing",
+  });
+
+  useEffect(() => {
+    if (purchaseState !== "processing" || !attempt) {
+      return;
+    }
+    if (
+      purchaseStartedAtMs !== null &&
+      attempt.createdAtMs < purchaseStartedAtMs
+    ) {
+      return;
+    }
+    switch (attempt.status) {
+      case "succeeded":
+        setPurchaseState("success");
+        onPurchaseSuccess?.();
+        break;
+      case "failed":
+        setErrorMessage(attempt.errorMessage ?? "Payment failed.");
+        setPurchaseState("error");
+        break;
+      case "pending":
+        break;
+      default:
+        assertNeverAndIgnore(attempt.status);
+    }
+  }, [attempt, purchaseState, purchaseStartedAtMs, onPurchaseSuccess]);
 
   const resetModalStateAndClose = useCallback(() => {
     setAmountInput("");
     setSelectedTab("one-time");
     setPurchaseState("idle");
     setErrorMessage("");
+    setPurchaseStartedAtMs(null);
     onClose();
   }, [onClose]);
 
@@ -164,13 +205,17 @@ export function BuyAwuCreditsDialog({
   const canPurchase = isValidAmount && !amountExceedsMax;
 
   const handlePurchase = async () => {
+    setPurchaseStartedAtMs(Date.now());
     setPurchaseState("processing");
     const amountCredits = Math.round(addedCredits);
     const result = await purchaseAwuCredits(amountCredits);
     switch (result.status) {
       case "success":
-        setPurchaseState("success");
-        onPurchaseSuccess?.();
+        // The Metronome commit is created but payment is still being
+        // attempted asynchronously. Stay in "processing" and let the
+        // status poll flip us to success or error based on the
+        // payment_gate.payment_status webhook outcome.
+        void mutateAwuPurchaseStatus();
         break;
       case "error":
         setErrorMessage(result.message);
@@ -188,7 +233,10 @@ export function BuyAwuCreditsDialog({
           <div className="flex flex-col items-center justify-center gap-4 py-8">
             <Spinner size="lg" />
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Processing purchase...
+              Processing payment...
+            </p>
+            <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              This may take a few seconds.
             </p>
           </div>
         );

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -57,6 +57,7 @@ export type RedisUsageTagsType =
   | "metronome_credit_cache"
   | "metronome_limit"
   | "metronome_webhook_dedup"
+  | "awu_purchase_status"
   | "message_events"
   | "notion_url_sync"
   | "poke_cache_invalidation"

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -1,6 +1,10 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getBillingCycle } from "@app/lib/client/subscription";
 import {
+  recordAwuPurchaseAttemptSyncFailure,
+  setAwuPurchaseAttemptPending,
+} from "@app/lib/credits/awu_purchase_status";
+import {
   AWU_PRICE_PER_CREDIT,
   metronomeAmount,
 } from "@app/lib/metronome/amounts";
@@ -279,6 +283,18 @@ export async function purchaseAwuCredits(
   const oneYearFromNow = new Date(now);
   oneYearFromNow.setUTCFullYear(oneYearFromNow.getUTCFullYear() + 1);
 
+  const uniquenessKey = `awuPurchase-${workspace.sId}-${now.getTime()}`;
+
+  // Record the attempt as pending BEFORE calling Metronome so the
+  // `payment_gate.payment_status` webhook can update it on arrival —
+  // the webhook can race ahead of this function returning.
+  await setAwuPurchaseAttemptPending({
+    workspaceId: workspace.sId,
+    contractId: metronomeContractId,
+    uniquenessKey,
+    amountCredits,
+  });
+
   const editResult = await addPaymentGatedCommitToContract({
     metronomeCustomerId,
     metronomeContractId,
@@ -293,7 +309,7 @@ export async function purchaseAwuCredits(
     invoiceTimestamp: now,
     priority: AWU_PRIORITY_PURCHASED_COMMIT,
     name: `Credit top-up: ${amountCredits.toLocaleString()} credits`,
-    uniquenessKey: `awuPurchase-${workspace.sId}-${now.getTime()}`,
+    uniquenessKey,
     // Stamped on the Stripe invoice Metronome pushes downstream so the
     // existing eligibility check (`isAwuPurchaseInvoice`) still recognises
     // pending AWU purchases.
@@ -313,6 +329,12 @@ export async function purchaseAwuCredits(
       },
       "[AWU Purchase] Failed to add payment-gated commit"
     );
+    // No webhook will fire for an edit that never landed in Metronome —
+    // flip the attempt to failed so the UI can show the error immediately.
+    await recordAwuPurchaseAttemptSyncFailure({
+      workspaceId: workspace.sId,
+      errorMessage: editResult.error.message,
+    });
     return new Err({
       code: "purchase_failed",
       message: editResult.error.message,

--- a/front/lib/credits/awu_purchase_status.ts
+++ b/front/lib/credits/awu_purchase_status.ts
@@ -1,0 +1,172 @@
+import { runOnRedisCache } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
+
+const REDIS_ORIGIN = "awu_purchase_status";
+
+// Status of the latest AWU purchase attempt for a workspace.
+// "pending" is set when the Metronome payment-gated commit is created;
+// the matching `payment_gate.payment_status` webhook flips it to
+// "succeeded" or "failed".
+export type AwuPurchaseAttemptStatus = "pending" | "succeeded" | "failed";
+
+export type AwuPurchaseAttempt = {
+  status: AwuPurchaseAttemptStatus;
+  uniquenessKey: string;
+  contractId: string;
+  amountCredits: number;
+  createdAtMs: number;
+  invoiceId?: string;
+  errorMessage?: string;
+};
+
+// 1 hour: matches a generous bound on the webhook delivery / UI polling
+// window. The UI polls for ~minutes; this TTL gives us margin for retries
+// and Stripe-side delays without leaving stale entries lying around.
+const TTL_SECONDS = 60 * 60;
+
+function redisKey(workspaceId: string): string {
+  return `awu_purchase_status:${workspaceId}`;
+}
+
+export async function setAwuPurchaseAttemptPending({
+  workspaceId,
+  contractId,
+  uniquenessKey,
+  amountCredits,
+}: {
+  workspaceId: string;
+  contractId: string;
+  uniquenessKey: string;
+  amountCredits: number;
+}): Promise<void> {
+  const attempt: AwuPurchaseAttempt = {
+    status: "pending",
+    uniquenessKey,
+    contractId,
+    amountCredits,
+    createdAtMs: Date.now(),
+  };
+  await runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
+    await cli.set(redisKey(workspaceId), JSON.stringify(attempt), {
+      EX: TTL_SECONDS,
+    });
+  });
+}
+
+export async function getAwuPurchaseAttempt(
+  workspaceId: string
+): Promise<AwuPurchaseAttempt | null> {
+  return runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
+    const raw = await cli.get(redisKey(workspaceId));
+    if (!raw) {
+      return null;
+    }
+    try {
+      return JSON.parse(raw) as AwuPurchaseAttempt;
+    } catch (err) {
+      logger.warn(
+        { workspaceId, raw, err },
+        "[AWU Purchase Status] Failed to parse stored attempt"
+      );
+      return null;
+    }
+  });
+}
+
+// Update the stored attempt for the workspace if (and only if) the
+// contractId matches what we wrote at purchase time. Mismatched contracts
+// could happen on stale webhook deliveries after a contract swap — ignore
+// rather than overwrite.
+async function updateAttemptIfContractMatches(
+  workspaceId: string,
+  contractId: string,
+  apply: (current: AwuPurchaseAttempt) => AwuPurchaseAttempt
+): Promise<AwuPurchaseAttempt | null> {
+  return runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
+    const raw = await cli.get(redisKey(workspaceId));
+    if (!raw) {
+      return null;
+    }
+    let current: AwuPurchaseAttempt;
+    try {
+      current = JSON.parse(raw) as AwuPurchaseAttempt;
+    } catch {
+      return null;
+    }
+    if (current.contractId !== contractId) {
+      return null;
+    }
+    const updated = apply(current);
+    await cli.set(redisKey(workspaceId), JSON.stringify(updated), {
+      EX: TTL_SECONDS,
+    });
+    return updated;
+  });
+}
+
+export async function markAwuPurchaseAttemptSucceeded({
+  workspaceId,
+  contractId,
+  invoiceId,
+}: {
+  workspaceId: string;
+  contractId: string;
+  invoiceId: string;
+}): Promise<AwuPurchaseAttempt | null> {
+  return updateAttemptIfContractMatches(workspaceId, contractId, (current) => ({
+    ...current,
+    status: "succeeded",
+    invoiceId,
+  }));
+}
+
+export async function markAwuPurchaseAttemptFailed({
+  workspaceId,
+  contractId,
+  errorMessage,
+  invoiceId,
+}: {
+  workspaceId: string;
+  contractId: string;
+  errorMessage: string;
+  invoiceId?: string;
+}): Promise<AwuPurchaseAttempt | null> {
+  return updateAttemptIfContractMatches(workspaceId, contractId, (current) => ({
+    ...current,
+    status: "failed",
+    errorMessage: errorMessage,
+    invoiceId: invoiceId ?? current.invoiceId,
+  }));
+}
+
+// Used when the Metronome edit call itself fails synchronously (no webhook
+// will ever fire for this attempt). Unconditional overwrite of the entry
+// we just wrote.
+export async function recordAwuPurchaseAttemptSyncFailure({
+  workspaceId,
+  errorMessage,
+}: {
+  workspaceId: string;
+  errorMessage: string;
+}): Promise<void> {
+  await runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
+    const raw = await cli.get(redisKey(workspaceId));
+    if (!raw) {
+      return;
+    }
+    let current: AwuPurchaseAttempt;
+    try {
+      current = JSON.parse(raw) as AwuPurchaseAttempt;
+    } catch {
+      return;
+    }
+    const updated: AwuPurchaseAttempt = {
+      ...current,
+      status: "failed",
+      errorMessage: errorMessage,
+    };
+    await cli.set(redisKey(workspaceId), JSON.stringify(updated), {
+      EX: TTL_SECONDS,
+    });
+  });
+}

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1309,6 +1309,7 @@ export async function addPaymentGatedCommitToContract({
           },
           payment_gate_config: {
             payment_gate_type: "STRIPE",
+            tax_type: "STRIPE",
             stripe_config: {
               payment_type: "INVOICE",
               invoice_metadata: stripeInvoiceMetadata,

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -81,6 +81,15 @@ export const PLAN_CODE_CUSTOM_FIELD_KEY = "DUST_PLAN_CODE";
 // which can change on redeploy).
 export const SEAT_TYPE_CUSTOM_FIELD_KEY = "DUST_SEAT_TYPE";
 
+// Product-level custom field carrying the Stripe product ID Metronome
+// should reference when invoicing this product. Populated manually in the
+// Metronome UI per product; read by Metronome (via the
+// `invoiceitem.price.product` mapping in the Stripe integration settings)
+// when generating Stripe invoices for payment-gated commits — without it,
+// the payment-gate workflow fails with "Failed to get Stripe product ID
+// for Metronome Product '…'".
+export const STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY = "STRIPE_PRODUCT_ID";
+
 // AWU (Agentic Work Units) differs per environment.
 export const DEV_CREDIT_TYPE_AWU_ID = "eb003cc7-4935-467d-a41c-c1738c1c9dc2";
 export const PROD_CREDIT_TYPE_AWU_ID = "8dfc9846-a38e-44f8-a625-bd9372af681c";

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -4,6 +4,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetCreditPurchaseInfoResponseBody } from "@app/pages/api/w/[wId]/credits/purchase";
 import type { GetAwuPurchaseInfoResponseBody } from "@app/pages/api/w/[wId]/subscriptions/awu-purchase";
+import type { GetAwuPurchaseStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/awu-purchase-status";
 import type {
   GetCreditsResponseBody,
   PendingCreditData,
@@ -259,6 +260,42 @@ export function useAwuPoolSummary({
     isAwuPoolSummaryError: error,
     isAwuPoolSummaryValidating: isValidating,
     mutateAwuPoolSummary: mutate,
+  };
+}
+
+// Polls the latest AWU purchase attempt status for a workspace. The dialog
+// drives `disabled` off its own "processing" state so we only poll while a
+// purchase is in flight.
+export function useAwuPurchaseStatus({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const statusFetcher: Fetcher<GetAwuPurchaseStatusResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/subscriptions/awu-purchase-status`,
+    statusFetcher,
+    {
+      disabled,
+      refreshInterval: (latest) => {
+        if (!latest?.attempt) {
+          return 2000;
+        }
+        return latest.attempt.status === "pending" ? 2000 : 0;
+      },
+    }
+  );
+
+  return {
+    attempt: data?.attempt ?? null,
+    isAwuPurchaseStatusLoading: !error && !data && !disabled,
+    isAwuPurchaseStatusValidating: isValidating,
+    isAwuPurchaseStatusError: error,
+    mutateAwuPurchaseStatus: mutate,
   };
 }
 

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -11,6 +11,10 @@ import {
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
 import {
+  markAwuPurchaseAttemptFailed,
+  markAwuPurchaseAttemptSucceeded,
+} from "@app/lib/credits/awu_purchase_status";
+import {
   calculateFreeCreditAmountMicroUsd,
   countEligibleUsersForFreeCredits,
   grantFreeCreditFromMetronomeSegment,
@@ -377,6 +381,14 @@ async function handler(
                 { customerId, contractId, invoiceId, paymentStatus },
                 "[Metronome Webhook] Payment-gated commit paid"
               );
+              // Resolve the AWU purchase attempt the UI is polling for. The
+              // store ignores the call if no attempt is pending on this
+              // contract (e.g. a non-AWU payment-gated commit).
+              await markAwuPurchaseAttemptSucceeded({
+                workspaceId: workspace.sId,
+                contractId,
+                invoiceId,
+              });
             } else {
               logger.warn(
                 {
@@ -388,6 +400,12 @@ async function handler(
                 },
                 "[Metronome Webhook] Payment-gated commit payment failed"
               );
+              await markAwuPurchaseAttemptFailed({
+                workspaceId: workspace.sId,
+                contractId,
+                errorMessage: errorMessage ?? "Payment failed",
+                invoiceId: invoiceId || undefined,
+              });
             }
             break;
           }

--- a/front/pages/api/w/[wId]/subscriptions/awu-purchase-status.ts
+++ b/front/pages/api/w/[wId]/subscriptions/awu-purchase-status.ts
@@ -1,0 +1,46 @@
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { AwuPurchaseAttempt } from "@app/lib/credits/awu_purchase_status";
+import { getAwuPurchaseAttempt } from "@app/lib/credits/awu_purchase_status";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetAwuPurchaseStatusResponseBody = {
+  attempt: AwuPurchaseAttempt | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetAwuPurchaseStatusResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can check AWU purchase status.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported.",
+      },
+    });
+  }
+
+  const attempt = await getAwuPurchaseAttempt(
+    auth.getNonNullableWorkspace().sId
+  );
+  return res.status(200).json({ attempt });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
@@ -166,6 +166,4 @@ async function handler(
   }
 }
 
-export default withSessionAuthenticationForWorkspace(handler, {
-  doesNotRequireCanUseProduct: true,
-});
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -23,6 +23,7 @@ import {
   PROD_CREDIT_TYPE_AWU_ID,
   PROD_CREDIT_TYPE_PROG_USD_ID,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
+  STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
 import { invalidateProductSeatTypesCache } from "@app/lib/metronome/seat_types";
@@ -2488,6 +2489,12 @@ const CUSTOM_FIELD_KEYS: Array<{
   // entity type returned by `v1.contracts.products.list()` — `product` is a
   // legacy plan-product type and 404s on these IDs.
   { entity: "contract_product", key: SEAT_TYPE_CUSTOM_FIELD_KEY },
+  // Per-product Stripe product ID. Read by Metronome (via the
+  // `invoiceitem.price.product` mapping configured in Metronome's Stripe
+  // integration settings) when generating Stripe invoices for
+  // payment-gated commits. Populated manually in the Metronome UI per
+  // product — this entry only registers the field so the UI exposes it.
+  { entity: "contract_product", key: STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY },
 ];
 
 async function syncCustomFields(): Promise<void> {


### PR DESCRIPTION
## Description

Two fixes around AWU credit purchases:

**1. Surface real payment outcome in the dialog.** Today `purchaseAwuCredits` only creates the Metronome payment-gated commit — the Stripe charge happens asynchronously, with the result reported via the `payment_gate.payment_status` webhook. The dialog was treating the POST response as proof of payment and showing \"Credits purchased successfully!\" even when Stripe later failed (e.g. a Metronome → Stripe product mapping issue).

The dialog now waits for the webhook outcome:

- `purchaseAwuCredits` writes a `pending` attempt to Redis (`awu_purchase_status:{workspaceId}`) before calling Metronome, and flips it to `failed` if the Metronome edit itself errors synchronously.
- The webhook handler updates the same Redis entry to `succeeded` / `failed` on `payment_gate.payment_status` (with the Stripe `error_message`). Update is gated on `contractId` match so unrelated payment-gated commits can't poison the entry.
- New `GET /api/w/[wId]/subscriptions/awu-purchase-status` returns the current attempt.
- `BuyAwuCreditsDialog` stays in a \"Processing payment…\" state after the POST and polls the status endpoint (via the new `useAwuPurchaseStatus` SWR hook) every 2s. Once resolved, it flips to success or to an error screen carrying the webhook's `errorMessage`. A `purchaseStartedAtMs` guard ignores stale cached attempts from earlier runs.
- Also fixes a latent bug: the webhook compared `payment_status === \"succeeded\"`, but Metronome emits `\"paid\"`. Successful payments were being treated as failures.

**2. Tax collection.** `addPaymentGatedCommitToContract` now sets `tax_type: \"STRIPE\"` in the payment gate config so Stripe applies tax to the invoice Metronome generates.

## Tests

Manual:
- Triggered an AWU purchase against a workspace with a broken Metronome product mapping → dialog shows the Stripe error message instead of false success.
- Triggered a normal AWU purchase → dialog correctly flips from \"Processing payment…\" to \"Credits purchased successfully!\" once the webhook lands.
- Verified the Stripe invoice picks up tax after the \`tax_type\` change.

## Risk

Low. Failure modes:
- Redis unavailable: status calls fall back to \`null\`, the dialog stays in \"processing\" until the user closes it. The purchase itself still goes through Metronome — Redis is purely for UX.
- Webhook never fires: dialog stays in \"processing\". User can close and reopen; the existing \`pending_purchase\` eligibility branch picks it up.
- The webhook \`payment_status\` fix is a behavior change for the log line, but the prior branch did nothing user-visible, so no regression risk.

Rollback: revert the PR; in-flight Redis entries TTL out after 1h.

## Deploy Plan

Standard front deploy. No migration. No config changes.