### PR TITLE
[front] enh: remove concurrency in skill import

### DIFF
--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -16,6 +16,7 @@ import logger from "@app/logger/logger";
 import type { SkillSourceType } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type formidable from "formidable";
 import { readFile, unlink } from "fs/promises";
 import path from "path";
@@ -176,9 +177,7 @@ export async function importSkillsFromFiles(
         { concurrency: FILE_IMPORT_CONCURRENCY }
       );
 
-      fileAttachments = uploadResults.filter(
-        (r): r is FileResource => r !== null
-      );
+      fileAttachments = removeNulls(uploadResults);
     }
 
     if (existing) {

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -20,7 +20,7 @@ import type formidable from "formidable";
 import { readFile, unlink } from "fs/promises";
 import path from "path";
 
-const IMPORT_CONCURRENCY = 4;
+const FILE_IMPORT_CONCURRENCY = 4;
 
 const IMPORT_CONFLICT_STRATEGIES = ["error", "skip", "override"] as const;
 
@@ -141,129 +141,125 @@ export async function importSkillsFromFiles(
 
   const existingSkillsMap = new Map(existingSkills.map((s) => [s.name, s]));
 
-  await concurrentExecutor(
-    selectedSkills,
-    async (skill) => {
-      const existing = existingSkillsMap.get(skill.name) ?? null;
+  for (const skill of selectedSkills) {
+    const existing = existingSkillsMap.get(skill.name) ?? null;
 
-      if (existing && existing.source !== source && onConflict !== "override") {
+    if (existing && existing.source !== source && onConflict !== "override") {
+      skipped.push({
+        name: skill.name,
+        message: `A different skill named "${skill.name}" already exists.`,
+      });
+      continue;
+    }
+
+    let fileAttachments: FileResource[] = [];
+    if (allowFileAttachments) {
+      const readEntry = readerBySkill.get(skill);
+      if (!readEntry) {
         skipped.push({
           name: skill.name,
-          message: `A different skill named "${skill.name}" already exists.`,
+          message: "Internal error: no zip reader for skill.",
         });
-        return;
+        continue;
       }
 
-      let fileAttachments: FileResource[] = [];
+      const skillDirPath = path.dirname(skill.skillMdPath);
+      const uploadResults = await concurrentExecutor(
+        skill.attachments,
+        (attachment) =>
+          uploadAttachment(auth, {
+            originalEntryName: attachment.originalEntryName,
+            contentType: attachment.contentType,
+            fileName: path.relative(skillDirPath, attachment.path),
+            readEntry,
+          }),
+        { concurrency: FILE_IMPORT_CONCURRENCY }
+      );
+
+      fileAttachments = uploadResults.filter(
+        (r): r is FileResource => r !== null
+      );
+    }
+
+    if (existing) {
+      const attachedKnowledge = await existing.getAttachedKnowledge(auth);
+
+      await existing.updateSkill(auth, {
+        name: skill.name,
+        agentFacingDescription: skill.description,
+        userFacingDescription: skill.description,
+        instructions: skill.instructions,
+        instructionsHtml: convertMarkdownToBlockHtml(skill.instructions),
+        icon: existing.icon,
+        mcpServerViews: existing.mcpServerViews,
+        attachedKnowledge,
+        requestedSpaceIds: existing.requestedSpaceIds,
+        ...(allowFileAttachments ? { fileAttachments } : {}),
+        source,
+        sourceMetadata: { filePath: skill.skillMdPath },
+      });
+
       if (allowFileAttachments) {
-        const readEntry = readerBySkill.get(skill);
-        if (!readEntry) {
-          skipped.push({
-            name: skill.name,
-            message: "Internal error: no zip reader for skill.",
-          });
-          return;
-        }
+        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+          skillId: existing.sId,
+        });
+      }
 
-        const skillDirPath = path.dirname(skill.skillMdPath);
-        const uploadResults = await concurrentExecutor(
-          skill.attachments,
-          (attachment) =>
-            uploadAttachment(auth, {
-              originalEntryName: attachment.originalEntryName,
-              contentType: attachment.contentType,
-              fileName: path.relative(skillDirPath, attachment.path),
-              readEntry,
-            }),
-          { concurrency: IMPORT_CONCURRENCY }
-        );
-
-        fileAttachments = uploadResults.filter(
-          (r): r is FileResource => r !== null
+      updated.push(existing);
+    } else {
+      let icon: string | null = null;
+      const iconResult = await getSkillIconSuggestion(auth, {
+        name: skill.name,
+        instructions: skill.instructions,
+        agentFacingDescription: skill.description,
+      });
+      if (iconResult.isOk()) {
+        icon = iconResult.value;
+      } else {
+        logger.warn(
+          { error: iconResult.error, skillName: skill.name },
+          "Failed to generate icon suggestion for imported skill"
         );
       }
 
-      if (existing) {
-        const attachedKnowledge = await existing.getAttachedKnowledge(auth);
+      const suggestedMCPServerViews = await suggestMCPServersForDetectedSkill(
+        auth,
+        skill
+      );
 
-        await existing.updateSkill(auth, {
+      const skillResource = await SkillResource.makeNew(
+        auth,
+        {
+          status: "active",
           name: skill.name,
           agentFacingDescription: skill.description,
           userFacingDescription: skill.description,
           instructions: skill.instructions,
           instructionsHtml: convertMarkdownToBlockHtml(skill.instructions),
-          icon: existing.icon,
-          mcpServerViews: existing.mcpServerViews,
-          attachedKnowledge,
-          requestedSpaceIds: existing.requestedSpaceIds,
-          ...(allowFileAttachments ? { fileAttachments } : {}),
+          editedBy: user?.id ?? null,
+          requestedSpaceIds: [],
+          extendedSkillId: null,
+          icon,
           source,
           sourceMetadata: { filePath: skill.skillMdPath },
+          isDefault: false,
+        },
+        {
+          mcpServerViews: suggestedMCPServerViews,
+          ...(allowFileAttachments ? { fileAttachments } : {}),
+          addCurrentUserAsEditor: auth.user() !== null,
+        }
+      );
+
+      if (allowFileAttachments) {
+        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+          skillId: skillResource.sId,
         });
-
-        if (allowFileAttachments) {
-          await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-            skillId: existing.sId,
-          });
-        }
-
-        updated.push(existing);
-      } else {
-        let icon: string | null = null;
-        const iconResult = await getSkillIconSuggestion(auth, {
-          name: skill.name,
-          instructions: skill.instructions,
-          agentFacingDescription: skill.description,
-        });
-        if (iconResult.isOk()) {
-          icon = iconResult.value;
-        } else {
-          logger.warn(
-            { error: iconResult.error, skillName: skill.name },
-            "Failed to generate icon suggestion for imported skill"
-          );
-        }
-
-        const suggestedMCPServerViews = await suggestMCPServersForDetectedSkill(
-          auth,
-          skill
-        );
-
-        const skillResource = await SkillResource.makeNew(
-          auth,
-          {
-            status: "active",
-            name: skill.name,
-            agentFacingDescription: skill.description,
-            userFacingDescription: skill.description,
-            instructions: skill.instructions,
-            instructionsHtml: convertMarkdownToBlockHtml(skill.instructions),
-            editedBy: user?.id ?? null,
-            requestedSpaceIds: [],
-            extendedSkillId: null,
-            icon,
-            source,
-            sourceMetadata: { filePath: skill.skillMdPath },
-            isDefault: false,
-          },
-          {
-            mcpServerViews: suggestedMCPServerViews,
-            ...(allowFileAttachments ? { fileAttachments } : {}),
-            addCurrentUserAsEditor: auth.user() !== null,
-          }
-        );
-
-        if (allowFileAttachments) {
-          await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-            skillId: skillResource.sId,
-          });
-        }
-
-        imported.push(skillResource);
       }
-    },
-    { concurrency: IMPORT_CONCURRENCY }
-  );
+
+      imported.push(skillResource);
+    }
+  }
 
   return new Ok({ imported, updated, skipped });
 }

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -26,7 +26,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import type { Octokit } from "@octokit/core";
 import path from "path";
 
-const IMPORT_CONCURRENCY = 4;
+const FILE_IMPORT_CONCURRENCY = 4;
 
 type ImportSkillsResult = {
   imported: SkillResource[];
@@ -104,125 +104,121 @@ export async function importSkillsFromGitHub(
   const updated: SkillResource[] = [];
   const skipped: { name: string; message: string }[] = [];
 
-  await concurrentExecutor(
-    selectedSkills,
-    async (skill) => {
-      const existing = existingSkillsMap.get(skill.name) ?? null;
+  for (const skill of selectedSkills) {
+    const existing = existingSkillsMap.get(skill.name) ?? null;
 
-      if (existing && !isSkillFromGitHubRepo(existing, { repoUrl })) {
-        skipped.push({
-          name: skill.name,
-          message: `A different skill named "${skill.name}" already exists.`,
-        });
-        return;
-      }
+    if (existing && !isSkillFromGitHubRepo(existing, { repoUrl })) {
+      skipped.push({
+        name: skill.name,
+        message: `A different skill named "${skill.name}" already exists.`,
+      });
+      continue;
+    }
 
-      let fileAttachments: FileResource[] = [];
+    let fileAttachments: FileResource[] = [];
+    if (allowFileAttachments) {
+      const skillDirPath = path.dirname(skill.skillMdPath);
+      const uploadResults = await concurrentExecutor(
+        skill.attachments,
+        (attachment) =>
+          uploadAttachment(auth, {
+            octokit,
+            owner,
+            repo,
+            attachment,
+            skillDirPath,
+          }),
+        { concurrency: FILE_IMPORT_CONCURRENCY }
+      );
+
+      fileAttachments = uploadResults.filter(
+        (r): r is FileResource => r !== null
+      );
+    }
+
+    if (existing) {
+      const attachedKnowledge = await existing.getAttachedKnowledge(auth);
+
+      await existing.updateSkill(auth, {
+        name: skill.name,
+        agentFacingDescription: skill.description,
+        userFacingDescription: skill.description,
+        instructions: skill.instructions,
+        icon: existing.icon,
+        mcpServerViews: existing.mcpServerViews,
+        attachedKnowledge,
+        requestedSpaceIds: existing.requestedSpaceIds,
+        ...(allowFileAttachments ? { fileAttachments } : {}),
+        source: "github",
+        sourceMetadata: {
+          repoUrl,
+          filePath: skill.skillMdPath,
+        },
+      });
+
       if (allowFileAttachments) {
-        const skillDirPath = path.dirname(skill.skillMdPath);
-        const uploadResults = await concurrentExecutor(
-          skill.attachments,
-          (attachment) =>
-            uploadAttachment(auth, {
-              octokit,
-              owner,
-              repo,
-              attachment,
-              skillDirPath,
-            }),
-          { concurrency: IMPORT_CONCURRENCY }
-        );
+        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+          skillId: existing.sId,
+        });
+      }
 
-        fileAttachments = uploadResults.filter(
-          (r): r is FileResource => r !== null
+      updated.push(existing);
+    } else {
+      let icon: string | null = null;
+      const iconResult = await getSkillIconSuggestion(auth, {
+        name: skill.name,
+        instructions: skill.instructions,
+        agentFacingDescription: skill.description,
+      });
+      if (iconResult.isOk()) {
+        icon = iconResult.value;
+      } else {
+        logger.warn(
+          { error: iconResult.error, skillName: skill.name },
+          "Failed to generate icon suggestion for imported skill"
         );
       }
 
-      if (existing) {
-        const attachedKnowledge = await existing.getAttachedKnowledge(auth);
+      const detectedMCPServerViews = await suggestMCPServersForDetectedSkill(
+        auth,
+        skill
+      );
 
-        await existing.updateSkill(auth, {
+      const skillResource = await SkillResource.makeNew(
+        auth,
+        {
+          status: "active",
           name: skill.name,
           agentFacingDescription: skill.description,
           userFacingDescription: skill.description,
           instructions: skill.instructions,
-          icon: existing.icon,
-          mcpServerViews: existing.mcpServerViews,
-          attachedKnowledge,
-          requestedSpaceIds: existing.requestedSpaceIds,
-          ...(allowFileAttachments ? { fileAttachments } : {}),
+          instructionsHtml: convertMarkdownToBlockHtml(skill.instructions),
+          editedBy: user.id,
+          requestedSpaceIds: [],
+          extendedSkillId: null,
+          icon,
           source: "github",
           sourceMetadata: {
             repoUrl,
             filePath: skill.skillMdPath,
           },
+          isDefault: false,
+        },
+        {
+          mcpServerViews: detectedMCPServerViews,
+          ...(allowFileAttachments ? { fileAttachments } : {}),
+        }
+      );
+
+      if (allowFileAttachments) {
+        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+          skillId: skillResource.sId,
         });
-
-        if (allowFileAttachments) {
-          await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-            skillId: existing.sId,
-          });
-        }
-
-        updated.push(existing);
-      } else {
-        let icon: string | null = null;
-        const iconResult = await getSkillIconSuggestion(auth, {
-          name: skill.name,
-          instructions: skill.instructions,
-          agentFacingDescription: skill.description,
-        });
-        if (iconResult.isOk()) {
-          icon = iconResult.value;
-        } else {
-          logger.warn(
-            { error: iconResult.error, skillName: skill.name },
-            "Failed to generate icon suggestion for imported skill"
-          );
-        }
-
-        const detectedMCPServerViews = await suggestMCPServersForDetectedSkill(
-          auth,
-          skill
-        );
-
-        const skillResource = await SkillResource.makeNew(
-          auth,
-          {
-            status: "active",
-            name: skill.name,
-            agentFacingDescription: skill.description,
-            userFacingDescription: skill.description,
-            instructions: skill.instructions,
-            instructionsHtml: convertMarkdownToBlockHtml(skill.instructions),
-            editedBy: user.id,
-            requestedSpaceIds: [],
-            extendedSkillId: null,
-            icon,
-            source: "github",
-            sourceMetadata: {
-              repoUrl,
-              filePath: skill.skillMdPath,
-            },
-            isDefault: false,
-          },
-          {
-            mcpServerViews: detectedMCPServerViews,
-            ...(allowFileAttachments ? { fileAttachments } : {}),
-          }
-        );
-
-        if (allowFileAttachments) {
-          await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-            skillId: skillResource.sId,
-          });
-        }
-
-        imported.push(skillResource);
       }
-    },
-    { concurrency: IMPORT_CONCURRENCY }
-  );
+
+      imported.push(skillResource);
+    }
+  }
 
   return new Ok({ imported, updated, skipped });
 }

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -23,6 +23,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type { Octokit } from "@octokit/core";
 import path from "path";
 
@@ -131,9 +132,7 @@ export async function importSkillsFromGitHub(
         { concurrency: FILE_IMPORT_CONCURRENCY }
       );
 
-      fileAttachments = uploadResults.filter(
-        (r): r is FileResource => r !== null
-      );
+      fileAttachments = removeNulls(uploadResults);
     }
 
     if (existing) {


### PR DESCRIPTION
## Description

- This PR removes the concurrency on skill import from GitHub/zip
- This prevents nested `concurrentExecutor` on file uploads

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25889">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->